### PR TITLE
Change travis config to only build master instead of any branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,6 @@ deploy:
   on:
     repo: triplea-game/triplea
     tags: false
-    all_branches: true
+    branches:
+      only:
+        - master


### PR DESCRIPTION
Travis built and tried to deploy a non-master branch.  The config needs correction.

This build failed because of that:  http://travis-ci.org/triplea-game/triplea/builds/89180193

To make things worst, only those with write access should be able to trigger a deployment, but if one is triggered and then if this command fails:
` git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags` prints the environment variable.

I'll add a commit to this to dev null any error message. I've already updated the access token that is used

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/266)
<!-- Reviewable:end -->
