### PR TITLE
Map Drawing Error Tolerance - Log an error rather than throwing an exception

### DIFF
--- a/src/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/games/strategy/triplea/image/TileImageFactory.java
@@ -31,6 +31,9 @@ import java.util.prefs.Preferences;
 
 import javax.imageio.ImageIO;
 
+import com.sun.javafx.iio.ImageStorage.ImageType;
+
+import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.image.BlendComposite.BlendingMode;
 import games.strategy.triplea.util.Stopwatch;
@@ -346,7 +349,8 @@ public final class TileImageFactory {
       fromFile.flush();
       copyingImage.done();
     } catch (final IOException e) {
-      throw new IllegalStateException(e.getMessage());
+      ClientLogger.logError("Could not load image, url: "+ imageLocation.toString(), e);
+      image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
     }
     final ImageRef ref = new ImageRef(image);
     if (cache) {


### PR DESCRIPTION
 Log an error rather than throwing an exception when failing to read a map 'blend' image. Allows the game to still be operational when this situation occurs and also notifies the user.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/371)
<!-- Reviewable:end -->
