### PR TITLE
Restore 'test' task for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk:
 - oraclejdk8
 install: true
 script:
+- gradle test
 - gradle shadowjar
 before_deploy:
 - git config --global user.email "tripleabuilderbot@gmail.com"


### PR DESCRIPTION
 Now that the script tasks are explicitly set, the default assemble task is no longer executed. Instead of using the assemble task, we'll explicitly call the test task since we that is what we want to do before we create the various build artifacts.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/255)
<!-- Reviewable:end -->
