### PR TITLE
Fix travis config, generate shadow jar as first step of deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ jdk:
 install: true
 script:
 - gradle test
-- gradle shadowjar
 before_deploy:
+- gradle shadowjar
 - git config --global user.email "tripleabuilderbot@gmail.com"
 - git config --global user.name "tripleabuilderbot"
 - export TAGGED_VERSION="$BUILD_VERSION.$TRAVIS_BUILD_NUMBER"


### PR DESCRIPTION
Perhaps hopefully the final fix for the travis configuration. Set gradle shadow jar task to be first step of deployment rather than the last step of a build.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/257)
<!-- Reviewable:end -->
