### PR TITLE
.travis.yml - Sed out the github personal access token when there is error output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_deploy:
 - git config --global user.email "tripleabuilderbot@gmail.com"
 - git config --global user.name "tripleabuilderbot"
 - git tag $TAGGED_VERSION -a -m "$TAGGED_VERSION"
-- git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags
+- git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags 2>&1 | sed 's|https://.*github|https://[secure]@github|'
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
Fix for #267 

Please see that issue for the travis output that is dangerous, and an example of how this fix updates that output to hide the secret token.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/273)
<!-- Reviewable:end -->
