### PR TITLE
Travis config - deploy shadow jar automatically to github releases 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,22 @@
 language: java
 jdk:
-  - oraclejdk8
+- oraclejdk8
+install: true
+script:
+- gradle shadowjar
+before_deploy:
+- git config --global user.email "tripleabuilderbot@gmail.com"
+- git config --global user.name "tripleabuilderbot"
+- export TAGGED_VERSION="$BUILD_VERSION.$TRAVIS_BUILD_NUMBER"
+- git tag $TAGGED_VERSION -a -m "$TAGGED_VERSION"
+- git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-triplea/triplea --tags
+deploy:
+  provider: releases
+  api_key:
+    secure: nxaqYrkXLGL3W20/eCnf63DLjMrQAhEuW44jggh1/nI383goa+u6w0bBtWCxRdVzos7t4dpVfS6+kv6oIHacm9zVA+RYrqy5opzCJhq8lmXVVRijbALzUeiFif2HURMaKWj0ynRNVlAyBHzazPTLZVWywifpdSubSkuMWkl20cmuKu/Hg3c1EC9se3OYhhTHx3Hya7xSrctrDEYLsEBAUZzkKfscqRVqwwltS88CgIMtRISDpSBGrtH0t1uAH6NitTSguGgb+QEpqnELcRLymX2G1yzMA4Xr5c/L34MfbBKf8vIuG9t411xYuLoyKoUbroTWxSnPwlSy6PHz+QJ7UCXbDkATOGO3chxlKxglppvI/G3n2YP5Zf2dAaDlHblpvarh55i/4i4sKB2AbvvzkIHrQJwUgmLCbpN8/Vp9GWcGkd6i5U7F8tNInCs6ttX3oGvGOfYEXs02Ctyiea4LAqk4S7GZTuV2QXqxXglL4eRIwZ4UETiwgoAAtHma63Eq7+9t2ykMlk7zAK96FGwJrB97wa08aPuSxL94IYEBmn9Ht/vKXRiNQMvpnfp4rWQtL3cqbVyYAg5EjKb4PsBmnb91+RXtnWFOY1RpZGt8sPXYd+KZYzN1BXTFJEpaLLsIDN6r7nMcAvJDUmucaM+m7giPXz1ZBGAic3UBM1qMCgI=
+  file: build/libs/triplea-all.jar
+  skip_cleanup: true
+  prerelease: true
+  on:
+    tags: false
+    all_branches: true


### PR DESCRIPTION
.travis.yml updated to push a tag automatically when master is updated. An encrypted API key was also added so travis can deploy to github releases.

Note, this is not yet fully functional. We'll need to give the bot write access, then it can generate a token which can be set as a secrete environment variable "GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS"

We'll also need to set a second one for "BUILD_VERSION" (environment variables available to the build are set in the travis web UI)

The API key was handled by a ruby script that Travis.org provides. The Ruby script also created a personal access token associated with the bot account along with the encrypted version found in this PR. A screenshot of the token that was generated on the bot account is below:
![bot_token](https://cloud.githubusercontent.com/assets/12397753/10686367/2c38a5be-7918-11e5-9df5-0c3f3c07ec4a.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/248)
<!-- Reviewable:end -->
