### PR TITLE
Undo unit moves with 'u' key

### DIFF
--- a/src/games/strategy/engine/data/Unit.java
+++ b/src/games/strategy/engine/data/Unit.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.data;
 
 import java.io.Serializable;
-import java.util.List;
 
 import com.google.common.base.Preconditions;
 
@@ -16,8 +15,7 @@ public class Unit extends GameDataComponent implements Serializable {
   private final UnitType m_type;
 
   /**
-   * Creates new Unit. Should use a call to UnitType.create() or Unit.create(..) instead.
-   * owner can be null
+   * Creates new Unit. Should use a call to UnitType.create(). Owner can be null
    */
   protected Unit(final UnitType type, final PlayerID owner, final GameData data) {
     super(data);

--- a/src/games/strategy/engine/data/Unit.java
+++ b/src/games/strategy/engine/data/Unit.java
@@ -15,23 +15,6 @@ public class Unit extends GameDataComponent implements Serializable {
   private int m_hits = 0;
   private final UnitType m_type;
 
-
-  public static Unit createUnit(final UnitType unitType) {
-    return createUnit(unitType, null);
-  }
-
-  public static Unit createUnit(final UnitType unitType, final PlayerID player) {
-    return unitType.create(player);
-  }
-
-  public static Unit createUnit(final String typeName, final GameData data) {
-    return createUnit(typeName, data, null);
-  }
-
-  public static Unit createUnit(final String typeName, final GameData data, final PlayerID owner) {
-    return createUnit( (new UnitType(typeName, data)), owner);
-  }
-
   /**
    * Creates new Unit. Should use a call to UnitType.create() or Unit.create(..) instead.
    * owner can be null

--- a/src/games/strategy/engine/data/Unit.java
+++ b/src/games/strategy/engine/data/Unit.java
@@ -1,6 +1,9 @@
 package games.strategy.engine.data;
 
 import java.io.Serializable;
+import java.util.List;
+
+import com.google.common.base.Preconditions;
 
 import games.strategy.engine.data.annotations.GameProperty;
 import games.strategy.net.GUID;
@@ -12,16 +15,30 @@ public class Unit extends GameDataComponent implements Serializable {
   private int m_hits = 0;
   private final UnitType m_type;
 
+
+  public static Unit createUnit(final UnitType unitType) {
+    return createUnit(unitType, null);
+  }
+
+  public static Unit createUnit(final UnitType unitType, final PlayerID player) {
+    return unitType.create(player);
+  }
+
+  public static Unit createUnit(final String typeName, final GameData data) {
+    return createUnit(typeName, data, null);
+  }
+
+  public static Unit createUnit(final String typeName, final GameData data, final PlayerID owner) {
+    return createUnit( (new UnitType(typeName, data)), owner);
+  }
+
   /**
-   * Creates new Unit. Should use a call to UnitType.create() instead.
+   * Creates new Unit. Should use a call to UnitType.create() or Unit.create(..) instead.
    * owner can be null
    */
   protected Unit(final UnitType type, final PlayerID owner, final GameData data) {
     super(data);
-    if (type == null) {
-      throw new IllegalArgumentException();
-    }
-    m_type = type;
+    m_type = Preconditions.checkNotNull(type);
     m_uid = new GUID();
     setOwner(owner);
   }

--- a/src/games/strategy/triplea/delegate/AbstractUndoableMove.java
+++ b/src/games/strategy/triplea/delegate/AbstractUndoableMove.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.delegate;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Set;
 
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
@@ -26,9 +27,31 @@ abstract public class AbstractUndoableMove implements Serializable {
   protected int m_index;
   protected final Collection<Unit> m_units;
 
+  public AbstractUndoableMove(final Collection<Unit> units) {
+    m_change = new CompositeChange();
+    m_units = units;
+  }
+
+
   public AbstractUndoableMove(final CompositeChange change, final Collection<Unit> units) {
     m_change = change;
     m_units = units;
+  }
+
+  public boolean containsAnyUnit(Set<Unit> units) {
+    if (units == null) {
+      return false;
+    }
+    for (Unit unit : units) {
+      if (containsUnit(unit)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean containsUnit(Unit unit) {
+    return m_units.contains(unit);
   }
 
   final public void undo(final GameData data, final IDelegateBridge delegateBridge) {

--- a/src/games/strategy/triplea/delegate/AbstractUndoableMove.java
+++ b/src/games/strategy/triplea/delegate/AbstractUndoableMove.java
@@ -28,8 +28,7 @@ abstract public class AbstractUndoableMove implements Serializable {
   protected final Collection<Unit> m_units;
 
   public AbstractUndoableMove(final Collection<Unit> units) {
-    m_change = new CompositeChange();
-    m_units = units;
+    this(new CompositeChange(), units);
   }
 
 

--- a/src/games/strategy/triplea/delegate/AbstractUndoableMove.java
+++ b/src/games/strategy/triplea/delegate/AbstractUndoableMove.java
@@ -49,7 +49,7 @@ abstract public class AbstractUndoableMove implements Serializable {
     return false;
   }
 
-  public boolean containsUnit(Unit unit) {
+  private boolean containsUnit(Unit unit) {
     return m_units.contains(unit);
   }
 

--- a/src/games/strategy/triplea/delegate/AbstractUndoableMove.java
+++ b/src/games/strategy/triplea/delegate/AbstractUndoableMove.java
@@ -37,7 +37,7 @@ abstract public class AbstractUndoableMove implements Serializable {
     m_units = units;
   }
 
-  public boolean containsAnyUnit(Set<Unit> units) {
+  public boolean containsAnyOf(Set<Unit> units) {
     if (units == null) {
       return false;
     }

--- a/src/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -126,12 +126,12 @@ public abstract class AbstractMovePanel extends ActionPanel {
     return m_bridge.getGameData();
   }
 
-  private IAbstractMoveDelegate getDelegate() {
+  private IAbstractMoveDelegate getMoveDelegate() {
     return (IAbstractMoveDelegate) m_bridge.getRemoteDelegate();
   }
 
   protected final void updateMoves() {
-    m_undoableMoves = getDelegate().getMovesMade();
+    m_undoableMoves = getMoveDelegate().getMovesMade();
     m_undoableMovesPanel.setMoves(m_undoableMoves);
   }
 
@@ -151,7 +151,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
    * failure rather than just one)
    */
   public void undoMoves(Set<Unit> units) {
-    Set<UndoableMove> movesToUndo = getMovesToUndo(units, getDelegate().getMovesMade());
+    Set<UndoableMove> movesToUndo = getMovesToUndo(units, getMoveDelegate().getMovesMade());
 
     if (movesToUndo.size() == 0) {
       String error = "Could not undo any moves, check that the unit has moved and that you can undo the move normally";
@@ -203,7 +203,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
     // clean up any state we may have
     m_CANCEL_MOVE_ACTION.actionPerformed(null);
     // undo the move
-    final String error = getDelegate().undoMove(moveIndex);
+    final String error = getMoveDelegate().undoMove(moveIndex);
     if (error != null && !suppressError) {
       JOptionPane.showMessageDialog(getTopLevelAncestor(), error, "Could not undo move", JOptionPane.ERROR_MESSAGE);
     } else {

--- a/src/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -164,8 +164,13 @@ public abstract class AbstractMovePanel extends ActionPanel {
       }
     }
 
-    List<Integer> moveIndexes = getSortedMoveIndexes(movesToUndo);
+    if( movesToUndo.size() == 0 ) {
+      String error = "Could not undo any moves, check that the unit has moved and that you can undo the move normally";
+      JOptionPane.showMessageDialog(getTopLevelAncestor(), error, "Could not undo move", JOptionPane.ERROR_MESSAGE);
+      return;
+   }
 
+    List<Integer> moveIndexes = getSortedMoveIndexes(movesToUndo);
     // Undo moves in reverse order, from largest index to smallest. Undo will reorder
     // move index numbers, so going top down avoids this renumbering.
     for( int i = moveIndexes.size()-1; i >= 0; i -- ) {

--- a/src/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -155,7 +155,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
 
     if (getDelegate().getMovesMade() != null) {
       for (Object undoableMoveObject : getDelegate().getMovesMade()) {
-        if(undoableMoveObject != null) {
+        if (undoableMoveObject != null) {
           UndoableMove move = (UndoableMove) undoableMoveObject;
           if (move.containsAnyUnit(units) && move.getcanUndo()) {
             movesToUndo.add(move);
@@ -164,23 +164,23 @@ public abstract class AbstractMovePanel extends ActionPanel {
       }
     }
 
-    if( movesToUndo.size() == 0 ) {
+    if (movesToUndo.size() == 0) {
       String error = "Could not undo any moves, check that the unit has moved and that you can undo the move normally";
       JOptionPane.showMessageDialog(getTopLevelAncestor(), error, "Could not undo move", JOptionPane.ERROR_MESSAGE);
       return;
-   }
+    }
 
     List<Integer> moveIndexes = getSortedMoveIndexes(movesToUndo);
     // Undo moves in reverse order, from largest index to smallest. Undo will reorder
     // move index numbers, so going top down avoids this renumbering.
-    for( int i = moveIndexes.size()-1; i >= 0; i -- ) {
+    for (int i = moveIndexes.size() - 1; i >= 0; i--) {
       undoMove(moveIndexes.get(i));
     }
   }
 
-  private static List<Integer> getSortedMoveIndexes(Set<UndoableMove> moves ) {
+  private static List<Integer> getSortedMoveIndexes(Set<UndoableMove> moves) {
     List<Integer> moveIndexes = Lists.newArrayList();
-    for(UndoableMove move : moves ) {
+    for (UndoableMove move : moves) {
       moveIndexes.add(move.getIndex());
     }
     Collections.sort(moveIndexes);

--- a/src/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -265,7 +265,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
 
   abstract protected boolean setCancelButton();
 
-  protected final JComponent leftBox(final JComponent c) {
+  protected static final JComponent leftBox(final JComponent c) {
     final Box b = new Box(BoxLayout.X_AXIS);
     b.add(c);
     b.add(Box.createHorizontalGlue());

--- a/src/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -169,7 +169,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
       for (Object undoableMoveObject : movesMade) {
         if (undoableMoveObject != null) {
           UndoableMove move = (UndoableMove) undoableMoveObject;
-          if (move.containsAnyUnit(units) && move.getcanUndo()) {
+          if (move.containsAnyOf(units) && move.getcanUndo()) {
             movesToUndo.add(move);
           }
         }

--- a/src/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/src/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -10,6 +10,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 import javax.swing.AbstractAction;
 import javax.swing.Box;
@@ -24,8 +27,13 @@ import javax.swing.JSeparator;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 
+import com.google.common.collect.Sets;
+
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.AbstractUndoableMove;
+import games.strategy.triplea.delegate.UndoableMove;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
 
@@ -53,6 +61,15 @@ abstract public class AbstractUndoableMovesPanel extends JPanel {
       }
     });
   }
+
+  public void undoMoves(Map<Territory, List<Unit>> highlightUnits) {
+    Set<Unit> units = Sets.newHashSet();
+    for( Entry<Territory,List<Unit>> unitEntry : highlightUnits.entrySet() ) {
+      units.addAll(unitEntry.getValue());
+    }
+    m_movePanel.undoMoves(units);
+  }
+
 
   private void initLayout() {
     removeAll();

--- a/src/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/src/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -33,7 +33,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.AbstractUndoableMove;
-import games.strategy.triplea.delegate.UndoableMove;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
 

--- a/src/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/src/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -61,10 +61,10 @@ abstract public class AbstractUndoableMovesPanel extends JPanel {
     });
   }
 
-  public void undoMoves(Map<Territory, List<Unit>> highlightUnits) {
+  public void undoMoves(Map<Territory, List<Unit>> highlightUnitByTerritory) {
     Set<Unit> units = Sets.newHashSet();
-    for( Entry<Territory,List<Unit>> unitEntry : highlightUnits.entrySet() ) {
-      units.addAll(unitEntry.getValue());
+    for( List<Unit> highlightedUnits : highlightUnitByTerritory.values() ) {
+      units.addAll(highlightedUnits );
     }
     m_movePanel.undoMoves(units);
   }

--- a/src/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/src/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -237,7 +237,5 @@ abstract public class AbstractUndoableMovesPanel extends JPanel {
     }
   }
 
-  protected void specificViewAction(final AbstractUndoableMove move) {
-    // do nothing if not overwritten in child class
-  }
+  protected abstract void specificViewAction(final AbstractUndoableMove move);
 }

--- a/src/games/strategy/triplea/ui/ActionButtons.java
+++ b/src/games/strategy/triplea/ui/ActionButtons.java
@@ -51,9 +51,9 @@ public class ActionButtons extends JPanel {
   private PickTerritoryAndUnitsPanel m_pickTerritoryAndUnitsPanel;
 
   /** Creates new ActionPanel */
-  public ActionButtons(final GameData data, final MapPanel map, final TripleAFrame parent) {
+  public ActionButtons(final GameData data, final MapPanel map, final MovePanel movePanel, final TripleAFrame parent) {
     m_battlePanel = new BattlePanel(data, map);
-    m_movePanel = new MovePanel(data, map, parent);
+    m_movePanel = movePanel;
     m_purchasePanel = new PurchasePanel(data, map);
     m_repairPanel = new RepairPanel(data, map);
     m_placePanel = new PlacePanel(data, map, parent);

--- a/src/games/strategy/triplea/ui/MapPanel.java
+++ b/src/games/strategy/triplea/ui/MapPanel.java
@@ -10,6 +10,8 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -140,7 +142,6 @@ public class MapPanel extends ImageScrollerLargeView {
       }
     });
   }
-
   LinkedBlockingQueue<Tile> getUndrawnTiles() {
     return m_undrawnTiles;
   }

--- a/src/games/strategy/triplea/ui/MapPanel.java
+++ b/src/games/strategy/triplea/ui/MapPanel.java
@@ -98,7 +98,7 @@ public class MapPanel extends ImageScrollerLargeView {
   private String m_movementLeftForCurrentUnits = "";
   private final IUIContext m_uiContext;
   private final LinkedBlockingQueue<Tile> m_undrawnTiles = new LinkedBlockingQueue<Tile>();
-  private Map<Territory, List<Unit>> m_highlightUnits;
+  private Map<Territory, List<Unit>> m_highlightedUnits;
   private Cursor m_hiddenCursor = null;
 
   /** Creates new MapPanel */
@@ -185,7 +185,7 @@ public class MapPanel extends ImageScrollerLargeView {
    * call with an null args
    */
   public void setUnitHighlight(final Map<Territory, List<Unit>> units) {
-    m_highlightUnits = units;
+    m_highlightedUnits = units;
     SwingUtilities.invokeLater(new Runnable() {
       @Override
       public void run() {
@@ -195,7 +195,7 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   public Map<Territory, List<Unit>> getHighlightUnits() {
-    return m_highlightUnits;
+    return m_highlightedUnits;
   }
 
   public void centerOn(final Territory territory) {
@@ -603,8 +603,8 @@ public class MapPanel extends ImageScrollerLargeView {
     // other references to the images are weak references
     m_images.clear();
     m_images.addAll(images);
-    if (m_highlightUnits != null) {
-      for (final Entry<Territory, List<Unit>> entry : m_highlightUnits.entrySet()) {
+    if (m_highlightedUnits != null) {
+      for (final Entry<Territory, List<Unit>> entry : m_highlightedUnits.entrySet()) {
         final Set<UnitCategory> categories = UnitSeperator.categorize(entry.getValue());
         for (final UnitCategory category : categories) {
           final List<Unit> territoryUnitsOfSameCategory = category.getUnits();

--- a/src/games/strategy/triplea/ui/MapPanel.java
+++ b/src/games/strategy/triplea/ui/MapPanel.java
@@ -193,6 +193,10 @@ public class MapPanel extends ImageScrollerLargeView {
     });
   }
 
+  public Map<Territory, List<Unit>> getHighlightUnits() {
+    return m_highlightUnits;
+  }
+
   public void centerOn(final Territory territory) {
     if (territory == null || m_uiContext.getLockMap()) {
       return;

--- a/src/games/strategy/triplea/ui/MapPanel.java
+++ b/src/games/strategy/triplea/ui/MapPanel.java
@@ -194,7 +194,7 @@ public class MapPanel extends ImageScrollerLargeView {
     });
   }
 
-  public Map<Territory, List<Unit>> getHighlightUnits() {
+  protected Map<Territory, List<Unit>> getHighlightedUnits() {
     return m_highlightedUnits;
   }
 

--- a/src/games/strategy/triplea/ui/MovePanel.java
+++ b/src/games/strategy/triplea/ui/MovePanel.java
@@ -1381,7 +1381,6 @@ public class MovePanel extends AbstractMovePanel {
     getMap().removeMapSelectionListener(m_MAP_SELECTION_LISTENER);
     getMap().removeUnitSelectionListener(m_UNIT_SELECTION_LISTENER);
     getMap().removeMouseOverUnitListener(m_MOUSE_OVER_UNIT_LISTENER);
-    getMap().removeKeyListener(undoUnitMoveKeyListener);
     getMap().setUnitHighlight(null);
     m_selectedUnits.clear();
     updateRouteAndMouseShadowUnits(null);
@@ -1426,24 +1425,26 @@ public class MovePanel extends AbstractMovePanel {
     getMap().addMapSelectionListener(m_MAP_SELECTION_LISTENER);
     getMap().addUnitSelectionListener(m_UNIT_SELECTION_LISTENER);
     getMap().addMouseOverUnitListener(m_MOUSE_OVER_UNIT_LISTENER);
-    getMap().addKeyListener(undoUnitMoveKeyListener);
   }
 
-  private final KeyListener undoUnitMoveKeyListener = new KeyListener() {
-    @Override
-    public void keyTyped(KeyEvent e) {}
+  public KeyListener getUndoMoveKeyListener() {
+    return new KeyListener() {
+      @Override
+      public void keyTyped(KeyEvent e) {}
 
-    @Override
-    public void keyPressed(KeyEvent e) {
-      if (e.getKeyCode() == KeyEvent.VK_U &&
-          getMap().getHighlightUnits() != null && !getMap().getHighlightUnits().isEmpty()) {
-        m_undoableMovesPanel.undoMoves(getMap().getHighlightUnits());
+      @Override
+      public void keyPressed(KeyEvent e) {
+        if (e.getKeyCode() == KeyEvent.VK_U &&
+            getMap().getHighlightUnits() != null && !getMap().getHighlightUnits().isEmpty()) {
+          m_undoableMovesPanel.undoMoves(getMap().getHighlightUnits());
+        }
       }
-    }
 
-    @Override
-    public void keyReleased(KeyEvent e) {}
-  };
+      @Override
+      public void keyReleased(KeyEvent e) {}
+    };
+
+  }
 
 
   @Override

--- a/src/games/strategy/triplea/ui/MovePanel.java
+++ b/src/games/strategy/triplea/ui/MovePanel.java
@@ -1432,7 +1432,7 @@ public class MovePanel extends AbstractMovePanel {
   private final KeyListener undoUnitMoveKeyListener = new KeyListener() {
     @Override
     public void keyTyped(KeyEvent e) {
-      if (e.getKeyChar() == 'u' && getMap().getHighlightUnits() != null && !getMap().getHighlightUnits().isEmpty()) {
+      if (e.getKeyCode() == KeyEvent.VK_U && getMap().getHighlightUnits() != null&& !getMap().getHighlightUnits().isEmpty()) {
         m_undoableMovesPanel.undoMoves(getMap().getHighlightUnits());
       }
     }

--- a/src/games/strategy/triplea/ui/MovePanel.java
+++ b/src/games/strategy/triplea/ui/MovePanel.java
@@ -1432,7 +1432,8 @@ public class MovePanel extends AbstractMovePanel {
   private final KeyListener undoUnitMoveKeyListener = new KeyListener() {
     @Override
     public void keyTyped(KeyEvent e) {
-      if (e.getKeyCode() == KeyEvent.VK_U && getMap().getHighlightUnits() != null&& !getMap().getHighlightUnits().isEmpty()) {
+      if (e.getKeyCode() == KeyEvent.VK_U && getMap().getHighlightUnits() != null
+          && !getMap().getHighlightUnits().isEmpty()) {
         m_undoableMovesPanel.undoMoves(getMap().getHighlightUnits());
       }
     }

--- a/src/games/strategy/triplea/ui/MovePanel.java
+++ b/src/games/strategy/triplea/ui/MovePanel.java
@@ -4,6 +4,7 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1382,6 +1383,7 @@ public class MovePanel extends AbstractMovePanel {
     getMap().removeMapSelectionListener(m_MAP_SELECTION_LISTENER);
     getMap().removeUnitSelectionListener(m_UNIT_SELECTION_LISTENER);
     getMap().removeMouseOverUnitListener(m_MOUSE_OVER_UNIT_LISTENER);
+    getMap().removeKeyListener(undoUnitMoveKeyListener);
     getMap().setUnitHighlight(null);
     m_selectedUnits.clear();
     updateRouteAndMouseShadowUnits(null);
@@ -1426,7 +1428,24 @@ public class MovePanel extends AbstractMovePanel {
     getMap().addMapSelectionListener(m_MAP_SELECTION_LISTENER);
     getMap().addUnitSelectionListener(m_UNIT_SELECTION_LISTENER);
     getMap().addMouseOverUnitListener(m_MOUSE_OVER_UNIT_LISTENER);
+    getMap().addKeyListener(undoUnitMoveKeyListener);
   }
+
+  private final KeyListener undoUnitMoveKeyListener = new KeyListener() {
+    @Override
+    public void keyTyped(KeyEvent e) {
+      if (e.getKeyChar() == 'u' && getMap().getHighlightUnits() != null && !getMap().getHighlightUnits().isEmpty()) {
+        m_undoableMovesPanel.undoMoves(getMap().getHighlightUnits());
+      }
+    }
+
+    @Override
+    public void keyPressed(KeyEvent e) {}
+
+    @Override
+    public void keyReleased(KeyEvent e) {}
+  };
+
 
   @Override
   protected boolean doneMoveAction() {

--- a/src/games/strategy/triplea/ui/MovePanel.java
+++ b/src/games/strategy/triplea/ui/MovePanel.java
@@ -1435,8 +1435,8 @@ public class MovePanel extends AbstractMovePanel {
       @Override
       public void keyPressed(KeyEvent e) {
         if (e.getKeyCode() == KeyEvent.VK_U &&
-            getMap().getHighlightUnits() != null && !getMap().getHighlightUnits().isEmpty()) {
-          m_undoableMovesPanel.undoMoves(getMap().getHighlightUnits());
+            getMap().getHighlightedUnits() != null && !getMap().getHighlightedUnits().isEmpty()) {
+          m_undoableMovesPanel.undoMoves(getMap().getHighlightedUnits());
         }
       }
 

--- a/src/games/strategy/triplea/ui/MovePanel.java
+++ b/src/games/strategy/triplea/ui/MovePanel.java
@@ -937,12 +937,10 @@ public class MovePanel extends AbstractMovePanel {
         minTransportCost = Math.min(minTransportCost, UnitAttachment.get(unit.getType()).getTransportCost());
       }
       final Collection<Unit> airTransportsToLoad = new ArrayList<Unit>();
-      int ttlCapacity = 0;
       for (final Unit bomber : capableTransportsToLoad) {
         final int capacity = TransportTracker.getAvailableCapacity(bomber);
         if (capacity >= minTransportCost) {
           airTransportsToLoad.add(bomber);
-          ttlCapacity += capacity;
         }
       }
       // If no airTransports can be loaded, return the empty set

--- a/src/games/strategy/triplea/ui/MovePanel.java
+++ b/src/games/strategy/triplea/ui/MovePanel.java
@@ -1431,15 +1431,15 @@ public class MovePanel extends AbstractMovePanel {
 
   private final KeyListener undoUnitMoveKeyListener = new KeyListener() {
     @Override
-    public void keyTyped(KeyEvent e) {
-      if (e.getKeyCode() == KeyEvent.VK_U && getMap().getHighlightUnits() != null
-          && !getMap().getHighlightUnits().isEmpty()) {
+    public void keyTyped(KeyEvent e) {}
+
+    @Override
+    public void keyPressed(KeyEvent e) {
+      if (e.getKeyCode() == KeyEvent.VK_U &&
+          getMap().getHighlightUnits() != null && !getMap().getHighlightUnits().isEmpty()) {
         m_undoableMovesPanel.undoMoves(getMap().getHighlightUnits());
       }
     }
-
-    @Override
-    public void keyPressed(KeyEvent e) {}
 
     @Override
     public void keyReleased(KeyEvent e) {}

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -83,6 +83,9 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.tree.DefaultMutableTreeNode;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
 import games.strategy.common.delegate.BaseEditDelegate;
 import games.strategy.common.ui.BasicGameMenuBar;
 import games.strategy.common.ui.MacWrapper;
@@ -241,8 +244,6 @@ public class TripleAFrame extends MainGameFrame {
     m_mapPanel = new MapPanel(m_data, m_smallView, m_uiContext, model);
     m_mapPanel.addMapSelectionListener(MAP_SELECTION_LISTENER);
     m_mapPanel.addMouseOverUnitListener(MOUSE_OVER_UNIT_LISTENER);
-    this.addKeyListener(m_arrowKeyActionListener);
-    m_mapPanel.addKeyListener(m_arrowKeyActionListener);
     // link the small and large images
     m_mapPanel.initSmallMap();
     m_mapAndChatPanel = new JPanel();
@@ -323,7 +324,15 @@ public class TripleAFrame extends MainGameFrame {
     m_rightHandSidePanel.add(m_smallView, BorderLayout.NORTH);
     m_tabsPanel.setBorder(null);
     m_rightHandSidePanel.add(m_tabsPanel, BorderLayout.CENTER);
-    m_actionButtons = new ActionButtons(m_data, m_mapPanel, this);
+
+    MovePanel movePanel = new MovePanel(m_data, m_mapPanel, this);
+    m_actionButtons = new ActionButtons(m_data, m_mapPanel, movePanel, this);
+
+    // set up key listeners
+    m_mapPanel.addKeyListener(this.getArrowKeyListener());
+    m_mapPanel.addKeyListener(movePanel.getUndoMoveKeyListener());
+
+
     m_tabsPanel.addTab("Actions", m_actionButtons);
     m_actionButtons.setBorder(null);
     m_statsPanel = new StatPanel(m_data, m_uiContext);
@@ -1715,9 +1724,12 @@ public class TripleAFrame extends MainGameFrame {
       }
     }
   };
-  final KeyListener m_arrowKeyActionListener = new KeyListener() {
-    @Override
-    public void keyPressed(final KeyEvent e) {
+
+  private KeyListener getArrowKeyListener() {
+    return new KeyListener() {
+      @Override
+      public void keyPressed(final KeyEvent e) {
+
       // scroll map according to wasd/arrowkeys
       final int diffPixel = computeScrollSpeed(e);
       final int x = m_mapPanel.getXOffset();
@@ -1788,6 +1800,7 @@ public class TripleAFrame extends MainGameFrame {
     @Override
     public void keyReleased(final KeyEvent e) {}
   };
+  }
 
   private static int computeScrollSpeed(final KeyEvent e) {
     int multiplier = 1;

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -84,7 +84,6 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.tree.DefaultMutableTreeNode;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import games.strategy.common.delegate.BaseEditDelegate;
 import games.strategy.common.ui.BasicGameMenuBar;
@@ -328,10 +327,12 @@ public class TripleAFrame extends MainGameFrame {
     MovePanel movePanel = new MovePanel(m_data, m_mapPanel, this);
     m_actionButtons = new ActionButtons(m_data, m_mapPanel, movePanel, this);
 
-    // set up key listeners
-    m_mapPanel.addKeyListener(this.getArrowKeyListener());
-    m_mapPanel.addKeyListener(movePanel.getUndoMoveKeyListener());
-
+    List<KeyListener> keyListeners = ImmutableList.of(this.getArrowKeyListener(), movePanel.getUndoMoveKeyListener());
+    for( KeyListener keyListener : keyListeners ) {
+      m_mapPanel.addKeyListener(keyListener );
+      // TODO: figure out if it is really needed to double add the key listener to both the frame and also the map panel
+      this.addKeyListener(keyListener);
+    }
 
     m_tabsPanel.addTab("Actions", m_actionButtons);
     m_actionButtons.setBorder(null);

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -1731,76 +1731,76 @@ public class TripleAFrame extends MainGameFrame {
       @Override
       public void keyPressed(final KeyEvent e) {
 
-      // scroll map according to wasd/arrowkeys
-      final int diffPixel = computeScrollSpeed(e);
-      final int x = m_mapPanel.getXOffset();
-      final int y = m_mapPanel.getYOffset();
-      final int keyCode = e.getKeyCode();
+        // scroll map according to wasd/arrowkeys
+        final int diffPixel = computeScrollSpeed(e);
+        final int x = m_mapPanel.getXOffset();
+        final int y = m_mapPanel.getYOffset();
+        final int keyCode = e.getKeyCode();
 
-      if (keyCode == KeyEvent.VK_RIGHT || keyCode == KeyEvent.VK_D) {
-        getMapPanel().setTopLeft(x + diffPixel, y);
-      } else if (keyCode == KeyEvent.VK_LEFT || keyCode == KeyEvent.VK_A) {
-        getMapPanel().setTopLeft(x - diffPixel, y);
-      } else if (keyCode == KeyEvent.VK_DOWN || keyCode == KeyEvent.VK_S) {
-        getMapPanel().setTopLeft(x, y + diffPixel);
-      } else if (keyCode == KeyEvent.VK_UP || keyCode == KeyEvent.VK_W) {
-        getMapPanel().setTopLeft(x, y - diffPixel);
-      }
-      // I for info
-      if (keyCode == KeyEvent.VK_I || keyCode == KeyEvent.VK_V) {
-        String unitInfo = "";
-        if (m_unitsBeingMousedOver != null && !m_unitsBeingMousedOver.isEmpty()) {
-          final Unit unit = m_unitsBeingMousedOver.get(0);
-          final UnitAttachment ua = UnitAttachment.get(unit.getType());
-          if (ua != null) {
-            unitInfo = "<b>Unit:</b><br>" + unit.getType().getName() + ": "
-                + ua.toStringShortAndOnlyImportantDifferences(unit.getOwner(), true, false);
-          }
+        if (keyCode == KeyEvent.VK_RIGHT || keyCode == KeyEvent.VK_D) {
+          getMapPanel().setTopLeft(x + diffPixel, y);
+        } else if (keyCode == KeyEvent.VK_LEFT || keyCode == KeyEvent.VK_A) {
+          getMapPanel().setTopLeft(x - diffPixel, y);
+        } else if (keyCode == KeyEvent.VK_DOWN || keyCode == KeyEvent.VK_S) {
+          getMapPanel().setTopLeft(x, y + diffPixel);
+        } else if (keyCode == KeyEvent.VK_UP || keyCode == KeyEvent.VK_W) {
+          getMapPanel().setTopLeft(x, y - diffPixel);
         }
-        String terrInfo = "";
-        if (m_territoryLastEntered != null) {
-          final TerritoryAttachment ta = TerritoryAttachment.get(m_territoryLastEntered);
-          if (ta != null) {
-            terrInfo = "<b>Territory:</b><br>" + ta.toStringForInfo(true, true) + "<br>";
-          } else {
-            terrInfo = "<b>Territory:</b><br>" + m_territoryLastEntered.getName() + "<br>Water Territory";
-          }
-        }
-        String tipText = unitInfo;
-        if (unitInfo.length() > 0 && terrInfo.length() > 0) {
-          tipText = tipText + "<br><br><br><br><br>";
-        }
-        tipText = tipText + terrInfo;
-        if (tipText.length() > 0) {
-          final Point currentPoint = MouseInfo.getPointerInfo().getLocation();
-          final PopupFactory popupFactory = PopupFactory.getSharedInstance();
-          final JToolTip info = new JToolTip();
-          info.setTipText("<html>" + tipText + "</html>");
-          final Popup popup = popupFactory.getPopup(m_mapPanel, info, currentPoint.x, currentPoint.y);
-          popup.show();
-          final Runnable disposePopup = new Runnable() {
-            @Override
-            public void run() {
-              try {
-                Thread.sleep(5000);
-              } catch (final InterruptedException e) {
-              }
-              popup.hide();
+        // I for info
+        if (keyCode == KeyEvent.VK_I || keyCode == KeyEvent.VK_V) {
+          String unitInfo = "";
+          if (m_unitsBeingMousedOver != null && !m_unitsBeingMousedOver.isEmpty()) {
+            final Unit unit = m_unitsBeingMousedOver.get(0);
+            final UnitAttachment ua = UnitAttachment.get(unit.getType());
+            if (ua != null) {
+              unitInfo = "<b>Unit:</b><br>" + unit.getType().getName() + ": "
+                  + ua.toStringShortAndOnlyImportantDifferences(unit.getOwner(), true, false);
             }
-          };
-          new Thread(disposePopup, "popup waiter").start();
+          }
+          String terrInfo = "";
+          if (m_territoryLastEntered != null) {
+            final TerritoryAttachment ta = TerritoryAttachment.get(m_territoryLastEntered);
+            if (ta != null) {
+              terrInfo = "<b>Territory:</b><br>" + ta.toStringForInfo(true, true) + "<br>";
+            } else {
+              terrInfo = "<b>Territory:</b><br>" + m_territoryLastEntered.getName() + "<br>Water Territory";
+            }
+          }
+          String tipText = unitInfo;
+          if (unitInfo.length() > 0 && terrInfo.length() > 0) {
+            tipText = tipText + "<br><br><br><br><br>";
+          }
+          tipText = tipText + terrInfo;
+          if (tipText.length() > 0) {
+            final Point currentPoint = MouseInfo.getPointerInfo().getLocation();
+            final PopupFactory popupFactory = PopupFactory.getSharedInstance();
+            final JToolTip info = new JToolTip();
+            info.setTipText("<html>" + tipText + "</html>");
+            final Popup popup = popupFactory.getPopup(m_mapPanel, info, currentPoint.x, currentPoint.y);
+            popup.show();
+            final Runnable disposePopup = new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  Thread.sleep(5000);
+                } catch (final InterruptedException e) {
+                }
+                popup.hide();
+              }
+            };
+            new Thread(disposePopup, "popup waiter").start();
+          }
         }
+        // and then we do stuff for any custom current action tab
+        m_actionButtons.keyPressed(e);
       }
-      // and then we do stuff for any custom current action tab
-      m_actionButtons.keyPressed(e);
-    }
 
-    @Override
-    public void keyTyped(final KeyEvent e) {}
+      @Override
+      public void keyTyped(final KeyEvent e) {}
 
-    @Override
-    public void keyReleased(final KeyEvent e) {}
-  };
+      @Override
+      public void keyReleased(final KeyEvent e) {}
+    };
   }
 
   private static int computeScrollSpeed(final KeyEvent e) {

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -161,7 +161,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
             + "Press 'N' to cycle through units with movement left (move phases only).<br>"
             + "Press 'F' to highlight all units you own that have movement left (move phases only).<br>"
             + "Press 'I' or 'V' to popup info on whatever territory and unit your mouse is currently over.<br>"
-            + "Press 'u' while mousing over a unit to undo all moves that unit has made.<br>";
+            + "Press 'u' while mousing over a unit to undo all moves that unit has made (beta).<br>";
         final JEditorPane editorPane = new JEditorPane();
         editorPane.setEditable(false);
         editorPane.setContentType("text/html");

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -160,7 +160,8 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
             + "<br><b> Other Things</b><br>"
             + "Press 'N' to cycle through units with movement left (move phases only).<br>"
             + "Press 'F' to highlight all units you own that have movement left (move phases only).<br>"
-            + "Press 'I' or 'V' to popup info on whatever territory and unit your mouse is currently over.<br>";
+            + "Press 'I' or 'V' to popup info on whatever territory and unit your mouse is currently over.<br>"
+            + "Press 'u' while mousing over a unit to undo all moves that unit has made.<br>";
         final JEditorPane editorPane = new JEditorPane();
         editorPane.setEditable(false);
         editorPane.setContentType("text/html");

--- a/src/games/strategy/triplea/ui/UndoablePlacementsPanel.java
+++ b/src/games/strategy/triplea/ui/UndoablePlacementsPanel.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.ui;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Route;
+import games.strategy.triplea.delegate.AbstractUndoableMove;
 
 public class UndoablePlacementsPanel extends AbstractUndoableMovesPanel {
   private static final long serialVersionUID = -8905646288832196354L;
@@ -12,5 +13,9 @@ public class UndoablePlacementsPanel extends AbstractUndoableMovesPanel {
 
   protected final String getSpecificComponentForMoveLabel(final Route route) {
     return route.getStart().getName();
+  }
+
+  @Override
+  protected void specificViewAction(AbstractUndoableMove move) {
   }
 }


### PR DESCRIPTION
Various cleanup and supporting fixes leading up to:
648e247  : Add support for undoing unit moves by hovering over and highlighting them and then typing 'u'

The implementation uses the highlighted unit and reverts any moves involving that unit. The supporting changes are mostly to add an API to making it easier to find that unit in the move list.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/253)
<!-- Reviewable:end -->
