### PR TITLE
PurchaseDelegate.java - Count unplaced units when considering max unit count restrictions..

### DIFF
--- a/src/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -178,14 +178,16 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
         if (maxBuilt == 0) {
           return "May not build any of this unit right now: " + type.getName();
         } else if (maxBuilt > 0) {
-          // check to see how many are currently fielded by this player
-          int currentlyBuilt = 0;
+          // count how many units are yet to be placed or are in the field
+          int currentlyBuilt = m_player.getUnits().countMatches(Matches.unitIsOfType(type));
+
           final CompositeMatch<Unit> unitTypeOwnedBy =
               new CompositeMatchAnd<Unit>(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(m_player));
           final Collection<Territory> allTerrs = getData().getMap().getTerritories();
           for (final Territory t : allTerrs) {
             currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);
           }
+
           final int allowedBuild = maxBuilt - currentlyBuilt;
           if (allowedBuild - quantity < 0) {
             return "May only build " + allowedBuild + " of " + type.getName() + " this turn, may only build " + maxBuilt


### PR DESCRIPTION
From this discussion:
http://tripleadev.1671093.n2.nabble.com/maxBuiltPerPlayer-work-around-or-bug-td7588981.html

Turns out if you have "maxBuiltPerPlayer == 1", the intent is that only one of that unit can exist (or ever be built). Though, that should be named something like maxExistPerPlayer perhaps. 

Regardless, when counting how many of the unit there are, only units on the map are counted and not also those that the player is holding. This change is pretty small, increments the count for any matching units that the player is holding.

See tripleadev link for screenshot of what it looks like when this patch is working.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/62)
<!-- Reviewable:end -->
