### PR TITLE
Add a null check - AbstractGameLoader.java. 

### DIFF
--- a/src/games/strategy/engine/framework/AbstractGameLoader.java
+++ b/src/games/strategy/engine/framework/AbstractGameLoader.java
@@ -17,6 +17,9 @@ abstract public class AbstractGameLoader implements IGameLoader {
   public void shutDown() {
     if (m_game != null && m_soundChannel != null) {
       m_game.removeSoundChannel(m_soundChannel);
+      // set sound channel to null to handle the case of shutdown being called multiple times.
+      // If/when shutdown is called exactly once, then the null assignment should be unnecessary.
+      m_soundChannel = null;
     }
   }
 }

--- a/src/games/strategy/engine/framework/AbstractGameLoader.java
+++ b/src/games/strategy/engine/framework/AbstractGameLoader.java
@@ -15,7 +15,7 @@ abstract public class AbstractGameLoader implements IGameLoader {
 
   @Override
   public void shutDown() {
-    if (m_game != null) {
+    if (m_game != null && m_soundChannel != null) {
       m_game.removeSoundChannel(m_soundChannel);
     }
   }


### PR DESCRIPTION
Potential illegal argument exception will be thrown further down the stack in 'UnifedMessenger.java', method: 'removeImplementor' in the cases when  m_soundChannel is null. This problem was introduced by PR#201.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/314)
<!-- Reviewable:end -->
