### PR TITLE
fix_mac_icon.sh - Replace character sequence "^M" in script used in a filename with actual DOS line ending

### DIFF
--- a/fix_mac_icon.sh
+++ b/fix_mac_icon.sh
@@ -3,10 +3,10 @@
 # Mac OS X handles appbundle icons very strangely
 #
 # The icon file has to be called Icon^M,
-#     where the ^M is really a carriage return
-#     (I think it's a carriage return, it's a \r)
+#     where the ^M is really a dos line ending
 #
 # Ant doesn't seem to play nice with this strange encoding,
 #     so run this file after running the macRelease ant target
+#
 
-mv release/TripleA.app/Icon release/TripleA.app/Icon^M 
+mv release/TripleA.app/Icon release/TripleA.app/Icon^M


### PR DESCRIPTION
The fix_mac_icon.sh script moves an "Icon" file, renaming it to end with a dos line ending. In the script, the line ending character was incorrectly entered as a "^" followed by "M" rather than the single character generated by typing (on a command shell) "ctrl+v" then "ctrl+m".

Second and very minor change, nearby script commentary was updated as well. (mention of carriage return removed, "\r" is not the same as "^M")

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/40)
<!-- Reviewable:end -->
