### PR TITLE
Pro purchase ai warning fixes

### DIFF
--- a/src/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProAI.java
@@ -109,8 +109,7 @@ public class ProAI extends AbstractAI {
         new ProNonCombatMoveAI(utils, battleUtils, transportUtils, attackOptionsUtils, moveUtils, territoryValueUtils,
             purchaseUtils);
     purchaseAI =
-        new ProPurchaseAI(this, utils, battleUtils, transportUtils, attackOptionsUtils, moveUtils, territoryValueUtils,
-            purchaseUtils);
+        new ProPurchaseAI(utils, battleUtils, transportUtils, attackOptionsUtils, territoryValueUtils, purchaseUtils);
     retreatAI = new ProRetreatAI(this, battleUtils);
     scrambleAI = new ProScrambleAI(this, battleUtils, attackOptionsUtils);
     politicsAI = new ProPoliticsAI(this, utils, attackOptionsUtils);

--- a/src/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProAI.java
@@ -277,7 +277,7 @@ public class ProAI extends AbstractAI {
     BattleCalculator.clearOOLCache();
     ProLogUI.notifyStartOfRound(data.getSequence().getRound(), player.getName());
     if (bid) {
-      purchaseAI.bidPlace(storedPurchaseTerritories, placeDelegate, data, player);
+      purchaseAI.bidPlace(placeDelegate, data, player);
     } else {
       purchaseAI.place(storedPurchaseTerritories, placeDelegate, data, player);
       storedPurchaseTerritories = null;

--- a/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -75,10 +75,9 @@ public class ProPurchaseAI {
   private double minCostPerHitPoint;
   private ProResourceTracker resourceTracker;
 
-  public ProPurchaseAI(final ProAI ai, final ProUtils utils, final ProBattleUtils battleUtils,
+  public ProPurchaseAI(final ProUtils utils, final ProBattleUtils battleUtils,
       final ProTransportUtils transportUtils, final ProAttackOptionsUtils attackOptionsUtils,
-      final ProMoveUtils moveUtils, final ProTerritoryValueUtils territoryValueUtils,
-      final ProPurchaseUtils purchaseUtils) {
+      final ProTerritoryValueUtils territoryValueUtils, final ProPurchaseUtils purchaseUtils) {
     this.utils = utils;
     this.battleUtils = battleUtils;
     this.transportUtils = transportUtils;

--- a/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -326,7 +326,7 @@ public class ProPurchaseAI {
       }
     }
     final boolean buyAttack = Math.random() > 0.25;
-    int buyThese = 0, numBought = 0;
+    int buyThese = 0;
     for (final ProductionRule rule1 : processRules) {
       final int cost = rule1.getCosts().getInt(pus);
       if (goTransports) {
@@ -344,7 +344,6 @@ public class ProPurchaseAI {
         PUsToSpend += cost;
       }
       if (buyThese > 0) {
-        numBought += buyThese;
         purchase.add(rule1, buyThese);
       }
     }

--- a/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -60,12 +60,10 @@ public class ProPurchaseAI {
   public final static double WIN_PERCENTAGE = 95.0;
 
   // Utilities
-  private final ProAI ai;
   private final ProUtils utils;
   private final ProBattleUtils battleUtils;
   private final ProTransportUtils transportUtils;
   private final ProAttackOptionsUtils attackOptionsUtils;
-  private final ProMoveUtils moveUtils;
   private final ProTerritoryValueUtils territoryValueUtils;
   private final ProPurchaseUtils purchaseUtils;
 
@@ -75,20 +73,16 @@ public class ProPurchaseAI {
   private PlayerID player;
   private Territory myCapital;
   private double minCostPerHitPoint;
-  private List<Territory> allTerritories;
-  private Map<Unit, Territory> unitTerritoryMap;
   private ProResourceTracker resourceTracker;
 
   public ProPurchaseAI(final ProAI ai, final ProUtils utils, final ProBattleUtils battleUtils,
       final ProTransportUtils transportUtils, final ProAttackOptionsUtils attackOptionsUtils,
       final ProMoveUtils moveUtils, final ProTerritoryValueUtils territoryValueUtils,
       final ProPurchaseUtils purchaseUtils) {
-    this.ai = ai;
     this.utils = utils;
     this.battleUtils = battleUtils;
     this.transportUtils = transportUtils;
     this.attackOptionsUtils = attackOptionsUtils;
-    this.moveUtils = moveUtils;
     this.territoryValueUtils = territoryValueUtils;
     this.purchaseUtils = purchaseUtils;
   }
@@ -101,7 +95,6 @@ public class ProPurchaseAI {
     this.data = data;
     this.player = player;
     myCapital = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
-    allTerritories = data.getMap().getTerritories();
     if (PUsToSpend == 0 && player.getResources().getQuantity(data.getResourceList().getResource(Constants.PUS)) == 0) {
       return;
     }
@@ -425,7 +418,6 @@ public class ProPurchaseAI {
     this.data = data;
     this.player = player;
     myCapital = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
-    allTerritories = data.getMap().getTerritories();
     final CompositeMatch<Unit> ourFactories =
         new CompositeMatchAnd<Unit>(Matches.unitIsOwnedBy(player), Matches.UnitCanProduceUnits,
             Matches.UnitIsInfrastructure);
@@ -485,7 +477,6 @@ public class ProPurchaseAI {
     this.startOfTurnData = startOfTurnData;
     this.player = player;
     myCapital = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
-    allTerritories = data.getMap().getTerritories();
     resourceTracker = new ProResourceTracker(player);
 
     ProLogger.info("Starting purchase phase with resources: " + resourceTracker);
@@ -887,7 +878,6 @@ public class ProPurchaseAI {
     this.data = data;
     this.player = player;
     myCapital = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
-    allTerritories = data.getMap().getTerritories();
 
     // Find all place territories
     final Map<Territory, ProPurchaseTerritory> placeNonConstructionTerritories =

--- a/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -523,8 +523,7 @@ public class ProPurchaseAI {
     // Prioritize land place options purchase AA then land units
     final List<ProPlaceTerritory> prioritizedLandTerritories = prioritizeLandTerritories(purchaseTerritories);
     purchaseAAUnits(purchaseTerritories, enemyAttackMap, prioritizedLandTerritories, purchaseOptions.getAAOptions());
-    purchaseLandUnits(purchaseTerritories, enemyAttackMap, prioritizedLandTerritories, purchaseOptions,
-        territoryValueMap);
+    purchaseLandUnits(purchaseTerritories, prioritizedLandTerritories, purchaseOptions, territoryValueMap);
 
     // Prioritize sea territories that need defended and purchase additional defenders
     final List<ProPlaceTerritory> needToDefendSeaTerritories =
@@ -1281,7 +1280,6 @@ public class ProPurchaseAI {
   }
 
   private void purchaseLandUnits(final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
-      final Map<Territory, ProAttackTerritoryData> enemyAttackMap,
       final List<ProPlaceTerritory> prioritizedLandTerritories, final ProPurchaseOptionMap purchaseOptions,
       final Map<Territory, Double> territoryValueMap) {
 

--- a/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -570,8 +570,7 @@ public class ProPurchaseAI {
   }
 
   // TODO: Rewrite this as its from the Moore AI
-  public void bidPlace(final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
-      final IAbstractPlaceDelegate placeDelegate, final GameData data, final PlayerID player) {
+  public void bidPlace(final IAbstractPlaceDelegate placeDelegate, final GameData data, final PlayerID player) {
     ProLogger.info("Starting bid place phase");
     // if we have purchased a factory, it will be a priority for placing units
     // should place most expensive on it


### PR DESCRIPTION
Fix eclipse warnings for ProPurchaseAI (two unused class variables).

Several methods accepted parameters that were used only to support those variables. Once the variables were removed the associated and now unused  method parameters were removed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/227)
<!-- Reviewable:end -->
