### PR TITLE
remove instanceof ChatPanel checks with "isHeadless()" method check

### DIFF
--- a/src/games/strategy/engine/chat/ChatPanel.java
+++ b/src/games/strategy/engine/chat/ChatPanel.java
@@ -45,6 +45,11 @@ public class ChatPanel extends JPanel implements IChatPanel {
   }
 
   @Override
+  public boolean isHeadless() {
+    return false;
+  }
+
+  @Override
   public String getAllText() {
     return m_chatMessagePanel.getAllText();
   }

--- a/src/games/strategy/engine/chat/HeadlessChat.java
+++ b/src/games/strategy/engine/chat/HeadlessChat.java
@@ -49,6 +49,11 @@ public class HeadlessChat implements IChatListener, IChatPanel {
     setChat(chat);
   }
 
+  @Override
+  public boolean isHeadless() {
+    return true;
+  }
+
   public Set<INode> getAllChatters() {
     return new HashSet<INode>(m_players);
   }

--- a/src/games/strategy/engine/chat/IChatPanel.java
+++ b/src/games/strategy/engine/chat/IChatPanel.java
@@ -7,6 +7,8 @@ import javax.swing.DefaultListCellRenderer;
  * or non-headless versions as we like.
  */
 public interface IChatPanel {
+  public boolean isHeadless();
+
   public void shutDown();
 
   public void setChat(final Chat chat);

--- a/src/games/strategy/engine/framework/startup/ui/MainPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MainPanel.java
@@ -122,15 +122,18 @@ public class MainPanel extends JPanel implements Observer {
     remove(m_chatSplit);
     m_chatPanelHolder.removeAll();
     final IChatPanel chat = m_gameTypePanelModel.getPanel().getChatPanel();
-    if (chat != null && chat instanceof ChatPanel) {
-      final ChatPanel chatPanel = (ChatPanel) chat;
+    if (chat != null && !chat.isHeadless() ) {
       m_chatPanelHolder = new JPanel();
       m_chatPanelHolder.setLayout(new BorderLayout());
+      m_chatPanelHolder.setPreferredSize(new Dimension(m_chatPanelHolder.getPreferredSize().width, 62));
+
+      final ChatPanel chatPanel = (ChatPanel) chat;
       m_chatPanelHolder.add(chatPanel, BorderLayout.CENTER);
+
       m_chatSplit.setTopComponent(m_mainPanel);
       m_chatSplit.setBottomComponent(m_chatPanelHolder);
+
       add(m_chatSplit, BorderLayout.CENTER);
-      m_chatPanelHolder.setPreferredSize(new Dimension(m_chatPanelHolder.getPreferredSize().width, 62));
     } else {
       add(m_mainPanel, BorderLayout.CENTER);
     }


### PR DESCRIPTION
Add a "isHeadless" method to IChatPanel, allows for "instanceof ChatPanel" checks to be replaced 
checks to be replaced instead with !isHeadless().

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/36)
<!-- Reviewable:end -->
