### PR TITLE
ClientModel.java - fix private method with typo in name

### DIFF
--- a/src/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -76,6 +76,7 @@ import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 
 public class ClientModel implements IMessengerErrorListener {
+
   public static final RemoteName CLIENT_READY_CHANNEL =
       new RemoteName("games.strategy.engine.framework.startup.mc.ClientModel.CLIENT_READY_CHANNEL", IServerReady.class);
   private static Logger s_logger = Logger.getLogger(ClientModel.class.getName());
@@ -193,7 +194,7 @@ public class ClientModel implements IMessengerErrorListener {
     m_gameDataOnStartup = m_gameSelectorModel.getGameData();
     final IServerStartupRemote serverStartup = getServerStartup();
     final PlayerListing players = serverStartup.getPlayerListing();
-    internalePlayerListingChanged(players);
+    internalPlayerListingChanged(players);
     if (!serverStartup.isGameStarted(m_messenger.getLocalNode())) {
       m_remoteMessenger.unregisterRemote(ServerModel.getObserverWaitingToStartName(m_messenger.getLocalNode()));
     }
@@ -246,7 +247,7 @@ public class ClientModel implements IMessengerErrorListener {
   private final IClientChannel m_channelListener = new IClientChannel() {
     @Override
     public void playerListingChanged(final PlayerListing listing) {
-      internalePlayerListingChanged(listing);
+      internalPlayerListingChanged(listing);
     }
 
     @Override
@@ -396,7 +397,7 @@ public class ClientModel implements IMessengerErrorListener {
     getServerStartup().enablePlayer(playerName);
   }
 
-  private void internalePlayerListingChanged(final PlayerListing listing) {
+  private void internalPlayerListingChanged(final PlayerListing listing) {
     SwingUtilities.invokeLater(new Runnable() {
       @Override
       public void run() {


### PR DESCRIPTION
rename a private method that had a typo in it, from:
internalePlayerListingChanged

to (note, no more "e" before Player)
internalPlayerListingChanged

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/34)
<!-- Reviewable:end -->
