### PR TITLE
Remove territory panel freeze

### DIFF
--- a/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -39,6 +39,10 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
   private Territory m_currentTerritory;
   private final TripleAFrame m_frame;
 
+  public static String getHoverText() {
+    return "Hover over or drag and drop from a territory to list those units in this panel";
+  }
+
   public TerritoryDetailPanel(final MapPanel mapPanel, final GameData data, final IUIContext uiContext,
       final TripleAFrame frame) {
     super(data);

--- a/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -2,8 +2,6 @@ package games.strategy.triplea.ui;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
@@ -40,8 +38,6 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
   private final JButton m_showOdds = new JButton("Battle Calculator (Ctrl-B)");
   private Territory m_currentTerritory;
   private final TripleAFrame m_frame;
-  // if not null, shift is pressed
-  private Territory m_new_territory = null;
 
   public TerritoryDetailPanel(final MapPanel mapPanel, final GameData data, final IUIContext uiContext,
       final TripleAFrame frame) {
@@ -51,13 +47,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     mapPanel.addMapSelectionListener(new DefaultMapSelectionListener() {
       @Override
       public void mouseEntered(final Territory territory) {
-        if (m_new_territory != null) {
-          if (territory != null) {
-            m_new_territory = territory;
-          }
-        } else {
           territoryChanged(territory);
-        }
       }
     });
     initLayout();
@@ -88,40 +78,6 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
         .put(KeyStroke.getKeyStroke('B', java.awt.event.InputEvent.CTRL_MASK), show_battle_calc);
     contentPane.getActionMap().put(show_battle_calc, showBattleCalc);
-    // freeze/unfreeze this panel when shift is pressed/released
-    final String freeze_panel = "freeze_panel";
-    final Action freezePanel = new AbstractAction(freeze_panel) {
-      private static final long serialVersionUID = -1863748437390486994L;
-
-      @Override
-      public void actionPerformed(final ActionEvent e) {
-        if (m_new_territory == null && m_currentTerritory != null) {
-          m_new_territory = m_currentTerritory;
-        }
-      }
-    };
-    final String unfreezePanelActionLabel = "unfreeze_panel";
-    final Action unfreezePanelAction = new AbstractAction(unfreezePanelActionLabel) {
-      private static final long serialVersionUID = -1863748437390486994L;
-
-      @Override
-      public void actionPerformed(final ActionEvent e) {
-        if (m_new_territory != null) {
-          if (m_new_territory != null) {
-            territoryChanged(m_new_territory);
-          }
-          m_new_territory = null;
-        }
-      }
-    };
-    contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke(KeyEvent.VK_SHIFT, InputEvent.SHIFT_DOWN_MASK, false), freeze_panel);
-    contentPane.getActionMap().put(freeze_panel, freezePanel);
-
-    boolean onKeyUp = true;
-    contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_SHIFT, 0, onKeyUp),
-        unfreezePanelActionLabel);
-    contentPane.getActionMap().put(unfreezePanelActionLabel, unfreezePanelAction);
   }
 
   @Override

--- a/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -100,8 +100,8 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
         }
       }
     };
-    final String unfreeze_panel = "unfreeze_panel";
-    final Action unfreezePanel = new AbstractAction(unfreeze_panel) {
+    final String unfreezePanelActionLabel = "unfreeze_panel";
+    final Action unfreezePanelAction = new AbstractAction(unfreezePanelActionLabel) {
       private static final long serialVersionUID = -1863748437390486994L;
 
       @Override
@@ -117,9 +117,11 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
         .put(KeyStroke.getKeyStroke(KeyEvent.VK_SHIFT, InputEvent.SHIFT_DOWN_MASK, false), freeze_panel);
     contentPane.getActionMap().put(freeze_panel, freezePanel);
-    contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_SHIFT, 0, true),
-        unfreeze_panel);
-    contentPane.getActionMap().put(unfreeze_panel, unfreezePanel);
+
+    boolean onKeyUp = true;
+    contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_SHIFT, 0, onKeyUp),
+        unfreezePanelActionLabel);
+    contentPane.getActionMap().put(unfreezePanelActionLabel, unfreezePanelAction);
   }
 
   @Override

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -350,7 +350,7 @@ public class TripleAFrame extends MainGameFrame {
     m_notesPanel = new NotesPanel(m_data, m_menu.getGameNotesJEditorPane());
     m_tabsPanel.addTab("Notes", m_notesPanel);
     m_details = new TerritoryDetailPanel(m_mapPanel, m_data, m_uiContext, this);
-    m_tabsPanel.addTab("Territory", m_details);
+    m_tabsPanel.addTab("Territory", null, m_details, TerritoryDetailPanel.getHoverText());
     m_editPanel = new EditPanel(m_data, m_mapPanel, this);
     // Register a change listener
     m_tabsPanel.addChangeListener(new ChangeListener() {

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -144,7 +144,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
             + "ALT-Right click on a unit stack to unselect 10 units of that type in the stack.<br>"
             + "CTRL-Right click on a unit stack to unselect all units of that type in the stack.<br>"
             + "CTRL-Right click somewhere not on a unit stack to unselect all units selected.<br>"
-            + "<br><b> Moving Units to a new Territories</b><br>"
+            + "<br><b> Moving Units</b><br>"
             + "After selecting units Left click on a territory to move units there (do not Left click and Drag, instead select units, then move the mouse, then select the territory).<br>"
             + "CTRL-Left click on a territory to select the territory as a way point (this will force the units to move through this territory on their way to the destination).<br>"
             + "<br><b> Moving the Map Screen</b><br>"
@@ -155,14 +155,15 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
             + "Scrolling the mouse wheel will move the map up and down.<br>" + "<br><b> Zooming Out</b><br>"
             + "Holding ALT while Scrolling the Mouse Wheel will zoom the map in and out.<br>"
             + "Select 'Zoom' from the 'View' menu, and change to the desired level.<br>"
-            + "<br><b> Turn off Art</b><br>"
+            + "<br><b> Turn off Map Artwork</b><br>"
             + "Deselect 'Map Details' in the 'View' menu, to show a map without the artwork.<br>"
             + "Select a new 'Map Skin' from the 'View' menu to show a different kind of artwork (not all maps have skins).<br>"
             + "<br><b> Other Things</b><br>"
             + "Press 'n' to cycle through units with movement left (move phases only).<br>"
             + "Press 'f' to highlight all units you own that have movement left (move phases only).<br>"
             + "Press 'i' or 'v' to popup info on whatever territory and unit your mouse is currently over.<br>"
-            + "Press 'u' while mousing over a unit to undo all moves that unit has made (beta).<br>";
+            + "Press 'u' while mousing over a unit to undo all moves that unit has made (beta).<br>"
+            + "To list specific units from a territory in the Territory panel, drag and drop from the territory on the map to the territory panel.<br>";
         final JEditorPane editorPane = new JEditorPane();
         editorPane.setEditable(false);
         editorPane.setContentType("text/html");


### PR DESCRIPTION
Instead, add documentation that the territory panel can be frozen by clicking and holding left mouse (ie: dragging)

The shift-up event is not acted upon when the game does not have focus, thus the existing implementation that uses shift key has a flaw that can leave the territory panel frozen.

Click and drag is a nice alternative since we do not need to rely on the swing listeners for key-up. Instead what happens is we bypass the 'territoryChanged' handler that is fired on mouseMove, rather than mouseDrag. Thus with mouseDrag, the teritory panel does not update.

With this change:
- remove feature to freeze territory panel with shift key
- add hover text to territory tab that you can drag and drop from a territory or hover it to see the units in that tab
- add game notes text with similar mention about drag and drop.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/416)
<!-- Reviewable:end -->
