### PR TITLE
Remove simple threadpool test

### DIFF
--- a/test/games/strategy/thread/ThreadPoolTest.java
+++ b/test/games/strategy/thread/ThreadPoolTest.java
@@ -36,23 +36,6 @@ public class ThreadPoolTest extends TestCase {
     pool.shutDown();
   }
 
-  public void testSimple() {
-    final ThreadPool pool = new ThreadPool(5, "test");
-    final Collection<Task> tasks = new ArrayList<Task>();
-    for (int i = 0; i < 3000; i++) {
-      final Task task = new Task();
-      tasks.add(task);
-      pool.runTask(task);
-    }
-    assertEquals(5, pool.getThreadCount());
-    pool.waitForAll();
-    final Iterator<Task> iter = tasks.iterator();
-    while (iter.hasNext()) {
-      assertTrue(iter.next().isDone());
-    }
-    pool.shutDown();
-  }
-
   public void testBlocked() {
     final Collection<Thread> threads = new ArrayList<Thread>();
     for (int j = 0; j < 15; j++) {


### PR DESCRIPTION
The implementation of ThreadPool will be changing to a library implementation, which reduces the value of this test. In addition, the test still does not pass all the time with a library implementation, indicating something is probably wrong with the test itself. Last, practically speaking, the test failure is being systematically ignored, so the test is providing no value (whiling having a significant cost)


An example of a recent failure that was ignored: https://travis-ci.org/triplea-game/triplea/jobs/79388752

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/158)
<!-- Reviewable:end -->
