### PR TITLE
Remove unused methods in two classes (EditProductionPanel.java and TabbedProductionPanel.java)

### DIFF
--- a/src/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/src/games/strategy/triplea/ui/EditProductionPanel.java
@@ -54,9 +54,6 @@ public class EditProductionPanel extends ProductionPanel {
     super(uiContext);
   }
 
-  protected void setLeft(final int left) {
-    // no limits, so do nothing here
-  }
 
   @Override
   protected void calculateLimits() {

--- a/src/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/src/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -63,12 +63,6 @@ public class TabbedProductionPanel extends ProductionPanel {
     super(uiContext);
   }
 
-  public static IntegerMap<ProductionRule> getProduction(final PlayerID id, final JFrame parent, final GameData data, final boolean bid,
-      final IntegerMap<ProductionRule> initialPurchase,
-      final IUIContext uiContext) {
-    return new TabbedProductionPanel(uiContext).show(id, parent, data, bid, initialPurchase);
-  }
-
   @Override
   protected void initLayout(final PlayerID id) {
     this.removeAll();


### PR DESCRIPTION
Remove unused methods in two classes : EditProductionPanel.java and TabbedProductionPanel.java

One is an unused protected method that could be final. The second one is a duplicate method and is not called, the clone of the method is in ProductionPanel.java, that is the one that is called.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/50)
<!-- Reviewable:end -->
