### PR TITLE
DiceRoll.java  fixes

### DIFF
--- a/src/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/games/strategy/triplea/delegate/AirBattle.java
@@ -99,11 +99,11 @@ public class AirBattle extends AbstractBattle {
     BattleCalculator.sortPreBattle(m_defendingUnits, m_data);
     m_steps = determineStepStrings(true, bridge);
     showBattle(bridge);
-    pushFightLoopOnStack(true, bridge);
+    pushFightLoopOnStack(true);
     m_stack.execute(bridge);
   }
 
-  private void pushFightLoopOnStack(final boolean firstRun, final IDelegateBridge bridge) {
+  private void pushFightLoopOnStack(final boolean firstRun) {
     if (m_isOver) {
       return;
     }
@@ -248,7 +248,7 @@ public class AirBattle extends AbstractBattle {
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        pushFightLoopOnStack(false, bridge);
+        pushFightLoopOnStack(false);
       }
     };
     steps.add(new IExecutable() {
@@ -293,7 +293,7 @@ public class AirBattle extends AbstractBattle {
     return steps;
   }
 
-  private void recordUnitsWereInAirBattle(final Collection<Unit> units, final IDelegateBridge bridge) {
+  private static void recordUnitsWereInAirBattle(final Collection<Unit> units, final IDelegateBridge bridge) {
     final CompositeChange wasInAirBattleChange = new CompositeChange();
     for (final Unit u : units) {
       wasInAirBattleChange.add(ChangeFactory.unitPropertyChange(u, true, TripleAUnit.WAS_IN_AIR_BATTLE));

--- a/src/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/games/strategy/triplea/delegate/AirBattle.java
@@ -579,7 +579,7 @@ public class AirBattle extends AbstractBattle {
           allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingWaitingToDie);
           if (shouldAirBattleUseAirCombatAttDefValues(m_isBombingRun)) {
             m_dice =
-                DiceRoll.airBattle(m_attackingUnits, false, m_attacker, bridge, AirBattle.this, "Attackers Fire, ");
+                DiceRoll.airBattle(m_attackingUnits, false, m_attacker, bridge, "Attackers Fire, ");
           } else {
             m_dice = DiceRoll.rollDice(m_attackingUnits, false, m_attacker, bridge, AirBattle.this, "Attackers Fire, ",
                 m_territoryEffects, allEnemyUnitsAliveOrWaitingToDie);
@@ -631,7 +631,7 @@ public class AirBattle extends AbstractBattle {
           allEnemyUnitsAliveOrWaitingToDie.addAll(m_attackingUnits);
           allEnemyUnitsAliveOrWaitingToDie.addAll(m_attackingWaitingToDie);
           if (shouldAirBattleUseAirCombatAttDefValues(m_isBombingRun)) {
-            m_dice = DiceRoll.airBattle(m_defendingUnits, true, m_defender, bridge, AirBattle.this, "Defenders Fire, ");
+            m_dice = DiceRoll.airBattle(m_defendingUnits, true, m_defender, bridge, "Defenders Fire, ");
           } else {
             m_dice = DiceRoll.rollDice(m_defendingUnits, true, m_defender, bridge, AirBattle.this, "Defenders Fire, ",
                 m_territoryEffects, allEnemyUnitsAliveOrWaitingToDie);

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -912,7 +912,7 @@ public class DiceRoll implements Externalizable {
   }
 
   public static DiceRoll airBattle(final List<Unit> unitsList, final boolean defending, final PlayerID player,
-      final IDelegateBridge bridge, final IBattle battle, final String annotation) {
+      final IDelegateBridge bridge, final String annotation) {
     {
       final Set<Unit> duplicatesCheckSet1 = new HashSet<Unit>(unitsList);
       if (unitsList.size() != duplicatesCheckSet1.size()) {

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -675,20 +675,6 @@ public class DiceRoll implements Externalizable {
     return 0;
   }
 
-  public static int getSupportableAvailable(final List<Unit> units, final boolean defending, final PlayerID player) {
-    if (!defending) {
-      return Match.countMatches(units, Matches.UnitIsArtillerySupportable);
-    }
-    return 0;
-  }
-
-  public static int getSupportableAvailable(final Unit u, final boolean defending, final PlayerID player) {
-    if (Matches.UnitIsArtillerySupportable.match(u) && !defending) {
-      return 1;
-    }
-    return 0;
-  }
-
   /**
    * Fills a set and map with the support possibly given by these units.
    *


### PR DESCRIPTION
Remove unnecessary static methods and unused params in DiceRoll.java

Static methods are never called by reflection, so from that point of view, the methods and unused params can be removed 'safely'.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/228)
<!-- Reviewable:end -->
