### PR TITLE
Add test for LobbyGameTableModel, add corner-case fixes and some simplification/reduction

### DIFF
--- a/src/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/src/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -28,8 +28,9 @@ public class LobbyGameTableModel extends AbstractTableModel {
   private final IMessenger m_messenger;
   private final IChannelMessenger m_channelMessenger;
   private final IRemoteMessenger m_remoteMessenger;
+
   // these must only be accessed in the swing event thread
-  private final List<Tuple<GUID,GameDescription>> gameList;
+  private final List<Tuple<GUID, GameDescription>> gameList;
   private final ILobbyGameBroadcaster lobbyGameBroadcaster;
 
 
@@ -51,7 +52,7 @@ public class LobbyGameTableModel extends AbstractTableModel {
       @Override
       public void gameAdded(final GUID gameId, final GameDescription description) {
         assertSentFromServer();
-        addGame(gameId, description);
+        updateGame(gameId, description);
       }
 
       @Override
@@ -65,7 +66,7 @@ public class LobbyGameTableModel extends AbstractTableModel {
     final Map<GUID, GameDescription> games =
         ((ILobbyGameController) m_remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE)).listGames();
     for (final GUID id : games.keySet()) {
-      addGame(id, games.get(id));
+      updateGame(id, games.get(id));
     }
   }
 
@@ -73,13 +74,13 @@ public class LobbyGameTableModel extends AbstractTableModel {
     SwingUtilities.invokeLater(new Runnable() {
       @Override
       public void run() {
-        if( gameId == null ) {
+        if (gameId == null) {
           return;
         }
 
-        Tuple<GUID, GameDescription> gameToRemove = findGame( gameId );
-        if( gameToRemove != null ) {
-          int index = gameList.indexOf(gameToRemove);
+        final Tuple<GUID, GameDescription> gameToRemove = findGame(gameId);
+        if (gameToRemove != null) {
+          final int index = gameList.indexOf(gameToRemove);
           gameList.remove(gameToRemove);
           fireTableRowsDeleted(index, index);
         }
@@ -87,27 +88,13 @@ public class LobbyGameTableModel extends AbstractTableModel {
     });
   }
 
-  private Tuple<GUID, GameDescription> findGame( final GUID gameId ) {
-    for(Tuple<GUID, GameDescription> game : gameList ) {
-      if( game.getFirst().equals(gameId)) {
+  private Tuple<GUID, GameDescription> findGame(final GUID gameId) {
+    for (final Tuple<GUID, GameDescription> game : gameList) {
+      if (game.getFirst().equals(gameId)) {
         return game;
       }
     }
     return null;
-  }
-
-  private void addGame(final GUID gameId, final GameDescription description) {
-    SwingUtilities.invokeLater(new Runnable() {
-      @Override
-      public void run() {
-          // bad data
-        if( gameId == null || findGame(gameId ) != null ) {
-          return;
-        }
-        gameList.add( new Tuple<GUID,GameDescription>( gameId, description ));
-        fireTableRowsInserted(gameList.size() - 1, gameList.size() - 1);
-      }
-    });
   }
 
 
@@ -137,16 +124,16 @@ public class LobbyGameTableModel extends AbstractTableModel {
     SwingUtilities.invokeLater(new Runnable() {
       @Override
       public void run() {
-        if( gameId == null ) {
+        if (gameId == null) {
           return;
         }
 
-        Tuple<GUID,GameDescription> toReplace = findGame(gameId);
-        if( toReplace == null ) {
-          gameList.add( new Tuple<GUID,GameDescription>(gameId,description));
+        final Tuple<GUID, GameDescription> toReplace = findGame(gameId);
+        if (toReplace == null) {
+          gameList.add(new Tuple<GUID, GameDescription>(gameId, description));
         } else {
-          int replaceIndex = gameList.indexOf(toReplace);
-          gameList.set(replaceIndex, new Tuple<GUID,GameDescription>(gameId, description));
+          final int replaceIndex = gameList.indexOf(toReplace);
+          gameList.set(replaceIndex, new Tuple<GUID, GameDescription>(gameId, description));
           fireTableRowsUpdated(replaceIndex, replaceIndex);
         }
       }

--- a/src/games/strategy/engine/lobby/server/ILobbyGameBroadcaster.java
+++ b/src/games/strategy/engine/lobby/server/ILobbyGameBroadcaster.java
@@ -8,6 +8,7 @@ public interface ILobbyGameBroadcaster extends IChannelSubscribor {
   public static final RemoteName GAME_BROADCASTER_CHANNEL =
       new RemoteName("games.strategy.engine.lobby.server.IGameBroadcaster.CHANNEL", ILobbyGameBroadcaster.class);
 
+  /** @deprecated Call gameUpdated instead, it will add or update */
   public void gameAdded(GUID gameId, GameDescription description);
 
   public void gameUpdated(GUID gameId, GameDescription description);

--- a/src/games/strategy/engine/lobby/server/LobbyGameController.java
+++ b/src/games/strategy/engine/lobby/server/LobbyGameController.java
@@ -66,10 +66,10 @@ public class LobbyGameController implements ILobbyGameController {
     synchronized (m_mutex) {
       m_allGames.put(gameID, description);
     }
-    m_broadcaster.gameAdded(gameID, description);
+    m_broadcaster.gameUpdated(gameID, description);
   }
 
-  private void assertCorrectHost(final GameDescription description, final INode from) {
+  private static void assertCorrectHost(final GameDescription description, final INode from) {
     if (!from.getAddress().getHostAddress().equals(description.getHostedBy().getAddress().getHostAddress())) {
       s_logger.severe("Game modified from wrong host, from:" + from + " game host:" + description.getHostedBy());
       throw new IllegalStateException("Game from the wrong host");

--- a/test/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
+++ b/test/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
@@ -72,29 +72,7 @@ public class LobbyGameTableModelTest {
   }
 
   @Test
-  public void addGame() {
-    testObj.getLobbyGameBroadcaster().gameAdded( new GUID(),  new GameDescription());
-    TestUtil.waitForSwingThreads();
-    assertThat( testObj.getRowCount(), is(2));
-  }
-
-  @Test
-  public void addGameWithDuplicateGuid() {
-    testObj.getLobbyGameBroadcaster().gameAdded( fakeGame.getFirst(), fakeGame.getSecond());
-    TestUtil.waitForSwingThreads();
-    assertThat( "Row count should remain at 1, already added this GUID before.",
-        testObj.getRowCount(), is(1));
-  }
-  @Test
-  public void addGameWithNullGuid() {
-    testObj.getLobbyGameBroadcaster().gameAdded( null, fakeGame.getSecond());
-    TestUtil.waitForSwingThreads();
-    assertThat( "Row count shoudl remain at 1, null GUID is bogus and best ignored.",
-        testObj.getRowCount(), is(1));
-  }
-
-  @Test
-  public void updateGames() {
+  public void updateGame() {
     int commentColumnIndex = testObj.getColumnIndex(LobbyGameTableModel.Column.Comments );
     assertThat((String) testObj.getValueAt(0, commentColumnIndex),nullValue());
 
@@ -109,21 +87,19 @@ public class LobbyGameTableModelTest {
   }
 
   @Test
-  public void updateGameAddsIfDoesAlreadyNotExist() {
+  public void updateGameAddsIfDoesNotExist() {
     testObj.getLobbyGameBroadcaster().gameUpdated(new GUID(), new GameDescription());
     TestUtil.waitForSwingThreads();
     assertThat( testObj.getRowCount(), is(2));
   }
 
   @Test
-  public void updateGameWithNullGuid() {
+  public void updateGameWithNullGuidIsIgnored() {
     testObj.getLobbyGameBroadcaster().gameUpdated(null, new GameDescription());
     TestUtil.waitForSwingThreads();
     assertThat( "expect row count to remain 1, null guid is bogus data",
         testObj.getRowCount(), is(1));
   }
-
-
 
   @Test
   public void removeGame() {
@@ -133,7 +109,7 @@ public class LobbyGameTableModelTest {
   }
 
   @Test
-  public void removeGameThatDoesNotExist() {
+  public void removeGameThatDoesNotExistIsIgnored() {
     testObj.getLobbyGameBroadcaster().gameRemoved(new GUID());
     TestUtil.waitForSwingThreads();
     assertThat( testObj.getRowCount(), is(1));

--- a/test/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
+++ b/test/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
@@ -1,0 +1,141 @@
+package games.strategy.engine.lobby.client.ui;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import games.strategy.engine.lobby.server.GameDescription;
+import games.strategy.engine.lobby.server.ILobbyGameController;
+import games.strategy.engine.message.IChannelMessenger;
+import games.strategy.engine.message.IRemoteMessenger;
+import games.strategy.engine.message.MessageContext;
+import games.strategy.net.GUID;
+import games.strategy.net.IMessenger;
+import games.strategy.net.INode;
+import games.strategy.test.TestUtil;
+import games.strategy.util.Tuple;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LobbyGameTableModelTest {
+
+  private LobbyGameTableModel testObj;
+
+  @Mock
+  private IMessenger mockMessenger;
+  @Mock
+  private IChannelMessenger mockChannelMessenger;
+  @Mock
+  private IRemoteMessenger mockRemoteMessenger;
+  @Mock
+  private ILobbyGameController mockLobbyController;
+
+  private Map<GUID, GameDescription> fakeGameMap;
+  private Tuple<GUID, GameDescription> fakeGame;
+
+  @Mock
+  private GameDescription mockGameDescription;
+
+  @Mock
+  private INode serverNode;
+
+  @Before
+  public void setUp() {
+    fakeGameMap = new HashMap<GUID, GameDescription>();
+    fakeGame = new Tuple<GUID, GameDescription>(new GUID(), mockGameDescription);
+    fakeGameMap.put(fakeGame.getFirst(), fakeGame.getSecond());
+
+    Mockito.when(mockRemoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE))
+        .thenReturn(mockLobbyController);
+    Mockito.when(mockLobbyController.listGames()).thenReturn(fakeGameMap);
+    testObj = new LobbyGameTableModel(mockMessenger, mockChannelMessenger, mockRemoteMessenger);
+    Mockito.verify(mockLobbyController, Mockito.times(1)).listGames();
+
+
+    MessageContext.setSenderNodeForThread( serverNode);
+    Mockito.when(mockMessenger.getServerNode()).thenReturn( serverNode );
+    TestUtil.waitForSwingThreads();
+  }
+
+  @Test
+  public void gamesAreLoadedOnInit() {
+    assertThat(testObj.getRowCount(), is(1));
+  }
+
+  @Test
+  public void addGame() {
+    testObj.getLobbyGameBroadcaster().gameAdded( new GUID(),  new GameDescription());
+    TestUtil.waitForSwingThreads();
+    assertThat( testObj.getRowCount(), is(2));
+  }
+
+  @Test
+  public void addGameWithDuplicateGuid() {
+    testObj.getLobbyGameBroadcaster().gameAdded( fakeGame.getFirst(), fakeGame.getSecond());
+    TestUtil.waitForSwingThreads();
+    assertThat( "Row count should remain at 1, already added this GUID before.",
+        testObj.getRowCount(), is(1));
+  }
+  @Test
+  public void addGameWithNullGuid() {
+    testObj.getLobbyGameBroadcaster().gameAdded( null, fakeGame.getSecond());
+    TestUtil.waitForSwingThreads();
+    assertThat( "Row count shoudl remain at 1, null GUID is bogus and best ignored.",
+        testObj.getRowCount(), is(1));
+  }
+
+  @Test
+  public void updateGames() {
+    int commentColumnIndex = testObj.getColumnIndex(LobbyGameTableModel.Column.Comments );
+    assertThat((String) testObj.getValueAt(0, commentColumnIndex),nullValue());
+
+    String newComment = "comment";
+    GameDescription newDescription = new GameDescription();
+    newDescription.setComment(newComment);
+
+    testObj.getLobbyGameBroadcaster().gameUpdated(fakeGame.getFirst(), newDescription);
+    TestUtil.waitForSwingThreads();
+    assertThat( testObj.getRowCount(), is(1));
+    assertThat((String) testObj.getValueAt(0, commentColumnIndex), is(newComment));
+  }
+
+  @Test
+  public void updateGameAddsIfDoesAlreadyNotExist() {
+    testObj.getLobbyGameBroadcaster().gameUpdated(new GUID(), new GameDescription());
+    TestUtil.waitForSwingThreads();
+    assertThat( testObj.getRowCount(), is(2));
+  }
+
+  @Test
+  public void updateGameWithNullGuid() {
+    testObj.getLobbyGameBroadcaster().gameUpdated(null, new GameDescription());
+    TestUtil.waitForSwingThreads();
+    assertThat( "expect row count to remain 1, null guid is bogus data",
+        testObj.getRowCount(), is(1));
+  }
+
+
+
+  @Test
+  public void removeGame() {
+    testObj.getLobbyGameBroadcaster().gameRemoved(fakeGame.getFirst());
+    TestUtil.waitForSwingThreads();
+    assertThat( testObj.getRowCount(), is(0));
+  }
+
+  @Test
+  public void removeGameThatDoesNotExist() {
+    testObj.getLobbyGameBroadcaster().gameRemoved(new GUID());
+    TestUtil.waitForSwingThreads();
+    assertThat( testObj.getRowCount(), is(1));
+  }
+}


### PR DESCRIPTION
A test for LobbyGameTableModel showed it doesn't handle messages that have NULL id, are out of order or duplicated. To fix that the add and update both become "add or update" operations. The second commit of this PR is to then remove the double implementation and have "gameAdded" call "gameUpdated"

This PR is based on other PRs:  #110

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/111)
<!-- Reviewable:end -->
