### PR TITLE
Map parsing performance improvement

### DIFF
--- a/src/games/strategy/triplea/attatchments/UnitAttachment.java
+++ b/src/games/strategy/triplea/attatchments/UnitAttachment.java
@@ -803,23 +803,25 @@ public class UnitAttachment extends DefaultAttachment {
   // m_unitPlacementRestrictions
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setUnitPlacementOnlyAllowedIn(final String value) throws GameParseException {
-    String valueRestricted = new String();
+    StringBuilder valueRestricted = new StringBuilder();
     final String valueAllowed[] = value.split(":");
     if (valueAllowed != null) {
       getListedTerritories(valueAllowed);
       for (final Territory item : getData().getMap().getTerritories()) {
         boolean match = false;
         for (final String allowed : valueAllowed) {
-          if (allowed.matches(item.getName())) {
+          if (allowed.equals(item.getName())) {
             match = true;
+            break;
           }
         }
         if (!match) {
-          valueRestricted = valueRestricted + ":" + item.getName();
+          valueRestricted.append(":").append(item.getName());
         }
       }
-      valueRestricted = valueRestricted.replaceFirst(":", "");
-      m_unitPlacementRestrictions = valueRestricted.split(":");
+
+      String newValue = valueRestricted.toString().replaceFirst(":", "");
+      m_unitPlacementRestrictions = newValue.split(":");
     }
   }
 


### PR DESCRIPTION
#### Replace String (regex) 'match(..)' method call with more performant 'equals(..)' instead.

This patch does three things to improve map parsing performance:
- Most importantly we replace the inner loop "allowed.matches" with "allowed.equals". Benchmarking how long it takes "Civil War - A House Divided" to "long" parse, this one change reduces the parse time down from 1.5s to 0.6
- Replace the String concactenation operations with a StringBuilder, helps shave off 100ms
- Add a break into the for loop to reduce the loop iteration count, does not reduce very much, but worth having since it boosts code clarity.

#### Context and reason why this helps:
When maps are loaded they are done so in sequence are done in "short" or "long" form. All of them are done in short form which generally takes about 20-50ms, except the "currently selected" map whose details are displayed by default on the initial opening screen. This map is parsed in "long" form which generally takes 250-350ms, but can take as long as 1.5 or 2.0 seconds for some maps. The slowdown happens from a long list of colon delimited Strings that represent territory names found in an XML attachment value. These long strings over 1000 characters long cause the "setValues" part of of game parsing to take the majority of the time. Breaking that down, it's when we iterate over each of those territories in the double loop in UnitAttachment do we start to see a slowdown, particularly using the slow (regex) "match" method instead of the more performant "equals" method.

Also of note, the game UI is blocked from displaying until all of this parsing completes. Civil War was one of the worst case maps, this change will help avoid those worst cases and allows the UI to load a little bit faster on initial launch in all cases.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/293)
<!-- Reviewable:end -->