### PR TITLE
Improvements to: UnitsThatCantFightUtilTest.java

### DIFF
--- a/test/games/strategy/triplea/delegate/UnitsThatCantFightUtilTest.java
+++ b/test/games/strategy/triplea/delegate/UnitsThatCantFightUtilTest.java
@@ -31,16 +31,6 @@ public class UnitsThatCantFightUtilTest extends TestCase {
     assertTrue(territories.contains(sz12));
   }
 
-  public void testSuicideAttackInAA50WithTransportedUnits() {
-    final GameData data = LoadGameUtil.loadGame("World War II v3 1941 Test", "ww2v3_1941_test.xml");
-    // add a german sub to sz 12
-    final Territory sz12 = territory("12 Sea Zone", data);
-    addTo(sz12, transports(data).create(1, germans(data)));
-    final Collection<Territory> territories =
-        new UnitsThatCantFightUtil(data).getTerritoriesWhereUnitsCantFight(germans(data));
-    assertTrue(territories.contains(sz12));
-  }
-
   public void testSuicideAttackInRevised() {
     final GameData data = LoadGameUtil.loadGame("World War II Revised Test", "revised_test.xml");
     final Territory sz15 = territory("15 Sea Zone", data);

--- a/test/games/strategy/triplea/delegate/UnitsThatCantFightUtilTest.java
+++ b/test/games/strategy/triplea/delegate/UnitsThatCantFightUtilTest.java
@@ -15,14 +15,14 @@ import junit.framework.TestCase;
 public class UnitsThatCantFightUtilTest extends TestCase {
   public void testNoSuicideAttacksAA50AtStart() {
     // at the start of the game, there are no suicide attacks
-    final GameData data = LoadGameUtil.loadGame("World War II v3 1941 Test", "ww2v3_1941_test.xml");
+    final GameData data = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
     final Collection<Territory> territories =
         new UnitsThatCantFightUtil(data).getTerritoriesWhereUnitsCantFight(germans(data));
     assertTrue(territories.isEmpty());
   }
 
   public void testSuicideAttackInAA50() {
-    final GameData data = LoadGameUtil.loadGame("World War II v3 1941 Test", "ww2v3_1941_test.xml");
+    final GameData data = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
     // add a german sub to sz 12
     final Territory sz12 = territory("12 Sea Zone", data);
     addTo(sz12, transports(data).create(1, germans(data)));
@@ -32,7 +32,7 @@ public class UnitsThatCantFightUtilTest extends TestCase {
   }
 
   public void testSuicideAttackInRevised() {
-    final GameData data = LoadGameUtil.loadGame("World War II Revised Test", "revised_test.xml");
+    final GameData data = LoadGameUtil.loadTestGame("revised_test.xml");
     final Territory sz15 = territory("15 Sea Zone", data);
     addTo(sz15, transports(data).create(1, germans(data)));
     final Collection<Territory> territories =

--- a/test/games/strategy/triplea/delegate/UnitsThatCantFightUtilTest.java
+++ b/test/games/strategy/triplea/delegate/UnitsThatCantFightUtilTest.java
@@ -16,18 +16,14 @@ public class UnitsThatCantFightUtilTest extends TestCase {
   public void testNoSuicideAttacksAA50AtStart() {
     // at the start of the game, there are no suicide attacks
     final GameData data = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
-    final Collection<Territory> territories =
+    Collection<Territory> territories =
         new UnitsThatCantFightUtil(data).getTerritoriesWhereUnitsCantFight(germans(data));
     assertTrue(territories.isEmpty());
-  }
 
-  public void testSuicideAttackInAA50() {
-    final GameData data = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
     // add a german sub to sz 12
     final Territory sz12 = territory("12 Sea Zone", data);
     addTo(sz12, transports(data).create(1, germans(data)));
-    final Collection<Territory> territories =
-        new UnitsThatCantFightUtil(data).getTerritoriesWhereUnitsCantFight(germans(data));
+    territories = new UnitsThatCantFightUtil(data).getTerritoriesWhereUnitsCantFight(germans(data));
     assertTrue(territories.contains(sz12));
   }
 


### PR DESCRIPTION
- Remove a duplicated test method
- Merge two methods to avoid calling `LoadGameUtil.loadTestGame` twice
- Fix calls to deprecated method `LoadGameUtil.loadGame`, drop unused param and call `loadTestGame` as recommended by the deprecation notes on `LoadGameUtil.loadGame`.

25% reduction in runtime on my computer for the unit test (~1s to ~0.75s)
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/225)
<!-- Reviewable:end -->
