### PR TITLE
Remove class structural comments

### DIFF
--- a/src/games/strategy/engine/framework/startup/LocalBeanCache.java
+++ b/src/games/strategy/engine/framework/startup/LocalBeanCache.java
@@ -21,28 +21,16 @@ import games.strategy.engine.framework.startup.ui.editors.IBean;
  * @author Klaus Groenbaek
  */
 public class LocalBeanCache {
-  // -----------------------------------------------------------------------
-  // class fields
-  // -----------------------------------------------------------------------
   private static final LocalBeanCache s_INSTANCE = new LocalBeanCache();
   private final File m_file;
   private final Object m_mutex = new Object();
 
-  // -----------------------------------------------------------------------
-  // class methods
-  // -----------------------------------------------------------------------
   public static LocalBeanCache getInstance() {
     return s_INSTANCE;
   }
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   Map<String, IBean> m_map = new HashMap<String, IBean>();
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   private LocalBeanCache() {
     m_file = new File(GameRunner2.getUserRootFolder(), "local.cache");
@@ -108,9 +96,6 @@ public class LocalBeanCache {
 
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * adds a new Serializable to the cache

--- a/src/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/src/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -21,16 +21,10 @@ import games.strategy.engine.framework.GameRunner2;
  * @author Klaus Groenbaek
  */
 public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
-  // -----------------------------------------------------------------------
-  // class constants
-  // -----------------------------------------------------------------------
   // chars illegal on windows (on linux/mac anything that is allowed on windows works fine)
   final static char[] s_illegalChars = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
       27, 28, 29, 30, 31, 34, 42, 58, 60, 62, 63, 92, 124};
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Caches the gameOptions stored in the game data, and associates with this game. only values that are serializable

--- a/src/games/strategy/engine/framework/startup/ui/IGamePropertiesCache.java
+++ b/src/games/strategy/engine/framework/startup/ui/IGamePropertiesCache.java
@@ -9,9 +9,6 @@ import games.strategy.engine.data.GameData;
  * @author Klaus Groenbaek
  */
 public interface IGamePropertiesCache {
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Caches the gameOptions stored in the game data, and associates with this game

--- a/src/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -64,14 +64,8 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
 
   private static final long serialVersionUID = 9006941131918034674L;
 
-  // -----------------------------------------------------------------------
-  // class fields
-  // -----------------------------------------------------------------------
   private static final String DICE_ROLLER = "games.strategy.engine.random.IRemoteDiceServer";
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private final GameSelectorModel m_gameSelectorModel;
   private final SelectAndViewEditor m_diceServerEditor;
   private final SelectAndViewEditor m_forumPosterEditor;
@@ -81,9 +75,6 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   private final JPanel m_localPlayerPanel = new JPanel();
   private final JButton m_localPlayerSelection = new JButton("Select Local Players and AI's");
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   /**
    * Creates a new instance
@@ -153,9 +144,6 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   @Override
   public void setWidgetActivation() {}
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   private void setupListeners() {
     // register, so we get notified when the game model (GameData) changes (e.g if the user load a save game or selects another game)
@@ -451,9 +439,6 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   }
 
 
-  // -----------------------------------------------------------------------
-  // inner classes
-  // -----------------------------------------------------------------------
 
   /**
    * A property change listener that notify our observers

--- a/src/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
@@ -20,9 +20,6 @@ import games.strategy.engine.random.PBEMDiceRoller;
  * @author Klaus Groenbaek
  */
 public class DiceServerEditor extends EditorPanel {
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
 
   private static final long serialVersionUID = -451810815037661114L;
   private final JButton m_testDiceyButton = new JButton("Test Server");
@@ -35,9 +32,6 @@ public class DiceServerEditor extends EditorPanel {
   private final JLabel m_gameIdLabel = new JLabel("Game ID:");
   private final IRemoteDiceServer m_bean;
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   /**
    * Creating a new instance
@@ -82,9 +76,6 @@ public class DiceServerEditor extends EditorPanel {
     setupListeners();
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Configures the listeners for the gui components

--- a/src/games/strategy/engine/framework/startup/ui/editors/EditorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/EditorPanel.java
@@ -24,22 +24,13 @@ import games.strategy.engine.framework.startup.ui.editors.validators.NonEmptyVal
 public abstract class EditorPanel extends JPanel {
   private static final long serialVersionUID = 8156959717037201321L;
   public static final String EDITOR_CHANGE = "EditorChange";
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   protected final Color m_labelColor;
 
-  // -----------------------------------------------------------------------
-  // constructor
-  // -----------------------------------------------------------------------
   public EditorPanel() {
     super(new GridBagLayout());
     m_labelColor = new JLabel().getForeground();
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * registers a listener for editor changes
@@ -176,9 +167,6 @@ public abstract class EditorPanel extends JPanel {
   }
 
 
-  // -----------------------------------------------------------------------
-  // inner classes
-  // -----------------------------------------------------------------------
   /**
    * Document listener which calls fireEditorChanged in response to any document change
    */

--- a/src/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -31,9 +31,6 @@ import games.strategy.ui.ProgressWindow;
  * @author Klaus Groenbaek
  */
 public class EmailSenderEditor extends EditorPanel {
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
 
   private static final long serialVersionUID = -4647781117491269926L;
   private final GenericEmailSender m_bean;
@@ -53,9 +50,6 @@ public class EmailSenderEditor extends EditorPanel {
   private final JButton m_testEmail = new JButton("Test Email");
   private final JCheckBox m_alsoPostAfterCombatMove = new JCheckBox("Also Post After Combat Move");
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   /**
    * creates a new instance
@@ -145,9 +139,6 @@ public class EmailSenderEditor extends EditorPanel {
     setupListeners();
   }
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
 
   private void setupListeners() {
     final EditorChangedFiringDocumentListener listener = new EditorChangedFiringDocumentListener();
@@ -259,9 +250,6 @@ public class EmailSenderEditor extends EditorPanel {
   }
 
 
-  // -----------------------------------------------------------------------
-  // inner classes
-  // -----------------------------------------------------------------------
 
   /**
    * class for configuring the editor so some fields can be hidden

--- a/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -34,9 +34,6 @@ import games.strategy.ui.ProgressWindow;
  */
 public class ForumPosterEditor extends EditorPanel {
   private static final long serialVersionUID = -6069315084412575053L;
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private final JButton m_viewPosts = new JButton("View Forum");
   private final JButton m_testForum = new JButton("Test Post");
 
@@ -52,9 +49,6 @@ public class ForumPosterEditor extends EditorPanel {
   private final JCheckBox m_alsoPostAfterCombatMove = new JCheckBox("Also Post After Combat Move");
   private final IForumPoster m_bean;
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   public ForumPosterEditor(final IForumPoster bean) {
     m_bean = bean;
@@ -106,9 +100,6 @@ public class ForumPosterEditor extends EditorPanel {
     setupListeners();
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Configures the listeners for the gui components

--- a/src/games/strategy/engine/framework/startup/ui/editors/IBean.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/IBean.java
@@ -9,9 +9,6 @@ import java.io.Serializable;
  * @author Klaus Groenbaek
  */
 public interface IBean extends Serializable {
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Get the displayName of the bean

--- a/src/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
@@ -41,9 +41,6 @@ import games.strategy.ui.ProgressWindow;
 public class MicroWebPosterEditor extends EditorPanel {
   private static final long serialVersionUID = -6069315084412575053L;
   public static final String HTTP_BLANK = "http://";
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private final JButton m_viewSite = new JButton("View Web Site");
   private final JButton m_testSite = new JButton("Test Web Site");
   private final JButton m_initGame = new JButton("Initialize Game");
@@ -59,9 +56,6 @@ public class MicroWebPosterEditor extends EditorPanel {
   private final JLabel m_gameNameLabel = new JLabel("Game Name:");
   private final JTextField m_gameName = new JTextField();
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   public MicroWebPosterEditor(final IWebPoster bean, final String[] parties) {
     m_bean = bean;
@@ -110,9 +104,6 @@ public class MicroWebPosterEditor extends EditorPanel {
     setupListeners();
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Configures the listeners for the gui components

--- a/src/games/strategy/engine/framework/startup/ui/editors/SelectAndViewEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/SelectAndViewEditor.java
@@ -34,9 +34,6 @@ import games.strategy.triplea.ui.JButtonDialog;
  */
 public class SelectAndViewEditor extends EditorPanel {
   private static final long serialVersionUID = 1580648148539524876L;
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   JComboBox m_selector = new JComboBox();
   JPanel m_view = new JPanel();
   JButton m_helpButton = new JButton("Help?");
@@ -46,9 +43,6 @@ public class SelectAndViewEditor extends EditorPanel {
   private final JEditorPane m_helpPanel;
   private final String m_defaultHelp;
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   /**
    * creates a new editor
@@ -127,9 +121,6 @@ public class SelectAndViewEditor extends EditorPanel {
 
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Updates the view panel below the combo box.

--- a/src/games/strategy/engine/framework/startup/ui/editors/validators/EmailValidator.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/validators/EmailValidator.java
@@ -11,9 +11,6 @@ public class EmailValidator implements IValidator {
 
   private final boolean m_validIfEmpty;
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * create a new instance

--- a/src/games/strategy/engine/framework/startup/ui/editors/validators/IValidator.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/validators/IValidator.java
@@ -7,9 +7,6 @@ package games.strategy.engine.framework.startup.ui.editors.validators;
  */
 public interface IValidator {
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Validates that the give input is valid

--- a/src/games/strategy/engine/framework/startup/ui/editors/validators/IntegerRangeValidator.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/validators/IntegerRangeValidator.java
@@ -6,15 +6,9 @@ package games.strategy.engine.framework.startup.ui.editors.validators;
  * @author Klaus Groenbaek
  */
 public class IntegerRangeValidator implements IValidator {
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private final int m_min;
   private final int m_max;
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   /**
    * create a new instance
@@ -29,9 +23,6 @@ public class IntegerRangeValidator implements IValidator {
     m_max = max;
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @Override
   public boolean isValid(final String text) {

--- a/src/games/strategy/engine/framework/startup/ui/editors/validators/NonEmptyValidator.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/validators/NonEmptyValidator.java
@@ -6,9 +6,6 @@ package games.strategy.engine.framework.startup.ui.editors.validators;
  * @author Klaus Groenbaek
  */
 public class NonEmptyValidator implements IValidator {
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @Override
   public boolean isValid(final String text) {

--- a/src/games/strategy/engine/pbem/AbstractForumPoster.java
+++ b/src/games/strategy/engine/pbem/AbstractForumPoster.java
@@ -12,19 +12,10 @@ import games.strategy.engine.framework.startup.ui.editors.IBean;
  * @author Klaus Groenbaek
  */
 public abstract class AbstractForumPoster implements IForumPoster {
-  // -----------------------------------------------------------------------
-  // constants
-  // -----------------------------------------------------------------------
   private static final String USE_TRANSITIVE_PASSWORD = "d0a11f0f-96d3-4303-8875-4965aefb2ce4";
   private static final long serialVersionUID = -734015230309508040L;
 
-  // -----------------------------------------------------------------------
-  // class methods
-  // -----------------------------------------------------------------------
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   protected String m_username = null;
   protected String m_password = null;
   protected transient String m_transPassword;
@@ -32,16 +23,10 @@ public abstract class AbstractForumPoster implements IForumPoster {
   protected boolean m_includeSaveGame = true;
   protected boolean m_alsoPostAfterCombatMove = false;
 
-  // -----------------------------------------------------------------------
-  // transitive fields
-  // -----------------------------------------------------------------------
   protected transient File m_saveGameFile = null;
   protected transient String m_turnSummaryRef = null;
   protected transient String m_saveGameFileName = null;
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @Override
   public String getTurnSummaryRef() {

--- a/src/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/src/games/strategy/engine/pbem/GenericEmailSender.java
@@ -37,9 +37,6 @@ import games.strategy.triplea.help.HelpSupport;
  * @author Klaus Groenbaek
  */
 public class GenericEmailSender implements IEmailSender {
-  // -----------------------------------------------------------------------
-  // class fields
-  // -----------------------------------------------------------------------
   private static final long serialVersionUID = 4644748856027574157L;
   /**
    * a value to assign to the non-transitive password, as we can see that is was cleared
@@ -47,9 +44,6 @@ public class GenericEmailSender implements IEmailSender {
   private static final String USE_TRANSITIVE_PASSWORD = "d0a11f0f-96d3-4303-8875-4965aefb2ce4";
 
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
 
   /**
    * Currently only message encryption is allowed. Later connect based encryption through SSL may be implementes
@@ -58,9 +52,6 @@ public class GenericEmailSender implements IEmailSender {
     NONE, TLS
   }
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   private long m_timeout = TimeUnit.SECONDS.toMillis(60);
   private String m_subjectPrefix;
@@ -73,9 +64,6 @@ public class GenericEmailSender implements IEmailSender {
   private Encryption m_encryption;
   private boolean m_alsoPostAfterCombatMove = false;
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @Override
   public void sendEmail(final String subject, final String htmlMessage, final File saveGame, final String saveGameName) throws IOException {

--- a/src/games/strategy/engine/pbem/GmailEmailSender.java
+++ b/src/games/strategy/engine/pbem/GmailEmailSender.java
@@ -11,9 +11,6 @@ import games.strategy.triplea.help.HelpSupport;
 public class GmailEmailSender extends GenericEmailSender {
   private static final long serialVersionUID = 3511375113962472063L;
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   public GmailEmailSender() {
     setHost("smtp.gmail.com");
@@ -21,9 +18,6 @@ public class GmailEmailSender extends GenericEmailSender {
     setEncryption(Encryption.TLS);
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @Override
   public EditorPanel getEditor() {

--- a/src/games/strategy/engine/pbem/HotmailEmailSender.java
+++ b/src/games/strategy/engine/pbem/HotmailEmailSender.java
@@ -13,9 +13,6 @@ import games.strategy.triplea.help.HelpSupport;
 public class HotmailEmailSender extends GenericEmailSender {
   private static final long serialVersionUID = 3511375113962472063L;
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   public HotmailEmailSender() {
     setHost("smtp.live.com");
@@ -23,9 +20,6 @@ public class HotmailEmailSender extends GenericEmailSender {
     setEncryption(Encryption.TLS);
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @Override
   public EditorPanel getEditor() {

--- a/src/games/strategy/engine/pbem/IEmailSender.java
+++ b/src/games/strategy/engine/pbem/IEmailSender.java
@@ -14,9 +14,6 @@ import games.strategy.engine.framework.startup.ui.editors.IBean;
  */
 public interface IEmailSender extends IBean {
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Sends an email with the given subject, optionally attaches a save game file.

--- a/src/games/strategy/engine/pbem/NullEmailSender.java
+++ b/src/games/strategy/engine/pbem/NullEmailSender.java
@@ -12,14 +12,8 @@ import games.strategy.engine.framework.startup.ui.editors.IBean;
  * @author Klaus Groenbaek
  */
 public class NullEmailSender implements IEmailSender {
-  // -----------------------------------------------------------------------
-  // class fields
-  // -----------------------------------------------------------------------
   private static final long serialVersionUID = 9138507282128548506L;
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @Override
   public String getDisplayName() {

--- a/src/games/strategy/engine/pbem/PBEMMessagePoster.java
+++ b/src/games/strategy/engine/pbem/PBEMMessagePoster.java
@@ -28,18 +28,12 @@ import games.strategy.ui.ProgressWindow;
  *
  */
 public class PBEMMessagePoster implements Serializable {
-  // -----------------------------------------------------------------------
-  // class fields
-  // -----------------------------------------------------------------------
   public static final String FORUM_POSTER_PROP_NAME = "games.strategy.engine.pbem.IForumPoster";
   public static final String EMAIL_SENDER_PROP_NAME = "games.strategy.engine.pbem.IEmailSender";
   public static final String WEB_POSTER_PROP_NAME = "games.strategy.engine.pbem.IWebPoster";
   public static final String PBEM_GAME_PROP_NAME = "games.strategy.engine.pbem.PBEMMessagePoster";
   private static final long serialVersionUID = 2256265436928530566L;
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private final IForumPoster m_forumPoster;
   private final IEmailSender m_emailSender;
   private final IWebPoster m_webSitePoster;
@@ -54,9 +48,6 @@ public class PBEMMessagePoster implements Serializable {
   private transient int m_roundNumber;
   private transient String m_gameNameAndInfo;
 
-  // -----------------------------------------------------------------------
-  // Constructors
-  // -----------------------------------------------------------------------
 
   public PBEMMessagePoster(final GameData gameData, final PlayerID currentPlayer, final int roundNumber, final String title) {
     m_gameData = gameData;
@@ -68,9 +59,6 @@ public class PBEMMessagePoster implements Serializable {
     m_gameNameAndInfo = "TripleA " + title + " for game: " + gameData.getGameName() + ", version: " + gameData.getGameVersion();
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
   public boolean hasMessengers() {
     return (m_forumPoster != null || m_emailSender != null || m_webSitePoster != null);
   }

--- a/src/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
+++ b/src/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
@@ -28,33 +28,18 @@ import games.strategy.triplea.help.HelpSupport;
  * @author Klaus Groenbaek
  */
 public class TripleAWarClubForumPoster extends AbstractForumPoster {
-  // -----------------------------------------------------------------------
-  // constants
-  // -----------------------------------------------------------------------
   private static final long serialVersionUID = -4017550807078258152L;
   private static String m_host = "www.tripleawarclub.org";
   private static String s_forumId = "20";
-  // -----------------------------------------------------------------------
-  // class fields
-  // -----------------------------------------------------------------------
   private static Pattern s_XOOPS_TOKEN_REQUEST =
       Pattern.compile(".*XOOPS_TOKEN_REQUEST[^>]*value=\"([^\"]*)\".*", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
 
   private transient HttpState m_httpState;
   private transient HostConfiguration m_hostConfiguration;
   private transient HttpClient m_client;
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Logs into the website

--- a/src/games/strategy/engine/pbem/TripleAWebPoster.java
+++ b/src/games/strategy/engine/pbem/TripleAWebPoster.java
@@ -32,17 +32,8 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.help.HelpSupport;
 
 public class TripleAWebPoster implements IWebPoster {
-  // -----------------------------------------------------------------------
-  // constants
-  // -----------------------------------------------------------------------
   private static final long serialVersionUID = -3013355800798928625L;
-  // -----------------------------------------------------------------------
-  // class fields
-  // -----------------------------------------------------------------------
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
 
   private String m_host = MicroWebPosterEditor.HTTP_BLANK;
   private Vector<String> m_allHosts = new Vector<String>();
@@ -55,9 +46,6 @@ public class TripleAWebPoster implements IWebPoster {
   private transient String m_saveGameFileName = "";
   private String[] parties;
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   private static Collection<String> getAlliances(final GameData gameData) {
 

--- a/src/games/strategy/engine/random/InternalDiceServer.java
+++ b/src/games/strategy/engine/random/InternalDiceServer.java
@@ -19,22 +19,13 @@ import games.strategy.engine.framework.startup.ui.editors.IBean;
  */
 public class InternalDiceServer implements IRemoteDiceServer {
   private static final long serialVersionUID = -8369097763085658445L;
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private transient IRandomSource _randomSource;
 
-  // -----------------------------------------------------------------------
-  // constructor
-  // -----------------------------------------------------------------------
 
   public InternalDiceServer() {
     _randomSource = new PlainRandomSource();
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @Override
   public EditorPanel getEditor() {

--- a/src/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -43,14 +43,8 @@ import games.strategy.engine.framework.startup.ui.editors.IBean;
  * @author sgb
  */
 public class PropertiesDiceRoller implements IRemoteDiceServer {
-  // -----------------------------------------------------------------------
-  // class fields
-  // -----------------------------------------------------------------------
   private static final long serialVersionUID = 6481409417543119539L;
 
-  // -----------------------------------------------------------------------
-  // class methods
-  // -----------------------------------------------------------------------
 
   /**
    * Loads the property dice rollers from the properties file
@@ -98,24 +92,15 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
     return rollers;
   }
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private final Properties m_props;
   private String m_toAddress;
   private String m_ccAddress;
   private String m_gameId;
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
   public PropertiesDiceRoller(final Properties props) {
     m_props = props;
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @Override
   public String getDisplayName() {

--- a/src/games/strategy/triplea/attatchments/TechAbilityAttachment.java
+++ b/src/games/strategy/triplea/attatchments/TechAbilityAttachment.java
@@ -99,7 +99,6 @@ public class TechAbilityAttachment extends DefaultAttachment {
   private IntegerMap<UnitType> m_bombingBonus = new IntegerMap<UnitType>();
 
   //
-  // constructor
   //
   public TechAbilityAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);

--- a/src/games/strategy/triplea/help/HelpSupport.java
+++ b/src/games/strategy/triplea/help/HelpSupport.java
@@ -12,9 +12,6 @@ import java.io.InputStreamReader;
  */
 public class HelpSupport {
 
-  // -----------------------------------------------------------------------
-  // class methods
-  // -----------------------------------------------------------------------
   public static String loadHelp(final String fileName) {
     try {
       final InputStream is = HelpSupport.class.getResourceAsStream(fileName);

--- a/src/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/games/strategy/triplea/image/TileImageFactory.java
@@ -161,7 +161,6 @@ public final class TileImageFactory {
     }
   }
 
-  // constructor
   public TileImageFactory() {}
 
   /**

--- a/src/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
+++ b/src/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
@@ -47,14 +47,8 @@ import games.strategy.triplea.help.HelpSupport;
  * @author Klaus Groenbaek
  */
 public class AxisAndAlliesForumPoster extends AbstractForumPoster {
-  // -----------------------------------------------------------------------
-  // constants
-  // -----------------------------------------------------------------------
   private static final long serialVersionUID = 8896923978584346664L;
 
-  // -----------------------------------------------------------------------
-  // class fields
-  // -----------------------------------------------------------------------
   // the patterns used to extract values from hidden form fields posted to the server
   public static final Pattern NUM_REPLIES_PATTERN =
       Pattern.compile(".*name=\"num_replies\" value=\"(\\d+)\".*", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
@@ -74,16 +68,10 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
   public static final Pattern ERROR_LIST_PATTERN =
       Pattern.compile(".*id=\"error_list[^>]*>\\s+([^<]*)\\s+<.*", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private transient HttpState m_httpState;
   private transient HostConfiguration m_hostConfiguration;
   private transient HttpClient m_client;
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Logs into axisandallies.org

--- a/src/games/strategy/triplea/ui/JButtonDialog.java
+++ b/src/games/strategy/triplea/ui/JButtonDialog.java
@@ -77,9 +77,6 @@ public class JButtonDialog {
     return (String) pane.getValue();
   }
 
-  // -----------------------------------------------------------------------
-  // constructor
-  // -----------------------------------------------------------------------
 
   private JButtonDialog() {}
 }

--- a/test/games/strategy/engine/data/annotations/ExampleAttachment.java
+++ b/test/games/strategy/engine/data/annotations/ExampleAttachment.java
@@ -15,9 +15,6 @@ import games.strategy.util.IntegerMap;
  */
 public class ExampleAttachment extends DefaultAttachment {
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
 
   private static final long serialVersionUID = -5820318094331518742L;
   private int m_techCost;
@@ -28,17 +25,11 @@ public class ExampleAttachment extends DefaultAttachment {
   @InternalDoNotExport
   private String m_notAProperty = "str";
 
-  // -----------------------------------------------------------------------
-  // constructors
-  // -----------------------------------------------------------------------
 
   public ExampleAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setTechCost(final String techCost) {

--- a/test/games/strategy/engine/data/annotations/InvalidClearExample.java
+++ b/test/games/strategy/engine/data/annotations/InvalidClearExample.java
@@ -19,14 +19,8 @@ public class InvalidClearExample extends DefaultAttachment {
     super(name, attachable, gameData);
   }
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private final IntegerMap<UnitType> m_givesMovement = new IntegerMap<UnitType>();
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
   public void setGivesMovement(final String value) {
 

--- a/test/games/strategy/engine/data/annotations/InvalidFieldNameExample.java
+++ b/test/games/strategy/engine/data/annotations/InvalidFieldNameExample.java
@@ -17,14 +17,8 @@ public class InvalidFieldNameExample extends DefaultAttachment {
     super(name, attachable, gameData);
   }
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private String attribute; // should have been prefixed with "m_". Should cause test to fail.
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   public String getAttribute() {
     return attribute;

--- a/test/games/strategy/engine/data/annotations/InvalidFieldTypeExample.java
+++ b/test/games/strategy/engine/data/annotations/InvalidFieldTypeExample.java
@@ -19,15 +19,9 @@ public class InvalidFieldTypeExample extends DefaultAttachment {
     super(name, attachable, gameData);
   }
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   @SuppressWarnings("unused")
   private String m_givesMovement; // this should be an integermap, since that is what we are returning. should cause test to fail.
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
   public void setGivesMovement(final String value) {
 

--- a/test/games/strategy/engine/data/annotations/InvalidGetterExample.java
+++ b/test/games/strategy/engine/data/annotations/InvalidGetterExample.java
@@ -17,14 +17,8 @@ public class InvalidGetterExample extends DefaultAttachment {
     super(name, attachable, gameData);
   }
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private String m_attribute;
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public String getAttribute() // annotation put on a getter instead of a setter, should cause test to fail

--- a/test/games/strategy/engine/data/annotations/InvalidResetExample.java
+++ b/test/games/strategy/engine/data/annotations/InvalidResetExample.java
@@ -19,14 +19,8 @@ public class InvalidResetExample extends DefaultAttachment {
     super(name, attachable, gameData);
   }
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   private IntegerMap<UnitType> m_givesMovement = new IntegerMap<UnitType>();
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
   public void setGivesMovement(final String value) {}
 

--- a/test/games/strategy/engine/data/annotations/InvalidReturnTypeExample.java
+++ b/test/games/strategy/engine/data/annotations/InvalidReturnTypeExample.java
@@ -17,15 +17,9 @@ public class InvalidReturnTypeExample extends DefaultAttachment {
     super(name, attachable, gameData);
   }
 
-  // -----------------------------------------------------------------------
-  // instance fields
-  // -----------------------------------------------------------------------
   @SuppressWarnings("unused")
   private String m_attribute;
 
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
   public int getAttribute() // is not returning our variable, so should cause test to fail
   {
     return 1;

--- a/test/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/test/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -25,9 +25,6 @@ import junit.framework.TestCase;
  * @author Klaus Groenbaek
  */
 public class ValidateAttachmentsTest extends TestCase {
-  // -----------------------------------------------------------------------
-  // instance methods
-  // -----------------------------------------------------------------------
 
   /**
    * Test that the Example Attachment is valid


### PR DESCRIPTION
Summary: remove needless class structural comments. This PR contains deleted comments only, so shouldn't take too long to review hopefully. The comments deleted look like this:

  // -----------------------------------------------------------------------		
  // class constants		
  // -----------------------------------------------------------------------

Details:
Comments were identified by finding the long line comments and then the following line:
$ find . -name "*.java" | xargs egrep -h -A1 "// --.{10}" | grep "//" | sort | uniq

This gives us a list of candidates. The list wasn't too long. The following were used to execute the deletions (note, one extra deletion is picked up, so FileOpen.java was reverted after):

 1847  find . -name "*.java" | xargs sed -i '|// -------|d'
 1848  find . -name "*.java" | xargs sed -i '/\/\/ -------/d'
 1849  find . -name "*.java" | xargs sed -i '/\/\/ class constants/d'
 1850  find . -name "*.java" | xargs sed -i '/\/\/ class methods/d'
 1851  find . -name "*.java" | xargs sed -i '/\/\/ class fields/d'
 1852  find . -name "*.java" | xargs sed -i '/\/\/ constructor/d'
 1853  find . -name "*.java" | xargs sed -i '/\/\/ Constructor/d'
 1854  find . -name "*.java" | xargs sed -i '/\/\/ inner classes/d'
 1855  find . -name "*.java" | xargs sed -i '/\/\/ inner fields/d'
 1856  find . -name "*.java" | xargs sed -i '/\/\/ inner methods/d'
 1857  find . -name "*.java" | xargs sed -i '/\/\/ instance methods/d'
 1858  find . -name "*.java" | xargs sed -i '/\/\/ instance fields/d'
 1859  find . -name "*.java" | xargs sed -i '/\/\/ transitive fields/d'
