### PR TITLE
Fix naval retreat bug where the code wasn't reverted all the way for

### DIFF
--- a/src/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/games/strategy/triplea/delegate/BattleTracker.java
@@ -392,8 +392,6 @@ public class BattleTracker implements java.io.Serializable {
     conquerable.add(new CompositeMatchOr<Territory>(
         Matches.territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(id),
         Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassibleOrRestricted(id, data)));
-    // new CompositeMatchAnd<Territory>(Matches.isTerritoryEnemy(id, data)
-    // Matches.TerritoryIsPassableAndNotRestricted(id, data))));
     final Collection<Territory> conquered = new ArrayList<Territory>();
     if (canConquerMiddleSteps) {
       conquered.addAll(route.getMatches(conquerable));

--- a/src/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/games/strategy/triplea/delegate/BattleTracker.java
@@ -74,7 +74,8 @@ public class BattleTracker implements java.io.Serializable {
   private final Map<Territory, Collection<Unit>> m_defendingAirThatCanNotLand =
       new HashMap<Territory, Collection<Unit>>();
   private BattleRecords m_battleRecords = null;
-  // to keep track of all relationships that have changed this turn (so we can validate things like transports loading in newly created
+  // to keep track of all relationships that have changed this turn (so we can validate things like transports loading
+  // in newly created
   // hostile zones)
   private final Collection<Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>>> m_relationshipChangesThisTurn =
       new ArrayList<Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>>>();
@@ -160,7 +161,8 @@ public class BattleTracker implements java.io.Serializable {
   }
 
   public boolean didThesePlayersJustGoToWarThisTurn(final PlayerID p1, final PlayerID p2) {
-    // check all relationship changes that are p1 and p2, to make sure that oldRelation is not war, and newRelation is war
+    // check all relationship changes that are p1 and p2, to make sure that oldRelation is not war, and newRelation is
+    // war
     for (final Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>> t : m_relationshipChangesThisTurn) {
       final Tuple<PlayerID, PlayerID> players = t.getFirst();
       if (players.getFirst().equals(p1)) {
@@ -218,7 +220,8 @@ public class BattleTracker implements java.io.Serializable {
     }
     final RelationshipTracker relationshipTracker = bridge.getData().getRelationshipTracker();
     // if we have no longer conquered it, clear the blitz state
-    // EW: Does this have to look at all Territories? or just middle-territories or steps? // answer: veq: yes, we look at all, because we
+    // EW: Does this have to look at all Territories? or just middle-territories or steps? // answer: veq: yes, we look
+    // at all, because we
     // could have conquered the end territory if there are no units there
     for (final Territory current : route.getAllTerritories()) {
       if (!relationshipTracker.isAllied(current.getOwner(), player) && m_conquered.contains(current)) {
@@ -258,7 +261,8 @@ public class BattleTracker implements java.io.Serializable {
       final boolean airBattleCompleted) {
     final GameData data = bridge.getData();
     if (bombing) {
-      // create only either an air battle OR a bombing battle. (the air battle will create a bombing battle when done, if needed)
+      // create only either an air battle OR a bombing battle. (the air battle will create a bombing battle when done,
+      // if needed)
       if (!airBattleCompleted && games.strategy.triplea.Properties.getRaidsMayBePreceededByAirBattles(data)
           && AirBattle.territoryCouldPossiblyHaveAirBattleDefenders(route.getEnd(), id, data, bombing)) {
         addAirBattle(route, units, id, data, true);
@@ -387,9 +391,9 @@ public class BattleTracker implements java.io.Serializable {
     conquerable.add(Matches.territoryIsEmptyOfCombatUnits(data, id));
     conquerable.add(new CompositeMatchOr<Territory>(
         Matches.territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(id),
-        // Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassibleOrRestricted(id, data),
-        new CompositeMatchAnd<Territory>(Matches.isTerritoryEnemy(id, data),
-            Matches.TerritoryIsPassableAndNotRestricted(id, data))));
+        Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassibleOrRestricted(id, data)));
+    // new CompositeMatchAnd<Territory>(Matches.isTerritoryEnemy(id, data)
+    // Matches.TerritoryIsPassableAndNotRestricted(id, data))));
     final Collection<Territory> conquered = new ArrayList<Territory>();
     if (canConquerMiddleSteps) {
       conquered.addAll(route.getMatches(conquerable));
@@ -405,7 +409,8 @@ public class BattleTracker implements java.io.Serializable {
     m_conquered.addAll(Match.getMatches(conquered, Matches.isTerritoryEnemy(id, data)));
     for (final Territory current : conquered) {
       IBattle nonFight = getPendingBattle(current, false, BattleType.NORMAL);
-      // TODO: if we ever want to scramble to a blitzed territory, then we need to fix this stuff (currently doesn't work because then the
+      // TODO: if we ever want to scramble to a blitzed territory, then we need to fix this stuff (currently doesn't
+      // work because then the
       if (nonFight == null) {
         nonFight = new FinishedBattle(current, id, this, false, BattleType.NORMAL, data,
             BattleRecord.BattleResultDescription.CONQUERED, WhoWon.ATTACKER, units);
@@ -427,7 +432,8 @@ public class BattleTracker implements java.io.Serializable {
         precede = getPendingBattle(route.getEnd(), true, null);
       }
       // if we have a preceding battle, then we must use a non-fighting-battle
-      // if we have scrambling on, and this is an amphibious attack, we may wish to scramble to kill the transports, so must use
+      // if we have scrambling on, and this is an amphibious attack, we may wish to scramble to kill the transports, so
+      // must use
       // non-fighting-battle also
       if (precede != null || (scramblingEnabled && route.isUnload() && route.hasExactlyOneStep())) {
         IBattle nonFight = getPendingBattle(route.getEnd(), false, BattleType.NORMAL);
@@ -481,7 +487,8 @@ public class BattleTracker implements java.io.Serializable {
     final RelationshipTracker relationshipTracker = data.getRelationshipTracker();
     final boolean isTerritoryOwnerAnEnemy = relationshipTracker.canTakeOverOwnedTerritory(id, territory.getOwner()); // .isAtWar(id,
                                                                                                                      // territory.getOwner());
-    // If this is a convoy (we wouldn't be in this method otherwise) check to make sure attackers have more than just transports. If they
+    // If this is a convoy (we wouldn't be in this method otherwise) check to make sure attackers have more than just
+    // transports. If they
     // don't, exit here.
     if (territory.isWater() && arrivedUnits != null) {
       int totalMatches = 0;
@@ -550,13 +557,15 @@ public class BattleTracker implements java.io.Serializable {
         System.out.println("Player, " + id.getName() + " attacks a Neutral territory, and should have had to pay "
             + PUChargeIdeal + ", but did not have enough PUs to pay! This is a bug.");
         bridge.getHistoryWriter()
-            .addChildToEvent(id.getName() + " loses " + -PUChargeReal + " " + MyFormatter.pluralize("PU", -PUChargeReal)
-                + " for violating " + territory.getName() + "s neutrality.  Correct amount to charge is: "
-                + PUChargeIdeal + ".  Player should not have been able to make this attack!");
+            .addChildToEvent(
+                id.getName() + " loses " + -PUChargeReal + " " + MyFormatter.pluralize("PU", -PUChargeReal)
+                    + " for violating " + territory.getName() + "s neutrality.  Correct amount to charge is: "
+                    + PUChargeIdeal + ".  Player should not have been able to make this attack!");
       }
     }
     // if its a capital we take the money
-    // NOTE: this is not checking to see if it is an enemy. instead it is relying on the fact that the capital should be owned by the person
+    // NOTE: this is not checking to see if it is an enemy. instead it is relying on the fact that the capital should be
+    // owned by the person
     // it is attached to
     if (ta != null && isTerritoryOwnerAnEnemy && ta.getCapital() != null) {
       // if the capital is owned by the capitols player
@@ -566,7 +575,9 @@ public class BattleTracker implements java.io.Serializable {
       final PlayerAttachment paWhoseCapital = PlayerAttachment.get(whoseCapital);
       final List<Territory> capitalsList =
           new ArrayList<Territory>(TerritoryAttachment.getAllCurrentlyOwnedCapitals(whoseCapital, data));
-      if (paWhoseCapital != null && paWhoseCapital.getRetainCapitalNumber() < capitalsList.size()) // we are losing one right now, so it is
+      if (paWhoseCapital != null && paWhoseCapital.getRetainCapitalNumber() < capitalsList.size()) // we are losing one
+                                                                                                   // right now, so it
+                                                                                                   // is
                                                                                                    // < not <=
       {
         // do nothing, we keep our money since we still control enough capitals
@@ -621,7 +632,8 @@ public class BattleTracker implements java.io.Serializable {
     // revert to original owner if it is, unless they dont own there captital
     final PlayerID terrOrigOwner = OriginalOwnerTracker.getOriginalOwner(territory);
     PlayerID newOwner = id;
-    // if the original owner is the current owner, and the current owner is our enemy / canTakeOver, then we do not worry about this.
+    // if the original owner is the current owner, and the current owner is our enemy / canTakeOver, then we do not
+    // worry about this.
     if (isTerritoryOwnerAnEnemy && terrOrigOwner != null && relationshipTracker.isAllied(terrOrigOwner, id)
         && !terrOrigOwner.equals(territory.getOwner())) {
       final List<Territory> capitalsListOwned =
@@ -634,12 +646,14 @@ public class BattleTracker implements java.io.Serializable {
             new ArrayList<Territory>(TerritoryAttachment.getAllCapitals(terrOrigOwner, data));
         for (final Territory current : capitalsListOriginal) {
           if (territory.equals(current) || current.getOwner().equals(PlayerID.NULL_PLAYERID)) {
-            newOwner = terrOrigOwner; // if a neutral controls our capital, our territories get liberated (ie: china in ww2v3)
+            newOwner = terrOrigOwner; // if a neutral controls our capital, our territories get liberated (ie: china in
+                                      // ww2v3)
           }
         }
       }
     }
-    // if we have specially set this territory to have whenCapturedByGoesTo, then we set that here (except we don't set it if we are
+    // if we have specially set this territory to have whenCapturedByGoesTo, then we set that here (except we don't set
+    // it if we are
     // liberating allied owned territory)
     if (ta != null && isTerritoryOwnerAnEnemy && newOwner.equals(id)
         && Matches.TerritoryHasWhenCapturedByGoesTo().match(territory)) {
@@ -666,9 +680,16 @@ public class BattleTracker implements java.io.Serializable {
       }
       // play a sound
       if (territory.isWater()) {
-        bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_SEA, id.getName()); // should probably see if
-                                                                                                                 // there is something
-                                                                                                                 // actually happening for
+        bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_SEA, id.getName()); // should
+                                                                                                                 // probably
+                                                                                                                 // see
+                                                                                                                 // if
+                                                                                                                 // there
+                                                                                                                 // is
+                                                                                                                 // something
+                                                                                                                 // actually
+                                                                                                                 // happening
+                                                                                                                 // for
                                                                                                                  // water
       } else if (ta != null && ta.getCapital() != null) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_CAPITAL, id.getName());
@@ -726,7 +747,8 @@ public class BattleTracker implements java.io.Serializable {
       }
     }
     // say they were in combat
-    // if the territory being taken over is water, then do not say any land units were in combat (they may want to unload from the transport
+    // if the territory being taken over is water, then do not say any land units were in combat (they may want to
+    // unload from the transport
     // and attack)
     if (Matches.TerritoryIsWater.match(territory) && arrivedUnits != null) {
       arrivedUnits.removeAll(Match.getMatches(arrivedUnits, Matches.UnitIsLand));
@@ -833,7 +855,8 @@ public class BattleTracker implements java.io.Serializable {
       }
     }
     if (!nonCom.isEmpty()) {
-      // FYI: a dummy delegate will not do anything with this change, meaning that the battle calculator will think this unit lived even
+      // FYI: a dummy delegate will not do anything with this change, meaning that the battle calculator will think this
+      // unit lived even
       // though it died or was captured, etc!
       final Change capture = ChangeFactory.changeOwner(nonCom, newOwner, territory);
       bridge.addChange(capture);


### PR DESCRIPTION
patch #105. This causes an empty battle to be created for the naval only
battle which made it show as being conquered and unable to retreat to
it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/127)
<!-- Reviewable:end -->
