### PR TITLE
TripleAFrame.java - faster arrow scroll when meta keys are held down

### DIFF
--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -1745,14 +1745,14 @@ public class TripleAFrame extends MainGameFrame {
     }
   };
   final KeyListener m_arrowKeyActionListener = new KeyListener() {
-    final int diffPixel = 50;
-
     @Override
     public void keyPressed(final KeyEvent e) {
       // scroll map according to wasd/arrowkeys
+      final int diffPixel = computeScrollSpeed(e);
       final int x = m_mapPanel.getXOffset();
       final int y = m_mapPanel.getYOffset();
       final int keyCode = e.getKeyCode();
+
       if (keyCode == KeyEvent.VK_RIGHT || keyCode == KeyEvent.VK_D) {
         getMapPanel().setTopLeft(x + diffPixel, y);
       } else if (keyCode == KeyEvent.VK_LEFT || keyCode == KeyEvent.VK_A) {
@@ -1817,6 +1817,17 @@ public class TripleAFrame extends MainGameFrame {
     @Override
     public void keyReleased(final KeyEvent e) {}
   };
+
+  private static int computeScrollSpeed(final KeyEvent e) {
+    int multiplier = 1;
+
+    if (e.isControlDown()) {
+      multiplier = 5;
+    }
+
+    final int starterDiffPixel = 100;
+    return (starterDiffPixel * multiplier);
+  }
 
   private void showEditMode() {
     m_tabsPanel.addTab("Edit", m_editPanel);

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -147,7 +147,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
             + "CTRL-Left click on a territory to select the territory as a way point (this will force the units to move through this territory on their way to the destination).<br>"
             + "<br><b> Moving the Map Screen</b><br>"
             + "Right click and Drag the mouse to move your screen over the map.<br>"
-            + "Left click on the map (anywhere), then use the Arrow Keys (or WASD) to move your map around.<br>"
+            + "Left click the map (anywhere), use the arrow keys (or WASD keys) to move your map around. Holding down control will move the map faster.<br />"
             + "Left click in the Minimap at the top right of the screen, and Drag the mouse.<br>"
             + "Move the mouse to the edge of the map window, and the screen will scroll in that direction.<br>"
             + "Scrolling the mouse wheel will move the map up and down.<br>" + "<br><b> Zooming Out</b><br>"


### PR DESCRIPTION
For example, hold down shift while using arrow keys to scroll faster.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/56)
<!-- Reviewable:end -->
