### PR TITLE
Replace custom threadpool with ExecutorService

### DIFF
--- a/src/games/strategy/engine/message/UnifiedMessenger.java
+++ b/src/games/strategy/engine/message/UnifiedMessenger.java
@@ -366,10 +366,6 @@ public class UnifiedMessenger {
     }
   }
 
-//  public void waitForAllJobs() {
-//    m_threadPool.waitForAll();
-//  }
-
   @Override
   public String toString() {
     return "Server:" + m_messenger.isServer() + " EndPoints:" + m_localEndPoints;

--- a/src/games/strategy/engine/message/UnifiedMessenger.java
+++ b/src/games/strategy/engine/message/UnifiedMessenger.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -30,8 +32,8 @@ import games.strategy.thread.ThreadPool;
  */
 public class UnifiedMessenger {
   private final static Logger s_logger = Logger.getLogger(UnifiedMessenger.class.getName());
-  // a thread pool to run the invoke on
-  private static ThreadPool m_threadPool = new ThreadPool(15, "UnifiedMessengerPool");
+
+  private static final ExecutorService threadPool = Executors.newFixedThreadPool(15);
   // the messenger we are based on
   private final IMessenger m_messenger;
   // lock on this for modifications to create or remove local end points
@@ -335,7 +337,7 @@ public class UnifiedMessenger {
           }
         }
       };
-      m_threadPool.runTask(task);
+      threadPool.execute(task);
     }
     // a remote machine is returning results
     else if (msg instanceof SpokeInvocationResults) {
@@ -364,9 +366,9 @@ public class UnifiedMessenger {
     }
   }
 
-  public void waitForAllJobs() {
-    m_threadPool.waitForAll();
-  }
+//  public void waitForAllJobs() {
+//    m_threadPool.waitForAll();
+//  }
 
   @Override
   public String toString() {

--- a/src/games/strategy/thread/ThreadPool.java
+++ b/src/games/strategy/thread/ThreadPool.java
@@ -1,6 +1,6 @@
 package games.strategy.thread;
 
-import java.util.Stack;
+import java.util.ArrayDeque;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -12,7 +12,7 @@ import games.strategy.debug.ClientLogger;
  */
 public class ThreadPool {
   private final ExecutorService executorService;
-  private Stack<Future> futuresStack = new Stack<Future>();
+  private ArrayDeque<Future> futuresStack = new ArrayDeque<Future>();
 
   /**
    * Creates a new instance of ThreadPool max is the maximum number of threads the pool can have. The pool may have

--- a/src/games/strategy/thread/ThreadPool.java
+++ b/src/games/strategy/thread/ThreadPool.java
@@ -1,95 +1,55 @@
 package games.strategy.thread;
 
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Stack;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import games.strategy.debug.ClientLogger;
 
 /**
- * A simple thread pool.
+ * An ExecutorService backed thread pool.
  */
 public class ThreadPool {
-  private final String m_name;
-  // the max number of threads we can have
-  private final int m_maxThreadCount;
-  // how many threads we have
-  private final AtomicInteger m_threadCount = new AtomicInteger();
-  // how many threads arent busy
-  private final AtomicInteger m_availableThreads = new AtomicInteger();
-  // how many tasks are queued or running,
-  // usually = m_threadCount - m_availableThreads + m_pendingTasks.size()
-  // but since we dont synchronize we need another atomic variable to hold this value
-  private final AtomicInteger m_unfinishedTaskCount = new AtomicInteger();
-  // queued tasks
-  private final LinkedBlockingQueue<Runnable> m_pendingTasks = new LinkedBlockingQueue<Runnable>();
-  // is the thread pool active
-  private volatile boolean m_isRunning = true;
+  private final ExecutorService executorService;
+  private Stack<Future> futuresStack = new Stack<Future>();
 
   /**
    * Creates a new instance of ThreadPool max is the maximum number of threads the pool can have. The pool may have
    * fewer threads at any
    * given time.
    */
-  public ThreadPool(final int max, final String name) {
+  public ThreadPool(final int max) {
     if (max < 1) {
       throw new IllegalArgumentException("Max must be >= 1, instead its:" + max);
     }
-    if (name == null) {
-      m_name = "Unamed";
-    } else {
-      m_name = name;
-    }
-    m_maxThreadCount = max;
+    executorService = Executors.newFixedThreadPool(max);
   }
 
-  /**
-   * Create a new thread.
-   */
-  private void grow() {
-    final int threadCount = m_threadCount.incrementAndGet();
-    // we cant grow
-    if (threadCount > m_maxThreadCount) {
-      m_threadCount.decrementAndGet();
-      return;
-    }
-    final ThreadTracker tracker = new ThreadTracker();
-    final Thread thread = new Thread(tracker, getClass().getName() + ":" + m_name + ":" + threadCount);
-    thread.start();
-  }
 
   /**
-   * Run the given task. This method returns immediatly
-   * If the thread pool has been shut down the task will not
-   * run.
+   * Run the given task.
    */
   public void runTask(final Runnable task) {
-    if (!m_isRunning) {
-      return;
-    }
-    m_unfinishedTaskCount.incrementAndGet();
-    if (m_availableThreads.get() == 0 && m_threadCount.get() < m_maxThreadCount) {
-      grow();
-    }
-    if (!m_pendingTasks.offer(task)) {
-      // this should never happen, but if it does, we should
-      // do something
-      throw new IllegalStateException("Could not offer to queue");
-    }
+    futuresStack.push(executorService.submit(task));
   }
+
 
   /**
-   * returns when all tasks run through the runTask method have finished.
+   * Returns when all tasks run through the runTask method have finished.
    */
   public void waitForAll() {
-    while (m_unfinishedTaskCount.get() != 0) {
-      try {
-        Thread.sleep(5);
-      } catch (final InterruptedException e) {
-        // ignore
+    try {
+      while (!futuresStack.isEmpty()) {
+        if (futuresStack.peek().isDone()) {
+          futuresStack.pop();
+        } else {
+          Thread.sleep(5);
+        }
       }
+    } catch (InterruptedException e) {
+      ClientLogger.logQuietly(e);
     }
-  }
-
-  int getThreadCount() {
-    return m_threadCount.get();
   }
 
   /**
@@ -98,58 +58,7 @@ public class ThreadPool {
    * A call to shutDown() followed by waitForAll() will ensure that no threads are running.
    */
   public void shutDown() {
-    m_isRunning = false;
-    // remove whats in the queue
-    while (m_pendingTasks.poll() != null) {
-      m_unfinishedTaskCount.decrementAndGet();
-    }
-    final Runnable dummy = new Runnable() {
-      @Override
-      public void run() {}
-    };
-    // we need to wake up the threads so that they will notice that m_run is false
-    // add dummy elements so that the threads will wake
-    for (int i = 0; i < m_maxThreadCount; i++) {
-      m_pendingTasks.offer(dummy);
-    }
+    executorService.shutdown();
   }
 
-  private class ThreadTracker implements Runnable {
-    @Override
-    public void run() {
-      while (m_isRunning) {
-        final Runnable task = getTask();
-        if (task == null) {
-          continue;
-        }
-        // clear the interupted state of this thread
-        Thread.interrupted();
-        if (m_isRunning) {
-          runTask(task);
-        }
-      } // end while run
-      m_threadCount.decrementAndGet();
-    }
-
-    private void runTask(final Runnable task) {
-      try {
-        task.run();
-      } catch (final Throwable t) {
-        t.printStackTrace();
-      }
-      m_unfinishedTaskCount.decrementAndGet();
-    }
-
-    private Runnable getTask() {
-      m_availableThreads.incrementAndGet();
-      Runnable task;
-      try {
-        task = m_pendingTasks.take();
-      } catch (final InterruptedException e) {
-        return null;
-      }
-      m_availableThreads.decrementAndGet();
-      return task;
-    }
-  }
 }

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -213,7 +213,7 @@ public class TripleAFrame extends MainGameFrame {
     super("TripleA - " + game.getData().getGameName(), players);
     m_game = game;
     m_data = game.getData();
-    m_messageAndDialogThreadPool = new ThreadPool(1, "Message And Dialog Thread Pool");
+    m_messageAndDialogThreadPool = new ThreadPool(1);
     addZoomKeyboardShortcuts();
     this.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
     this.addWindowListener(WINDOW_LISTENER);

--- a/test/games/strategy/engine/chat/ChatTest.java
+++ b/test/games/strategy/engine/chat/ChatTest.java
@@ -94,15 +94,12 @@ public class ChatTest extends TestCase {
     // and we really need to test it working with sockets
     // rather than some mocked up implementation
     final ChatController controller = new ChatController("c", m_server, m_srm, m_scm, m_smc);
-    flush();
-    Thread.sleep(20);
     final Chat server = new Chat(m_server, "c", m_scm, m_srm, Chat.CHAT_SOUND_PROFILE.NO_SOUND);
     server.addChatListener(m_serverChatListener);
     final Chat client1 = new Chat(m_client1, "c", m_c1cm, m_c1rm, Chat.CHAT_SOUND_PROFILE.NO_SOUND);
     client1.addChatListener(m_client1ChatListener);
     final Chat client2 = new Chat(m_client2, "c", m_c2cm, m_c2rm, Chat.CHAT_SOUND_PROFILE.NO_SOUND);
     client2.addChatListener(m_client2ChatListener);
-    flush();
     // we need to wait for all the messages to write
     for (int i = 0; i < 10; i++) {
       try {
@@ -144,7 +141,6 @@ public class ChatTest extends TestCase {
     }
     serverThread.join();
     clientThread.join();
-    flush();
     // we need to wait for all the messages to write
     for (int i = 0; i < 10; i++) {
       try {
@@ -161,7 +157,6 @@ public class ChatTest extends TestCase {
     assertEquals(m_serverChatListener.m_messages.size(), 3 * messageCount);
     client1.shutdown();
     client2.shutdown();
-    flush();
     // we need to wait for all the messages to write
     for (int i = 0; i < 10; i++) {
       try {
@@ -182,17 +177,6 @@ public class ChatTest extends TestCase {
       }
     }
     assertEquals(m_serverChatListener.m_players.size(), 0);
-  }
-
-  private void flush() {
-    // this doesnt really flush
-    // but it does something
-    for (int i = 0; i < 5; i++) {
-      m_sum.waitForAllJobs();
-      m_c1um.waitForAllJobs();
-      m_c2um.waitForAllJobs();
-      Thread.yield();
-    }
   }
 }
 

--- a/test/games/strategy/thread/ThreadPoolTest.java
+++ b/test/games/strategy/thread/ThreadPoolTest.java
@@ -13,7 +13,7 @@ public class ThreadPoolTest extends TestCase {
   }
 
   public void testRunOneTask() {
-    final ThreadPool pool = new ThreadPool(50, "test");
+    final ThreadPool pool = new ThreadPool(50);
     final Task task = new Task();
     pool.runTask(task);
     pool.waitForAll();
@@ -21,7 +21,7 @@ public class ThreadPoolTest extends TestCase {
   }
 
   public void testSingleThread() {
-    final ThreadPool pool = new ThreadPool(1, "test");
+    final ThreadPool pool = new ThreadPool(1);
     final Collection<Runnable> tasks = new ArrayList<Runnable>();
     for (int i = 0; i < 30; i++) {
       final Runnable task = new Task();
@@ -37,14 +37,14 @@ public class ThreadPoolTest extends TestCase {
   }
 
   public void testSimple() {
-    final ThreadPool pool = new ThreadPool(5, "test");
+    final ThreadPool pool = new ThreadPool(5);
     final Collection<Task> tasks = new ArrayList<Task>();
     for (int i = 0; i < 3000; i++) {
       final Task task = new Task();
       tasks.add(task);
       pool.runTask(task);
     }
-    assertEquals(5, pool.getThreadCount());
+
     pool.waitForAll();
     final Iterator<Task> iter = tasks.iterator();
     while (iter.hasNext()) {
@@ -76,8 +76,8 @@ public class ThreadPoolTest extends TestCase {
     }
   }
 
-  private void threadTestBlock() {
-    final ThreadPool pool = new ThreadPool(8, "test");
+  private static void threadTestBlock() {
+    final ThreadPool pool = new ThreadPool(8);
     final ArrayList<BlockedTask> blockedTasks = new ArrayList<BlockedTask>();
     for (int i = 0; i < 40; i++) {
       final BlockedTask task = new BlockedTask();


### PR DESCRIPTION
We have been getting one-off failures due to the ThreadPool test (for example: https://travis-ci.org/triplea-game/triplea/builds/76565151). Replacing the custom ThreadPool implemention  with library code hopefully will help.

For the most part our implementation of ThreadPool is replaced with ExecutorService. The reason for this is "waitForAll" expects the thread pool to still be usable afterwards. ExecutorService to blcok appropriately needs a shutdown() first and then is no longer usable. In the cases where we just want a straight ThreadPool, ExecutorService has been substituted for ThreadPool, otherwise the implmenetation of ThreadPool has been replaced.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/109)
<!-- Reviewable:end -->
