### PR TITLE
Speed up background map parsing time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ description = 'TripleA is a free online turn based strategy game and board game 
 mainClassName = "games.strategy.engine.framework.GameRunner"
 
 compileJava.options.encoding = 'UTF-8'
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 tasks.withType(JavaCompile) { options.incremental = true }
 
 sourceSets {

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.xml.sax.SAXException;
@@ -21,6 +22,20 @@ public class NewGameChooserEntry {
   private GameData m_data;
   private boolean m_gameDataFullyLoaded = false;
   private final String m_gameNameAndMapNameProperty;
+
+
+  public static Comparator<NewGameChooserEntry> getComparator() {
+    return new Comparator<NewGameChooserEntry>() {
+      @Override
+      public int compare(final NewGameChooserEntry o1, final NewGameChooserEntry o2) {
+        return getLowerCaseComparable(o1).compareTo(getLowerCaseComparable(o2));
+      }
+      private String getLowerCaseComparable(NewGameChooserEntry newGameChooserEntry) {
+        return newGameChooserEntry.getGameData().getGameName().toLowerCase();
+      }
+    };
+  }
+
 
   public NewGameChooserEntry(final URI uri)
       throws IOException, GameParseException, SAXException, EngineVersionException {

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -71,26 +71,10 @@ public class NewGameChooserModel extends DefaultListModel {
     return rVal;
   }
 
-
-  private static List<File> allMapFiles() {
-    final List<File> rVal = new ArrayList<File>();
-    // prioritize user maps folder over root folder
-    rVal.addAll(safeListFiles(GameRunner2.getUserMapsFolder()));
-    rVal.addAll(safeListFiles(getDefaultMapsDir()));
-    return rVal;
-  }
-
   public static File getDefaultMapsDir() {
     return new File(GameRunner2.getRootFolder(), "maps");
   }
 
-  private static List<File> safeListFiles(final File f) {
-    final File[] files = f.listFiles();
-    if (files == null) {
-      return Collections.emptyList();
-    }
-    return Arrays.asList(files);
-  }
 
   private void populate() {
     final List<File> mapFileList = allMapFiles();
@@ -102,6 +86,22 @@ public class NewGameChooserModel extends DefaultListModel {
     for (final NewGameChooserEntry entry : entries) {
       addElement(entry);
     }
+  }
+
+  private static List<File> allMapFiles() {
+    final List<File> rVal = new ArrayList<File>();
+    // prioritize user maps folder over root folder
+    rVal.addAll(safeListFiles(GameRunner2.getUserMapsFolder()));
+    rVal.addAll(safeListFiles(getDefaultMapsDir()));
+    return rVal;
+  }
+
+  private static List<File> safeListFiles(final File f) {
+    final File[] files = f.listFiles();
+    if (files == null) {
+      return Collections.emptyList();
+    }
+    return Arrays.asList(files);
   }
 
 

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -97,24 +97,13 @@ public class NewGameChooserModel extends DefaultListModel {
     final Set<NewGameChooserEntry> parsedMapSet = parseMapFiles(mapFileList);
 
     final List<NewGameChooserEntry> entries = Lists.newArrayList(parsedMapSet);
-    Collections.sort(entries, getNewGameChooserEntryComparator());
+    Collections.sort(entries, NewGameChooserEntry.getComparator());
 
     for (final NewGameChooserEntry entry : entries) {
       addElement(entry);
     }
   }
 
-  private static Comparator<NewGameChooserEntry> getNewGameChooserEntryComparator() {
-    return new Comparator<NewGameChooserEntry>() {
-      @Override
-      public int compare(final NewGameChooserEntry o1, final NewGameChooserEntry o2) {
-        return getLowerCaseComparable(o1).compareTo(getLowerCaseComparable(o2));
-      }
-      private String getLowerCaseComparable(NewGameChooserEntry newGameChooserEntry) {
-        return newGameChooserEntry.getGameData().getGameName().toLowerCase();
-      }
-    };
-  }
 
   private Set<NewGameChooserEntry> parseMapFiles(List<File> mapFileList) {
     final Set<NewGameChooserEntry> parsedMapSet = parseMapFiles(mapFileList);

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -37,17 +37,19 @@ import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.startup.ui.MainFrame;
-import games.strategy.triplea.util.Stopwatch;
 import games.strategy.util.ClassLoaderUtil;
 
 public class NewGameChooserModel extends DefaultListModel {
   private static final long serialVersionUID = -2044689419834812524L;
+  private final ClearGameChooserCacheMessenger clearCacheMessenger;
 
   private enum ZipProcessingResult {
     SUCCESS, ERROR
   }
 
-  public NewGameChooserModel() {
+
+  public NewGameChooserModel(ClearGameChooserCacheMessenger clearCacheMessenger) {
+    this.clearCacheMessenger = clearCacheMessenger;
     populate();
   }
 
@@ -98,6 +100,9 @@ public class NewGameChooserModel extends DefaultListModel {
     ExecutorService threadPool = Executors.newFixedThreadPool(halfCoreCount);
 
     for (final File map : allMapFiles()) {
+      if (clearCacheMessenger.isCancelled()) {
+        return;
+      }
       if (map.isDirectory()) {
         threadPool.submit(new Runnable() {
           @Override

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -32,6 +32,7 @@ import org.xml.sax.SAXParseException;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.EngineVersionException;
@@ -77,8 +78,7 @@ public class NewGameChooserModel extends DefaultListModel {
 
 
   private void populate() {
-    final List<File> mapFileList = allMapFiles();
-    final Set<NewGameChooserEntry> parsedMapSet = parseMapFiles(mapFileList);
+    final Set<NewGameChooserEntry> parsedMapSet = parseMapFiles();
 
     final List<NewGameChooserEntry> entries = Lists.newArrayList(parsedMapSet);
     Collections.sort(entries, NewGameChooserEntry.getComparator());
@@ -105,16 +105,17 @@ public class NewGameChooserModel extends DefaultListModel {
   }
 
 
-  private Set<NewGameChooserEntry> parseMapFiles(List<File> mapFileList) {
-    final Set<NewGameChooserEntry> parsedMapSet = parseMapFiles(mapFileList);
+  private Set<NewGameChooserEntry> parseMapFiles() {
+    List<File> allMapFiles = allMapFiles();
+    final Set<NewGameChooserEntry> parsedMapSet = Sets.newHashSet();
 
-    Collections.newSetFromMap(new ConcurrentHashMap(mapFileList.size()));
+    Collections.newSetFromMap(new ConcurrentHashMap(allMapFiles.size()));
 
     // Half the total number of cores being used as a generic sweet spot. @DanVanAtta found with 6 cores that 2 to 4 threads were best.
     final int halfCoreCount = (int) Math.ceil(Runtime.getRuntime().availableProcessors()/2);
     final ExecutorService threadPool = Executors.newFixedThreadPool(halfCoreCount);
 
-    for (final File map : allMapFiles()) {
+    for (final File map : allMapFiles) {
       if (clearCacheMessenger.isCancelled()) {
         return ImmutableSet.of();
       }

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -93,12 +93,19 @@ public class NewGameChooserModel extends DefaultListModel {
   }
 
   private void populate() {
-
     final List<File> mapFileList = allMapFiles();
     final Set<NewGameChooserEntry> parsedMapSet = parseMapFiles(mapFileList);
-    final List<NewGameChooserEntry> entries = Lists.newArrayList(parsedMapSet);
 
-    Collections.sort(entries, new Comparator<NewGameChooserEntry>() {
+    final List<NewGameChooserEntry> entries = Lists.newArrayList(parsedMapSet);
+    Collections.sort(entries, getNewGameChooserEntryComparator());
+
+    for (final NewGameChooserEntry entry : entries) {
+      addElement(entry);
+    }
+  }
+
+  private static Comparator<NewGameChooserEntry> getNewGameChooserEntryComparator() {
+    return new Comparator<NewGameChooserEntry>() {
       @Override
       public int compare(final NewGameChooserEntry o1, final NewGameChooserEntry o2) {
         return getLowerCaseComparable(o1).compareTo(getLowerCaseComparable(o2));
@@ -106,11 +113,7 @@ public class NewGameChooserModel extends DefaultListModel {
       private String getLowerCaseComparable(NewGameChooserEntry newGameChooserEntry) {
         return newGameChooserEntry.getGameData().getGameName().toLowerCase();
       }
-    });
-
-    for (final NewGameChooserEntry entry : entries) {
-      addElement(entry);
-    }
+    };
   }
 
   private Set<NewGameChooserEntry> parseMapFiles(List<File> mapFileList) {


### PR DESCRIPTION
 Using a benchmark of 110 map zips, 1.8G of data, a couple of changes reduced map parsing time from 20s to 2s.

Performance changes:
- Use ZipFile (requires Java 1.7) instead of ZipFileInputStream  (20s -> 4s)
- Boost the parallelism, introduce multi-threading using half of the number of available cores  (4s -> 2s) 

Commit comment from b3a9d97 with more details about the conversion to ZipFile:

> NewGameChooserModel - Speed up background zip file parsing use ZipFile instead of a ZipFileInputStream. ZipFile can use file system information embedded in the Zip to go directly to the XML files rather than scanning through the entire Zip. As a benchmark, with 110 map zips (1.8G) and this update, map parsing time dropped from 20s to 4s.

Commit comment from 68cf809 with more details about the multi-threading:

> NewGameChooserModel - Multi-threaded background map parsing using half of the available CPU cores. ZipFile already reduced parsing time of 110 maps (1.8G) down to 4s, this change reduces parsing time by an additional 50% to 2s. Analysis on a six core machine showed the sweet spot for the number of threads to be between 2 and 4. Hence the choice of using half the number of cores both falls in this range and is a bit more conservative (for example considering the impact of extra threads on a 4 core or a 2 core machine, +1 and +0 threads is relatively minimal)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/240)
<!-- Reviewable:end -->