### PR TITLE
Unlock button for Territory panel

### DIFF
--- a/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -100,8 +100,8 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
         }
       }
     };
-    final String unfreeze_panel = "unfreeze_panel";
-    final Action unfreezePanel = new AbstractAction(unfreeze_panel) {
+    final String unfreezePanelActionLabel = "unfreeze_panel";
+    final Action unfreezePanelAction = new AbstractAction(unfreezePanelActionLabel) {
       private static final long serialVersionUID = -1863748437390486994L;
 
       @Override
@@ -117,9 +117,11 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
         .put(KeyStroke.getKeyStroke(KeyEvent.VK_SHIFT, InputEvent.SHIFT_DOWN_MASK, false), freeze_panel);
     contentPane.getActionMap().put(freeze_panel, freezePanel);
-    contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_SHIFT, 0, true),
-        unfreeze_panel);
-    contentPane.getActionMap().put(unfreeze_panel, unfreezePanel);
+
+    boolean onKeyUp = true;
+    contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_SHIFT, 0, onKeyUp),
+        unfreezePanelActionLabel);
+    contentPane.getActionMap().put(unfreezePanelActionLabel, unfreezePanelAction);
   }
 
   @Override

--- a/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -37,7 +37,10 @@ import games.strategy.ui.OverlayIcon;
 public class TerritoryDetailPanel extends AbstractStatPanel {
   private static final long serialVersionUID = 1377022163587438988L;
   private final IUIContext m_uiContext;
+
   private final JButton m_showOdds = new JButton("Battle Calculator (Ctrl-B)");
+  private final JButton unfreezeButton = new JButton("Unlock");
+
   private Territory m_currentTerritory;
   private final TripleAFrame m_frame;
   // if not null, shift is pressed
@@ -68,6 +71,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     setBorder(new EmptyBorder(5, 5, 0, 0));
     final String show_battle_calc = "show_battle_calc";
+
     final Action showBattleCalc = new AbstractAction(show_battle_calc) {
       private static final long serialVersionUID = -1863748437390486994L;
 
@@ -76,6 +80,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
         OddsCalculatorDialog.show(m_frame, m_currentTerritory);
       }
     };
+
     m_showOdds.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent e) {
@@ -98,6 +103,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
         if (m_new_territory == null && m_currentTerritory != null) {
           m_new_territory = m_currentTerritory;
         }
+        unfreezeButton.setEnabled(true);
       }
     };
     final String unfreezePanelActionLabel = "unfreeze_panel";
@@ -111,9 +117,18 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
             territoryChanged(m_new_territory);
           }
           m_new_territory = null;
+          unfreezeButton.setEnabled(false);
         }
       }
     };
+    unfreezeButton.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        unfreezePanelAction.actionPerformed(e);
+      }
+    });
+    unfreezeButton.setEnabled(false);
+    unfreezeButton.setToolTipText("Lock the territory panel by holding shift.");
     contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
         .put(KeyStroke.getKeyStroke(KeyEvent.VK_SHIFT, InputEvent.SHIFT_DOWN_MASK, false), freeze_panel);
     contentPane.getActionMap().put(freeze_panel, freezePanel);
@@ -138,6 +153,8 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
       return;
     }
     add(m_showOdds);
+    add(unfreezeButton);
+
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     String labelText;
     if (ta == null) {


### PR DESCRIPTION
See commit comment: e18ea05

Adding a button to unfreeze the territory panel. The hover text of the button will let users know you can hold shift to freeze the territory panel (at which point the button is active). Sadly, we rely on a key-up listener to unfreeze the panel that only fires when the game screen has keyboard focus.

Thus, if you are moving units around, holding shift and clicking in territories and dragging, and an OS pop-up, or anything, takes keyboard focus, the territory panel will be frozen until the next time that:
 - the game has keyboard focus again
 - you press shift key

I was able to trigger this with screen capture software, shift + print screen, and noticed that it caused the territory panel to freeze. Looking at the code I found the holding shift feature.

The holding shift feature is a somewhat funny feature. It's obviously there so you can move the mouse over and press the battle calc button. But, if you can hold shift, couldn't a person press control+b pretty easily as well?

Rather than remove the feature, I chose an alternative route. An "unlock" button that is active when the panel is frozen. If this problem happens, then at least there will be an onscreen control to unlock the territory panel. Killing two birds with one stone, the tool tip text of the button tells users they can lock the territory panel by holding shift, a feature I only learned about after finding the code.

One problem with this PR, the tool tip text font color is black. So the default skin has black on dark gray, very hard to read. I'd rather not hold this up over that one problem, and roll forward with a fix for that when we figure out what it would be. (IE: if all is agreeable - let's merge with the bug, and cut an issue to track it)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/411)
<!-- Reviewable:end -->
