### PR TITLE
Update to use Java7 auto-close try blocks (~36 files)

### DIFF
--- a/src/games/strategy/common/delegate/AbstractDelegate.java
+++ b/src/games/strategy/common/delegate/AbstractDelegate.java
@@ -127,7 +127,8 @@ public abstract class AbstractDelegate implements IDelegate {
   }
 
   /**
-   * You should override this class with some variation of the following code (changing the AI to be something meaningful if needed)
+   * You should override this class with some variation of the following code (changing the AI to be something
+   * meaningful if needed)
    * because otherwise an "isNull" (ie: the static "Neutral" player) will not have any remote:
    * <p>
    * if (player.isNull()) {
@@ -141,13 +142,14 @@ public abstract class AbstractDelegate implements IDelegate {
   }
 }
 /*
- * All overriding classes should use the following format for saveState and loadState, in order to save and load the superstate
+ * All overriding classes should use the following format for saveState and loadState, in order to save and load the
+ * superstate
  * class ExtendedDelegateState implements Serializable
  * {
  * Serializable superState;
  * // add other variables here:
  * }
- * 
+ *
  * @Override
  * public Serializable saveState()
  * {
@@ -156,7 +158,7 @@ public abstract class AbstractDelegate implements IDelegate {
  * // add other variables to state here:
  * return state;
  * }
- * 
+ *
  * @Override
  * public void loadState(Serializable state)
  * {

--- a/src/games/strategy/common/delegate/AbstractDelegate.java
+++ b/src/games/strategy/common/delegate/AbstractDelegate.java
@@ -127,8 +127,7 @@ public abstract class AbstractDelegate implements IDelegate {
   }
 
   /**
-   * You should override this class with some variation of the following code (changing the AI to be something
-   * meaningful if needed)
+   * You should override this class with some variation of the following code (changing the AI to be something meaningful if needed)
    * because otherwise an "isNull" (ie: the static "Neutral" player) will not have any remote:
    * <p>
    * if (player.isNull()) {
@@ -142,14 +141,13 @@ public abstract class AbstractDelegate implements IDelegate {
   }
 }
 /*
- * All overriding classes should use the following format for saveState and loadState, in order to save and load the
- * superstate
+ * All overriding classes should use the following format for saveState and loadState, in order to save and load the superstate
  * class ExtendedDelegateState implements Serializable
  * {
  * Serializable superState;
  * // add other variables here:
  * }
- *
+ * 
  * @Override
  * public Serializable saveState()
  * {
@@ -158,7 +156,7 @@ public abstract class AbstractDelegate implements IDelegate {
  * // add other variables to state here:
  * return state;
  * }
- *
+ * 
  * @Override
  * public void loadState(Serializable state)
  * {

--- a/src/games/strategy/common/delegate/BaseTripleADelegate.java
+++ b/src/games/strategy/common/delegate/BaseTripleADelegate.java
@@ -34,8 +34,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate implements ID
   /**
    * Called before the delegate will run.
    * All classes should call super.start if they override this.
-   * Persistent delegates like Edit Delegate should not extend BaseDelegate, because we do not want to fire triggers in
-   * the edit delegate.
+   * Persistent delegates like Edit Delegate should not extend BaseDelegate, because we do not want to fire triggers in the edit delegate.
    */
   @Override
   public void start() {
@@ -49,8 +48,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate implements ID
   /**
    * Called before the delegate will stop running.
    * All classes should call super.end if they override this.
-   * Persistent delegates like Edit Delegate should not extend BaseDelegate, because we do not want to fire triggers in
-   * the edit delegate.
+   * Persistent delegates like Edit Delegate should not extend BaseDelegate, because we do not want to fire triggers in the edit delegate.
    */
   @Override
   public void end() {
@@ -60,8 +58,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate implements ID
       m_endBaseStepsFinished = true;
       triggerWhenTriggerAttachments(TriggerAttachment.AFTER);
     }
-    // these should probably be somewhere else, but we are relying on the fact that reloading a save go into the start
-    // step,
+    // these should probably be somewhere else, but we are relying on the fact that reloading a save go into the start step,
     // but nothing goes into the end step, and therefore there is no way to save then have the end step repeat itself
     m_startBaseStepsFinished = false;
     m_endBaseStepsFinished = false;

--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -847,14 +847,11 @@ public class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> extends JMe
           data.releaseReadLock();
         }
         try {
-          final FileWriter writer = new FileWriter(chooser.getSelectedFile());
-          try {
+          try(final FileWriter writer = new FileWriter(chooser.getSelectedFile());) {
             writer.write(xmlFile);
-          } finally {
-            writer.close();
           }
         } catch (final IOException e1) {
-          e1.printStackTrace();
+          ClientLogger.logQuietly(e1);
         }
       }
     };

--- a/src/games/strategy/engine/data/properties/GameProperties.java
+++ b/src/games/strategy/engine/data/properties/GameProperties.java
@@ -131,75 +131,28 @@ public class GameProperties extends GameDataComponent {
   public static void toOutputStream(final OutputStream sink, final List<IEditableProperty> editableProperties)
       throws IOException {
     // write internally first in case of error
-    final ByteArrayOutputStream bos = new ByteArrayOutputStream(5000);
-    ObjectOutputStream outStream = null;
-    GZIPOutputStream zippedOut = null;
-    try {
-      outStream = new ObjectOutputStream(bos);
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream(5000);
+        ObjectOutputStream outStream = new ObjectOutputStream(bos);
+        GZIPOutputStream zippedOut = new GZIPOutputStream(sink);) {
+
       outStream.writeObject(editableProperties);
-      // final byte[] byteArray = bos.toByteArray();
-      zippedOut = new GZIPOutputStream(sink);
-      // now write to file
       zippedOut.write(bos.toByteArray());
       zippedOut.flush();
-    } finally {
-      try {
-        if (outStream != null) {
-          outStream.close();
-        }
-      } catch (final IOException e) {
-        e.printStackTrace();
-      }
-      try {
-        bos.close();
-      } catch (final IOException e) {
-        e.printStackTrace();
-      }
-      try {
-        if (zippedOut != null) {
-          zippedOut.close();
-        }
-      } catch (final IOException e) {
-        e.printStackTrace();
-      }
     }
   }
 
   @SuppressWarnings("unchecked")
   public static List<IEditableProperty> streamToIEditablePropertiesList(final byte[] byteArray)
       throws IOException, ClassNotFoundException, ClassCastException {
-    ByteArrayInputStream byteStream = null;
-    InputStream inputStream = null;
-    ObjectInputStream objectStream = null;
     List<IEditableProperty> editableProperties = null;
-    try {
-      byteStream = new ByteArrayInputStream(byteArray);
-      inputStream = new BufferedInputStream(byteStream);
-      objectStream = new ObjectInputStream(new GZIPInputStream(inputStream));
+
+    try (ByteArrayInputStream byteStream = new ByteArrayInputStream(byteArray);
+        InputStream inputStream = new BufferedInputStream(byteStream);
+        ObjectInputStream objectStream = new ObjectInputStream(new GZIPInputStream(inputStream));) {
+
       editableProperties = (List<IEditableProperty>) objectStream.readObject();
-    } finally {
-      if (byteStream != null) {
-        try {
-          byteStream.close();
-        } catch (final IOException e) {
-          e.printStackTrace();
-        }
-      }
-      if (inputStream != null) {
-        try {
-          inputStream.close();
-        } catch (final IOException e) {
-          e.printStackTrace();
-        }
-      }
-      if (objectStream != null) {
-        try {
-          objectStream.close();
-        } catch (final IOException e) {
-          e.printStackTrace();
-        }
-      }
     }
+
     return editableProperties;
   }
 

--- a/src/games/strategy/engine/data/properties/GameProperties.java
+++ b/src/games/strategy/engine/data/properties/GameProperties.java
@@ -133,7 +133,7 @@ public class GameProperties extends GameDataComponent {
     // write internally first in case of error
     try (ByteArrayOutputStream bos = new ByteArrayOutputStream(5000);
         ObjectOutputStream outStream = new ObjectOutputStream(bos);
-        GZIPOutputStream zippedOut = new GZIPOutputStream(sink);) {
+        GZIPOutputStream zippedOut = new GZIPOutputStream(sink)) {
 
       outStream.writeObject(editableProperties);
       zippedOut.write(bos.toByteArray());
@@ -148,7 +148,8 @@ public class GameProperties extends GameDataComponent {
 
     try (ByteArrayInputStream byteStream = new ByteArrayInputStream(byteArray);
         InputStream inputStream = new BufferedInputStream(byteStream);
-        ObjectInputStream objectStream = new ObjectInputStream(new GZIPInputStream(inputStream));) {
+        GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream);
+        ObjectInputStream objectStream = new ObjectInputStream(gzipInputStream)) {
 
       editableProperties = (List<IEditableProperty>) objectStream.readObject();
     }

--- a/src/games/strategy/engine/framework/ClientGame.java
+++ b/src/games/strategy/engine/framework/ClientGame.java
@@ -215,7 +215,7 @@ public class ClientGame extends AbstractGame {
   public void saveGame(final File f) {
     final IServerRemote server = (IServerRemote) m_remoteMessenger.getRemote(ServerGame.SERVER_REMOTE);
     final byte[] bytes = server.getSavedGame();
-    try (FileOutputStream fout = new FileOutputStream(f);) {
+    try (FileOutputStream fout = new FileOutputStream(f)) {
       fout.write(bytes);
     } catch (final IOException e) {
       e.printStackTrace();

--- a/src/games/strategy/engine/framework/ClientGame.java
+++ b/src/games/strategy/engine/framework/ClientGame.java
@@ -215,21 +215,11 @@ public class ClientGame extends AbstractGame {
   public void saveGame(final File f) {
     final IServerRemote server = (IServerRemote) m_remoteMessenger.getRemote(ServerGame.SERVER_REMOTE);
     final byte[] bytes = server.getSavedGame();
-    FileOutputStream fout = null;
-    try {
-      fout = new FileOutputStream(f);
+    try (FileOutputStream fout = new FileOutputStream(f);) {
       fout.write(bytes);
     } catch (final IOException e) {
       e.printStackTrace();
       throw new IllegalStateException(e.getMessage());
-    } finally {
-      if (fout != null) {
-        try {
-          fout.close();
-        } catch (final IOException e) {
-          e.printStackTrace();
-        }
-      }
     }
   }
 }

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -41,9 +41,7 @@ public class GameDataManager {
   public GameDataManager() {}
 
   public GameData loadGame(final File savedGameFile) throws IOException {
-    InputStream input = null;
-    try {
-      input = new BufferedInputStream(new FileInputStream(savedGameFile));
+    try (InputStream input = new BufferedInputStream(new FileInputStream(savedGameFile));) {
       String path;
       try {
         path = savedGameFile.getCanonicalPath();
@@ -51,13 +49,6 @@ public class GameDataManager {
         path = savedGameFile.getPath();
       }
       return loadGame(input, path);
-    } finally {
-      try {
-        if (input != null) {
-          input.close();
-        }
-      } catch (final Exception e) {
-      }
     }
   }
 
@@ -217,19 +208,10 @@ public class GameDataManager {
   }
 
   public void saveGame(final File destination, final GameData data) throws IOException {
-    BufferedOutputStream out = null;
-    try {
-      final OutputStream fileStream = new FileOutputStream(destination);
-      out = new BufferedOutputStream(fileStream);
+    try (final OutputStream fileStream = new FileOutputStream(destination);
+        BufferedOutputStream out = new BufferedOutputStream(fileStream);) {
+
       saveGame(fileStream, data);
-    } finally {
-      try {
-        if (out != null) {
-          out.close();
-        }
-      } catch (final Exception e) {
-        e.printStackTrace();
-      }
     }
   }
 
@@ -254,11 +236,10 @@ public class GameDataManager {
     } finally {
       data.releaseReadLock();
     }
-    final GZIPOutputStream zippedOut = new GZIPOutputStream(sink);
-    // now write to file
-    zippedOut.write(bytes.toByteArray());
-    zippedOut.flush();
-    zippedOut.close();
+    try (final GZIPOutputStream zippedOut = new GZIPOutputStream(sink);) {
+      // now write to file
+      zippedOut.write(bytes.toByteArray());
+    }
   }
 
   private void writeDelegates(final GameData data, final ObjectOutputStream out) throws IOException {

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -41,7 +41,9 @@ public class GameDataManager {
   public GameDataManager() {}
 
   public GameData loadGame(final File savedGameFile) throws IOException {
-    try (InputStream input = new BufferedInputStream(new FileInputStream(savedGameFile))) {
+    try (
+        FileInputStream fileInputStream = new FileInputStream(savedGameFile);
+        InputStream input = new BufferedInputStream(fileInputStream)) {
       String path;
       try {
         path = savedGameFile.getCanonicalPath();

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -41,7 +41,7 @@ public class GameDataManager {
   public GameDataManager() {}
 
   public GameData loadGame(final File savedGameFile) throws IOException {
-    try (InputStream input = new BufferedInputStream(new FileInputStream(savedGameFile));) {
+    try (InputStream input = new BufferedInputStream(new FileInputStream(savedGameFile))) {
       String path;
       try {
         path = savedGameFile.getCanonicalPath();
@@ -236,7 +236,7 @@ public class GameDataManager {
     } finally {
       data.releaseReadLock();
     }
-    try (final GZIPOutputStream zippedOut = new GZIPOutputStream(sink);) {
+    try (final GZIPOutputStream zippedOut = new GZIPOutputStream(sink)) {
       // now write to file
       zippedOut.write(bytes.toByteArray());
     }

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -448,7 +448,7 @@ public class GameRunner2 {
     final Properties rVal = new Properties();
     final File systemIni = new File(GameRunner2.getRootFolder(), SYSTEM_INI);
     if (systemIni != null && systemIni.exists()) {
-      try (FileInputStream fis = new FileInputStream(systemIni);) {
+      try (FileInputStream fis = new FileInputStream(systemIni)) {
         rVal.load(fis);
       } catch (final IOException e) {
         ClientLogger.logQuietly(e);
@@ -470,7 +470,7 @@ public class GameRunner2 {
 
     final File systemIni = new File(GameRunner2.getRootFolder(), SYSTEM_INI);
 
-    try (FileOutputStream fos = new FileOutputStream(systemIni);) {
+    try (FileOutputStream fos = new FileOutputStream(systemIni)) {
       toWrite.store(fos, SYSTEM_INI);
     } catch (final IOException e) {
       ClientLogger.logQuietly(e);

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -448,22 +448,10 @@ public class GameRunner2 {
     final Properties rVal = new Properties();
     final File systemIni = new File(GameRunner2.getRootFolder(), SYSTEM_INI);
     if (systemIni != null && systemIni.exists()) {
-      FileInputStream fis = null;
-      try {
-        fis = new FileInputStream(systemIni);
+      try (FileInputStream fis = new FileInputStream(systemIni);) {
         rVal.load(fis);
-        // rVal.loadFromXML(fis);
-      } catch (final FileNotFoundException e) {
-        e.printStackTrace();
       } catch (final IOException e) {
-        e.printStackTrace();
-      } finally {
-        if (fis != null) {
-          try {
-            fis.close();
-          } catch (final IOException e) {
-          }
-        }
+        ClientLogger.logQuietly(e);
       }
     }
     return rVal;
@@ -479,21 +467,13 @@ public class GameRunner2 {
         toWrite.put(entry.getKey(), entry.getValue());
       }
     }
-    FileOutputStream fos = null;
-    try {
-      final File systemIni = new File(GameRunner2.getRootFolder(), SYSTEM_INI);
-      fos = new FileOutputStream(systemIni);
+
+    final File systemIni = new File(GameRunner2.getRootFolder(), SYSTEM_INI);
+
+    try (FileOutputStream fos = new FileOutputStream(systemIni);) {
       toWrite.store(fos, SYSTEM_INI);
-      // toWrite.storeToXML(fos, SYSTEM_INI);
     } catch (final IOException e) {
-      e.printStackTrace();
-    } finally {
-      if (fos != null) {
-        try {
-          fos.close();
-        } catch (final IOException e) {
-        }
-      }
+      ClientLogger.logQuietly(e);
     }
   }
 
@@ -509,12 +489,10 @@ public class GameRunner2 {
       proxyPortArgument = System.getProperty(HTTP_PROXYPORT);
     }
     // arguments should override and set user preferences
-    // host
     String proxyHost = null;
     if (proxyHostArgument != null && proxyHostArgument.trim().length() > 0) {
       proxyHost = proxyHostArgument;
     }
-    // port
     String proxyPort = null;
     if (proxyPortArgument != null && proxyPortArgument.trim().length() > 0) {
       try {
@@ -582,13 +560,9 @@ public class GameRunner2 {
         pref.flush();
         pref.sync();
       } catch (final BackingStoreException e) {
-        e.printStackTrace();
+        ClientLogger.logQuietly(e);
       }
     }
-    /*
-     * System.out.println(System.getProperty(HTTP_PROXYHOST));
-     * System.out.println(System.getProperty(HTTP_PROXYPORT));
-     */
   }
 
   private static void setToUseSystemProxies() {

--- a/src/games/strategy/engine/framework/ServerGame.java
+++ b/src/games/strategy/engine/framework/ServerGame.java
@@ -65,8 +65,7 @@ public class ServerGame extends AbstractGame {
   private InGameLobbyWatcherWrapper m_inGameLobbyWatcher;
   private boolean m_needToInitialize = true;
   /**
-   * When the delegate execution is stopped, we countdown on this latch to prevent the startgame(...) method from
-   * returning.
+   * When the delegate execution is stopped, we countdown on this latch to prevent the startgame(...) method from returning.
    * <p>
    */
   private final CountDownLatch m_delegateExecutionStoppedLatch = new CountDownLatch(1);
@@ -359,73 +358,45 @@ public class ServerGame extends AbstractGame {
   }
 
   private void autoSave() {
-    FileOutputStream out = null;
-    try {
+    final File f1 = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSaveFileName());
+    final File f2 = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSave2FileName());
+    final File f;
+    if (f1.lastModified() > f2.lastModified()) {
+      f = f2;
+    } else {
+      f = f1;
+    }
+
+    try (FileOutputStream out = new FileOutputStream(f);) {
       SaveGameFileChooser.ensureDefaultDirExists();
-      final File f1 = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSaveFileName());
-      final File f2 = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSave2FileName());
-      final File f;
-      if (f1.lastModified() > f2.lastModified()) {
-        f = f2;
-      } else {
-        f = f1;
-      }
-      out = new FileOutputStream(f);
       saveGame(out);
     } catch (final Exception e) {
       e.printStackTrace();
-    } finally {
-      try {
-        if (out != null) {
-          out.close();
-        }
-      } catch (final IOException e) {
-        e.printStackTrace();
-      }
     }
   }
 
   private void autoSaveRound() {
-    FileOutputStream out = null;
-    try {
-      SaveGameFileChooser.ensureDefaultDirExists();
-      File autosaveFile;
-      if (m_data.getSequence().getRound() % 2 == 0) {
-        autosaveFile = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSaveEvenFileName());
-      } else {
-        autosaveFile = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSaveOddFileName());
-      }
-      out = new FileOutputStream(autosaveFile);
+    SaveGameFileChooser.ensureDefaultDirExists();
+    final File autosaveFile;
+    if (m_data.getSequence().getRound() % 2 == 0) {
+      autosaveFile = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSaveEvenFileName());
+    } else {
+      autosaveFile = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSaveOddFileName());
+    }
+
+    try (FileOutputStream out = new FileOutputStream(autosaveFile);) {
       saveGame(out);
     } catch (final Exception e) {
       e.printStackTrace();
-    } finally {
-      try {
-        if (out != null) {
-          out.close();
-        }
-      } catch (final IOException e) {
-        e.printStackTrace();
-      }
     }
   }
 
   @Override
   public void saveGame(final File f) {
-    FileOutputStream fout = null;
-    try {
-      fout = new FileOutputStream(f);
+    try (FileOutputStream fout = new FileOutputStream(f);) {
       saveGame(fout);
     } catch (final IOException e) {
       e.printStackTrace();
-    } finally {
-      if (fout != null) {
-        try {
-          fout.close();
-        } catch (final IOException e) {
-          e.printStackTrace();
-        }
-      }
     }
   }
 
@@ -535,8 +506,7 @@ public class ServerGame extends AbstractGame {
     }
     bridge.setRandomSource(m_delegateRandomSource);
     // do any initialization of game data for all players here (not based on a delegate, and should not be)
-    // we can not do this the very first run through, because there are no history nodes yet. We should do after first
-    // node is created.
+    // we can not do this the very first run through, because there are no history nodes yet. We should do after first node is created.
     if (m_needToInitialize) {
       addPlayerTypesToGameData(m_gamePlayers.values(), m_playerManager, bridge);
     }

--- a/src/games/strategy/engine/framework/ServerGame.java
+++ b/src/games/strategy/engine/framework/ServerGame.java
@@ -358,6 +358,7 @@ public class ServerGame extends AbstractGame {
   }
 
   private void autoSave() {
+    SaveGameFileChooser.ensureDefaultDirExists();
     final File f1 = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSaveFileName());
     final File f2 = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSave2FileName());
     final File f;
@@ -368,7 +369,6 @@ public class ServerGame extends AbstractGame {
     }
 
     try (FileOutputStream out = new FileOutputStream(f)) {
-      SaveGameFileChooser.ensureDefaultDirExists();
       saveGame(out);
     } catch (final Exception e) {
       e.printStackTrace();

--- a/src/games/strategy/engine/framework/ServerGame.java
+++ b/src/games/strategy/engine/framework/ServerGame.java
@@ -367,7 +367,7 @@ public class ServerGame extends AbstractGame {
       f = f1;
     }
 
-    try (FileOutputStream out = new FileOutputStream(f);) {
+    try (FileOutputStream out = new FileOutputStream(f)) {
       SaveGameFileChooser.ensureDefaultDirExists();
       saveGame(out);
     } catch (final Exception e) {
@@ -384,7 +384,7 @@ public class ServerGame extends AbstractGame {
       autosaveFile = new File(SaveGameFileChooser.DEFAULT_DIRECTORY, SaveGameFileChooser.getAutoSaveOddFileName());
     }
 
-    try (FileOutputStream out = new FileOutputStream(autosaveFile);) {
+    try (FileOutputStream out = new FileOutputStream(autosaveFile)) {
       saveGame(out);
     } catch (final Exception e) {
       e.printStackTrace();
@@ -393,7 +393,7 @@ public class ServerGame extends AbstractGame {
 
   @Override
   public void saveGame(final File f) {
-    try (FileOutputStream fout = new FileOutputStream(f);) {
+    try (FileOutputStream fout = new FileOutputStream(f)) {
       saveGame(fout);
     } catch (final IOException e) {
       e.printStackTrace();

--- a/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
@@ -20,7 +20,7 @@ class DownloadFileProperties {
       return new DownloadFileProperties();
     }
     final DownloadFileProperties rVal = new DownloadFileProperties();
-    try (final FileInputStream fis = new FileInputStream(fromZip(zipFile));) {
+    try (final FileInputStream fis = new FileInputStream(fromZip(zipFile))) {
       rVal.props.load(fis);
     } catch (final IOException e) {
       e.printStackTrace(System.out);
@@ -29,7 +29,7 @@ class DownloadFileProperties {
   }
 
   public static void saveForZip(final File zipFile, final DownloadFileProperties props) {
-    try ( final FileOutputStream fos = new FileOutputStream(fromZip(zipFile));) {
+    try ( final FileOutputStream fos = new FileOutputStream(fromZip(zipFile))) {
         props.props.store(fos, null);
     } catch (final IOException e) {
       e.printStackTrace(System.out);

--- a/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.Properties;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.EngineVersion;
 import games.strategy.util.Version;
 
@@ -19,13 +20,8 @@ class DownloadFileProperties {
       return new DownloadFileProperties();
     }
     final DownloadFileProperties rVal = new DownloadFileProperties();
-    try {
-      final FileInputStream fis = new FileInputStream(fromZip(zipFile));
-      try {
-        rVal.props.load(fis);
-      } finally {
-        fis.close();
-      }
+    try (final FileInputStream fis = new FileInputStream(fromZip(zipFile));) {
+      rVal.props.load(fis);
     } catch (final IOException e) {
       e.printStackTrace(System.out);
     }
@@ -33,13 +29,8 @@ class DownloadFileProperties {
   }
 
   public static void saveForZip(final File zipFile, final DownloadFileProperties props) {
-    try {
-      final FileOutputStream fos = new FileOutputStream(fromZip(zipFile));
-      try {
+    try ( final FileOutputStream fos = new FileOutputStream(fromZip(zipFile));) {
         props.props.store(fos, null);
-      } finally {
-        fos.close();
-      }
     } catch (final IOException e) {
       e.printStackTrace(System.out);
     }

--- a/src/games/strategy/engine/framework/mapDownload/DownloadRunnable.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadRunnable.java
@@ -62,8 +62,8 @@ public class DownloadRunnable implements Runnable {
       return;
     }
 
-    try ( InputStream stream = url.openStream()){
-      final ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    try (InputStream stream = url.openStream();
+        ByteArrayOutputStream sink = new ByteArrayOutputStream()) {
       InstallMapDialog.copy(sink, stream);
       contents = sink.toByteArray();
     } catch (final Exception e) {

--- a/src/games/strategy/engine/framework/mapDownload/DownloadRunnable.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadRunnable.java
@@ -62,7 +62,7 @@ public class DownloadRunnable implements Runnable {
       return;
     }
 
-    try ( InputStream stream = url.openStream();){
+    try ( InputStream stream = url.openStream()){
       final ByteArrayOutputStream sink = new ByteArrayOutputStream();
       InstallMapDialog.copy(sink, stream);
       contents = sink.toByteArray();

--- a/src/games/strategy/engine/framework/mapDownload/DownloadRunnable.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadRunnable.java
@@ -61,16 +61,11 @@ public class DownloadRunnable implements Runnable {
       error = "invalid url";
       return;
     }
-    InputStream stream;
-    try {
-      stream = url.openStream();
-      try {
-        final ByteArrayOutputStream sink = new ByteArrayOutputStream();
-        InstallMapDialog.copy(sink, stream);
-        contents = sink.toByteArray();
-      } finally {
-        stream.close();
-      }
+
+    try ( InputStream stream = url.openStream();){
+      final ByteArrayOutputStream sink = new ByteArrayOutputStream();
+      InstallMapDialog.copy(sink, stream);
+      contents = sink.toByteArray();
     } catch (final Exception e) {
       error = e.getMessage();
     }

--- a/src/games/strategy/engine/framework/mapDownload/InstallMapDialog.java
+++ b/src/games/strategy/engine/framework/mapDownload/InstallMapDialog.java
@@ -315,8 +315,8 @@ public class InstallMapDialog extends JDialog {
       return;
     }
     // try to make sure it is a valid zip file
-
-    try (final ZipInputStream zis = new ZipInputStream(new FileInputStream(tempFile))) {
+    try (final FileInputStream fileInputStream = new FileInputStream(tempFile);
+        final ZipInputStream zis = new ZipInputStream(fileInputStream)) {
       while (zis.getNextEntry() != null) {
         zis.read(new byte[128]);
       }

--- a/src/games/strategy/engine/framework/mapDownload/InstallMapDialog.java
+++ b/src/games/strategy/engine/framework/mapDownload/InstallMapDialog.java
@@ -303,7 +303,7 @@ public class InstallMapDialog extends JDialog {
       return;
     }
 
-    try ( FileOutputStream sink = new FileOutputStream(tempFile);){
+    try ( FileOutputStream sink = new FileOutputStream(tempFile)){
       validateZip(download);
       sink.write(download.getContents());
       sink.getFD().sync();
@@ -316,7 +316,7 @@ public class InstallMapDialog extends JDialog {
     }
     // try to make sure it is a valid zip file
 
-    try (final ZipInputStream zis = new ZipInputStream(new FileInputStream(tempFile));) {
+    try (final ZipInputStream zis = new ZipInputStream(new FileInputStream(tempFile))) {
       while (zis.getNextEntry() != null) {
         zis.read(new byte[128]);
       }
@@ -342,7 +342,7 @@ public class InstallMapDialog extends JDialog {
 
   private static void validateZip(final DownloadRunnable download) throws IOException {
     // try to unzip it to make sure it is valid
-    try ( final ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(download.getContents()));) {
+    try ( final ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(download.getContents()))) {
       ZipEntry ze;
       while ((ze = zis.getNextEntry()) != null) {
         // make sure we can read something from each stream

--- a/src/games/strategy/engine/framework/mapDownload/InstallMapDialog.java
+++ b/src/games/strategy/engine/framework/mapDownload/InstallMapDialog.java
@@ -302,10 +302,9 @@ public class InstallMapDialog extends JDialog {
       Util.notifyError(this, download.getError());
       return;
     }
-    FileOutputStream sink = null;
-    try {
+
+    try ( FileOutputStream sink = new FileOutputStream(tempFile);){
       validateZip(download);
-      sink = new FileOutputStream(tempFile);
       sink.write(download.getContents());
       sink.getFD().sync();
       final DownloadFileProperties props = new DownloadFileProperties();
@@ -314,24 +313,12 @@ public class InstallMapDialog extends JDialog {
     } catch (final IOException e) {
       Util.notifyError(this, "Could not create write to temp file:" + e.getMessage());
       return;
-    } finally {
-      if (sink != null) {
-        try {
-          sink.close();
-        } catch (final IOException e) {
-          // ignore
-        }
-      }
     }
     // try to make sure it is a valid zip file
-    try {
-      final ZipInputStream zis = new ZipInputStream(new FileInputStream(tempFile));
-      try {
-        while (zis.getNextEntry() != null) {
-          zis.read(new byte[128]);
-        }
-      } finally {
-        zis.close();
+
+    try (final ZipInputStream zis = new ZipInputStream(new FileInputStream(tempFile));) {
+      while (zis.getNextEntry() != null) {
+        zis.read(new byte[128]);
       }
     } catch (final IOException e) {
       Util.notifyError(this, "Invalid zip file:" + e.getMessage());
@@ -340,31 +327,22 @@ public class InstallMapDialog extends JDialog {
     // move it to the games folder
     // try to rename first
     if (!tempFile.renameTo(destination)) {
-      try {
-        final FileInputStream source = new FileInputStream(tempFile);
-        try {
-          final FileOutputStream destSink = new FileOutputStream(destination);
-          try {
-            copy(destSink, source);
-            destSink.getFD().sync();
-          } finally {
-            destSink.close();
-          }
-        } finally {
-          source.close();
-          tempFile.delete();
-        }
+      try (final FileInputStream source = new FileInputStream(tempFile);
+          final FileOutputStream destSink = new FileOutputStream(destination);) {
+        copy(destSink, source);
+        destSink.getFD().sync();
       } catch (final IOException e) {
         Util.notifyError(this, e.getMessage());
         return;
+      } finally {
+        tempFile.delete();
       }
     }
   }
 
-  private void validateZip(final DownloadRunnable download) throws IOException {
+  private static void validateZip(final DownloadRunnable download) throws IOException {
     // try to unzip it to make sure it is valid
-    try {
-      final ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(download.getContents()));
+    try ( final ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(download.getContents()));) {
       ZipEntry ze;
       while ((ze = zis.getNextEntry()) != null) {
         // make sure we can read something from each stream

--- a/src/games/strategy/engine/framework/mapDownload/InstallMapDialog.java
+++ b/src/games/strategy/engine/framework/mapDownload/InstallMapDialog.java
@@ -342,7 +342,9 @@ public class InstallMapDialog extends JDialog {
 
   private static void validateZip(final DownloadRunnable download) throws IOException {
     // try to unzip it to make sure it is valid
-    try ( final ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(download.getContents()))) {
+    try (
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(download.getContents());
+        final ZipInputStream zis = new ZipInputStream(byteArrayInputStream)) {
       ZipEntry ze;
       while ((ze = zis.getNextEntry()) != null) {
         // make sure we can read something from each stream

--- a/src/games/strategy/engine/framework/networkMaintenance/ChangeGameOptionsClientAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/ChangeGameOptionsClientAction.java
@@ -52,7 +52,7 @@ public class ChangeGameOptionsClientAction extends AbstractAction {
         // ok was clicked. changing them in the ui changes the underlying properties,
         // but it doesn't change the hosts, so we need to send it back to the host.
         byte[] newBytes = null;
-        try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(1000);) {
+        try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(1000)) {
           GameProperties.toOutputStream(sink, properties);
           newBytes = sink.toByteArray();
         } catch (final IOException e2) {

--- a/src/games/strategy/engine/framework/networkMaintenance/ChangeGameOptionsClientAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/ChangeGameOptionsClientAction.java
@@ -49,21 +49,14 @@ public class ChangeGameOptionsClientAction extends AbstractAction {
       if (buttonPressed == null || buttonPressed.equals(cancel)) {
         return;
       } else {
-        // ok was clicked. changing them in the ui changes the underlying properties, but it doesn't change the hosts,
-        // so we need to send it
-        // back to the host.
-        final ByteArrayOutputStream sink = new ByteArrayOutputStream(1000);
+        // ok was clicked. changing them in the ui changes the underlying properties,
+        // but it doesn't change the hosts, so we need to send it back to the host.
         byte[] newBytes = null;
-        try {
+        try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(1000);) {
           GameProperties.toOutputStream(sink, properties);
           newBytes = sink.toByteArray();
         } catch (final IOException e2) {
           e2.printStackTrace();
-        } finally {
-          try {
-            sink.close();
-          } catch (final IOException e2) {
-          }
         }
         if (newBytes != null) {
           m_serverRemote.changeToGameOptions(newBytes);

--- a/src/games/strategy/engine/framework/networkMaintenance/GetGameSaveClientAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/GetGameSaveClientAction.java
@@ -30,7 +30,7 @@ public class GetGameSaveClientAction extends AbstractAction {
     final File f = BasicGameMenuBar.getSaveGameLocationDialog(frame);
     if (f != null) {
       final byte[] bytes = m_serverRemote.getSaveGame();
-      try (FileOutputStream fout = new FileOutputStream(f);) {
+      try (FileOutputStream fout = new FileOutputStream(f)) {
         fout.write(bytes);
       } catch (final IOException exception) {
         exception.printStackTrace();

--- a/src/games/strategy/engine/framework/networkMaintenance/GetGameSaveClientAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/GetGameSaveClientAction.java
@@ -30,20 +30,10 @@ public class GetGameSaveClientAction extends AbstractAction {
     final File f = BasicGameMenuBar.getSaveGameLocationDialog(frame);
     if (f != null) {
       final byte[] bytes = m_serverRemote.getSaveGame();
-      FileOutputStream fout = null;
-      try {
-        fout = new FileOutputStream(f);
+      try (FileOutputStream fout = new FileOutputStream(f);) {
         fout.write(bytes);
       } catch (final IOException exception) {
         exception.printStackTrace();
-      } finally {
-        if (fout != null) {
-          try {
-            fout.close();
-          } catch (final IOException exception) {
-            exception.printStackTrace();
-          }
-        }
       }
       JOptionPane.showMessageDialog(frame, "Game Saved", "Game Saved", JOptionPane.INFORMATION_MESSAGE);
     }

--- a/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -147,7 +147,7 @@ public class GameSelectorModel extends Observable {
     try {
       // if the file name is xml, load it as a new game
       if (file.getName().toLowerCase().endsWith("xml")) {
-        try (FileInputStream fis = new FileInputStream(file);) {
+        try (FileInputStream fis = new FileInputStream(file)) {
           newData = (new GameParser()).parse(fis, gameName, false);
         }
       }

--- a/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -147,14 +147,8 @@ public class GameSelectorModel extends Observable {
     try {
       // if the file name is xml, load it as a new game
       if (file.getName().toLowerCase().endsWith("xml")) {
-        FileInputStream fis = null;
-        try {
-          fis = new FileInputStream(file);
+        try (FileInputStream fis = new FileInputStream(file);) {
           newData = (new GameParser()).parse(fis, gameName, false);
-        } finally {
-          if (fis != null) {
-            fis.close();
-          }
         }
       }
       // the extension should be tsvg, but

--- a/src/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -333,7 +333,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
       System.out.println("Sending save game");
 
       byte[] bytes = null;
-      try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(5000);) {
+      try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(5000)) {
         new GameDataManager().saveGame(sink, m_data);
         bytes = sink.toByteArray();
       } catch (final IOException e) {
@@ -352,7 +352,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
       }
       final List<IEditableProperty> currentEditableProperties = m_data.getProperties().getEditableProperties();
 
-      try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(1000);) {
+      try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(1000)) {
         GameProperties.toOutputStream(sink, currentEditableProperties);
         bytes = sink.toByteArray();
       } catch (final IOException e) {

--- a/src/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -331,19 +331,14 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     @Override
     public byte[] getSaveGame() {
       System.out.println("Sending save game");
-      final ByteArrayOutputStream sink = new ByteArrayOutputStream(5000);
+
       byte[] bytes = null;
-      try {
+      try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(5000);) {
         new GameDataManager().saveGame(sink, m_data);
         bytes = sink.toByteArray();
       } catch (final IOException e) {
         e.printStackTrace();
         throw new IllegalStateException(e);
-      } finally {
-        try {
-          sink.close();
-        } catch (final IOException e) {
-        }
       }
       return bytes;
     }
@@ -356,18 +351,12 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
         return bytes;
       }
       final List<IEditableProperty> currentEditableProperties = m_data.getProperties().getEditableProperties();
-      final ByteArrayOutputStream sink = new ByteArrayOutputStream(1000);
-      try {
+
+      try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(1000);) {
         GameProperties.toOutputStream(sink, currentEditableProperties);
         bytes = sink.toByteArray();
       } catch (final IOException e) {
         e.printStackTrace();
-        // throw new IllegalStateException(e);
-      } finally {
-        try {
-          sink.close();
-        } catch (final IOException e) {
-        }
       }
       return bytes;
     }
@@ -425,29 +414,11 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
         return;
       }
       System.out.println("Changing to user savegame: " + fileName);
-      ByteArrayInputStream input = null;
-      InputStream oinput = null;
-      try {
-        input = new ByteArrayInputStream(bytes);
-        oinput = new BufferedInputStream(input);
+      try (ByteArrayInputStream input = new ByteArrayInputStream(bytes);
+          InputStream oinput = new BufferedInputStream(input);) {
         headless.loadGameSave(oinput, fileName);
       } catch (final Exception e) {
         e.printStackTrace();
-      } finally {
-        if (input != null) {
-          try {
-            input.close();
-          } catch (final IOException e) {
-            e.printStackTrace();
-          }
-        }
-        if (oinput != null) {
-          try {
-            oinput.close();
-          } catch (final IOException e) {
-            e.printStackTrace();
-          }
-        }
       }
     }
 

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -42,7 +42,7 @@ public class NewGameChooserEntry {
       throws IOException, GameParseException, SAXException, EngineVersionException {
     m_url = uri;
     final AtomicReference<String> gameName = new AtomicReference<String>();
-    try (InputStream input = uri.toURL().openStream();) {
+    try (InputStream input = uri.toURL().openStream()) {
       final boolean delayParsing = GameRunner2.getDelayedParsing();
       m_data = new GameParser().parse(input, gameName, delayParsing);
       m_gameDataFullyLoaded = !delayParsing;
@@ -56,7 +56,7 @@ public class NewGameChooserEntry {
     String error = null;
     final AtomicReference<String> gameName = new AtomicReference<String>();
 
-    try (InputStream input = m_url.toURL().openStream();) {
+    try (InputStream input = m_url.toURL().openStream()) {
       m_data = new GameParser().parse(input, gameName, false);
       m_gameDataFullyLoaded = true;
 
@@ -87,7 +87,7 @@ public class NewGameChooserEntry {
     m_data = null;
 
     final AtomicReference<String> gameName = new AtomicReference<String>();
-    try (InputStream input = m_url.toURL().openStream();) {
+    try (InputStream input = m_url.toURL().openStream()) {
       m_data = new GameParser().parse(input, gameName, true);
       m_gameDataFullyLoaded = false;
     } catch (final EngineVersionException e) {

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
@@ -40,60 +41,38 @@ public class NewGameChooserEntry {
   public NewGameChooserEntry(final URI uri)
       throws IOException, GameParseException, SAXException, EngineVersionException {
     m_url = uri;
-    InputStream input = null;
     final AtomicReference<String> gameName = new AtomicReference<String>();
-    try {
-      input = uri.toURL().openStream();
+    try (InputStream input = uri.toURL().openStream();) {
       final boolean delayParsing = GameRunner2.getDelayedParsing();
       m_data = new GameParser().parse(input, gameName, delayParsing);
       m_gameDataFullyLoaded = !delayParsing;
       m_gameNameAndMapNameProperty = getGameName() + ":" + getMapNameProperty();
-    } finally {
-      try {
-        if (input != null) {
-          input.close();
-        }
-      } catch (final IOException e) {// ignore
-      }
     }
   }
 
   public void fullyParseGameData() throws GameParseException {
     m_data = null;
-    InputStream input = null;
+
     String error = null;
     final AtomicReference<String> gameName = new AtomicReference<String>();
-    try {
-      input = m_url.toURL().openStream();
-      try {
-        m_data = new GameParser().parse(input, gameName, false);
-        m_gameDataFullyLoaded = true;
-      } catch (final EngineVersionException e) {
-        System.out.println(e.getMessage());
-        error = e.getMessage();
-      } catch (final SAXParseException e) {
-        System.err.println(
-            "Could not parse:" + m_url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber());
-        e.printStackTrace();
-        error = e.getMessage();
-      } catch (final Exception e) {
-        System.err.println("Could not parse:" + m_url);
-        e.printStackTrace();
-        error = e.getMessage();
-      }
-    } catch (final MalformedURLException e1) {
-      e1.printStackTrace();
-      error = e1.getMessage();
-    } catch (final IOException e1) {
-      e1.printStackTrace();
-      error = e1.getMessage();
-    } finally {
-      try {
-        if (input != null) {
-          input.close();
-        }
-      } catch (final IOException e) {// ignore
-      }
+
+    try (InputStream input = m_url.toURL().openStream();) {
+      m_data = new GameParser().parse(input, gameName, false);
+      m_gameDataFullyLoaded = true;
+
+    } catch (final EngineVersionException e) {
+      ClientLogger.logQuietly(e);
+      error = e.getMessage();
+    } catch (final SAXParseException e) {
+      String msg = "Could not parse:" + m_url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber();
+      ClientLogger.logError(msg);
+      e.printStackTrace();
+      error = e.getMessage();
+    } catch (final Exception e) {
+      String msg = "Could not parse:" + m_url;
+      ClientLogger.logError(msg);
+      e.printStackTrace();
+      error = e.getMessage();
     }
     if (error != null) {
       throw new GameParseException(error);
@@ -106,34 +85,20 @@ public class NewGameChooserEntry {
    */
   public void delayParseGameData() {
     m_data = null;
-    InputStream input = null;
+
     final AtomicReference<String> gameName = new AtomicReference<String>();
-    try {
-      input = m_url.toURL().openStream();
-      try {
-        m_data = new GameParser().parse(input, gameName, true);
-        m_gameDataFullyLoaded = false;
-      } catch (final EngineVersionException e) {
-        System.out.println(e.getMessage());
-      } catch (final SAXParseException e) {
-        System.err.println(
-            "Could not parse:" + m_url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber());
-        e.printStackTrace();
-      } catch (final Exception e) {
-        System.err.println("Could not parse:" + m_url);
-        e.printStackTrace();
-      }
-    } catch (final MalformedURLException e1) {
-      e1.printStackTrace();
-    } catch (final IOException e1) {
-      e1.printStackTrace();
-    } finally {
-      try {
-        if (input != null) {
-          input.close();
-        }
-      } catch (final IOException e) {// ignore
-      }
+    try (InputStream input = m_url.toURL().openStream();) {
+      m_data = new GameParser().parse(input, gameName, true);
+      m_gameDataFullyLoaded = false;
+    } catch (final EngineVersionException e) {
+      System.out.println(e.getMessage());
+    } catch (final SAXParseException e) {
+      System.err.println(
+          "Could not parse:" + m_url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber());
+      e.printStackTrace();
+    } catch (final Exception e) {
+      System.err.println("Could not parse:" + m_url);
+      e.printStackTrace();
     }
   }
 

--- a/src/games/strategy/engine/history/History.java
+++ b/src/games/strategy/engine/history/History.java
@@ -132,10 +132,6 @@ public class History extends DefaultTreeModel implements java.io.Serializable {
     getGameData().acquireWriteLock();
     try {
       final int lastChange = getLastChange(removeAfterNode);
-      // final List<Change> changesToRemove = m_changes.subList(Math.min(m_changes.size(), lastChange),
-      // Math.max(m_changes.size(),
-      // lastChange));
-      // m_changes.removeAll(changesToRemove);
       while (m_changes.size() > lastChange) {
         m_changes.remove(lastChange);
       }

--- a/src/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/src/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -62,10 +62,7 @@ public class LobbyServerProperties {
     final HttpClient client = new HttpClient();
     final HostConfiguration config = client.getHostConfiguration();
     config.setHost(url.getHost());
-    // add the proxy
-    // since lobby actually uses a different port and connection type (TCP), we should not use a proxy for
-    // GameRunner2.addProxy(config);
-    // the properties file until we allow the lobby to accept proxy connections
+
     final GetMethod method = new GetMethod(url.getPath());
     // pretend to be ie
     method.setRequestHeader("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)");

--- a/src/games/strategy/engine/lobby/server/headless/HeadlessLobbyConsole.java
+++ b/src/games/strategy/engine/lobby/server/headless/HeadlessLobbyConsole.java
@@ -129,8 +129,7 @@ public class HeadlessLobbyConsole {
   }
 
   private void executeSql(final String sql) {
-    final Connection con = Database.getConnection();
-    try {
+    try (final Connection con = Database.getConnection();) {
       final Statement ps = con.createStatement();
       if (DBExplorerPanel.isNotQuery(sql)) {
         final int rs = ps.executeUpdate(sql);
@@ -143,19 +142,11 @@ public class HeadlessLobbyConsole {
     } catch (final SQLException sqle) {
       sqle.printStackTrace();
       out.println(sqle.getMessage());
-    } finally {
-      try {
-        con.close();
-      } catch (final SQLException e) {
-        // TODO Auto-generated catch block
-        e.printStackTrace();
-      }
     }
   }
 
   private void print(final ResultSet rs) {
-    try {
-      final Formatter f = new Formatter(out);
+    try (final Formatter f = new Formatter(out);) {
       final String itemFormat = "%20s ";
       f.format(itemFormat, "Count");
       final int count = rs.getMetaData().getColumnCount();

--- a/src/games/strategy/engine/lobby/server/headless/HeadlessLobbyConsole.java
+++ b/src/games/strategy/engine/lobby/server/headless/HeadlessLobbyConsole.java
@@ -129,7 +129,7 @@ public class HeadlessLobbyConsole {
   }
 
   private void executeSql(final String sql) {
-    try (final Connection con = Database.getConnection();) {
+    try (final Connection con = Database.getConnection()) {
       final Statement ps = con.createStatement();
       if (DBExplorerPanel.isNotQuery(sql)) {
         final int rs = ps.executeUpdate(sql);
@@ -146,7 +146,7 @@ public class HeadlessLobbyConsole {
   }
 
   private void print(final ResultSet rs) {
-    try (final Formatter f = new Formatter(out);) {
+    try (final Formatter f = new Formatter(out)) {
       final String itemFormat = "%20s ";
       f.format(itemFormat, "Count");
       final int count = rs.getMetaData().getColumnCount();

--- a/src/games/strategy/engine/lobby/server/ui/DBExplorerPanel.java
+++ b/src/games/strategy/engine/lobby/server/ui/DBExplorerPanel.java
@@ -67,7 +67,7 @@ public class DBExplorerPanel extends JPanel {
   }
 
   private void execute() {
-    try (final Connection con = Database.getConnection();) {
+    try (final Connection con = Database.getConnection()) {
       String sql = m_sql.getSelectedText();
       if (sql == null || sql.length() == 0) {
         sql = m_sql.getText();

--- a/src/games/strategy/engine/lobby/server/ui/DBExplorerPanel.java
+++ b/src/games/strategy/engine/lobby/server/ui/DBExplorerPanel.java
@@ -67,8 +67,7 @@ public class DBExplorerPanel extends JPanel {
   }
 
   private void execute() {
-    final Connection con = Database.getConnection();
-    try {
+    try (final Connection con = Database.getConnection();) {
       String sql = m_sql.getSelectedText();
       if (sql == null || sql.length() == 0) {
         sql = m_sql.getText();
@@ -89,13 +88,6 @@ public class DBExplorerPanel extends JPanel {
       }
     } catch (final SQLException sqle) {
       sqle.printStackTrace();
-    } finally {
-      try {
-        con.close();
-      } catch (final SQLException e) {
-        // TODO Auto-generated catch block
-        e.printStackTrace();
-      }
     }
   }
 

--- a/src/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/games/strategy/engine/lobby/server/userDB/Database.java
@@ -241,8 +241,7 @@ public class Database {
       return;
     }
     s_logger.log(Level.INFO, "Backing up database to " + backupDir.getAbsolutePath());
-    final Connection con = getConnection();
-    try {
+    try (final Connection con = getConnection();) {
       // http://www-128.ibm.com/developerworks/db2/library/techarticle/dm-0502thalamati/
       final String sqlstmt = "CALL SYSCS_UTIL.SYSCS_BACKUP_DATABASE(?)";
       final CallableStatement cs = con.prepareCall(sqlstmt);
@@ -251,12 +250,6 @@ public class Database {
       cs.close();
     } catch (final Exception e) {
       s_logger.log(Level.SEVERE, "Could not back up database", e);
-    } finally {
-      try {
-        con.close();
-      } catch (final SQLException e) {
-        e.printStackTrace();
-      }
     }
     s_logger.log(Level.INFO, "Done backing up database");
   }

--- a/src/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/games/strategy/engine/lobby/server/userDB/Database.java
@@ -241,7 +241,7 @@ public class Database {
       return;
     }
     s_logger.log(Level.INFO, "Backing up database to " + backupDir.getAbsolutePath());
-    try (final Connection con = getConnection();) {
+    try (final Connection con = getConnection()) {
       // http://www-128.ibm.com/developerworks/db2/library/techarticle/dm-0502thalamati/
       final String sqlstmt = "CALL SYSCS_UTIL.SYSCS_BACKUP_DATABASE(?)";
       final CallableStatement cs = con.prepareCall(sqlstmt);

--- a/src/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -46,7 +46,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       if (!file.isDirectory() && file.getName().endsWith(".properties")) {
         try {
           final Properties props = new Properties();
-          try (final FileInputStream fin = new FileInputStream(file);) {
+          try (final FileInputStream fin = new FileInputStream(file)) {
             props.load(fin);
             propFiles.add(props);
           }

--- a/src/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -46,12 +46,9 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       if (!file.isDirectory() && file.getName().endsWith(".properties")) {
         try {
           final Properties props = new Properties();
-          final FileInputStream fin = new FileInputStream(file);
-          try {
+          try (final FileInputStream fin = new FileInputStream(file);) {
             props.load(fin);
             propFiles.add(props);
-          } finally {
-            fin.close();
           }
         } catch (final IOException e) {
           System.out.println("error reading file:" + file);

--- a/src/games/strategy/net/ClientMessenger.java
+++ b/src/games/strategy/net/ClientMessenger.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.message.HubInvoke;
@@ -296,20 +297,11 @@ public class ClientMessenger implements IClientMessenger, NIOSocketListener {
     }
     // Create the byte array to hold the data
     final byte[] bytes = new byte[(int) length];
-    InputStream is = null;
-    try {
-      is = new FileInputStream(file);
+    try (InputStream is = new FileInputStream(file);) {
       is.read(bytes);
     } catch (final IOException e) {
-      e.printStackTrace();
-    } finally {
-      // Close the input stream and return bytes
-      if (is != null) {
-        try {
-          is.close();
-        } catch (final IOException e) {
-        }
-      }
+      ClientLogger.logQuietly("Failed to read file: " + file);
+      ClientLogger.logQuietly(e);
     }
     return bytes;
   }

--- a/src/games/strategy/net/ClientMessenger.java
+++ b/src/games/strategy/net/ClientMessenger.java
@@ -297,7 +297,7 @@ public class ClientMessenger implements IClientMessenger, NIOSocketListener {
     }
     // Create the byte array to hold the data
     final byte[] bytes = new byte[(int) length];
-    try (InputStream is = new FileInputStream(file);) {
+    try (InputStream is = new FileInputStream(file)) {
       is.read(bytes);
     } catch (final IOException e) {
       ClientLogger.logQuietly("Failed to read file: " + file);

--- a/src/games/strategy/net/UniversalPlugAndPlayHelper.java
+++ b/src/games/strategy/net/UniversalPlugAndPlayHelper.java
@@ -93,7 +93,7 @@ public class UniversalPlugAndPlayHelper {
     final int internalPort = m_port;
     boolean connection = false;
     // boolean bytes = false;
-    try (ServerSocket ss = new ServerSocket(internalPort);) {
+    try (ServerSocket ss = new ServerSocket(internalPort)) {
       ss.setSoTimeout(5000);
       try {
         final Socket s = ss.accept();

--- a/src/games/strategy/net/UniversalPlugAndPlayHelper.java
+++ b/src/games/strategy/net/UniversalPlugAndPlayHelper.java
@@ -93,9 +93,7 @@ public class UniversalPlugAndPlayHelper {
     final int internalPort = m_port;
     boolean connection = false;
     // boolean bytes = false;
-    ServerSocket ss = null;
-    try {
-      ss = new ServerSocket(internalPort);
+    try (ServerSocket ss = new ServerSocket(internalPort);) {
       ss.setSoTimeout(5000);
       try {
         final Socket s = ss.accept();
@@ -108,21 +106,12 @@ public class UniversalPlugAndPlayHelper {
       } catch (final SocketTimeoutException stoe) {
         System.out.println("Connection Test Timed Out. Port Forward may still work anyway.");
         return "Connection Test Timed Out. Port Forward may still work anyway.";
-      } finally {
-        ss.close();
       }
     } catch (final IOException e) {
       System.out.println("Connection Test Timed Out. Port Forward may still work anyway. \r\n " + e.getMessage());
       return "Connection Test Timed Out. Port Forward may still work anyway. \r\n " + e.getMessage();
-    } finally {
-      if (ss != null) {
-        try {
-          ss.close();
-        } catch (final IOException e) {
-          e.printStackTrace();
-        }
-      }
     }
+
     if (!connection) {
       System.out.println("Connection Test Timed Out. Port Forward may still work anyway.");
       return "Connection Test Timed Out. Port Forward may still work anyway.";

--- a/src/games/strategy/sound/ClipPlayer.java
+++ b/src/games/strategy/sound/ClipPlayer.java
@@ -474,7 +474,7 @@ public class ClipPlayer {
           try {
             final File zipFile = new File(decoded);
             if (zipFile != null && zipFile.exists()) {
-              try (ZipFile zf = new ZipFile(zipFile);) {
+              try (ZipFile zf = new ZipFile(zipFile)) {
                 if (zf != null) {
                   final Enumeration<? extends ZipEntry> zipEnumeration = zf.entries();
                   while (zipEnumeration.hasMoreElements()) {

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -101,7 +101,7 @@ public class ResourceLoader {
       if (dependencesURL != null) {
         final java.util.Properties dependenciesFile = new java.util.Properties();
 
-        try (final InputStream stream = dependencesURL.openStream();) {
+        try (final InputStream stream = dependencesURL.openStream()) {
           dependenciesFile.load(stream);
           final String dependencies = dependenciesFile.getProperty("dependencies");
           final StringTokenizer tokens = new StringTokenizer(dependencies, ",", false);

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -100,8 +100,8 @@ public class ResourceLoader {
       ClassLoaderUtil.closeLoader(url);
       if (dependencesURL != null) {
         final java.util.Properties dependenciesFile = new java.util.Properties();
-        final InputStream stream = dependencesURL.openStream();
-        try {
+
+        try (final InputStream stream = dependencesURL.openStream();) {
           dependenciesFile.load(stream);
           final String dependencies = dependenciesFile.getProperty("dependencies");
           final StringTokenizer tokens = new StringTokenizer(dependencies, ",", false);
@@ -109,8 +109,6 @@ public class ResourceLoader {
             // add the dependencies recursivly
             rVal.addAll(getPaths(tokens.nextToken(), allowNoneFound));
           }
-        } finally {
-          stream.close();
         }
       }
     } catch (final Exception e) {

--- a/src/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
+++ b/src/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
@@ -45,10 +45,9 @@ public class ProLogSettings implements Serializable {
 
   public static void saveSettings(final ProLogSettings settings) {
     s_lastSettings = settings;
-    ObjectOutputStream outputStream = null;
-    try {
-      final ByteArrayOutputStream pool = new ByteArrayOutputStream(10000);
-      outputStream = new ObjectOutputStream(pool);
+    try (final ByteArrayOutputStream pool = new ByteArrayOutputStream(10000);
+        ObjectOutputStream outputStream = new ObjectOutputStream(pool);) {
+
       outputStream.writeObject(settings);
       final Preferences prefs = Preferences.userNodeForPackage(ProAI.class);
       prefs.putByteArray(PROGRAM_SETTINGS, pool.toByteArray());
@@ -59,14 +58,6 @@ public class ProLogSettings implements Serializable {
       }
     } catch (final Exception ex) {
       ex.printStackTrace();
-    } finally {
-      try {
-        if (outputStream != null) {
-          outputStream.close();
-        }
-      } catch (final Exception ex) {
-        ex.printStackTrace();
-      }
     }
   }
 }

--- a/src/games/strategy/triplea/ui/MapData.java
+++ b/src/games/strategy/triplea/ui/MapData.java
@@ -214,21 +214,11 @@ public class MapData {
       return;
     }
     m_decorations = new HashMap<Image, List<Point>>();
-    InputStream stream = null;
-    try {
-      stream = decorations.openStream();
+    try (InputStream stream = decorations.openStream();) {
       final Map<String, List<Point>> points = PointFileReaderWriter.readOneToMany(stream);
       for (final String name : points.keySet()) {
         final Image img = loadImage("misc/" + name);
         m_decorations.put(img, points.get(name));
-      }
-    } finally {
-      if (stream != null) {
-        try {
-          stream.close();
-        } catch (final IOException e) {
-          e.printStackTrace();
-        }
       }
     }
   }

--- a/src/games/strategy/triplea/ui/MapData.java
+++ b/src/games/strategy/triplea/ui/MapData.java
@@ -214,7 +214,7 @@ public class MapData {
       return;
     }
     m_decorations = new HashMap<Image, List<Point>>();
-    try (InputStream stream = decorations.openStream();) {
+    try (InputStream stream = decorations.openStream()) {
       final Map<String, List<Point>> points = PointFileReaderWriter.readOneToMany(stream);
       for (final String name : points.keySet()) {
         final Image img = loadImage("misc/" + name);

--- a/src/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -154,7 +154,6 @@ public class ProductionRepairPanel extends JPanel {
             if (initialPurchase.get(u) != null) {
               initialQuantity = initialPurchase.get(u).getInt(repairRule);
             }
-            // initialQuantity = initialPurchase.get(repairRule).getInt(repairRule);
             rule.setQuantity(initialQuantity);
             rule.setMax(taUnit.getHowMuchCanThisUnitBeRepaired(u, terr));
             rule.setName(u.toString());

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -87,6 +87,7 @@ import games.strategy.common.delegate.BaseEditDelegate;
 import games.strategy.common.ui.BasicGameMenuBar;
 import games.strategy.common.ui.MacWrapper;
 import games.strategy.common.ui.MainGameFrame;
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.chat.ChatPanel;
 import games.strategy.engine.chat.PlayerChatRenderer;
 import games.strategy.engine.data.Change;
@@ -1537,30 +1538,13 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   public static int save(final String filename, final GameData m_data) {
-    FileOutputStream fos = null;
-    ObjectOutputStream oos = null;
-    try {
-      fos = new FileOutputStream(filename);
-      oos = new ObjectOutputStream(fos);
+    try (FileOutputStream fos = new FileOutputStream(filename);
+        ObjectOutputStream oos = new ObjectOutputStream(fos);) {
       oos.writeObject(m_data);
       return 0;
     } catch (final Throwable t) {
-      // t.printStackTrace();
       System.err.println(t.getMessage());
       return -1;
-    } finally {
-      try {
-        if (fos != null) {
-          fos.flush();
-        }
-      } catch (final Exception ignore) {
-      }
-      try {
-        if (oos != null) {
-          oos.close();
-        }
-      } catch (final Exception ignore) {
-      }
     }
   }
 
@@ -1955,9 +1939,7 @@ public class TripleAFrame extends MainGameFrame {
         try {
           final File f = BasicGameMenuBar.getSaveGameLocationDialog(TripleAFrame.this);
           if (f != null) {
-            FileOutputStream fout = null;
-            try {
-              fout = new FileOutputStream(f);
+            try (FileOutputStream fout = new FileOutputStream(f);) {
               final GameData datacopy = GameDataUtils.cloneGameData(m_data, true);
               datacopy.getHistory().gotoNode(m_historyPanel.getCurrentPopupNode());
               datacopy.getHistory().removeAllHistoryAfterNode(m_historyPanel.getCurrentPopupNode());
@@ -1990,19 +1972,10 @@ public class TripleAFrame extends MainGameFrame {
               JOptionPane.showMessageDialog(TripleAFrame.this, "Game Saved", "Game Saved",
                   JOptionPane.INFORMATION_MESSAGE);
             } catch (final IOException e) {
-              e.printStackTrace();
-            } finally {
-              if (fout != null) {
-                try {
-                  fout.close();
-                } catch (final IOException e) {
-                  e.printStackTrace();
-                }
-              }
+              ClientLogger.logQuietly(e);
             }
           }
         } finally {
-          // m_data.releaseWriteLock();
           m_data.releaseReadLock();
         }
         m_historyPanel.clearCurrentPopupNode();

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -1939,7 +1939,7 @@ public class TripleAFrame extends MainGameFrame {
         try {
           final File f = BasicGameMenuBar.getSaveGameLocationDialog(TripleAFrame.this);
           if (f != null) {
-            try (FileOutputStream fout = new FileOutputStream(f);) {
+            try (FileOutputStream fout = new FileOutputStream(f)) {
               final GameData datacopy = GameDataUtils.cloneGameData(m_data, true);
               datacopy.getHistory().gotoNode(m_historyPanel.getCurrentPopupNode());
               datacopy.getHistory().removeAllHistoryAfterNode(m_historyPanel.getCurrentPopupNode());

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -62,6 +62,7 @@ import javax.swing.event.MenuListener;
 import javax.swing.tree.DefaultMutableTreeNode;
 
 import games.strategy.common.ui.BasicGameMenuBar;
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.ProductionRule;
@@ -1158,15 +1159,10 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
     } finally {
       getData().releaseReadLock();
     }
-    try {
-      final FileWriter writer = new FileWriter(chooser.getSelectedFile());
-      try {
-        writer.write(text.toString());
-      } finally {
-        writer.close();
-      }
+    try (final FileWriter writer = new FileWriter(chooser.getSelectedFile());) {
+      writer.write(text.toString());
     } catch (final IOException e1) {
-      e1.printStackTrace();
+      ClientLogger.logQuietly(e1);
     }
   }
 
@@ -1186,16 +1182,11 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
         if (chooser.showSaveDialog(m_frame) != JOptionPane.OK_OPTION) {
           return;
         }
-        try {
-          final FileWriter writer = new FileWriter(chooser.getSelectedFile());
-          try {
+        try (final FileWriter writer = new FileWriter(chooser.getSelectedFile());) {
             writer.write(getUnitStatsTable().toString().replaceAll("<p>", "<p>\r\n").replaceAll("</p>", "</p>\r\n")
                 .replaceAll("</tr>", "</tr>\r\n").replaceAll(LocalizeHTML.PATTERN_HTML_IMG_TAG, ""));
-          } finally {
-            writer.close();
-          }
         } catch (final IOException e1) {
-          e1.printStackTrace();
+          ClientLogger.logQuietly(e1);
         }
       }
     });

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -1159,7 +1159,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
     } finally {
       getData().releaseReadLock();
     }
-    try (final FileWriter writer = new FileWriter(chooser.getSelectedFile());) {
+    try (final FileWriter writer = new FileWriter(chooser.getSelectedFile())) {
       writer.write(text.toString());
     } catch (final IOException e1) {
       ClientLogger.logQuietly(e1);
@@ -1182,7 +1182,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
         if (chooser.showSaveDialog(m_frame) != JOptionPane.OK_OPTION) {
           return;
         }
-        try (final FileWriter writer = new FileWriter(chooser.getSelectedFile());) {
+        try (final FileWriter writer = new FileWriter(chooser.getSelectedFile())) {
             writer.write(getUnitStatsTable().toString().replaceAll("<p>", "<p>\r\n").replaceAll("</p>", "</p>\r\n")
                 .replaceAll("</tr>", "</tr>\r\n").replaceAll(LocalizeHTML.PATTERN_HTML_IMG_TAG, ""));
         } catch (final IOException e1) {

--- a/src/games/strategy/util/PointFileReaderWriter.java
+++ b/src/games/strategy/util/PointFileReaderWriter.java
@@ -36,7 +36,8 @@ public class PointFileReaderWriter {
     }
     final Map<String, Point> mapping = new HashMap<String, Point>();
 
-    try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream))) {
+    try (InputStreamReader inputStreamReader = new InputStreamReader(stream);
+        LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {
@@ -54,7 +55,8 @@ public class PointFileReaderWriter {
   public static Map<String, Point> readOneToOneCenters(final InputStream stream) throws IOException {
     final Map<String, Point> mapping = new HashMap<String, Point>();
 
-    try(LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream)); ) {
+    try (InputStreamReader inputStreamReader = new InputStreamReader(stream);
+        LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {
@@ -157,7 +159,8 @@ public class PointFileReaderWriter {
     }
 
     final HashMap<String, List<Point>> mapping = new HashMap<String, List<Point>>();
-    try( LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream));) {
+    try (InputStreamReader inputStreamReader = new InputStreamReader(stream);
+        LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {
@@ -177,7 +180,8 @@ public class PointFileReaderWriter {
    */
   public static Map<String, List<Polygon>> readOneToManyPolygons(final InputStream stream) throws IOException {
     final HashMap<String, List<Polygon>> mapping = new HashMap<String, List<Polygon>>();
-    try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream))) {
+    try (InputStreamReader inputStreamReader = new InputStreamReader(stream);
+        LineNumberReader reader = new LineNumberReader(inputStreamReader)) {
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {

--- a/src/games/strategy/util/PointFileReaderWriter.java
+++ b/src/games/strategy/util/PointFileReaderWriter.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
+import games.strategy.debug.ClientLogger;
+
 /**
  * Utiltity to read and write files in the form of
  * String -> a list of points, or string-> list of polygons
@@ -33,19 +35,14 @@ public class PointFileReaderWriter {
       return Collections.emptyMap();
     }
     final Map<String, Point> mapping = new HashMap<String, Point>();
-    LineNumberReader reader = null;
-    try {
-      reader = new LineNumberReader(new InputStreamReader(stream));
+
+    try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream));) {
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {
           readSingle(current, mapping);
         }
         current = reader.readLine();
-      }
-    } finally {
-      if (reader != null) {
-        reader.close();
       }
     }
     return mapping;
@@ -56,19 +53,14 @@ public class PointFileReaderWriter {
    */
   public static Map<String, Point> readOneToOneCenters(final InputStream stream) throws IOException {
     final Map<String, Point> mapping = new HashMap<String, Point>();
-    LineNumberReader reader = null;
-    try {
-      reader = new LineNumberReader(new InputStreamReader(stream));
+
+    try(LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream)); ) {
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {
           readSingle(current, mapping);
         }
         current = reader.readLine();
-      }
-    } finally {
-      if (reader != null) {
-        reader.close();
       }
     }
     return mapping;
@@ -160,14 +152,12 @@ public class PointFileReaderWriter {
    * Returns a map of the form String -> Collection of points.
    */
   public static Map<String, List<Point>> readOneToMany(final InputStream stream) throws IOException {
+    if (stream == null) {
+      return Collections.emptyMap();
+    }
+
     final HashMap<String, List<Point>> mapping = new HashMap<String, List<Point>>();
-    LineNumberReader reader = null;
-    try {
-      // Check to see if there's null input
-      if (stream == null) {
-        return Collections.emptyMap();
-      }
-      reader = new LineNumberReader(new InputStreamReader(stream));
+    try( LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream));) {
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {
@@ -176,15 +166,8 @@ public class PointFileReaderWriter {
         current = reader.readLine();
       }
     } catch (final IOException ioe) {
-      ioe.printStackTrace();
+      ClientLogger.logError(ioe);
       System.exit(0);
-    } finally {
-      try {
-        if (reader != null) {
-          reader.close();
-        }
-      } catch (final IOException e) {
-      }
     }
     return mapping;
   }
@@ -194,9 +177,7 @@ public class PointFileReaderWriter {
    */
   public static Map<String, List<Polygon>> readOneToManyPolygons(final InputStream stream) throws IOException {
     final HashMap<String, List<Polygon>> mapping = new HashMap<String, List<Polygon>>();
-    LineNumberReader reader = null;
-    try {
-      reader = new LineNumberReader(new InputStreamReader(stream));
+    try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream));) {
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {
@@ -207,13 +188,6 @@ public class PointFileReaderWriter {
     } catch (final IOException ioe) {
       ioe.printStackTrace();
       System.exit(0);
-    } finally {
-      try {
-        if (reader != null) {
-          reader.close();
-        }
-      } catch (final IOException e) {
-      }
     }
     return mapping;
   }

--- a/src/games/strategy/util/PointFileReaderWriter.java
+++ b/src/games/strategy/util/PointFileReaderWriter.java
@@ -36,7 +36,7 @@ public class PointFileReaderWriter {
     }
     final Map<String, Point> mapping = new HashMap<String, Point>();
 
-    try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream));) {
+    try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream))) {
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {
@@ -177,7 +177,7 @@ public class PointFileReaderWriter {
    */
   public static Map<String, List<Polygon>> readOneToManyPolygons(final InputStream stream) throws IOException {
     final HashMap<String, List<Polygon>> mapping = new HashMap<String, List<Polygon>>();
-    try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream));) {
+    try (LineNumberReader reader = new LineNumberReader(new InputStreamReader(stream))) {
       String current = reader.readLine();
       while (current != null) {
         if (current.trim().length() != 0) {

--- a/src/util/image/XmlUpdater.java
+++ b/src/util/image/XmlUpdater.java
@@ -36,7 +36,7 @@ public class XmlUpdater {
     final Transformer trans = TransformerFactory.newInstance().newTransformer(new StreamSource(source));
 
     ByteArrayOutputStream resultBuf;
-    try (final InputStream gameXmlStream = new BufferedInputStream(new FileInputStream(gameXmlFile));) {
+    try (final InputStream gameXmlStream = new BufferedInputStream(new FileInputStream(gameXmlFile))) {
       final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       factory.setValidating(true);
       // use a dummy game.dtd, this prevents the xml parser from adding default values

--- a/src/util/image/XmlUpdater.java
+++ b/src/util/image/XmlUpdater.java
@@ -29,26 +29,22 @@ public class XmlUpdater {
       System.out.println("No file selected");
       return;
     }
-    // File gameXmlFile = new File("/Users/sgb/Documents/workspace/triplea/maps/revised/games/revised.xml");
     final InputStream source = XmlUpdater.class.getResourceAsStream("gameupdate.xslt");
     if (source == null) {
       throw new IllegalStateException("Could not find xslt file");
     }
     final Transformer trans = TransformerFactory.newInstance().newTransformer(new StreamSource(source));
-    final InputStream gameXmlStream = new BufferedInputStream(new FileInputStream(gameXmlFile));
+
     ByteArrayOutputStream resultBuf;
-    try {
+    try (final InputStream gameXmlStream = new BufferedInputStream(new FileInputStream(gameXmlFile));) {
       final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       factory.setValidating(true);
-      // use a dummy game.dtd, this prevents the xml parser from adding
-      // default values
+      // use a dummy game.dtd, this prevents the xml parser from adding default values
       final URL url = XmlUpdater.class.getResource("");
       final String system = url.toExternalForm();
       final Source xmlSource = new StreamSource(gameXmlStream, system);
       resultBuf = new ByteArrayOutputStream();
       trans.transform(xmlSource, new StreamResult(resultBuf));
-    } finally {
-      gameXmlStream.close();
     }
     gameXmlFile.renameTo(new File(gameXmlFile.getAbsolutePath() + ".backup"));
     final FileOutputStream outStream = new FileOutputStream(gameXmlFile);

--- a/src/util/image/XmlUpdater.java
+++ b/src/util/image/XmlUpdater.java
@@ -36,7 +36,9 @@ public class XmlUpdater {
     final Transformer trans = TransformerFactory.newInstance().newTransformer(new StreamSource(source));
 
     ByteArrayOutputStream resultBuf;
-    try (final InputStream gameXmlStream = new BufferedInputStream(new FileInputStream(gameXmlFile))) {
+    try (
+        final FileInputStream fileInputStream = new FileInputStream(gameXmlFile);
+        final InputStream gameXmlStream = new BufferedInputStream(fileInputStream)) {
       final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       factory.setValidating(true);
       // use a dummy game.dtd, this prevents the xml parser from adding default values

--- a/test/games/strategy/engine/lobby/server/userDB/DBUserControllerTest.java
+++ b/test/games/strategy/engine/lobby/server/userDB/DBUserControllerTest.java
@@ -16,7 +16,7 @@ public class DBUserControllerTest extends TestCase {
     controller.createUser(name, email, password, false);
     assertTrue(controller.doesUserExist(name));
 
-    try (final Connection con = Database.getConnection();) {
+    try (final Connection con = Database.getConnection()) {
       final String sql = " select * from TA_USERS where userName = '" + name + "'";
       final ResultSet rs = con.createStatement().executeQuery(sql);
       assertTrue(rs.next());
@@ -69,7 +69,7 @@ public class DBUserControllerTest extends TestCase {
     loginTimeMustBeAfter = System.currentTimeMillis();
     assertTrue(controller.login(name, password));
 
-    try (final Connection con = Database.getConnection();) {
+    try (final Connection con = Database.getConnection()) {
       final String sql = " select * from TA_USERS where userName = '" + name + "'";
       final ResultSet rs = con.createStatement().executeQuery(sql);
       assertTrue(rs.next());
@@ -88,7 +88,7 @@ public class DBUserControllerTest extends TestCase {
     final String password2 = MD5Crypt.crypt("foo");
     final String email2 = "foo@foo.foo";
     controller.updateUser(name, email2, password2, false);
-    try (final Connection con = Database.getConnection();) {
+    try (final Connection con = Database.getConnection()) {
       final String sql = " select * from TA_USERS where userName = '" + name + "'";
       final ResultSet rs = con.createStatement().executeQuery(sql);
       assertTrue(rs.next());

--- a/test/games/strategy/engine/lobby/server/userDB/DBUserControllerTest.java
+++ b/test/games/strategy/engine/lobby/server/userDB/DBUserControllerTest.java
@@ -15,15 +15,13 @@ public class DBUserControllerTest extends TestCase {
     final DBUserController controller = new DBUserController();
     controller.createUser(name, email, password, false);
     assertTrue(controller.doesUserExist(name));
-    final Connection con = Database.getConnection();
-    try {
+
+    try (final Connection con = Database.getConnection();) {
       final String sql = " select * from TA_USERS where userName = '" + name + "'";
       final ResultSet rs = con.createStatement().executeQuery(sql);
       assertTrue(rs.next());
       assertEquals(email, rs.getString("email"));
       assertEquals(password, rs.getString("password"));
-    } finally {
-      con.close();
     }
   }
 
@@ -70,14 +68,12 @@ public class DBUserControllerTest extends TestCase {
     }
     loginTimeMustBeAfter = System.currentTimeMillis();
     assertTrue(controller.login(name, password));
-    final Connection con = Database.getConnection();
-    try {
+
+    try (final Connection con = Database.getConnection();) {
       final String sql = " select * from TA_USERS where userName = '" + name + "'";
       final ResultSet rs = con.createStatement().executeQuery(sql);
       assertTrue(rs.next());
       assertTrue(rs.getTimestamp("lastLogin").getTime() >= loginTimeMustBeAfter);
-    } finally {
-      con.close();
     }
     // make sure last login time was updated
   }
@@ -92,15 +88,12 @@ public class DBUserControllerTest extends TestCase {
     final String password2 = MD5Crypt.crypt("foo");
     final String email2 = "foo@foo.foo";
     controller.updateUser(name, email2, password2, false);
-    final Connection con = Database.getConnection();
-    try {
+    try (final Connection con = Database.getConnection();) {
       final String sql = " select * from TA_USERS where userName = '" + name + "'";
       final ResultSet rs = con.createStatement().executeQuery(sql);
       assertTrue(rs.next());
       assertEquals(email2, rs.getString("email"));
       assertEquals(password2, rs.getString("password"));
-    } finally {
-      con.close();
     }
   }
 }

--- a/test/games/strategy/triplea/xml/LoadGameUtil.java
+++ b/test/games/strategy/triplea/xml/LoadGameUtil.java
@@ -31,7 +31,7 @@ public class LoadGameUtil {
 
   private static GameData loadGame(final String game, final String[] possibleFolders) {
 
-    try (final InputStream is = openInputStream(game, possibleFolders);) {
+    try (final InputStream is = openInputStream(game, possibleFolders)) {
       if (is == null) {
         throw new IllegalStateException(game + " does not exist");
       }

--- a/test/games/strategy/triplea/xml/LoadGameUtil.java
+++ b/test/games/strategy/triplea/xml/LoadGameUtil.java
@@ -30,16 +30,12 @@ public class LoadGameUtil {
   }
 
   private static GameData loadGame(final String game, final String[] possibleFolders) {
-    final InputStream is = openInputStream(game, possibleFolders);
-    if (is == null) {
-      throw new IllegalStateException(game + " does not exist");
-    }
-    try {
-      try {
-        return (new GameParser()).parse(is, new AtomicReference<String>(), false);
-      } finally {
-        is.close();
+
+    try (final InputStream is = openInputStream(game, possibleFolders);) {
+      if (is == null) {
+        throw new IllegalStateException(game + " does not exist");
       }
+      return (new GameParser()).parse(is, new AtomicReference<String>(), false);
     } catch (final Exception e) {
       throw new IllegalStateException(e);
     }
@@ -49,7 +45,7 @@ public class LoadGameUtil {
    * First try to load the game as a file on the classpath, if not found there
    * then try to load it from either the "maps" or "test_data" folders.
    */
-  private static InputStream openInputStream(final String game, final String[] possibleFolders) {
+  private static InputStream openInputStream(final String game, String[] possibleFolders) {
     InputStream is = LoadGameUtil.class.getResourceAsStream(game);
     if (is == null) {
       final File f = GameRunner2.getFile(game, possibleFolders);


### PR DESCRIPTION
Simplification change that makes some finally blocks unnecessary. Fixes one or two resource leaks where a stream was not closed. Couple other small minor tweaks included, notably use ClientLogger instead of printing stack traces in some catch blocks (ClientLogger will capture exception message as well as stack traces).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/140)
<!-- Reviewable:end -->
