### PR TITLE
NewGameChooser - Cancel Map Zip Parsing When The Game Starts (clear is called)  

### DIFF
--- a/src/games/strategy/engine/framework/ui/ClearGameChooserCacheMessenger.java
+++ b/src/games/strategy/engine/framework/ui/ClearGameChooserCacheMessenger.java
@@ -1,14 +1,30 @@
 package games.strategy.engine.framework.ui;
 
+/**
+ * A messenger between user actions and background map parsing threads. There are a number of
+ * complications that arise because it can take some time to parse maps. If a game is started
+ * before map parsing has completed then the results of map parsing are no longer needed.
+ *
+ * The game engine calls a "clear" cache method to clear out the map parsing cache when a game starts.
+ * This messenger relays that "clear" message to the threads that are doing the background map parsing.
+ */
 public class ClearGameChooserCacheMessenger {
   private volatile boolean canceled = false;
 
-  public ClearGameChooserCacheMessenger() {
-  }
+  public ClearGameChooserCacheMessenger() {}
 
+  /**
+   * Call this method to indicate that no new map zip files are to be processed,
+   * once the current map is processed, map 'refresh' parsing should return.
+   */
   public void sendCancel() {
     canceled = true;
   }
+
+  /**
+   * Turn indicates population of the map cache has been cancelled and is no longer needed. False
+   * indicates a game is not currently being played and background map parsing should proceed.
+   */
   public boolean isCancelled() {
     return canceled;
   }

--- a/src/games/strategy/engine/framework/ui/ClearGameChooserCacheMessenger.java
+++ b/src/games/strategy/engine/framework/ui/ClearGameChooserCacheMessenger.java
@@ -1,0 +1,15 @@
+package games.strategy.engine.framework.ui;
+
+public class ClearGameChooserCacheMessenger {
+  private volatile boolean canceled = false;
+
+  public ClearGameChooserCacheMessenger() {
+  }
+
+  public void sendCancel() {
+    canceled = true;
+  }
+  public boolean isCancelled() {
+    return canceled;
+  }
+}

--- a/src/games/strategy/engine/framework/ui/NewGameChooser.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooser.java
@@ -268,7 +268,9 @@ public class NewGameChooser extends JDialog {
     synchronized( mapParsingInProgressLock ) {
       mapParsingInProgress = false;
     }
-    cacheClearedMessenger.sendCancel();
+    if (cacheClearedMessenger != null) {
+      cacheClearedMessenger.sendCancel();
+    }
     cacheClearedMessenger = null;
     s_cachedGameModel = null;
   }

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -34,8 +34,10 @@ import games.strategy.util.ClassLoaderUtil;
 
 public class NewGameChooserModel extends DefaultListModel {
   private static final long serialVersionUID = -2044689419834812524L;
+  private final ClearGameChooserCacheMessenger clearCacheMessenger;
 
-  public NewGameChooserModel() {
+  public NewGameChooserModel(ClearGameChooserCacheMessenger clearCacheMessenger ) {
+    this.clearCacheMessenger = clearCacheMessenger;
     populate();
   }
 
@@ -79,6 +81,9 @@ public class NewGameChooserModel extends DefaultListModel {
   private void populate() {
     final List<NewGameChooserEntry> entries = new ArrayList<NewGameChooserEntry>();
     for (final File map : allMapFiles()) {
+      if(clearCacheMessenger.isCancelled()) {
+        return;
+      }
       if (map.isDirectory()) {
         populateFromDirectory(map, entries);
       } else if (map.isFile() && map.getName().toLowerCase().endsWith(".zip")) {

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -36,7 +36,7 @@ public class NewGameChooserModel extends DefaultListModel {
   private static final long serialVersionUID = -2044689419834812524L;
   private final ClearGameChooserCacheMessenger clearCacheMessenger;
 
-  public NewGameChooserModel(ClearGameChooserCacheMessenger clearCacheMessenger ) {
+  public NewGameChooserModel(ClearGameChooserCacheMessenger clearCacheMessenger) {
     this.clearCacheMessenger = clearCacheMessenger;
     populate();
   }

--- a/test/games/strategy/engine/framework/ui/NewGameChooserModelTest.java
+++ b/test/games/strategy/engine/framework/ui/NewGameChooserModelTest.java
@@ -1,11 +1,17 @@
 package games.strategy.engine.framework.ui;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+import org.mockito.Mock;
 
-public class NewGameChooserModelTest extends TestCase {
+public class NewGameChooserModelTest  {
+
+  @Mock
+  private ClearGameChooserCacheMessenger mockClearGameChooserCacheMessenger;
+
   /** Simply create the object to see that we can do that without exception */
   @SuppressWarnings("unused")
+  @Test
   public void testCreate() {
-    new NewGameChooserModel();
+    new NewGameChooserModel(mockClearGameChooserCacheMessenger);
   }
 }

--- a/test/games/strategy/engine/framework/ui/NewGameChooserModelTest.java
+++ b/test/games/strategy/engine/framework/ui/NewGameChooserModelTest.java
@@ -1,17 +1,14 @@
 package games.strategy.engine.framework.ui;
 
 import org.junit.Test;
-import org.mockito.Mock;
 
 public class NewGameChooserModelTest  {
 
-  @Mock
-  private ClearGameChooserCacheMessenger mockClearGameChooserCacheMessenger;
 
   /** Simply create the object to see that we can do that without exception */
   @SuppressWarnings("unused")
   @Test
   public void testCreate() {
-    new NewGameChooserModel(mockClearGameChooserCacheMessenger);
+    new NewGameChooserModel(new ClearGameChooserCacheMessenger());
   }
 }


### PR DESCRIPTION
Allows games to start without having to wait for background map parsing to complete, that data is cleared anyways when a game starts. We do this by making the clear operation non-blocking, we now set a flag to notify refresh operations that they should ignore their results when done computing. Secondly, we will also actively cancel refresh operations to avoid unnecessary resource usage.

For context: map data is loaded in the background when tripleA is launched or when a user leaves a game. This data is used to pre-compute the game selection window, letting a user choose a game quickly.  To save memory, we remove this preloaded background data while a user is playing a game. By restarting a local game rapidly, you can notice the delay of loading map data (I had 5 seconds with 11 maps on a powerful 6 core CPU with rotating rotating hard disks)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/74)
<!-- Reviewable:end -->
