### PR TITLE
Add Total Attack Power and Defense Power to Territory Panel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
 - oraclejdk8
 install: true
 script:
-- gradle test
+- gradle test -i
 before_deploy:
 - wget -O setup https://github.com/triplea-game/triplea/blob/master/.travis/setup?raw=true
 - chmod +x setup && ./setup

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,13 @@ dependencies {
 	testCompile 'org.mockito:mockito-all:2.0.2-beta'
 }
 
+test {
+	testLogging {
+		exceptionFormat = 'full'
+	}
+}
+
+
 def assetsDirectory = file("${buildDir}/assets")
 git {
 	assets {

--- a/src/games/strategy/triplea/ai/proAI/ProRetreatAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProRetreatAI.java
@@ -109,7 +109,7 @@ public class ProRetreatAI {
           break;
         }
         final double strength =
-            ProBattleUtils.estimateStrength(player, t, t.getUnits().getMatches(Matches.isUnitAllied(player, data)),
+            ProBattleUtils.estimateStrength(t, t.getUnits().getMatches(Matches.isUnitAllied(player, data)),
                 new ArrayList<Unit>(), false);
         if (strength > maxStrength) {
           retreatTerritory = t;

--- a/src/games/strategy/triplea/ai/proAI/ProScrambleAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProScrambleAI.java
@@ -69,10 +69,10 @@ public class ProScrambleAI {
           @Override
           public int compare(final Unit o1, final Unit o2) {
             final double strength1 =
-                ProBattleUtils.estimateStrength(player, scrambleTo, Collections.singletonList(o1),
+                ProBattleUtils.estimateStrength(scrambleTo, Collections.singletonList(o1),
                     new ArrayList<Unit>(), false);
             final double strength2 =
-                ProBattleUtils.estimateStrength(player, scrambleTo, Collections.singletonList(o2),
+                ProBattleUtils.estimateStrength(scrambleTo, Collections.singletonList(o2),
                     new ArrayList<Unit>(), false);
             return Double.compare(strength2, strength1);
           }

--- a/src/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
+++ b/src/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.Lists;
+
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
@@ -80,12 +82,10 @@ public class ProOtherMoveOptions {
           double maxStrength = 0;
           if (!maxUnits.isEmpty()) {
             maxStrength =
-                ProBattleUtils.estimateStrength(maxUnits.iterator().next().getOwner(), t,
-                    new ArrayList<Unit>(maxUnits), new ArrayList<Unit>(), isAttacker);
+                ProBattleUtils.estimateStrength(t, Lists.newArrayList(maxUnits), Lists.newArrayList(), isAttacker);
           }
           final double currentStrength =
-              ProBattleUtils.estimateStrength(currentUnits.iterator().next().getOwner(), t, new ArrayList<Unit>(
-                  currentUnits), new ArrayList<Unit>(), isAttacker);
+              ProBattleUtils.estimateStrength(t, Lists.newArrayList(currentUnits), Lists.newArrayList(), isAttacker);
           final boolean currentHasLandUnits = Match.someMatch(currentUnits, Matches.UnitIsLand);
           final boolean maxHasLandUnits = Match.someMatch(maxUnits, Matches.UnitIsLand);
           if ((currentHasLandUnits && ((!maxHasLandUnits && !t.isWater()) || currentStrength > maxStrength))

--- a/src/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -237,10 +237,10 @@ public class ProTerritoryManager {
               @Override
               public int compare(final Unit o1, final Unit o2) {
                 final double strength1 =
-                    ProBattleUtils.estimateStrength(player, to, Collections.singletonList(o1), new ArrayList<Unit>(),
+                    ProBattleUtils.estimateStrength(to, Collections.singletonList(o1), new ArrayList<Unit>(),
                         false);
                 final double strength2 =
-                    ProBattleUtils.estimateStrength(player, to, Collections.singletonList(o2), new ArrayList<Unit>(),
+                    ProBattleUtils.estimateStrength(to, Collections.singletonList(o2), new ArrayList<Unit>(),
                         false);
                 return Double.compare(strength2, strength1);
               }

--- a/src/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -55,7 +55,7 @@ public class ProBattleUtils {
     Collections.reverse(sortedUnitsList);
     final int attackPower =
         DiceRoll.getTotalPower(
-            DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits, false,
+            DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defendingUnits, false,
                 false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
     final List<Unit> defendersWithHitPoints = Match.getMatches(defendingUnits, Matches.UnitIsInfrastructure.invert());
     final int totalDefenderHitPoints = BattleCalculator.getTotalHitpointsLeft(defendersWithHitPoints);
@@ -106,7 +106,7 @@ public class ProBattleUtils {
     Collections.reverse(sortedUnitsList);
     final int myPower =
         DiceRoll.getTotalPower(
-            DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, enemyUnits, !attacking,
+            DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, enemyUnits, !attacking,
                 false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
     return (myPower * 6.0 / data.getDiceSides());
   }

--- a/src/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -43,7 +43,7 @@ public class ProBattleUtils {
     }
 
     // Check that defender has at least 1 power
-    final double power = estimatePower(defendingUnits.get(0).getOwner(), t, defendingUnits, attackingUnits, false);
+    final double power = estimatePower(t, defendingUnits, attackingUnits, false);
     if (power == 0 && !attackingUnits.isEmpty()) {
       return true;
     }
@@ -56,7 +56,7 @@ public class ProBattleUtils {
     final int attackPower =
         DiceRoll.getTotalPower(
             DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits, false,
-                false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+                false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
     final List<Unit> defendersWithHitPoints = Match.getMatches(defendingUnits, Matches.UnitIsInfrastructure.invert());
     final int totalDefenderHitPoints = BattleCalculator.getTotalHitpointsLeft(defendersWithHitPoints);
     return ((attackPower / data.getDiceSides()) >= totalDefenderHitPoints);
@@ -73,13 +73,13 @@ public class ProBattleUtils {
       return 100;
     }
     final double attackerStrength =
-        estimateStrength(attackingUnits.get(0).getOwner(), t, attackingUnits, actualDefenders, true);
+        estimateStrength(t, attackingUnits, actualDefenders, true);
     final double defenderStrength =
-        estimateStrength(actualDefenders.get(0).getOwner(), t, actualDefenders, attackingUnits, false);
+        estimateStrength(t, actualDefenders, attackingUnits, false);
     return ((attackerStrength - defenderStrength) / Math.pow(defenderStrength, 0.85) * 50 + 50);
   }
 
-  public static double estimateStrength(final PlayerID player, final Territory t, final List<Unit> myUnits,
+  public static double estimateStrength(final Territory t, final List<Unit> myUnits,
       final List<Unit> enemyUnits, final boolean attacking) {
     final GameData data = ProData.getData();
 
@@ -89,11 +89,11 @@ public class ProBattleUtils {
       unitsThatCanFight = Match.getMatches(unitsThatCanFight, Matches.UnitIsTransportButNotCombatTransport.invert());
     }
     final int myHP = BattleCalculator.getTotalHitpointsLeft(unitsThatCanFight);
-    final double myPower = estimatePower(player, t, myUnits, enemyUnits, attacking);
+    final double myPower = estimatePower(t, myUnits, enemyUnits, attacking);
     return (2 * myHP) + myPower;
   }
 
-  private static double estimatePower(final PlayerID player, final Territory t, final List<Unit> myUnits,
+  private static double estimatePower(final Territory t, final List<Unit> myUnits,
       final List<Unit> enemyUnits, final boolean attacking) {
     final GameData data = ProData.getData();
 
@@ -107,7 +107,7 @@ public class ProBattleUtils {
     final int myPower =
         DiceRoll.getTotalPower(
             DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, enemyUnits, !attacking,
-                false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+                false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
     return (myPower * 6.0 / data.getDiceSides());
   }
 

--- a/src/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -54,9 +54,9 @@ public class ProBattleUtils {
         new UnitBattleComparator(false, ProData.unitValueMap, TerritoryEffectHelper.getEffects(t), data, false, false));
     Collections.reverse(sortedUnitsList);
     final int attackPower =
-        DiceRoll.getTotalPowerAndRolls(
+        DiceRoll.getTotalPower(
             DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits, false,
-                false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data).getFirst();
+                false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
     final List<Unit> defendersWithHitPoints = Match.getMatches(defendingUnits, Matches.UnitIsInfrastructure.invert());
     final int totalDefenderHitPoints = BattleCalculator.getTotalHitpointsLeft(defendersWithHitPoints);
     return ((attackPower / data.getDiceSides()) >= totalDefenderHitPoints);
@@ -105,9 +105,9 @@ public class ProBattleUtils {
             false));
     Collections.reverse(sortedUnitsList);
     final int myPower =
-        DiceRoll.getTotalPowerAndRolls(
+        DiceRoll.getTotalPower(
             DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, enemyUnits, !attacking,
-                false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data).getFirst();
+                false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
     return (myPower * 6.0 / data.getDiceSides());
   }
 

--- a/src/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
@@ -157,19 +157,17 @@ public class ProSortMoveOptionsUtils {
                 TerritoryEffectHelper.getEffects(t), data, false, false));
             Collections.reverse(sortedUnitsList);
             final int powerWithout =
-                DiceRoll.getTotalPowerAndRolls(
+                DiceRoll.getTotalPower(
                     DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
-                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data)
-                    .getFirst();
+                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             sortedUnitsList.add(o1.getKey());
             Collections.sort(sortedUnitsList, new UnitBattleComparator(false, ProData.unitValueMap,
                 TerritoryEffectHelper.getEffects(t), data, false, false));
             Collections.reverse(sortedUnitsList);
             final int powerWith =
-                DiceRoll.getTotalPowerAndRolls(
+                DiceRoll.getTotalPower(
                     DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
-                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data)
-                    .getFirst();
+                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             final int power = powerWith - powerWithout;
             if (power < minPower1) {
               minPower1 = power;
@@ -190,19 +188,17 @@ public class ProSortMoveOptionsUtils {
                 TerritoryEffectHelper.getEffects(t), data, false, false));
             Collections.reverse(sortedUnitsList);
             final int powerWithout =
-                DiceRoll.getTotalPowerAndRolls(
+                DiceRoll.getTotalPower(
                     DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
-                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data)
-                    .getFirst();
+                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             sortedUnitsList.add(o2.getKey());
             Collections.sort(sortedUnitsList, new UnitBattleComparator(false, ProData.unitValueMap,
                 TerritoryEffectHelper.getEffects(t), data, false, false));
             Collections.reverse(sortedUnitsList);
             final int powerWith =
-                DiceRoll.getTotalPowerAndRolls(
+                DiceRoll.getTotalPower(
                     DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
-                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data)
-                    .getFirst();
+                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             final int power = powerWith - powerWithout;
             if (power < minPower2) {
               minPower2 = power;

--- a/src/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
@@ -159,7 +159,7 @@ public class ProSortMoveOptionsUtils {
             final int powerWithout =
                 DiceRoll.getTotalPower(
                     DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
-                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+                        false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             sortedUnitsList.add(o1.getKey());
             Collections.sort(sortedUnitsList, new UnitBattleComparator(false, ProData.unitValueMap,
                 TerritoryEffectHelper.getEffects(t), data, false, false));
@@ -167,7 +167,7 @@ public class ProSortMoveOptionsUtils {
             final int powerWith =
                 DiceRoll.getTotalPower(
                     DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
-                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+                        false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             final int power = powerWith - powerWithout;
             if (power < minPower1) {
               minPower1 = power;
@@ -190,7 +190,7 @@ public class ProSortMoveOptionsUtils {
             final int powerWithout =
                 DiceRoll.getTotalPower(
                     DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
-                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+                        false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             sortedUnitsList.add(o2.getKey());
             Collections.sort(sortedUnitsList, new UnitBattleComparator(false, ProData.unitValueMap,
                 TerritoryEffectHelper.getEffects(t), data, false, false));
@@ -198,7 +198,7 @@ public class ProSortMoveOptionsUtils {
             final int powerWith =
                 DiceRoll.getTotalPower(
                     DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
-                        false, false, player, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
+                        false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             final int power = powerWith - powerWithout;
             if (power < minPower2) {
               minPower2 = power;

--- a/src/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
@@ -158,7 +158,7 @@ public class ProSortMoveOptionsUtils {
             Collections.reverse(sortedUnitsList);
             final int powerWithout =
                 DiceRoll.getTotalPower(
-                    DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
+                    DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defendingUnits,
                         false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             sortedUnitsList.add(o1.getKey());
             Collections.sort(sortedUnitsList, new UnitBattleComparator(false, ProData.unitValueMap,
@@ -166,7 +166,7 @@ public class ProSortMoveOptionsUtils {
             Collections.reverse(sortedUnitsList);
             final int powerWith =
                 DiceRoll.getTotalPower(
-                    DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
+                    DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defendingUnits,
                         false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             final int power = powerWith - powerWithout;
             if (power < minPower1) {
@@ -189,7 +189,7 @@ public class ProSortMoveOptionsUtils {
             Collections.reverse(sortedUnitsList);
             final int powerWithout =
                 DiceRoll.getTotalPower(
-                    DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
+                    DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defendingUnits,
                         false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             sortedUnitsList.add(o2.getKey());
             Collections.sort(sortedUnitsList, new UnitBattleComparator(false, ProData.unitValueMap,
@@ -197,7 +197,7 @@ public class ProSortMoveOptionsUtils {
             Collections.reverse(sortedUnitsList);
             final int powerWith =
                 DiceRoll.getTotalPower(
-                    DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, sortedUnitsList, defendingUnits,
+                    DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defendingUnits,
                         false, false, data, t, TerritoryEffectHelper.getEffects(t), false, null), data);
             final int power = powerWith - powerWithout;
             if (power < minPower2) {

--- a/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -31,7 +31,7 @@ public class ProTerritoryValueUtils {
     double value = 3 * TerritoryAttachment.getProduction(t) * (isEnemyFactory + 1);
     if (!t.isWater() && t.getOwner().isNull()) {
       final double strength =
-          ProBattleUtils.estimateStrength(t.getOwner(), t, new ArrayList<Unit>(t.getUnits().getUnits()),
+          ProBattleUtils.estimateStrength(t, new ArrayList<Unit>(t.getUnits().getUnits()),
               new ArrayList<Unit>(), false);
 
       // Estimate TUV swing as number of casualties * cost

--- a/src/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/games/strategy/triplea/delegate/AirBattle.java
@@ -95,8 +95,8 @@ public class AirBattle extends AbstractBattle {
     }
     updateDefendingUnits();
     bridge.getHistoryWriter().startEvent("Air Battle in " + m_battleSite, m_battleSite);
-    BattleCalculator.sortPreBattle(m_attackingUnits, m_data);
-    BattleCalculator.sortPreBattle(m_defendingUnits, m_data);
+    BattleCalculator.sortPreBattle(m_attackingUnits);
+    BattleCalculator.sortPreBattle(m_defendingUnits);
     m_steps = determineStepStrings(true, bridge);
     showBattle(bridge);
     pushFightLoopOnStack(true);

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -131,7 +131,7 @@ public class BattleCalculator {
           dice.getHits(), allowMultipleHitsPerUnit);
     } else {
       if (Properties.getLow_Luck(data) || Properties.getLL_AA_ONLY(data)) {
-        return getLowLuckAACasualties(defending, planes, defendingAA, dice, terr, bridge, allowMultipleHitsPerUnit);
+        return getLowLuckAACasualties(defending, planes, defendingAA, dice, bridge, allowMultipleHitsPerUnit);
       } else {
         // priority goes: choose -> individually -> random
         // if none are set, we roll individually
@@ -175,7 +175,7 @@ public class BattleCalculator {
   }
 
   private static CasualtyDetails getLowLuckAACasualties(final boolean defending, final Collection<Unit> planes,
-      final Collection<Unit> defendingAA, final DiceRoll dice, final Territory location, final IDelegateBridge bridge,
+      final Collection<Unit> defendingAA, final DiceRoll dice, final IDelegateBridge bridge,
       final boolean allowMultipleHitsPerUnit) {
     {
       final Set<Unit> duplicatesCheckSet1 = new HashSet<Unit>(planes);

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -1345,7 +1345,7 @@ public class BattleCalculator {
     return false;
   }
 
-  public static int getRolls(final Collection<Unit> units, final Territory location, final PlayerID id,
+  public static int getRolls(final Collection<Unit> units, final PlayerID id,
       final boolean defend, final boolean bombing, final Set<List<UnitSupportAttachment>> supportRulesFriendly,
       final IntegerMap<UnitSupportAttachment> supportLeftFriendlyCopy,
       final Set<List<UnitSupportAttachment>> supportRulesEnemy,
@@ -1353,21 +1353,21 @@ public class BattleCalculator {
       final Collection<TerritoryEffect> territoryEffects) {
     int count = 0;
     for (final Unit unit : units) {
-      final int unitRoll = getRolls(unit, location, id, defend, bombing, supportRulesFriendly, supportLeftFriendlyCopy,
+      final int unitRoll = getRolls(unit, id, defend, bombing, supportRulesFriendly, supportLeftFriendlyCopy,
           supportRulesEnemy, supportLeftEnemyCopy, territoryEffects);
       count += unitRoll;
     }
     return count;
   }
 
-  public static int getRolls(final Collection<Unit> units, final Territory location, final PlayerID id,
-      final boolean defend, final boolean bombing, final Collection<TerritoryEffect> territoryEffects) {
-    return getRolls(units, location, id, defend, bombing, new HashSet<List<UnitSupportAttachment>>(),
+  public static int getRolls(final Collection<Unit> units, final PlayerID id, final boolean defend,
+      final boolean bombing, final Collection<TerritoryEffect> territoryEffects) {
+    return getRolls(units, id, defend, bombing, new HashSet<List<UnitSupportAttachment>>(),
         new IntegerMap<UnitSupportAttachment>(), new HashSet<List<UnitSupportAttachment>>(),
         new IntegerMap<UnitSupportAttachment>(), territoryEffects);
   }
 
-  public static int getRolls(final Unit unit, final Territory location, final PlayerID id, final boolean defend,
+  public static int getRolls(final Unit unit, final PlayerID id, final boolean defend,
       final boolean bombing, final Set<List<UnitSupportAttachment>> supportRulesFriendly,
       final IntegerMap<UnitSupportAttachment> supportLeftFriendlyCopy,
       final Set<List<UnitSupportAttachment>> supportRulesEnemy,
@@ -1406,9 +1406,9 @@ public class BattleCalculator {
     return rolls;
   }
 
-  public static int getRolls(final Unit unit, final Territory location, final PlayerID id, final boolean defend,
+  public static int getRolls(final Unit unit, final PlayerID id, final boolean defend,
       final boolean bombing, final Collection<TerritoryEffect> territoryEffects) {
-    return getRolls(unit, location, id, defend, bombing, new HashSet<List<UnitSupportAttachment>>(),
+    return getRolls(unit, id, defend, bombing, new HashSet<List<UnitSupportAttachment>>(),
         new IntegerMap<UnitSupportAttachment>(), new HashSet<List<UnitSupportAttachment>>(),
         new IntegerMap<UnitSupportAttachment>(), territoryEffects);
   }

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -136,14 +136,12 @@ public class BattleCalculator {
         // priority goes: choose -> individually -> random
         // if none are set, we roll individually
         if (isRollAAIndividually(data)) {
-          return IndividuallyFiredAACasualties(defending, planes, defendingAA, dice, terr, bridge,
-              allowMultipleHitsPerUnit);
+          return IndividuallyFiredAACasualties(defending, planes, defendingAA, dice, bridge, allowMultipleHitsPerUnit);
         }
         if (isRandomAACasualties(data)) {
           return RandomAACasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
         }
-        return IndividuallyFiredAACasualties(defending, planes, defendingAA, dice, terr, bridge,
-            allowMultipleHitsPerUnit);
+        return IndividuallyFiredAACasualties(defending, planes, defendingAA, dice, bridge, allowMultipleHitsPerUnit);
       }
     }
   }
@@ -408,7 +406,7 @@ public class BattleCalculator {
    * Choose plane casualties based on individual AA shots at each aircraft.
    */
   private static CasualtyDetails IndividuallyFiredAACasualties(final boolean defending, final Collection<Unit> planes,
-      final Collection<Unit> defendingAA, final DiceRoll dice, final Territory location, final IDelegateBridge bridge,
+      final Collection<Unit> defendingAA, final DiceRoll dice, final IDelegateBridge bridge,
       final boolean allowMultipleHitsPerUnit) {
     // if we have aa guns that are not infinite, then we need to randomly decide the aa casualties since there are not
     // enough rolls to have

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -981,13 +981,13 @@ public class BattleCalculator {
         Collections.reverse(units);
         final int power = DiceRoll
             .getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units, enemyUnitList, defending,
-                false, player, data, battlesite, territoryEffects, amphibious, amphibiousLandAttackers), data);
+                false, data, battlesite, territoryEffects, amphibious, amphibiousLandAttackers), data);
         // Find enemy power without current unit (need to consider this since supports can decrease enemy
         // attack/defense)
         final int enemyPower = DiceRoll
             .getTotalPower(
                 DiceRoll.getUnitPowerAndRollsForNormalBattles(enemyUnitList, enemyUnitList, units, !defending, false,
-                    enemyPlayer, data, battlesite, territoryEffects, amphibious, amphibiousLandAttackers),
+                    data, battlesite, territoryEffects, amphibious, amphibiousLandAttackers),
                 data);
         // Check if unit has higher power
         final int powerDifference = power - enemyPower;

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -68,7 +68,7 @@ public class BattleCalculator {
   // can tell what dice is for who
   // we also want to sort by movement, so casualties will be choosen as the
   // units with least movement
-  public static void sortPreBattle(final List<Unit> units, final GameData data) {
+  public static void sortPreBattle(final List<Unit> units) {
     final Comparator<Unit> comparator = new Comparator<Unit>() {
       @Override
       public int compare(final Unit u1, final Unit u2) {

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -416,7 +416,7 @@ public class BattleCalculator {
     // normal behavior is instant kill, which means planes.size()
     final int planeHP = (allowMultipleHitsPerUnit ? getTotalHitpointsLeft(planes) : planes.size());
 
-    if (DiceRoll.getTotalAAattacks(defendingAA, planes, bridge.getData()) != planeHP) {
+    if (DiceRoll.getTotalAAattacks(defendingAA, planes) != planeHP) {
       return RandomAACasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }
     final Triple<Integer, Integer, Boolean> triple =

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -778,7 +778,7 @@ public class BattleCalculator {
     final Map<Unit, IntegerMap<Unit>> unitSupportPowerMap = new HashMap<Unit, IntegerMap<Unit>>();
     final Map<Unit, IntegerMap<Unit>> unitSupportRollsMap = new HashMap<Unit, IntegerMap<Unit>>();
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(
-        sortedUnitsList, sortedUnitsList, new ArrayList<Unit>(enemyUnits), defending, false, player, data, battlesite,
+        sortedUnitsList, sortedUnitsList, new ArrayList<Unit>(enemyUnits), defending, false, data, battlesite,
         territoryEffects, amphibious, amphibiousLandAttackers, unitSupportPowerMap, unitSupportRollsMap);
     // Sort units starting with weakest for finding the worst units
     Collections.reverse(sortedUnitsList);

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -778,7 +778,7 @@ public class BattleCalculator {
     final Map<Unit, IntegerMap<Unit>> unitSupportPowerMap = new HashMap<Unit, IntegerMap<Unit>>();
     final Map<Unit, IntegerMap<Unit>> unitSupportRollsMap = new HashMap<Unit, IntegerMap<Unit>>();
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(
-        sortedUnitsList, sortedUnitsList, new ArrayList<Unit>(enemyUnits), defending, false, data, battlesite,
+        sortedUnitsList, new ArrayList<Unit>(enemyUnits), defending, false, data, battlesite,
         territoryEffects, amphibious, amphibiousLandAttackers, unitSupportPowerMap, unitSupportRollsMap);
     // Sort units starting with weakest for finding the worst units
     Collections.reverse(sortedUnitsList);

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -532,7 +532,7 @@ public class BattleCalculator {
     // Create production cost map, Maybe should do this elsewhere, but in case prices change, we do it here.
     final IntegerMap<UnitType> costs = getCostsForTUV(player, data);
     final Tuple<CasualtyList, List<Unit>> defaultCasualtiesAndSortedTargets = getDefaultCasualties(targetsToPickFrom,
-        hitsRemaining, defending, player, enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers,
+        hitsRemaining, defending, player, enemyUnits, amphibious, amphibiousLandAttackers,
         battlesite, costs, territoryEffects, data, allowMultipleHitsPerUnit, true);
     final CasualtyList defaultCasualties = defaultCasualtiesAndSortedTargets.getFirst();
     final List<Unit> sortedTargetsToPickFrom = defaultCasualtiesAndSortedTargets.getSecond();
@@ -652,15 +652,14 @@ public class BattleCalculator {
    * are listed, it is dead.
    */
   private static Tuple<CasualtyList, List<Unit>> getDefaultCasualties(final Collection<Unit> targetsToPickFrom,
-      final int hits, final boolean defending, final PlayerID player,
-      final PlayerID enemyPlayer, final Collection<Unit> enemyUnits, final boolean amphibious,
-      final Collection<Unit> amphibiousLandAttackers, final Territory battlesite, final IntegerMap<UnitType> costs,
-      final Collection<TerritoryEffect> territoryEffects, final GameData data, final boolean allowMultipleHitsPerUnit,
-      final boolean bonus) {
+      final int hits, final boolean defending, final PlayerID player, final Collection<Unit> enemyUnits,
+      final boolean amphibious, final Collection<Unit> amphibiousLandAttackers, final Territory battlesite,
+      final IntegerMap<UnitType> costs, final Collection<TerritoryEffect> territoryEffects, final GameData data,
+      final boolean allowMultipleHitsPerUnit, final boolean bonus) {
     final CasualtyList defaultCasualtySelection = new CasualtyList();
     // Sort units by power and cost in ascending order
     final List<Unit> sorted = sortUnitsForCasualtiesWithSupport(targetsToPickFrom, hits, defending, player,
-        enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs,
+        enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs,
         territoryEffects, data, allowMultipleHitsPerUnit, bonus);
     // Remove two hit bb's selecting them first for default casualties
     int numSelectedCasualties = 0;
@@ -704,17 +703,17 @@ public class BattleCalculator {
    * (Veqryn)
    */
   private static List<Unit> sortUnitsForCasualtiesWithSupport(final Collection<Unit> targetsToPickFrom, final int hits,
-      final boolean defending, final PlayerID player, final PlayerID enemyPlayer,
-      final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
-      final Territory battlesite, final IntegerMap<UnitType> costs, final Collection<TerritoryEffect> territoryEffects,
-      final GameData data, final boolean allowMultipleHitsPerUnit, final boolean bonus) {
+      final boolean defending, final PlayerID player, final Collection<Unit> enemyUnits, final boolean amphibious,
+      final Collection<Unit> amphibiousLandAttackers, final Territory battlesite, final IntegerMap<UnitType> costs,
+      final Collection<TerritoryEffect> territoryEffects, final GameData data, final boolean allowMultipleHitsPerUnit,
+      final boolean bonus) {
     if (!GameRunner2.getCasualtySelectionSlow()) {
       return sortUnitsForCasualtiesWithSupportNewWithCaching(targetsToPickFrom, defending, player,
           enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs, territoryEffects, data,
           bonus);
     } else {
-      return sortUnitsForCasualtiesWithSupportBruteForce(targetsToPickFrom, hits, defending, player,
-          enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs, territoryEffects, data,
+      return sortUnitsForCasualtiesWithSupportBruteForce(targetsToPickFrom, hits, defending, enemyUnits, amphibious,
+          amphibiousLandAttackers, battlesite, costs, territoryEffects, data,
           allowMultipleHitsPerUnit, bonus);
     }
   }
@@ -931,8 +930,7 @@ public class BattleCalculator {
   }
 
   private static List<Unit> sortUnitsForCasualtiesWithSupportBruteForce(final Collection<Unit> targetsToPickFrom,
-      final int hits, final boolean defending, final PlayerID player,
-      final PlayerID enemyPlayer, final Collection<Unit> enemyUnits, final boolean amphibious,
+      final int hits, final boolean defending, final Collection<Unit> enemyUnits, final boolean amphibious,
       final Collection<Unit> amphibiousLandAttackers, final Territory battlesite, final IntegerMap<UnitType> costs,
       final Collection<TerritoryEffect> territoryEffects, final GameData data, final boolean allowMultipleHitsPerUnit,
       final boolean bonus) {

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -980,13 +980,13 @@ public class BattleCalculator {
         final List<Unit> enemyUnitList = new ArrayList<Unit>(enemyUnits);
         Collections.reverse(units);
         final int power = DiceRoll
-            .getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units, enemyUnitList, defending,
+            .getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(units, enemyUnitList, defending,
                 false, data, battlesite, territoryEffects, amphibious, amphibiousLandAttackers), data);
         // Find enemy power without current unit (need to consider this since supports can decrease enemy
         // attack/defense)
         final int enemyPower = DiceRoll
             .getTotalPower(
-                DiceRoll.getUnitPowerAndRollsForNormalBattles(enemyUnitList, enemyUnitList, units, !defending, false,
+                DiceRoll.getUnitPowerAndRollsForNormalBattles(enemyUnitList, units, !defending, false,
                     data, battlesite, territoryEffects, amphibious, amphibiousLandAttackers),
                 data);
         // Check if unit has higher power

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -795,7 +795,7 @@ public class BattleCalculator {
         // Find unit power
         final Map<Unit, Tuple<Integer, Integer>> currentUnitMap = new HashMap<Unit, Tuple<Integer, Integer>>();
         currentUnitMap.put(u, unitPowerAndRollsMap.get(u));
-        int power = DiceRoll.getTotalPowerAndRolls(currentUnitMap, data).getFirst();
+        int power = DiceRoll.getTotalPower(currentUnitMap, data);
         // Add any support power that it provides to other units
         final IntegerMap<Unit> unitSupportPowerMapForUnit = unitSupportPowerMap.get(u);
         if (unitSupportPowerMapForUnit != null) {
@@ -818,14 +818,14 @@ public class BattleCalculator {
             // Find supported unit power with support
             final Map<Unit, Tuple<Integer, Integer>> supportedUnitMap = new HashMap<Unit, Tuple<Integer, Integer>>();
             supportedUnitMap.put(supportedUnit, strengthAndRolls);
-            final int powerWithSupport = DiceRoll.getTotalPowerAndRolls(supportedUnitMap, data).getFirst();
+            final int powerWithSupport = DiceRoll.getTotalPower(supportedUnitMap, data);
             // Find supported unit power without support
             final int strengthWithoutSupport =
                 strengthAndRolls.getFirst() - unitSupportPowerMapForUnit.getInt(supportedUnit);
             final Tuple<Integer, Integer> strengthAndRollsWithoutSupport =
                 Tuple.of(strengthWithoutSupport, strengthAndRolls.getSecond());
             supportedUnitMap.put(supportedUnit, strengthAndRollsWithoutSupport);
-            final int powerWithoutSupport = DiceRoll.getTotalPowerAndRolls(supportedUnitMap, data).getFirst();
+            final int powerWithoutSupport = DiceRoll.getTotalPower(supportedUnitMap, data);
             // Add the actual power provided by the support
             final int addedPower = powerWithSupport - powerWithoutSupport;
             power += addedPower;
@@ -842,14 +842,14 @@ public class BattleCalculator {
             // Find supported unit power with support
             final Map<Unit, Tuple<Integer, Integer>> supportedUnitMap = new HashMap<Unit, Tuple<Integer, Integer>>();
             supportedUnitMap.put(supportedUnit, strengthAndRolls);
-            final int powerWithSupport = DiceRoll.getTotalPowerAndRolls(supportedUnitMap, data).getFirst();
+            final int powerWithSupport = DiceRoll.getTotalPower(supportedUnitMap, data);
             // Find supported unit power without support
             final int rollsWithoutSupport =
                 strengthAndRolls.getSecond() - unitSupportRollsMap.get(u).getInt(supportedUnit);
             final Tuple<Integer, Integer> strengthAndRollsWithoutSupport =
                 Tuple.of(strengthAndRolls.getFirst(), rollsWithoutSupport);
             supportedUnitMap.put(supportedUnit, strengthAndRollsWithoutSupport);
-            final int powerWithoutSupport = DiceRoll.getTotalPowerAndRolls(supportedUnitMap, data).getFirst();
+            final int powerWithoutSupport = DiceRoll.getTotalPower(supportedUnitMap, data);
             // Add the actual power provided by the support
             final int addedPower = powerWithSupport - powerWithoutSupport;
             power += addedPower;
@@ -980,17 +980,15 @@ public class BattleCalculator {
         final List<Unit> enemyUnitList = new ArrayList<Unit>(enemyUnits);
         Collections.reverse(units);
         final int power = DiceRoll
-            .getTotalPowerAndRolls(DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units, enemyUnitList, defending,
-                false, player, data, battlesite, territoryEffects, amphibious, amphibiousLandAttackers), data)
-            .getFirst();
+            .getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units, enemyUnitList, defending,
+                false, player, data, battlesite, territoryEffects, amphibious, amphibiousLandAttackers), data);
         // Find enemy power without current unit (need to consider this since supports can decrease enemy
         // attack/defense)
         final int enemyPower = DiceRoll
-            .getTotalPowerAndRolls(
+            .getTotalPower(
                 DiceRoll.getUnitPowerAndRollsForNormalBattles(enemyUnitList, enemyUnitList, units, !defending, false,
                     enemyPlayer, data, battlesite, territoryEffects, amphibious, amphibiousLandAttackers),
-                data)
-            .getFirst();
+                data);
         // Check if unit has higher power
         final int powerDifference = power - enemyPower;
         if (powerDifference > maxPowerDifference

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -153,7 +153,7 @@ public class BattleCalculator {
    * the second list is all the air units that do not fit in the first list
    */
   private static Tuple<List<List<Unit>>, List<Unit>> categorizeLowLuckAirUnits(final Collection<Unit> units,
-      final Territory location, final int diceSides, final int groupSize) {
+      final int groupSize) {
     final Collection<UnitCategory> categorizedAir = UnitSeperator.categorize(units, null, false, true);
     final List<List<Unit>> groupsOfSize = new ArrayList<List<Unit>>();
     final List<Unit> toRoll = new ArrayList<Unit>();
@@ -245,8 +245,7 @@ public class BattleCalculator {
       // (ie: attack is 2, and
       // we have 3 fighters and 2 bombers, we would want 1 fighter to die for sure).
       // categorize with groupSize
-      final Tuple<List<List<Unit>>, List<Unit>> airSplit =
-          categorizeLowLuckAirUnits(planesList, location, chosenDiceSize, groupSize);
+      final Tuple<List<List<Unit>>, List<Unit>> airSplit = categorizeLowLuckAirUnits(planesList, groupSize);
       // the non rolling air units
       // if we are less hits than the number of groups, OR we have equal hits to number of groups but we also have a
       // remainder that is equal

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -498,7 +498,7 @@ public class BattleCalculator {
     if (headLess) {
       dependents = Collections.emptyMap();
     } else {
-      dependents = getDependents(targetsToPickFrom, data);
+      dependents = getDependents(targetsToPickFrom);
     }
     if (isEditMode && !headLess) {
       final CasualtyDetails editSelection = tripleaPlayer.selectCasualties(targetsToPickFrom, dependents, 0, text, dice,
@@ -709,9 +709,9 @@ public class BattleCalculator {
       final Territory battlesite, final IntegerMap<UnitType> costs, final Collection<TerritoryEffect> territoryEffects,
       final GameData data, final boolean allowMultipleHitsPerUnit, final boolean bonus) {
     if (!GameRunner2.getCasualtySelectionSlow()) {
-      return sortUnitsForCasualtiesWithSupportNewWithCaching(targetsToPickFrom, hits, defending, player, friendlyUnits,
-          enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs, territoryEffects, data,
-          allowMultipleHitsPerUnit, bonus);
+      return sortUnitsForCasualtiesWithSupportNewWithCaching(targetsToPickFrom, defending, player,
+          enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs, territoryEffects, data,
+          bonus);
     } else {
       return sortUnitsForCasualtiesWithSupportBruteForce(targetsToPickFrom, hits, defending, player, friendlyUnits,
           enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs, territoryEffects, data,
@@ -720,10 +720,10 @@ public class BattleCalculator {
   }
 
   private static List<Unit> sortUnitsForCasualtiesWithSupportNewWithCaching(final Collection<Unit> targetsToPickFrom,
-      final int hits, final boolean defending, final PlayerID player, final Collection<Unit> friendlyUnits,
-      final PlayerID enemyPlayer, final Collection<Unit> enemyUnits, final boolean amphibious,
+      final boolean defending, final PlayerID player,
+      final Collection<Unit> enemyUnits, final boolean amphibious,
       final Collection<Unit> amphibiousLandAttackers, final Territory battlesite, final IntegerMap<UnitType> costs,
-      final Collection<TerritoryEffect> territoryEffects, final GameData data, final boolean allowMultipleHitsPerUnit,
+      final Collection<TerritoryEffect> territoryEffects, final GameData data,
       final boolean bonus) {
     // Convert unit lists to unit type lists
     final List<UnitType> targetTypes = new ArrayList<UnitType>();
@@ -1006,7 +1006,7 @@ public class BattleCalculator {
     return sortedWellEnoughUnitsList;
   }
 
-  public static Map<Unit, Collection<Unit>> getDependents(final Collection<Unit> targets, final GameData data) {
+  public static Map<Unit, Collection<Unit>> getDependents(final Collection<Unit> targets) {
     // just worry about transports
     final Map<Unit, Collection<Unit>> dependents = new HashMap<Unit, Collection<Unit>>();
     for (final Unit target : targets) {

--- a/src/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/games/strategy/triplea/delegate/BattleCalculator.java
@@ -532,7 +532,7 @@ public class BattleCalculator {
     // Create production cost map, Maybe should do this elsewhere, but in case prices change, we do it here.
     final IntegerMap<UnitType> costs = getCostsForTUV(player, data);
     final Tuple<CasualtyList, List<Unit>> defaultCasualtiesAndSortedTargets = getDefaultCasualties(targetsToPickFrom,
-        hitsRemaining, defending, player, friendlyUnits, enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers,
+        hitsRemaining, defending, player, enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers,
         battlesite, costs, territoryEffects, data, allowMultipleHitsPerUnit, true);
     final CasualtyList defaultCasualties = defaultCasualtiesAndSortedTargets.getFirst();
     final List<Unit> sortedTargetsToPickFrom = defaultCasualtiesAndSortedTargets.getSecond();
@@ -652,7 +652,7 @@ public class BattleCalculator {
    * are listed, it is dead.
    */
   private static Tuple<CasualtyList, List<Unit>> getDefaultCasualties(final Collection<Unit> targetsToPickFrom,
-      final int hits, final boolean defending, final PlayerID player, final Collection<Unit> friendlyUnits,
+      final int hits, final boolean defending, final PlayerID player,
       final PlayerID enemyPlayer, final Collection<Unit> enemyUnits, final boolean amphibious,
       final Collection<Unit> amphibiousLandAttackers, final Territory battlesite, final IntegerMap<UnitType> costs,
       final Collection<TerritoryEffect> territoryEffects, final GameData data, final boolean allowMultipleHitsPerUnit,
@@ -660,7 +660,7 @@ public class BattleCalculator {
     final CasualtyList defaultCasualtySelection = new CasualtyList();
     // Sort units by power and cost in ascending order
     final List<Unit> sorted = sortUnitsForCasualtiesWithSupport(targetsToPickFrom, hits, defending, player,
-        friendlyUnits, enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs,
+        enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs,
         territoryEffects, data, allowMultipleHitsPerUnit, bonus);
     // Remove two hit bb's selecting them first for default casualties
     int numSelectedCasualties = 0;
@@ -704,7 +704,7 @@ public class BattleCalculator {
    * (Veqryn)
    */
   private static List<Unit> sortUnitsForCasualtiesWithSupport(final Collection<Unit> targetsToPickFrom, final int hits,
-      final boolean defending, final PlayerID player, final Collection<Unit> friendlyUnits, final PlayerID enemyPlayer,
+      final boolean defending, final PlayerID player, final PlayerID enemyPlayer,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
       final Territory battlesite, final IntegerMap<UnitType> costs, final Collection<TerritoryEffect> territoryEffects,
       final GameData data, final boolean allowMultipleHitsPerUnit, final boolean bonus) {
@@ -713,7 +713,7 @@ public class BattleCalculator {
           enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs, territoryEffects, data,
           bonus);
     } else {
-      return sortUnitsForCasualtiesWithSupportBruteForce(targetsToPickFrom, hits, defending, player, friendlyUnits,
+      return sortUnitsForCasualtiesWithSupportBruteForce(targetsToPickFrom, hits, defending, player,
           enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs, territoryEffects, data,
           allowMultipleHitsPerUnit, bonus);
     }
@@ -931,7 +931,7 @@ public class BattleCalculator {
   }
 
   private static List<Unit> sortUnitsForCasualtiesWithSupportBruteForce(final Collection<Unit> targetsToPickFrom,
-      final int hits, final boolean defending, final PlayerID player, final Collection<Unit> friendlyUnits,
+      final int hits, final boolean defending, final PlayerID player,
       final PlayerID enemyPlayer, final Collection<Unit> enemyUnits, final boolean amphibious,
       final Collection<Unit> amphibiousLandAttackers, final Territory battlesite, final IntegerMap<UnitType> costs,
       final Collection<TerritoryEffect> territoryEffects, final GameData data, final boolean allowMultipleHitsPerUnit,

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -541,6 +541,15 @@ public class DiceRoll implements Externalizable {
     return rVal;
   }
 
+  public static Integer getTotalPower( final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap, final GameData data) {
+    return getTotalPowerAndRolls( unitPowerAndRollsMap, data).getFirst();
+  }
+
+  public static Integer getTotalRolls( final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap, final GameData data) {
+    return getTotalPowerAndRolls( unitPowerAndRollsMap, data).getSecond();
+  }
+
+
   public static Tuple<Integer, Integer> getTotalPowerAndRolls(
       final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap, final GameData data) {
     final int diceSides = data.getDiceSides();

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -405,16 +405,6 @@ public class DiceRoll implements Externalizable {
   /**
    * @param unitsGettingPowerFor
    *        should be sorted from weakest to strongest, before the method is called, for the actual battle
-   * @param allFriendlyUnitsAliveOrWaitingToDie
-   * @param allEnemyUnitsAliveOrWaitingToDie
-   * @param defending
-   * @param bombing
-   * @param player
-   * @param data
-   * @param location
-   * @param territoryEffects
-   * @param isAmphibiousBattle
-   * @param amphibiousLandAttackers
    */
   public static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
       final List<Unit> unitsGettingPowerFor, final List<Unit> allFriendlyUnitsAliveOrWaitingToDie,
@@ -431,18 +421,6 @@ public class DiceRoll implements Externalizable {
   /**
    * @param unitsGettingPowerFor
    *        should be sorted from weakest to strongest, before the method is called, for the actual battle
-   * @param allFriendlyUnitsAliveOrWaitingToDie
-   * @param allEnemyUnitsAliveOrWaitingToDie
-   * @param defending
-   * @param bombing
-   * @param player
-   * @param data
-   * @param location
-   * @param territoryEffects
-   * @param isAmphibiousBattle
-   * @param amphibiousLandAttackers
-   * @param unitSupportPowerMap
-   * @param unitSupportRollsMap
    */
   public static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
       final List<Unit> unitsGettingPowerFor, final List<Unit> allFriendlyUnitsAliveOrWaitingToDie,

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -14,9 +14,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import com.google.common.collect.Lists;
-
 import java.util.Set;
 
 import com.google.common.collect.Lists;
@@ -413,10 +410,7 @@ public class DiceRoll implements Externalizable {
       final Collection<TerritoryEffect> territoryEffects, final boolean isAmphibiousBattle,
       final Collection<Unit> amphibiousLandAttackers) {
 
-      // TODO:   See if the next function called can be simplified so we do not need to duplicate a parameter value.
-    List<Unit> allFriendlyUnitsAliveOrWaitingToDie = unitsGettingPowerFor;
-
-    return getUnitPowerAndRollsForNormalBattles(unitsGettingPowerFor, allFriendlyUnitsAliveOrWaitingToDie,
+    return getUnitPowerAndRollsForNormalBattles(unitsGettingPowerFor,
         allEnemyUnitsAliveOrWaitingToDie, defending, bombing, data, location, territoryEffects,
         isAmphibiousBattle, amphibiousLandAttackers, new HashMap<Unit, IntegerMap<Unit>>(),
         new HashMap<Unit, IntegerMap<Unit>>());
@@ -427,7 +421,7 @@ public class DiceRoll implements Externalizable {
    *        should be sorted from weakest to strongest, before the method is called, for the actual battle
    */
   protected static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
-      final List<Unit> unitsGettingPowerFor, final List<Unit> allFriendlyUnitsAliveOrWaitingToDie,
+      final List<Unit> unitsGettingPowerFor,
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie, final boolean defending, final boolean bombing,
       final GameData data, final Territory location,
       final Collection<TerritoryEffect> territoryEffects, final boolean isAmphibiousBattle,
@@ -442,7 +436,7 @@ public class DiceRoll implements Externalizable {
     final IntegerMap<UnitSupportAttachment> supportLeftFriendly = new IntegerMap<UnitSupportAttachment>();
     final Map<UnitSupportAttachment, LinkedIntegerMap<Unit>> supportUnitsLeftFriendly =
         new HashMap<UnitSupportAttachment, LinkedIntegerMap<Unit>>();
-    getSupport(allFriendlyUnitsAliveOrWaitingToDie, supportRulesFriendly, supportLeftFriendly, supportUnitsLeftFriendly,
+    getSupport(unitsGettingPowerFor, supportRulesFriendly, supportLeftFriendly, supportUnitsLeftFriendly,
         data, defending, true);
     final Set<List<UnitSupportAttachment>> supportRulesEnemy = new HashSet<List<UnitSupportAttachment>>();
     final IntegerMap<UnitSupportAttachment> supportLeftEnemy = new IntegerMap<UnitSupportAttachment>();

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -425,7 +425,7 @@ public class DiceRoll implements Externalizable {
    * @param gameData GameData object for looking up unit values
    * @param territory Used to determine if any territory effects apply to the units defensive power
    */
-  public static Integer getTotalDefensivePower(final List<Unit> units, final GameData gameData, Territory territory) {
+  public static Integer getTotalDefensivePower(final Collection<Unit> units, final GameData gameData, Territory territory) {
     boolean defending = true;
     return getTotalPower(units, gameData, territory, defending);
   }
@@ -439,14 +439,14 @@ public class DiceRoll implements Externalizable {
    * @param gameData GameData object for looking up unit values
    * @param territory Used to determine if any territory effects apply to the units offensive power
    */
-  public static Integer getTotalOffensivePower(final List<Unit> units, final GameData gameData, Territory territory) {
+  public static Integer getTotalOffensivePower(final Collection<Unit> units, final GameData gameData, Territory territory) {
     boolean defending = false;
     return getTotalPower(units, gameData, territory, defending);
   }
 
-  private static Integer getTotalPower(final List<Unit> units, final GameData gameData, Territory territory,
+  private static Integer getTotalPower(final Collection<Unit> units, final GameData gameData, Territory territory,
       boolean defending) {
-    final List<Unit> unitsGettingPowerFor = units;
+    final List<Unit> unitsGettingPowerFor = Lists.newArrayList(units);
     final List<Unit> allEnemyUnitsAliveOrWaitingToDie = Collections.EMPTY_LIST;
     final boolean bombing = false;
     final GameData data = gameData;
@@ -460,10 +460,9 @@ public class DiceRoll implements Externalizable {
         allEnemyUnitsAliveOrWaitingToDie, defending, bombing, data, location, territoryEffects,
         isAmphibiousBattle, amphibiousLandAttackers, Collections.EMPTY_MAP, Collections.EMPTY_MAP);
 
-    // power of any unit is multiplied if they can roll multiple dice.
-    // TODO: we should test this with LHTR, verify that works.
     int sum = 0;
     for (Tuple<Integer, Integer> entry : value.values()) {
+      // power of any unit is multiplied if they can roll multiple dice.
       sum += entry.getFirst() * entry.getSecond();
     }
     return sum;

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -51,32 +51,7 @@ public class DiceRoll implements Externalizable {
   // since for low luck we get many hits with few dice
   private int m_hits;
 
-  private static void sortAAHighToLow(final List<Unit> units, final GameData data, final boolean defending) {
-    final Comparator<Unit> comparator = new Comparator<Unit>() {
-      @Override
-      public int compare(final Unit u1, final Unit u2) {
-        final Tuple<Integer, Integer> tuple1 = getAAattackAndMaxDiceSides(Collections.singleton(u1), data, defending);
-        final Tuple<Integer, Integer> tuple2 = getAAattackAndMaxDiceSides(Collections.singleton(u2), data, defending);
-        if (tuple1.getFirst() == 0) {
-          if (tuple2.getFirst() == 0) {
-            return 0;
-          }
-          return 1;
-        } else if (tuple2.getFirst() == 0) {
-          return -1;
-        }
-        final float value1 = ((float) tuple1.getFirst()) / ((float) tuple1.getSecond());
-        final float value2 = ((float) tuple2.getFirst()) / ((float) tuple2.getSecond());
-        if (value1 < value2) {
-          return 1;
-        } else if (value1 > value2) {
-          return -1;
-        }
-        return 0;
-      }
-    };
-    Collections.sort(units, comparator);
-  }
+
 
   /**
    * Returns a Tuple with 2 values, the first is the max attack, the second is the max dice sides for the AA unit with
@@ -341,6 +316,33 @@ public class DiceRoll implements Externalizable {
       }
     }
     return Triple.of(totalPower, hits, (rolledAt.size() == 1));
+  }
+
+  private static void sortAAHighToLow(final List<Unit> units, final GameData data, final boolean defending) {
+    final Comparator<Unit> comparator = new Comparator<Unit>() {
+      @Override
+      public int compare(final Unit u1, final Unit u2) {
+        final Tuple<Integer, Integer> tuple1 = getAAattackAndMaxDiceSides(Collections.singleton(u1), data, defending);
+        final Tuple<Integer, Integer> tuple2 = getAAattackAndMaxDiceSides(Collections.singleton(u2), data, defending);
+        if (tuple1.getFirst() == 0) {
+          if (tuple2.getFirst() == 0) {
+            return 0;
+          }
+          return 1;
+        } else if (tuple2.getFirst() == 0) {
+          return -1;
+        }
+        final float value1 = ((float) tuple1.getFirst()) / ((float) tuple1.getSecond());
+        final float value2 = ((float) tuple2.getFirst()) / ((float) tuple2.getSecond());
+        if (value1 < value2) {
+          return 1;
+        } else if (value1 > value2) {
+          return -1;
+        }
+        return 0;
+      }
+    };
+    Collections.sort(units, comparator);
   }
 
   private static int getLowLuckHits(final IDelegateBridge bridge, final List<Die> sortedDice, final int totalPower,

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -550,7 +550,7 @@ public class DiceRoll implements Externalizable {
   }
 
 
-  public static Tuple<Integer, Integer> getTotalPowerAndRolls(
+  private static Tuple<Integer, Integer> getTotalPowerAndRolls(
       final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap, final GameData data) {
     final int diceSides = data.getDiceSides();
     final boolean lowLuck = games.strategy.triplea.Properties.getLow_Luck(data);

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.google.common.collect.Lists;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
@@ -388,18 +390,14 @@ public class DiceRoll implements Externalizable {
   public static DiceRoll rollNDice(final IDelegateBridge bridge, final int rollCount, final int sides,
       final PlayerID playerRolling, final DiceType diceType, final String annotation) {
     if (rollCount == 0) {
-      return new DiceRoll(new ArrayList<Die>(), 0);
+      return new DiceRoll(Lists.newArrayList(), 0);
     }
-    int[] random;
-    random = bridge.getRandom(sides, rollCount, playerRolling, diceType, annotation);
+    int[] random = bridge.getRandom(sides, rollCount, playerRolling, diceType, annotation);
     final List<Die> dice = new ArrayList<Die>();
-    int diceIndex = 0;
     for (int i = 0; i < rollCount; i++) {
-      dice.add(new Die(random[diceIndex], 1, DieType.IGNORED));
-      diceIndex++;
+      dice.add(new Die(random[i], 1, DieType.IGNORED));
     }
-    final DiceRoll rVal = new DiceRoll(dice, rollCount);
-    return rVal;
+    return new DiceRoll(dice, rollCount);
   }
 
   /**

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -409,7 +409,7 @@ public class DiceRoll implements Externalizable {
   public static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
       final List<Unit> unitsGettingPowerFor, final List<Unit> allFriendlyUnitsAliveOrWaitingToDie,
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie, final boolean defending, final boolean bombing,
-      final PlayerID player, final GameData data, final Territory location,
+      final GameData data, final Territory location,
       final Collection<TerritoryEffect> territoryEffects, final boolean isAmphibiousBattle,
       final Collection<Unit> amphibiousLandAttackers) {
     return getUnitPowerAndRollsForNormalBattles(unitsGettingPowerFor, allFriendlyUnitsAliveOrWaitingToDie,
@@ -519,8 +519,9 @@ public class DiceRoll implements Externalizable {
     return rVal;
   }
 
-  public static Integer getTotalPower( final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap, final GameData data) {
-    return getTotalPowerAndRolls( unitPowerAndRollsMap, data).getFirst();
+  public static Integer getTotalPower(final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap,
+      final GameData data) {
+    return getTotalPowerAndRolls(unitPowerAndRollsMap, data).getFirst();
   }
 
 
@@ -596,7 +597,7 @@ public class DiceRoll implements Externalizable {
     final Collection<Unit> amphibiousLandAttackers = battle.getAmphibiousLandAttackers();
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap =
         DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units, allEnemyUnitsAliveOrWaitingToDie, defending, false,
-            player, data, location, territoryEffects, isAmphibiousBattle, amphibiousLandAttackers);
+            data, location, territoryEffects, isAmphibiousBattle, amphibiousLandAttackers);
     final int power = getTotalPower(unitPowerAndRollsMap, data);
     if (power == 0) {
       return new DiceRoll(new ArrayList<Die>(0), 0);
@@ -985,7 +986,7 @@ public class DiceRoll implements Externalizable {
     final Collection<Unit> amphibiousLandAttackers = battle.getAmphibiousLandAttackers();
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap =
         DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units, allEnemyUnitsAliveOrWaitingToDie, defending, false,
-            player, data, location, territoryEffects, isAmphibiousBattle, amphibiousLandAttackers);
+            data, location, territoryEffects, isAmphibiousBattle, amphibiousLandAttackers);
     final Tuple<Integer, Integer> totalPowerAndRolls = getTotalPowerAndRolls(unitPowerAndRollsMap, data);
     final int rollCount = totalPowerAndRolls.getSecond();
     if (rollCount == 0) {

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -413,7 +413,7 @@ public class DiceRoll implements Externalizable {
       final Collection<TerritoryEffect> territoryEffects, final boolean isAmphibiousBattle,
       final Collection<Unit> amphibiousLandAttackers) {
     return getUnitPowerAndRollsForNormalBattles(unitsGettingPowerFor, allFriendlyUnitsAliveOrWaitingToDie,
-        allEnemyUnitsAliveOrWaitingToDie, defending, bombing, player, data, location, territoryEffects,
+        allEnemyUnitsAliveOrWaitingToDie, defending, bombing, data, location, territoryEffects,
         isAmphibiousBattle, amphibiousLandAttackers, new HashMap<Unit, IntegerMap<Unit>>(),
         new HashMap<Unit, IntegerMap<Unit>>());
   }
@@ -422,10 +422,10 @@ public class DiceRoll implements Externalizable {
    * @param unitsGettingPowerFor
    *        should be sorted from weakest to strongest, before the method is called, for the actual battle
    */
-  public static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
+  protected static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
       final List<Unit> unitsGettingPowerFor, final List<Unit> allFriendlyUnitsAliveOrWaitingToDie,
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie, final boolean defending, final boolean bombing,
-      final PlayerID player, final GameData data, final Territory location,
+      final GameData data, final Territory location,
       final Collection<TerritoryEffect> territoryEffects, final boolean isAmphibiousBattle,
       final Collection<Unit> amphibiousLandAttackers, final Map<Unit, IntegerMap<Unit>> unitSupportPowerMap,
       final Map<Unit, IntegerMap<Unit>> unitSupportRollsMap) {

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -416,6 +416,60 @@ public class DiceRoll implements Externalizable {
         new HashMap<Unit, IntegerMap<Unit>>());
   }
 
+
+  /**
+   * For a given set of units, returns their total defensive power, as if they were to defend in the territory in which
+   * are currently located.
+   *
+   * @param units The List of units we wish to consider, and sum their defensive power
+   * @param gameData GameData object for looking up unit values
+   * @param territory Used to determine if any territory effects apply to the units defensive power
+   */
+  public static Integer getTotalDefensivePower(final List<Unit> units, final GameData gameData, Territory territory) {
+    boolean defending = true;
+    return getTotalPower(units, gameData, territory, defending);
+  }
+
+
+  /**
+   * For a given set of units, returns their total offensive power, as if they were to attack the territory in which are
+   * currently located.
+   *
+   * @param units The List of units we wish to consider, and sum their offensive power
+   * @param gameData GameData object for looking up unit values
+   * @param territory Used to determine if any territory effects apply to the units offensive power
+   */
+  public static Integer getTotalOffensivePower(final List<Unit> units, final GameData gameData, Territory territory) {
+    boolean defending = false;
+    return getTotalPower(units, gameData, territory, defending);
+  }
+
+  private static Integer getTotalPower(final List<Unit> units, final GameData gameData, Territory territory,
+      boolean defending) {
+    final List<Unit> unitsGettingPowerFor = units;
+    final List<Unit> allEnemyUnitsAliveOrWaitingToDie = Collections.EMPTY_LIST;
+    final boolean bombing = false;
+    final GameData data = gameData;
+    final Territory location = territory;
+
+    final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(territory);
+    final boolean isAmphibiousBattle = false;
+    final Collection<Unit> amphibiousLandAttackers = Collections.EMPTY_LIST;
+
+    final Map<Unit, Tuple<Integer, Integer>> value = getUnitPowerAndRollsForNormalBattles(unitsGettingPowerFor,
+        allEnemyUnitsAliveOrWaitingToDie, defending, bombing, data, location, territoryEffects,
+        isAmphibiousBattle, amphibiousLandAttackers, Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+
+    // power of any unit is multiplied if they can roll multiple dice.
+    // TODO: we should test this with LHTR, verify that works.
+    int sum = 0;
+    for (Tuple<Integer, Integer> entry : value.values()) {
+      sum += entry.getFirst() * entry.getSecond();
+    }
+    return sum;
+  }
+
+
   /**
    * @param unitsGettingPowerFor
    *        should be sorted from weakest to strongest, before the method is called, for the actual battle

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -17,6 +17,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -446,6 +447,10 @@ public class DiceRoll implements Externalizable {
 
   private static Integer getTotalPower(final Collection<Unit> units, final GameData gameData, Territory territory,
       boolean defending) {
+    if( units == null || units.size() == 0) {
+      return 0;
+    }
+
     final List<Unit> unitsGettingPowerFor = Lists.newArrayList(units);
     final List<Unit> allEnemyUnitsAliveOrWaitingToDie = Collections.EMPTY_LIST;
     final boolean bombing = false;
@@ -458,7 +463,7 @@ public class DiceRoll implements Externalizable {
 
     final Map<Unit, Tuple<Integer, Integer>> value = getUnitPowerAndRollsForNormalBattles(unitsGettingPowerFor,
         allEnemyUnitsAliveOrWaitingToDie, defending, bombing, data, location, territoryEffects,
-        isAmphibiousBattle, amphibiousLandAttackers, Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+        isAmphibiousBattle, amphibiousLandAttackers, Maps.newHashMap(), Maps.newHashMap());
 
     int sum = 0;
     for (Tuple<Integer, Integer> entry : value.values()) {

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -545,10 +545,6 @@ public class DiceRoll implements Externalizable {
     return getTotalPowerAndRolls( unitPowerAndRollsMap, data).getFirst();
   }
 
-  public static Integer getTotalRolls( final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap, final GameData data) {
-    return getTotalPowerAndRolls( unitPowerAndRollsMap, data).getSecond();
-  }
-
 
   private static Tuple<Integer, Integer> getTotalPowerAndRolls(
       final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap, final GameData data) {
@@ -598,6 +594,7 @@ public class DiceRoll implements Externalizable {
         }
       }
     }
+
     return Tuple.of(totalPower, totalRolls);
   }
 
@@ -622,8 +619,7 @@ public class DiceRoll implements Externalizable {
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap =
         DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units, allEnemyUnitsAliveOrWaitingToDie, defending, false,
             player, data, location, territoryEffects, isAmphibiousBattle, amphibiousLandAttackers);
-    final Tuple<Integer, Integer> totalPowerAndRolls = getTotalPowerAndRolls(unitPowerAndRollsMap, data);
-    final int power = totalPowerAndRolls.getFirst();
+    final int power = getTotalPower(unitPowerAndRollsMap, data);
     if (power == 0) {
       return new DiceRoll(new ArrayList<Die>(0), 0);
     }

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -14,6 +14,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import com.google.common.collect.Lists;
+
 import java.util.Set;
 
 import com.google.common.collect.Lists;
@@ -405,11 +408,14 @@ public class DiceRoll implements Externalizable {
    *        should be sorted from weakest to strongest, before the method is called, for the actual battle
    */
   public static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
-      final List<Unit> unitsGettingPowerFor, final List<Unit> allFriendlyUnitsAliveOrWaitingToDie,
-      final List<Unit> allEnemyUnitsAliveOrWaitingToDie, final boolean defending, final boolean bombing,
-      final GameData data, final Territory location,
+      final List<Unit> unitsGettingPowerFor, final List<Unit> allEnemyUnitsAliveOrWaitingToDie,
+      final boolean defending, final boolean bombing, final GameData data, final Territory location,
       final Collection<TerritoryEffect> territoryEffects, final boolean isAmphibiousBattle,
       final Collection<Unit> amphibiousLandAttackers) {
+
+      // TODO:   See if the next function called can be simplified so we do not need to duplicate a parameter value.
+    List<Unit> allFriendlyUnitsAliveOrWaitingToDie = unitsGettingPowerFor;
+
     return getUnitPowerAndRollsForNormalBattles(unitsGettingPowerFor, allFriendlyUnitsAliveOrWaitingToDie,
         allEnemyUnitsAliveOrWaitingToDie, defending, bombing, data, location, territoryEffects,
         isAmphibiousBattle, amphibiousLandAttackers, new HashMap<Unit, IntegerMap<Unit>>(),
@@ -594,7 +600,7 @@ public class DiceRoll implements Externalizable {
     final boolean isAmphibiousBattle = battle.isAmphibious();
     final Collection<Unit> amphibiousLandAttackers = battle.getAmphibiousLandAttackers();
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap =
-        DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units, allEnemyUnitsAliveOrWaitingToDie, defending, false,
+        DiceRoll.getUnitPowerAndRollsForNormalBattles(units, allEnemyUnitsAliveOrWaitingToDie, defending, false,
             data, location, territoryEffects, isAmphibiousBattle, amphibiousLandAttackers);
     final int power = getTotalPower(unitPowerAndRollsMap, data);
     if (power == 0) {
@@ -983,7 +989,7 @@ public class DiceRoll implements Externalizable {
     final boolean isAmphibiousBattle = battle.isAmphibious();
     final Collection<Unit> amphibiousLandAttackers = battle.getAmphibiousLandAttackers();
     final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap =
-        DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units, allEnemyUnitsAliveOrWaitingToDie, defending, false,
+        DiceRoll.getUnitPowerAndRollsForNormalBattles(units, allEnemyUnitsAliveOrWaitingToDie, defending, false,
             data, location, territoryEffects, isAmphibiousBattle, amphibiousLandAttackers);
     final Tuple<Integer, Integer> totalPowerAndRolls = getTotalPowerAndRolls(unitPowerAndRollsMap, data);
     final int rollCount = totalPowerAndRolls.getSecond();

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -86,7 +86,7 @@ public class DiceRoll implements Externalizable {
   }
 
   public static int getTotalAAattacks(final Collection<Unit> defendingEnemyAA,
-      final Collection<Unit> validAttackingUnitsForThisRoll, final GameData data) {
+      final Collection<Unit> validAttackingUnitsForThisRoll) {
     if (defendingEnemyAA.isEmpty() || validAttackingUnitsForThisRoll.isEmpty()) {
       return 0;
     }
@@ -130,7 +130,7 @@ public class DiceRoll implements Externalizable {
       return new DiceRoll(new ArrayList<Die>(0), 0);
     }
     final GameData data = bridge.getData();
-    final int totalAAattacksTotal = getTotalAAattacks(defendingAA, validAttackingUnitsForThisRoll, data);
+    final int totalAAattacksTotal = getTotalAAattacks(defendingAA, validAttackingUnitsForThisRoll);
     if (totalAAattacksTotal <= 0) {
       return new DiceRoll(new ArrayList<Die>(0), 0);
     }
@@ -217,14 +217,14 @@ public class DiceRoll implements Externalizable {
     normalNonInfiniteAA.removeAll(infiniteAA);
     normalNonInfiniteAA.removeAll(overstackAA);
     // determine maximum total attacks
-    final int totalAAattacksTotal = getTotalAAattacks(defendingAA, validAttackingUnitsForThisRoll, data);
+    final int totalAAattacksTotal = getTotalAAattacks(defendingAA, validAttackingUnitsForThisRoll);
     // determine individual totals
     final int normalNonInfiniteAAtotalAAattacks =
-        getTotalAAattacks(normalNonInfiniteAA, validAttackingUnitsForThisRoll, data);
+        getTotalAAattacks(normalNonInfiniteAA, validAttackingUnitsForThisRoll);
     final int infiniteAAtotalAAattacks =
         Math.min((validAttackingUnitsForThisRoll.size() - normalNonInfiniteAAtotalAAattacks),
-            getTotalAAattacks(infiniteAA, validAttackingUnitsForThisRoll, data));
-    final int overstackAAtotalAAattacks = getTotalAAattacks(overstackAA, validAttackingUnitsForThisRoll, data);
+            getTotalAAattacks(infiniteAA, validAttackingUnitsForThisRoll));
+    final int overstackAAtotalAAattacks = getTotalAAattacks(overstackAA, validAttackingUnitsForThisRoll);
     if (totalAAattacksTotal != (normalNonInfiniteAAtotalAAattacks + infiniteAAtotalAAattacks
         + overstackAAtotalAAattacks)) {
       throw new IllegalStateException("Total attacks should be: " + totalAAattacksTotal + " but instead is: "

--- a/src/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/games/strategy/triplea/delegate/MustFightBattle.java
@@ -378,9 +378,9 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
       if (isAmphibious()) {
         sortAmphib(m_attackingUnits, m_data);
       } else {
-        BattleCalculator.sortPreBattle(m_attackingUnits, m_data);
+        BattleCalculator.sortPreBattle(m_attackingUnits);
       }
-      BattleCalculator.sortPreBattle(m_defendingUnits, m_data);
+      BattleCalculator.sortPreBattle(m_defendingUnits);
       // play a sound
       if (Match.someMatch(m_attackingUnits, Matches.UnitIsSea)
           || Match.someMatch(m_defendingUnits, Matches.UnitIsSea)) {

--- a/src/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -183,7 +183,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       endBeforeRolling(bridge);
       return;
     }
-    BattleCalculator.sortPreBattle(m_attackingUnits, m_data);
+    BattleCalculator.sortPreBattle(m_attackingUnits);
     // TODO: determine if the target has the property, not just any unit with the property isAAforBombingThisUnitOnly
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);

--- a/src/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -562,7 +562,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         }
       }
       final int rollCount =
-          BattleCalculator.getRolls(m_attackingUnits, m_battleSite, m_attacker, false, true, m_territoryEffects);
+          BattleCalculator.getRolls(m_attackingUnits, m_attacker, false, true, m_territoryEffects);
       if (rollCount == 0) {
         m_dice = null;
         return;
@@ -590,7 +590,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             int i = 0;
             final int diceSides = m_data.getDiceSides();
             for (final Unit u : m_attackingUnits) {
-              final int rolls = BattleCalculator.getRolls(u, m_battleSite, m_attacker, false, true, m_territoryEffects);
+              final int rolls = BattleCalculator.getRolls(u, m_attacker, false, true, m_territoryEffects);
               if (rolls < 1) {
                 continue;
               }
@@ -624,7 +624,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           int i = 0;
           final int diceSides = m_data.getDiceSides();
           for (final Unit u : m_attackingUnits) {
-            final int rolls = BattleCalculator.getRolls(u, m_battleSite, m_attacker, false, true, m_territoryEffects);
+            final int rolls = BattleCalculator.getRolls(u, m_attacker, false, true, m_territoryEffects);
             if (rolls < 1) {
               continue;
             }
@@ -695,7 +695,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       for (final Unit attacker : m_attackingUnits) {
         final UnitAttachment ua = UnitAttachment.get(attacker.getType());
         int rolls;
-        rolls = BattleCalculator.getRolls(attacker, m_battleSite, m_attacker, false, true, m_territoryEffects);
+        rolls = BattleCalculator.getRolls(attacker, m_attacker, false, true, m_territoryEffects);
         int costThisUnit = 0;
         if (rolls > 1 && (lhtrBombers || ua.getChooseBestRoll())) {
           // LHTR means we select the best Dice roll for the unit

--- a/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -661,18 +661,17 @@ class DummyPlayer extends AbstractAI {
           final int ourHP = BattleCalculator.getTotalHitpointsLeft(ourUnits);
           final int enemyHP = BattleCalculator.getTotalHitpointsLeft(enemyUnits);
           final int ourPower = DiceRoll
-              .getTotalPowerAndRolls(DiceRoll.getUnitPowerAndRollsForNormalBattles(ourUnits, ourUnits, enemyUnits,
+              .getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(ourUnits, ourUnits, enemyUnits,
                   !m_isAttacker, false, (m_isAttacker ? battle.getAttacker() : battle.getDefender()),
                   m_bridge.getData(), battle.getTerritory(), battle.getTerritoryEffects(), battle.isAmphibious(),
-                  (battle.isAmphibious() && m_isAttacker ? ourUnits : new ArrayList<Unit>())), m_bridge.getData())
-              .getFirst();
+                  (battle.isAmphibious() && m_isAttacker ? ourUnits : new ArrayList<Unit>())), m_bridge.getData());
           final int enemyPower =
-              DiceRoll.getTotalPowerAndRolls(
+              DiceRoll.getTotalPower(
                   DiceRoll.getUnitPowerAndRollsForNormalBattles(enemyUnits, enemyUnits, ourUnits, m_isAttacker, false,
                       (m_isAttacker ? battle.getDefender() : battle.getAttacker()), m_bridge.getData(),
                       battle.getTerritory(), battle.getTerritoryEffects(), battle.isAmphibious(),
                       (battle.isAmphibious() && !m_isAttacker ? enemyUnits : new ArrayList<Unit>())),
-                  m_bridge.getData()).getFirst();
+                  m_bridge.getData());
           final int diceSides = m_bridge.getData().getDiceSides();
           final int ourMetaPower = BattleCalculator.getNormalizedMetaPower(ourPower, ourHP, diceSides);
           final int enemyMetaPower = BattleCalculator.getNormalizedMetaPower(enemyPower, enemyHP, diceSides);

--- a/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -661,13 +661,13 @@ class DummyPlayer extends AbstractAI {
           // assume we are attacker
           final int ourHP = BattleCalculator.getTotalHitpointsLeft(ourUnits);
           final int enemyHP = BattleCalculator.getTotalHitpointsLeft(enemyUnits);
-          final int ourPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(ourUnits, ourUnits,
+          final int ourPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(ourUnits,
               enemyUnits, !m_isAttacker, false, m_bridge.getData(), battle.getTerritory(), battle.getTerritoryEffects(),
               battle.isAmphibious(), (battle.isAmphibious() && m_isAttacker ? ourUnits : new ArrayList<Unit>())),
               m_bridge.getData());
           final int enemyPower =
               DiceRoll.getTotalPower(
-                  DiceRoll.getUnitPowerAndRollsForNormalBattles(enemyUnits, enemyUnits, ourUnits, m_isAttacker, false,
+                  DiceRoll.getUnitPowerAndRollsForNormalBattles(enemyUnits, ourUnits, m_isAttacker, false,
                       m_bridge.getData(), battle.getTerritory(), battle.getTerritoryEffects(), battle.isAmphibious(),
                       (battle.isAmphibious() && !m_isAttacker ? enemyUnits : new ArrayList<Unit>())),
               m_bridge.getData());

--- a/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -328,7 +328,8 @@ public class OddsCalculator implements IOddsCalculator, Callable<AggregateResult
     return true;
   }
 
-  private static List<Unit> getUnitListByOrderOfLoss(final String ool, final Collection<Unit> units, final GameData data) {
+  private static List<Unit> getUnitListByOrderOfLoss(final String ool, final Collection<Unit> units,
+      final GameData data) {
     if (ool == null || ool.trim().length() == 0) {
       return null;
     }
@@ -660,18 +661,16 @@ class DummyPlayer extends AbstractAI {
           // assume we are attacker
           final int ourHP = BattleCalculator.getTotalHitpointsLeft(ourUnits);
           final int enemyHP = BattleCalculator.getTotalHitpointsLeft(enemyUnits);
-          final int ourPower = DiceRoll
-              .getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(ourUnits, ourUnits, enemyUnits,
-                  !m_isAttacker, false, (m_isAttacker ? battle.getAttacker() : battle.getDefender()),
-                  m_bridge.getData(), battle.getTerritory(), battle.getTerritoryEffects(), battle.isAmphibious(),
-                  (battle.isAmphibious() && m_isAttacker ? ourUnits : new ArrayList<Unit>())), m_bridge.getData());
+          final int ourPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(ourUnits, ourUnits,
+              enemyUnits, !m_isAttacker, false, m_bridge.getData(), battle.getTerritory(), battle.getTerritoryEffects(),
+              battle.isAmphibious(), (battle.isAmphibious() && m_isAttacker ? ourUnits : new ArrayList<Unit>())),
+              m_bridge.getData());
           final int enemyPower =
               DiceRoll.getTotalPower(
                   DiceRoll.getUnitPowerAndRollsForNormalBattles(enemyUnits, enemyUnits, ourUnits, m_isAttacker, false,
-                      (m_isAttacker ? battle.getDefender() : battle.getAttacker()), m_bridge.getData(),
-                      battle.getTerritory(), battle.getTerritoryEffects(), battle.isAmphibious(),
+                      m_bridge.getData(), battle.getTerritory(), battle.getTerritoryEffects(), battle.isAmphibious(),
                       (battle.isAmphibious() && !m_isAttacker ? enemyUnits : new ArrayList<Unit>())),
-                  m_bridge.getData());
+              m_bridge.getData());
           final int diceSides = m_bridge.getData().getDiceSides();
           final int ourMetaPower = BattleCalculator.getNormalizedMetaPower(ourPower, ourHP, diceSides);
           final int enemyMetaPower = BattleCalculator.getNormalizedMetaPower(enemyPower, enemyHP, diceSides);

--- a/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -846,14 +846,14 @@ public class OddsCalculatorPanel extends JPanel {
       Collections.sort(attackers, new UnitBattleComparator(false, costs, territoryEffects, m_data, false, false));
       Collections.reverse(attackers);
       final int attackPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(attackers,
-          attackers, defenders, false, false, getAttacker(), m_data, m_location, territoryEffects, isAmphibiousBattle,
+          attackers, defenders, false, false, m_data, m_location, territoryEffects, isAmphibiousBattle,
           (isAmphibiousBattle ? attackers : new ArrayList<Unit>())), m_data);
       // defender is never amphibious
       final int defensePower =
           DiceRoll
               .getTotalPower(
                   DiceRoll.getUnitPowerAndRollsForNormalBattles(defenders, defenders, attackers, true, false,
-                      getDefender(), m_data, m_location, territoryEffects, isAmphibiousBattle, new ArrayList<Unit>()),
+                      m_data, m_location, territoryEffects, isAmphibiousBattle, new ArrayList<Unit>()),
                   m_data);
       m_attackerUnitsTotalPower.setText("Power: " + attackPower);
       m_defenderUnitsTotalPower.setText("Power: " + defensePower);

--- a/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -845,17 +845,16 @@ public class OddsCalculatorPanel extends JPanel {
       final IntegerMap<UnitType> costs = BattleCalculator.getCostsForTUV(getAttacker(), m_data);
       Collections.sort(attackers, new UnitBattleComparator(false, costs, territoryEffects, m_data, false, false));
       Collections.reverse(attackers);
-      final int attackPower = DiceRoll.getTotalPowerAndRolls(DiceRoll.getUnitPowerAndRollsForNormalBattles(attackers,
+      final int attackPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(attackers,
           attackers, defenders, false, false, getAttacker(), m_data, m_location, territoryEffects, isAmphibiousBattle,
-          (isAmphibiousBattle ? attackers : new ArrayList<Unit>())), m_data).getFirst();
+          (isAmphibiousBattle ? attackers : new ArrayList<Unit>())), m_data);
       // defender is never amphibious
       final int defensePower =
           DiceRoll
-              .getTotalPowerAndRolls(
+              .getTotalPower(
                   DiceRoll.getUnitPowerAndRollsForNormalBattles(defenders, defenders, attackers, true, false,
                       getDefender(), m_data, m_location, territoryEffects, isAmphibiousBattle, new ArrayList<Unit>()),
-                  m_data)
-              .getFirst();
+                  m_data);
       m_attackerUnitsTotalPower.setText("Power: " + attackPower);
       m_defenderUnitsTotalPower.setText("Power: " + defensePower);
       m_attackerUnitsTotalPower.setToolTipText(

--- a/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -845,14 +845,14 @@ public class OddsCalculatorPanel extends JPanel {
       final IntegerMap<UnitType> costs = BattleCalculator.getCostsForTUV(getAttacker(), m_data);
       Collections.sort(attackers, new UnitBattleComparator(false, costs, territoryEffects, m_data, false, false));
       Collections.reverse(attackers);
-      final int attackPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(attackers,
-          attackers, defenders, false, false, m_data, m_location, territoryEffects, isAmphibiousBattle,
+      final int attackPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(attackers, defenders,
+          false, false, m_data, m_location, territoryEffects, isAmphibiousBattle,
           (isAmphibiousBattle ? attackers : new ArrayList<Unit>())), m_data);
       // defender is never amphibious
       final int defensePower =
           DiceRoll
               .getTotalPower(
-                  DiceRoll.getUnitPowerAndRollsForNormalBattles(defenders, defenders, attackers, true, false,
+                  DiceRoll.getUnitPowerAndRollsForNormalBattles(defenders, attackers, true, false,
                       m_data, m_location, territoryEffects, isAmphibiousBattle, new ArrayList<Unit>()),
                   m_data);
       m_attackerUnitsTotalPower.setText("Power: " + attackPower);

--- a/src/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/games/strategy/triplea/ui/BattleDisplay.java
@@ -872,7 +872,7 @@ class BattleModel extends DefaultTableModel {
         unitPowerAndRollsMap = null;
       } else {
         unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units,
-            new ArrayList<Unit>(m_enemyBattleModel.getUnits()), !m_attack, false, m_player, m_data, m_location,
+            new ArrayList<Unit>(m_enemyBattleModel.getUnits()), !m_attack, false, m_data, m_location,
             m_territoryEffects, m_isAmphibious, m_amphibiousLandAttackers);
       }
     } finally {

--- a/src/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/games/strategy/triplea/ui/BattleDisplay.java
@@ -219,7 +219,7 @@ public class BattleDisplay extends JPanel {
     Map<Unit, Collection<Unit>> dependentsMap;
     m_data.acquireReadLock();
     try {
-      dependentsMap = BattleCalculator.getDependents(aKilledUnits, m_data);
+      dependentsMap = BattleCalculator.getDependents(aKilledUnits);
     } finally {
       m_data.releaseReadLock();
     }

--- a/src/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/games/strategy/triplea/ui/BattleDisplay.java
@@ -53,6 +53,8 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableCellRenderer;
 
+import com.google.common.collect.Lists;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
@@ -871,8 +873,8 @@ class BattleModel extends DefaultTableModel {
       if (m_battleType.isAirPreBattleOrPreRaid()) {
         unitPowerAndRollsMap = null;
       } else {
-        unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(units, units,
-            new ArrayList<Unit>(m_enemyBattleModel.getUnits()), !m_attack, false, m_data, m_location,
+        unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(units,
+            Lists.newArrayList(m_enemyBattleModel.getUnits()), !m_attack, false, m_data, m_location,
             m_territoryEffects, m_isAmphibious, m_amphibiousLandAttackers);
       }
     } finally {

--- a/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -29,6 +29,7 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attatchments.TerritoryAttachment;
+import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.oddsCalculator.ta.OddsCalculatorDialog;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
@@ -152,6 +153,13 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
       m_data.releaseReadLock();
     }
     add(new JLabel("Units: " + unitsInTerritory.size()));
+
+    if( unitsInTerritory.size() > 0 ) {
+      add(new JLabel("Attack: " +     DiceRoll.getTotalOffensivePower( territory.getUnits().getUnits(), m_data, territory)));
+      add(new JLabel("Defense: " +     DiceRoll.getTotalDefensivePower( territory.getUnits().getUnits(), m_data, territory)));
+    }
+
+
     final JScrollPane scroll = new JScrollPane(unitsInTerritoryPanel(unitsInTerritory, m_uiContext, m_data));
     scroll.setBorder(BorderFactory.createEmptyBorder());
     add(scroll);

--- a/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -145,20 +145,19 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
       labelText = "<html>" + ta.toStringForInfo(true, true) + "<br></html>";
     }
     add(new JLabel(labelText));
-    Collection<Unit> unitsInTerritory;
+    final Collection<Unit> unitsInTerritory;
     m_data.acquireReadLock();
     try {
       unitsInTerritory = territory.getUnits().getUnits();
     } finally {
       m_data.releaseReadLock();
     }
-    add(new JLabel("Units: " + unitsInTerritory.size()));
 
-    if( unitsInTerritory.size() > 0 ) {
-      add(new JLabel("Attack: " +     DiceRoll.getTotalOffensivePower( territory.getUnits().getUnits(), m_data, territory)));
-      add(new JLabel("Defense: " +     DiceRoll.getTotalDefensivePower( territory.getUnits().getUnits(), m_data, territory)));
+    if( unitsInTerritory != null  && unitsInTerritory.size() > 0 ) {
+      add(new JLabel("Units: " + unitsInTerritory.size()));
+      add(new JLabel("Attack: " +     DiceRoll.getTotalOffensivePower(unitsInTerritory, m_data, territory)));
+      add(new JLabel("Defense: " +     DiceRoll.getTotalDefensivePower(unitsInTerritory, m_data, territory)));
     }
-
 
     final JScrollPane scroll = new JScrollPane(unitsInTerritoryPanel(unitsInTerritory, m_uiContext, m_data));
     scroll.setBorder(BorderFactory.createEmptyBorder());

--- a/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -154,9 +154,16 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     }
 
     if( unitsInTerritory != null  && unitsInTerritory.size() > 0 ) {
-      add(new JLabel("Units: " + unitsInTerritory.size()));
-      add(new JLabel("Attack: " +     DiceRoll.getTotalOffensivePower(unitsInTerritory, m_data, territory)));
-      add(new JLabel("Defense: " +     DiceRoll.getTotalDefensivePower(unitsInTerritory, m_data, territory)));
+
+      int totalAttackPower =  DiceRoll.getTotalOffensivePower(unitsInTerritory, m_data, territory);
+      int totalDefensePower =  DiceRoll.getTotalDefensivePower(unitsInTerritory, m_data, territory);
+
+      final String indent = "&nbsp;&nbsp;&nbsp;&nbsp;";
+
+      String unitsLabel = "<html>Units: " + unitsInTerritory.size() + "<br>";
+      unitsLabel += indent + "Attack:  " + totalAttackPower + "<br>";
+      unitsLabel += indent + "Defense: " +totalDefensePower + "</html>";
+      add(new JLabel(unitsLabel));
     }
 
     final JScrollPane scroll = new JScrollPane(unitsInTerritoryPanel(unitsInTerritory, m_uiContext, m_data));

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -25,28 +25,23 @@ import games.strategy.util.Match;
 import junit.framework.TestCase;
 
 public class DiceRollTest extends TestCase {
-  private GameData m_data;
+  private GameData gameData;
 
   @Override
   protected void setUp() throws Exception {
-    m_data = LoadGameUtil.loadTestGame("lhtr_test.xml");
+    gameData = LoadGameUtil.loadTestGame("lhtr_test.xml");
   }
 
   private ITestDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, m_data);
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-    m_data = null;
+    return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
   public void testSimple() {
-    final Territory westRussia = m_data.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final MockBattle battle = new MockBattle(westRussia);
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
-    final UnitType infantryType = GameDataTestUtil.infantry(m_data);
+    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final List<Unit> infantry = infantryType.create(1, russians);
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(westRussia);
     // infantry defends and hits at 1 (0 based)
@@ -68,12 +63,12 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testSimpleLowLuck() {
-    GameDataTestUtil.makeGameLowLuck(m_data);
-    final Territory westRussia = m_data.getMap().getTerritory("West Russia");
+    GameDataTestUtil.makeGameLowLuck(gameData);
+    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final MockBattle battle = new MockBattle(westRussia);
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
-    final UnitType infantryType = GameDataTestUtil.infantry(m_data);
+    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final List<Unit> infantry = infantryType.create(1, russians);
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(westRussia);
     // infantry defends and hits at 1 (0 based)
@@ -95,13 +90,13 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testArtillerySupport() {
-    final Territory westRussia = m_data.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final MockBattle battle = new MockBattle(westRussia);
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
-    final UnitType infantryType = GameDataTestUtil.infantry(m_data);
+    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final List<Unit> units = infantryType.create(1, russians);
-    final UnitType artillery = m_data.getUnitTypeList().getUnitType("artillery");
+    final UnitType artillery = gameData.getUnitTypeList().getUnitType("artillery");
     units.addAll(artillery.create(1, russians));
     // artillery supported infantry and art attack at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1, 1}));
@@ -111,12 +106,12 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testVariableArtillerySupport() {
-    final Territory westRussia = m_data.getMap().getTerritory("West Russia");
+    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final MockBattle battle = new MockBattle(westRussia);
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
     // Add 1 artillery
-    final UnitType artillery = m_data.getUnitTypeList().getUnitType("artillery");
+    final UnitType artillery = gameData.getUnitTypeList().getUnitType("artillery");
     final List<Unit> units = artillery.create(1, russians);
     // Set the supported unit count
     for (final Unit unit : units) {
@@ -124,7 +119,7 @@ public class DiceRollTest extends TestCase {
       ua.setUnitSupportCount("2");
     }
     // Now add the infantry
-    final UnitType infantryType = GameDataTestUtil.infantry(m_data);
+    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     units.addAll(infantryType.create(2, russians));
     // artillery supported infantry and art attack at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1, 1, 1}));
@@ -134,12 +129,12 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testLowLuck() {
-    GameDataTestUtil.makeGameLowLuck(m_data);
-    final Territory westRussia = m_data.getMap().getTerritory("West Russia");
+    GameDataTestUtil.makeGameLowLuck(gameData);
+    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final MockBattle battle = new MockBattle(westRussia);
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
-    final UnitType infantryType = GameDataTestUtil.infantry(m_data);
+    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     final List<Unit> units = infantryType.create(3, russians);
     // 3 infantry on defense should produce exactly one hit, without rolling the dice
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
@@ -162,10 +157,10 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testMarineAttackPlus1() throws Exception {
-    m_data = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
-    final Territory algeria = m_data.getMap().getTerritory("Algeria");
-    final PlayerID americans = GameDataTestUtil.americans(m_data);
-    final UnitType marine = m_data.getUnitTypeList().getUnitType("marine");
+    gameData = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
+    final Territory algeria = gameData.getMap().getTerritory("Algeria");
+    final PlayerID americans = GameDataTestUtil.americans(gameData);
+    final UnitType marine = gameData.getUnitTypeList().getUnitType("marine");
     final List<Unit> attackers = marine.create(1, americans);
     final ITestDelegateBridge bridge = getDelegateBridge(americans);
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
@@ -178,11 +173,11 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testMarineAttackPlus1LowLuck() throws Exception {
-    m_data = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
-    GameDataTestUtil.makeGameLowLuck(m_data);
-    final Territory algeria = m_data.getMap().getTerritory("Algeria");
-    final PlayerID americans = GameDataTestUtil.americans(m_data);
-    final UnitType marine = m_data.getUnitTypeList().getUnitType("marine");
+    gameData = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
+    GameDataTestUtil.makeGameLowLuck(gameData);
+    final Territory algeria = gameData.getMap().getTerritory("Algeria");
+    final PlayerID americans = GameDataTestUtil.americans(gameData);
+    final UnitType marine = gameData.getUnitTypeList().getUnitType("marine");
     final List<Unit> attackers = marine.create(3, americans);
     final ITestDelegateBridge bridge = getDelegateBridge(americans);
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
@@ -195,10 +190,10 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testMarineAttacNormalIfNotAmphibious() throws Exception {
-    m_data = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
-    final Territory algeria = m_data.getMap().getTerritory("Algeria");
-    final PlayerID americans = GameDataTestUtil.americans(m_data);
-    final UnitType marine = m_data.getUnitTypeList().getUnitType("marine");
+    gameData = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
+    final Territory algeria = gameData.getMap().getTerritory("Algeria");
+    final PlayerID americans = GameDataTestUtil.americans(gameData);
+    final UnitType marine = gameData.getUnitTypeList().getUnitType("marine");
     final List<Unit> attackers = marine.create(1, americans);
     final ITestDelegateBridge bridge = getDelegateBridge(americans);
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
@@ -211,18 +206,18 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testAA() {
-    final Territory westRussia = m_data.getMap().getTerritory("West Russia");
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final UnitType aaGunType = GameDataTestUtil.aaGun(m_data);
+    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final UnitType aaGunType = GameDataTestUtil.aaGun(gameData);
     final List<Unit> aaGunList = aaGunType.create(1, germans);
     GameDataTestUtil.addTo(westRussia, aaGunList);
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
-    final List<Unit> bombers = bomber(m_data).create(1, british(m_data));
+    final List<Unit> bombers = bomber(gameData).create(1, british(gameData));
     // aa hits at 0 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0}));
     final DiceRoll hit =
-        DiceRoll.rollAA(bomber(m_data).create(1, british(m_data)), aaGunList, bridge, westRussia, true);
+        DiceRoll.rollAA(bomber(gameData).create(1, british(gameData)), aaGunList, bridge, westRussia, true);
     assertEquals(hit.getHits(), 1);
     // aa missses at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
@@ -231,14 +226,14 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testAALowLuck() {
-    GameDataTestUtil.makeGameLowLuck(m_data);
-    final Territory westRussia = m_data.getMap().getTerritory("West Russia");
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final UnitType aaGunType = GameDataTestUtil.aaGun(m_data);
+    GameDataTestUtil.makeGameLowLuck(gameData);
+    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final UnitType aaGunType = GameDataTestUtil.aaGun(gameData);
     final List<Unit> aaGunList = aaGunType.create(1, germans);
     GameDataTestUtil.addTo(westRussia, aaGunList);
-    final UnitType fighterType = GameDataTestUtil.fighter(m_data);
+    final UnitType fighterType = GameDataTestUtil.fighter(gameData);
     List<Unit> fighterList = fighterType.create(1, russians);
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
     // aa hits at 0 (0 based)
@@ -248,7 +243,7 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(m_data))),
+                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, westRussia, true);
     assertEquals(hit.getHits(), 1);
     // aa missses at 1 (0 based)
@@ -258,7 +253,7 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(m_data))),
+                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, westRussia, true);
     assertEquals(miss.getHits(), 0);
     // 6 bombers, 1 should hit, and nothing should be rolled
@@ -269,20 +264,20 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(m_data))),
+                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, westRussia, true);
     assertEquals(hitNoRoll.getHits(), 1);
   }
 
   public void testAALowLuckDifferentMovement() {
-    GameDataTestUtil.makeGameLowLuck(m_data);
-    final Territory westRussia = m_data.getMap().getTerritory("West Russia");
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final UnitType aaGunType = GameDataTestUtil.aaGun(m_data);
+    GameDataTestUtil.makeGameLowLuck(gameData);
+    final Territory westRussia = gameData.getMap().getTerritory("West Russia");
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final UnitType aaGunType = GameDataTestUtil.aaGun(gameData);
     final List<Unit> aaGunList = aaGunType.create(1, germans);
     GameDataTestUtil.addTo(westRussia, aaGunList);
-    final UnitType fighterType = GameDataTestUtil.fighter(m_data);
+    final UnitType fighterType = GameDataTestUtil.fighter(gameData);
     final List<Unit> fighterList = fighterType.create(6, russians);
     TripleAUnit.get(fighterList.get(0)).setAlreadyMoved(1);
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
@@ -293,21 +288,21 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(m_data))),
+                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, westRussia, true);
     assertEquals(hit.getHits(), 1);
   }
 
   public void testAALowLuckWithRadar() {
-    m_data = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
-    GameDataTestUtil.makeGameLowLuck(m_data);
-    final Territory finnland = m_data.getMap().getTerritory("Finland");
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final UnitType aaGunType = GameDataTestUtil.aaGun(m_data);
+    gameData = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
+    GameDataTestUtil.makeGameLowLuck(gameData);
+    final Territory finnland = gameData.getMap().getTerritory("Finland");
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final UnitType aaGunType = GameDataTestUtil.aaGun(gameData);
     final List<Unit> aaGunList = aaGunType.create(1, germans);
     GameDataTestUtil.addTo(finnland, aaGunList);
-    final UnitType fighterType = GameDataTestUtil.fighter(m_data);
+    final UnitType fighterType = GameDataTestUtil.fighter(gameData);
     List<Unit> fighterList = fighterType.create(1, russians);
     TechAttachment.get(germans).setAARadar("true");
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
@@ -318,7 +313,7 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(m_data))),
+                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, finnland, true);
     assertEquals(hit.getHits(), 1);
     // aa missses at 2 (0 based)
@@ -328,7 +323,7 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(m_data))),
+                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, finnland, true);
     assertEquals(miss.getHits(), 0);
     // 6 bombers, 2 should hit, and nothing should be rolled
@@ -339,21 +334,21 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(m_data))),
+                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, finnland, true);
     assertEquals(hitNoRoll.getHits(), 2);
   }
 
   public void testHeavyBombers() {
-    m_data = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    gameData = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
+    final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, m_data, british));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        m_data.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {2, 3}));
-    final Territory germany = m_data.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
     assertEquals(Die.DieType.HIT, dice.getRolls(4).get(0).getType());
@@ -361,15 +356,15 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testHeavyBombersDefend() {
-    m_data = LoadGameUtil.loadGame("Classic: Iron Blitz 3rd Edition Test", "iron_blitz_test.xml");
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    gameData = LoadGameUtil.loadGame("Classic: Iron Blitz 3rd Edition Test", "iron_blitz_test.xml");
+    final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, m_data, british));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        m_data.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {0, 1}));
-    final Territory germany = m_data.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
     assertEquals(1, dice.getRolls(1).size());
@@ -377,13 +372,13 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testLHTRBomberDefend() {
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    m_data.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, true);
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, true);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     final List<Unit> bombers =
-        m_data.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {0, 1}));
-    final Territory germany = m_data.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
     assertEquals(1, dice.getRolls(1).size());
@@ -391,15 +386,15 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testHeavyBombersLHTR() {
-    m_data.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
+    final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, m_data, british));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        m_data.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {2, 3}));
-    final Territory germany = m_data.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
     assertEquals(Die.DieType.HIT, dice.getRolls(4).get(0).getType());
@@ -408,15 +403,15 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testHeavyBombersLHTR2() {
-    m_data.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
+    final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, m_data, british));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        m_data.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {3, 2}));
-    final Territory germany = m_data.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
     assertEquals(Die.DieType.HIT, dice.getRolls(4).get(0).getType());
@@ -425,15 +420,15 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testHeavyBombersDefendLHTR() {
-    m_data.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
+    final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, m_data, british));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        m_data.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber);
     testDelegateBridge.setRandomSource(new ScriptedRandomSource(new int[] {0, 1}));
-    final Territory germany = m_data.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
     assertEquals(2, dice.getRolls(1).size());
@@ -443,10 +438,10 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testDiceRollCount() {
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    final Territory location = m_data.getMap().getTerritory("United Kingdom");
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    final Territory location = gameData.getMap().getTerritory("United Kingdom");
     final Unit bombers =
-        m_data.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber).get(0);
+        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber).get(0);
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(location);
     // default 1 roll
     assertEquals(1, BattleCalculator.getRolls(bombers, british, false, true, territoryEffects));
@@ -454,9 +449,9 @@ public class DiceRollTest extends TestCase {
     // hb, for revised 2 on attack, 1 on defence
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, m_data, british));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     // lhtr hb, 2 for both
-    m_data.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
+    gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     assertEquals(2, BattleCalculator.getRolls(bombers, british, false, true, territoryEffects));
     assertEquals(2, BattleCalculator.getRolls(bombers, british, true, true, territoryEffects));
     // non-lhtr, only 1 for defense.

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -468,6 +468,7 @@ public class DiceRollTest {
     assertThat(dice.getRolls(1).get(1).getType(), is(Die.DieType.IGNORED));
   }
 
+  @Test
   public void testDiceRollCount() {
     final PlayerID british = GameDataTestUtil.british(gameData);
     final Territory location = gameData.getMap().getTerritory("United Kingdom");
@@ -486,4 +487,7 @@ public class DiceRollTest {
     assertThat(BattleCalculator.getRolls(bombers, british, false, true, territoryEffects), is(2));
     assertThat(BattleCalculator.getRolls(bombers, british, true, true, territoryEffects), is(2));
   }
+
+
+
 }

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -29,7 +29,7 @@ public class DiceRollTest extends TestCase {
 
   @Override
   protected void setUp() throws Exception {
-    m_data = LoadGameUtil.loadGame("World War II Revised LHTR Test", "lhtr_test.xml");
+    m_data = LoadGameUtil.loadTestGame("lhtr_test.xml");
   }
 
   private ITestDelegateBridge getDelegateBridge(final PlayerID player) {
@@ -162,7 +162,7 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testMarineAttackPlus1() throws Exception {
-    m_data = LoadGameUtil.loadGame("Classic: Iron Blitz 3rd Edition Test", "iron_blitz_test.xml");
+    m_data = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
     final Territory algeria = m_data.getMap().getTerritory("Algeria");
     final PlayerID americans = GameDataTestUtil.americans(m_data);
     final UnitType marine = m_data.getUnitTypeList().getUnitType("marine");
@@ -178,7 +178,7 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testMarineAttackPlus1LowLuck() throws Exception {
-    m_data = LoadGameUtil.loadGame("Classic: Iron Blitz 3rd Edition Test", "iron_blitz_test.xml");
+    m_data = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
     GameDataTestUtil.makeGameLowLuck(m_data);
     final Territory algeria = m_data.getMap().getTerritory("Algeria");
     final PlayerID americans = GameDataTestUtil.americans(m_data);
@@ -195,7 +195,7 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testMarineAttacNormalIfNotAmphibious() throws Exception {
-    m_data = LoadGameUtil.loadGame("Classic: Iron Blitz 3rd Edition Test", "iron_blitz_test.xml");
+    m_data = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
     final Territory algeria = m_data.getMap().getTerritory("Algeria");
     final PlayerID americans = GameDataTestUtil.americans(m_data);
     final UnitType marine = m_data.getUnitTypeList().getUnitType("marine");
@@ -299,7 +299,7 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testAALowLuckWithRadar() {
-    m_data = LoadGameUtil.loadGame("World War II v3 1941 Test", "ww2v3_1941_test.xml");
+    m_data = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
     GameDataTestUtil.makeGameLowLuck(m_data);
     final Territory finnland = m_data.getMap().getTerritory("Finland");
     final PlayerID russians = GameDataTestUtil.russians(m_data);
@@ -345,7 +345,7 @@ public class DiceRollTest extends TestCase {
   }
 
   public void testHeavyBombers() {
-    m_data = LoadGameUtil.loadGame("Classic: Iron Blitz 3rd Edition Test", "iron_blitz_test.xml");
+    m_data = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
     final PlayerID british = GameDataTestUtil.british(m_data);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -52,11 +52,11 @@ public class DiceRollTest {
     // infantry defends and hits at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     final DiceRoll roll = DiceRoll.rollDice(infantry, true, russians, bridge, battle, "", territoryEffects, null);
-    assertThat(roll.getHits(),is(1));
+    assertThat(roll.getHits(), is(1));
     // infantry does not hit at 2 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {2}));
     final DiceRoll roll2 = DiceRoll.rollDice(infantry, true, russians, bridge, battle, "", territoryEffects, null);
-    assertThat(roll2.getHits(),is(0));
+    assertThat(roll2.getHits(), is(0));
     // infantry attacks and hits at 0 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0}));
     final DiceRoll roll3 = DiceRoll.rollDice(infantry, false, russians, bridge, battle, "", territoryEffects, null);
@@ -80,11 +80,11 @@ public class DiceRollTest {
     // infantry defends and hits at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     final DiceRoll roll = DiceRoll.rollDice(infantry, true, russians, bridge, battle, "", territoryEffects, null);
-    assertThat(roll.getHits(),is(1));
+    assertThat(roll.getHits(), is(1));
     // infantry does not hit at 2 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {2}));
     final DiceRoll roll2 = DiceRoll.rollDice(infantry, true, russians, bridge, battle, "", territoryEffects, null);
-    assertThat(roll2.getHits(),is(0));
+    assertThat(roll2.getHits(), is(0));
     // infantry attacks and hits at 0 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0}));
     final DiceRoll roll3 = DiceRoll.rollDice(infantry, false, russians, bridge, battle, "", territoryEffects, null);
@@ -392,7 +392,7 @@ public class DiceRollTest {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
-    assertThat(dice.getRolls(1).size(),is(1));
+    assertThat(dice.getRolls(1).size(), is(1));
     assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));
   }
 
@@ -408,7 +408,7 @@ public class DiceRollTest {
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
 
-    assertThat(dice.getRolls(1).size(),is(1));
+    assertThat(dice.getRolls(1).size(), is(1));
     assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));
   }
 
@@ -495,23 +495,23 @@ public class DiceRollTest {
     final Territory territory = gameData.getMap().getTerritory("Finland");
 
 
-    assertThat(DiceRoll.getTotalOffensivePower( null, gameData, territory), is(0));
-    assertThat(DiceRoll.getTotalOffensivePower( Collections.EMPTY_LIST, gameData, territory), is(0));
+    assertThat(DiceRoll.getTotalOffensivePower(null, gameData, territory), is(0));
+    assertThat(DiceRoll.getTotalOffensivePower(Collections.EMPTY_LIST, gameData, territory), is(0));
 
-    List<Unit> units = GameDataTestUtil.infantry(1,gameData);
-    assertThat( DiceRoll.getTotalOffensivePower(units, gameData,  territory), is(1));
+    List<Unit> units = GameDataTestUtil.infantry(1, gameData);
+    assertThat(DiceRoll.getTotalOffensivePower(units, gameData, territory), is(1));
 
-    units.addAll(GameDataTestUtil.infantry(2,gameData));
-    assertThat( DiceRoll.getTotalOffensivePower(units, gameData,  territory), is(3));
+    units.addAll(GameDataTestUtil.infantry(2, gameData));
+    assertThat(DiceRoll.getTotalOffensivePower(units, gameData, territory), is(3));
 
-    units.addAll(GameDataTestUtil.tank(1,gameData));
-    assertThat( DiceRoll.getTotalOffensivePower(units, gameData,  territory), is(6));
+    units.addAll(GameDataTestUtil.tank(1, gameData));
+    assertThat(DiceRoll.getTotalOffensivePower(units, gameData, territory), is(6));
 
-    units.addAll(GameDataTestUtil.tank(2,gameData));
-    assertThat( DiceRoll.getTotalOffensivePower(units, gameData,  territory), is(12));
+    units.addAll(GameDataTestUtil.tank(2, gameData));
+    assertThat(DiceRoll.getTotalOffensivePower(units, gameData, territory), is(12));
 
-    units.addAll(GameDataTestUtil.fighter(1,gameData));
-    assertThat( DiceRoll.getTotalOffensivePower(units, gameData,  territory), is(15));
+    units.addAll(GameDataTestUtil.fighter(1, gameData));
+    assertThat(DiceRoll.getTotalOffensivePower(units, gameData, territory), is(15));
   }
 
   @Test
@@ -519,23 +519,23 @@ public class DiceRollTest {
     gameData = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
     final Territory territory = gameData.getMap().getTerritory("Finland");
 
-    assertThat(DiceRoll.getTotalDefensivePower( null, gameData, territory), is(0));
-    assertThat(DiceRoll.getTotalDefensivePower( Collections.EMPTY_LIST, gameData, territory), is(0));
+    assertThat(DiceRoll.getTotalDefensivePower(null, gameData, territory), is(0));
+    assertThat(DiceRoll.getTotalDefensivePower(Collections.EMPTY_LIST, gameData, territory), is(0));
 
-    List<Unit> units = GameDataTestUtil.infantry(1,gameData);
-    assertThat( DiceRoll.getTotalDefensivePower(units, gameData,  territory), is(2));
+    List<Unit> units = GameDataTestUtil.infantry(1, gameData);
+    assertThat(DiceRoll.getTotalDefensivePower(units, gameData, territory), is(2));
 
-    units.addAll(GameDataTestUtil.infantry(2,gameData));
-    assertThat( DiceRoll.getTotalDefensivePower(units, gameData,  territory), is(6));
+    units.addAll(GameDataTestUtil.infantry(2, gameData));
+    assertThat(DiceRoll.getTotalDefensivePower(units, gameData, territory), is(6));
 
-    units.addAll(GameDataTestUtil.tank(1,gameData));
-    assertThat( DiceRoll.getTotalDefensivePower(units, gameData,  territory), is(9));
+    units.addAll(GameDataTestUtil.tank(1, gameData));
+    assertThat(DiceRoll.getTotalDefensivePower(units, gameData, territory), is(9));
 
-    units.addAll(GameDataTestUtil.tank(2,gameData));
-    assertThat( DiceRoll.getTotalDefensivePower(units, gameData,  territory), is(15));
+    units.addAll(GameDataTestUtil.tank(2, gameData));
+    assertThat(DiceRoll.getTotalDefensivePower(units, gameData, territory), is(15));
 
-    units.addAll(GameDataTestUtil.fighter(1,gameData));
-    assertThat( DiceRoll.getTotalDefensivePower(units, gameData,  territory), is(19));
+    units.addAll(GameDataTestUtil.fighter(1, gameData));
+    assertThat(DiceRoll.getTotalDefensivePower(units, gameData, territory), is(19));
 
   }
 }

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;
 import games.strategy.engine.data.PlayerID;
@@ -489,5 +491,53 @@ public class DiceRollTest {
   }
 
 
+  @Test
+  public void testGetTotalOffensivePower() {
+    gameData = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
+    final Territory territory = gameData.getMap().getTerritory("Finland");
 
+
+    assertThat(DiceRoll.getTotalOffensivePower( null, gameData, territory), is(0));
+    assertThat(DiceRoll.getTotalOffensivePower( Collections.EMPTY_LIST, gameData, territory), is(0));
+
+    List<Unit> units = GameDataTestUtil.infantry(1,gameData);
+    assertThat( DiceRoll.getTotalOffensivePower(units, gameData,  territory), is(1));
+
+    units.addAll(GameDataTestUtil.infantry(2,gameData));
+    assertThat( DiceRoll.getTotalOffensivePower(units, gameData,  territory), is(3));
+
+    units.addAll(GameDataTestUtil.tank(1,gameData));
+    assertThat( DiceRoll.getTotalOffensivePower(units, gameData,  territory), is(6));
+
+    units.addAll(GameDataTestUtil.tank(2,gameData));
+    assertThat( DiceRoll.getTotalOffensivePower(units, gameData,  territory), is(12));
+
+    units.addAll(GameDataTestUtil.fighter(1,gameData));
+    assertThat( DiceRoll.getTotalOffensivePower(units, gameData,  territory), is(15));
+  }
+
+  @Test
+  public void testGetTotalDefensivePower() {
+    gameData = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
+    final Territory territory = gameData.getMap().getTerritory("Finland");
+
+    assertThat(DiceRoll.getTotalDefensivePower( null, gameData, territory), is(0));
+    assertThat(DiceRoll.getTotalDefensivePower( Collections.EMPTY_LIST, gameData, territory), is(0));
+
+    List<Unit> units = GameDataTestUtil.infantry(1,gameData);
+    assertThat( DiceRoll.getTotalDefensivePower(units, gameData,  territory), is(2));
+
+    units.addAll(GameDataTestUtil.infantry(2,gameData));
+    assertThat( DiceRoll.getTotalDefensivePower(units, gameData,  territory), is(6));
+
+    units.addAll(GameDataTestUtil.tank(1,gameData));
+    assertThat( DiceRoll.getTotalDefensivePower(units, gameData,  territory), is(9));
+
+    units.addAll(GameDataTestUtil.tank(2,gameData));
+    assertThat( DiceRoll.getTotalDefensivePower(units, gameData,  territory), is(15));
+
+    units.addAll(GameDataTestUtil.fighter(1,gameData));
+    assertThat( DiceRoll.getTotalDefensivePower(units, gameData,  territory), is(19));
+
+  }
 }

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -32,7 +32,7 @@ public class DiceRollTest {
   private GameData gameData;
 
   @Before
-  protected void setUp() {
+  public void setUp() {
     gameData = LoadGameUtil.loadTestGame("lhtr_test.xml");
   }
 

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -12,8 +12,6 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;
 import games.strategy.engine.data.PlayerID;

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -381,7 +381,7 @@ public class DiceRollTest {
 
   @Test
   public void testHeavyBombersDefend() {
-    gameData = LoadGameUtil.loadGame("Classic: Iron Blitz 3rd Edition Test", "iron_blitz_test.xml");
+    gameData = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
     final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -499,19 +499,31 @@ public class DiceRollTest {
     assertThat(DiceRoll.getTotalOffensivePower(Collections.EMPTY_LIST, gameData, territory), is(0));
 
     List<Unit> units = GameDataTestUtil.infantry(1, gameData);
-    assertThat(DiceRoll.getTotalOffensivePower(units, gameData, territory), is(1));
+    assertThat("1 inf attacking", DiceRoll.getTotalOffensivePower(units, gameData, territory), is(1));
 
     units.addAll(GameDataTestUtil.infantry(2, gameData));
-    assertThat(DiceRoll.getTotalOffensivePower(units, gameData, territory), is(3));
+    assertThat("3 inf", DiceRoll.getTotalOffensivePower(units, gameData, territory), is(3));
 
     units.addAll(GameDataTestUtil.tank(1, gameData));
-    assertThat(DiceRoll.getTotalOffensivePower(units, gameData, territory), is(6));
+    assertThat("3 inf + 1 tank", DiceRoll.getTotalOffensivePower(units, gameData, territory), is(6));
 
     units.addAll(GameDataTestUtil.tank(2, gameData));
-    assertThat(DiceRoll.getTotalOffensivePower(units, gameData, territory), is(12));
+    assertThat("3 inf + 3 tanks", DiceRoll.getTotalOffensivePower(units, gameData, territory), is(12));
 
     units.addAll(GameDataTestUtil.fighter(1, gameData));
-    assertThat(DiceRoll.getTotalOffensivePower(units, gameData, territory), is(15));
+    assertThat("3 inf + 3 tanks(9) + 1 fig(3) = 3+3*3+3 = 15",
+        DiceRoll.getTotalOffensivePower(units, gameData, territory), is(15));
+
+    units = GameDataTestUtil.artillery(1, gameData);
+    assertThat("1 arty attacks at 2", DiceRoll.getTotalOffensivePower(units, gameData, territory), is(2));
+
+    units.addAll(GameDataTestUtil.infantry(1, gameData));
+    assertThat("1 arty + 1 inf, arty supports inf, attacks at 4",
+        DiceRoll.getTotalOffensivePower(units, gameData, territory), is(4));
+
+    units.addAll(GameDataTestUtil.infantry(1, gameData));
+    assertThat("1 arty + 2 inf, second infantry not supported, attack at 5",
+        DiceRoll.getTotalOffensivePower(units, gameData, territory), is(5));
   }
 
   @Test
@@ -523,19 +535,27 @@ public class DiceRollTest {
     assertThat(DiceRoll.getTotalDefensivePower(Collections.EMPTY_LIST, gameData, territory), is(0));
 
     List<Unit> units = GameDataTestUtil.infantry(1, gameData);
-    assertThat(DiceRoll.getTotalDefensivePower(units, gameData, territory), is(2));
+    assertThat("1 inf on defense", DiceRoll.getTotalDefensivePower(units, gameData, territory), is(2));
 
     units.addAll(GameDataTestUtil.infantry(2, gameData));
-    assertThat(DiceRoll.getTotalDefensivePower(units, gameData, territory), is(6));
+    assertThat("2 inf", DiceRoll.getTotalDefensivePower(units, gameData, territory), is(6));
 
     units.addAll(GameDataTestUtil.tank(1, gameData));
-    assertThat(DiceRoll.getTotalDefensivePower(units, gameData, territory), is(9));
+    assertThat("2 inf + 1 tank", DiceRoll.getTotalDefensivePower(units, gameData, territory), is(9));
 
     units.addAll(GameDataTestUtil.tank(2, gameData));
-    assertThat(DiceRoll.getTotalDefensivePower(units, gameData, territory), is(15));
+    assertThat("2 inf + 3 tanks", DiceRoll.getTotalDefensivePower(units, gameData, territory), is(15));
 
     units.addAll(GameDataTestUtil.fighter(1, gameData));
-    assertThat(DiceRoll.getTotalDefensivePower(units, gameData, territory), is(19));
+    assertThat("2 inf + 3 tanks + 1 fig", DiceRoll.getTotalDefensivePower(units, gameData, territory), is(19));
 
+    units = GameDataTestUtil.artillery(1, gameData);
+    assertThat("Reset to: 1 artillery defending", DiceRoll.getTotalDefensivePower(units, gameData, territory), is(2));
+
+    units.addAll(GameDataTestUtil.infantry(1, gameData));
+    assertThat("1 arty + 1 inf", DiceRoll.getTotalDefensivePower(units, gameData, territory), is(4));
+
+    units.addAll(GameDataTestUtil.infantry(1, gameData));
+    assertThat("2 inf + 1 arty defending", DiceRoll.getTotalDefensivePower(units, gameData, territory), is(6));
   }
 }

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -449,16 +449,16 @@ public class DiceRollTest extends TestCase {
         m_data.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber).get(0);
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(location);
     // default 1 roll
-    assertEquals(1, BattleCalculator.getRolls(bombers, location, british, false, true, territoryEffects));
-    assertEquals(1, BattleCalculator.getRolls(bombers, location, british, true, true, territoryEffects));
+    assertEquals(1, BattleCalculator.getRolls(bombers, british, false, true, territoryEffects));
+    assertEquals(1, BattleCalculator.getRolls(bombers, british, true, true, territoryEffects));
     // hb, for revised 2 on attack, 1 on defence
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, m_data, british));
     // lhtr hb, 2 for both
     m_data.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
-    assertEquals(2, BattleCalculator.getRolls(bombers, location, british, false, true, territoryEffects));
-    assertEquals(2, BattleCalculator.getRolls(bombers, location, british, true, true, territoryEffects));
+    assertEquals(2, BattleCalculator.getRolls(bombers, british, false, true, territoryEffects));
+    assertEquals(2, BattleCalculator.getRolls(bombers, british, true, true, territoryEffects));
     // non-lhtr, only 1 for defense.
     // m_data.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.FALSE);
     // assertEquals(2, BattleCalculator.getRolls(bombers, location, british, false));

--- a/test/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/test/games/strategy/triplea/delegate/DiceRollTest.java
@@ -2,10 +2,15 @@ package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
 import static games.strategy.triplea.delegate.GameDataTestUtil.british;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ITestDelegateBridge;
@@ -22,13 +27,12 @@ import games.strategy.triplea.attatchments.UnitAttachment;
 import games.strategy.triplea.delegate.Die.DieType;
 import games.strategy.triplea.xml.LoadGameUtil;
 import games.strategy.util.Match;
-import junit.framework.TestCase;
 
-public class DiceRollTest extends TestCase {
+public class DiceRollTest {
   private GameData gameData;
 
-  @Override
-  protected void setUp() throws Exception {
+  @Before
+  protected void setUp() {
     gameData = LoadGameUtil.loadTestGame("lhtr_test.xml");
   }
 
@@ -36,6 +40,7 @@ public class DiceRollTest extends TestCase {
     return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
+  @Test
   public void testSimple() {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final MockBattle battle = new MockBattle(westRussia);
@@ -47,21 +52,22 @@ public class DiceRollTest extends TestCase {
     // infantry defends and hits at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     final DiceRoll roll = DiceRoll.rollDice(infantry, true, russians, bridge, battle, "", territoryEffects, null);
-    assertEquals(1, roll.getHits());
+    assertThat(roll.getHits(),is(1));
     // infantry does not hit at 2 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {2}));
     final DiceRoll roll2 = DiceRoll.rollDice(infantry, true, russians, bridge, battle, "", territoryEffects, null);
-    assertEquals(0, roll2.getHits());
+    assertThat(roll2.getHits(),is(0));
     // infantry attacks and hits at 0 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0}));
     final DiceRoll roll3 = DiceRoll.rollDice(infantry, false, russians, bridge, battle, "", territoryEffects, null);
-    assertEquals(1, roll3.getHits());
+    assertThat(roll3.getHits(), is(1));
     // infantry attack does not hit at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     final DiceRoll roll4 = DiceRoll.rollDice(infantry, false, russians, bridge, battle, "", territoryEffects, null);
-    assertEquals(0, roll4.getHits());
+    assertThat(roll4.getHits(), is(0));
   }
 
+  @Test
   public void testSimpleLowLuck() {
     GameDataTestUtil.makeGameLowLuck(gameData);
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
@@ -74,21 +80,22 @@ public class DiceRollTest extends TestCase {
     // infantry defends and hits at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     final DiceRoll roll = DiceRoll.rollDice(infantry, true, russians, bridge, battle, "", territoryEffects, null);
-    assertEquals(1, roll.getHits());
+    assertThat(roll.getHits(),is(1));
     // infantry does not hit at 2 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {2}));
     final DiceRoll roll2 = DiceRoll.rollDice(infantry, true, russians, bridge, battle, "", territoryEffects, null);
-    assertEquals(0, roll2.getHits());
+    assertThat(roll2.getHits(),is(0));
     // infantry attacks and hits at 0 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0}));
     final DiceRoll roll3 = DiceRoll.rollDice(infantry, false, russians, bridge, battle, "", territoryEffects, null);
-    assertEquals(1, roll3.getHits());
+    assertThat(roll3.getHits(), is(1));
     // infantry attack does not hit at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     final DiceRoll roll4 = DiceRoll.rollDice(infantry, false, russians, bridge, battle, "", territoryEffects, null);
-    assertEquals(0, roll4.getHits());
+    assertThat(roll4.getHits(), is(0));
   }
 
+  @Test
   public void testArtillerySupport() {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final MockBattle battle = new MockBattle(westRussia);
@@ -102,9 +109,10 @@ public class DiceRollTest extends TestCase {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1, 1}));
     final DiceRoll roll = DiceRoll.rollDice(units, false, russians, bridge, battle, "",
         TerritoryEffectHelper.getEffects(westRussia), null);
-    assertEquals(2, roll.getHits());
+    assertThat(roll.getHits(), is(2));
   }
 
+  @Test
   public void testVariableArtillerySupport() {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final MockBattle battle = new MockBattle(westRussia);
@@ -125,9 +133,10 @@ public class DiceRollTest extends TestCase {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1, 1, 1}));
     final DiceRoll roll = DiceRoll.rollDice(units, false, russians, bridge, battle, "",
         TerritoryEffectHelper.getEffects(westRussia), null);
-    assertEquals(3, roll.getHits());
+    assertThat(roll.getHits(), is(3));
   }
 
+  @Test
   public void testLowLuck() {
     GameDataTestUtil.makeGameLowLuck(gameData);
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
@@ -140,22 +149,24 @@ public class DiceRollTest extends TestCase {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll = DiceRoll.rollDice(units, true, russians, bridge, battle, "",
         TerritoryEffectHelper.getEffects(westRussia), null);
-    assertEquals(1, roll.getHits());
+    assertThat(roll.getHits(), is(1));
   }
 
+  @Test
   public void testSerialize() throws Exception {
     for (int i = 0; i < 254; i++) {
       for (int j = 0; j < 254; j++) {
         final Die hit = new Die(i, j, DieType.MISS);
-        assertEquals(hit, Die.getFromWriteValue(hit.getCompressedValue()));
+        assertThat(hit, is(Die.getFromWriteValue(hit.getCompressedValue())));
         final Die notHit = new Die(i, j, DieType.HIT);
-        assertEquals(notHit, Die.getFromWriteValue(notHit.getCompressedValue()));
+        assertThat(notHit, is(Die.getFromWriteValue(notHit.getCompressedValue())));
         final Die ignored = new Die(i, j, DieType.IGNORED);
-        assertEquals(ignored, Die.getFromWriteValue(ignored.getCompressedValue()));
+        assertThat(ignored, is(Die.getFromWriteValue(ignored.getCompressedValue())));
       }
     }
   }
 
+  @Test
   public void testMarineAttackPlus1() throws Exception {
     gameData = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
     final Territory algeria = gameData.getMap().getTerritory("Algeria");
@@ -169,9 +180,10 @@ public class DiceRollTest extends TestCase {
     battle.setIsAmphibious(true);
     final DiceRoll roll = DiceRoll.rollDice(attackers, false, americans, bridge, battle, "",
         TerritoryEffectHelper.getEffects(algeria), null);
-    assertEquals(1, roll.getHits());
+    assertThat(roll.getHits(), is(1));
   }
 
+  @Test
   public void testMarineAttackPlus1LowLuck() throws Exception {
     gameData = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
     GameDataTestUtil.makeGameLowLuck(gameData);
@@ -186,9 +198,10 @@ public class DiceRollTest extends TestCase {
     battle.setIsAmphibious(true);
     final DiceRoll roll = DiceRoll.rollDice(attackers, false, americans, bridge, battle, "",
         TerritoryEffectHelper.getEffects(algeria), null);
-    assertEquals(1, roll.getHits());
+    assertThat(roll.getHits(), is(1));
   }
 
+  @Test
   public void testMarineAttacNormalIfNotAmphibious() throws Exception {
     gameData = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
     final Territory algeria = gameData.getMap().getTerritory("Algeria");
@@ -202,9 +215,10 @@ public class DiceRollTest extends TestCase {
     battle.setIsAmphibious(true);
     final DiceRoll roll = DiceRoll.rollDice(attackers, false, americans, bridge, battle, "",
         TerritoryEffectHelper.getEffects(algeria), null);
-    assertEquals(0, roll.getHits());
+    assertThat(roll.getHits(), is(0));
   }
 
+  @Test
   public void testAA() {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final PlayerID russians = GameDataTestUtil.russians(gameData);
@@ -218,13 +232,14 @@ public class DiceRollTest extends TestCase {
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0}));
     final DiceRoll hit =
         DiceRoll.rollAA(bomber(gameData).create(1, british(gameData)), aaGunList, bridge, westRussia, true);
-    assertEquals(hit.getHits(), 1);
+    assertThat(hit.getHits(), is(1));
     // aa missses at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     final DiceRoll miss = DiceRoll.rollAA(bombers, aaGunList, bridge, westRussia, true);
-    assertEquals(miss.getHits(), 0);
+    assertThat(miss.getHits(), is(0));
   }
 
+  @Test
   public void testAALowLuck() {
     GameDataTestUtil.makeGameLowLuck(gameData);
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
@@ -243,9 +258,10 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                        .unitIsOfTypes(
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, westRussia, true);
-    assertEquals(hit.getHits(), 1);
+    assertThat(hit.getHits(), is(1));
     // aa missses at 1 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     final DiceRoll miss =
@@ -253,9 +269,10 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                        .unitIsOfTypes(
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, westRussia, true);
-    assertEquals(miss.getHits(), 0);
+    assertThat(miss.getHits(), is(0));
     // 6 bombers, 1 should hit, and nothing should be rolled
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     fighterList = fighterType.create(6, russians);
@@ -264,11 +281,13 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                        .unitIsOfTypes(
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, westRussia, true);
-    assertEquals(hitNoRoll.getHits(), 1);
+    assertThat(hitNoRoll.getHits(), is(1));
   }
 
+  @Test
   public void testAALowLuckDifferentMovement() {
     GameDataTestUtil.makeGameLowLuck(gameData);
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
@@ -288,11 +307,13 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                        .unitIsOfTypes(
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, westRussia, true);
-    assertEquals(hit.getHits(), 1);
+    assertThat(hit.getHits(), is(1));
   }
 
+  @Test
   public void testAALowLuckWithRadar() {
     gameData = LoadGameUtil.loadTestGame("ww2v3_1941_test.xml");
     GameDataTestUtil.makeGameLowLuck(gameData);
@@ -312,10 +333,10 @@ public class DiceRollTest extends TestCase {
         DiceRoll
             .rollAA(
                 Match.getMatches(fighterList,
-                    Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                    Matches.unitIsOfTypes(
+                        UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, finnland, true);
-    assertEquals(hit.getHits(), 1);
+    assertThat(hit.getHits(), is(1));
     // aa missses at 2 (0 based)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {2}));
     final DiceRoll miss =
@@ -323,9 +344,10 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                        .unitIsOfTypes(
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, finnland, true);
-    assertEquals(miss.getHits(), 0);
+    assertThat(miss.getHits(), is(0));
     // 6 bombers, 2 should hit, and nothing should be rolled
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     fighterList = fighterType.create(6, russians);
@@ -334,11 +356,13 @@ public class DiceRollTest extends TestCase {
             .rollAA(
                 Match.getMatches(fighterList,
                     Matches
-                        .unitIsOfTypes(UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
+                        .unitIsOfTypes(
+                            UnitAttachment.get(aaGunList.iterator().next().getType()).getTargetsAA(gameData))),
                 aaGunList, bridge, finnland, true);
-    assertEquals(hitNoRoll.getHits(), 2);
+    assertThat(hitNoRoll.getHits(), is(2));
   }
 
+  @Test
   public void testHeavyBombers() {
     gameData = LoadGameUtil.loadTestGame("iron_blitz_test.xml");
     final PlayerID british = GameDataTestUtil.british(gameData);
@@ -351,10 +375,11 @@ public class DiceRollTest extends TestCase {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
-    assertEquals(Die.DieType.HIT, dice.getRolls(4).get(0).getType());
-    assertEquals(Die.DieType.HIT, dice.getRolls(4).get(1).getType());
+    assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
+    assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.HIT));
   }
 
+  @Test
   public void testHeavyBombersDefend() {
     gameData = LoadGameUtil.loadGame("Classic: Iron Blitz 3rd Edition Test", "iron_blitz_test.xml");
     final PlayerID british = GameDataTestUtil.british(gameData);
@@ -367,10 +392,11 @@ public class DiceRollTest extends TestCase {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
-    assertEquals(1, dice.getRolls(1).size());
-    assertEquals(Die.DieType.HIT, dice.getRolls(1).get(0).getType());
+    assertThat(dice.getRolls(1).size(),is(1));
+    assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));
   }
 
+  @Test
   public void testLHTRBomberDefend() {
     final PlayerID british = GameDataTestUtil.british(gameData);
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, true);
@@ -381,10 +407,12 @@ public class DiceRollTest extends TestCase {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
-    assertEquals(1, dice.getRolls(1).size());
-    assertEquals(Die.DieType.HIT, dice.getRolls(1).get(0).getType());
+
+    assertThat(dice.getRolls(1).size(),is(1));
+    assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));
   }
 
+  @Test
   public void testHeavyBombersLHTR() {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     final PlayerID british = GameDataTestUtil.british(gameData);
@@ -397,11 +425,13 @@ public class DiceRollTest extends TestCase {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
-    assertEquals(Die.DieType.HIT, dice.getRolls(4).get(0).getType());
-    assertEquals(Die.DieType.IGNORED, dice.getRolls(4).get(1).getType());
-    assertEquals(1, dice.getHits());
+
+    assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
+    assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.IGNORED));
+    assertThat(dice.getHits(), is(1));
   }
 
+  @Test
   public void testHeavyBombersLHTR2() {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     final PlayerID british = GameDataTestUtil.british(gameData);
@@ -414,11 +444,12 @@ public class DiceRollTest extends TestCase {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
-    assertEquals(Die.DieType.HIT, dice.getRolls(4).get(0).getType());
-    assertEquals(Die.DieType.IGNORED, dice.getRolls(4).get(1).getType());
-    assertEquals(1, dice.getHits());
+    assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
+    assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.IGNORED));
+    assertThat(dice.getHits(), is(1));
   }
 
+  @Test
   public void testHeavyBombersDefendLHTR() {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     final PlayerID british = GameDataTestUtil.british(gameData);
@@ -431,10 +462,10 @@ public class DiceRollTest extends TestCase {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, new MockBattle(germany), "",
         TerritoryEffectHelper.getEffects(germany), null);
-    assertEquals(2, dice.getRolls(1).size());
-    assertEquals(1, dice.getHits());
-    assertEquals(Die.DieType.HIT, dice.getRolls(1).get(0).getType());
-    assertEquals(Die.DieType.IGNORED, dice.getRolls(1).get(1).getType());
+    assertThat(dice.getRolls(1).size(), is(2));
+    assertThat(dice.getHits(), is(1));
+    assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));
+    assertThat(dice.getRolls(1).get(1).getType(), is(Die.DieType.IGNORED));
   }
 
   public void testDiceRollCount() {
@@ -444,22 +475,15 @@ public class DiceRollTest extends TestCase {
         gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.UnitIsStrategicBomber).get(0);
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(location);
     // default 1 roll
-    assertEquals(1, BattleCalculator.getRolls(bombers, british, false, true, territoryEffects));
-    assertEquals(1, BattleCalculator.getRolls(bombers, british, true, true, territoryEffects));
+    assertThat(BattleCalculator.getRolls(bombers, british, false, true, territoryEffects), is(1));
+    assertThat(BattleCalculator.getRolls(bombers, british, true, true, territoryEffects), is(1));
     // hb, for revised 2 on attack, 1 on defence
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     // lhtr hb, 2 for both
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
-    assertEquals(2, BattleCalculator.getRolls(bombers, british, false, true, territoryEffects));
-    assertEquals(2, BattleCalculator.getRolls(bombers, british, true, true, territoryEffects));
-    // non-lhtr, only 1 for defense.
-    // m_data.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.FALSE);
-    // assertEquals(2, BattleCalculator.getRolls(bombers, location, british, false));
-    // assertEquals(1, BattleCalculator.getRolls(bombers, location, british, true));
-    // this last bit can not be tested because with the new way tech works, changing the game option once the game
-    // starts does not remove or
-    // add the extra die roll
+    assertThat(BattleCalculator.getRolls(bombers, british, false, true, territoryEffects), is(2));
+    assertThat(BattleCalculator.getRolls(bombers, british, true, true, territoryEffects), is(2));
   }
 }

--- a/test/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/test/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -3,6 +3,8 @@ package games.strategy.triplea.delegate;
 import java.util.Collection;
 import java.util.List;
 
+import com.google.common.collect.Lists;
+
 import games.strategy.engine.data.ChangeFactory;
 import games.strategy.engine.data.ChangePerformer;
 import games.strategy.engine.data.GameData;
@@ -100,6 +102,21 @@ public class GameDataTestUtil {
 
   public static UnitType factory(final GameData data) {
     return unitType("factory", data);
+  }
+
+  public static List<Unit> infantry(int count, GameData data) {
+    UnitType type = infantry(data);
+    return type.create(count, PlayerID.NULL_PLAYERID);
+  }
+
+  public static List<Unit> tank(int count, GameData data) {
+    UnitType type = armour(data);
+    return type.create(count, PlayerID.NULL_PLAYERID);
+  }
+
+  public static List<Unit> fighter(int count, GameData data) {
+    UnitType type = fighter(data);
+    return type.create(count, PlayerID.NULL_PLAYERID);
   }
 
   private static UnitType unitType(final String name, final GameData data) {

--- a/test/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/test/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -109,6 +109,11 @@ public class GameDataTestUtil {
     return type.create(count, PlayerID.NULL_PLAYERID);
   }
 
+  public static List<Unit> artillery(int count, GameData data) {
+    UnitType type = unitType("artillery", data);
+    return type.create(count, PlayerID.NULL_PLAYERID);
+  }
+
   public static List<Unit> tank(int count, GameData data) {
     UnitType type = armour(data);
     return type.create(count, PlayerID.NULL_PLAYERID);


### PR DESCRIPTION
### Add attack and Defense Power to Territory Panel

- Territory Panel below where it reads "Units: X" (where X is the count of units), it will now also have the attack and defensive power of the units in the territory. Here is what it looks like:

![attack-defense-stats-showing](https://cloud.githubusercontent.com/assets/12397753/12711644/6fdd9cc2-c876-11e5-8dd6-33cfe94d169a.png)

Contrast that to:

![no-attack-power-showing](https://cloud.githubusercontent.com/assets/12397753/12711665/8cfa887e-c876-11e5-8635-f5a0adb0b5bd.png)


### Don't show "Units: 0" in territory panel

On the territory panel, when hovering over a territory where there is no production, we don't show PUs. Similarly, when there are no units, do not show the "units: 0"

Before:
![0-unit-count](https://cloud.githubusercontent.com/assets/12397753/12711699/bb0580de-c876-11e5-83be-c1494596d8f9.png)


After:
![no_empty_units_display](https://cloud.githubusercontent.com/assets/12397753/12711702/bf607daa-c876-11e5-856b-977ad4e2a1a9.png)

### BattleCalculator.java changes

- lots of unused args in static methods. These are 'safe' to cleanup (from a reflection point of view, none of these methods will be called via reflection)


### DiceRoll changes
- similar to battle calc, lots of unused args
- most importantly, created a cleaner API to allow us to get the total attack and defensive power for a set of units.
- there was a pretty gnarly method returning a tuple of both firepower, and rolls that I broke up into two. Part of the reasoning  being that the return value was ambiguous, for example, it the firepower returned the total firepower, or the firepower per roll? (the answer is the latter, but it's not necessarily clear)
- Test cases were added for the get power API, before this the test was cleaned up and converted from Junit3 to Junit4, and the assertions were updated to be hamcrest style
- 'rollNDice' method was simplified


### General notes
- commits are structured generally so you can review this commit by commit
- the code that is refactored is mainly to try and clean things up before adding the main feature in the last few commits. There is quite a bit to do to break up the DiceRoll code, so I stopped where I did mainly so I could stop somewhere in a relatively reasonable amount of time. 
- the cleanup/refactor is mostly removing unused args, largely with the goal of simplifying these APIs before adding new clients to them.
- BattleCalculator could perhaps be split off maybe, but to avoid merge conflicts it's here.  The changes there are similar to a lot of the changes in the DiceRoll class, where we are simplifying things and removing unused args.
- DiceRoll knows *way* too much about how to sum up attack and defense values for units, and the rules that apply. There is a lot more to do to fix this, for this PR I want to keep the code in place rather than extract it to a more appropriate location. 


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/409)
<!-- Reviewable:end -->
