### PR TITLE
Remove class loader util close loader method

### DIFF
--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -136,8 +136,8 @@ public class NewGameChooserModel extends DefaultListModel {
     boolean badMapZip = false;
     final List<NewGameChooserEntry> entries = Lists.newArrayList();
 
-    try (ZipFile zipFile = new ZipFile(map)) {
-      final URLClassLoader loader = new URLClassLoader(new URL[] {map.toURI().toURL()});
+    try (ZipFile zipFile = new ZipFile(map);
+        final URLClassLoader loader = new URLClassLoader(new URL[] {map.toURI().toURL()})) {
       Enumeration<? extends ZipEntry> zipEntryEnumeration = zipFile.entries();
       while (zipEntryEnumeration.hasMoreElements()) {
         ZipEntry entry = zipEntryEnumeration.nextElement();
@@ -149,8 +149,6 @@ public class NewGameChooserModel extends DefaultListModel {
           }
         }
       }
-      // we have to close the loader to allow files to be deleted on windows
-      ClassLoaderUtil.closeLoader(loader);
     } catch (final IOException ioe) {
       ClientLogger.logQuietly(ioe);
     }

--- a/src/games/strategy/util/ClassLoaderUtil.java
+++ b/src/games/strategy/util/ClassLoaderUtil.java
@@ -120,37 +120,6 @@ public class ClassLoaderUtil {
     return result;
   }
 
-  public static void closeLoader(final URLClassLoader loader) {
-    try {
-      try {
-        // java 1.7 has a close method, thanks guys
-        // Method close = loader.getClass().getMethod("close", null);
-        // close.invoke(loader, null);
-        final Method close = loader.getClass().getMethod("close");
-        close.invoke(loader);
-        return;
-      } catch (final Exception e) {
-        // ignore
-      }
-      releaseLoader(loader);
-    } catch (final Exception e) {
-      e.printStackTrace(System.out);
-    }
-  }
-
-  /**
-   * Releases resources held by the URLClassLoader. Notably, close the jars
-   * opened by the loader. This does not prevent the class loader from
-   * continuing to return classes it has already resolved.
-   *
-   * @param classLoader
-   *        the instance of URLClassLoader (or a subclass)
-   * @return array of IOExceptions reporting jars that failed to close
-   */
-  private static void releaseLoader(final URLClassLoader classLoader) {
-    releaseLoader(classLoader, null);
-  }
-
   /**
    * Releases resources held by the URLClassLoader. Notably, close the jars
    * opened by the loader. This does not prevent the class loader from


### PR DESCRIPTION
We have a utility method that call close on ClassLoader via reflection and then fails if it is not present (this is to support java 6 compilation yet still close the class on Java7 and Java8). Now that we no longer compile to Java6, this can be removed.

Based on top of #240 to avoid conflicting changes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/243)
<!-- Reviewable:end -->
