### PR TITLE
Error handler update

### DIFF
--- a/src/games/strategy/engine/framework/ClientGame.java
+++ b/src/games/strategy/engine/framework/ClientGame.java
@@ -119,7 +119,6 @@ public class ClientGame extends AbstractGame {
       return;
     }
     m_isGameOver = true;
-    ErrorHandler.setGameOver(true);
     try {
       m_channelMessenger.unregisterChannelSubscriber(m_gameModifiedChannel, IGame.GAME_MODIFICATION_CHANNEL);
       m_remoteMessenger.unregisterRemote(getRemoteStepAdvancerName(m_channelMessenger.getLocalNode()));

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -147,7 +147,7 @@ public class GameRunner2 {
     setupLogging();
     Console.getConsole().displayStandardError();
     Console.getConsole().displayStandardOutput();
-    System.setProperty("sun.awt.exception.handler", ErrorHandler.class.getName());
+    ErrorHandler.registerExceptionHandler();
     System.setProperty("triplea.engine.version", EngineVersion.VERSION.toString());
     handleCommandLineArgs(args);
     // do after we handle command line args

--- a/src/games/strategy/engine/framework/ServerGame.java
+++ b/src/games/strategy/engine/framework/ServerGame.java
@@ -298,7 +298,6 @@ public class ServerGame extends AbstractGame {
       System.out.println("Attempting to stop game.");
     }
     m_isGameOver = true;
-    ErrorHandler.setGameOver(true);
     m_delegateExecutionStoppedLatch.countDown();
     for (final IGamePlayer player : m_gamePlayers.values()) { // tell the players (especially the AI's) that the game is stopping, so stop
                                                               // doing stuff.

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -676,7 +676,6 @@ public class HeadlessGameServer {
   private synchronized static boolean startHeadlessGame(final SetupPanelModel setupPanelModel) {
     try {
       if (setupPanelModel != null && setupPanelModel.getPanel() != null && setupPanelModel.getPanel().canGameStart()) {
-        ErrorHandler.setGameOver(false);
         System.out.println("Starting Game: " + setupPanelModel.getGameSelectorModel().getGameData().getGameName()
             + ", Round: " + setupPanelModel.getGameSelectorModel().getGameData().getSequence().getRound());
         setupPanelModel.getPanel().preStartGame();

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessServerMainPanel.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessServerMainPanel.java
@@ -213,7 +213,6 @@ public class HeadlessServerMainPanel extends JPanel implements Observer {
   }
 
   private void play() {
-    ErrorHandler.setGameOver(false);
     System.out.println("Starting Game: " + m_gameSelectorModel.getGameData().getGameName() + ", Round: "
         + m_gameSelectorModel.getGameData().getSequence().getRound());
     m_gameSetupPanel.preStartGame();

--- a/src/games/strategy/engine/framework/startup/ui/MainPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MainPanel.java
@@ -234,7 +234,6 @@ public class MainPanel extends JPanel implements Observer {
   }
 
   private void play() {
-    ErrorHandler.setGameOver(false);
     m_gameSetupPanel.preStartGame();
     final ILauncher launcher = m_gameTypePanelModel.getPanel().getLauncher();
     if (launcher != null) {

--- a/src/games/strategy/triplea/ui/ErrorHandler.java
+++ b/src/games/strategy/triplea/ui/ErrorHandler.java
@@ -1,26 +1,47 @@
 package games.strategy.triplea.ui;
 
-import games.strategy.engine.GameOverException;
+import games.strategy.debug.ClientLogger;
 
 /**
- * NOt entirly safe or elegant.
- * We want to ignore game over exceptions when the game is actually over.
- * This assumes only 1 game in a vm at a time.
+ * When dealing with swing threads and new threads, exception handling can get tricky. Namely without
+ * a handler to catch exceptions in these new threads, the stack traces will be poor. Specifically you
+ * will get a stack trace that points to where you started the thread and not to the actual line within
+ * the thread that had the problem.
+ *
+ * To solve this unhandled exception handlers get registered. For more details, see:
+ * http://stackoverflow.com/questions/75218/how-can-i-detect-when-an-exceptions-been-thrown-globally-in-java#75439
  */
-public class ErrorHandler {
-  private static volatile boolean m_isGameOver;
+public class ErrorHandler implements Thread.UncaughtExceptionHandler, ErrorHandlerAwtEvents {
 
-  public static void setGameOver(final boolean aBool) {
-    m_isGameOver = aBool;
+  @Override
+  public void uncaughtException(Thread t, Throwable e) {
+    handle(e);
   }
 
-  public ErrorHandler() {}
-
-  public void handle(final Throwable t) {
-    if (t instanceof GameOverException && m_isGameOver) {
-      // ignore
-      return;
+  /**
+   * Method used to handle errors. Called auto-magically by sun property
+   */
+  @Override
+  public void handle(Throwable throwable) {
+    try {
+      ClientLogger.logError(throwable);
+    } catch (Throwable t) {
+      try {
+          // if client logger fails fall back to methods that may still work
+        String msg = "Original error: " + throwable.getMessage() + ", next error while handling it: " + t.getMessage();
+        System.err.println(msg);
+        t.printStackTrace();
+      } catch (Throwable fatal) {
+        // Swallow this last error, if anything is thrown we can have an infinite loop of error handling.
+      }
     }
-    t.printStackTrace();
+  }
+
+  /**
+   * Registers this class as an uncaught exception error handler.
+   */
+  public static void registerExceptionHandler() {
+    Thread.setDefaultUncaughtExceptionHandler(new ErrorHandler());
+    System.setProperty("sun.awt.exception.handler", ErrorHandler.class.getName());
   }
 }

--- a/src/games/strategy/triplea/ui/ErrorHandlerAwtEvents.java
+++ b/src/games/strategy/triplea/ui/ErrorHandlerAwtEvents.java
@@ -1,0 +1,17 @@
+package games.strategy.triplea.ui;
+
+/**
+ * Captures the interface needed to be able to handle unhandled AWT exceptions thrown on other threads.
+ * The intent of this class is to allow child class to mark the required method as "@Override" so that
+ * static checkers will not think it is unused. The AWT system auto-magically calls that method.
+ *
+ * Otherwise, to implement this interface successfully, a class would also need to:
+ * - have a zero arg constructor
+ * - register the class name with a system property, like this:
+ *          System.setProperty("sun.awt.exception.handler", <your_implementing_instance>.class.getName());
+ *
+ * @see ErrorHandler.java
+ */
+public interface ErrorHandlerAwtEvents {
+  public void handle(Throwable throwable);
+}


### PR DESCRIPTION

1 commit on top of  #103 and #114


Updates to error handler:
- now implement: 'UncaughtExceptionHandler', handles even more uncaught exceptions
- improve code commentary/documentation
- remove isGameOver(boolean) functionality that suppresses error handling output. If we find a use case for it, we can avoid redundant exception logging by remembering exceptions and printing unique traces and counts. Until then a simple implementation is being favored that outputs all exceptions (and avoid reliance on static logic being correctly sprinkled throughout the rest of the code base).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/123)
<!-- Reviewable:end -->
