### PR TITLE
Travis/Gradle - update test failure output to show stack trace and unit test failure message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
 - oraclejdk8
 install: true
 script:
-- gradle test
+- gradle test -i
 before_deploy:
 - wget -O setup https://github.com/triplea-game/triplea/blob/master/.travis/setup?raw=true
 - chmod +x setup && ./setup

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,13 @@ dependencies {
 	testCompile 'org.mockito:mockito-all:2.0.2-beta'
 }
 
+test {
+	testLogging {
+		exceptionFormat = 'full'
+	}
+}
+
+
 def assetsDirectory = file("${buildDir}/assets")
 git {
 	assets {


### PR DESCRIPTION
When unit tests fail when run by Travis, update it so we'll get more information, not just the line number of the failing unit test, but the output message and stack traces.

- Pass in the '-i' flag when running gradle from Travis, bumps up the verbosity. 
- Update gradle to show full stack traces
- We'll now get to see in Travis output what is sent to stdout/stderr from the tests
- Changes based on: http://mrhaki.blogspot.com/2013/05/gradle-goodness-show-more-information.html

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/413)
<!-- Reviewable:end -->
