### PR TITLE
Fix gradle build - Backwards compatible fix and update of how test map game data is found

### DIFF
--- a/src/games/strategy/debug/ClientLogger.java
+++ b/src/games/strategy/debug/ClientLogger.java
@@ -24,4 +24,9 @@ public class ClientLogger {
   public static void logError(final Exception e) {
     log(userOutputStream, e);
   }
+
+  public static void logError(final String msg) {
+    userOutputStream.println(msg);
+  }
+
 }

--- a/test/games/strategy/engine/data/ChangeTripleATest.java
+++ b/test/games/strategy/engine/data/ChangeTripleATest.java
@@ -20,8 +20,7 @@ public class ChangeTripleATest extends TestCase {
 
   @Override
   public void setUp() throws Exception {
-    m_data = LoadGameUtil.loadGame("Big World : 1942",
-        "big_world" + File.separator + "games" + File.separator + "big_world_1942.xml");
+    m_data = LoadGameUtil.loadGame("Big World : 1942", "big_world_1942_test.xml");
   }
 
   private Change serialize(final Change aChange) throws Exception {

--- a/test/games/strategy/triplea/delegate/BigWorldTest.java
+++ b/test/games/strategy/triplea/delegate/BigWorldTest.java
@@ -20,8 +20,7 @@ public class BigWorldTest extends TestCase {
 
   @Override
   protected void setUp() throws Exception {
-    m_data = LoadGameUtil.loadGame("Big World : 1942",
-        "big_world" + File.separator + "games" + File.separator + "big_world_1942.xml");
+    m_data = LoadGameUtil.loadGame("big_world_1942_test.xml");
   }
 
   @Override

--- a/test/games/strategy/triplea/xml/LoadGameUtil.java
+++ b/test/games/strategy/triplea/xml/LoadGameUtil.java
@@ -11,8 +11,25 @@ import games.strategy.engine.data.GameParser;
 import games.strategy.engine.framework.GameRunner2;
 
 public class LoadGameUtil {
+
+  public static GameData loadGame( final String game ) {
+    return loadGame(game, new String[] { "maps" } );
+  }
+
+  public static GameData loadTestGame( final String game ) {
+    return loadGame(game, new String[] { "test_data" } );
+  }
+
+  /**
+   * @deprecated drop the first parameter and call either loadGame(String game)
+   * or LoadTestGame(String game) instead
+   */
   public static GameData loadGame(final String map, final String game) {
-    final InputStream is = openInputStream(game);
+    return loadGame(game,new String[] { "maps", "test_data" }  );
+  }
+
+  private static GameData loadGame(final String game, final String[] possibleFolders) {
+    final InputStream is = openInputStream(game, possibleFolders);
     if (is == null) {
       throw new IllegalStateException(game + " does not exist");
     }
@@ -31,19 +48,15 @@ public class LoadGameUtil {
    * First try to load the game as a file on the classpath, if not found there
    * then try to load it from either the "maps" or "test_data" folders.
    */
-  private static InputStream openInputStream(final String game) {
+  private static InputStream openInputStream(final String game, String[] possibleFolders ) {
     InputStream is = LoadGameUtil.class.getResourceAsStream(game);
     if (is == null) {
-      File f = new File(new File(GameRunner2.getRootFolder(), "maps"), game);
-      if (!f.exists()) {
-        f = new File(new File(GameRunner2.getRootFolder(), "test_data"), game);
-      }
+      File f = GameRunner2.getFile( game, possibleFolders );
       if (f.exists()) {
         try {
           is = new FileInputStream(f);
         } catch (final FileNotFoundException e) {
-          // ignore, can't happen because of the if check, and we'll throw
-          // an exception anyways when the client sees we returned null
+          // ignore, we'll throw an exception anyways when the client sees we returned null
         }
       }
     }

--- a/test_data/big_world_1942_test.xml
+++ b/test_data/big_world_1942_test.xml
@@ -1,0 +1,3222 @@
+<?xml version="1.0" ?>
+
+<!DOCTYPE game SYSTEM "game.dtd">
+
+<game>
+        <info name="Big World : 1942" version="2.5"/>
+
+        <loader javaClass="games.strategy.triplea.TripleA"/>
+		
+		<triplea minimumVersion="1.5"/>
+
+        <map>
+                <!-- Territory Definitions -->
+                <territory name="SZ 1 Hudson Bay" water="true"/>
+                <territory name="SZ 2 Labrador Sea" water="true"/>
+                <territory name="SZ 3 Labrador Sea" water="true"/>
+                <territory name="SZ 4 Denmark Straight" water="true"/>
+                <territory name="SZ 5 Greenland Sea" water="true"/>
+                <territory name="SZ 6 Norwegian Sea" water="true"/>
+                <territory name="SZ 7 Barents Sea" water="true"/>
+                <territory name="SZ 8 Kara Sea" water="true"/>
+                <territory name="SZ 9 North Atlantic" water="true"/>
+                <territory name="SZ 10 North Sea" water="true"/>
+                <territory name="SZ 11 West Baltic Sea" water="true"/>
+                <territory name="SZ 12 East Baltic Sea" water="true"/>
+                <territory name="SZ 13 Gulf of St Lawrence" water="true"/>
+                <territory name="SZ 14 North Atlantic" water="true"/>
+                <territory name="SZ 15 North Atlantic" water="true"/>
+                <territory name="SZ 16 North Atlantic" water="true"/>
+                <territory name="SZ 17 English Channel" water="true"/>
+                <territory name="SZ 18 West Atlantic" water="true"/>
+                <territory name="SZ 19 Atlantic" water="true"/>
+                <territory name="SZ 20 Atlantic" water="true"/>
+                <territory name="SZ 21 East Atlantic" water="true"/>
+                <territory name="SZ 22 East Atlantic" water="true"/>
+                <territory name="SZ 23 West Mediterranean" water="true"/>
+                <territory name="SZ 24 Tyrrhenian Sea" water="true"/>
+                <territory name="SZ 25 Adriatic Sea" water="true"/>
+                <territory name="SZ 26 Central Mediterranean" water="true"/>
+                <territory name="SZ 27 Aegean Sea" water="true"/>
+                <territory name="SZ 28 Eastern Mediterranean" water="true"/>
+                <territory name="SZ 29 Black Sea" water="true"/>
+                <territory name="SZ 30 Gulf of Mexico" water="true"/>
+                <territory name="SZ 31 West Atlantic" water="true"/>
+                <territory name="SZ 32 Atlantic" water="true"/>
+                <territory name="SZ 33 Atlantic" water="true"/>
+                <territory name="SZ 34 Atlantic" water="true"/>
+                <territory name="SZ 35 East Atlantic" water="true"/>
+                <territory name="SZ 36 East Pacific" water="true"/>
+                <territory name="SZ 37 Caribbean Sea" water="true"/>
+                <territory name="SZ 38 Mid Atlantic" water="true"/>
+                <territory name="SZ 39 Mid Atlantic" water="true"/>
+                <territory name="SZ 40 Mid Atlantic" water="true"/>
+                <territory name="SZ 41 Eastern Pacific" water="true"/>
+                <territory name="SZ 42 Eastern Pacific" water="true"/>
+                <territory name="SZ 43 Mid Atlantic" water="true"/>
+                <territory name="SZ 44 Mid Atlantic" water="true"/>
+                <territory name="SZ 45 Mid Atlantic" water="true"/>
+                <territory name="SZ 46 Southeastern Pacific" water="true"/>
+                <territory name="SZ 47 Southeastern Pacific" water="true"/>
+                <territory name="SZ 48 South Atlantic" water="true"/>
+                <territory name="SZ 49 South Atlantic" water="true"/>
+                <territory name="SZ 50 South Atlantic" water="true"/>
+                <territory name="SZ 52 South Atlantic" water="true"/>
+                <territory name="SZ 53 South Atlantic" water="true"/>
+                <territory name="SZ 54 South Atlantic" water="true"/>
+                <territory name="SZ 55 Red Sea" water="true"/>
+                <territory name="SZ 56 Persian Gulf" water="true"/>
+                <territory name="SZ 57 Arabian Sea" water="true"/>
+                <territory name="SZ 58 Bay of Bengal" water="true"/>
+                <territory name="SZ 59 Northeastern Indian" water="true"/>
+                <territory name="SZ 60 Western Indian" water="true"/>
+                <territory name="SZ 61 Indian" water="true"/>
+                <territory name="SZ 62 Indian" water="true"/>
+                <territory name="SZ 63 Timor Sea" water="true"/>
+                <territory name="SZ 64 South West Indian" water="true"/>
+                <territory name="SZ 65 Indian" water="true"/>
+                <territory name="SZ 66 Indian" water="true"/>
+                <territory name="SZ 67 South East Indian" water="true"/>
+                <territory name="SZ 68 South Indian" water="true"/>
+                <territory name="SZ 69 Indian" water="true"/>
+                <territory name="SZ 70 Southern Ocean" water="true"/>
+                <territory name="SZ 71 South China Sea" water="true"/>
+                <territory name="SZ 72 South China Sea" water="true"/>
+                <territory name="SZ 73 East China Sea" water="true"/>
+                <territory name="SZ 74 Sea of Japan" water="true"/>
+                <territory name="SZ 75 Sea of Okhotsk" water="true"/>
+                <territory name="SZ 76 West Bering Sea" water="true"/>
+                <territory name="SZ 77 Bering Sea" water="true"/>
+                <territory name="SZ 78 Arctic Ocean" water="true"/>
+                <territory name="SZ 79 Arctic Ocean" water="true"/>
+                <territory name="SZ 80 Northwest Pacific" water="true"/>
+                <territory name="SZ 81 North Pacific" water="true"/>
+                <territory name="SZ 82 North Pacific" water="true"/>
+                <territory name="SZ 83 Gulf of Alaska" water="true"/>
+                <territory name="SZ 84 Northeastern Pacific" water="true"/>
+                <territory name="SZ 85 Northeast Pacific" water="true"/>
+                <territory name="SZ 86 West Pacific" water="true"/>
+                <territory name="SZ 87 West Pacific" water="true"/>
+                <territory name="SZ 88 Pacific" water="true"/>
+                <territory name="SZ 89 Pacific" water="true"/>
+                <territory name="SZ 90 East Pacific" water="true"/>
+                <territory name="SZ 91 East Pacific" water="true"/>
+                <territory name="SZ 92 Philippine Sea" water="true"/>
+                <territory name="SZ 93 West Pacific" water="true"/>
+                <territory name="SZ 94 Pacific" water="true"/>
+                <territory name="SZ 95 Pacific" water="true"/>
+                <territory name="SZ 96 Pacific" water="true"/>
+                <territory name="SZ 97 East Pacific" water="true"/>
+                <territory name="SZ 98 Philippine Sea" water="true"/>
+                <territory name="SZ 99 West Pacific" water="true"/>
+                <territory name="SZ 100 Pacific" water="true"/>
+                <territory name="SZ 101 Pacific" water="true"/>
+                <territory name="SZ 102 East Pacific" water="true"/>
+                <territory name="SZ 103 Arafura Sea" water="true"/>
+                <territory name="SZ 104 Coral Sea" water="true"/>
+                <territory name="SZ 105 Tasman Sea" water="true"/>
+                <territory name="SZ 106 Southwest Pacific" water="true"/>
+                <territory name="SZ 107 South Pacific" water="true"/>
+                <territory name="SZ 108 South Pacific" water="true"/>
+                <territory name="SZ 109 South Pacific" water="true"/>
+                <territory name="Eastern Canada"/>
+                <territory name="England"/>
+                <territory name="France"/>
+                <territory name="Southwestern United States"/>
+                <territory name="Greenland"/>
+                <territory name="Sumatra"/>
+                <territory name="New South Wales"/>
+                <territory name="Northern Manchukuo"/>
+                <territory name="Chosen"/>
+                <territory name="Inner Mongolia"/>
+                <territory name="Alaska"/>
+                <territory name="Baluchistan"/>
+                <territory name="Sicily"/>
+                <territory name="Archangel'sk"/>
+                <territory name="Western Turkey"/>
+                <territory name="Eastern Turkey"/>
+                <territory name="French West Africa"/>
+                <territory name="Queensland"/>
+                <territory name="Southern Russia"/>
+                <territory name="Sakhalin Island"/>
+                <territory name="Belgian Congo"/>
+                <territory name="Central Canada"/>
+                <territory name="Delhi"/>
+                <territory name="Bombay"/>
+                <territory name="Calcutta"/>
+                <territory name="Ceylon"/>
+                <territory name="Caucasus"/>
+                <territory name="Scotland"/>
+                <territory name="Okhotsk"/>
+                <territory name="Yakutsk"/>
+                <territory name="Spain"/>
+                <territory name="Afghanistan"/>
+                <territory name="Newfoundland"/>
+                <territory name="Angola"/>
+                <territory name="Eastern Siberia"/>
+                <territory name="Kamchatka"/>
+                <territory name="Mozambique"/>
+                <territory name="Ethiopia"/>
+                <territory name="Kashmir"/>
+                <territory name="Northern Russia"/>
+                <territory name="Eastern Russia"/>
+                <territory name="Ireland"/>
+                <territory name="Iwo Jima"/>
+                <territory name="Hungary-Romania"/>
+                <territory name="Macedonia"/>
+                <territory name="Tasmania"/>
+                <territory name="Northern Brazil"/>
+                <territory name="Southern Brazil"/>
+                <territory name="Kwangtung"/>
+                <territory name="Borneo"/>
+                <territory name="Western Australia"/>
+                <territory name="Cape Verde Islands"/>
+                <territory name="Northern Japan"/>
+                <territory name="Kyrgyz"/>
+                <territory name="Southeastern Siberia"/>
+                <territory name="Moscow"/>
+                <territory name="Hawaiian Islands"/>
+                <territory name="Stalingrad"/>
+                <territory name="Kansu"/>
+                <territory name="Java"/>
+                <territory name="Switzerland"/>
+                <territory name="Norway"/>
+                <territory name="Himalaya-Tibet"/>
+                <territory name="Baffin Island"/>
+                <territory name="West Indies"/>
+                <territory name="Southern Japan"/>
+                <territory name="Finland"/>
+                <territory name="Syria"/>
+                <territory name="Iraq"/>
+                <territory name="South Philippines"/>
+                <territory name="Southern Africa"/>
+                <territory name="Azores"/>
+                <territory name="Madagascar"/>
+                <territory name="Shantung"/>
+                <territory name="Kazakh"/>
+                <territory name="Western Germany"/>
+                <territory name="French Indo-China"/>
+                <territory name="Baltic States"/>
+                <territory name="Bermuda"/>
+                <territory name="Omsk"/>
+                <territory name="Sverdlovsk"/>
+                <territory name="Western South America"/>
+                <territory name="New Zealand"/>
+                <territory name="Iceland"/>
+                <territory name="Sahara"/>
+                <territory name="Novo-Sibirsk"/>
+                <territory name="Midwestern United States"/>
+                <territory name="Gibraltar"/>
+                <territory name="French Equatorial Africa"/>
+                <territory name="Midway Island"/>
+                <territory name="Portugal"/>
+                <territory name="Fiji"/>
+                <territory name="Karelija"/>
+                <territory name="Solomon Islands"/>
+                <territory name="Burma"/>
+                <territory name="Thai-Malay"/>
+                <territory name="Rio de Oro"/>
+                <territory name="Western Aleutian Islands"/>
+                <territory name="Eastern Aleutian Islands"/>
+                <territory name="Uzbek"/>
+                <territory name="Western Siberia"/>
+                <territory name="Kenya-Tanganyika"/>
+                <territory name="Ukraine"/>
+                <territory name="Egypt"/>
+                <territory name="Southern United States"/>
+                <territory name="Iran"/>
+                <territory name="Northeastern United States"/>
+                <territory name="Western Sinkiang"/>
+                <territory name="Eastern Sinkiang"/>
+                <territory name="Rhodesia"/>
+                <territory name="Algeria"/>
+                <territory name="Southern South America"/>
+                <territory name="Western Russia"/>
+                <territory name="Anglo-Egyptian Sudan"/>
+                <territory name="Marshall Islands"/>
+                <territory name="North Philippines"/>
+                <territory name="Balkans"/>
+                <territory name="Central Australia"/>
+                <territory name="Cuba"/>
+                <territory name="Guinean Coast"/>
+                <territory name="Western Poland"/>
+                <territory name="Sweden"/>
+                <territory name="Siberia"/>
+                <territory name="Southern Siberia"/>
+                <territory name="Libya"/>
+                <territory name="Mongolia"/>
+                <territory name="Arabian Peninsula"/>
+                <territory name="Belorussia"/>
+                <territory name="Eastern Mexico"/>
+                <territory name="Central America"/>
+                <territory name="Eastern Germany"/>
+                <territory name="Wake"/>
+                <territory name="New Guinea"/>
+                <territory name="Szechwan"/>
+                <territory name="Yunnan"/>
+                <territory name="Guam"/>
+                <territory name="Southwestern Siberia"/>
+                <territory name="Okinawa"/>
+                <territory name="Novgorod"/>
+                <territory name="Leningrad"/>
+                <territory name="Italy"/>
+                <territory name="Western Mexico"/>
+                <territory name="Western Canada"/>
+                <territory name="Vichy France"/>
+                <territory name="Morocco"/>
+                <territory name="Vladivostok"/>
+                <territory name="Amurskaya"/>
+                <territory name="Buryatia"/>
+                <territory name="Austria-Czechoslovakia"/>
+                <territory name="Sardinia"/>
+                <territory name="Northwestern United States"/>
+                <territory name="Irkutsk"/>
+                <territory name="Celebes"/>
+                <territory name="Novaya-Zemlya"/>
+                <territory name="Northern South America"/>
+                <territory name="Eastern Poland"/>
+
+                <!-- Territory Connections -->
+                <connection t1="SZ 1 Hudson Bay" t2="SZ 2 Labrador Sea"/>
+                <connection t1="SZ 1 Hudson Bay" t2="Eastern Canada"/>
+                <connection t1="SZ 1 Hudson Bay" t2="Central Canada"/>
+                <connection t1="SZ 1 Hudson Bay" t2="Baffin Island"/>
+
+                <connection t1="SZ 2 Labrador Sea" t2="SZ 3 Labrador Sea"/>
+                <connection t1="SZ 2 Labrador Sea" t2="SZ 14 North Atlantic"/>
+                <connection t1="SZ 2 Labrador Sea" t2="SZ 13 Gulf of St Lawrence"/>
+                <connection t1="SZ 2 Labrador Sea" t2="Eastern Canada"/>
+                <connection t1="SZ 2 Labrador Sea" t2="Baffin Island"/>
+
+                <connection t1="SZ 3 Labrador Sea" t2="SZ 4 Denmark Straight"/>
+                <connection t1="SZ 3 Labrador Sea" t2="SZ 14 North Atlantic"/>
+                <connection t1="SZ 3 Labrador Sea" t2="Greenland"/>
+                <connection t1="SZ 3 Labrador Sea" t2="Baffin Island"/>
+
+                <connection t1="SZ 4 Denmark Straight" t2="SZ 14 North Atlantic"/>
+                <connection t1="SZ 4 Denmark Straight" t2="SZ 15 North Atlantic"/>
+                <connection t1="SZ 4 Denmark Straight" t2="SZ 9 North Atlantic"/>
+                <connection t1="SZ 4 Denmark Straight" t2="SZ 5 Greenland Sea"/>
+                <connection t1="SZ 4 Denmark Straight" t2="Greenland"/>
+                <connection t1="SZ 4 Denmark Straight" t2="Iceland"/>
+
+                <connection t1="SZ 5 Greenland Sea" t2="SZ 6 Norwegian Sea"/>
+                <connection t1="SZ 5 Greenland Sea" t2="Greenland"/>
+                <connection t1="SZ 5 Greenland Sea" t2="SZ 9 North Atlantic"/>
+
+                <connection t1="SZ 6 Norwegian Sea" t2="SZ 9 North Atlantic"/>
+                <connection t1="SZ 6 Norwegian Sea" t2="SZ 10 North Sea"/>
+                <connection t1="SZ 6 Norwegian Sea" t2="SZ 7 Barents Sea"/>
+                <connection t1="SZ 6 Norwegian Sea" t2="Norway"/>
+
+                <connection t1="SZ 7 Barents Sea" t2="SZ 8 Kara Sea"/>
+                <connection t1="SZ 7 Barents Sea" t2="Novaya-Zemlya"/>
+                <connection t1="SZ 7 Barents Sea" t2="Karelija"/>
+                <connection t1="SZ 7 Barents Sea" t2="Archangel'sk"/>
+                <connection t1="SZ 7 Barents Sea" t2="Finland"/>
+
+                <connection t1="SZ 8 Kara Sea" t2="Novaya-Zemlya"/>
+                <connection t1="SZ 8 Kara Sea" t2="Western Siberia"/>
+                <connection t1="SZ 8 Kara Sea" t2="Archangel'sk"/>
+
+                <connection t1="SZ 9 North Atlantic" t2="SZ 10 North Sea"/>
+                <connection t1="SZ 9 North Atlantic" t2="SZ 15 North Atlantic"/>
+                <connection t1="SZ 9 North Atlantic" t2="SZ 16 North Atlantic"/>
+                <connection t1="SZ 9 North Atlantic" t2="Iceland"/>
+                <connection t1="SZ 9 North Atlantic" t2="Scotland"/>
+                <connection t1="SZ 9 North Atlantic" t2="Ireland"/>
+
+                <connection t1="SZ 10 North Sea" t2="SZ 17 English Channel"/>
+                <connection t1="SZ 10 North Sea" t2="SZ 11 West Baltic Sea"/>
+                <connection t1="SZ 10 North Sea" t2="Scotland"/>
+                <connection t1="SZ 10 North Sea" t2="Norway"/>
+
+                <connection t1="SZ 11 West Baltic Sea" t2="SZ 17 English Channel"/>
+                <connection t1="SZ 11 West Baltic Sea" t2="SZ 12 East Baltic Sea"/>
+                <connection t1="SZ 11 West Baltic Sea" t2="Norway"/>
+                <connection t1="SZ 11 West Baltic Sea" t2="Sweden"/>
+                <connection t1="SZ 11 West Baltic Sea" t2="Western Germany"/>
+                <connection t1="SZ 11 West Baltic Sea" t2="Eastern Germany"/>
+
+                <connection t1="SZ 12 East Baltic Sea" t2="Sweden"/>
+                <connection t1="SZ 12 East Baltic Sea" t2="Finland"/>
+                <connection t1="SZ 12 East Baltic Sea" t2="Leningrad"/>
+                <connection t1="SZ 12 East Baltic Sea" t2="Baltic States"/>
+                <connection t1="SZ 12 East Baltic Sea" t2="Western Poland"/>
+                <connection t1="SZ 12 East Baltic Sea" t2="Novgorod"/>
+
+                <connection t1="SZ 13 Gulf of St Lawrence" t2="SZ 14 North Atlantic"/>
+                <connection t1="SZ 13 Gulf of St Lawrence" t2="SZ 19 Atlantic"/>
+                <connection t1="SZ 13 Gulf of St Lawrence" t2="SZ 18 West Atlantic"/>
+                <connection t1="SZ 13 Gulf of St Lawrence" t2="Eastern Canada"/>
+                <connection t1="SZ 13 Gulf of St Lawrence" t2="Newfoundland"/>
+
+                <connection t1="SZ 14 North Atlantic" t2="SZ 15 North Atlantic"/>
+                <connection t1="SZ 14 North Atlantic" t2="SZ 20 Atlantic"/>
+                <connection t1="SZ 14 North Atlantic" t2="SZ 19 Atlantic"/>
+
+                <connection t1="SZ 15 North Atlantic" t2="SZ 16 North Atlantic"/>
+                <connection t1="SZ 15 North Atlantic" t2="SZ 21 East Atlantic"/>
+                <connection t1="SZ 15 North Atlantic" t2="SZ 20 Atlantic"/>
+
+                <connection t1="SZ 16 North Atlantic" t2="SZ 22 East Atlantic"/>
+                <connection t1="SZ 16 North Atlantic" t2="SZ 17 English Channel"/>
+                <connection t1="SZ 16 North Atlantic" t2="SZ 21 East Atlantic"/>
+                <connection t1="SZ 16 North Atlantic" t2="Ireland"/>
+                <connection t1="SZ 16 North Atlantic" t2="England"/>
+
+                <connection t1="SZ 17 English Channel" t2="SZ 22 East Atlantic"/>
+                <connection t1="SZ 17 English Channel" t2="England"/>
+                <connection t1="SZ 17 English Channel" t2="France"/>
+
+                <connection t1="SZ 18 West Atlantic" t2="SZ 31 West Atlantic"/>
+                <connection t1="SZ 18 West Atlantic" t2="SZ 32 Atlantic"/>
+                <connection t1="SZ 18 West Atlantic" t2="SZ 19 Atlantic"/>
+                <connection t1="SZ 18 West Atlantic" t2="Northeastern United States"/>
+                <connection t1="SZ 18 West Atlantic" t2="Eastern Canada"/>
+                <connection t1="SZ 18 West Atlantic" t2="Bermuda"/>
+
+                <connection t1="SZ 19 Atlantic" t2="SZ 20 Atlantic"/>
+                <connection t1="SZ 19 Atlantic" t2="SZ 33 Atlantic"/>
+                <connection t1="SZ 19 Atlantic" t2="SZ 32 Atlantic"/>
+                <connection t1="SZ 19 Atlantic" t2="Bermuda"/>
+
+                <connection t1="SZ 20 Atlantic" t2="SZ 21 East Atlantic"/>
+                <connection t1="SZ 20 Atlantic" t2="SZ 34 Atlantic"/>
+                <connection t1="SZ 20 Atlantic" t2="SZ 33 Atlantic"/>
+                <connection t1="SZ 20 Atlantic" t2="Azores"/>
+
+                <connection t1="SZ 21 East Atlantic" t2="SZ 22 East Atlantic"/>
+                <connection t1="SZ 21 East Atlantic" t2="SZ 35 East Atlantic"/>
+                <connection t1="SZ 21 East Atlantic" t2="SZ 34 Atlantic"/>
+                <connection t1="SZ 21 East Atlantic" t2="Azores"/>
+
+                <connection t1="SZ 22 East Atlantic" t2="SZ 23 West Mediterranean"/>
+                <connection t1="SZ 22 East Atlantic" t2="SZ 35 East Atlantic"/>
+                <connection t1="SZ 22 East Atlantic" t2="Spain"/>
+                <connection t1="SZ 22 East Atlantic" t2="Portugal"/>
+                <connection t1="SZ 22 East Atlantic" t2="Morocco"/>
+                <connection t1="SZ 22 East Atlantic" t2="Sahara"/>
+                <connection t1="SZ 22 East Atlantic" t2="Gibraltar"/>
+
+                <connection t1="SZ 23 West Mediterranean" t2="SZ 24 Tyrrhenian Sea"/>
+                <connection t1="SZ 23 West Mediterranean" t2="SZ 26 Central Mediterranean"/>
+                <connection t1="SZ 23 West Mediterranean" t2="Gibraltar"/>
+                <connection t1="SZ 23 West Mediterranean" t2="Spain"/>
+                <connection t1="SZ 23 West Mediterranean" t2="Sardinia"/>
+                <connection t1="SZ 23 West Mediterranean" t2="Sicily"/>
+                <connection t1="SZ 23 West Mediterranean" t2="Algeria"/>
+                <connection t1="SZ 23 West Mediterranean" t2="Morocco"/>
+
+                <connection t1="SZ 24 Tyrrhenian Sea" t2="SZ 26 Central Mediterranean"/>
+                <connection t1="SZ 24 Tyrrhenian Sea" t2="Vichy France"/>
+                <connection t1="SZ 24 Tyrrhenian Sea" t2="Italy"/>
+                <connection t1="SZ 24 Tyrrhenian Sea" t2="Sardinia"/>
+
+                <connection t1="SZ 25 Adriatic Sea" t2="SZ 26 Central Mediterranean"/>
+                <connection t1="SZ 25 Adriatic Sea" t2="Italy"/>
+                <connection t1="SZ 25 Adriatic Sea" t2="Balkans"/>
+                <connection t1="SZ 25 Adriatic Sea" t2="Macedonia"/>
+
+                <connection t1="SZ 26 Central Mediterranean" t2="SZ 27 Aegean Sea"/>
+                <connection t1="SZ 26 Central Mediterranean" t2="SZ 28 Eastern Mediterranean"/>
+                <connection t1="SZ 26 Central Mediterranean" t2="Sicily"/>
+                <connection t1="SZ 26 Central Mediterranean" t2="Italy"/>
+                <connection t1="SZ 26 Central Mediterranean" t2="Macedonia"/>
+                <connection t1="SZ 26 Central Mediterranean" t2="Libya"/>
+
+                <connection t1="SZ 27 Aegean Sea" t2="SZ 29 Black Sea"/>
+                <connection t1="SZ 27 Aegean Sea" t2="SZ 28 Eastern Mediterranean"/>
+                <connection t1="SZ 27 Aegean Sea" t2="Macedonia"/>
+                <connection t1="SZ 27 Aegean Sea" t2="Western Turkey"/>
+
+                <connection t1="SZ 28 Eastern Mediterranean" t2="SZ 55 Red Sea"/>
+                <connection t1="SZ 28 Eastern Mediterranean" t2="Western Turkey"/>
+                <connection t1="SZ 28 Eastern Mediterranean" t2="Syria"/>
+                <connection t1="SZ 28 Eastern Mediterranean" t2="Egypt"/>
+
+                <connection t1="SZ 29 Black Sea" t2="Balkans"/>
+                <connection t1="SZ 29 Black Sea" t2="Hungary-Romania"/>
+                <connection t1="SZ 29 Black Sea" t2="Ukraine"/>
+                <connection t1="SZ 29 Black Sea" t2="Caucasus"/>
+                <connection t1="SZ 29 Black Sea" t2="Western Turkey"/>
+                <connection t1="SZ 29 Black Sea" t2="Eastern Turkey"/>
+                <connection t1="SZ 29 Black Sea" t2="Southern Russia"/>
+
+                <connection t1="SZ 30 Gulf of Mexico" t2="SZ 31 West Atlantic"/>
+                <connection t1="SZ 30 Gulf of Mexico" t2="SZ 37 Caribbean Sea"/>
+                <connection t1="SZ 30 Gulf of Mexico" t2="Cuba"/>
+                <connection t1="SZ 30 Gulf of Mexico" t2="Eastern Mexico"/>
+                <connection t1="SZ 30 Gulf of Mexico" t2="Southern United States"/>
+
+                <connection t1="SZ 31 West Atlantic" t2="SZ 32 Atlantic"/>
+                <connection t1="SZ 31 West Atlantic" t2="SZ 37 Caribbean Sea"/>
+                <connection t1="SZ 31 West Atlantic" t2="Cuba"/>
+                <connection t1="SZ 31 West Atlantic" t2="Southern United States"/>
+
+                <connection t1="SZ 32 Atlantic" t2="SZ 33 Atlantic"/>
+                <connection t1="SZ 32 Atlantic" t2="SZ 38 Mid Atlantic"/>
+                <connection t1="SZ 32 Atlantic" t2="SZ 37 Caribbean Sea"/>
+                <connection t1="SZ 32 Atlantic" t2="West Indies"/>
+
+                <connection t1="SZ 33 Atlantic" t2="SZ 34 Atlantic"/>
+                <connection t1="SZ 33 Atlantic" t2="SZ 39 Mid Atlantic"/>
+                <connection t1="SZ 33 Atlantic" t2="SZ 38 Mid Atlantic"/>
+
+                <connection t1="SZ 34 Atlantic" t2="SZ 35 East Atlantic"/>
+                <connection t1="SZ 34 Atlantic" t2="SZ 39 Mid Atlantic"/>
+                <connection t1="SZ 34 Atlantic" t2="Cape Verde Islands"/>
+
+                <connection t1="SZ 35 East Atlantic" t2="SZ 40 Mid Atlantic"/>
+                <connection t1="SZ 35 East Atlantic" t2="SZ 39 Mid Atlantic"/>
+                <connection t1="SZ 35 East Atlantic" t2="Cape Verde Islands"/>
+                <connection t1="SZ 35 East Atlantic" t2="Rio de Oro"/>
+                <connection t1="SZ 35 East Atlantic" t2="French West Africa"/>
+                <connection t1="SZ 35 East Atlantic" t2="Sahara"/>
+
+                <connection t1="SZ 36 East Pacific" t2="SZ 37 Caribbean Sea"/>
+                <connection t1="SZ 36 East Pacific" t2="SZ 42 Eastern Pacific"/>
+                <connection t1="SZ 36 East Pacific" t2="SZ 102 East Pacific"/>
+                <connection t1="SZ 36 East Pacific" t2="SZ 41 Eastern Pacific"/>
+                <connection t1="SZ 36 East Pacific" t2="SZ 97 East Pacific"/>
+                <connection t1="SZ 36 East Pacific" t2="Eastern Mexico"/>
+                <connection t1="SZ 36 East Pacific" t2="Central America"/>
+                <connection t1="SZ 36 East Pacific" t2="Northern South America"/>
+
+                <connection t1="SZ 37 Caribbean Sea" t2="SZ 38 Mid Atlantic"/>
+                <connection t1="SZ 37 Caribbean Sea" t2="Eastern Mexico"/>
+                <connection t1="SZ 37 Caribbean Sea" t2="Cuba"/>
+                <connection t1="SZ 37 Caribbean Sea" t2="West Indies"/>
+                <connection t1="SZ 37 Caribbean Sea" t2="Northern South America"/>
+                <connection t1="SZ 37 Caribbean Sea" t2="Central America"/>
+
+                <connection t1="SZ 38 Mid Atlantic" t2="SZ 39 Mid Atlantic"/>
+                <connection t1="SZ 38 Mid Atlantic" t2="SZ 43 Mid Atlantic"/>
+                <connection t1="SZ 38 Mid Atlantic" t2="Northern South America"/>
+
+                <connection t1="SZ 39 Mid Atlantic" t2="SZ 40 Mid Atlantic"/>
+                <connection t1="SZ 39 Mid Atlantic" t2="SZ 44 Mid Atlantic"/>
+                <connection t1="SZ 39 Mid Atlantic" t2="SZ 43 Mid Atlantic"/>
+                <connection t1="SZ 39 Mid Atlantic" t2="Cape Verde Islands"/>
+
+                <connection t1="SZ 40 Mid Atlantic" t2="SZ 45 Mid Atlantic"/>
+                <connection t1="SZ 40 Mid Atlantic" t2="SZ 44 Mid Atlantic"/>
+                <connection t1="SZ 40 Mid Atlantic" t2="Guinean Coast"/>
+
+                <connection t1="SZ 41 Eastern Pacific" t2="SZ 42 Eastern Pacific"/>
+                <connection t1="SZ 41 Eastern Pacific" t2="SZ 46 Southeastern Pacific"/>
+                <connection t1="SZ 41 Eastern Pacific" t2="SZ 102 East Pacific"/>
+                <connection t1="SZ 41 Eastern Pacific" t2="SZ 107 South Pacific"/>
+
+                <connection t1="SZ 42 Eastern Pacific" t2="SZ 46 Southeastern Pacific"/>
+                <connection t1="SZ 42 Eastern Pacific" t2="SZ 47 Southeastern Pacific"/>
+                <connection t1="SZ 42 Eastern Pacific" t2="Western South America"/>
+
+                <connection t1="SZ 43 Mid Atlantic" t2="SZ 44 Mid Atlantic"/>
+                <connection t1="SZ 43 Mid Atlantic" t2="SZ 49 South Atlantic"/>
+                <connection t1="SZ 43 Mid Atlantic" t2="SZ 48 South Atlantic"/>
+                <connection t1="SZ 43 Mid Atlantic" t2="Northern Brazil"/>
+
+                <connection t1="SZ 44 Mid Atlantic" t2="SZ 45 Mid Atlantic"/>
+                <connection t1="SZ 44 Mid Atlantic" t2="SZ 50 South Atlantic"/>
+                <connection t1="SZ 44 Mid Atlantic" t2="SZ 49 South Atlantic"/>
+
+                <connection t1="SZ 45 Mid Atlantic" t2="SZ 50 South Atlantic"/>
+                <connection t1="SZ 45 Mid Atlantic" t2="French Equatorial Africa"/>
+                <connection t1="SZ 45 Mid Atlantic" t2="Belgian Congo"/>
+                <connection t1="SZ 45 Mid Atlantic" t2="Angola"/>
+
+                <connection t1="SZ 46 Southeastern Pacific" t2="SZ 47 Southeastern Pacific"/>
+                <connection t1="SZ 46 Southeastern Pacific" t2="SZ 107 South Pacific"/>
+                <connection t1="SZ 46 Southeastern Pacific" t2="SZ 109 South Pacific"/>
+
+                <connection t1="SZ 47 Southeastern Pacific" t2="Western South America"/>
+                <connection t1="SZ 47 Southeastern Pacific" t2="SZ 52 South Atlantic"/>
+
+                <connection t1="SZ 48 South Atlantic" t2="SZ 49 South Atlantic"/>
+                <connection t1="SZ 48 South Atlantic" t2="SZ 53 South Atlantic"/>
+                <connection t1="SZ 48 South Atlantic" t2="SZ 52 South Atlantic"/>
+                <connection t1="SZ 48 South Atlantic" t2="Southern Brazil"/>
+
+                <connection t1="SZ 49 South Atlantic" t2="SZ 50 South Atlantic"/>
+                <connection t1="SZ 49 South Atlantic" t2="SZ 54 South Atlantic"/>
+                <connection t1="SZ 49 South Atlantic" t2="SZ 53 South Atlantic"/>
+
+                <connection t1="SZ 50 South Atlantic" t2="SZ 64 South West Indian"/>
+                <connection t1="SZ 50 South Atlantic" t2="SZ 54 South Atlantic"/>
+                <connection t1="SZ 50 South Atlantic" t2="Southern Africa"/>
+
+                <connection t1="SZ 52 South Atlantic" t2="SZ 53 South Atlantic"/>
+                <connection t1="SZ 52 South Atlantic" t2="Southern South America"/>
+
+                <connection t1="SZ 53 South Atlantic" t2="SZ 54 South Atlantic"/>
+
+                <connection t1="SZ 54 South Atlantic" t2="SZ 64 South West Indian"/>
+                <connection t1="SZ 54 South Atlantic" t2="SZ 68 South Indian"/>
+
+                <connection t1="SZ 55 Red Sea" t2="SZ 56 Persian Gulf"/>
+                <connection t1="SZ 55 Red Sea" t2="SZ 57 Arabian Sea"/>
+                <connection t1="SZ 55 Red Sea" t2="SZ 60 Western Indian"/>
+                <connection t1="SZ 55 Red Sea" t2="Syria"/>
+                <connection t1="SZ 55 Red Sea" t2="Arabian Peninsula"/>
+                <connection t1="SZ 55 Red Sea" t2="Ethiopia"/>
+                <connection t1="SZ 55 Red Sea" t2="Anglo-Egyptian Sudan"/>
+                <connection t1="SZ 55 Red Sea" t2="Egypt"/>
+
+                <connection t1="SZ 56 Persian Gulf" t2="SZ 57 Arabian Sea"/>
+                <connection t1="SZ 56 Persian Gulf" t2="Iraq"/>
+                <connection t1="SZ 56 Persian Gulf" t2="Iran"/>
+                <connection t1="SZ 56 Persian Gulf" t2="Arabian Peninsula"/>
+                <connection t1="SZ 56 Persian Gulf" t2="Baluchistan"/>
+
+                <connection t1="SZ 57 Arabian Sea" t2="SZ 58 Bay of Bengal"/>
+                <connection t1="SZ 57 Arabian Sea" t2="SZ 59 Northeastern Indian"/>
+                <connection t1="SZ 57 Arabian Sea" t2="SZ 61 Indian"/>
+                <connection t1="SZ 57 Arabian Sea" t2="SZ 60 Western Indian"/>
+                <connection t1="SZ 57 Arabian Sea" t2="Ceylon"/>
+                <connection t1="SZ 57 Arabian Sea" t2="Arabian Peninsula"/>
+                <connection t1="SZ 57 Arabian Sea" t2="Bombay"/>
+
+                <connection t1="SZ 58 Bay of Bengal" t2="SZ 59 Northeastern Indian"/>
+                <connection t1="SZ 58 Bay of Bengal" t2="SZ 71 South China Sea"/>
+                <connection t1="SZ 58 Bay of Bengal" t2="Ceylon"/>
+                <connection t1="SZ 58 Bay of Bengal" t2="Calcutta"/>
+                <connection t1="SZ 58 Bay of Bengal" t2="Burma"/>
+
+                <connection t1="SZ 59 Northeastern Indian" t2="SZ 71 South China Sea"/>
+                <connection t1="SZ 59 Northeastern Indian" t2="SZ 61 Indian"/>
+                <connection t1="SZ 59 Northeastern Indian" t2="SZ 62 Indian"/>
+                <connection t1="SZ 59 Northeastern Indian" t2="Ceylon"/>
+                <connection t1="SZ 59 Northeastern Indian" t2="Sumatra"/>
+
+                <connection t1="SZ 60 Western Indian" t2="SZ 61 Indian"/>
+                <connection t1="SZ 60 Western Indian" t2="SZ 65 Indian"/>
+                <connection t1="SZ 60 Western Indian" t2="SZ 64 South West Indian"/>
+                <connection t1="SZ 60 Western Indian" t2="Kenya-Tanganyika"/>
+                <connection t1="SZ 60 Western Indian" t2="Mozambique"/>
+                <connection t1="SZ 60 Western Indian" t2="Madagascar"/>
+
+                <connection t1="SZ 61 Indian" t2="SZ 62 Indian"/>
+                <connection t1="SZ 61 Indian" t2="SZ 66 Indian"/>
+                <connection t1="SZ 61 Indian" t2="SZ 65 Indian"/>
+
+                <connection t1="SZ 62 Indian" t2="SZ 66 Indian"/>
+                <connection t1="SZ 62 Indian" t2="SZ 71 South China Sea"/>
+                <connection t1="SZ 62 Indian" t2="SZ 63 Timor Sea"/>
+                <connection t1="SZ 62 Indian" t2="SZ 67 South East Indian"/>
+
+                <connection t1="SZ 63 Timor Sea" t2="SZ 71 South China Sea"/>
+                <connection t1="SZ 63 Timor Sea" t2="SZ 98 Philippine Sea"/>
+                <connection t1="SZ 63 Timor Sea" t2="SZ 103 Arafura Sea"/>
+                <connection t1="SZ 63 Timor Sea" t2="SZ 67 South East Indian"/>
+                <connection t1="SZ 63 Timor Sea" t2="Java"/>
+                <connection t1="SZ 63 Timor Sea" t2="Celebes"/>
+                <connection t1="SZ 63 Timor Sea" t2="Western Australia"/>
+
+                <connection t1="SZ 64 South West Indian" t2="SZ 65 Indian"/>
+                <connection t1="SZ 64 South West Indian" t2="SZ 68 South Indian"/>
+                <connection t1="SZ 64 South West Indian" t2="Southern Africa"/>
+                <connection t1="SZ 64 South West Indian" t2="Mozambique"/>
+                <connection t1="SZ 64 South West Indian" t2="Madagascar"/>
+
+                <connection t1="SZ 65 Indian" t2="SZ 66 Indian"/>
+                <connection t1="SZ 65 Indian" t2="SZ 69 Indian"/>
+                <connection t1="SZ 65 Indian" t2="SZ 68 South Indian"/>
+                <connection t1="SZ 65 Indian" t2="Madagascar"/>
+
+                <connection t1="SZ 66 Indian" t2="SZ 67 South East Indian"/>
+                <connection t1="SZ 66 Indian" t2="SZ 69 Indian"/>
+
+                <connection t1="SZ 67 South East Indian" t2="SZ 70 Southern Ocean"/>
+                <connection t1="SZ 67 South East Indian" t2="SZ 69 Indian"/>
+                <connection t1="SZ 67 South East Indian" t2="Western Australia"/>
+
+                <connection t1="SZ 68 South Indian" t2="SZ 69 Indian"/>
+
+                <connection t1="SZ 69 Indian" t2="SZ 70 Southern Ocean"/>
+
+                <connection t1="SZ 70 Southern Ocean" t2="SZ 105 Tasman Sea"/>
+                <connection t1="SZ 70 Southern Ocean" t2="SZ 108 South Pacific"/>
+                <connection t1="SZ 70 Southern Ocean" t2="Central Australia"/>
+                <connection t1="SZ 70 Southern Ocean" t2="Tasmania"/>
+
+                <connection t1="SZ 71 South China Sea" t2="SZ 72 South China Sea"/>
+                <connection t1="SZ 71 South China Sea" t2="SZ 98 Philippine Sea"/>
+                <connection t1="SZ 71 South China Sea" t2="Thai-Malay"/>
+                <connection t1="SZ 71 South China Sea" t2="French Indo-China"/>
+                <connection t1="SZ 71 South China Sea" t2="Borneo"/>
+                <connection t1="SZ 71 South China Sea" t2="Java"/>
+                <connection t1="SZ 71 South China Sea" t2="Sumatra"/>
+
+                <connection t1="SZ 72 South China Sea" t2="SZ 73 East China Sea"/>
+                <connection t1="SZ 72 South China Sea" t2="SZ 92 Philippine Sea"/>
+                <connection t1="SZ 72 South China Sea" t2="SZ 98 Philippine Sea"/>
+                <connection t1="SZ 72 South China Sea" t2="French Indo-China"/>
+                <connection t1="SZ 72 South China Sea" t2="Kwangtung"/>
+                <connection t1="SZ 72 South China Sea" t2="North Philippines"/>
+                <connection t1="SZ 72 South China Sea" t2="South Philippines"/>
+                <connection t1="SZ 72 South China Sea" t2="Borneo"/>
+
+                <connection t1="SZ 73 East China Sea" t2="SZ 74 Sea of Japan"/>
+                <connection t1="SZ 73 East China Sea" t2="SZ 86 West Pacific"/>
+                <connection t1="SZ 73 East China Sea" t2="SZ 92 Philippine Sea"/>
+                <connection t1="SZ 73 East China Sea" t2="Shantung"/>
+                <connection t1="SZ 73 East China Sea" t2="Chosen"/>
+                <connection t1="SZ 73 East China Sea" t2="Southern Japan"/>
+                <connection t1="SZ 73 East China Sea" t2="Okinawa"/>
+
+                <connection t1="SZ 74 Sea of Japan" t2="SZ 75 Sea of Okhotsk"/>
+                <connection t1="SZ 74 Sea of Japan" t2="SZ 80 Northwest Pacific"/>
+                <connection t1="SZ 74 Sea of Japan" t2="Chosen"/>
+                <connection t1="SZ 74 Sea of Japan" t2="Vladivostok"/>
+                <connection t1="SZ 74 Sea of Japan" t2="Sakhalin Island"/>
+                <connection t1="SZ 74 Sea of Japan" t2="Northern Japan"/>
+                <connection t1="SZ 74 Sea of Japan" t2="Southern Japan"/>
+
+                <connection t1="SZ 75 Sea of Okhotsk" t2="SZ 80 Northwest Pacific"/>
+                <connection t1="SZ 75 Sea of Okhotsk" t2="Okhotsk"/>
+                <connection t1="SZ 75 Sea of Okhotsk" t2="Kamchatka"/>
+                <connection t1="SZ 75 Sea of Okhotsk" t2="Sakhalin Island"/>
+                <connection t1="SZ 75 Sea of Okhotsk" t2="SZ 76 West Bering Sea"/>
+
+                <connection t1="SZ 76 West Bering Sea" t2="SZ 77 Bering Sea"/>
+                <connection t1="SZ 76 West Bering Sea" t2="SZ 81 North Pacific"/>
+                <connection t1="SZ 76 West Bering Sea" t2="SZ 80 Northwest Pacific"/>
+                <connection t1="SZ 76 West Bering Sea" t2="Kamchatka"/>
+                <connection t1="SZ 76 West Bering Sea" t2="Western Aleutian Islands"/>
+
+                <connection t1="SZ 77 Bering Sea" t2="SZ 78 Arctic Ocean"/>
+                <connection t1="SZ 77 Bering Sea" t2="SZ 83 Gulf of Alaska"/>
+                <connection t1="SZ 77 Bering Sea" t2="SZ 82 North Pacific"/>
+                <connection t1="SZ 77 Bering Sea" t2="SZ 81 North Pacific"/>
+                <connection t1="SZ 77 Bering Sea" t2="Alaska"/>
+                <connection t1="SZ 77 Bering Sea" t2="Eastern Aleutian Islands"/>
+                <connection t1="SZ 77 Bering Sea" t2="Kamchatka"/>
+                <connection t1="SZ 77 Bering Sea" t2="Western Aleutian Islands"/>
+
+                <connection t1="SZ 78 Arctic Ocean" t2="Alaska"/>
+                <connection t1="SZ 78 Arctic Ocean" t2="Kamchatka"/>
+
+                <connection t1="SZ 79 Arctic Ocean" t2="Alaska"/>
+                <connection t1="SZ 79 Arctic Ocean" t2="Western Canada"/>
+
+                <connection t1="SZ 80 Northwest Pacific" t2="SZ 81 North Pacific"/>
+                <connection t1="SZ 80 Northwest Pacific" t2="SZ 87 West Pacific"/>
+                <connection t1="SZ 80 Northwest Pacific" t2="SZ 86 West Pacific"/>
+                <connection t1="SZ 80 Northwest Pacific" t2="Northern Japan"/>
+
+                <connection t1="SZ 81 North Pacific" t2="SZ 82 North Pacific"/>
+                <connection t1="SZ 81 North Pacific" t2="SZ 88 Pacific"/>
+                <connection t1="SZ 81 North Pacific" t2="SZ 87 West Pacific"/>
+                <connection t1="SZ 81 North Pacific" t2="Western Aleutian Islands"/>
+
+                <connection t1="SZ 82 North Pacific" t2="SZ 83 Gulf of Alaska"/>
+                <connection t1="SZ 82 North Pacific" t2="SZ 84 Northeastern Pacific"/>
+                <connection t1="SZ 82 North Pacific" t2="SZ 89 Pacific"/>
+                <connection t1="SZ 82 North Pacific" t2="SZ 88 Pacific"/>
+                <connection t1="SZ 82 North Pacific" t2="Eastern Aleutian Islands"/>
+
+                <connection t1="SZ 83 Gulf of Alaska" t2="SZ 84 Northeastern Pacific"/>
+                <connection t1="SZ 83 Gulf of Alaska" t2="SZ 85 Northeast Pacific"/>
+                <connection t1="SZ 83 Gulf of Alaska" t2="Alaska"/>
+
+                <connection t1="SZ 84 Northeastern Pacific" t2="SZ 89 Pacific"/>
+                <connection t1="SZ 84 Northeastern Pacific" t2="SZ 85 Northeast Pacific"/>
+                <connection t1="SZ 84 Northeastern Pacific" t2="SZ 90 East Pacific"/>
+
+                <connection t1="SZ 85 Northeast Pacific" t2="SZ 91 East Pacific"/>
+                <connection t1="SZ 85 Northeast Pacific" t2="SZ 90 East Pacific"/>
+                <connection t1="SZ 85 Northeast Pacific" t2="Western Canada"/>
+                <connection t1="SZ 85 Northeast Pacific" t2="Northwestern United States"/>
+
+                <connection t1="SZ 86 West Pacific" t2="SZ 87 West Pacific"/>
+                <connection t1="SZ 86 West Pacific" t2="SZ 93 West Pacific"/>
+                <connection t1="SZ 86 West Pacific" t2="SZ 92 Philippine Sea"/>
+                <connection t1="SZ 86 West Pacific" t2="Southern Japan"/>
+                <connection t1="SZ 86 West Pacific" t2="Iwo Jima"/>
+
+                <connection t1="SZ 87 West Pacific" t2="SZ 88 Pacific"/>
+                <connection t1="SZ 87 West Pacific" t2="SZ 94 Pacific"/>
+                <connection t1="SZ 87 West Pacific" t2="SZ 93 West Pacific"/>
+
+                <connection t1="SZ 88 Pacific" t2="SZ 89 Pacific"/>
+                <connection t1="SZ 88 Pacific" t2="SZ 95 Pacific"/>
+                <connection t1="SZ 88 Pacific" t2="SZ 94 Pacific"/>
+                <connection t1="SZ 88 Pacific" t2="Midway Island"/>
+
+                <connection t1="SZ 89 Pacific" t2="SZ 90 East Pacific"/>
+                <connection t1="SZ 89 Pacific" t2="SZ 95 Pacific"/>
+                <connection t1="SZ 89 Pacific" t2="Hawaiian Islands"/>
+
+                <connection t1="SZ 90 East Pacific" t2="SZ 91 East Pacific"/>
+                <connection t1="SZ 90 East Pacific" t2="SZ 96 Pacific"/>
+                <connection t1="SZ 90 East Pacific" t2="SZ 95 Pacific"/>
+
+                <connection t1="SZ 91 East Pacific" t2="SZ 97 East Pacific"/>
+                <connection t1="SZ 91 East Pacific" t2="SZ 96 Pacific"/>
+                <connection t1="SZ 91 East Pacific" t2="Southwestern United States"/>
+                <connection t1="SZ 91 East Pacific" t2="Western Mexico"/>
+
+                <connection t1="SZ 92 Philippine Sea" t2="SZ 93 West Pacific"/>
+                <connection t1="SZ 92 Philippine Sea" t2="SZ 99 West Pacific"/>
+                <connection t1="SZ 92 Philippine Sea" t2="SZ 98 Philippine Sea"/>
+                <connection t1="SZ 92 Philippine Sea" t2="Okinawa"/>
+                <connection t1="SZ 92 Philippine Sea" t2="Iwo Jima"/>
+                <connection t1="SZ 92 Philippine Sea" t2="North Philippines"/>
+
+                <connection t1="SZ 93 West Pacific" t2="SZ 94 Pacific"/>
+                <connection t1="SZ 93 West Pacific" t2="SZ 99 West Pacific"/>
+                <connection t1="SZ 93 West Pacific" t2="Wake"/>
+                <connection t1="SZ 93 West Pacific" t2="Guam"/>
+
+                <connection t1="SZ 94 Pacific" t2="SZ 95 Pacific"/>
+                <connection t1="SZ 94 Pacific" t2="SZ 100 Pacific"/>
+                <connection t1="SZ 94 Pacific" t2="SZ 99 West Pacific"/>
+                <connection t1="SZ 94 Pacific" t2="Midway Island"/>
+                <connection t1="SZ 94 Pacific" t2="Marshall Islands"/>
+                <connection t1="SZ 94 Pacific" t2="Wake"/>
+
+                <connection t1="SZ 95 Pacific" t2="SZ 96 Pacific"/>
+                <connection t1="SZ 95 Pacific" t2="SZ 101 Pacific"/>
+                <connection t1="SZ 95 Pacific" t2="SZ 100 Pacific"/>
+                <connection t1="SZ 95 Pacific" t2="Hawaiian Islands"/>
+
+                <connection t1="SZ 96 Pacific" t2="SZ 97 East Pacific"/>
+                <connection t1="SZ 96 Pacific" t2="SZ 102 East Pacific"/>
+                <connection t1="SZ 96 Pacific" t2="SZ 101 Pacific"/>
+
+                <connection t1="SZ 97 East Pacific" t2="SZ 102 East Pacific"/>
+                <connection t1="SZ 97 East Pacific" t2="Western Mexico"/>
+
+                <connection t1="SZ 98 Philippine Sea" t2="SZ 99 West Pacific"/>
+                <connection t1="SZ 98 Philippine Sea" t2="SZ 103 Arafura Sea"/>
+                <connection t1="SZ 98 Philippine Sea" t2="South Philippines"/>
+                <connection t1="SZ 98 Philippine Sea" t2="New Guinea"/>
+                <connection t1="SZ 98 Philippine Sea" t2="Celebes"/>
+                <connection t1="SZ 98 Philippine Sea" t2="Borneo"/>
+
+                <connection t1="SZ 99 West Pacific" t2="SZ 100 Pacific"/>
+                <connection t1="SZ 99 West Pacific" t2="SZ 104 Coral Sea"/>
+                <connection t1="SZ 99 West Pacific" t2="SZ 103 Arafura Sea"/>
+                <connection t1="SZ 99 West Pacific" t2="Guam"/>
+                <connection t1="SZ 99 West Pacific" t2="Marshall Islands"/>
+                <connection t1="SZ 99 West Pacific" t2="Solomon Islands"/>
+                <connection t1="SZ 99 West Pacific" t2="New Guinea"/>
+
+                <connection t1="SZ 100 Pacific" t2="SZ 101 Pacific"/>
+                <connection t1="SZ 100 Pacific" t2="SZ 106 Southwest Pacific"/>
+                <connection t1="SZ 100 Pacific" t2="SZ 104 Coral Sea"/>
+                <connection t1="SZ 100 Pacific" t2="Fiji"/>
+
+                <connection t1="SZ 101 Pacific" t2="SZ 102 East Pacific"/>
+                <connection t1="SZ 101 Pacific" t2="SZ 107 South Pacific"/>
+                <connection t1="SZ 101 Pacific" t2="SZ 106 Southwest Pacific"/>
+
+                <connection t1="SZ 102 East Pacific" t2="SZ 107 South Pacific"/>
+
+                <connection t1="SZ 103 Arafura Sea" t2="SZ 104 Coral Sea"/>
+                <connection t1="SZ 103 Arafura Sea" t2="SZ 105 Tasman Sea"/>
+                <connection t1="SZ 103 Arafura Sea" t2="New Guinea"/>
+                <connection t1="SZ 103 Arafura Sea" t2="Queensland"/>
+                <connection t1="SZ 103 Arafura Sea" t2="Central Australia"/>
+
+                <connection t1="SZ 104 Coral Sea" t2="SZ 106 Southwest Pacific"/>
+                <connection t1="SZ 104 Coral Sea" t2="SZ 105 Tasman Sea"/>
+                <connection t1="SZ 104 Coral Sea" t2="Solomon Islands"/>
+
+                <connection t1="SZ 105 Tasman Sea" t2="SZ 106 Southwest Pacific"/>
+                <connection t1="SZ 105 Tasman Sea" t2="SZ 108 South Pacific"/>
+                <connection t1="SZ 105 Tasman Sea" t2="New South Wales"/>
+                <connection t1="SZ 105 Tasman Sea" t2="New Zealand"/>
+                <connection t1="SZ 105 Tasman Sea" t2="Tasmania"/>
+
+                <connection t1="SZ 106 Southwest Pacific" t2="SZ 107 South Pacific"/>
+                <connection t1="SZ 106 Southwest Pacific" t2="SZ 108 South Pacific"/>
+                <connection t1="SZ 106 Southwest Pacific" t2="Fiji"/>
+                <connection t1="SZ 106 Southwest Pacific" t2="New Zealand"/>
+
+                <connection t1="SZ 107 South Pacific" t2="SZ 109 South Pacific"/>
+                <connection t1="SZ 107 South Pacific" t2="SZ 108 South Pacific"/>
+
+                <connection t1="SZ 108 South Pacific" t2="SZ 109 South Pacific"/>
+                <connection t1="SZ 108 South Pacific" t2="New Zealand"/>
+
+                <connection t1="Eastern Canada" t2="Northeastern United States"/>
+                <connection t1="Eastern Canada" t2="Midwestern United States"/>
+                <connection t1="Eastern Canada" t2="Central Canada"/>
+
+                <connection t1="England" t2="Scotland"/>
+
+                <connection t1="France" t2="Western Germany"/>
+                <connection t1="France" t2="Vichy France"/>
+                <connection t1="France" t2="Spain"/>
+
+                <connection t1="Southwestern United States" t2="Northwestern United States"/>
+                <connection t1="Southwestern United States" t2="Midwestern United States"/>
+                <connection t1="Southwestern United States" t2="Southern United States"/>
+                <connection t1="Southwestern United States" t2="Western Mexico"/>
+
+                <connection t1="New South Wales" t2="Queensland"/>
+                <connection t1="New South Wales" t2="Central Australia"/>
+
+                <connection t1="Northern Manchukuo" t2="Amurskaya"/>
+                <connection t1="Northern Manchukuo" t2="Vladivostok"/>
+                <connection t1="Northern Manchukuo" t2="Shantung"/>
+                <connection t1="Northern Manchukuo" t2="Chosen"/>
+                <connection t1="Northern Manchukuo" t2="Mongolia"/>
+
+                <connection t1="Chosen" t2="Vladivostok"/>
+                <connection t1="Chosen" t2="Shantung"/>
+
+                <connection t1="Inner Mongolia" t2="Shantung"/>
+                <connection t1="Inner Mongolia" t2="Szechwan"/>
+                <connection t1="Inner Mongolia" t2="Kansu"/>
+                <connection t1="Inner Mongolia" t2="Mongolia"/>
+
+                <connection t1="Alaska" t2="Western Canada"/>
+
+                <connection t1="Baluchistan" t2="Afghanistan"/>
+                <connection t1="Baluchistan" t2="Kashmir"/>
+                <connection t1="Baluchistan" t2="Delhi"/>
+                <connection t1="Baluchistan" t2="Bombay"/>
+                <connection t1="Baluchistan" t2="Iran"/>
+
+                <connection t1="Archangel'sk" t2="Western Siberia"/>
+                <connection t1="Archangel'sk" t2="Eastern Russia"/>
+                <connection t1="Archangel'sk" t2="Karelija"/>
+                <connection t1="Archangel'sk" t2="Northern Russia"/>
+                <connection t1="Archangel'sk" t2="Sverdlovsk"/>
+
+                <connection t1="Western Turkey" t2="Eastern Turkey"/>
+                <connection t1="Western Turkey" t2="Balkans"/>
+                <connection t1="Western Turkey" t2="Syria"/>
+                <connection t1="Western Turkey" t2="Macedonia"/>
+
+                <connection t1="Eastern Turkey" t2="Caucasus"/>
+                <connection t1="Eastern Turkey" t2="Iran"/>
+                <connection t1="Eastern Turkey" t2="Iraq"/>
+                <connection t1="Eastern Turkey" t2="Syria"/>
+
+                <connection t1="French West Africa" t2="Rio de Oro"/>
+                <connection t1="French West Africa" t2="Sahara"/>
+                <connection t1="French West Africa" t2="French Equatorial Africa"/>
+                <connection t1="French West Africa" t2="Guinean Coast"/>
+
+                <connection t1="Queensland" t2="Central Australia"/>
+
+                <connection t1="Southern Russia" t2="Belorussia"/>
+                <connection t1="Southern Russia" t2="Western Russia"/>
+                <connection t1="Southern Russia" t2="Eastern Russia"/>
+                <connection t1="Southern Russia" t2="Stalingrad"/>
+                <connection t1="Southern Russia" t2="Caucasus"/>
+                <connection t1="Southern Russia" t2="Ukraine"/>
+                <connection t1="Southern Russia" t2="Moscow"/>
+
+                <connection t1="Belgian Congo" t2="French Equatorial Africa"/>
+                <connection t1="Belgian Congo" t2="Anglo-Egyptian Sudan"/>
+                <connection t1="Belgian Congo" t2="Kenya-Tanganyika"/>
+                <connection t1="Belgian Congo" t2="Rhodesia"/>
+                <connection t1="Belgian Congo" t2="Angola"/>
+
+                <connection t1="Central Canada" t2="Midwestern United States"/>
+                <connection t1="Central Canada" t2="Western Canada"/>
+
+                <connection t1="Delhi" t2="Kashmir"/>
+                <connection t1="Delhi" t2="Himalaya-Tibet"/>
+                <connection t1="Delhi" t2="Bombay"/>
+                <connection t1="Delhi" t2="Calcutta"/>
+
+                <connection t1="Bombay" t2="Calcutta"/>
+
+                <connection t1="Calcutta" t2="Himalaya-Tibet"/>
+                <connection t1="Calcutta" t2="Burma"/>
+
+                <connection t1="Caucasus" t2="Stalingrad"/>
+                <connection t1="Caucasus" t2="Kazakh"/>
+                <connection t1="Caucasus" t2="Iran"/>
+
+                <connection t1="Okhotsk" t2="Eastern Siberia"/>
+                <connection t1="Okhotsk" t2="Kamchatka"/>
+                <connection t1="Okhotsk" t2="Vladivostok"/>
+                <connection t1="Okhotsk" t2="Yakutsk"/>
+                <connection t1="Okhotsk" t2="Amurskaya"/>
+
+                <connection t1="Yakutsk" t2="Southeastern Siberia"/>
+                <connection t1="Yakutsk" t2="Eastern Siberia"/>
+                <connection t1="Yakutsk" t2="Amurskaya"/>
+                <connection t1="Yakutsk" t2="Buryatia"/>
+                <connection t1="Yakutsk" t2="Siberia"/>
+
+                <connection t1="Spain" t2="Portugal"/>
+                <connection t1="Spain" t2="Gibraltar"/>
+                <connection t1="Spain" t2="Vichy France"/>
+
+                <connection t1="Afghanistan" t2="Uzbek"/>
+                <connection t1="Afghanistan" t2="Kyrgyz"/>
+                <connection t1="Afghanistan" t2="Kashmir"/>
+                <connection t1="Afghanistan" t2="Iran"/>
+
+                <connection t1="Angola" t2="Rhodesia"/>
+                <connection t1="Angola" t2="Southern Africa"/>
+
+                <connection t1="Eastern Siberia" t2="Kamchatka"/>
+                <connection t1="Eastern Siberia" t2="Siberia"/>
+
+                <connection t1="Mozambique" t2="Southern Africa"/>
+                <connection t1="Mozambique" t2="Rhodesia"/>
+                <connection t1="Mozambique" t2="Kenya-Tanganyika"/>
+
+                <connection t1="Ethiopia" t2="Kenya-Tanganyika"/>
+                <connection t1="Ethiopia" t2="Anglo-Egyptian Sudan"/>
+
+                <connection t1="Kashmir" t2="Kyrgyz"/>
+                <connection t1="Kashmir" t2="Western Sinkiang"/>
+                <connection t1="Kashmir" t2="Himalaya-Tibet"/>
+
+                <connection t1="Northern Russia" t2="Moscow"/>
+                <connection t1="Northern Russia" t2="Western Russia"/>
+                <connection t1="Northern Russia" t2="Eastern Russia"/>
+                <connection t1="Northern Russia" t2="Karelija"/>
+                <connection t1="Northern Russia" t2="Leningrad"/>
+                <connection t1="Northern Russia" t2="Novgorod"/>
+
+                <connection t1="Eastern Russia" t2="Moscow"/>
+                <connection t1="Eastern Russia" t2="Sverdlovsk"/>
+                <connection t1="Eastern Russia" t2="Kazakh"/>
+                <connection t1="Eastern Russia" t2="Stalingrad"/>
+
+                <connection t1="Hungary-Romania" t2="Austria-Czechoslovakia"/>
+                <connection t1="Hungary-Romania" t2="Western Poland"/>
+                <connection t1="Hungary-Romania" t2="Eastern Poland"/>
+                <connection t1="Hungary-Romania" t2="Ukraine"/>
+                <connection t1="Hungary-Romania" t2="Balkans"/>
+
+                <connection t1="Macedonia" t2="Balkans"/>
+
+                <connection t1="Northern Brazil" t2="Western South America"/>
+                <connection t1="Northern Brazil" t2="Northern South America"/>
+                <connection t1="Northern Brazil" t2="Southern Brazil"/>
+
+                <connection t1="Southern Brazil" t2="Southern South America"/>
+                <connection t1="Southern Brazil" t2="Western South America"/>
+
+                <connection t1="Kwangtung" t2="French Indo-China"/>
+                <connection t1="Kwangtung" t2="Szechwan"/>
+                <connection t1="Kwangtung" t2="Shantung"/>
+                <connection t1="Kwangtung" t2="Yunnan"/>
+
+                <connection t1="Western Australia" t2="Central Australia"/>
+
+                <connection t1="Northern Japan" t2="Southern Japan"/>
+
+                <connection t1="Kyrgyz" t2="Kazakh"/>
+                <connection t1="Kyrgyz" t2="Omsk"/>
+                <connection t1="Kyrgyz" t2="Novo-Sibirsk"/>
+                <connection t1="Kyrgyz" t2="Western Sinkiang"/>
+                <connection t1="Kyrgyz" t2="Uzbek"/>
+
+                <connection t1="Southeastern Siberia" t2="Siberia"/>
+                <connection t1="Southeastern Siberia" t2="Irkutsk"/>
+                <connection t1="Southeastern Siberia" t2="Southern Siberia"/>
+                <connection t1="Southeastern Siberia" t2="Buryatia"/>
+
+                <connection t1="Moscow" t2="Western Russia"/>
+
+                <connection t1="Stalingrad" t2="Kazakh"/>
+
+                <connection t1="Kansu" t2="Mongolia"/>
+                <connection t1="Kansu" t2="Szechwan"/>
+                <connection t1="Kansu" t2="Himalaya-Tibet"/>
+                <connection t1="Kansu" t2="Eastern Sinkiang"/>
+
+                <connection t1="Switzerland" t2="Western Germany"/>
+                <connection t1="Switzerland" t2="Austria-Czechoslovakia"/>
+                <connection t1="Switzerland" t2="Italy"/>
+                <connection t1="Switzerland" t2="Vichy France"/>
+
+                <connection t1="Norway" t2="Sweden"/>
+                <connection t1="Norway" t2="Finland"/>
+
+                <connection t1="Himalaya-Tibet" t2="Western Sinkiang"/>
+                <connection t1="Himalaya-Tibet" t2="Eastern Sinkiang"/>
+                <connection t1="Himalaya-Tibet" t2="Szechwan"/>
+                <connection t1="Himalaya-Tibet" t2="Burma"/>
+                <connection t1="Himalaya-Tibet" t2="Yunnan"/>
+
+                <connection t1="Finland" t2="Sweden"/>
+                <connection t1="Finland" t2="Karelija"/>
+                <connection t1="Finland" t2="Leningrad"/>
+
+                <connection t1="Syria" t2="Arabian Peninsula"/>
+                <connection t1="Syria" t2="Egypt"/>
+                <connection t1="Syria" t2="Iraq"/>
+
+                <connection t1="Iraq" t2="Iran"/>
+                <connection t1="Iraq" t2="Arabian Peninsula"/>
+
+                <connection t1="Southern Africa" t2="Rhodesia"/>
+
+                <connection t1="Shantung" t2="Mongolia"/>
+                <connection t1="Shantung" t2="Szechwan"/>
+
+                <connection t1="Kazakh" t2="Omsk"/>
+                <connection t1="Kazakh" t2="Uzbek"/>
+                <connection t1="Kazakh" t2="Sverdlovsk"/>
+
+                <connection t1="Western Germany" t2="Eastern Germany"/>
+                <connection t1="Western Germany" t2="Austria-Czechoslovakia"/>
+                <connection t1="Western Germany" t2="Vichy France"/>
+
+                <connection t1="French Indo-China" t2="Burma"/>
+                <connection t1="French Indo-China" t2="Yunnan"/>
+                <connection t1="French Indo-China" t2="Thai-Malay"/>
+
+                <connection t1="Baltic States" t2="Belorussia"/>
+                <connection t1="Baltic States" t2="Novgorod"/>
+                <connection t1="Baltic States" t2="Eastern Poland"/>
+                <connection t1="Baltic States" t2="Western Poland"/>
+
+                <connection t1="Omsk" t2="Sverdlovsk"/>
+                <connection t1="Omsk" t2="Western Siberia"/>
+                <connection t1="Omsk" t2="Novo-Sibirsk"/>
+                <connection t1="Omsk" t2="Southwestern Siberia"/>
+
+                <connection t1="Sverdlovsk" t2="Western Siberia"/>
+
+                <connection t1="Western South America" t2="Northern South America"/>
+                <connection t1="Western South America" t2="Southern South America"/>
+
+                <connection t1="Sahara" t2="Morocco"/>
+                <connection t1="Sahara" t2="Algeria"/>
+                <connection t1="Sahara" t2="Libya"/>
+                <connection t1="Sahara" t2="Anglo-Egyptian Sudan"/>
+                <connection t1="Sahara" t2="French Equatorial Africa"/>
+                <connection t1="Sahara" t2="Rio de Oro"/>
+
+                <connection t1="Novo-Sibirsk" t2="Southwestern Siberia"/>
+                <connection t1="Novo-Sibirsk" t2="Irkutsk"/>
+                <connection t1="Novo-Sibirsk" t2="Mongolia"/>
+                <connection t1="Novo-Sibirsk" t2="Western Sinkiang"/>
+                <connection t1="Novo-Sibirsk" t2="Eastern Sinkiang"/>
+
+                <connection t1="Midwestern United States" t2="Northeastern United States"/>
+                <connection t1="Midwestern United States" t2="Southern United States"/>
+                <connection t1="Midwestern United States" t2="Northwestern United States"/>
+
+                <connection t1="French Equatorial Africa" t2="Anglo-Egyptian Sudan"/>
+                <connection t1="French Equatorial Africa" t2="Guinean Coast"/>
+
+                <connection t1="Karelija" t2="Leningrad"/>
+
+                <connection t1="Burma" t2="Yunnan"/>
+                <connection t1="Burma" t2="Thai-Malay"/>
+
+                <connection t1="Uzbek" t2="Iran"/>
+
+                <connection t1="Western Siberia" t2="Siberia"/>
+                <connection t1="Western Siberia" t2="Southwestern Siberia"/>
+
+                <connection t1="Kenya-Tanganyika" t2="Rhodesia"/>
+                <connection t1="Kenya-Tanganyika" t2="Anglo-Egyptian Sudan"/>
+
+                <connection t1="Ukraine" t2="Eastern Poland"/>
+                <connection t1="Ukraine" t2="Belorussia"/>
+
+                <connection t1="Egypt" t2="Libya"/>
+                <connection t1="Egypt" t2="Anglo-Egyptian Sudan"/>
+
+                <connection t1="Southern United States" t2="Northeastern United States"/>
+                <connection t1="Southern United States" t2="Eastern Mexico"/>
+
+                <connection t1="Western Sinkiang" t2="Eastern Sinkiang"/>
+
+                <connection t1="Eastern Sinkiang" t2="Mongolia"/>
+
+                <connection t1="Algeria" t2="Morocco"/>
+                <connection t1="Algeria" t2="Libya"/>
+
+                <connection t1="Western Russia" t2="Novgorod"/>
+                <connection t1="Western Russia" t2="Belorussia"/>
+
+                <connection t1="Anglo-Egyptian Sudan" t2="Libya"/>
+
+                <connection t1="Balkans" t2="Italy"/>
+                <connection t1="Balkans" t2="Austria-Czechoslovakia"/>
+
+                <connection t1="Western Poland" t2="Eastern Poland"/>
+                <connection t1="Western Poland" t2="Austria-Czechoslovakia"/>
+                <connection t1="Western Poland" t2="Eastern Germany"/>
+
+                <connection t1="Siberia" t2="Southern Siberia"/>
+                <connection t1="Siberia" t2="Southwestern Siberia"/>
+
+                <connection t1="Southern Siberia" t2="Irkutsk"/>
+                <connection t1="Southern Siberia" t2="Southwestern Siberia"/>
+
+                <connection t1="Mongolia" t2="Irkutsk"/>
+                <connection t1="Mongolia" t2="Buryatia"/>
+
+                <connection t1="Belorussia" t2="Novgorod"/>
+                <connection t1="Belorussia" t2="Eastern Poland"/>
+
+                <connection t1="Eastern Mexico" t2="Western Mexico"/>
+                <connection t1="Eastern Mexico" t2="Central America"/>
+
+                <connection t1="Central America" t2="Northern South America"/>
+
+                <connection t1="Eastern Germany" t2="Austria-Czechoslovakia"/>
+
+                <connection t1="Szechwan" t2="Yunnan"/>
+
+                <connection t1="Southwestern Siberia" t2="Irkutsk"/>
+
+                <connection t1="Novgorod" t2="Leningrad"/>
+
+                <connection t1="Italy" t2="Vichy France"/>
+                <connection t1="Italy" t2="Austria-Czechoslovakia"/>
+
+                <connection t1="Western Canada" t2="Northwestern United States"/>
+
+                <connection t1="Vladivostok" t2="Amurskaya"/>
+
+                <connection t1="Amurskaya" t2="Buryatia"/>
+
+                <connection t1="Buryatia" t2="Irkutsk"/>
+
+
+        </map>
+
+        <resourceList>
+                <resource name="PUs"/>
+        </resourceList>
+
+        <playerList>
+                <!-- In turn order -->
+                <player name="Russians" optional="false"/>
+                <player name="Germans" optional="false"/>
+                <player name="British" optional="false"/>
+                <player name="Chinese" optional="false"/>
+                <player name="Japanese" optional="false"/>
+                <player name="Americans" optional="false"/>
+
+
+                <!-- Axis Alliances -->
+                <alliance player="Germans" alliance="Axis"/>
+                <alliance player="Japanese" alliance="Axis"/>
+
+                <!-- Allies Alliances -->
+                <alliance player="British" alliance="Allies"/>
+                <alliance player="Russians" alliance="Allies"/>
+                <alliance player="Americans" alliance="Allies"/>
+                <alliance player="Chinese" alliance="Allies"/>
+
+        </playerList>
+
+        <unitList>
+                <unit name="infantry"/>
+                <unit name="armour"/>
+                <unit name="fighter"/>
+                <unit name="bomber"/>
+                <unit name="transport"/>
+                <unit name="battleship"/>
+                <unit name="carrier"/>
+                <unit name="submarine"/>
+                <unit name="factory"/>
+                <unit name="aaGun"/>
+                <unit name="artillery"/>
+                <unit name="destroyer"/>
+                <unit name="cruiser"/>        </unitList>
+
+        <gamePlay>
+                <delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate" display="Initializing Delegates"/>
+                <delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate" display="Research Technology"/>
+                <delegate name="tech_activation" javaClass="games.strategy.triplea.delegate.TechActivationDelegate" display="Activate Technology"/>
+                <delegate name="battle" javaClass="games.strategy.triplea.delegate.BattleDelegate" display="Combat"/>
+                <delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Combat Move"/>
+                <delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Units"/>
+                <delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
+                <delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate" display="Turn Complete"/>
+                <delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
+                <delegate name="placeBid" javaClass="games.strategy.triplea.delegate.BidPlaceDelegate" display="Bid Placement"/>
+                <delegate name="bid" javaClass="games.strategy.triplea.delegate.BidPurchaseDelegate" display="Bid Purchase"/>
+                
+
+                <sequence>
+                        <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
+                        
+                        <!-- Bidding Phase -->
+			
+                        <step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
+                        <step name="russianBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
+                        
+                        <step name="germanBid" delegate="bid" player="Germans" maxRunCount="1"/>
+                        <step name="germanBidPlace" delegate="placeBid" player="Germans" maxRunCount="1"/>
+
+                        <step name="britishBid" delegate="bid" player="British" maxRunCount="1"/>
+                        <step name="britishBidPlace" delegate="placeBid" player="British" maxRunCount="1"/>
+
+                        <step name="chineseBid" delegate="bid" player="Chinese" maxRunCount="1"/>
+                        <step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
+                        
+                        <step name="japaneseBid" delegate="bid" player="Japanese" maxRunCount="1"/>
+                        <step name="japaneseBidPlace" delegate="placeBid" player="Japanese" maxRunCount="1"/>
+
+                        <step name="americanBid" delegate="bid" player="Americans" maxRunCount="1"/>
+                        <step name="americanBidPlace" delegate="placeBid" player="Americans" maxRunCount="1"/>
+
+                        
+                        
+
+                        <!-- Russians Game Sequence -->
+                        
+                        <step name="russianTech" delegate="tech" player="Russians"/>
+                        <step name="russianPurchase" delegate="purchase" player="Russians"/>
+                        <step name="russianCombatMove" delegate="move" player="Russians"/>
+                        <step name="russianBattle" delegate="battle" player="Russians"/>
+                        <step name="russianNonCombatMove" delegate="move" player="Russians" display="Non Combat Move"/>
+                        <step name="russianPlace" delegate="place" player="Russians"/>
+                        <step name="russianTechActivation" delegate="tech_activation" player="Russians"/>
+                        <step name="russianEndTurn" delegate="endTurn" player="Russians"/>
+
+                        <!-- Germans Game Sequence -->
+                        
+                        <step name="germanTech" delegate="tech" player="Germans"/>
+                        <step name="germanPurchase" delegate="purchase" player="Germans"/>
+                        <step name="germanCombatMove" delegate="move" player="Germans"/>
+                        <step name="germanBattle" delegate="battle" player="Germans"/>
+                        <step name="germanNonCombatMove" delegate="move" player="Germans" display="Non Combat Move"/>
+                        <step name="germanPlace" delegate="place" player="Germans"/>
+                        <step name="germanTechActivation" delegate="tech_activation" player="Germans"/>
+                        <step name="germanEndTurn" delegate="endTurn" player="Germans"/>
+
+                        <!-- British Game Sequence -->
+                        
+                        <step name="britishTech" delegate="tech" player="British"/>
+                        <step name="britishPurchase" delegate="purchase" player="British"/>
+                        <step name="britishCombatMove" delegate="move" player="British"/>
+                        <step name="britishBattle" delegate="battle" player="British"/>
+                        <step name="britishNonCombatMove" delegate="move" player="British" display="Non Combat Move"/>
+                        <step name="britishPlace" delegate="place" player="British"/>
+                        <step name="britishTechActivation" delegate="tech_activation" player="British"/>
+                        <step name="britishEndTurn" delegate="endTurn" player="British"/>
+
+                        <!-- Chinese Game Sequence -->
+                        
+                        <step name="chineseTech" delegate="tech" player="Chinese"/>
+                        <step name="chinesePurchase" delegate="purchase" player="Chinese"/>
+                        <step name="chineseCombatMove" delegate="move" player="Chinese"/>
+                        <step name="chineseBattle" delegate="battle" player="Chinese"/>
+                        <step name="chineseNonCombatMove" delegate="move" player="Chinese" display="Non Combat Move"/>
+                        <step name="chinesePlace" delegate="place" player="Chinese"/>
+                        <step name="chineseTechActivation" delegate="tech_activation" player="Chinese"/>
+                        <step name="chineseEndTurn" delegate="endTurn" player="Chinese"/>
+
+                        <!-- Japanese Game Sequence -->
+                        
+                        <step name="japaneseTech" delegate="tech" player="Japanese"/>
+                        <step name="japanesePurchase" delegate="purchase" player="Japanese"/>
+                        <step name="japaneseCombatMove" delegate="move" player="Japanese"/>
+                        <step name="japaneseBattle" delegate="battle" player="Japanese"/>
+                        <step name="japaneseNonCombatMove" delegate="move" player="Japanese" display="Non Combat Move"/>
+                        <step name="japanesePlace" delegate="place" player="Japanese"/>
+                        <step name="japaneseTechActivation" delegate="tech_activation" player="Japanese"/>
+                        <step name="japaneseEndTurn" delegate="endTurn" player="Japanese"/>
+
+                        <!-- Americans Game Sequence -->
+                        
+                        <step name="americanTech" delegate="tech" player="Americans"/>
+                        <step name="americanPurchase" delegate="purchase" player="Americans"/>
+                        <step name="americanCombatMove" delegate="move" player="Americans"/>
+                        <step name="americanBattle" delegate="battle" player="Americans"/>
+                        <step name="americanNonCombatMove" delegate="move" player="Americans" display="Non Combat Move"/>
+                        <step name="americanPlace" delegate="place" player="Americans"/>
+                        <step name="americanTechActivation" delegate="tech_activation" player="Americans"/>
+                        <step name="americanEndTurn" delegate="endTurn" player="Americans"/>
+                        
+                        <step name="endRoundStep" delegate="endRound"/>
+                </sequence>
+        </gamePlay>
+
+        <production>
+                <!-- Unit Production Cost -->
+                <productionRule name="buyInfantry">
+                        <cost resource="PUs" quantity="3" />
+                        <result resourceOrUnit="infantry" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyArtillery">
+                        <cost resource="PUs" quantity="4" />
+                        <result resourceOrUnit="artillery" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyArmour">
+                        <cost resource="PUs" quantity="5" />
+                        <result resourceOrUnit="armour" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyFighter">
+                        <cost resource="PUs" quantity="10" />
+                        <result resourceOrUnit="fighter" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyBomber">
+                        <cost resource="PUs" quantity="14" />
+                        <result resourceOrUnit="bomber" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyTransport">
+                        <cost resource="PUs" quantity="8" />
+                        <result resourceOrUnit="transport" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyCarrier">
+                        <cost resource="PUs" quantity="14" />
+                        <result resourceOrUnit="carrier" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyDestroyer">
+                        <cost resource="PUs" quantity="8" />
+                        <result resourceOrUnit="destroyer" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyCruiser">
+                        <cost resource="PUs" quantity="10" />
+                        <result resourceOrUnit="cruiser" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyBattleship">
+                        <cost resource="PUs" quantity="22" />
+                        <result resourceOrUnit="battleship" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySubmarine">
+                        <cost resource="PUs" quantity="8" />
+                        <result resourceOrUnit="submarine" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyFactory">
+                        <cost resource="PUs" quantity="15" />
+                        <result resourceOrUnit="factory" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyAAGun">
+                        <cost resource="PUs" quantity="5" />
+                        <result resourceOrUnit="aaGun" quantity="1"/>
+                </productionRule>
+
+                <!-- Advanced Industrial Production -->
+                <productionRule name="buyInfantryIndustrialTechnology">
+                        <cost resource="PUs" quantity="2" />
+                        <result resourceOrUnit="infantry" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyArtilleryIndustrialTechnology">
+                        <cost resource="PUs" quantity="3" />
+                        <result resourceOrUnit="artillery" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyArmourIndustrialTechnology">
+                        <cost resource="PUs" quantity="4" />
+                        <result resourceOrUnit="armour" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyFighterIndustrialTechnology">
+                        <cost resource="PUs" quantity="9" />
+                        <result resourceOrUnit="fighter" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyBomberIndustrialTechnology">
+                        <cost resource="PUs" quantity="13" />
+                        <result resourceOrUnit="bomber" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyTransportIndustrialTechnology">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="transport" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyCarrierIndustrialTechnology">
+                        <cost resource="PUs" quantity="13" />
+                        <result resourceOrUnit="carrier" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyDestroyerIndustrialTechnology">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="destroyer" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyCruiserIndustrialTechnology">
+                        <cost resource="PUs" quantity="9" />
+                        <result resourceOrUnit="cruiser" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyBattleshipIndustrialTechnology">
+                        <cost resource="PUs" quantity="21" />
+                        <result resourceOrUnit="battleship" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buySubmarineIndustrialTechnology">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="submarine" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyFactoryIndustrialTechnology">
+                        <cost resource="PUs" quantity="14" />
+                        <result resourceOrUnit="factory" quantity="1"/>
+                </productionRule>
+                
+                <productionRule name="buyAAGunIndustrialTechnology">
+                        <cost resource="PUs" quantity="4" />
+                        <result resourceOrUnit="aaGun" quantity="1"/>
+                </productionRule>
+
+                <productionFrontier name="production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                        <frontierRules name="buyArmour"/>
+                        <frontierRules name="buyFighter"/>
+                        <frontierRules name="buyBomber"/>
+                        <frontierRules name="buyTransport"/>
+                        <frontierRules name="buySubmarine"/>
+                        <frontierRules name="buyCarrier"/>
+                        <frontierRules name="buyDestroyer"/>
+                        <frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyBattleship"/>
+                        <frontierRules name="buyAAGun"/>
+                        <frontierRules name="buyFactory"/>        
+                </productionFrontier>
+                
+                <productionFrontier name="productionIndustrialTechnology">
+                        <frontierRules name="buyInfantryIndustrialTechnology"/>
+                        <frontierRules name="buyArtilleryIndustrialTechnology"/>
+                        <frontierRules name="buyArmourIndustrialTechnology"/>
+                        <frontierRules name="buyFighterIndustrialTechnology"/>
+                        <frontierRules name="buyBomberIndustrialTechnology"/>
+                        <frontierRules name="buyTransportIndustrialTechnology"/>
+                        <frontierRules name="buySubmarineIndustrialTechnology"/>
+                        <frontierRules name="buyCarrierIndustrialTechnology"/>
+                        <frontierRules name="buyDestroyerIndustrialTechnology"/>
+                        <frontierRules name="buyCruiserIndustrialTechnology"/>
+                        <frontierRules name="buyBattleshipIndustrialTechnology"/>
+                        <frontierRules name="buyAAGunIndustrialTechnology"/>
+                        <frontierRules name="buyFactoryIndustrialTechnology"/>        
+                </productionFrontier>
+
+
+                <playerProduction player="British" frontier="production"/>
+                <playerProduction player="Japanese" frontier="production"/>
+                <playerProduction player="Americans" frontier="production"/>
+                <playerProduction player="Germans" frontier="production"/>
+                <playerProduction player="Russians" frontier="production"/>
+                <playerProduction player="Chinese" frontier="production"/>
+
+        </production> 
+        
+        <attatchmentList>
+                    <attatchment name="techAttatchment" attatchTo="Germans" javaClass="games.strategy.triplea.attatchments.TechAttachment" type="player">
+                           <option name="heavyBomber" value="false"/>
+                           <option name="jetPower" value="false"/>
+                           <option name="industrialTechnology" value="false"/>
+                           <option name="superSub" value="false"/>
+                           <option name="rocket" value="false"/>
+                           <option name="longRangeAir" value="false"/>
+                    </attatchment>
+
+                    <attatchment name="techAttatchment" attatchTo="Japanese" javaClass="games.strategy.triplea.attatchments.TechAttachment" type="player">
+                           <option name="heavyBomber" value="false"/>
+                           <option name="jetPower" value="false"/>
+                           <option name="industrialTechnology" value="false"/>
+                           <option name="superSub" value="false"/>
+                           <option name="rocket" value="false"/>
+                           <option name="longRangeAir" value="false"/>
+                    </attatchment>
+
+                    <attatchment name="techAttatchment" attatchTo="Russians" javaClass="games.strategy.triplea.attatchments.TechAttachment" type="player">
+                           <option name="heavyBomber" value="false"/>
+                           <option name="jetPower" value="false"/>
+                           <option name="industrialTechnology" value="false"/>
+                           <option name="superSub" value="false"/>
+                           <option name="rocket" value="false"/>
+                           <option name="longRangeAir" value="false"/>
+                    </attatchment>
+
+                    <attatchment name="techAttatchment" attatchTo="British" javaClass="games.strategy.triplea.attatchments.TechAttachment" type="player">
+                           <option name="heavyBomber" value="false"/>
+                           <option name="jetPower" value="false"/>
+                           <option name="industrialTechnology" value="false"/>
+                           <option name="superSub" value="false"/>
+                           <option name="rocket" value="false"/>
+                           <option name="longRangeAir" value="false"/>
+                    </attatchment>
+
+                    <attatchment name="techAttatchment" attatchTo="Americans" javaClass="games.strategy.triplea.attatchments.TechAttachment" type="player">
+                           <option name="heavyBomber" value="false"/>
+                           <option name="jetPower" value="false"/>
+                           <option name="industrialTechnology" value="false"/>
+                           <option name="superSub" value="false"/>
+                           <option name="rocket" value="false"/>
+                           <option name="longRangeAir" value="false"/>
+                    </attatchment>
+
+                    <attatchment name="techAttatchment" attatchTo="Chinese" javaClass="games.strategy.triplea.attatchments.TechAttachment" type="player">
+                           <option name="heavyBomber" value="false"/>
+                           <option name="jetPower" value="false"/>
+                           <option name="industrialTechnology" value="false"/>
+                           <option name="superSub" value="false"/>
+                           <option name="rocket" value="false"/>
+                           <option name="longRangeAir" value="false"/>
+                    </attatchment>
+
+
+                    <attatchment name="unitAttatchment" attatchTo="infantry" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="movement" value="1"/>
+                         <option name="transportCost" value="2"/>
+                         <option name="attack" value="1"/>
+                         <option name="defense" value="2"/>
+                         <option name="isInfantry" value="true"/>
+                         <option name="artillerySupportable" value="true"/>
+                    </attatchment>
+            
+                    <attatchment name="unitAttatchment" attatchTo="artillery" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="movement" value="1"/>
+                         <option name="transportCost" value="3"/>
+                         <option name="attack" value="2"/>
+                         <option name="defense" value="2"/>
+                         <option name="artillery" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="unitAttatchment" attatchTo="armour" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="movement" value="2"/>
+                         <option name="transportCost" value="3"/>
+                         <option name="canBlitz" value="true"/>
+                         <option name="attack" value="3"/>
+                         <option name="defense" value="3"/>
+                    </attatchment>
+            
+                    <attatchment name="unitAttatchment" attatchTo="fighter" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="movement" value="4"/>
+                         <option name="carrierCost" value="1"/>
+                         <option name="isAir" value="true"/>   
+                         <option name="attack" value="3"/>
+                         <option name="defense" value="4"/>
+                    </attatchment>
+            
+                    <attatchment name="unitAttatchment" attatchTo="bomber" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="movement" value="6"/>
+                         <option name="isAir" value="true"/>
+                         <option name="attack" value="4"/>
+                         <option name="defense" value="1"/>
+                         <option name="isStrategicBomber" value="true"/>
+                    </attatchment>
+            
+                    <attatchment name="unitAttatchment" attatchTo="transport" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="movement" value="2"/>
+                         <option name="isSea" value="true"/>   
+                         <option name="transportCapacity" value="5"/>   
+                         <option name="attack" value="0"/>
+                         <option name="defense" value="1"/>
+                    </attatchment>
+            
+                    <attatchment name="unitAttatchment" attatchTo="battleship" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="movement" value="2"/>
+                         <option name="isSea" value="true"/>
+                         <option name="attack" value="4"/>
+                         <option name="defense" value="4"/>
+                         <option name="canBombard" value="true"/>
+                         <option name="isTwoHit" value="false"/>
+                    </attatchment>
+
+                    <attatchment name="unitAttatchment" attatchTo="destroyer" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="movement" value="2"/>
+                         <option name="isSea" value="true"/>   
+                         <option name="attack" value="2"/>
+                         <option name="defense" value="2"/>
+                         <option name="isDestroyer" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="unitAttatchment" attatchTo="cruiser" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="movement" value="2"/>
+                         <option name="isSea" value="true"/>   
+                         <option name="attack" value="3"/>
+                         <option name="defense" value="3"/>
+                    </attatchment>
+            
+                    <attatchment name="unitAttatchment" attatchTo="carrier" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="carrierCapacity" value="2"/>
+                         <option name="movement" value="2"/>
+                         <option name="isSea" value="true"/>   
+                         <option name="attack" value="1"/>
+                         <option name="defense" value="1"/>
+                    </attatchment>
+                    <attatchment name="unitAttatchment" attatchTo="submarine" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="isSub" value="true"/>
+                         <option name="movement" value="2"/>
+                         <option name="isSea" value="true"/>   
+                         <option name="attack" value="2"/>
+                         <option name="defense" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="unitAttatchment" attatchTo="factory" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="isFactory" value="true"/>   
+                    </attatchment>
+            
+                    <attatchment name="unitAttatchment" attatchTo="aaGun" javaClass="games.strategy.triplea.attatchments.UnitAttachment" type="unitType">
+                         <option name="isAA" value="true"/>   
+                         <option name="transportCost" value="3"/>
+                         <option name="movement" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Eastern Canada" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="England" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                        <option name="capital" value="British"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="France" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Southwestern United States" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="8"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Greenland" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Sumatra" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="New South Wales" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Northern Manchukuo" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Chosen" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Inner Mongolia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Alaska" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Baluchistan" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Sicily" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Archangel'sk" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western Turkey" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Eastern Turkey" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="French West Africa" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Queensland" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Southern Russia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Sakhalin Island" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Belgian Congo" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Central Canada" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Delhi" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Bombay" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Calcutta" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Ceylon" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Caucasus" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Scotland" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Okhotsk" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Yakutsk" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Spain" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Afghanistan" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassible" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Newfoundland" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Angola" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Eastern Siberia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Kamchatka" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Mozambique" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Ethiopia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Kashmir" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassible" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Northern Russia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Eastern Russia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Ireland" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Iwo Jima" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Hungary-Romania" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Macedonia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Tasmania" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Northern Brazil" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Southern Brazil" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Kwangtung" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Borneo" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western Australia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Cape Verde Islands" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Northern Japan" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Kyrgyz" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Southeastern Siberia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Moscow" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                        <option name="capital" value="Russians"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Hawaiian Islands" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Stalingrad" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Kansu" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Java" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Switzerland" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Norway" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Himalaya-Tibet" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassible" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Baffin Island" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="West Indies" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Southern Japan" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                        <option name="capital" value="Japanese"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Finland" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Syria" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Iraq" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="South Philippines" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Southern Africa" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Azores" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Madagascar" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Shantung" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Kazakh" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western Germany" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="7"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="French Indo-China" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Baltic States" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Bermuda" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Omsk" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Sverdlovsk" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western South America" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassible" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="New Zealand" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Iceland" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Sahara" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassible" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Novo-Sibirsk" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Midwestern United States" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="8"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Gibraltar" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="French Equatorial Africa" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Midway Island" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Portugal" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Fiji" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Karelija" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Solomon Islands" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Burma" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Thai-Malay" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Rio de Oro" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western Aleutian Islands" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Eastern Aleutian Islands" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Uzbek" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western Siberia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Kenya-Tanganyika" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Ukraine" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Egypt" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Southern United States" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Iran" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Northeastern United States" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="8"/>
+                        <option name="capital" value="Americans"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western Sinkiang" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="capital" value="Chinese"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Eastern Sinkiang" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Rhodesia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Algeria" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Southern South America" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western Russia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Anglo-Egyptian Sudan" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Marshall Islands" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="North Philippines" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Balkans" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Central Australia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Cuba" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Guinean Coast" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western Poland" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Sweden" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Siberia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassible" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Southern Siberia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Libya" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Mongolia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassible" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Arabian Peninsula" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Belorussia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Eastern Mexico" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Central America" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Eastern Germany" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="7"/>
+                        <option name="capital" value="Germans"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Wake" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="New Guinea" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Szechwan" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Yunnan" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Guam" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Southwestern Siberia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Okinawa" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Novgorod" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Leningrad" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Italy" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western Mexico" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Western Canada" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Vichy France" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Morocco" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Vladivostok" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Amurskaya" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Buryatia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Austria-Czechoslovakia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="5"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Sardinia" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Northwestern United States" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Irkutsk" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Celebes" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Novaya-Zemlya" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Northern South America" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attatchment>
+
+                    <attatchment name="territoryAttatchment" attatchTo="Eastern Poland" javaClass="games.strategy.triplea.attatchments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="true"/>
+                    </attatchment>
+
+			<!-- Canals -->
+			<attatchment name="canalAttatchment" attatchTo="SZ 27 Aegean Sea" javaClass="games.strategy.triplea.attatchments.CanalAttachment" type="territory">
+				<option name="canalName" value="Dardanelles"/>
+				<option name="landTerritories" value="Western Turkey"/>
+			</attatchment>
+
+			<attatchment name="canalAttatchment" attatchTo="SZ 29 Black Sea" javaClass="games.strategy.triplea.attatchments.CanalAttachment" type="territory">
+				<option name="canalName" value="Dardanelles"/>
+				<option name="landTerritories" value="Western Turkey"/>
+			</attatchment>
+
+			<attatchment name="canalAttatchment" attatchTo="SZ 28 Eastern Mediterranean" javaClass="games.strategy.triplea.attatchments.CanalAttachment" type="territory">
+				<option name="canalName" value="Suez Canal"/>
+				<option name="landTerritories" value="Egypt:Syria"/>
+			</attatchment>
+
+			<attatchment name="canalAttatchment" attatchTo="SZ 55 Red Sea" javaClass="games.strategy.triplea.attatchments.CanalAttachment" type="territory">
+				<option name="canalName" value="Suez Canal"/>
+				<option name="landTerritories" value="Egypt:Syria"/>
+			</attatchment>
+
+			<attatchment name="canalAttatchment" attatchTo="SZ 36 East Pacific" javaClass="games.strategy.triplea.attatchments.CanalAttachment" type="territory">
+				<option name="canalName" value="Panama Canal"/>
+				<option name="landTerritories" value="Central America"/>
+			</attatchment>
+
+			<attatchment name="canalAttatchment" attatchTo="SZ 37 Caribbean Sea" javaClass="games.strategy.triplea.attatchments.CanalAttachment" type="territory">
+				<option name="canalName" value="Panama Canal"/>
+				<option name="landTerritories" value="Central America"/>
+			</attatchment>
+
+
+        </attatchmentList>
+        
+        <initialize>
+                <ownerInitialize>
+                        <!-- Russians Owned Territories -->
+                        <territoryOwner territory="Archangel'sk" owner="Russians"/>
+                        <territoryOwner territory="Caucasus" owner="Russians"/>
+                        <territoryOwner territory="Okhotsk" owner="Russians"/>
+                        <territoryOwner territory="Yakutsk" owner="Russians"/>
+                        <territoryOwner territory="Eastern Siberia" owner="Russians"/>
+                        <territoryOwner territory="Kamchatka" owner="Russians"/>
+                        <territoryOwner territory="Northern Russia" owner="Russians"/>
+                        <territoryOwner territory="Eastern Russia" owner="Russians"/>
+                        <territoryOwner territory="Kyrgyz" owner="Russians"/>
+                        <territoryOwner territory="Southeastern Siberia" owner="Russians"/>
+                        <territoryOwner territory="Moscow" owner="Russians"/>
+                        <territoryOwner territory="Stalingrad" owner="Russians"/>
+                        <territoryOwner territory="Kazakh" owner="Russians"/>
+                        <territoryOwner territory="Omsk" owner="Russians"/>
+                        <territoryOwner territory="Sverdlovsk" owner="Russians"/>
+                        <territoryOwner territory="Novo-Sibirsk" owner="Russians"/>
+                        <territoryOwner territory="Karelija" owner="Russians"/>
+                        <territoryOwner territory="Uzbek" owner="Russians"/>
+                        <territoryOwner territory="Western Siberia" owner="Russians"/>
+                        <territoryOwner territory="Southern Siberia" owner="Russians"/>
+                        <territoryOwner territory="Southwestern Siberia" owner="Russians"/>
+                        <territoryOwner territory="Leningrad" owner="Russians"/>
+                        <territoryOwner territory="Vladivostok" owner="Russians"/>
+                        <territoryOwner territory="Amurskaya" owner="Russians"/>
+                        <territoryOwner territory="Buryatia" owner="Russians"/>
+                        <territoryOwner territory="Irkutsk" owner="Russians"/>
+                        <territoryOwner territory="Novaya-Zemlya" owner="Russians"/>
+
+                        <!-- Germans Owned Territories -->
+                        <territoryOwner territory="France" owner="Germans"/>
+                        <territoryOwner territory="Sicily" owner="Germans"/>
+                        <territoryOwner territory="Southern Russia" owner="Germans"/>
+                        <territoryOwner territory="Hungary-Romania" owner="Germans"/>
+                        <territoryOwner territory="Macedonia" owner="Germans"/>
+                        <territoryOwner territory="Norway" owner="Germans"/>
+                        <territoryOwner territory="Finland" owner="Germans"/>
+                        <territoryOwner territory="Western Germany" owner="Germans"/>
+                        <territoryOwner territory="Baltic States" owner="Germans"/>
+                        <territoryOwner territory="Ukraine" owner="Germans"/>
+                        <territoryOwner territory="Algeria" owner="Germans"/>
+                        <territoryOwner territory="Western Russia" owner="Germans"/>
+                        <territoryOwner territory="Balkans" owner="Germans"/>
+                        <territoryOwner territory="Western Poland" owner="Germans"/>
+                        <territoryOwner territory="Belorussia" owner="Germans"/>
+                        <territoryOwner territory="Eastern Germany" owner="Germans"/>
+                        <territoryOwner territory="Novgorod" owner="Germans"/>
+                        <territoryOwner territory="Italy" owner="Germans"/>
+                        <territoryOwner territory="Vichy France" owner="Germans"/>
+                        <territoryOwner territory="Morocco" owner="Germans"/>
+                        <territoryOwner territory="Austria-Czechoslovakia" owner="Germans"/>
+                        <territoryOwner territory="Sardinia" owner="Germans"/>
+                        <territoryOwner territory="Eastern Poland" owner="Germans"/>
+
+                        <!-- British Owned Territories -->
+                        <territoryOwner territory="Eastern Canada" owner="British"/>
+                        <territoryOwner territory="England" owner="British"/>
+                        <territoryOwner territory="New South Wales" owner="British"/>
+                        <territoryOwner territory="Baluchistan" owner="British"/>
+                        <territoryOwner territory="French West Africa" owner="British"/>
+                        <territoryOwner territory="Queensland" owner="British"/>
+                        <territoryOwner territory="Belgian Congo" owner="British"/>
+                        <territoryOwner territory="Central Canada" owner="British"/>
+                        <territoryOwner territory="Delhi" owner="British"/>
+                        <territoryOwner territory="Bombay" owner="British"/>
+                        <territoryOwner territory="Calcutta" owner="British"/>
+                        <territoryOwner territory="Ceylon" owner="British"/>
+                        <territoryOwner territory="Scotland" owner="British"/>
+                        <territoryOwner territory="Newfoundland" owner="British"/>
+                        <territoryOwner territory="Ethiopia" owner="British"/>
+                        <territoryOwner territory="Tasmania" owner="British"/>
+                        <territoryOwner territory="Western Australia" owner="British"/>
+                        <territoryOwner territory="Baffin Island" owner="British"/>
+                        <territoryOwner territory="Syria" owner="British"/>
+                        <territoryOwner territory="Iraq" owner="British"/>
+                        <territoryOwner territory="Southern Africa" owner="British"/>
+                        <territoryOwner territory="Madagascar" owner="British"/>
+                        <territoryOwner territory="Bermuda" owner="British"/>
+                        <territoryOwner territory="New Zealand" owner="British"/>
+                        <territoryOwner territory="Gibraltar" owner="British"/>
+                        <territoryOwner territory="French Equatorial Africa" owner="British"/>
+                        <territoryOwner territory="Burma" owner="British"/>
+                        <territoryOwner territory="Kenya-Tanganyika" owner="British"/>
+                        <territoryOwner territory="Egypt" owner="British"/>
+                        <territoryOwner territory="Iran" owner="British"/>
+                        <territoryOwner territory="Rhodesia" owner="British"/>
+                        <territoryOwner territory="Anglo-Egyptian Sudan" owner="British"/>
+                        <territoryOwner territory="Central Australia" owner="British"/>
+                        <territoryOwner territory="Guinean Coast" owner="British"/>
+                        <territoryOwner territory="Libya" owner="British"/>
+                        <territoryOwner territory="Western Canada" owner="British"/>
+
+                        <!-- Japanese Owned Territories -->
+                        <territoryOwner territory="Sumatra" owner="Japanese"/>
+                        <territoryOwner territory="Northern Manchukuo" owner="Japanese"/>
+                        <territoryOwner territory="Chosen" owner="Japanese"/>
+                        <territoryOwner territory="Sakhalin Island" owner="Japanese"/>
+                        <territoryOwner territory="Iwo Jima" owner="Japanese"/>
+                        <territoryOwner territory="Kwangtung" owner="Japanese"/>
+                        <territoryOwner territory="Borneo" owner="Japanese"/>
+                        <territoryOwner territory="Northern Japan" owner="Japanese"/>
+                        <territoryOwner territory="Java" owner="Japanese"/>
+                        <territoryOwner territory="Southern Japan" owner="Japanese"/>
+                        <territoryOwner territory="South Philippines" owner="Japanese"/>
+                        <territoryOwner territory="Shantung" owner="Japanese"/>
+                        <territoryOwner territory="French Indo-China" owner="Japanese"/>
+                        <territoryOwner territory="Solomon Islands" owner="Japanese"/>
+                        <territoryOwner territory="Thai-Malay" owner="Japanese"/>
+                        <territoryOwner territory="Western Aleutian Islands" owner="Japanese"/>
+                        <territoryOwner territory="Marshall Islands" owner="Japanese"/>
+                        <territoryOwner territory="North Philippines" owner="Japanese"/>
+                        <territoryOwner territory="Wake" owner="Japanese"/>
+                        <territoryOwner territory="New Guinea" owner="Japanese"/>
+                        <territoryOwner territory="Guam" owner="Japanese"/>
+                        <territoryOwner territory="Okinawa" owner="Japanese"/>
+                        <territoryOwner territory="Celebes" owner="Japanese"/>
+
+                        <!-- Americans Owned Territories -->
+                        <territoryOwner territory="Southwestern United States" owner="Americans"/>
+                        <territoryOwner territory="Greenland" owner="Americans"/>
+                        <territoryOwner territory="Alaska" owner="Americans"/>
+                        <territoryOwner territory="Northern Brazil" owner="Americans"/>
+                        <territoryOwner territory="Southern Brazil" owner="Americans"/>
+                        <territoryOwner territory="Hawaiian Islands" owner="Americans"/>
+                        <territoryOwner territory="West Indies" owner="Americans"/>
+                        <territoryOwner territory="Iceland" owner="Americans"/>
+                        <territoryOwner territory="Midwestern United States" owner="Americans"/>
+                        <territoryOwner territory="Midway Island" owner="Americans"/>
+                        <territoryOwner territory="Fiji" owner="Americans"/>
+                        <territoryOwner territory="Eastern Aleutian Islands" owner="Americans"/>
+                        <territoryOwner territory="Southern United States" owner="Americans"/>
+                        <territoryOwner territory="Northeastern United States" owner="Americans"/>
+                        <territoryOwner territory="Cuba" owner="Americans"/>
+                        <territoryOwner territory="Eastern Mexico" owner="Americans"/>
+                        <territoryOwner territory="Central America" owner="Americans"/>
+                        <territoryOwner territory="Western Mexico" owner="Americans"/>
+                        <territoryOwner territory="Northwestern United States" owner="Americans"/>
+
+                        <!-- Chinese Owned Territories -->
+                        <territoryOwner territory="Inner Mongolia" owner="Chinese"/>
+                        <territoryOwner territory="Kansu" owner="Chinese"/>
+                        <territoryOwner territory="Western Sinkiang" owner="Chinese"/>
+                        <territoryOwner territory="Eastern Sinkiang" owner="Chinese"/>
+                        <territoryOwner territory="Szechwan" owner="Chinese"/>
+                        <territoryOwner territory="Yunnan" owner="Chinese"/>
+
+
+                </ownerInitialize>
+
+                <unitInitialize>
+                        <!-- Russians  Unit Placements -->
+                        <unitPlacement unitType="transport" territory="SZ 7 Barents Sea" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="submarine" territory="SZ 7 Barents Sea" quantity="1" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Archangel'sk" quantity="2" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Caucasus" quantity="2" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Okhotsk" quantity="2" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Yakutsk" quantity="1" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Kamchatka" quantity="1" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Northern Russia" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="armour" territory="Northern Russia" quantity="2" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Eastern Russia" quantity="3" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Kyrgyz" quantity="1" owner="Russians"/>
+
+                        <unitPlacement unitType="factory" territory="Moscow" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Moscow" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Moscow" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="artillery" territory="Moscow" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="armour" territory="Moscow" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="fighter" territory="Moscow" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="bomber" territory="Moscow" quantity="1" owner="Russians"/>
+
+                        <unitPlacement unitType="factory" territory="Stalingrad" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Stalingrad" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Stalingrad" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="artillery" territory="Stalingrad" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="armour" territory="Stalingrad" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="fighter" territory="Stalingrad" quantity="1" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Kazakh" quantity="3" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Omsk" quantity="2" owner="Russians"/>
+
+                        <unitPlacement unitType="factory" territory="Sverdlovsk" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Sverdlovsk" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="artillery" territory="Sverdlovsk" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="armour" territory="Sverdlovsk" quantity="1" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Novo-Sibirsk" quantity="2" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Karelija" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="fighter" territory="Karelija" quantity="1" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Uzbek" quantity="2" owner="Russians"/>
+
+                        <unitPlacement unitType="factory" territory="Leningrad" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Leningrad" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Leningrad" quantity="3" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Vladivostok" quantity="3" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Amurskaya" quantity="2" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Buryatia" quantity="1" owner="Russians"/>
+
+                        <unitPlacement unitType="infantry" territory="Irkutsk" quantity="1" owner="Russians"/>
+
+
+
+                        <!-- Germans  Unit Placements -->
+                        <unitPlacement unitType="submarine" territory="SZ 6 Norwegian Sea" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 11 West Baltic Sea" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="submarine" territory="SZ 11 West Baltic Sea" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="cruiser" territory="SZ 11 West Baltic Sea" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 12 East Baltic Sea" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="cruiser" territory="SZ 12 East Baltic Sea" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="submarine" territory="SZ 19 Atlantic" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="submarine" territory="SZ 20 Atlantic" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="submarine" territory="SZ 24 Tyrrhenian Sea" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="battleship" territory="SZ 24 Tyrrhenian Sea" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 25 Adriatic Sea" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="submarine" territory="SZ 32 Atlantic" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="submarine" territory="SZ 33 Atlantic" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="submarine" territory="SZ 39 Mid Atlantic" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="aaGun" territory="France" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="France" quantity="4" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="France" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="France" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="France" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Southern Russia" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Southern Russia" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Southern Russia" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Southern Russia" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Hungary-Romania" quantity="2" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Macedonia" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Macedonia" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Norway" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Norway" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Finland" quantity="2" owner="Germans"/>
+
+                        <unitPlacement unitType="factory" territory="Western Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="aaGun" territory="Western Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Western Germany" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Western Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Western Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Western Germany" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Baltic States" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Baltic States" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="bomber" territory="Baltic States" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Ukraine" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Ukraine" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Algeria" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Algeria" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Western Russia" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Western Russia" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Western Russia" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Balkans" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Balkans" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Western Poland" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Western Poland" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Belorussia" quantity="4" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Belorussia" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Belorussia" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="factory" territory="Eastern Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="aaGun" territory="Eastern Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Eastern Germany" quantity="5" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Eastern Germany" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Eastern Germany" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Eastern Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="bomber" territory="Eastern Germany" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Novgorod" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Novgorod" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="factory" territory="Italy" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="aaGun" territory="Italy" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Italy" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Italy" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Italy" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Italy" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Vichy France" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Morocco" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Morocco" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Morocco" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Austria-Czechoslovakia" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Austria-Czechoslovakia" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Sardinia" quantity="1" owner="Germans"/>
+
+                        <unitPlacement unitType="infantry" territory="Eastern Poland" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Eastern Poland" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Eastern Poland" quantity="1" owner="Germans"/>
+
+
+
+                        <!-- British  Unit Placements -->
+                        <unitPlacement unitType="transport" territory="SZ 2 Labrador Sea" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 9 North Atlantic" quantity="1" owner="British"/>
+                        <unitPlacement unitType="submarine" territory="SZ 9 North Atlantic" quantity="1" owner="British"/>
+                        <unitPlacement unitType="battleship" territory="SZ 9 North Atlantic" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="submarine" territory="SZ 10 North Sea" quantity="1" owner="British"/>
+                        <unitPlacement unitType="cruiser" territory="SZ 10 North Sea" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 16 North Atlantic" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="SZ 16 North Atlantic" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="submarine" territory="SZ 17 English Channel" quantity="1" owner="British"/>
+                        <unitPlacement unitType="cruiser" territory="SZ 17 English Channel" quantity="1" owner="British"/>
+                        <unitPlacement unitType="battleship" territory="SZ 17 English Channel" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="battleship" territory="SZ 23 West Mediterranean" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 28 Eastern Mediterranean" quantity="1" owner="British"/>
+                        <unitPlacement unitType="cruiser" territory="SZ 28 Eastern Mediterranean" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="fighter" territory="SZ 57 Arabian Sea" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="SZ 57 Arabian Sea" quantity="1" owner="British"/>
+                        <unitPlacement unitType="carrier" territory="SZ 57 Arabian Sea" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="submarine" territory="SZ 59 Northeastern Indian" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 105 Tasman Sea" quantity="1" owner="British"/>
+                        <unitPlacement unitType="cruiser" territory="SZ 105 Tasman Sea" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="factory" territory="Eastern Canada" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Eastern Canada" quantity="2" owner="British"/>
+                        <unitPlacement unitType="armour" territory="Eastern Canada" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="factory" territory="England" quantity="1" owner="British"/>
+                        <unitPlacement unitType="aaGun" territory="England" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="England" quantity="4" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="England" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="England" quantity="1" owner="British"/>
+                        <unitPlacement unitType="bomber" territory="England" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="factory" territory="New South Wales" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="New South Wales" quantity="1" owner="British"/>
+                        <unitPlacement unitType="armour" territory="New South Wales" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Baluchistan" quantity="2" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Queensland" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Central Canada" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Delhi" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="factory" territory="Bombay" quantity="1" owner="British"/>
+                        <unitPlacement unitType="aaGun" territory="Bombay" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Bombay" quantity="1" owner="British"/>
+                        <unitPlacement unitType="armour" territory="Bombay" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Calcutta" quantity="1" owner="British"/>
+                        <unitPlacement unitType="armour" territory="Calcutta" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="factory" territory="Scotland" quantity="1" owner="British"/>
+                        <unitPlacement unitType="aaGun" territory="Scotland" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Scotland" quantity="2" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="Scotland" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Ethiopia" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Western Australia" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Syria" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Iraq" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Southern Africa" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="New Zealand" quantity="2" owner="British"/>
+
+                        <unitPlacement unitType="aaGun" territory="Gibraltar" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Gibraltar" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="Gibraltar" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Burma" quantity="2" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Egypt" quantity="1" owner="British"/>
+                        <unitPlacement unitType="armour" territory="Egypt" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="Egypt" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Iran" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Rhodesia" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Libya" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Western Canada" quantity="1" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="Western Canada" quantity="1" owner="British"/>
+
+
+
+                        <!-- Japanese  Unit Placements -->
+                        <unitPlacement unitType="transport" territory="SZ 71 South China Sea" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="destroyer" territory="SZ 71 South China Sea" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="fighter" territory="SZ 72 South China Sea" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="transport" territory="SZ 72 South China Sea" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="SZ 72 South China Sea" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="battleship" territory="SZ 72 South China Sea" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 73 East China Sea" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="destroyer" territory="SZ 73 East China Sea" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="cruiser" territory="SZ 73 East China Sea" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 80 Northwest Pacific" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="fighter" territory="SZ 87 West Pacific" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="submarine" territory="SZ 87 West Pacific" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="SZ 87 West Pacific" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="battleship" territory="SZ 87 West Pacific" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="fighter" territory="SZ 99 West Pacific" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="submarine" territory="SZ 99 West Pacific" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="SZ 99 West Pacific" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Sumatra" quantity="2" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Northern Manchukuo" quantity="2" owner="Japanese"/>
+
+                        <unitPlacement unitType="factory" territory="Chosen" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Chosen" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Chosen" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Sakhalin Island" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Iwo Jima" quantity="3" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Kwangtung" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="armour" territory="Kwangtung" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Kwangtung" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Borneo" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="factory" territory="Northern Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="aaGun" territory="Northern Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Northern Japan" quantity="4" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Java" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="factory" territory="Southern Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="aaGun" territory="Southern Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Southern Japan" quantity="5" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="Southern Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="armour" territory="Southern Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="bomber" territory="Southern Japan" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="South Philippines" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Shantung" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="Shantung" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="French Indo-China" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="French Indo-China" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Solomon Islands" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Thai-Malay" quantity="2" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Western Aleutian Islands" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Marshall Islands" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="North Philippines" quantity="2" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Wake" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="New Guinea" quantity="2" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Guam" quantity="2" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Okinawa" quantity="2" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Celebes" quantity="2" owner="Japanese"/>
+
+
+
+                        <!-- Americans  Unit Placements -->
+                        <unitPlacement unitType="transport" territory="SZ 18 West Atlantic" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="SZ 18 West Atlantic" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="cruiser" territory="SZ 18 West Atlantic" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="cruiser" territory="SZ 37 Caribbean Sea" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="fighter" territory="SZ 88 Pacific" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="SZ 88 Pacific" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="submarine" territory="SZ 88 Pacific" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="cruiser" territory="SZ 88 Pacific" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="carrier" territory="SZ 88 Pacific" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 91 East Pacific" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 95 Pacific" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="SZ 95 Pacific" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="battleship" territory="SZ 96 Pacific" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="transport" territory="SZ 100 Pacific" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="cruiser" territory="SZ 100 Pacific" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="factory" territory="Southwestern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="aaGun" territory="Southwestern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Southwestern United States" quantity="2" owner="Americans"/>
+
+                        <unitPlacement unitType="infantry" territory="Alaska" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="factory" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="fighter" territory="Iceland" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="factory" territory="Midwestern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="artillery" territory="Midwestern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="armour" territory="Midwestern United States" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="infantry" territory="Midway Island" quantity="2" owner="Americans"/>
+
+                        <unitPlacement unitType="infantry" territory="Fiji" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="artillery" territory="Fiji" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="infantry" territory="Southern United States" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="factory" territory="Northeastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="aaGun" territory="Northeastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Northeastern United States" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="armour" territory="Northeastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="bomber" territory="Northeastern United States" quantity="2" owner="Americans"/>
+
+                        <unitPlacement unitType="infantry" territory="Central America" quantity="1" owner="Americans"/>
+
+                        <unitPlacement unitType="infantry" territory="Northwestern United States" quantity="1" owner="Americans"/>
+
+
+
+                        <!-- Chinese  Unit Placements -->
+                        <unitPlacement unitType="infantry" territory="Inner Mongolia" quantity="1" owner="Chinese"/>
+
+                        <unitPlacement unitType="factory" territory="Kansu" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Kansu" quantity="1" owner="Chinese"/>
+
+                        <unitPlacement unitType="factory" territory="Western Sinkiang" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Western Sinkiang" quantity="2" owner="Chinese"/>
+
+                        <unitPlacement unitType="infantry" territory="Eastern Sinkiang" quantity="2" owner="Chinese"/>
+
+                        <unitPlacement unitType="infantry" territory="Szechwan" quantity="1" owner="Chinese"/>
+
+                        <unitPlacement unitType="infantry" territory="Yunnan" quantity="2" owner="Chinese"/>
+                        <unitPlacement unitType="fighter" territory="Yunnan" quantity="1" owner="Chinese"/>
+
+
+
+                        <!-- Neutral  Unit Placements -->
+                        <unitPlacement unitType="infantry" territory="Western Turkey" quantity="8"/>
+
+                        <unitPlacement unitType="infantry" territory="Eastern Turkey" quantity="5"/>
+
+                        <unitPlacement unitType="aaGun" territory="Spain" quantity="1"/>
+                        <unitPlacement unitType="infantry" territory="Spain" quantity="8"/>
+
+                        <unitPlacement unitType="infantry" territory="Angola" quantity="1"/>
+
+                        <unitPlacement unitType="infantry" territory="Mozambique" quantity="1"/>
+
+                        <unitPlacement unitType="infantry" territory="Ireland" quantity="3"/>
+
+                        <unitPlacement unitType="infantry" territory="Cape Verde Islands" quantity="2"/>
+
+                        <unitPlacement unitType="infantry" territory="Switzerland" quantity="9"/>
+
+                        <unitPlacement unitType="infantry" territory="Azores" quantity="2"/>
+
+                        <unitPlacement unitType="infantry" territory="Portugal" quantity="5"/>
+
+                        <unitPlacement unitType="infantry" territory="Rio de Oro" quantity="1"/>
+
+                        <unitPlacement unitType="infantry" territory="Southern South America" quantity="1"/>
+
+                        <unitPlacement unitType="infantry" territory="Sweden" quantity="5"/>
+
+                        <unitPlacement unitType="infantry" territory="Northern South America" quantity="1"/>
+
+
+
+
+                </unitInitialize>
+        
+                <resourceInitialize>
+                        <resourceGiven player="British" resource="PUs" quantity="40"/>
+                        <resourceGiven player="Americans" resource="PUs" quantity="50"/>
+                        <resourceGiven player="Japanese" resource="PUs" quantity="41"/>
+                        <resourceGiven player="Chinese" resource="PUs" quantity="10"/>
+                        <resourceGiven player="Russians" resource="PUs" quantity="34"/>
+                        <resourceGiven player="Germans" resource="PUs" quantity="60"/>
+
+                </resourceInitialize>
+        </initialize>
+
+        <propertyList>
+		
+				<!-- Bids -->
+				<property name="Germans bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+                
+                <property name="Japanese bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Americans bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="British bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Russians bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Chinese bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+		<property name="Projection of Power" value="false" editable="true">
+			<boolean/>
+		</property>
+
+		<property name="Axis Projection of Power VCs" value="14" editable="false">
+			<number min="13" max="21"/>
+		</property>
+
+		<property name="Allies Projection of Power VCs" value="14" editable="false">
+			<number min="13" max="21"/>
+		</property>
+
+		<property name="Honorable Surrender" value="false" editable="true">
+			<boolean/>
+		</property>
+
+		<property name="Axis Honorable Victory VCs" value="15" editable="false">
+			<number min="13" max="21"/>
+		</property>
+
+		<property name="Allies Honorable Victory VCs" value="15" editable="false">
+			<number min="13" max="21"/>
+		</property>
+
+		<property name="Total Victory" value="true" editable="true">
+			<boolean/>
+		</property>
+
+		<property name="Axis Total Victory VCs" value="17" editable="false">
+			<number min="13" max="21"/>
+		</property>
+
+		<property name="Allies Total Victory VCs" value="17" editable="false">
+			<number min="13" max="21"/>
+		</property>
+        
+				<!-- Low Luck -->
+
+                <property name="Low Luck" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+				<property name="Low Luck for AntiAircraft" value="false" editable="true">
+						<boolean/>
+				</property>
+
+				<property name="Low Luck for Technology" value="false" editable="true">
+						<boolean/>
+				</property>
+
+				<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+						<boolean/>
+				</property>
+                
+				<property name="Tech Development" value="true" editable="true">
+                        <boolean/>
+                </property>
+				
+				<property name="Heavy Bomber Dice Rolls" value="2" editable="false">
+                        <number min="2" max="3"/>
+                </property>
+
+                <property name="LHTR Heavy Bombers" value="true" editable="true">
+                	  <boolean/>
+                </property>
+				
+				<property name="Territory Turn Limit" value="true" editable="true">
+                        <boolean/>
+                </property>
+				
+				<property name="Super Sub Defence Bonus" value="0" editable="true">
+					<number min="0" max="1"/>
+                </property>
+
+                <property name="Always on AA" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Battleships repair at end of round" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+				<property name="Battleships repair at beginning of round" value="false" editable="true">
+						<boolean/>
+				</property>
+
+                <!-- Use WW2V2 Rules -->
+
+				<property name="WW2V2" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Submersible Subs" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                
+
+                <property name="Two hit battleship" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Produce fighters on carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Move existing fighters to new carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="LHTR Carrier production rules" value="false" editable="true">
+					<boolean/>
+                </property>
+				
+				<property name="Produce new fighters on old carriers" value="false" editable="false">
+					<boolean/>
+				</property>
+
+				<property name="Land existing fighters on new carriers" value="false" editable="false">
+						<boolean/>
+				</property>
+				
+                <property name="Allied Air Dependents" value="true" editable="false">
+					<boolean/>
+				</property>
+				
+				<property name="neutralCharge" value="0"/>
+
+                <property name="maxFactoriesPerTerritory" value="1"/>
+
+				<property name="Kamikaze Airplanes" value="false" editable="true">
+					<boolean/>
+				</property>
+
+				<property name="Neutrals Are Blitzable" value="false" editable="true">
+						<boolean/>
+				</property>
+
+				<property name="Neutral Flyover Allowed" value="false" editable="true">
+						<boolean/>
+				</property>
+				
+				
+				<property name="mapName" value="big_world" editable="false"/>
+
+				<property name="notes">
+					<value>
+					<![CDATA[  
+					                <!-- Map Name: also used for map utils when asked -->
+               
+				
+				A scenario loosely based on the year 1942 of the global conflict of 1939-1945. In Europe, 
+				Germany has Leningrad besieged, <br>stands at the gates of Moscow and the verge of defeat 
+				at Stalingrad (Dec 1942). In the Pacific, Japan has expanded <br>explosively but faces the 
+				turning point at Midway (May 1942). 
+				
+				<br><br>
+				Standard TripleA 'WW2V2' + 'LHTR' bomber rules apply. 
+				However, there are also variant rules to consider.<br>Also 'LHTR' 
+				delayed tech activation is applied.<br>
+				<h2>Capitols</h2>
+				The capitols of the world powers are as follows: <br>  Russia - Moscow <br>  Germany - Eastern Germany <br> 
+				 Britain - England <br>  China - Western Sinkiang <br>  Japan - Southern Japan <br> 
+				  USA - Northeastern United States <br>
+				  
+				  <h2>Unit definitions</h2>Units have been revised in an 
+				  effort to bring better balance to the naval cost structure. This
+				   <br>includes the addition of a Cruiser unit, and downgrading of the Destroyer.
+				    Please note that with this change the Destroyer Bombard tech should be 
+				    replaced with a Cruiser Bombard tech, but as of this writing (2005-05-01)
+				     the required code changes have not been made. <br><br>Unit definitions (attack, defend, PU cost)<br> 
+				      infantry:   1, 2, 3 (special: artillery enhances attack to 2)<br>  artillery:  2, 2, 4
+				       (special: enhances infantry)<br>  armour:     3, 3, 5<br>  fighter:    3, 4, 10<br>  
+				       bomber:     4, 1, 14 (special: SBR)<br>  submarine:  2, 2, 8 (special: submerge, sneak attack)<br> 
+				        destroyer:  2, 2, 8 (special: ASW [subs cannot submerge, no sneak attack])<br>  cruiser:   
+				         3, 3, 10<br>  carrier:    1, 1, 14 (special: 2 fighters may land on a carrier)<br>  battleship:
+				          4, 4, 22 (special: 2 hits [same turn] to destroy, can shore bombard)<br>
+				
+				<br>
+				<br>Victory Conditions:
+				<br>Until Surrender, or
+				<br>Total Victory: 17 victory cities
+				<br>Honorable Surrender: 15 victory cities
+				<br>Projection of Power: 14 victory cities
+				<br>
+				<br>Notable changes since version 2.4:
+				<br>Iwo Gima, Guam, and Wake are now worth 1 pu each (and Japan starts with 3 more pu's).
+				<br>Addition of relief tiles, flags, victory cities, and other minor corrections to the xml.
+				
+					]]>	
+					</value>
+				</property>
+
+
+
+        </propertyList>
+</game>
+


### PR DESCRIPTION
Secondly, make a copy paste of the big world map data in "maps" and move it to "test_data", then update the two tests that used the "maps" version rather than a test version.

The code for finding maps can take a lot of branches, depends on if you run from IDE, ant, gradle, or which packaged version of the game. In addition the test and prod search paths for map data are mixed together. In the test case we find we are running from a class file and assume we are running from ant. In that case all we need to do is ascend up enough directories to get out of the packages and then plus a fixed amount. For gradle this is not enough, the compiled classes are nested a bit deeper.

To fix this, instead of having GameRunner2 tell us what the root folder is, and then from there try to find parent folders with a map file in it, we instead ask GameRunner2 to find us a file and give it a list of potential parent folders. The method that looks at both test and prod paths has been deprecated so we can migrate away from it (so eventually the list woudl perhaps become a scalar). Secondly, GameRunner2 now has different behavior in the finding files in the case of finding relative to a class file (as opposed to relative to a jar). Instead of going up enough directories to match the packages plus one, instead we are given a folder and file, and we keep ascending directories until we find that folder containing the file. This works in both the ant and gradle cases.

Lastly, some extract method was done on GameRunner2, so there is some additional refactoring that was done to clean up the methods so that this change would be clear and make sense. So one can expect some extracted methods in the diff.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/101)
<!-- Reviewable:end -->
