### PR TITLE
Another travis fix, only build triplea-game/triplea repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ deploy:
   skip_cleanup: true
   prerelease: true
   on:
+    repo: triplea-game/triplea
     tags: false
     all_branches: true


### PR DESCRIPTION
Setting fixes builds on forks. Otherwise forks try to do the deployment and then run into problems because the encrypted api key is incorrect.


I will be merge this one as well without review since it's a break-fix for .travis.yml and is relatively safe.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/256)
<!-- Reviewable:end -->
