### PR TITLE
[Cleanup for IRandomSource API] - Remove unnecessary throws clause. 

### DIFF
--- a/src/games/strategy/engine/random/IRandomSource.java
+++ b/src/games/strategy/engine/random/IRandomSource.java
@@ -4,7 +4,12 @@ package games.strategy.engine.random;
  * A source for random numbers.
  */
 public interface IRandomSource {
-  public int getRandom(int max, String annotation) throws IllegalArgumentException, IllegalStateException;
 
-  public int[] getRandom(int max, int count, String annotation) throws IllegalArgumentException, IllegalStateException;
+  /**
+   * @param annotation Used by dice servers as the email subject when dice roll results are emailed. Active for
+   *        PBEM games. @see HttpDiceRollerDialog
+   */
+  public int getRandom(int max, String annotation);
+
+  public int[] getRandom(int max, int count, String annotation);
 }


### PR DESCRIPTION
- Remove unnecessary throws clause. 
- Add a javadoc to getRandom() method, explaining the 'annotation' param.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/402)
<!-- Reviewable:end -->
