### PR TITLE
Download file parser test improvements

### DIFF
--- a/src/games/strategy/engine/framework/mapDownload/DownloadFileParser.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadFileParser.java
@@ -57,8 +57,6 @@ public class DownloadFileParser {
           content = new StringBuilder();
         }
       });
-    } catch (final RuntimeException e) {
-      throw e;
     } catch (final SAXParseException e) {
       throw new IllegalStateException("Could not parse xml error at line:" + e.getLineNumber() + " column:"
           + e.getColumnNumber() + " error:" + e.getMessage());

--- a/test/games/strategy/engine/framework/mapDownload/DownloadFileParserTest.java
+++ b/test/games/strategy/engine/framework/mapDownload/DownloadFileParserTest.java
@@ -1,30 +1,73 @@
 package games.strategy.engine.framework.mapDownload;
 
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.io.ByteArrayInputStream;
 import java.util.List;
 
-import junit.framework.TestCase;
+import org.hamcrest.Matchers;
+import org.junit.Test;
 
-public class DownloadFileParserTest extends TestCase {
+public class DownloadFileParserTest {
+
+  @Test
   public void testParse() {
-    final List<DownloadFileDescription> games =
-        new DownloadFileParser().parse(new ByteArrayInputStream(xml.getBytes()), "hostedurl");
-    assertEquals(2, games.size());
+    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestXml().getBytes());
+    final List<DownloadFileDescription> games = new DownloadFileParser().parse(inputStream, "hostedurl");
+
+    assertThat(games.size(), is(2));
+
     DownloadFileDescription desc = games.get(0);
-    assertEquals(desc.getUrl(), "http://example.com/games/game.zip");
-    assertTrue(desc.getDescription().contains("Some notes"));
-    assertEquals(desc.getMapName(), "myGame");
+    assertThat(desc.getUrl(), is("http://example.com/games/game.zip"));
+    assertThat( desc.getDescription(), Matchers.containsString("Some notes"));
+    assertThat(desc.getMapName(), is("myGame"));
+
     desc = games.get(1);
-    assertEquals(desc.getUrl(), "http://example.com/games/game2.zip");
-    assertTrue(desc.getDescription().contains("second game"));
-    assertEquals(desc.getMapName(), "mySecondGame");
-    assertEquals(desc.getHostedUrl(), "hostedurl");
+    assertThat(desc.getUrl(), is("http://example.com/games/game2.zip"));
+    assertThat(desc.getDescription(), Matchers.containsString("second game"));
+    assertThat(desc.getMapName(), is("mySecondGame"));
+    assertThat(desc.getHostedUrl(), is("hostedurl"));
   }
 
-  private static final String xml = "<games>\n" + "  <game>\n" + "    <url>http://example.com/games/game.zip</url>\n"
-      + "    <mapName>myGame</mapName>\n" + "    <description><![CDATA[\n"
-      + "	<pre>Some notes about the game, simple html allowed.\n" + "	</pre>\n" + "    ]]></description>\n"
-      + "  </game>\n" + "  <game>\n" + "    <url>http://example.com/games/game2.zip</url>\n"
-      + "    <mapName>mySecondGame</mapName>\n" + "    <description><![CDATA[\n" + "	<pre>this is the second game.\n"
-      + "	</pre>\n" + "    ]]></description>\n" + "  </game>\n" + "\n" + "</games>\n";
+
+  private static String buildTestXml() {
+    String xml = "";
+    xml += "<games>\n";
+    xml += "  <game>\n";
+    xml += "    <url>http://example.com/games/game.zip</url>\n";
+    xml += "    <mapName>myGame</mapName>\n";
+    xml += "    <description><![CDATA[\n";
+    xml += "	<pre>Some notes about the game, simple html allowed.\n";
+    xml += "	</pre>\n";
+    xml += "    ]]></description>\n";
+    xml += "  </game>\n";
+    xml += "  <game>\n";
+    xml += "    <url>http://example.com/games/game2.zip</url>\n";
+    xml += "    <mapName>mySecondGame</mapName>\n";
+    xml += "    <description><![CDATA[\n";
+    xml += "	<pre>this is the second game.\n";
+    xml += "	</pre>\n";
+    xml += "    ]]></description>\n";
+    xml += "  </game>\n";
+    xml += "</games>\n";
+    return xml;
+  }
+
+
+    // TODO we probably should do clientLogger.logError( ) to handle this, show an error
+    // to the user and abort, rather than sending a stack trace and exception to the user.
+  @Test(expected=IllegalStateException.class)
+  public void testParseBadData() {
+    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildBadTestXml().getBytes());
+    final List<DownloadFileDescription> games = new DownloadFileParser().parse(inputStream, "hostedurl");
+    assertThat(games.size(), is(0));
+  }
+
+  private static String buildBadTestXml() {
+    String xml = "";
+    xml += "<games>\n";
+    return xml;
+  }
 }


### PR DESCRIPTION
Convert DownloadFileParserTest to Junit4, use hamcrest matchers, fix test data format, add a test case for bad data case, and remove an unnecessary catch block for RuntimeException in the business code.

Based on top of:  #103

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/112)
<!-- Reviewable:end -->
