### PR TITLE
Larger map scroll zone with faster scrolling feature.

### DIFF
--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -149,7 +149,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
             + "Right click and Drag the mouse to move your screen over the map.<br>"
             + "Left click on the map (anywhere), then use the Arrow Keys (or WASD) to move your map around.<br>"
             + "Left click in the Minimap at the top right of the screen, and Drag the mouse.<br>"
-            + "Move the mouse to the edge of the map window, and the screen will scroll in that direction.<br>"
+            + "Move the mouse to the edge of the map to scroll in that direction. Moving the mouse even closer to the edge will scroll faster.<br>"
             + "Scrolling the mouse wheel will move the map up and down.<br>" + "<br><b> Zooming Out</b><br>"
             + "Holding ALT while Scrolling the Mouse Wheel will zoom the map in and out.<br>"
             + "Select 'Zoom' from the 'View' menu, and change to the desired level.<br>"


### PR DESCRIPTION
Map edge scroll zone increased from 25 to 70. Moving mouse closer to edge will trigger faster scroll (threshold set currently to 1/4 the total width of the scroll zeon, or 16~17 pixels away from the map edge). Also the movement help notes were updated.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/80)
<!-- Reviewable:end -->
