### PR TITLE
(1.8.0.7 release fix) Revert "fix_mac_icon.sh - Fix DOS end of line character used in script."

### DIFF
--- a/fix_mac_icon.sh
+++ b/fix_mac_icon.sh
@@ -3,10 +3,10 @@
 # Mac OS X handles appbundle icons very strangely
 #
 # The icon file has to be called Icon^M,
-#     where the ^M is really a dos line ending
+#     where the ^M is really a carriage return
+#     (I think it's a carriage return, it's a \r)
 #
 # Ant doesn't seem to play nice with this strange encoding,
 #     so run this file after running the macRelease ant target
-#
 
-mv release/TripleA.app/Icon release/TripleA.app/Icon^M
+mv release/TripleA.app/Icon release/TripleA.app/Icon^M 


### PR DESCRIPTION
This reverts commit f1b80152cf29f07c1f3336ffebcd934ce15e956a.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/85)
<!-- Reviewable:end -->
