### PR TITLE
CompositeChange.java - mark serialVersionUID as private, fixes a warning of serialVersionUID shadowing variable of same name.

### DIFF
--- a/src/games/strategy/engine/data/CompositeChange.java
+++ b/src/games/strategy/engine/data/CompositeChange.java
@@ -7,7 +7,7 @@ import java.util.List;
  * A Change made of several changes.
  */
 public class CompositeChange extends Change {
-  static final long serialVersionUID = 8152962976769419486L;
+  private static final long serialVersionUID = 8152962976769419486L;
   private final List<Change> m_changes;
 
   public CompositeChange(final Change... changes) {


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/325)
<!-- Reviewable:end -->
