### PR TITLE
Small fix to some travis builds - restore build.gradle default value for game version 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = 'triplea'
 
-version = System.getenv("TRAVIS_TAG") ?: ""
+version = System.getenv("TRAVIS_TAG") ?: "1.8.0.7"
 
 description = 'TripleA is a free online turn based strategy game and board game engine, similar to such board games as Axis & Allies or Risk.'
 mainClassName = "games.strategy.engine.framework.GameRunner"


### PR DESCRIPTION
Add a default value for game version. Some forked and pull request builds were consistently failing and looks to be due to this. Examples:
https://travis-ci.org/triplea-game/triplea/builds/82909423
https://travis-ci.org/triplea-game/triplea/builds/82910725
https://travis-ci.org/DanVanAtta/triplea/builds/

A recent change to demo travis configuration removed the game version, it appears the testing was not comprehensive enough.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/213)
<!-- Reviewable:end -->
