### PR TITLE
Suppress map parse error

### DIFF
--- a/src/games/strategy/debug/ClientLogger.java
+++ b/src/games/strategy/debug/ClientLogger.java
@@ -8,11 +8,16 @@ public class ClientLogger
 	
 	public static void logQuietly(final Exception e)
 	{
-		developerOutputStream.println("Exception: " + e.getMessage());
+		logQuietly("Exception: " + e.getMessage());
 		for (final StackTraceElement stackTraceElement : e.getStackTrace())
 		{
 			developerOutputStream.println(stackTraceElement.toString());
 		}
+	}
+	
+	public static void logQuietly(String msg)
+	{
+		developerOutputStream.println(msg);
 	}
 	
 }

--- a/src/games/strategy/engine/data/GameParser.java
+++ b/src/games/strategy/engine/data/GameParser.java
@@ -18,6 +18,7 @@
  */
 package games.strategy.engine.data;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.data.properties.BooleanProperty;
 import games.strategy.engine.data.properties.ColorProperty;
@@ -129,8 +130,9 @@ public class GameParser
 		{
 			for (final SAXParseException error : errorsSAX)
 			{
-				System.err.println("SAXParseException: game: " + (data == null ? "?" : (data.getGameName() == null ? "?" : data.getGameName())) + ", line: " + error.getLineNumber() + ", column: "
-							+ error.getColumnNumber() + ", error: " + error.getMessage());
+				String msg = "SAXParseException: game: " + (data == null ? "?" : (data.getGameName() == null ? "?" : data.getGameName())) + ", line: " + error.getLineNumber() + ", column: "
+							+ error.getColumnNumber() + ", error: " + error.getMessage();
+				ClientLogger.logQuietly(msg);
 			}
 		}
 		parseDiceSides(getSingleChild("diceSides", root, true));


### PR DESCRIPTION
commit message details this change pretty well, but I'm getting mass errors when loading tripleA due to apparently a bad map that I downloaded (nothing experimental going on yet, things are pretty cleanly set up). Map parse errors are best handled when selecting maps perhaps, not at bootup with the scary "an error has occurred" window. Particularly when I haven't yet ran into the error, namely I haven't tried to play those maps yet or select them.