### PR TITLE
Add a 'clear' button to the error console. 

### DIFF
--- a/src/games/strategy/debug/Console.java
+++ b/src/games/strategy/debug/Console.java
@@ -45,11 +45,16 @@ public class Console extends JFrame {
     m_actions.add(m_memoryAction);
     m_actions.add(m_propertiesAction);
     m_actions.add(m_copyAction);
+    m_actions.add(m_clearAction);
     pack();
   }
 
   public void append(final String s) {
     m_text.append(s);
+  }
+
+  public void clear() {
+    m_text.setText("");
   }
 
   public void dumpStacks() {
@@ -116,6 +121,14 @@ public class Console extends JFrame {
     public void actionPerformed(final ActionEvent e) {
       final String s = DebugUtils.getProperties();
       append(s);
+    }
+  };
+  private final AbstractAction m_clearAction = new AbstractAction("Clear") {
+    private static final long serialVersionUID = -6041425265177989146L;
+
+    @Override
+    public void actionPerformed(final ActionEvent e) {
+      clear();
     }
   };
 }


### PR DESCRIPTION
Button allows for the text in the console window to be cleared.

![clear_button_screenshot](https://cloud.githubusercontent.com/assets/12397753/12165128/2403ee14-b4d0-11e5-8dae-828c16a94d12.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/332)
<!-- Reviewable:end -->
