### PR TITLE
Update in-game user documentation labeling of activator keys N,F,I,V

### DIFF
--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -158,9 +158,9 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
             + "Deselect 'Map Details' in the 'View' menu, to show a map without the artwork.<br>"
             + "Select a new 'Map Skin' from the 'View' menu to show a different kind of artwork (not all maps have skins).<br>"
             + "<br><b> Other Things</b><br>"
-            + "Press 'N' to cycle through units with movement left (move phases only).<br>"
-            + "Press 'F' to highlight all units you own that have movement left (move phases only).<br>"
-            + "Press 'I' or 'V' to popup info on whatever territory and unit your mouse is currently over.<br>"
+            + "Press 'n' to cycle through units with movement left (move phases only).<br>"
+            + "Press 'f' to highlight all units you own that have movement left (move phases only).<br>"
+            + "Press 'i' or 'v' to popup info on whatever territory and unit your mouse is currently over.<br>"
             + "Press 'u' while mousing over a unit to undo all moves that unit has made (beta).<br>";
         final JEditorPane editorPane = new JEditorPane();
         editorPane.setEditable(false);


### PR DESCRIPTION
1 commit (a8fc263) based on #253


 By labelling the keys in the documentation exactly as they are, we are sparing users from needing to learn that for example: 'F' means 'shift+f' or 'f'. It is not an automatic assumption for those who have not played before.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/347)
<!-- Reviewable:end -->
