### PR TITLE
(1.8.0.7) Quietly log map parse errors rather than bringing the error to the fo…

### DIFF
--- a/src/games/strategy/engine/data/GameParser.java
+++ b/src/games/strategy/engine/data/GameParser.java
@@ -31,6 +31,7 @@ import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.data.properties.BooleanProperty;
 import games.strategy.engine.data.properties.ColorProperty;
@@ -99,9 +100,10 @@ public class GameParser {
     // SAX errors we need to show
     if (!errorsSAX.isEmpty()) {
       for (final SAXParseException error : errorsSAX) {
-        System.err.println("SAXParseException: game: "
+        String msg = "SAXParseException: game: "
             + (data == null ? "?" : (data.getGameName() == null ? "?" : data.getGameName())) + ", line: "
-            + error.getLineNumber() + ", column: " + error.getColumnNumber() + ", error: " + error.getMessage());
+            + error.getLineNumber() + ", column: " + error.getColumnNumber() + ", error: " + error.getMessage();
+        ClientLogger.logQuietly(msg);
       }
     }
     parseDiceSides(getSingleChild("diceSides", root, true));


### PR DESCRIPTION
…reground. Future changes will allow for an option for map editors and developers to be able to optionally always have these errors come to the foreground. In the meantime this is a patch so that when we remove Map Delegates, you do not always get an error on startup because of those maps still being around.

Similar to #16

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/92)
<!-- Reviewable:end -->
