### PR TITLE
Enable git lfs, large file storage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,9 @@
 MacOS_users_read_this_first.txt eol=lf
 
 # Denote all files that are truly binary and should not be modified.
+*.docx binary
+*.pdf binary
+*.exe binary
 *.png binary
 *.jpeg binary
 *.jpg binary
@@ -38,3 +41,11 @@ MacOS_users_read_this_first.txt eol=lf
 *.xls binary
 *.xlsx binary
 
+# Git LFS
+*.png filter=lfs diff=lfs merge=lfs -text
+*.mp3 filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.bmp filter=lfs diff=lfs merge=lfs -text
+*.jar filter=lfs diff=lfs merge=lfs -text
+*.docx filter=lfs diff=lfs merge=lfs -text
+*.pdf filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,49 +3,46 @@
 
 # Declare files that will always have CRLF line endings on checkout.
 *.bat eol=crlf
-*.txt eol=crlf
-*.ini eol=crlf
-*.properties eol=crlf
-*.xml eol=crlf
-*.html eol=crlf
 *.css eol=crlf
 *.dtd eol=crlf
+*.html eol=crlf
+*.ini eol=crlf
+*.properties eol=crlf
+*.txt eol=crlf
+*.xml eol=crlf
 *.xslt eol=crlf
 
 # Declare files that will always have LF line endings on checkout.
-*.sh eol=lf
 *.plist eol=lf
+*.sh eol=lf
 MacOS_users_read_this_first.txt eol=lf
 
 # Denote all files that are truly binary and should not be modified.
-*.docx binary
-*.pdf binary
-*.exe binary
-*.png binary
-*.jpeg binary
-*.jpg binary
-*.gif binary
 *.bmp binary
-*.ico binary
-*.icns binary
-*.pdn binary
-*.wav binary
-*.mp3 binary
-*.zip binary
-*.jar binary
-*.exe binary
-*.nsi binary
-*.pdf binary
 *.doc binary
 *.docx binary
+*.exe binary
+*.gif binary
+*.icns binary
+*.ico binary
+*.jar binary
+*.jpeg binary
+*.jpg binary
+*.mp3 binary
+*.nsi binary
+*.pdf binary
+*.png binary
+*.pdn binary
+*.wav binary
 *.xls binary
 *.xlsx binary
+*.zip binary
 
 # Git LFS
-*.png filter=lfs diff=lfs merge=lfs -text
-*.mp3 filter=lfs diff=lfs merge=lfs -text
-*.wav filter=lfs diff=lfs merge=lfs -text
 *.bmp filter=lfs diff=lfs merge=lfs -text
-*.jar filter=lfs diff=lfs merge=lfs -text
 *.docx filter=lfs diff=lfs merge=lfs -text
+*.jar filter=lfs diff=lfs merge=lfs -text
+*.mp3 filter=lfs diff=lfs merge=lfs -text
 *.pdf filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Github LFS is recently out for all repositories. It helps with binary file storage.

We're about 75% of the way towards the 1GB limit, so perhaps good timing before it has become a problem. With some luck, the repo size should shrink with LFS (or perhaps not grow when we modify binary files).

Git produces a client that you can install. All it does really is update .gitattrbutes: http://git-lfs.github.com/, https://www.youtube.com/watch?v=uLR1RNqJ1Mw

Apparently to enable Github LFS, all that is needed is a modification to .gitattributes

Updates that were auto-generated by the client are included in this PR.



<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/217)
<!-- Reviewable:end -->
