### PR TITLE
Show Engine Version on the UI + Consolidate Engine Version and Game Configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
-game_engine.properties=lf
 MacOS_users_read_this_first.txt eol=lf
 triplea_maps.xml eol=lf
 
@@ -9,7 +8,6 @@ triplea_maps.xml eol=lf
 *.bat eol=crlf
 *.txt eol=crlf
 *.ini eol=crlf
-*.properties eol=crlf
 *.xml eol=crlf
 *.html eol=crlf
 *.css eol=crlf
@@ -19,6 +17,7 @@ triplea_maps.xml eol=lf
 # Declare files that will always have LF line endings on checkout.
 *.sh eol=lf
 *.plist eol=lf
+*.properties eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
+game_engine.properties=lf
+MacOS_users_read_this_first.txt eol=lf
+triplea_maps.xml eol=lf
+
 # Declare files that will always have CRLF line endings on checkout.
 *.bat eol=crlf
 *.txt eol=crlf
@@ -15,9 +19,6 @@
 # Declare files that will always have LF line endings on checkout.
 *.sh eol=lf
 *.plist eol=lf
-MacOS_users_read_this_first.txt eol=lf
-triplea_maps.xml eol=lf
-game_engine.properties=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@
 *.plist eol=lf
 MacOS_users_read_this_first.txt eol=lf
 triplea_maps.xml eol=lf
+game_engine.properties=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ script:
 before_deploy:
 - wget -O setup https://github.com/triplea-game/triplea/blob/master/.travis/setup?raw=true
 - chmod +x setup && ./setup
-- export TAGGED_VERSION="$BUILD_VERSION.$TRAVIS_BUILD_NUMBER"
+- GAME_CONFIG=game_engine.properties
+- ENGINE_VERSION=$(grep "engine_version" $GAME_CONFIG | sed 's/.*= *//g')
+- export TAGGED_VERSION="$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER"
+- sed -i "s/engine_version.*/engine_version = $TAGGED_VERSION/" $GAME_CONFIG
 - gradle release
 - wget -O push_tag https://github.com/triplea-game/triplea/blob/master/.travis/push_tag?raw=true
 - chmod +x push_tag && ./push_tag

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ task allPlatform(type: Zip, group: 'release', dependsOn: [renameShadowJar, updat
 		into('icons')
 		exclude("icon.icns")
 	}
-	['readme.html', 'changelog.txt', 'system.ini', 'TripleA_RuleBook.pdf', 'mapDownload.properties',
+	['readme.html', 'changelog.txt', 'system.ini', 'TripleA_RuleBook.pdf', 'game_engine.properties',
 	 'run-headless-game-host-mac-os.sh', 'run-headless-game-host.sh', 'run-headless-game-host-windows.bat',
 	 'triplea_unix.sh', 'triplea_windows.bat', 'triplea_mac_os_x.sh'].each { fileName ->
 		from(fileName)
@@ -140,7 +140,7 @@ task bots(type: Zip, group: 'release', dependsOn: [renameShadowJar, updateAssets
 			into(folder)
 		}
 	}
-	['readme.html', 'changelog.txt', 'system.ini', 'mapDownload.properties',
+	['readme.html', 'changelog.txt', 'system.ini', 'game_engine.properties',
 	 'run-headless-game-host-mac-os.sh', 'run-headless-game-host.sh', 'run-headless-game-host-windows.bat',
 	 'triplea_unix.sh', 'triplea_windows.bat', 'triplea_mac_os_x.sh'].each { fileName ->
 		from(fileName)

--- a/game_engine.properties
+++ b/game_engine.properties
@@ -1,3 +1,5 @@
+engine_version = 1.8.0.10
+
 ## Map_List_File
 # URL if the value begins with http, otherwise assumed to be a file. This file lists which maps are available
 # to tripleA for download.

--- a/game_engine.properties
+++ b/game_engine.properties
@@ -1,4 +1,3 @@
-
 ## Map_List_File
 # URL if the value begins with http, otherwise assumed to be a file. This file lists which maps are available
 # to tripleA for download.

--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -56,6 +56,7 @@ import com.apple.eawt.ApplicationEvent;
 import games.strategy.debug.ClientLogger;
 import games.strategy.debug.ErrorConsole;
 import games.strategy.debug.DebugUtils;
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.PlayerID;
@@ -413,7 +414,7 @@ public class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> extends JMe
 
   protected void addAboutMenu(final JMenu parentMenu) {
     final String text = "<h2>" + getData().getGameName() + "</h2>" + "<p><b>Engine Version:</b> "
-        + games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion().toString() + "<br><b>Game:</b> " + getData().getGameName()
+        + ClientContext.engineVersion().getCompatabilityVersion() + "<br><b>Game:</b> " + getData().getGameName()
         + "<br><b>Game Version:</b>" + getData().getGameVersion() + "</p>"
         + "<p>For more information please visit,<br><br>"
         + "<b><a hlink='http://triplea.sourceforge.net/'>http://triplea.sourceforge.net/</a></b><br><br>";

--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -413,7 +413,7 @@ public class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> extends JMe
 
   protected void addAboutMenu(final JMenu parentMenu) {
     final String text = "<h2>" + getData().getGameName() + "</h2>" + "<p><b>Engine Version:</b> "
-        + games.strategy.engine.EngineVersion.VERSION.toString() + "<br><b>Game:</b> " + getData().getGameName()
+        + games.strategy.engine.ClientContext.getInstance().engineVersion().getVersion().toString() + "<br><b>Game:</b> " + getData().getGameName()
         + "<br><b>Game Version:</b>" + getData().getGameVersion() + "</p>"
         + "<p>For more information please visit,<br><br>"
         + "<b><a hlink='http://triplea.sourceforge.net/'>http://triplea.sourceforge.net/</a></b><br><br>";

--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -414,7 +414,7 @@ public class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> extends JMe
 
   protected void addAboutMenu(final JMenu parentMenu) {
     final String text = "<h2>" + getData().getGameName() + "</h2>" + "<p><b>Engine Version:</b> "
-        + ClientContext.engineVersion().getVersion() + "<br><b>Game:</b> " + getData().getGameName()
+        + ClientContext.engineVersion() + "<br><b>Game:</b> " + getData().getGameName()
         + "<br><b>Game Version:</b>" + getData().getGameVersion() + "</p>"
         + "<p>For more information please visit,<br><br>"
         + "<b><a hlink='http://triplea.sourceforge.net/'>http://triplea.sourceforge.net/</a></b><br><br>";

--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -414,7 +414,7 @@ public class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> extends JMe
 
   protected void addAboutMenu(final JMenu parentMenu) {
     final String text = "<h2>" + getData().getGameName() + "</h2>" + "<p><b>Engine Version:</b> "
-        + ClientContext.engineVersion().getCompatabilityVersion() + "<br><b>Game:</b> " + getData().getGameName()
+        + ClientContext.engineVersion().getVersion() + "<br><b>Game:</b> " + getData().getGameName()
         + "<br><b>Game Version:</b>" + getData().getGameVersion() + "</p>"
         + "<p>For more information please visit,<br><br>"
         + "<b><a hlink='http://triplea.sourceforge.net/'>http://triplea.sourceforge.net/</a></b><br><br>";

--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -413,7 +413,7 @@ public class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> extends JMe
 
   protected void addAboutMenu(final JMenu parentMenu) {
     final String text = "<h2>" + getData().getGameName() + "</h2>" + "<p><b>Engine Version:</b> "
-        + games.strategy.engine.ClientContext.engineVersion().getVersion().toString() + "<br><b>Game:</b> " + getData().getGameName()
+        + games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion().toString() + "<br><b>Game:</b> " + getData().getGameName()
         + "<br><b>Game Version:</b>" + getData().getGameVersion() + "</p>"
         + "<p>For more information please visit,<br><br>"
         + "<b><a hlink='http://triplea.sourceforge.net/'>http://triplea.sourceforge.net/</a></b><br><br>";

--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -413,7 +413,7 @@ public class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> extends JMe
 
   protected void addAboutMenu(final JMenu parentMenu) {
     final String text = "<h2>" + getData().getGameName() + "</h2>" + "<p><b>Engine Version:</b> "
-        + games.strategy.engine.ClientContext.getInstance().engineVersion().getVersion().toString() + "<br><b>Game:</b> " + getData().getGameName()
+        + games.strategy.engine.ClientContext.engineVersion().getVersion().toString() + "<br><b>Game:</b> " + getData().getGameName()
         + "<br><b>Game Version:</b>" + getData().getGameVersion() + "</p>"
         + "<p>For more information please visit,<br><br>"
         + "<b><a hlink='http://triplea.sourceforge.net/'>http://triplea.sourceforge.net/</a></b><br><br>";

--- a/src/games/strategy/debug/DebugUtils.java
+++ b/src/games/strategy/debug/DebugUtils.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Properties;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.framework.GameRunner2;
 
@@ -97,7 +98,7 @@ public class DebugUtils {
     result.append(getThreadDumps());
     result.append(getProperties());
     result.append(getMemory());
-    result.append("ENGINE VERSION: ").append(EngineVersion.VERSION).append("\n");
+    result.append("ENGINE VERSION: ").append(ClientContext.getInstance().engineVersion().getVersion()).append("\n");
     return result.toString();
   }
 
@@ -110,7 +111,7 @@ public class DebugUtils {
     result.append(getProperties());
     result.append(getMemory());
     result.append(getOpenAppWindows());
-    result.append("ENGINE VERSION: ").append(EngineVersion.VERSION).append("\n");
+    result.append("ENGINE VERSION: ").append(ClientContext.getInstance().engineVersion().getVersion()).append("\n");
     return result.toString();
   }
 

--- a/src/games/strategy/debug/DebugUtils.java
+++ b/src/games/strategy/debug/DebugUtils.java
@@ -98,7 +98,7 @@ public class DebugUtils {
     result.append(getThreadDumps());
     result.append(getProperties());
     result.append(getMemory());
-    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getVersion()).append("\n");
+    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getCompatabilityVersion()).append("\n");
     return result.toString();
   }
 
@@ -111,7 +111,7 @@ public class DebugUtils {
     result.append(getProperties());
     result.append(getMemory());
     result.append(getOpenAppWindows());
-    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getVersion()).append("\n");
+    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getCompatabilityVersion()).append("\n");
     return result.toString();
   }
 

--- a/src/games/strategy/debug/DebugUtils.java
+++ b/src/games/strategy/debug/DebugUtils.java
@@ -98,7 +98,7 @@ public class DebugUtils {
     result.append(getThreadDumps());
     result.append(getProperties());
     result.append(getMemory());
-    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getVersion()).append("\n");
+    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion()).append("\n");
     return result.toString();
   }
 

--- a/src/games/strategy/debug/DebugUtils.java
+++ b/src/games/strategy/debug/DebugUtils.java
@@ -98,7 +98,7 @@ public class DebugUtils {
     result.append(getThreadDumps());
     result.append(getProperties());
     result.append(getMemory());
-    result.append("ENGINE VERSION: ").append(ClientContext.getInstance().engineVersion().getVersion()).append("\n");
+    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getVersion()).append("\n");
     return result.toString();
   }
 
@@ -111,7 +111,7 @@ public class DebugUtils {
     result.append(getProperties());
     result.append(getMemory());
     result.append(getOpenAppWindows());
-    result.append("ENGINE VERSION: ").append(ClientContext.getInstance().engineVersion().getVersion()).append("\n");
+    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getVersion()).append("\n");
     return result.toString();
   }
 

--- a/src/games/strategy/debug/DebugUtils.java
+++ b/src/games/strategy/debug/DebugUtils.java
@@ -98,7 +98,7 @@ public class DebugUtils {
     result.append(getThreadDumps());
     result.append(getProperties());
     result.append(getMemory());
-    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getCompatabilityVersion()).append("\n");
+    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getVersion()).append("\n");
     return result.toString();
   }
 
@@ -111,7 +111,7 @@ public class DebugUtils {
     result.append(getProperties());
     result.append(getMemory());
     result.append(getOpenAppWindows());
-    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getCompatabilityVersion()).append("\n");
+    result.append("ENGINE VERSION: ").append(ClientContext.engineVersion().getVersion()).append("\n");
     return result.toString();
   }
 

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -63,167 +63,16 @@ public final class ClientContext {
    * Get the root folder for the application
    */
   public static File getRootFolder() {
-    final String fileName = getGameRunnerFileLocation("GameRunner2.class");
-
-    final String tripleaJarName = "triplea.jar!";
-    if (fileName.contains(tripleaJarName)) {
-      return getRootFolderRelativeToJar(fileName, tripleaJarName);
-    }
-
-//    final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
-    if (fileName.contains("triplea_") && fileName.contains(".jar!")) {
-      Pattern pattern = Pattern.compile("triplea_.*\\.jar!");
-      Matcher matcher = pattern.matcher(fileName);
-
-      String tripleaJarNameWithEngineVersion =   matcher.group();
-
-      return getRootFolderRelativeToJar(fileName, tripleaJarNameWithEngineVersion);
-    }
-
-    return getRootRelativeToClassFile(fileName);
+    return ClientFileSystemHelper.getRootFolder();
   }
 
-  private static String getGameRunnerFileLocation(final String runnerClassName) {
-    final URL url = GameRunner2.class.getResource(runnerClassName);
-    String fileName = url.getFile();
-
-    try {
-      // Deal with spaces in the file name which would be url encoded
-      fileName = URLDecoder.decode(fileName, "UTF-8");
-    } catch (final UnsupportedEncodingException e) {
-      ClientLogger.logError("Unsupported encoding of fileName: " + fileName + ", error: " + e.getMessage());
-    }
-    return fileName;
-  }
-
-
-  private static String getTripleaJarWithEngineVersionStringPath() {
-    ClientContext context = ClientContext.getInstance();
-    EngineVersion engine = context.engineVersion();
-    Version version = engine.getVersion();
-
-    return "triplea_" + version.toStringFull("_") + ".jar!";
-  }
-
-  private static File getRootFolderRelativeToJar(final String fileName, final String tripleaJarName) {
-    final String subString =
-        fileName.substring("file:/".length() - (GameRunner.isWindows() ? 0 : 1), fileName.indexOf(tripleaJarName) - 1);
-    final File f = new File(subString).getParentFile();
-    if (!f.exists()) {
-      throw new IllegalStateException("File not found:" + f);
-    }
-    return f;
-  }
-
-  private static File getRootRelativeToClassFile(final String fileName) {
-    File f = new File(fileName);
-
-    // move up 1 directory for each package
-    final int moveUpCount = GameRunner2.class.getName().split("\\.").length + 1;
-    for (int i = 0; i < moveUpCount; i++) {
-      f = f.getParentFile();
-    }
-    if (!f.exists()) {
-      System.err.println("Could not find root folder, does  not exist:" + f);
-      return new File(System.getProperties().getProperty("user.dir"));
-    }
-    return f;
-  }
 
   /**
    * Our jar is named with engine number and we are in "old" folder.
    */
   public static boolean areWeOldExtraJar() {
-    final URL url = GameRunner2.class.getResource("GameRunner2.class");
-    String fileName = url.getFile();
-    try {
-      fileName = URLDecoder.decode(fileName, "UTF-8");
-    } catch (final UnsupportedEncodingException e) {
-      e.printStackTrace();
-    }
-    final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
-    if (fileName.contains(tripleaJarNameWithEngineVersion)) {
-      final String subString = fileName.substring("file:/".length() - (GameRunner.isWindows() ? 0 : 1),
-          fileName.indexOf(tripleaJarNameWithEngineVersion) - 1);
-      final File f = new File(subString);
-      if (!f.exists()) {
-        throw new IllegalStateException("File not found:" + f);
-      }
-      String path;
-      try {
-        path = f.getCanonicalPath();
-      } catch (final IOException e) {
-        path = f.getPath();
-      }
-      return path.contains("old");
-    }
-    return false;
+    return ClientFileSystemHelper.areWeOldExtraJar();
   }
-  /**
-   * Search for a file that may be contained in one of multiple folders.
-   *
-   * The file to search for is given by first parameter, second is the list of folders.
-   * We will search all possible paths of the first folder before moving on to the next,
-   * so ordering of the possible folders is more important than the ordering of search paths.
-   *
-   * The search paths vary by if this class is being run from a class file instance,
-   * or a copy compiled into a jar.
-   *
-   * @param game The name of the file to find
-   * @param possibleFolders An array containing a sequence of possible folders that may contain
-   *        the search file.
-   * @return Throws illegal state if not found. Otherwise returns a file reference whose name
-   *         matches the first parameter and parent folder matches an element of "possibleFolders"
-   */
-  public static File getFile(final String game, final String[] possibleFolders) {
-    for (final String possibleFolder : possibleFolders) {
-      final File start = ClientContext.getRootFolder();
-      if (folderContainsFolderAndFile(start, possibleFolder, game)) {
-        return new File(new File(start, possibleFolder), game);
-      }
-
-      final File secondStart = getParentFolder(possibleFolder);
-      if (folderContainsFolderAndFile(secondStart, possibleFolder, game)) {
-        return new File(new File(secondStart, possibleFolder), game);
-      }
-
-    }
-    throw new IllegalStateException(
-        "Could not find any of these folders: " + Arrays.asList(possibleFolders) + ", containing game file: " + game);
-  }
-
-  /* From the Game Runner root location, walk up directories until we find a given folder */
-  private static File getParentFolder(final String folderToFind) {
-    File f = new File(getGameRunnerFileLocation("GameRunner2.class"));
-
-    while (f != null && f.exists() && !folderContains(f, folderToFind)) {
-      f = f.getParentFile();
-    }
-    return f;
-  }
-
-
-  /* Check if a folder contains another folder or file */
-  private static boolean folderContains(final File folder, final String childToFind) {
-    if (folder == null || folder.list() == null || folder.list().length == 0) {
-      return false;
-    }
-    return Arrays.asList(folder.list()).contains(childToFind);
-  }
-
-
-
-  /* Check if a given folder contains another folder that in turn contains a given file */
-  private static boolean folderContainsFolderAndFile(final File f, final String childFolder, final String child) {
-    if (folderContains(f, childFolder)) {
-      final File possibleParent = new File(f, childFolder);
-      if (folderContains(possibleParent, child)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
 
 
 

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -13,6 +13,17 @@ import games.strategy.engine.framework.mapDownload.MapListingSource;
  * This class roughly follows the singleton pattern. The singleton instance
  * can be updated, this is allowed to enable a mock instance of this class to
  * be used.
+ *
+ * Caution: the public API of this class will grow to be fairly large. For every object we wish to return, we'll have an
+ * "object()" method that will returns that same object. When things become hard to manage it'll be a good time
+ * to move to an annotation or configuration based IOC framework.
+ *
+ * Second note, try to put as much class specific construction logic into the constructor of each class managed by this
+ * container. This class should focus on just creating and wiring classes together. Contrast that with generating the data
+ * needed to create classes. For example, instead of parsing a file and passing that value to the constructor of another class,
+ * we would instead create an intermediary class that knows everything about which file to parse and how to parse it, and we would
+ * pass that intermediary class to the new class we wish to create. Said in another way, this class should not contain any 'business'
+ * logic.
  */
 public final class ClientContext {
 
@@ -25,7 +36,7 @@ public final class ClientContext {
   }
 
   /** Useful for testing, not meant for normal code paths */
-  public static void setMockHandler( ClientContext mockHandler) {
+  public static void setMockHandler(ClientContext mockHandler) {
     instance = mockHandler;
   }
 

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -20,14 +20,19 @@ import games.strategy.engine.framework.mapDownload.MapListingSource;
  * to move to an annotation or configuration based IOC framework.
  *
  * Second note, try to put as much class specific construction logic into the constructor of each class managed by this
- * container. This class should focus on just creating and wiring classes together. Contrast that with generating the data
- * needed to create classes. For example, instead of parsing a file and passing that value to the constructor of another class,
- * we would instead create an intermediary class that knows everything about which file to parse and how to parse it, and we would
- * pass that intermediary class to the new class we wish to create. Said in another way, this class should not contain any 'business'
+ * container. This class should focus on just creating and wiring classes together. Contrast that with generating the
+ * data
+ * needed to create classes. For example, instead of parsing a file and passing that value to the constructor of another
+ * class,
+ * we would instead create an intermediary class that knows everything about which file to parse and how to parse it,
+ * and we would
+ * pass that intermediary class to the new class we wish to create. Said in another way, this class should not contain
+ * any 'business'
  * logic.
  *
- * Third Note: Any classes created by ClientContext cannot call ClientContext in their constructor, all dependencies must be passed to them.
- *   Since GameRunner2 creates ClientContext, similar none of the classes created by Client Context can game runner 2
+ * Third Note: Any classes created by ClientContext cannot call ClientContext in their constructor, all dependencies
+ * must be passed to them.
+ * Since GameRunner2 creates ClientContext, similar none of the classes created by Client Context can game runner 2
  */
 public final class ClientContext {
   private static ClientContext instance;
@@ -35,8 +40,8 @@ public final class ClientContext {
 
 
   public static synchronized ClientContext getInstance() {
-    if( instance == null ) {
-      instance = new  ClientContext();
+    if (instance == null) {
+      instance = new ClientContext();
     }
     return instance;
   }
@@ -45,25 +50,6 @@ public final class ClientContext {
   public static void setMockHandler(ClientContext mockHandler) {
     instance = mockHandler;
   }
-
-
-
-  /**
-   * Get the root folder for the application
-   */
-  public static File getRootFolder() {
-    return ClientFileSystemHelper.getRootFolder();
-  }
-
-
-  /**
-   * Our jar is named with engine number and we are in "old" folder.
-   */
-  public static boolean areWeOldExtraJar() {
-    return ClientFileSystemHelper.areWeOldExtraJar();
-  }
-
-
 
 
   private MapDownloadController mapDownloadController;

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -1,0 +1,48 @@
+package games.strategy.engine;
+
+import java.io.File;
+
+import games.strategy.engine.framework.GameRunner2;
+import games.strategy.engine.framework.mapDownload.MapDownloadController;
+import games.strategy.engine.framework.mapDownload.MapListingSource;
+
+/**
+ * IOC container for storing objects needed by the TripleA Swing client
+ * A full blow dependency injection framework would deprecate this class.
+ *
+ * This class roughly follows the singleton pattern. The singleton instance
+ * can be updated, this is allowed to enable a mock instance of this class to
+ * be used.
+ */
+public final class ClientContext {
+
+  private static ClientContext instance = new ClientContext();
+
+
+
+  public static ClientContext getInstance() {
+    return instance;
+  }
+
+  /** Useful for testing, not meant for normal code paths */
+  public static void setMockHandler( ClientContext mockHandler) {
+    instance = mockHandler;
+  }
+
+
+  private final MapDownloadController mapDownloadController;
+
+
+  private ClientContext() {
+    File mapDownloadPropertiesFile = new File(GameRunner2.getRootFolder(), "mapDownload.properties");
+    MapListingSource listingSource = new MapListingSource(mapDownloadPropertiesFile);
+    mapDownloadController = new MapDownloadController(listingSource);
+  }
+
+
+  public MapDownloadController mapDownloadController() {
+    return mapDownloadController;
+  }
+
+
+}

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -36,10 +36,6 @@ public final class ClientContext {
   private static ClientContext instance = new ClientContext();
 
 
-  public static ClientContext getInstance() {
-    return instance;
-  }
-
   /** Useful for testing, not meant for normal code paths */
   public static void setMockHandler(ClientContext mockHandler) {
     instance = mockHandler;
@@ -57,12 +53,12 @@ public final class ClientContext {
   }
 
 
-  public MapDownloadController mapDownloadController() {
-    return mapDownloadController;
+  public static MapDownloadController mapDownloadController() {
+    return instance.mapDownloadController;
   }
 
-  public EngineVersion engineVersion() {
-    return engineVersion;
+  public static EngineVersion engineVersion() {
+    return instance.engineVersion;
   }
 
 

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -1,22 +1,11 @@
 package games.strategy.engine;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.config.GameEnginePropertyFileReader;
 import games.strategy.engine.config.PropertyReader;
-import games.strategy.engine.framework.GameRunner;
-import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.mapDownload.MapDownloadController;
 import games.strategy.engine.framework.mapDownload.MapListingSource;
-import games.strategy.util.Version;
 
 /**
  * IOC container for storing objects needed by the TripleA Swing client
@@ -73,6 +62,7 @@ public final class ClientContext {
   public static boolean areWeOldExtraJar() {
     return ClientFileSystemHelper.areWeOldExtraJar();
   }
+
 
 
 

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -34,7 +34,7 @@ public final class ClientContext {
 
 
   private ClientContext() {
-    File mapDownloadPropertiesFile = new File(GameRunner2.getRootFolder(), "mapDownload.properties");
+    File mapDownloadPropertiesFile = new File(GameRunner2.getRootFolder(), "game_engine.properties");
     MapListingSource listingSource = new MapListingSource(mapDownloadPropertiesFile);
     mapDownloadController = new MapDownloadController(listingSource);
   }

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -35,14 +35,10 @@ import games.strategy.engine.framework.mapDownload.MapListingSource;
  * Since GameRunner2 creates ClientContext, similar none of the classes created by Client Context can game runner 2
  */
 public final class ClientContext {
-  private static ClientContext instance;
+  private static ClientContext instance = new ClientContext();
 
 
-
-  public static synchronized ClientContext getInstance() {
-    if (instance == null) {
-      instance = new ClientContext();
-    }
+  public static ClientContext getInstance() {
     return instance;
   }
 
@@ -56,10 +52,6 @@ public final class ClientContext {
   private EngineVersion engineVersion;
 
   private ClientContext() {
-    initObjects();
-  }
-
-  private void initObjects() {
     PropertyReader reader = new GameEnginePropertyFileReader();
     MapListingSource listingSource = new MapListingSource(reader);
     mapDownloadController = new MapDownloadController(listingSource);

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -2,6 +2,8 @@ package games.strategy.engine;
 
 import java.io.File;
 
+import games.strategy.engine.config.GameEnginePropertyFileReader;
+import games.strategy.engine.config.PropertyReader;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.mapDownload.MapDownloadController;
 import games.strategy.engine.framework.mapDownload.MapListingSource;
@@ -45,8 +47,8 @@ public final class ClientContext {
 
 
   private ClientContext() {
-    File mapDownloadPropertiesFile = new File(GameRunner2.getRootFolder(), "game_engine.properties");
-    MapListingSource listingSource = new MapListingSource(mapDownloadPropertiesFile);
+    PropertyReader reader = new GameEnginePropertyFileReader();
+    MapListingSource listingSource = new MapListingSource(reader);
     mapDownloadController = new MapDownloadController(listingSource);
   }
 

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -1,7 +1,5 @@
 package games.strategy.engine;
 
-import java.io.File;
-
 import games.strategy.engine.config.GameEnginePropertyFileReader;
 import games.strategy.engine.config.PropertyReader;
 import games.strategy.engine.framework.mapDownload.MapDownloadController;

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -1,12 +1,22 @@
 package games.strategy.engine;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.config.GameEnginePropertyFileReader;
 import games.strategy.engine.config.PropertyReader;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.mapDownload.MapDownloadController;
 import games.strategy.engine.framework.mapDownload.MapListingSource;
+import games.strategy.util.Version;
 
 /**
  * IOC container for storing objects needed by the TripleA Swing client
@@ -26,14 +36,19 @@ import games.strategy.engine.framework.mapDownload.MapListingSource;
  * we would instead create an intermediary class that knows everything about which file to parse and how to parse it, and we would
  * pass that intermediary class to the new class we wish to create. Said in another way, this class should not contain any 'business'
  * logic.
+ *
+ * Third Note: Any classes created by ClientContext cannot call ClientContext in their constructor, all dependencies must be passed to them.
+ *   Since GameRunner2 creates ClientContext, similar none of the classes created by Client Context can game runner 2
  */
 public final class ClientContext {
-
-  private static ClientContext instance = new ClientContext();
-
+  private static ClientContext instance;
 
 
-  public static ClientContext getInstance() {
+
+  public static synchronized ClientContext getInstance() {
+    if( instance == null ) {
+      instance = new  ClientContext();
+    }
     return instance;
   }
 
@@ -43,10 +58,183 @@ public final class ClientContext {
   }
 
 
-  private final MapDownloadController mapDownloadController;
-  private final EngineVersion engineVersion;
+
+  /**
+   * Get the root folder for the application
+   */
+  public static File getRootFolder() {
+    final String fileName = getGameRunnerFileLocation("GameRunner2.class");
+
+    final String tripleaJarName = "triplea.jar!";
+    if (fileName.contains(tripleaJarName)) {
+      return getRootFolderRelativeToJar(fileName, tripleaJarName);
+    }
+
+//    final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
+    if (fileName.contains("triplea_") && fileName.contains(".jar!")) {
+      Pattern pattern = Pattern.compile("triplea_.*\\.jar!");
+      Matcher matcher = pattern.matcher(fileName);
+
+      String tripleaJarNameWithEngineVersion =   matcher.group();
+
+      return getRootFolderRelativeToJar(fileName, tripleaJarNameWithEngineVersion);
+    }
+
+    return getRootRelativeToClassFile(fileName);
+  }
+
+  private static String getGameRunnerFileLocation(final String runnerClassName) {
+    final URL url = GameRunner2.class.getResource(runnerClassName);
+    String fileName = url.getFile();
+
+    try {
+      // Deal with spaces in the file name which would be url encoded
+      fileName = URLDecoder.decode(fileName, "UTF-8");
+    } catch (final UnsupportedEncodingException e) {
+      ClientLogger.logError("Unsupported encoding of fileName: " + fileName + ", error: " + e.getMessage());
+    }
+    return fileName;
+  }
+
+
+  private static String getTripleaJarWithEngineVersionStringPath() {
+    ClientContext context = ClientContext.getInstance();
+    EngineVersion engine = context.engineVersion();
+    Version version = engine.getVersion();
+
+    return "triplea_" + version.toStringFull("_") + ".jar!";
+  }
+
+  private static File getRootFolderRelativeToJar(final String fileName, final String tripleaJarName) {
+    final String subString =
+        fileName.substring("file:/".length() - (GameRunner.isWindows() ? 0 : 1), fileName.indexOf(tripleaJarName) - 1);
+    final File f = new File(subString).getParentFile();
+    if (!f.exists()) {
+      throw new IllegalStateException("File not found:" + f);
+    }
+    return f;
+  }
+
+  private static File getRootRelativeToClassFile(final String fileName) {
+    File f = new File(fileName);
+
+    // move up 1 directory for each package
+    final int moveUpCount = GameRunner2.class.getName().split("\\.").length + 1;
+    for (int i = 0; i < moveUpCount; i++) {
+      f = f.getParentFile();
+    }
+    if (!f.exists()) {
+      System.err.println("Could not find root folder, does  not exist:" + f);
+      return new File(System.getProperties().getProperty("user.dir"));
+    }
+    return f;
+  }
+
+  /**
+   * Our jar is named with engine number and we are in "old" folder.
+   */
+  public static boolean areWeOldExtraJar() {
+    final URL url = GameRunner2.class.getResource("GameRunner2.class");
+    String fileName = url.getFile();
+    try {
+      fileName = URLDecoder.decode(fileName, "UTF-8");
+    } catch (final UnsupportedEncodingException e) {
+      e.printStackTrace();
+    }
+    final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
+    if (fileName.contains(tripleaJarNameWithEngineVersion)) {
+      final String subString = fileName.substring("file:/".length() - (GameRunner.isWindows() ? 0 : 1),
+          fileName.indexOf(tripleaJarNameWithEngineVersion) - 1);
+      final File f = new File(subString);
+      if (!f.exists()) {
+        throw new IllegalStateException("File not found:" + f);
+      }
+      String path;
+      try {
+        path = f.getCanonicalPath();
+      } catch (final IOException e) {
+        path = f.getPath();
+      }
+      return path.contains("old");
+    }
+    return false;
+  }
+  /**
+   * Search for a file that may be contained in one of multiple folders.
+   *
+   * The file to search for is given by first parameter, second is the list of folders.
+   * We will search all possible paths of the first folder before moving on to the next,
+   * so ordering of the possible folders is more important than the ordering of search paths.
+   *
+   * The search paths vary by if this class is being run from a class file instance,
+   * or a copy compiled into a jar.
+   *
+   * @param game The name of the file to find
+   * @param possibleFolders An array containing a sequence of possible folders that may contain
+   *        the search file.
+   * @return Throws illegal state if not found. Otherwise returns a file reference whose name
+   *         matches the first parameter and parent folder matches an element of "possibleFolders"
+   */
+  public static File getFile(final String game, final String[] possibleFolders) {
+    for (final String possibleFolder : possibleFolders) {
+      final File start = ClientContext.getRootFolder();
+      if (folderContainsFolderAndFile(start, possibleFolder, game)) {
+        return new File(new File(start, possibleFolder), game);
+      }
+
+      final File secondStart = getParentFolder(possibleFolder);
+      if (folderContainsFolderAndFile(secondStart, possibleFolder, game)) {
+        return new File(new File(secondStart, possibleFolder), game);
+      }
+
+    }
+    throw new IllegalStateException(
+        "Could not find any of these folders: " + Arrays.asList(possibleFolders) + ", containing game file: " + game);
+  }
+
+  /* From the Game Runner root location, walk up directories until we find a given folder */
+  private static File getParentFolder(final String folderToFind) {
+    File f = new File(getGameRunnerFileLocation("GameRunner2.class"));
+
+    while (f != null && f.exists() && !folderContains(f, folderToFind)) {
+      f = f.getParentFile();
+    }
+    return f;
+  }
+
+
+  /* Check if a folder contains another folder or file */
+  private static boolean folderContains(final File folder, final String childToFind) {
+    if (folder == null || folder.list() == null || folder.list().length == 0) {
+      return false;
+    }
+    return Arrays.asList(folder.list()).contains(childToFind);
+  }
+
+
+
+  /* Check if a given folder contains another folder that in turn contains a given file */
+  private static boolean folderContainsFolderAndFile(final File f, final String childFolder, final String child) {
+    if (folderContains(f, childFolder)) {
+      final File possibleParent = new File(f, childFolder);
+      if (folderContains(possibleParent, child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+
+
+  private MapDownloadController mapDownloadController;
+  private EngineVersion engineVersion;
 
   private ClientContext() {
+    initObjects();
+  }
+
+  private void initObjects() {
     PropertyReader reader = new GameEnginePropertyFileReader();
     MapListingSource listingSource = new MapListingSource(reader);
     mapDownloadController = new MapDownloadController(listingSource);
@@ -61,5 +249,6 @@ public final class ClientContext {
   public EngineVersion engineVersion() {
     return engineVersion;
   }
+
 
 }

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -44,12 +44,13 @@ public final class ClientContext {
 
 
   private final MapDownloadController mapDownloadController;
-
+  private final EngineVersion engineVersion;
 
   private ClientContext() {
     PropertyReader reader = new GameEnginePropertyFileReader();
     MapListingSource listingSource = new MapListingSource(reader);
     mapDownloadController = new MapDownloadController(listingSource);
+    engineVersion = new EngineVersion(reader);
   }
 
 
@@ -57,5 +58,8 @@ public final class ClientContext {
     return mapDownloadController;
   }
 
+  public EngineVersion engineVersion() {
+    return engineVersion;
+  }
 
 }

--- a/src/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/games/strategy/engine/ClientFileSystemHelper.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -25,7 +24,7 @@ public final class ClientFileSystemHelper {
   }
 
   /** This method is available via ClientContext */
-  protected static File getRootFolder() {
+  public static File getRootFolder() {
     final String fileName = getGameRunnerFileLocation("GameRunner2.class");
 
     final String tripleaJarName = "triplea.jar!";
@@ -95,7 +94,7 @@ public final class ClientFileSystemHelper {
     return f;
   }
 
-  protected static boolean areWeOldExtraJar() {
+  public static boolean areWeOldExtraJar() {
     final URL url = GameRunner2.class.getResource("GameRunner2.class");
     String fileName = url.getFile();
     try {
@@ -121,8 +120,5 @@ public final class ClientFileSystemHelper {
     }
     return false;
   }
-
-
-
 
 }

--- a/src/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/games/strategy/engine/ClientFileSystemHelper.java
@@ -121,4 +121,29 @@ public final class ClientFileSystemHelper {
     return false;
   }
 
+  public static File getUserRootFolder() {
+    final File userHome = new File(System.getProperties().getProperty("user.home"));
+    // the default
+    File rootDir;
+    if (GameRunner.isMac()) {
+      rootDir = new File(new File(userHome, "Documents"), "triplea");
+    } else {
+      rootDir = new File(userHome, "triplea");
+    }
+    return rootDir;
+  }
+
+  public static File getUserMapsFolder() {
+    final File f = new File(getUserRootFolder(), "maps");
+    if (!f.exists()) {
+      try {
+        f.mkdirs();
+      } catch (final SecurityException e) {
+        e.printStackTrace();
+      }
+    }
+    return f;
+  }
+
+
 }

--- a/src/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/games/strategy/engine/ClientFileSystemHelper.java
@@ -13,7 +13,7 @@ import games.strategy.util.Version;
 
 /**
  * Pure utility class, final and private constructor to enforce this
- * WARNING: do not call ClientContext.getInstance() in this class. ClientContext call this class in turn
+ * WARNING: do not call ClientContext in this class. ClientContext call this class in turn
  * during construction, depending upon ordering this can cause an infinite call loop.
  */
 public final class ClientFileSystemHelper {
@@ -56,8 +56,7 @@ public final class ClientFileSystemHelper {
   private static String getTripleaJarWithEngineVersionStringPath() {
     // TODO: This is begging for trouble since we call ClientFileSystem during the construction of
     // ClientContext. Though, we will at this point already have parsed the game engine version, so it is okay (but brittle)
-    ClientContext context = ClientContext.getInstance();
-    EngineVersion engine = context.engineVersion();
+    EngineVersion engine = ClientContext.engineVersion();
     Version version = engine.getVersion();
 
     return "triplea_" + version.toStringFull("_") + ".jar!";

--- a/src/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/games/strategy/engine/ClientFileSystemHelper.java
@@ -1,0 +1,186 @@
+package games.strategy.engine;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import games.strategy.debug.ClientLogger;
+import games.strategy.engine.framework.GameRunner;
+import games.strategy.engine.framework.GameRunner2;
+import games.strategy.util.Version;
+
+/** Pure utility class, final and private constructor to enforce this */
+public final class ClientFileSystemHelper {
+  private ClientFileSystemHelper() {
+
+  }
+
+  /** This method is available via ClientContext */
+  protected static File getRootFolder() {
+    final String fileName = getGameRunnerFileLocation("GameRunner2.class");
+
+    final String tripleaJarName = "triplea.jar!";
+    if (fileName.contains(tripleaJarName)) {
+      return getRootFolderRelativeToJar(fileName, tripleaJarName);
+    }
+
+//    final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
+    if (fileName.contains("triplea_") && fileName.contains(".jar!")) {
+      Pattern pattern = Pattern.compile("triplea_.*\\.jar!");
+      Matcher matcher = pattern.matcher(fileName);
+
+      String tripleaJarNameWithEngineVersion =   matcher.group();
+      return getRootFolderRelativeToJar(fileName, tripleaJarNameWithEngineVersion);
+    }
+
+    return getRootRelativeToClassFile(fileName);
+  }
+
+
+  private static String getGameRunnerFileLocation(final String runnerClassName) {
+    final URL url = GameRunner2.class.getResource(runnerClassName);
+    String fileName = url.getFile();
+
+    try {
+      // Deal with spaces in the file name which would be url encoded
+      fileName = URLDecoder.decode(fileName, "UTF-8");
+    } catch (final UnsupportedEncodingException e) {
+      ClientLogger.logError("Unsupported encoding of fileName: " + fileName + ", error: " + e.getMessage());
+    }
+    return fileName;
+  }
+
+
+  private static String getTripleaJarWithEngineVersionStringPath() {
+    ClientContext context = ClientContext.getInstance();
+    EngineVersion engine = context.engineVersion();
+    Version version = engine.getVersion();
+
+    return "triplea_" + version.toStringFull("_") + ".jar!";
+  }
+
+  private static File getRootFolderRelativeToJar(final String fileName, final String tripleaJarName) {
+    final String subString =
+        fileName.substring("file:/".length() - (GameRunner.isWindows() ? 0 : 1), fileName.indexOf(tripleaJarName) - 1);
+    final File f = new File(subString).getParentFile();
+    if (!f.exists()) {
+      throw new IllegalStateException("File not found:" + f);
+    }
+    return f;
+  }
+
+  private static File getRootRelativeToClassFile(final String fileName) {
+    File f = new File(fileName);
+
+    // move up 1 directory for each package
+    final int moveUpCount = GameRunner2.class.getName().split("\\.").length + 1;
+    for (int i = 0; i < moveUpCount; i++) {
+      f = f.getParentFile();
+    }
+    if (!f.exists()) {
+      System.err.println("Could not find root folder, does  not exist:" + f);
+      return new File(System.getProperties().getProperty("user.dir"));
+    }
+    return f;
+  }
+
+  protected static boolean areWeOldExtraJar() {
+    final URL url = GameRunner2.class.getResource("GameRunner2.class");
+    String fileName = url.getFile();
+    try {
+      fileName = URLDecoder.decode(fileName, "UTF-8");
+    } catch (final UnsupportedEncodingException e) {
+      e.printStackTrace();
+    }
+    final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
+    if (fileName.contains(tripleaJarNameWithEngineVersion)) {
+      final String subString = fileName.substring("file:/".length() - (GameRunner.isWindows() ? 0 : 1),
+          fileName.indexOf(tripleaJarNameWithEngineVersion) - 1);
+      final File f = new File(subString);
+      if (!f.exists()) {
+        throw new IllegalStateException("File not found:" + f);
+      }
+      String path;
+      try {
+        path = f.getCanonicalPath();
+      } catch (final IOException e) {
+        path = f.getPath();
+      }
+      return path.contains("old");
+    }
+    return false;
+  }
+
+
+  /**
+   * Search for a file that may be contained in one of multiple folders.
+   *
+   * The file to search for is given by first parameter, second is the list of folders.
+   * We will search all possible paths of the first folder before moving on to the next,
+   * so ordering of the possible folders is more important than the ordering of search paths.
+   *
+   * The search paths vary by if this class is being run from a class file instance,
+   * or a copy compiled into a jar.
+   *
+   * @param game The name of the file to find
+   * @param possibleFolders An array containing a sequence of possible folders that may contain
+   *        the search file.
+   * @return Throws illegal state if not found. Otherwise returns a file reference whose name
+   *         matches the first parameter and parent folder matches an element of "possibleFolders"
+   */
+  public static File getFile(final String game, final String[] possibleFolders) {
+    for (final String possibleFolder : possibleFolders) {
+      final File start = ClientContext.getRootFolder();
+      if (folderContainsFolderAndFile(start, possibleFolder, game)) {
+        return new File(new File(start, possibleFolder), game);
+      }
+
+      final File secondStart = getParentFolder(possibleFolder);
+      if (folderContainsFolderAndFile(secondStart, possibleFolder, game)) {
+        return new File(new File(secondStart, possibleFolder), game);
+      }
+
+    }
+    throw new IllegalStateException(
+        "Could not find any of these folders: " + Arrays.asList(possibleFolders) + ", containing game file: " + game);
+  }
+
+  /* From the Game Runner root location, walk up directories until we find a given folder */
+  private static File getParentFolder(final String folderToFind) {
+    File f = new File(getGameRunnerFileLocation("GameRunner2.class"));
+
+    while (f != null && f.exists() && !folderContains(f, folderToFind)) {
+      f = f.getParentFile();
+    }
+    return f;
+  }
+
+
+  /* Check if a folder contains another folder or file */
+  private static boolean folderContains(final File folder, final String childToFind) {
+    if (folder == null || folder.list() == null || folder.list().length == 0) {
+      return false;
+    }
+    return Arrays.asList(folder.list()).contains(childToFind);
+  }
+
+
+
+  /* Check if a given folder contains another folder that in turn contains a given file */
+  private static boolean folderContainsFolderAndFile(final File f, final String childFolder, final String child) {
+    if (folderContains(f, childFolder)) {
+      final File possibleParent = new File(f, childFolder);
+      if (folderContains(possibleParent, child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+}

--- a/src/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/games/strategy/engine/ClientFileSystemHelper.java
@@ -57,7 +57,7 @@ public final class ClientFileSystemHelper {
     // TODO: This is begging for trouble since we call ClientFileSystem during the construction of
     // ClientContext. Though, we will at this point already have parsed the game engine version, so it is okay (but brittle)
     EngineVersion engine = ClientContext.engineVersion();
-    Version version = engine.getVersion();
+    Version version = engine.getCompatabilityVersion();
 
     return "triplea_" + version.toStringFull("_") + ".jar!";
   }

--- a/src/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/games/strategy/engine/ClientFileSystemHelper.java
@@ -57,7 +57,7 @@ public final class ClientFileSystemHelper {
     // TODO: This is begging for trouble since we call ClientFileSystem during the construction of
     // ClientContext. Though, we will at this point already have parsed the game engine version, so it is okay (but brittle)
     EngineVersion engine = ClientContext.engineVersion();
-    Version version = engine.getCompatabilityVersion();
+    Version version = engine.getVersion();
 
     return "triplea_" + version.toStringFull("_") + ".jar!";
   }

--- a/src/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/games/strategy/engine/ClientFileSystemHelper.java
@@ -5,8 +5,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.GameRunner;
@@ -32,12 +30,8 @@ public final class ClientFileSystemHelper {
       return getRootFolderRelativeToJar(fileName, tripleaJarName);
     }
 
-//    final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
-    if (fileName.contains("triplea_") && fileName.contains(".jar!")) {
-      Pattern pattern = Pattern.compile("triplea_.*\\.jar!");
-      Matcher matcher = pattern.matcher(fileName);
-
-      String tripleaJarNameWithEngineVersion =   matcher.group();
+    final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
+    if (fileName.contains("triplea_"+ tripleaJarNameWithEngineVersion + ".jar!")) {
       return getRootFolderRelativeToJar(fileName, tripleaJarNameWithEngineVersion);
     }
 

--- a/src/games/strategy/engine/EngineVersion.java
+++ b/src/games/strategy/engine/EngineVersion.java
@@ -1,7 +1,33 @@
 package games.strategy.engine;
 
+import games.strategy.engine.config.GameEngineProperty;
+import games.strategy.engine.config.PropertyReader;
 import games.strategy.util.Version;
 
 public class EngineVersion {
-  public static final Version VERSION = new Version(1, 8, 0, 9);
+  private final Version version;
+  private final String exactVersion;
+
+  public EngineVersion(PropertyReader propertyReader) {
+    exactVersion = propertyReader.readProperty(GameEngineProperty.ENGINE_VERSION);
+    version = new Version(exactVersion);
+  }
+
+
+  /**
+   * @return the game engine 'Version' used for in-game compatibility checks.
+   */
+  public Version getVersion() {
+    return version;
+  }
+
+
+  /**
+   * Intended for use when displaying the game engine version to users.
+   *
+   * @return the full non-truncated game engine version String, as found in the game engine configuration
+   */
+  public String getExactVersion() {
+    return exactVersion;
+  }
 }

--- a/src/games/strategy/engine/EngineVersion.java
+++ b/src/games/strategy/engine/EngineVersion.java
@@ -17,7 +17,7 @@ public class EngineVersion {
   /**
    * @return the game engine 'Version' used for in-game compatibility checks.
    */
-  public Version getVersion() {
+  public Version getCompatabilityVersion() {
     return version;
   }
 
@@ -30,4 +30,5 @@ public class EngineVersion {
   public String getExactVersion() {
     return exactVersion;
   }
+
 }

--- a/src/games/strategy/engine/EngineVersion.java
+++ b/src/games/strategy/engine/EngineVersion.java
@@ -31,4 +31,9 @@ public class EngineVersion {
     return exactVersion;
   }
 
+  @Override
+  public String toString() {
+    return getVersion().toString();
+  }
+
 }

--- a/src/games/strategy/engine/EngineVersion.java
+++ b/src/games/strategy/engine/EngineVersion.java
@@ -17,7 +17,7 @@ public class EngineVersion {
   /**
    * @return the game engine 'Version' used for in-game compatibility checks.
    */
-  public Version getCompatabilityVersion() {
+  public Version getVersion() {
     return version;
   }
 
@@ -27,7 +27,7 @@ public class EngineVersion {
    *
    * @return the full non-truncated game engine version String, as found in the game engine configuration
    */
-  public String getExactVersion() {
+  public String getFullVersion() {
     return exactVersion;
   }
 

--- a/src/games/strategy/engine/config/GameEngineProperty.java
+++ b/src/games/strategy/engine/config/GameEngineProperty.java
@@ -1,0 +1,17 @@
+package games.strategy.engine.config;
+
+public final class GameEngineProperty {
+
+  public static final GameEngineProperty MAP_LISTING_SOURCE_FILE = new GameEngineProperty("Map_List_File");
+
+
+  private final String value;
+  private GameEngineProperty(String value) {
+    this.value = value;
+  }
+  @Override
+  public String toString() {
+    return value;
+  }
+
+}

--- a/src/games/strategy/engine/config/GameEngineProperty.java
+++ b/src/games/strategy/engine/config/GameEngineProperty.java
@@ -1,8 +1,8 @@
 package games.strategy.engine.config;
 
 public final class GameEngineProperty {
-
   public static final GameEngineProperty MAP_LISTING_SOURCE_FILE = new GameEngineProperty("Map_List_File");
+  public static final GameEngineProperty ENGINE_VERSION = new GameEngineProperty("engine_version");
 
 
   private final String value;

--- a/src/games/strategy/engine/config/GameEngineProperty.java
+++ b/src/games/strategy/engine/config/GameEngineProperty.java
@@ -1,14 +1,14 @@
 package games.strategy.engine.config;
 
-public final class GameEngineProperty {
-  public static final GameEngineProperty MAP_LISTING_SOURCE_FILE = new GameEngineProperty("Map_List_File");
-  public static final GameEngineProperty ENGINE_VERSION = new GameEngineProperty("engine_version");
-
+public enum GameEngineProperty {
+  MAP_LISTING_SOURCE_FILE("Map_List_File"), ENGINE_VERSION("engine_version");
 
   private final String value;
-  private GameEngineProperty(String value) {
+
+  private GameEngineProperty(final String value) {
     this.value = value;
   }
+
   @Override
   public String toString() {
     return value;

--- a/src/games/strategy/engine/config/GameEnginePropertyFileReader.java
+++ b/src/games/strategy/engine/config/GameEnginePropertyFileReader.java
@@ -8,8 +8,7 @@ import java.util.Properties;
 
 import com.google.common.base.Throwables;
 
-import games.strategy.engine.ClientContext;
-import games.strategy.engine.framework.GameRunner2;
+import games.strategy.engine.ClientFileSystemHelper;
 
 /**
  * Reads property values from the game engine configuration file.
@@ -21,7 +20,7 @@ public class GameEnginePropertyFileReader implements PropertyReader {
   private final File propertyFile;
 
   public GameEnginePropertyFileReader() {
-    this(new File(ClientContext.getRootFolder(), GAME_ENGINE_PROPERTY_FILE));
+    this(new File(ClientFileSystemHelper.getRootFolder(), GAME_ENGINE_PROPERTY_FILE));
   }
 
   /** This constructor here for testing purposes, use the simple no-arg constructor instead */
@@ -48,7 +47,7 @@ public class GameEnginePropertyFileReader implements PropertyReader {
   }
 
   public static String getConfigFilePath() {
-    File f = new File(ClientContext.getRootFolder(), GAME_ENGINE_PROPERTY_FILE);
+    File f = new File(ClientFileSystemHelper.getRootFolder(), GAME_ENGINE_PROPERTY_FILE);
     return f.getAbsolutePath();
   }
 }

--- a/src/games/strategy/engine/config/GameEnginePropertyFileReader.java
+++ b/src/games/strategy/engine/config/GameEnginePropertyFileReader.java
@@ -8,6 +8,7 @@ import java.util.Properties;
 
 import com.google.common.base.Throwables;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner2;
 
 /**
@@ -20,7 +21,7 @@ public class GameEnginePropertyFileReader implements PropertyReader {
   private final File propertyFile;
 
   public GameEnginePropertyFileReader() {
-    this(new File(GameRunner2.getRootFolder(), GAME_ENGINE_PROPERTY_FILE));
+    this(new File(ClientContext.getRootFolder(), GAME_ENGINE_PROPERTY_FILE));
   }
 
   /** This constructor here for testing purposes, use the simple no-arg constructor instead */
@@ -47,7 +48,7 @@ public class GameEnginePropertyFileReader implements PropertyReader {
   }
 
   public static String getConfigFilePath() {
-    File f = new File(GameRunner2.getRootFolder(), GAME_ENGINE_PROPERTY_FILE);
+    File f = new File(ClientContext.getRootFolder(), GAME_ENGINE_PROPERTY_FILE);
     return f.getAbsolutePath();
   }
 }

--- a/src/games/strategy/engine/config/GameEnginePropertyFileReader.java
+++ b/src/games/strategy/engine/config/GameEnginePropertyFileReader.java
@@ -1,0 +1,53 @@
+package games.strategy.engine.config;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Properties;
+
+import com.google.common.base.Throwables;
+
+import games.strategy.engine.framework.GameRunner2;
+
+/**
+ * Reads property values from the game engine configuration file.
+ * @see PropertyReader for a complete listing of property keys
+ */
+public class GameEnginePropertyFileReader implements PropertyReader {
+
+  private static final String GAME_ENGINE_PROPERTY_FILE =  "game_engine.properties";
+  private final File propertyFile;
+
+  public GameEnginePropertyFileReader() {
+    this(new File(GameRunner2.getRootFolder(), GAME_ENGINE_PROPERTY_FILE));
+  }
+
+  /** This constructor here for testing purposes, use the simple no-arg constructor instead */
+  protected GameEnginePropertyFileReader(File propertyFile) {
+    this.propertyFile = propertyFile;
+  }
+
+  @Override
+  public String readProperty(GameEngineProperty propertyKey) {
+    try (FileInputStream inputStream = new FileInputStream(propertyFile)) {
+      Properties props = new Properties();
+      props.load(inputStream);
+
+      if(!props.containsKey(propertyKey.toString())) {
+        throw new PropertyNotFoundException(propertyKey);
+      } else {
+        return props.getProperty(propertyKey.toString()).trim();
+      }
+    } catch (FileNotFoundException e) {
+      throw Throwables.propagate(e);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to read propertyFile: " + propertyFile.getAbsolutePath(), e);
+    }
+  }
+
+  public static String getConfigFilePath() {
+    File f = new File(GameRunner2.getRootFolder(), GAME_ENGINE_PROPERTY_FILE);
+    return f.getAbsolutePath();
+  }
+}

--- a/src/games/strategy/engine/config/GameEnginePropertyFileReader.java
+++ b/src/games/strategy/engine/config/GameEnginePropertyFileReader.java
@@ -20,7 +20,7 @@ public class GameEnginePropertyFileReader implements PropertyReader {
   private final File propertyFile;
 
   public GameEnginePropertyFileReader() {
-    this(new File(ClientFileSystemHelper.getRootFolder(), GAME_ENGINE_PROPERTY_FILE));
+    this(new File(GAME_ENGINE_PROPERTY_FILE));
   }
 
   /** This constructor here for testing purposes, use the simple no-arg constructor instead */

--- a/src/games/strategy/engine/config/PropertyNotFoundException.java
+++ b/src/games/strategy/engine/config/PropertyNotFoundException.java
@@ -1,0 +1,9 @@
+package games.strategy.engine.config;
+
+public class PropertyNotFoundException extends IllegalStateException {
+  private static final long serialVersionUID = -7834937010739816090L;
+
+  public PropertyNotFoundException(GameEngineProperty property) {
+    super("Could not find property: " + property.toString() + ", in game engine configuration file: "+ GameEnginePropertyFileReader.getConfigFilePath());
+  }
+}

--- a/src/games/strategy/engine/config/PropertyReader.java
+++ b/src/games/strategy/engine/config/PropertyReader.java
@@ -1,0 +1,5 @@
+package games.strategy.engine.config;
+
+public interface PropertyReader {
+  public String readProperty(GameEngineProperty propertyKey);
+}

--- a/src/games/strategy/engine/data/GameParser.java
+++ b/src/games/strategy/engine/data/GameParser.java
@@ -30,6 +30,7 @@ import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.data.properties.BooleanProperty;
 import games.strategy.engine.data.properties.ColorProperty;
@@ -190,7 +191,7 @@ public class GameParser {
     }
     final Version mapCompatibleWithTripleaVersion =
         new Version(((Element) minimumVersion).getAttribute("minimumVersion"));
-    if (mapCompatibleWithTripleaVersion.isGreaterThan(EngineVersion.VERSION, true)) {
+    if (mapCompatibleWithTripleaVersion.isGreaterThan(ClientContext.getInstance().engineVersion().getVersion(), true)) {
       throw new EngineVersionException("Trying to play a map made for a newer version of TripleA. Map named '"
           + data.getGameName() + "' requires at least TripleA version " + mapCompatibleWithTripleaVersion.toString());
     }

--- a/src/games/strategy/engine/data/GameParser.java
+++ b/src/games/strategy/engine/data/GameParser.java
@@ -191,7 +191,7 @@ public class GameParser {
     }
     final Version mapCompatibleWithTripleaVersion =
         new Version(((Element) minimumVersion).getAttribute("minimumVersion"));
-    if (mapCompatibleWithTripleaVersion.isGreaterThan(ClientContext.engineVersion().getVersion(), true)) {
+    if (mapCompatibleWithTripleaVersion.isGreaterThan(ClientContext.engineVersion().getCompatabilityVersion(), true)) {
       throw new EngineVersionException("Trying to play a map made for a newer version of TripleA. Map named '"
           + data.getGameName() + "' requires at least TripleA version " + mapCompatibleWithTripleaVersion.toString());
     }

--- a/src/games/strategy/engine/data/GameParser.java
+++ b/src/games/strategy/engine/data/GameParser.java
@@ -191,7 +191,7 @@ public class GameParser {
     }
     final Version mapCompatibleWithTripleaVersion =
         new Version(((Element) minimumVersion).getAttribute("minimumVersion"));
-    if (mapCompatibleWithTripleaVersion.isGreaterThan(ClientContext.getInstance().engineVersion().getVersion(), true)) {
+    if (mapCompatibleWithTripleaVersion.isGreaterThan(ClientContext.engineVersion().getVersion(), true)) {
       throw new EngineVersionException("Trying to play a map made for a newer version of TripleA. Map named '"
           + data.getGameName() + "' requires at least TripleA version " + mapCompatibleWithTripleaVersion.toString());
     }

--- a/src/games/strategy/engine/data/GameParser.java
+++ b/src/games/strategy/engine/data/GameParser.java
@@ -191,7 +191,7 @@ public class GameParser {
     }
     final Version mapCompatibleWithTripleaVersion =
         new Version(((Element) minimumVersion).getAttribute("minimumVersion"));
-    if (mapCompatibleWithTripleaVersion.isGreaterThan(ClientContext.engineVersion().getCompatabilityVersion(), true)) {
+    if (mapCompatibleWithTripleaVersion.isGreaterThan(ClientContext.engineVersion().getVersion(), true)) {
       throw new EngineVersionException("Trying to play a map made for a newer version of TripleA. Map named '"
           + data.getGameName() + "' requires at least TripleA version " + mapCompatibleWithTripleaVersion.toString());
     }

--- a/src/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/games/strategy/engine/data/export/GameDataExporter.java
@@ -68,7 +68,7 @@ public class GameDataExporter {
     // Since we do not keep the minimum version info in the game data, just put the current version of triplea here
     // (since we have
     // successfully started the map, it is basically correct)
-    xmlfile.append("    <triplea minimumVersion=\"" + ClientContext.engineVersion().getVersion() + "\"/>\n");
+    xmlfile.append("    <triplea minimumVersion=\"" + ClientContext.engineVersion().getCompatabilityVersion() + "\"/>\n");
   }
 
   private void diceSides(final GameData data) {

--- a/src/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/games/strategy/engine/data/export/GameDataExporter.java
@@ -8,7 +8,6 @@ import java.util.Iterator;
 import java.util.Map;
 
 import games.strategy.engine.ClientContext;
-import games.strategy.engine.EngineVersion;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GameStep;
@@ -68,7 +67,7 @@ public class GameDataExporter {
     // Since we do not keep the minimum version info in the game data, just put the current version of triplea here
     // (since we have
     // successfully started the map, it is basically correct)
-    xmlfile.append("    <triplea minimumVersion=\"" + ClientContext.engineVersion().getVersion() + "\"/>\n");
+    xmlfile.append("    <triplea minimumVersion=\"" + ClientContext.engineVersion() + "\"/>\n");
   }
 
   private void diceSides(final GameData data) {

--- a/src/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/games/strategy/engine/data/export/GameDataExporter.java
@@ -68,7 +68,7 @@ public class GameDataExporter {
     // Since we do not keep the minimum version info in the game data, just put the current version of triplea here
     // (since we have
     // successfully started the map, it is basically correct)
-    xmlfile.append("    <triplea minimumVersion=\"" + ClientContext.engineVersion().getCompatabilityVersion() + "\"/>\n");
+    xmlfile.append("    <triplea minimumVersion=\"" + ClientContext.engineVersion().getVersion() + "\"/>\n");
   }
 
   private void diceSides(final GameData data) {

--- a/src/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/games/strategy/engine/data/export/GameDataExporter.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameMap;
@@ -67,7 +68,7 @@ public class GameDataExporter {
     // Since we do not keep the minimum version info in the game data, just put the current version of triplea here
     // (since we have
     // successfully started the map, it is basically correct)
-    xmlfile.append("    <triplea minimumVersion=\"" + EngineVersion.VERSION + "\"/>\n");
+    xmlfile.append("    <triplea minimumVersion=\"" + ClientContext.getInstance().engineVersion().getVersion() + "\"/>\n");
   }
 
   private void diceSides(final GameData data) {

--- a/src/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/games/strategy/engine/data/export/GameDataExporter.java
@@ -68,7 +68,7 @@ public class GameDataExporter {
     // Since we do not keep the minimum version info in the game data, just put the current version of triplea here
     // (since we have
     // successfully started the map, it is basically correct)
-    xmlfile.append("    <triplea minimumVersion=\"" + ClientContext.getInstance().engineVersion().getVersion() + "\"/>\n");
+    xmlfile.append("    <triplea minimumVersion=\"" + ClientContext.engineVersion().getVersion() + "\"/>\n");
   }
 
   private void diceSides(final GameData data) {

--- a/src/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/src/games/strategy/engine/data/properties/DoubleProperty.java
@@ -5,7 +5,7 @@ import java.math.BigDecimal;
 
 import javax.swing.JComponent;
 
-import games.strategy.engine.framework.GameRunner2;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.ui.DoubleTextField;
 import games.strategy.ui.DoubleTextFieldChangeListener;
 
@@ -49,7 +49,7 @@ public class DoubleProperty extends AEditableProperty {
       // todo (kg) remove at a later point
       throw new RuntimeException(
           "Double and Number properties are no longer stored as Strings. You should delete your option cache, located at "
-              + new File(GameRunner2.getUserRootFolder(), "optionCache").toString());
+              + new File(ClientFileSystemHelper.getUserRootFolder(), "optionCache").toString());
     } else {
       m_value = roundToPlace((Double) value, m_places, BigDecimal.ROUND_FLOOR);
     }

--- a/src/games/strategy/engine/data/properties/NumberProperty.java
+++ b/src/games/strategy/engine/data/properties/NumberProperty.java
@@ -4,6 +4,7 @@ import java.io.File;
 
 import javax.swing.JComponent;
 
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.ui.IntTextField;
 import games.strategy.ui.IntTextFieldChangeListener;
@@ -40,7 +41,7 @@ public class NumberProperty extends AEditableProperty {
       // todo (kg) remove at a later point
       throw new RuntimeException(
           "Number properties are no longer stored as Strings. You should delete your option cache, located at "
-              + new File(GameRunner2.getUserRootFolder(), "optionCache").toString());
+              + new File(ClientFileSystemHelper.getUserRootFolder(), "optionCache").toString());
     } else {
       m_value = (Integer) value;
     }

--- a/src/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/src/games/strategy/engine/framework/EngineVersionProperties.java
@@ -30,6 +30,7 @@ import org.apache.commons.httpclient.HostConfiguration;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.net.DesktopUtilityBrowserLauncher;
 import games.strategy.util.Version;
@@ -51,11 +52,11 @@ public class EngineVersionProperties {
   }
 
   private EngineVersionProperties(final Properties props) {
-    m_latestVersionOut = new Version(props.getProperty("LATEST", EngineVersion.VERSION.toStringFull(".")));
+    m_latestVersionOut = new Version(props.getProperty("LATEST", ClientContext.getInstance().engineVersion().getVersion().toStringFull(".")));
     final Version showUpdatesFromTemp =
-        new Version(props.getProperty("SHOW_FROM", EngineVersion.VERSION.toStringFull(".")));
+        new Version(props.getProperty("SHOW_FROM", ClientContext.getInstance().engineVersion().getVersion().toStringFull(".")));
     m_showUpdatesFrom =
-        (EngineVersion.VERSION.isLessThan(showUpdatesFromTemp, false) ? EngineVersion.VERSION : showUpdatesFromTemp);
+        (ClientContext.getInstance().engineVersion().getVersion().isLessThan(showUpdatesFromTemp, false) ? ClientContext.getInstance().engineVersion().getVersion() : showUpdatesFromTemp);
     m_link = props.getProperty("LINK", "http://triplea.sourceforge.net/");
     m_linkAlt = props.getProperty("LINK_ALT", "http://sourceforge.net/projects/tripleamaps/files/TripleA/stable/");
     m_changelogLink = props.getProperty("CHANGELOG",
@@ -184,7 +185,7 @@ public class EngineVersionProperties {
   private String getOutOfDateMessage() {
     final StringBuilder text = new StringBuilder("<html>");
     text.append("<h2>A new version of TripleA is out.  Please Update TripleA!</h2>");
-    text.append("<br />Your current version: " + EngineVersion.VERSION);
+    text.append("<br />Your current version: " + ClientContext.getInstance().engineVersion().getVersion());
     text.append("<br />Latest version available for download: " + getLatestVersionOut());
     text.append("<br /><br />Click to download: <a class=\"external\" href=\"" + getLinkToDownloadLatestVersion()
         + "\">" + getLinkToDownloadLatestVersion() + "</a>");
@@ -204,7 +205,7 @@ public class EngineVersionProperties {
     versions.addAll(getReleaseNotes().keySet());
     Collections.sort(versions, Version.getHighestToLowestComparator(false));
     for (final Version v : versions) {
-      if (showAll || EngineVersion.VERSION.isLessThan(v, false)) {
+      if (showAll || ClientContext.getInstance().engineVersion().getVersion().isLessThan(v, false)) {
         text.append("<br />" + getReleaseNotes().get(v) + "<br /><br />");
       }
     }
@@ -216,7 +217,7 @@ public class EngineVersionProperties {
 
   public Component getCurrentFeaturesComponent() {
     final JPanel panel = new JPanel(new BorderLayout());
-    final JEditorPane intro = new JEditorPane("text/html", "<html><h2>What is new in version " + EngineVersion.VERSION
+    final JEditorPane intro = new JEditorPane("text/html", "<html><h2>What is new in version " + ClientContext.getInstance().engineVersion().getVersion()
         + "</h2><br />" + "Please visit our forum to get involved: "
         + "<a class=\"external\" href=\"http://triplea.sourceforge.net/mywiki/Forum\">http://triplea.sourceforge.net/mywiki/Forum</a><br /><br /></html>");
     intro.setEditable(false);

--- a/src/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/src/games/strategy/engine/framework/EngineVersionProperties.java
@@ -52,11 +52,11 @@ public class EngineVersionProperties {
   }
 
   private EngineVersionProperties(final Properties props) {
-    m_latestVersionOut = new Version(props.getProperty("LATEST", ClientContext.engineVersion().getVersion().toStringFull(".")));
+    m_latestVersionOut = new Version(props.getProperty("LATEST", ClientContext.engineVersion().getCompatabilityVersion().toStringFull(".")));
     final Version showUpdatesFromTemp =
-        new Version(props.getProperty("SHOW_FROM", ClientContext.engineVersion().getVersion().toStringFull(".")));
+        new Version(props.getProperty("SHOW_FROM", ClientContext.engineVersion().getCompatabilityVersion().toStringFull(".")));
     m_showUpdatesFrom =
-        (ClientContext.engineVersion().getVersion().isLessThan(showUpdatesFromTemp, false) ? ClientContext.engineVersion().getVersion() : showUpdatesFromTemp);
+        (ClientContext.engineVersion().getCompatabilityVersion().isLessThan(showUpdatesFromTemp, false) ? ClientContext.engineVersion().getCompatabilityVersion() : showUpdatesFromTemp);
     m_link = props.getProperty("LINK", "http://triplea.sourceforge.net/");
     m_linkAlt = props.getProperty("LINK_ALT", "http://sourceforge.net/projects/tripleamaps/files/TripleA/stable/");
     m_changelogLink = props.getProperty("CHANGELOG",
@@ -185,7 +185,7 @@ public class EngineVersionProperties {
   private String getOutOfDateMessage() {
     final StringBuilder text = new StringBuilder("<html>");
     text.append("<h2>A new version of TripleA is out.  Please Update TripleA!</h2>");
-    text.append("<br />Your current version: " + ClientContext.engineVersion().getVersion());
+    text.append("<br />Your current version: " + ClientContext.engineVersion().getCompatabilityVersion());
     text.append("<br />Latest version available for download: " + getLatestVersionOut());
     text.append("<br /><br />Click to download: <a class=\"external\" href=\"" + getLinkToDownloadLatestVersion()
         + "\">" + getLinkToDownloadLatestVersion() + "</a>");
@@ -205,7 +205,7 @@ public class EngineVersionProperties {
     versions.addAll(getReleaseNotes().keySet());
     Collections.sort(versions, Version.getHighestToLowestComparator(false));
     for (final Version v : versions) {
-      if (showAll || ClientContext.engineVersion().getVersion().isLessThan(v, false)) {
+      if (showAll || ClientContext.engineVersion().getCompatabilityVersion().isLessThan(v, false)) {
         text.append("<br />" + getReleaseNotes().get(v) + "<br /><br />");
       }
     }
@@ -217,7 +217,7 @@ public class EngineVersionProperties {
 
   public Component getCurrentFeaturesComponent() {
     final JPanel panel = new JPanel(new BorderLayout());
-    final JEditorPane intro = new JEditorPane("text/html", "<html><h2>What is new in version " + ClientContext.engineVersion().getVersion()
+    final JEditorPane intro = new JEditorPane("text/html", "<html><h2>What is new in version " + ClientContext.engineVersion().getCompatabilityVersion()
         + "</h2><br />" + "Please visit our forum to get involved: "
         + "<a class=\"external\" href=\"http://triplea.sourceforge.net/mywiki/Forum\">http://triplea.sourceforge.net/mywiki/Forum</a><br /><br /></html>");
     intro.setEditable(false);

--- a/src/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/src/games/strategy/engine/framework/EngineVersionProperties.java
@@ -52,11 +52,11 @@ public class EngineVersionProperties {
   }
 
   private EngineVersionProperties(final Properties props) {
-    m_latestVersionOut = new Version(props.getProperty("LATEST", ClientContext.engineVersion().getCompatabilityVersion().toStringFull(".")));
+    m_latestVersionOut = new Version(props.getProperty("LATEST", ClientContext.engineVersion().getVersion().toStringFull(".")));
     final Version showUpdatesFromTemp =
-        new Version(props.getProperty("SHOW_FROM", ClientContext.engineVersion().getCompatabilityVersion().toStringFull(".")));
+        new Version(props.getProperty("SHOW_FROM", ClientContext.engineVersion().getVersion().toStringFull(".")));
     m_showUpdatesFrom =
-        (ClientContext.engineVersion().getCompatabilityVersion().isLessThan(showUpdatesFromTemp, false) ? ClientContext.engineVersion().getCompatabilityVersion() : showUpdatesFromTemp);
+        (ClientContext.engineVersion().getVersion().isLessThan(showUpdatesFromTemp, false) ? ClientContext.engineVersion().getVersion() : showUpdatesFromTemp);
     m_link = props.getProperty("LINK", "http://triplea.sourceforge.net/");
     m_linkAlt = props.getProperty("LINK_ALT", "http://sourceforge.net/projects/tripleamaps/files/TripleA/stable/");
     m_changelogLink = props.getProperty("CHANGELOG",
@@ -185,7 +185,7 @@ public class EngineVersionProperties {
   private String getOutOfDateMessage() {
     final StringBuilder text = new StringBuilder("<html>");
     text.append("<h2>A new version of TripleA is out.  Please Update TripleA!</h2>");
-    text.append("<br />Your current version: " + ClientContext.engineVersion().getCompatabilityVersion());
+    text.append("<br />Your current version: " + ClientContext.engineVersion().getVersion());
     text.append("<br />Latest version available for download: " + getLatestVersionOut());
     text.append("<br /><br />Click to download: <a class=\"external\" href=\"" + getLinkToDownloadLatestVersion()
         + "\">" + getLinkToDownloadLatestVersion() + "</a>");
@@ -205,7 +205,7 @@ public class EngineVersionProperties {
     versions.addAll(getReleaseNotes().keySet());
     Collections.sort(versions, Version.getHighestToLowestComparator(false));
     for (final Version v : versions) {
-      if (showAll || ClientContext.engineVersion().getCompatabilityVersion().isLessThan(v, false)) {
+      if (showAll || ClientContext.engineVersion().getVersion().isLessThan(v, false)) {
         text.append("<br />" + getReleaseNotes().get(v) + "<br /><br />");
       }
     }
@@ -217,7 +217,7 @@ public class EngineVersionProperties {
 
   public Component getCurrentFeaturesComponent() {
     final JPanel panel = new JPanel(new BorderLayout());
-    final JEditorPane intro = new JEditorPane("text/html", "<html><h2>What is new in version " + ClientContext.engineVersion().getCompatabilityVersion()
+    final JEditorPane intro = new JEditorPane("text/html", "<html><h2>What is new in version " + ClientContext.engineVersion().getVersion()
         + "</h2><br />" + "Please visit our forum to get involved: "
         + "<a class=\"external\" href=\"http://triplea.sourceforge.net/mywiki/Forum\">http://triplea.sourceforge.net/mywiki/Forum</a><br /><br /></html>");
     intro.setEditable(false);

--- a/src/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/src/games/strategy/engine/framework/EngineVersionProperties.java
@@ -52,11 +52,11 @@ public class EngineVersionProperties {
   }
 
   private EngineVersionProperties(final Properties props) {
-    m_latestVersionOut = new Version(props.getProperty("LATEST", ClientContext.getInstance().engineVersion().getVersion().toStringFull(".")));
+    m_latestVersionOut = new Version(props.getProperty("LATEST", ClientContext.engineVersion().getVersion().toStringFull(".")));
     final Version showUpdatesFromTemp =
-        new Version(props.getProperty("SHOW_FROM", ClientContext.getInstance().engineVersion().getVersion().toStringFull(".")));
+        new Version(props.getProperty("SHOW_FROM", ClientContext.engineVersion().getVersion().toStringFull(".")));
     m_showUpdatesFrom =
-        (ClientContext.getInstance().engineVersion().getVersion().isLessThan(showUpdatesFromTemp, false) ? ClientContext.getInstance().engineVersion().getVersion() : showUpdatesFromTemp);
+        (ClientContext.engineVersion().getVersion().isLessThan(showUpdatesFromTemp, false) ? ClientContext.engineVersion().getVersion() : showUpdatesFromTemp);
     m_link = props.getProperty("LINK", "http://triplea.sourceforge.net/");
     m_linkAlt = props.getProperty("LINK_ALT", "http://sourceforge.net/projects/tripleamaps/files/TripleA/stable/");
     m_changelogLink = props.getProperty("CHANGELOG",
@@ -185,7 +185,7 @@ public class EngineVersionProperties {
   private String getOutOfDateMessage() {
     final StringBuilder text = new StringBuilder("<html>");
     text.append("<h2>A new version of TripleA is out.  Please Update TripleA!</h2>");
-    text.append("<br />Your current version: " + ClientContext.getInstance().engineVersion().getVersion());
+    text.append("<br />Your current version: " + ClientContext.engineVersion().getVersion());
     text.append("<br />Latest version available for download: " + getLatestVersionOut());
     text.append("<br /><br />Click to download: <a class=\"external\" href=\"" + getLinkToDownloadLatestVersion()
         + "\">" + getLinkToDownloadLatestVersion() + "</a>");
@@ -205,7 +205,7 @@ public class EngineVersionProperties {
     versions.addAll(getReleaseNotes().keySet());
     Collections.sort(versions, Version.getHighestToLowestComparator(false));
     for (final Version v : versions) {
-      if (showAll || ClientContext.getInstance().engineVersion().getVersion().isLessThan(v, false)) {
+      if (showAll || ClientContext.engineVersion().getVersion().isLessThan(v, false)) {
         text.append("<br />" + getReleaseNotes().get(v) + "<br /><br />");
       }
     }
@@ -217,7 +217,7 @@ public class EngineVersionProperties {
 
   public Component getCurrentFeaturesComponent() {
     final JPanel panel = new JPanel(new BorderLayout());
-    final JEditorPane intro = new JEditorPane("text/html", "<html><h2>What is new in version " + ClientContext.getInstance().engineVersion().getVersion()
+    final JEditorPane intro = new JEditorPane("text/html", "<html><h2>What is new in version " + ClientContext.engineVersion().getVersion()
         + "</h2><br />" + "Please visit our forum to get involved: "
         + "<a class=\"external\" href=\"http://triplea.sourceforge.net/mywiki/Forum\">http://triplea.sourceforge.net/mywiki/Forum</a><br /><br /></html>");
     intro.setEditable(false);

--- a/src/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/src/games/strategy/engine/framework/EngineVersionProperties.java
@@ -185,7 +185,7 @@ public class EngineVersionProperties {
   private String getOutOfDateMessage() {
     final StringBuilder text = new StringBuilder("<html>");
     text.append("<h2>A new version of TripleA is out.  Please Update TripleA!</h2>");
-    text.append("<br />Your current version: " + ClientContext.engineVersion().getVersion());
+    text.append("<br />Your current version: " + ClientContext.engineVersion().getFullVersion());
     text.append("<br />Latest version available for download: " + getLatestVersionOut());
     text.append("<br /><br />Click to download: <a class=\"external\" href=\"" + getLinkToDownloadLatestVersion()
         + "\">" + getLinkToDownloadLatestVersion() + "</a>");
@@ -217,7 +217,7 @@ public class EngineVersionProperties {
 
   public Component getCurrentFeaturesComponent() {
     final JPanel panel = new JPanel(new BorderLayout());
-    final JEditorPane intro = new JEditorPane("text/html", "<html><h2>What is new in version " + ClientContext.engineVersion().getVersion()
+    final JEditorPane intro = new JEditorPane("text/html", "<html><h2>What is new in version " + ClientContext.engineVersion()
         + "</h2><br />" + "Please visit our forum to get involved: "
         + "<a class=\"external\" href=\"http://triplea.sourceforge.net/mywiki/Forum\">http://triplea.sourceforge.net/mywiki/Forum</a><br /><br /></html>");
     intro.setEditable(false);

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -19,6 +19,7 @@ import java.util.zip.GZIPOutputStream;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.delegate.IDelegate;
@@ -62,17 +63,17 @@ public class GameDataManager {
     try {
       final Version readVersion = (Version) input.readObject();
       final boolean headless = HeadlessGameServer.headless();
-      if (!readVersion.equals(EngineVersion.VERSION, true)) {
+      if (!readVersion.equals(ClientContext.getInstance().engineVersion().getVersion(), true)) {
         // a hack for now, but a headless server should not try to open any savegame that is not its version
         if (headless) {
-          final String message = "Incompatible game save, we are: " + EngineVersion.VERSION
+          final String message = "Incompatible game save, we are: " + ClientContext.getInstance().engineVersion().getVersion()
               + "  Trying to load game created with: " + readVersion;
           HeadlessGameServer.sendChat(message);
           System.out.println(message);
           return null;
         }
         final String error = "<html>Incompatible engine versions, and no old engine found. We are: "
-            + EngineVersion.VERSION + " . Trying to load game created with: " + readVersion
+            + ClientContext.getInstance().engineVersion().getVersion() + " . Trying to load game created with: " + readVersion
             + "<br>To download the latest version of TripleA, Please visit http://triplea.sourceforge.net/</html>";
         if (savegamePath == null) {
           throw new IOException(error);
@@ -83,7 +84,7 @@ public class GameDataManager {
         try {
           final String newClassPath = TripleAProcessRunner.findOldJar(readVersion, true);
           // ask user if we really want to do this?
-          final String messageString = "<html>This TripleA engine is version " + EngineVersion.VERSION.toString()
+          final String messageString = "<html>This TripleA engine is version " + ClientContext.getInstance().engineVersion().getVersion().toString()
               + " and you are trying to open a savegame made with version " + readVersion.toString()
               + "<br>However, this TripleA can not open any savegame made by any engine other than engines with the same first three version numbers as it (x_x_x_x)."
               + "<br><br>TripleA now comes with older engines included with it, and has found the engine to run this savegame. This is a new feature and is in 'beta' stage."
@@ -112,23 +113,23 @@ public class GameDataManager {
             System.exit(0);
           }
         } catch (final IOException e) {
-          if (GameRunner2.areWeOldExtraJar()) {
+          if (ClientContext.areWeOldExtraJar()) {
             throw new IOException("<html>Please run the default TripleA and try to open this game again. "
                 + "<br>This TripleA engine is old and kept only for backwards compatibility and can only open savegames created by engines with these first 3 version digits: "
-                + EngineVersion.VERSION.toStringFull("_", true) + "</html>");
+                + ClientContext.getInstance().engineVersion().getVersion().toStringFull("_", true) + "</html>");
           } else {
             throw new IOException(error);
           }
         }
         return null;
-      } else if (!headless && readVersion.isGreaterThan(EngineVersion.VERSION, false)) {
+      } else if (!headless && readVersion.isGreaterThan(ClientContext.getInstance().engineVersion().getVersion(), false)) {
         // we can still load it because first 3 numbers of the version are the same, however this save was made by a
         // newer engine, so prompt
         // the user to upgrade
         final String messageString =
             "<html>Your TripleA engine is OUT OF DATE.  This save was made by a newer version of TripleA."
                 + "<br>However, because the first 3 version numbers are the same as your current version, we can still open the savegame."
-                + "<br><br>This TripleA engine is version " + EngineVersion.VERSION.toStringFull("_")
+                + "<br><br>This TripleA engine is version " + ClientContext.getInstance().engineVersion().getVersion().toStringFull("_")
                 + " and you are trying to open a savegame made with version " + readVersion.toStringFull("_")
                 + "<br><br>To download the latest version of TripleA, Please visit http://triplea.sourceforge.net/"
                 + "<br><br>It is recommended that you upgrade to the latest version of TripleA before playing this savegame."
@@ -167,8 +168,8 @@ public class GameDataManager {
      * example1:
      * final Version v1610 = new Version(1, 6, 1, 0);
      * final Version v1620 = new Version(1, 6, 2, 0);
-     * if (originalEngineVersion.equals(v1610, false) && EngineVersion.VERSION.isGreaterThan(v1610, false) &&
-     * EngineVersion.VERSION.isLessThan(v1620, true))
+     * if (originalEngineVersion.equals(v1610, false) && ClientContext.getInstance().engineVersion().getVersion().isGreaterThan(v1610, false) &&
+     * ClientContext.getInstance().engineVersion().getVersion().isLessThan(v1620, true))
      * {
      * // if original save was done under 1.6.1.0, and new engine is greater than 1.6.1.0 and less than 1.6.2.0
      * try
@@ -226,7 +227,7 @@ public class GameDataManager {
     // write internally first in case of error
     final ByteArrayOutputStream bytes = new ByteArrayOutputStream(25000);
     final ObjectOutputStream outStream = new ObjectOutputStream(bytes);
-    outStream.writeObject(games.strategy.engine.EngineVersion.VERSION);
+    outStream.writeObject(games.strategy.engine.ClientContext.getInstance().engineVersion().getVersion());
     data.acquireReadLock();
     try {
       outStream.writeObject(data);

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -64,17 +64,17 @@ public class GameDataManager {
     try {
       final Version readVersion = (Version) input.readObject();
       final boolean headless = HeadlessGameServer.headless();
-      if (!readVersion.equals(ClientContext.getInstance().engineVersion().getVersion(), true)) {
+      if (!readVersion.equals(ClientContext.engineVersion().getVersion(), true)) {
         // a hack for now, but a headless server should not try to open any savegame that is not its version
         if (headless) {
-          final String message = "Incompatible game save, we are: " + ClientContext.getInstance().engineVersion().getVersion()
+          final String message = "Incompatible game save, we are: " + ClientContext.engineVersion().getVersion()
               + "  Trying to load game created with: " + readVersion;
           HeadlessGameServer.sendChat(message);
           System.out.println(message);
           return null;
         }
         final String error = "<html>Incompatible engine versions, and no old engine found. We are: "
-            + ClientContext.getInstance().engineVersion().getVersion() + " . Trying to load game created with: " + readVersion
+            + ClientContext.engineVersion().getVersion() + " . Trying to load game created with: " + readVersion
             + "<br>To download the latest version of TripleA, Please visit http://triplea.sourceforge.net/</html>";
         if (savegamePath == null) {
           throw new IOException(error);
@@ -85,7 +85,7 @@ public class GameDataManager {
         try {
           final String newClassPath = TripleAProcessRunner.findOldJar(readVersion, true);
           // ask user if we really want to do this?
-          final String messageString = "<html>This TripleA engine is version " + ClientContext.getInstance().engineVersion().getVersion().toString()
+          final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getVersion().toString()
               + " and you are trying to open a savegame made with version " + readVersion.toString()
               + "<br>However, this TripleA can not open any savegame made by any engine other than engines with the same first three version numbers as it (x_x_x_x)."
               + "<br><br>TripleA now comes with older engines included with it, and has found the engine to run this savegame. This is a new feature and is in 'beta' stage."
@@ -117,20 +117,20 @@ public class GameDataManager {
           if (ClientFileSystemHelper.areWeOldExtraJar()) {
             throw new IOException("<html>Please run the default TripleA and try to open this game again. "
                 + "<br>This TripleA engine is old and kept only for backwards compatibility and can only open savegames created by engines with these first 3 version digits: "
-                + ClientContext.getInstance().engineVersion().getVersion().toStringFull("_", true) + "</html>");
+                + ClientContext.engineVersion().getVersion().toStringFull("_", true) + "</html>");
           } else {
             throw new IOException(error);
           }
         }
         return null;
-      } else if (!headless && readVersion.isGreaterThan(ClientContext.getInstance().engineVersion().getVersion(), false)) {
+      } else if (!headless && readVersion.isGreaterThan(ClientContext.engineVersion().getVersion(), false)) {
         // we can still load it because first 3 numbers of the version are the same, however this save was made by a
         // newer engine, so prompt
         // the user to upgrade
         final String messageString =
             "<html>Your TripleA engine is OUT OF DATE.  This save was made by a newer version of TripleA."
                 + "<br>However, because the first 3 version numbers are the same as your current version, we can still open the savegame."
-                + "<br><br>This TripleA engine is version " + ClientContext.getInstance().engineVersion().getVersion().toStringFull("_")
+                + "<br><br>This TripleA engine is version " + ClientContext.engineVersion().getVersion().toStringFull("_")
                 + " and you are trying to open a savegame made with version " + readVersion.toStringFull("_")
                 + "<br><br>To download the latest version of TripleA, Please visit http://triplea.sourceforge.net/"
                 + "<br><br>It is recommended that you upgrade to the latest version of TripleA before playing this savegame."
@@ -169,8 +169,8 @@ public class GameDataManager {
      * example1:
      * final Version v1610 = new Version(1, 6, 1, 0);
      * final Version v1620 = new Version(1, 6, 2, 0);
-     * if (originalEngineVersion.equals(v1610, false) && ClientContext.getInstance().engineVersion().getVersion().isGreaterThan(v1610, false) &&
-     * ClientContext.getInstance().engineVersion().getVersion().isLessThan(v1620, true))
+     * if (originalEngineVersion.equals(v1610, false) && ClientContext.engineVersion().getVersion().isGreaterThan(v1610, false) &&
+     * ClientContext.engineVersion().getVersion().isLessThan(v1620, true))
      * {
      * // if original save was done under 1.6.1.0, and new engine is greater than 1.6.1.0 and less than 1.6.2.0
      * try
@@ -228,7 +228,7 @@ public class GameDataManager {
     // write internally first in case of error
     final ByteArrayOutputStream bytes = new ByteArrayOutputStream(25000);
     final ObjectOutputStream outStream = new ObjectOutputStream(bytes);
-    outStream.writeObject(games.strategy.engine.ClientContext.getInstance().engineVersion().getVersion());
+    outStream.writeObject(games.strategy.engine.ClientContext.engineVersion().getVersion());
     data.acquireReadLock();
     try {
       outStream.writeObject(data);

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -21,7 +21,6 @@ import javax.swing.JOptionPane;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.EngineVersion;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -85,7 +85,7 @@ public class GameDataManager {
         try {
           final String newClassPath = TripleAProcessRunner.findOldJar(readVersion, true);
           // ask user if we really want to do this?
-          final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getCompatabilityVersion().toString()
+          final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getCompatabilityVersion()
               + " and you are trying to open a savegame made with version " + readVersion.toString()
               + "<br>However, this TripleA can not open any savegame made by any engine other than engines with the same first three version numbers as it (x_x_x_x)."
               + "<br><br>TripleA now comes with older engines included with it, and has found the engine to run this savegame. This is a new feature and is in 'beta' stage."

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -20,6 +20,7 @@ import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.delegate.IDelegate;
@@ -113,7 +114,7 @@ public class GameDataManager {
             System.exit(0);
           }
         } catch (final IOException e) {
-          if (ClientContext.areWeOldExtraJar()) {
+          if (ClientFileSystemHelper.areWeOldExtraJar()) {
             throw new IOException("<html>Please run the default TripleA and try to open this game again. "
                 + "<br>This TripleA engine is old and kept only for backwards compatibility and can only open savegames created by engines with these first 3 version digits: "
                 + ClientContext.getInstance().engineVersion().getVersion().toStringFull("_", true) + "</html>");

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -64,17 +64,17 @@ public class GameDataManager {
     try {
       final Version readVersion = (Version) input.readObject();
       final boolean headless = HeadlessGameServer.headless();
-      if (!readVersion.equals(ClientContext.engineVersion().getVersion(), true)) {
+      if (!readVersion.equals(ClientContext.engineVersion().getCompatabilityVersion(), true)) {
         // a hack for now, but a headless server should not try to open any savegame that is not its version
         if (headless) {
-          final String message = "Incompatible game save, we are: " + ClientContext.engineVersion().getVersion()
+          final String message = "Incompatible game save, we are: " + ClientContext.engineVersion().getCompatabilityVersion()
               + "  Trying to load game created with: " + readVersion;
           HeadlessGameServer.sendChat(message);
           System.out.println(message);
           return null;
         }
         final String error = "<html>Incompatible engine versions, and no old engine found. We are: "
-            + ClientContext.engineVersion().getVersion() + " . Trying to load game created with: " + readVersion
+            + ClientContext.engineVersion().getCompatabilityVersion() + " . Trying to load game created with: " + readVersion
             + "<br>To download the latest version of TripleA, Please visit http://triplea.sourceforge.net/</html>";
         if (savegamePath == null) {
           throw new IOException(error);
@@ -85,7 +85,7 @@ public class GameDataManager {
         try {
           final String newClassPath = TripleAProcessRunner.findOldJar(readVersion, true);
           // ask user if we really want to do this?
-          final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getVersion().toString()
+          final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getCompatabilityVersion().toString()
               + " and you are trying to open a savegame made with version " + readVersion.toString()
               + "<br>However, this TripleA can not open any savegame made by any engine other than engines with the same first three version numbers as it (x_x_x_x)."
               + "<br><br>TripleA now comes with older engines included with it, and has found the engine to run this savegame. This is a new feature and is in 'beta' stage."
@@ -117,20 +117,20 @@ public class GameDataManager {
           if (ClientFileSystemHelper.areWeOldExtraJar()) {
             throw new IOException("<html>Please run the default TripleA and try to open this game again. "
                 + "<br>This TripleA engine is old and kept only for backwards compatibility and can only open savegames created by engines with these first 3 version digits: "
-                + ClientContext.engineVersion().getVersion().toStringFull("_", true) + "</html>");
+                + ClientContext.engineVersion().getCompatabilityVersion().toStringFull("_", true) + "</html>");
           } else {
             throw new IOException(error);
           }
         }
         return null;
-      } else if (!headless && readVersion.isGreaterThan(ClientContext.engineVersion().getVersion(), false)) {
+      } else if (!headless && readVersion.isGreaterThan(ClientContext.engineVersion().getCompatabilityVersion(), false)) {
         // we can still load it because first 3 numbers of the version are the same, however this save was made by a
         // newer engine, so prompt
         // the user to upgrade
         final String messageString =
             "<html>Your TripleA engine is OUT OF DATE.  This save was made by a newer version of TripleA."
                 + "<br>However, because the first 3 version numbers are the same as your current version, we can still open the savegame."
-                + "<br><br>This TripleA engine is version " + ClientContext.engineVersion().getVersion().toStringFull("_")
+                + "<br><br>This TripleA engine is version " + ClientContext.engineVersion().getCompatabilityVersion().toStringFull("_")
                 + " and you are trying to open a savegame made with version " + readVersion.toStringFull("_")
                 + "<br><br>To download the latest version of TripleA, Please visit http://triplea.sourceforge.net/"
                 + "<br><br>It is recommended that you upgrade to the latest version of TripleA before playing this savegame."
@@ -228,7 +228,7 @@ public class GameDataManager {
     // write internally first in case of error
     final ByteArrayOutputStream bytes = new ByteArrayOutputStream(25000);
     final ObjectOutputStream outStream = new ObjectOutputStream(bytes);
-    outStream.writeObject(games.strategy.engine.ClientContext.engineVersion().getVersion());
+    outStream.writeObject(games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion());
     data.acquireReadLock();
     try {
       outStream.writeObject(data);

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -64,17 +64,17 @@ public class GameDataManager {
     try {
       final Version readVersion = (Version) input.readObject();
       final boolean headless = HeadlessGameServer.headless();
-      if (!readVersion.equals(ClientContext.engineVersion().getCompatabilityVersion(), true)) {
+      if (!readVersion.equals(ClientContext.engineVersion().getVersion(), true)) {
         // a hack for now, but a headless server should not try to open any savegame that is not its version
         if (headless) {
-          final String message = "Incompatible game save, we are: " + ClientContext.engineVersion().getCompatabilityVersion()
+          final String message = "Incompatible game save, we are: " + ClientContext.engineVersion().getVersion()
               + "  Trying to load game created with: " + readVersion;
           HeadlessGameServer.sendChat(message);
           System.out.println(message);
           return null;
         }
         final String error = "<html>Incompatible engine versions, and no old engine found. We are: "
-            + ClientContext.engineVersion().getCompatabilityVersion() + " . Trying to load game created with: " + readVersion
+            + ClientContext.engineVersion().getVersion() + " . Trying to load game created with: " + readVersion
             + "<br>To download the latest version of TripleA, Please visit http://triplea.sourceforge.net/</html>";
         if (savegamePath == null) {
           throw new IOException(error);
@@ -85,7 +85,7 @@ public class GameDataManager {
         try {
           final String newClassPath = TripleAProcessRunner.findOldJar(readVersion, true);
           // ask user if we really want to do this?
-          final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getCompatabilityVersion()
+          final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getVersion()
               + " and you are trying to open a savegame made with version " + readVersion.toString()
               + "<br>However, this TripleA can not open any savegame made by any engine other than engines with the same first three version numbers as it (x_x_x_x)."
               + "<br><br>TripleA now comes with older engines included with it, and has found the engine to run this savegame. This is a new feature and is in 'beta' stage."
@@ -117,20 +117,20 @@ public class GameDataManager {
           if (ClientFileSystemHelper.areWeOldExtraJar()) {
             throw new IOException("<html>Please run the default TripleA and try to open this game again. "
                 + "<br>This TripleA engine is old and kept only for backwards compatibility and can only open savegames created by engines with these first 3 version digits: "
-                + ClientContext.engineVersion().getCompatabilityVersion().toStringFull("_", true) + "</html>");
+                + ClientContext.engineVersion().getVersion().toStringFull("_", true) + "</html>");
           } else {
             throw new IOException(error);
           }
         }
         return null;
-      } else if (!headless && readVersion.isGreaterThan(ClientContext.engineVersion().getCompatabilityVersion(), false)) {
+      } else if (!headless && readVersion.isGreaterThan(ClientContext.engineVersion().getVersion(), false)) {
         // we can still load it because first 3 numbers of the version are the same, however this save was made by a
         // newer engine, so prompt
         // the user to upgrade
         final String messageString =
             "<html>Your TripleA engine is OUT OF DATE.  This save was made by a newer version of TripleA."
                 + "<br>However, because the first 3 version numbers are the same as your current version, we can still open the savegame."
-                + "<br><br>This TripleA engine is version " + ClientContext.engineVersion().getCompatabilityVersion().toStringFull("_")
+                + "<br><br>This TripleA engine is version " + ClientContext.engineVersion().getVersion().toStringFull("_")
                 + " and you are trying to open a savegame made with version " + readVersion.toStringFull("_")
                 + "<br><br>To download the latest version of TripleA, Please visit http://triplea.sourceforge.net/"
                 + "<br><br>It is recommended that you upgrade to the latest version of TripleA before playing this savegame."
@@ -228,7 +228,7 @@ public class GameDataManager {
     // write internally first in case of error
     final ByteArrayOutputStream bytes = new ByteArrayOutputStream(25000);
     final ObjectOutputStream outStream = new ObjectOutputStream(bytes);
-    outStream.writeObject(games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion());
+    outStream.writeObject(games.strategy.engine.ClientContext.engineVersion().getVersion());
     data.acquireReadLock();
     try {
       outStream.writeObject(data);

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -7,14 +7,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.URI;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map.Entry;
@@ -34,7 +30,7 @@ import games.strategy.common.ui.BasicGameMenuBar;
 import games.strategy.debug.ClientLogger;
 import games.strategy.debug.ErrorConsole;
 import games.strategy.engine.ClientContext;
-import games.strategy.engine.EngineVersion;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.mapDownload.MapDownloadController;
 import games.strategy.engine.framework.startup.ui.MainFrame;
 import games.strategy.engine.framework.ui.background.WaitWindow;
@@ -440,7 +436,7 @@ public class GameRunner2 {
 
   public static Properties getSystemIni() {
     final Properties rVal = new Properties();
-    final File systemIni = new File(ClientContext.getRootFolder(), SYSTEM_INI);
+    final File systemIni = new File(ClientFileSystemHelper.getRootFolder(), SYSTEM_INI);
     if (systemIni != null && systemIni.exists()) {
       try (FileInputStream fis = new FileInputStream(systemIni)) {
         rVal.load(fis);
@@ -462,7 +458,7 @@ public class GameRunner2 {
       }
     }
 
-    final File systemIni = new File(ClientContext.getRootFolder(), SYSTEM_INI);
+    final File systemIni = new File(ClientFileSystemHelper.getRootFolder(), SYSTEM_INI);
 
     try (FileOutputStream fos = new FileOutputStream(systemIni)) {
       toWrite.store(fos, SYSTEM_INI);
@@ -709,7 +705,7 @@ public class GameRunner2 {
       @Override
       public void run() {
         // do not check if we are the old extra jar. (a jar kept for backwards compatibility only)
-        if (ClientContext.areWeOldExtraJar()) {
+        if (ClientFileSystemHelper.areWeOldExtraJar()) {
           return;
         }
         // if we are joining a game online, or hosting, or loading straight into a savegame, do not check
@@ -859,7 +855,4 @@ public class GameRunner2 {
     }
     return f;
   }
-
-
-
 }

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -82,7 +82,7 @@ public class GameRunner2 {
   // non-commandline-argument-properties (for preferences)
   // first time we've run this version of triplea?
   private static final String TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY =
-      "triplea.firstTimeThisVersion" + ClientContext.engineVersion().getVersion();
+      "triplea.firstTimeThisVersion" + ClientContext.engineVersion();
   private static final String TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE = "triplea.lastCheckForEngineUpdate";
   // only for Online?
   public static final String TRIPLEA_MEMORY_ONLINE_ONLY = "triplea.memory.onlineOnly";
@@ -141,7 +141,7 @@ public class GameRunner2 {
     ErrorConsole.getConsole().displayStandardError();
     ErrorConsole.getConsole().displayStandardOutput();
     ErrorHandler.registerExceptionHandler();
-    System.setProperty("triplea.engine.version", ClientContext.engineVersion().getVersion().toString());
+    System.setProperty("triplea.engine.version", ClientContext.engineVersion().toString());
     handleCommandLineArgs(args);
     // do after we handle command line args
     checkForMemoryXMX();
@@ -239,12 +239,12 @@ public class GameRunner2 {
           System.out.println("Current Engine version in use: " + ClientContext.engineVersion().getVersion());
         }
       } catch (final Exception e) {
-        System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getVersion().toString());
+        System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().toString());
         System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getVersion());
         return;
       }
     } else {
-      System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getVersion().toString());
+      System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().toString());
       System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getVersion());
     }
   }

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -44,6 +44,7 @@ import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.Version;
 
 public class GameRunner2 {
+
   // not arguments:
   public static final int PORT = 3300;
   public static final String LOOK_AND_FEEL_PREF = "LookAndFeel";
@@ -85,7 +86,7 @@ public class GameRunner2 {
   // non-commandline-argument-properties (for preferences)
   // first time we've run this version of triplea?
   private static final String TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY =
-      "triplea.firstTimeThisVersion" + EngineVersion.VERSION.toString();
+      "triplea.firstTimeThisVersion" + ClientContext.getInstance().engineVersion().getVersion().toString();
   private static final String TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE = "triplea.lastCheckForEngineUpdate";
   // only for Online?
   public static final String TRIPLEA_MEMORY_ONLINE_ONLY = "triplea.memory.onlineOnly";
@@ -144,7 +145,7 @@ public class GameRunner2 {
     ErrorConsole.getConsole().displayStandardError();
     ErrorConsole.getConsole().displayStandardOutput();
     ErrorHandler.registerExceptionHandler();
-    System.setProperty("triplea.engine.version", EngineVersion.VERSION.toString());
+    System.setProperty("triplea.engine.version", ClientContext.getInstance().engineVersion().getVersion().toString());
     handleCommandLineArgs(args);
     // do after we handle command line args
     checkForMemoryXMX();
@@ -238,17 +239,17 @@ public class GameRunner2 {
         testVersion = new Version(version);
         // if successful we don't do anything
         System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + version);
-        if (!EngineVersion.VERSION.equals(testVersion, false)) {
-          System.out.println("Current Engine version in use: " + EngineVersion.VERSION.toString());
+        if (!ClientContext.getInstance().engineVersion().getVersion().equals(testVersion, false)) {
+          System.out.println("Current Engine version in use: " + ClientContext.getInstance().engineVersion().getVersion().toString());
         }
       } catch (final Exception e) {
-        System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, EngineVersion.VERSION.toString());
-        System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + EngineVersion.VERSION.toString());
+        System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.getInstance().engineVersion().getVersion().toString());
+        System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.getInstance().engineVersion().getVersion().toString());
         return;
       }
     } else {
-      System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, EngineVersion.VERSION.toString());
-      System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + EngineVersion.VERSION.toString());
+      System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.getInstance().engineVersion().getVersion().toString());
+      System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.getInstance().engineVersion().getVersion().toString());
     }
   }
 
@@ -439,7 +440,7 @@ public class GameRunner2 {
 
   public static Properties getSystemIni() {
     final Properties rVal = new Properties();
-    final File systemIni = new File(GameRunner2.getRootFolder(), SYSTEM_INI);
+    final File systemIni = new File(ClientContext.getRootFolder(), SYSTEM_INI);
     if (systemIni != null && systemIni.exists()) {
       try (FileInputStream fis = new FileInputStream(systemIni)) {
         rVal.load(fis);
@@ -461,7 +462,7 @@ public class GameRunner2 {
       }
     }
 
-    final File systemIni = new File(GameRunner2.getRootFolder(), SYSTEM_INI);
+    final File systemIni = new File(ClientContext.getRootFolder(), SYSTEM_INI);
 
     try (FileOutputStream fos = new FileOutputStream(systemIni)) {
       toWrite.store(fos, SYSTEM_INI);
@@ -708,7 +709,7 @@ public class GameRunner2 {
       @Override
       public void run() {
         // do not check if we are the old extra jar. (a jar kept for backwards compatibility only)
-        if (areWeOldExtraJar()) {
+        if (ClientContext.areWeOldExtraJar()) {
           return;
         }
         // if we are joining a game online, or hosting, or loading straight into a savegame, do not check
@@ -776,7 +777,7 @@ public class GameRunner2 {
       if (latestEngineOut == null) {
         return false;
       }
-      if (EngineVersion.VERSION.isLessThan(latestEngineOut.getLatestVersionOut(), false)) {
+      if (ClientContext.getInstance().engineVersion().getVersion().isLessThan(latestEngineOut.getLatestVersionOut(), false)) {
         SwingUtilities.invokeLater(new Runnable() {
           @Override
           public void run() {
@@ -787,7 +788,7 @@ public class GameRunner2 {
         return true;
       } else {
         // if this is the first time we are running THIS version of TripleA, then show what is new.
-        if (firstTimeThisVersion && latestEngineOut.getReleaseNotes().containsKey(EngineVersion.VERSION)) {
+        if (firstTimeThisVersion && latestEngineOut.getReleaseNotes().containsKey(ClientContext.getInstance().engineVersion().getVersion())) {
           SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
@@ -817,39 +818,6 @@ public class GameRunner2 {
     return downloadController.checkDownloadedMapsAreLatest();
   }
 
-  /**
-   * Our jar is named with engine number and we are in "old" folder.
-   */
-  public static boolean areWeOldExtraJar() {
-    final URL url = GameRunner2.class.getResource("GameRunner2.class");
-    String fileName = url.getFile();
-    try {
-      fileName = URLDecoder.decode(fileName, "UTF-8");
-    } catch (final UnsupportedEncodingException e) {
-      e.printStackTrace();
-    }
-    final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
-    if (fileName.contains(tripleaJarNameWithEngineVersion)) {
-      final String subString = fileName.substring("file:/".length() - (GameRunner.isWindows() ? 0 : 1),
-          fileName.indexOf(tripleaJarNameWithEngineVersion) - 1);
-      final File f = new File(subString);
-      if (!f.exists()) {
-        throw new IllegalStateException("File not found:" + f);
-      }
-      String path;
-      try {
-        path = f.getCanonicalPath();
-      } catch (final IOException e) {
-        path = f.getPath();
-      }
-      return path.contains("old");
-    }
-    return false;
-  }
-
-  private static String getTripleaJarWithEngineVersionStringPath() {
-    return "triplea_" + EngineVersion.VERSION.toStringFull("_") + ".jar!";
-  }
 
   public static Image getGameIcon(final Window frame) {
     Image img = null;
@@ -892,123 +860,6 @@ public class GameRunner2 {
     return f;
   }
 
-  /**
-   * Get the root folder for the application
-   */
-  public static File getRootFolder() {
-    final String fileName = getGameRunnerFileLocation("GameRunner2.class");
-
-    final String tripleaJarName = "triplea.jar!";
-    if (fileName.contains(tripleaJarName)) {
-      return getRootFolderRelativeToJar(fileName, tripleaJarName);
-    }
-
-    final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
-    if (fileName.contains(tripleaJarNameWithEngineVersion)) {
-      return getRootFolderRelativeToJar(fileName, tripleaJarNameWithEngineVersion);
-    }
-
-    return getRootRelativeToClassFile(fileName);
-  }
-
-  private static String getGameRunnerFileLocation(final String runnerClassName) {
-    final URL url = GameRunner2.class.getResource(runnerClassName);
-    String fileName = url.getFile();
-
-    try {
-      // Deal with spaces in the file name which would be url encoded
-      fileName = URLDecoder.decode(fileName, "UTF-8");
-    } catch (final UnsupportedEncodingException e) {
-      ClientLogger.logError("Unsupported encoding of fileName: " + fileName + ", error: " + e.getMessage());
-    }
-    return fileName;
-  }
-
-  private static File getRootFolderRelativeToJar(final String fileName, final String tripleaJarName) {
-    final String subString =
-        fileName.substring("file:/".length() - (GameRunner.isWindows() ? 0 : 1), fileName.indexOf(tripleaJarName) - 1);
-    final File f = new File(subString).getParentFile();
-    if (!f.exists()) {
-      throw new IllegalStateException("File not found:" + f);
-    }
-    return f;
-  }
-
-  private static File getRootRelativeToClassFile(final String fileName) {
-    File f = new File(fileName);
-
-    // move up 1 directory for each package
-    final int moveUpCount = GameRunner2.class.getName().split("\\.").length + 1;
-    for (int i = 0; i < moveUpCount; i++) {
-      f = f.getParentFile();
-    }
-    if (!f.exists()) {
-      System.err.println("Could not find root folder, does  not exist:" + f);
-      return new File(System.getProperties().getProperty("user.dir"));
-    }
-    return f;
-  }
 
 
-  /* Check if a folder contains another folder or file */
-  private static boolean folderContains(final File folder, final String childToFind) {
-    if (folder == null || folder.list() == null || folder.list().length == 0) {
-      return false;
-    }
-    return Arrays.asList(folder.list()).contains(childToFind);
-  }
-
-  /**
-   * Search for a file that may be contained in one of multiple folders.
-   *
-   * The file to search for is given by first parameter, second is the list of folders.
-   * We will search all possible paths of the first folder before moving on to the next,
-   * so ordering of the possible folders is more important than the ordering of search paths.
-   *
-   * The search paths vary by if this class is being run from a class file instance,
-   * or a copy compiled into a jar.
-   *
-   * @param game The name of the file to find
-   * @param possibleFolders An array containing a sequence of possible folders that may contain
-   *        the search file.
-   * @return Throws illegal state if not found. Otherwise returns a file reference whose name
-   *         matches the first parameter and parent folder matches an element of "possibleFolders"
-   */
-  public static File getFile(final String game, final String[] possibleFolders) {
-    for (final String possibleFolder : possibleFolders) {
-      final File start = GameRunner2.getRootFolder();
-      if (folderContainsFolderAndFile(start, possibleFolder, game)) {
-        return new File(new File(start, possibleFolder), game);
-      }
-
-      final File secondStart = GameRunner2.getParentFolder(possibleFolder);
-      if (folderContainsFolderAndFile(secondStart, possibleFolder, game)) {
-        return new File(new File(secondStart, possibleFolder), game);
-      }
-
-    }
-    throw new IllegalStateException(
-        "Could not find any of these folders: " + Arrays.asList(possibleFolders) + ", containing game file: " + game);
-  }
-
-  /* Check if a given folder contains another folder that in turn contains a given file */
-  private static boolean folderContainsFolderAndFile(final File f, final String childFolder, final String child) {
-    if (folderContains(f, childFolder)) {
-      final File possibleParent = new File(f, childFolder);
-      if (folderContains(possibleParent, child)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /* From the Game Runner root location, walk up directories until we find a given folder */
-  private static File getParentFolder(final String folderToFind) {
-    File f = new File(getGameRunnerFileLocation("GameRunner2.class"));
-
-    while (f != null && f.exists() && !folderContains(f, folderToFind)) {
-      f = f.getParentFile();
-    }
-    return f;
-  }
 }

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -82,7 +82,7 @@ public class GameRunner2 {
   // non-commandline-argument-properties (for preferences)
   // first time we've run this version of triplea?
   private static final String TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY =
-      "triplea.firstTimeThisVersion" + ClientContext.engineVersion().getCompatabilityVersion().toString();
+      "triplea.firstTimeThisVersion" + ClientContext.engineVersion().getCompatabilityVersion();
   private static final String TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE = "triplea.lastCheckForEngineUpdate";
   // only for Online?
   public static final String TRIPLEA_MEMORY_ONLINE_ONLY = "triplea.memory.onlineOnly";
@@ -236,16 +236,16 @@ public class GameRunner2 {
         // if successful we don't do anything
         System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + version);
         if (!ClientContext.engineVersion().getCompatabilityVersion().equals(testVersion, false)) {
-          System.out.println("Current Engine version in use: " + ClientContext.engineVersion().getCompatabilityVersion().toString());
+          System.out.println("Current Engine version in use: " + ClientContext.engineVersion().getCompatabilityVersion());
         }
       } catch (final Exception e) {
         System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getCompatabilityVersion().toString());
-        System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getCompatabilityVersion().toString());
+        System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getCompatabilityVersion());
         return;
       }
     } else {
       System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getCompatabilityVersion().toString());
-      System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getCompatabilityVersion().toString());
+      System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getCompatabilityVersion());
     }
   }
 

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -82,7 +82,7 @@ public class GameRunner2 {
   // non-commandline-argument-properties (for preferences)
   // first time we've run this version of triplea?
   private static final String TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY =
-      "triplea.firstTimeThisVersion" + ClientContext.engineVersion().getVersion().toString();
+      "triplea.firstTimeThisVersion" + ClientContext.engineVersion().getCompatabilityVersion().toString();
   private static final String TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE = "triplea.lastCheckForEngineUpdate";
   // only for Online?
   public static final String TRIPLEA_MEMORY_ONLINE_ONLY = "triplea.memory.onlineOnly";
@@ -141,7 +141,7 @@ public class GameRunner2 {
     ErrorConsole.getConsole().displayStandardError();
     ErrorConsole.getConsole().displayStandardOutput();
     ErrorHandler.registerExceptionHandler();
-    System.setProperty("triplea.engine.version", ClientContext.engineVersion().getVersion().toString());
+    System.setProperty("triplea.engine.version", ClientContext.engineVersion().getCompatabilityVersion().toString());
     handleCommandLineArgs(args);
     // do after we handle command line args
     checkForMemoryXMX();
@@ -235,17 +235,17 @@ public class GameRunner2 {
         testVersion = new Version(version);
         // if successful we don't do anything
         System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + version);
-        if (!ClientContext.engineVersion().getVersion().equals(testVersion, false)) {
-          System.out.println("Current Engine version in use: " + ClientContext.engineVersion().getVersion().toString());
+        if (!ClientContext.engineVersion().getCompatabilityVersion().equals(testVersion, false)) {
+          System.out.println("Current Engine version in use: " + ClientContext.engineVersion().getCompatabilityVersion().toString());
         }
       } catch (final Exception e) {
-        System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getVersion().toString());
-        System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getVersion().toString());
+        System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getCompatabilityVersion().toString());
+        System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getCompatabilityVersion().toString());
         return;
       }
     } else {
-      System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getVersion().toString());
-      System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getVersion().toString());
+      System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getCompatabilityVersion().toString());
+      System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getCompatabilityVersion().toString());
     }
   }
 
@@ -773,7 +773,7 @@ public class GameRunner2 {
       if (latestEngineOut == null) {
         return false;
       }
-      if (ClientContext.engineVersion().getVersion().isLessThan(latestEngineOut.getLatestVersionOut(), false)) {
+      if (ClientContext.engineVersion().getCompatabilityVersion().isLessThan(latestEngineOut.getLatestVersionOut(), false)) {
         SwingUtilities.invokeLater(new Runnable() {
           @Override
           public void run() {
@@ -784,7 +784,7 @@ public class GameRunner2 {
         return true;
       } else {
         // if this is the first time we are running THIS version of TripleA, then show what is new.
-        if (firstTimeThisVersion && latestEngineOut.getReleaseNotes().containsKey(ClientContext.engineVersion().getVersion())) {
+        if (firstTimeThisVersion && latestEngineOut.getReleaseNotes().containsKey(ClientContext.engineVersion().getCompatabilityVersion())) {
           SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -82,7 +82,7 @@ public class GameRunner2 {
   // non-commandline-argument-properties (for preferences)
   // first time we've run this version of triplea?
   private static final String TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY =
-      "triplea.firstTimeThisVersion" + ClientContext.getInstance().engineVersion().getVersion().toString();
+      "triplea.firstTimeThisVersion" + ClientContext.engineVersion().getVersion().toString();
   private static final String TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE = "triplea.lastCheckForEngineUpdate";
   // only for Online?
   public static final String TRIPLEA_MEMORY_ONLINE_ONLY = "triplea.memory.onlineOnly";
@@ -141,7 +141,7 @@ public class GameRunner2 {
     ErrorConsole.getConsole().displayStandardError();
     ErrorConsole.getConsole().displayStandardOutput();
     ErrorHandler.registerExceptionHandler();
-    System.setProperty("triplea.engine.version", ClientContext.getInstance().engineVersion().getVersion().toString());
+    System.setProperty("triplea.engine.version", ClientContext.engineVersion().getVersion().toString());
     handleCommandLineArgs(args);
     // do after we handle command line args
     checkForMemoryXMX();
@@ -235,17 +235,17 @@ public class GameRunner2 {
         testVersion = new Version(version);
         // if successful we don't do anything
         System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + version);
-        if (!ClientContext.getInstance().engineVersion().getVersion().equals(testVersion, false)) {
-          System.out.println("Current Engine version in use: " + ClientContext.getInstance().engineVersion().getVersion().toString());
+        if (!ClientContext.engineVersion().getVersion().equals(testVersion, false)) {
+          System.out.println("Current Engine version in use: " + ClientContext.engineVersion().getVersion().toString());
         }
       } catch (final Exception e) {
-        System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.getInstance().engineVersion().getVersion().toString());
-        System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.getInstance().engineVersion().getVersion().toString());
+        System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getVersion().toString());
+        System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getVersion().toString());
         return;
       }
     } else {
-      System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.getInstance().engineVersion().getVersion().toString());
-      System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.getInstance().engineVersion().getVersion().toString());
+      System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getVersion().toString());
+      System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getVersion().toString());
     }
   }
 
@@ -773,7 +773,7 @@ public class GameRunner2 {
       if (latestEngineOut == null) {
         return false;
       }
-      if (ClientContext.getInstance().engineVersion().getVersion().isLessThan(latestEngineOut.getLatestVersionOut(), false)) {
+      if (ClientContext.engineVersion().getVersion().isLessThan(latestEngineOut.getLatestVersionOut(), false)) {
         SwingUtilities.invokeLater(new Runnable() {
           @Override
           public void run() {
@@ -784,7 +784,7 @@ public class GameRunner2 {
         return true;
       } else {
         // if this is the first time we are running THIS version of TripleA, then show what is new.
-        if (firstTimeThisVersion && latestEngineOut.getReleaseNotes().containsKey(ClientContext.getInstance().engineVersion().getVersion())) {
+        if (firstTimeThisVersion && latestEngineOut.getReleaseNotes().containsKey(ClientContext.engineVersion().getVersion())) {
           SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
@@ -810,7 +810,7 @@ public class GameRunner2 {
    * @return true if we have any out of date maps
    */
   private static boolean checkForUpdatedMaps() {
-    MapDownloadController downloadController = ClientContext.getInstance().mapDownloadController();
+    MapDownloadController downloadController = ClientContext.mapDownloadController();
     return downloadController.checkDownloadedMapsAreLatest();
   }
 

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -832,27 +832,4 @@ public class GameRunner2 {
     return img;
   }
 
-  public static File getUserRootFolder() {
-    final File userHome = new File(System.getProperties().getProperty("user.home"));
-    // the default
-    File rootDir;
-    if (GameRunner.isMac()) {
-      rootDir = new File(new File(userHome, "Documents"), "triplea");
-    } else {
-      rootDir = new File(userHome, "triplea");
-    }
-    return rootDir;
-  }
-
-  public static File getUserMapsFolder() {
-    final File f = new File(getUserRootFolder(), "maps");
-    if (!f.exists()) {
-      try {
-        f.mkdirs();
-      } catch (final SecurityException e) {
-        e.printStackTrace();
-      }
-    }
-    return f;
-  }
 }

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -33,6 +33,7 @@ import org.apache.commons.httpclient.HostConfiguration;
 import games.strategy.common.ui.BasicGameMenuBar;
 import games.strategy.debug.ClientLogger;
 import games.strategy.debug.ErrorConsole;
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.framework.mapDownload.MapDownloadController;
 import games.strategy.engine.framework.startup.ui.MainFrame;
@@ -812,7 +813,7 @@ public class GameRunner2 {
    * @return true if we have any out of date maps
    */
   private static boolean checkForUpdatedMaps() {
-    MapDownloadController downloadController = new MapDownloadController();
+    MapDownloadController downloadController = ClientContext.getInstance().mapDownloadController();
     return downloadController.checkDownloadedMapsAreLatest();
   }
 

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -82,7 +82,7 @@ public class GameRunner2 {
   // non-commandline-argument-properties (for preferences)
   // first time we've run this version of triplea?
   private static final String TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY =
-      "triplea.firstTimeThisVersion" + ClientContext.engineVersion().getCompatabilityVersion();
+      "triplea.firstTimeThisVersion" + ClientContext.engineVersion().getVersion();
   private static final String TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE = "triplea.lastCheckForEngineUpdate";
   // only for Online?
   public static final String TRIPLEA_MEMORY_ONLINE_ONLY = "triplea.memory.onlineOnly";
@@ -141,7 +141,7 @@ public class GameRunner2 {
     ErrorConsole.getConsole().displayStandardError();
     ErrorConsole.getConsole().displayStandardOutput();
     ErrorHandler.registerExceptionHandler();
-    System.setProperty("triplea.engine.version", ClientContext.engineVersion().getCompatabilityVersion().toString());
+    System.setProperty("triplea.engine.version", ClientContext.engineVersion().getVersion().toString());
     handleCommandLineArgs(args);
     // do after we handle command line args
     checkForMemoryXMX();
@@ -235,17 +235,17 @@ public class GameRunner2 {
         testVersion = new Version(version);
         // if successful we don't do anything
         System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + version);
-        if (!ClientContext.engineVersion().getCompatabilityVersion().equals(testVersion, false)) {
-          System.out.println("Current Engine version in use: " + ClientContext.engineVersion().getCompatabilityVersion());
+        if (!ClientContext.engineVersion().getVersion().equals(testVersion, false)) {
+          System.out.println("Current Engine version in use: " + ClientContext.engineVersion().getVersion());
         }
       } catch (final Exception e) {
-        System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getCompatabilityVersion().toString());
-        System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getCompatabilityVersion());
+        System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getVersion().toString());
+        System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getVersion());
         return;
       }
     } else {
-      System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getCompatabilityVersion().toString());
-      System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getCompatabilityVersion());
+      System.getProperties().setProperty(TRIPLEA_ENGINE_VERSION_BIN, ClientContext.engineVersion().getVersion().toString());
+      System.out.println(TRIPLEA_ENGINE_VERSION_BIN + ":" + ClientContext.engineVersion().getVersion());
     }
   }
 
@@ -773,7 +773,7 @@ public class GameRunner2 {
       if (latestEngineOut == null) {
         return false;
       }
-      if (ClientContext.engineVersion().getCompatabilityVersion().isLessThan(latestEngineOut.getLatestVersionOut(), false)) {
+      if (ClientContext.engineVersion().getVersion().isLessThan(latestEngineOut.getLatestVersionOut(), false)) {
         SwingUtilities.invokeLater(new Runnable() {
           @Override
           public void run() {
@@ -784,7 +784,7 @@ public class GameRunner2 {
         return true;
       } else {
         // if this is the first time we are running THIS version of TripleA, then show what is new.
-        if (firstTimeThisVersion && latestEngineOut.getReleaseNotes().containsKey(ClientContext.engineVersion().getCompatabilityVersion())) {
+        if (firstTimeThisVersion && latestEngineOut.getReleaseNotes().containsKey(ClientContext.engineVersion().getVersion())) {
           SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {

--- a/src/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/src/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.util.Version;
 
 /**
@@ -58,7 +58,7 @@ public class ProcessRunnerUtil {
     if (GameRunner.isMac()) {
       commands.add("-Dapple.laf.useScreenMenuBar=true");
       commands.add("-Xdock:name=\"TripleA\"");
-      final File icons = new File(ClientContext.getRootFolder(), "icons/triplea_icon.png");
+      final File icons = new File(ClientFileSystemHelper.getRootFolder(), "icons/triplea_icon.png");
       if (!icons.exists()) {
         throw new IllegalStateException("Icon file not found");
       }

--- a/src/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/src/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.util.Version;
 
 /**
@@ -57,7 +58,7 @@ public class ProcessRunnerUtil {
     if (GameRunner.isMac()) {
       commands.add("-Dapple.laf.useScreenMenuBar=true");
       commands.add("-Xdock:name=\"TripleA\"");
-      final File icons = new File(GameRunner2.getRootFolder(), "icons/triplea_icon.png");
+      final File icons = new File(ClientContext.getRootFolder(), "icons/triplea_icon.png");
       if (!icons.exists()) {
         throw new IllegalStateException("Icon file not found");
       }

--- a/src/games/strategy/engine/framework/TripleAProcessRunner.java
+++ b/src/games/strategy/engine/framework/TripleAProcessRunner.java
@@ -89,7 +89,7 @@ public class TripleAProcessRunner {
     }
     final Version engineVersionOfGameToJoin = new Version(description.getEngineVersion());
     String newClassPath = null;
-    if (!ClientContext.engineVersion().getCompatabilityVersion().equals(engineVersionOfGameToJoin)) {
+    if (!ClientContext.engineVersion().getVersion().equals(engineVersionOfGameToJoin)) {
       try {
         newClassPath = findOldJar(engineVersionOfGameToJoin, false);
       } catch (final Exception e) {
@@ -109,7 +109,7 @@ public class TripleAProcessRunner {
         return;
       }
       // ask user if we really want to do this?
-      final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getCompatabilityVersion()
+      final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getVersion()
           + " and you are trying to join a game made with version " + engineVersionOfGameToJoin.toString()
           + "<br>However, this TripleA can only play with engines that are the exact same version as itself (x_x_x_x)."
           + "<br><br>TripleA now comes with older engines included with it, and has found the engine used by the host. This is a new feature and is in 'beta' stage."
@@ -140,7 +140,7 @@ public class TripleAProcessRunner {
   }
 
   public static String findOldJar(final Version oldVersionNeeded, final boolean ignoreMicro) throws IOException {
-    if (ClientContext.engineVersion().getCompatabilityVersion().equals(oldVersionNeeded, ignoreMicro)) {
+    if (ClientContext.engineVersion().getVersion().equals(oldVersionNeeded, ignoreMicro)) {
       return System.getProperty("java.class.path");
     }
     // first, see if the default/main triplea can run it

--- a/src/games/strategy/engine/framework/TripleAProcessRunner.java
+++ b/src/games/strategy/engine/framework/TripleAProcessRunner.java
@@ -89,7 +89,7 @@ public class TripleAProcessRunner {
     }
     final Version engineVersionOfGameToJoin = new Version(description.getEngineVersion());
     String newClassPath = null;
-    if (!ClientContext.getInstance().engineVersion().getVersion().equals(engineVersionOfGameToJoin)) {
+    if (!ClientContext.engineVersion().getVersion().equals(engineVersionOfGameToJoin)) {
       try {
         newClassPath = findOldJar(engineVersionOfGameToJoin, false);
       } catch (final Exception e) {
@@ -109,7 +109,7 @@ public class TripleAProcessRunner {
         return;
       }
       // ask user if we really want to do this?
-      final String messageString = "<html>This TripleA engine is version " + ClientContext.getInstance().engineVersion().getVersion().toString()
+      final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getVersion().toString()
           + " and you are trying to join a game made with version " + engineVersionOfGameToJoin.toString()
           + "<br>However, this TripleA can only play with engines that are the exact same version as itself (x_x_x_x)."
           + "<br><br>TripleA now comes with older engines included with it, and has found the engine used by the host. This is a new feature and is in 'beta' stage."
@@ -140,7 +140,7 @@ public class TripleAProcessRunner {
   }
 
   public static String findOldJar(final Version oldVersionNeeded, final boolean ignoreMicro) throws IOException {
-    if (ClientContext.getInstance().engineVersion().getVersion().equals(oldVersionNeeded, ignoreMicro)) {
+    if (ClientContext.engineVersion().getVersion().equals(oldVersionNeeded, ignoreMicro)) {
       return System.getProperty("java.class.path");
     }
     // first, see if the default/main triplea can run it

--- a/src/games/strategy/engine/framework/TripleAProcessRunner.java
+++ b/src/games/strategy/engine/framework/TripleAProcessRunner.java
@@ -10,7 +10,7 @@ import java.util.List;
 import javax.swing.JOptionPane;
 
 import games.strategy.engine.ClientContext;
-import games.strategy.engine.EngineVersion;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.lobby.server.GameDescription.GameStatus;
 import games.strategy.net.Messengers;
@@ -93,7 +93,7 @@ public class TripleAProcessRunner {
       try {
         newClassPath = findOldJar(engineVersionOfGameToJoin, false);
       } catch (final Exception e) {
-        if (ClientContext.areWeOldExtraJar()) {
+        if (ClientFileSystemHelper.areWeOldExtraJar()) {
           JOptionPane.showMessageDialog(parent,
               "<html>Please run the default TripleA and try joining the online lobby for it instead. "
                   + "<br>This TripleA engine is old and kept only for backwards compatibility and can only play with people using the exact same version as this one. "
@@ -144,7 +144,7 @@ public class TripleAProcessRunner {
       return System.getProperty("java.class.path");
     }
     // first, see if the default/main triplea can run it
-    if (ClientContext.areWeOldExtraJar()) {
+    if (ClientFileSystemHelper.areWeOldExtraJar()) {
       final String version = System.getProperty(GameRunner2.TRIPLEA_ENGINE_VERSION_BIN);
       if (version != null && version.length() > 0) {
         Version defaultVersion = null;
@@ -157,9 +157,9 @@ public class TripleAProcessRunner {
           if (defaultVersion.equals(oldVersionNeeded, ignoreMicro)) {
             final String jarName = "triplea.jar";
             // windows is in 'bin' folder, mac is in 'Java' folder.
-            File binFolder = new File(ClientContext.getRootFolder(), "bin/");
+            File binFolder = new File(ClientFileSystemHelper.getRootFolder(), "bin/");
             if (!binFolder.exists()) {
-              binFolder = new File(ClientContext.getRootFolder(), "Java/");
+              binFolder = new File(ClientFileSystemHelper.getRootFolder(), "Java/");
             }
             if (binFolder.exists()) {
               final File[] files = binFolder.listFiles();
@@ -201,7 +201,7 @@ public class TripleAProcessRunner {
     // we don't care what the last (micro) number is of the version number. example: triplea 1.5.2.1 can open 1.5.2.0
     // savegames.
     final String jarName = "triplea_" + oldVersionNeeded.toStringFull("_", ignoreMicro);
-    final File oldJarsFolder = new File(ClientContext.getRootFolder(), "old/");
+    final File oldJarsFolder = new File(ClientFileSystemHelper.getRootFolder(), "old/");
     if (!oldJarsFolder.exists()) {
       throw new IOException("Can not find 'old' engine jars folder");
     }

--- a/src/games/strategy/engine/framework/TripleAProcessRunner.java
+++ b/src/games/strategy/engine/framework/TripleAProcessRunner.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import javax.swing.JOptionPane;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.lobby.server.GameDescription.GameStatus;
@@ -88,11 +89,11 @@ public class TripleAProcessRunner {
     }
     final Version engineVersionOfGameToJoin = new Version(description.getEngineVersion());
     String newClassPath = null;
-    if (!EngineVersion.VERSION.equals(engineVersionOfGameToJoin)) {
+    if (!ClientContext.getInstance().engineVersion().getVersion().equals(engineVersionOfGameToJoin)) {
       try {
         newClassPath = findOldJar(engineVersionOfGameToJoin, false);
       } catch (final Exception e) {
-        if (GameRunner2.areWeOldExtraJar()) {
+        if (ClientContext.areWeOldExtraJar()) {
           JOptionPane.showMessageDialog(parent,
               "<html>Please run the default TripleA and try joining the online lobby for it instead. "
                   + "<br>This TripleA engine is old and kept only for backwards compatibility and can only play with people using the exact same version as this one. "
@@ -108,7 +109,7 @@ public class TripleAProcessRunner {
         return;
       }
       // ask user if we really want to do this?
-      final String messageString = "<html>This TripleA engine is version " + EngineVersion.VERSION.toString()
+      final String messageString = "<html>This TripleA engine is version " + ClientContext.getInstance().engineVersion().getVersion().toString()
           + " and you are trying to join a game made with version " + engineVersionOfGameToJoin.toString()
           + "<br>However, this TripleA can only play with engines that are the exact same version as itself (x_x_x_x)."
           + "<br><br>TripleA now comes with older engines included with it, and has found the engine used by the host. This is a new feature and is in 'beta' stage."
@@ -139,11 +140,11 @@ public class TripleAProcessRunner {
   }
 
   public static String findOldJar(final Version oldVersionNeeded, final boolean ignoreMicro) throws IOException {
-    if (EngineVersion.VERSION.equals(oldVersionNeeded, ignoreMicro)) {
+    if (ClientContext.getInstance().engineVersion().getVersion().equals(oldVersionNeeded, ignoreMicro)) {
       return System.getProperty("java.class.path");
     }
     // first, see if the default/main triplea can run it
-    if (GameRunner2.areWeOldExtraJar()) {
+    if (ClientContext.areWeOldExtraJar()) {
       final String version = System.getProperty(GameRunner2.TRIPLEA_ENGINE_VERSION_BIN);
       if (version != null && version.length() > 0) {
         Version defaultVersion = null;
@@ -156,9 +157,9 @@ public class TripleAProcessRunner {
           if (defaultVersion.equals(oldVersionNeeded, ignoreMicro)) {
             final String jarName = "triplea.jar";
             // windows is in 'bin' folder, mac is in 'Java' folder.
-            File binFolder = new File(GameRunner2.getRootFolder(), "bin/");
+            File binFolder = new File(ClientContext.getRootFolder(), "bin/");
             if (!binFolder.exists()) {
-              binFolder = new File(GameRunner2.getRootFolder(), "Java/");
+              binFolder = new File(ClientContext.getRootFolder(), "Java/");
             }
             if (binFolder.exists()) {
               final File[] files = binFolder.listFiles();
@@ -200,7 +201,7 @@ public class TripleAProcessRunner {
     // we don't care what the last (micro) number is of the version number. example: triplea 1.5.2.1 can open 1.5.2.0
     // savegames.
     final String jarName = "triplea_" + oldVersionNeeded.toStringFull("_", ignoreMicro);
-    final File oldJarsFolder = new File(GameRunner2.getRootFolder(), "old/");
+    final File oldJarsFolder = new File(ClientContext.getRootFolder(), "old/");
     if (!oldJarsFolder.exists()) {
       throw new IOException("Can not find 'old' engine jars folder");
     }

--- a/src/games/strategy/engine/framework/TripleAProcessRunner.java
+++ b/src/games/strategy/engine/framework/TripleAProcessRunner.java
@@ -89,7 +89,7 @@ public class TripleAProcessRunner {
     }
     final Version engineVersionOfGameToJoin = new Version(description.getEngineVersion());
     String newClassPath = null;
-    if (!ClientContext.engineVersion().getVersion().equals(engineVersionOfGameToJoin)) {
+    if (!ClientContext.engineVersion().getCompatabilityVersion().equals(engineVersionOfGameToJoin)) {
       try {
         newClassPath = findOldJar(engineVersionOfGameToJoin, false);
       } catch (final Exception e) {
@@ -109,7 +109,7 @@ public class TripleAProcessRunner {
         return;
       }
       // ask user if we really want to do this?
-      final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getVersion().toString()
+      final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getCompatabilityVersion().toString()
           + " and you are trying to join a game made with version " + engineVersionOfGameToJoin.toString()
           + "<br>However, this TripleA can only play with engines that are the exact same version as itself (x_x_x_x)."
           + "<br><br>TripleA now comes with older engines included with it, and has found the engine used by the host. This is a new feature and is in 'beta' stage."
@@ -140,7 +140,7 @@ public class TripleAProcessRunner {
   }
 
   public static String findOldJar(final Version oldVersionNeeded, final boolean ignoreMicro) throws IOException {
-    if (ClientContext.engineVersion().getVersion().equals(oldVersionNeeded, ignoreMicro)) {
+    if (ClientContext.engineVersion().getCompatabilityVersion().equals(oldVersionNeeded, ignoreMicro)) {
       return System.getProperty("java.class.path");
     }
     // first, see if the default/main triplea can run it

--- a/src/games/strategy/engine/framework/TripleAProcessRunner.java
+++ b/src/games/strategy/engine/framework/TripleAProcessRunner.java
@@ -109,7 +109,7 @@ public class TripleAProcessRunner {
         return;
       }
       // ask user if we really want to do this?
-      final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getCompatabilityVersion().toString()
+      final String messageString = "<html>This TripleA engine is version " + ClientContext.engineVersion().getCompatabilityVersion()
           + " and you are trying to join a game made with version " + engineVersionOfGameToJoin.toString()
           + "<br>However, this TripleA can only play with engines that are the exact same version as itself (x_x_x_x)."
           + "<br><br>TripleA now comes with older engines included with it, and has found the engine used by the host. This is a new feature and is in 'beta' stage."

--- a/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
 import games.strategy.engine.framework.GameRunner2;
@@ -185,7 +186,7 @@ public class AvailableGames {
       return null;
     }
     final String raw = uri.toString();
-    final String base = GameRunner2.getRootFolder().toURI().toString() + "maps";
+    final String base = ClientContext.getRootFolder().toURI().toString() + "maps";
     if (raw.startsWith(base)) {
       return raw.substring(base.length());
     }

--- a/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
 import games.strategy.engine.framework.GameRunner2;
@@ -186,7 +186,7 @@ public class AvailableGames {
       return null;
     }
     final String raw = uri.toString();
-    final String base = ClientContext.getRootFolder().toURI().toString() + "maps";
+    final String base = ClientFileSystemHelper.getRootFolder().toURI().toString() + "maps";
     if (raw.startsWith(base)) {
       return raw.substring(base.length());
     }

--- a/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -84,7 +84,7 @@ public class AvailableGames {
   private static List<File> allMapFiles() {
     final List<File> rVal = new ArrayList<File>();
     // prioritize user maps folder over root folder
-    rVal.addAll(safeListFiles(GameRunner2.getUserMapsFolder()));
+    rVal.addAll(safeListFiles(ClientFileSystemHelper.getUserMapsFolder()));
     rVal.addAll(safeListFiles(NewGameChooserModel.getDefaultMapsDir()));
     return rVal;
   }

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameSelectorPanel.java
@@ -28,6 +28,7 @@ import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUI;
 import games.strategy.engine.framework.GameRunner;
@@ -235,7 +236,7 @@ public class HeadlessGameSelectorPanel extends JPanel implements Observer {
       m_gameOptions.setEnabled(false);
     }
     // we don't want them starting new games if we are an old jar
-    if (GameRunner2.areWeOldExtraJar()) {
+    if (ClientContext.areWeOldExtraJar()) {
       m_loadNewGame.setEnabled(false);
       m_loadNewGame.setToolTipText(
           "This is disabled on older engine jars, please start new games with the latest version of TripleA.");

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameSelectorPanel.java
@@ -28,11 +28,10 @@ import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 
-import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUI;
 import games.strategy.engine.framework.GameRunner;
-import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.ui.MainFrame;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
@@ -236,7 +235,7 @@ public class HeadlessGameSelectorPanel extends JPanel implements Observer {
       m_gameOptions.setEnabled(false);
     }
     // we don't want them starting new games if we are an old jar
-    if (ClientContext.areWeOldExtraJar()) {
+    if (ClientFileSystemHelper.areWeOldExtraJar()) {
       m_loadNewGame.setEnabled(false);
       m_loadNewGame.setToolTipText(
           "This is disabled on older engine jars, please start new games with the latest version of TripleA.");

--- a/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
@@ -60,6 +60,6 @@ class DownloadFileProperties {
     props.setProperty("map.url", selected.getUrl());
     props.setProperty("download.time", new Date().toString());
     props.setProperty("download.hostedBy", selected.getHostedUrl());
-    props.setProperty("engine.version", ClientContext.engineVersion().getVersion().toString());
+    props.setProperty("engine.version", ClientContext.engineVersion().getCompatabilityVersion().toString());
   }
 }

--- a/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Date;
 import java.util.Properties;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.util.Version;
 
@@ -59,6 +60,6 @@ class DownloadFileProperties {
     props.setProperty("map.url", selected.getUrl());
     props.setProperty("download.time", new Date().toString());
     props.setProperty("download.hostedBy", selected.getHostedUrl());
-    props.setProperty("engine.version", EngineVersion.VERSION.toString());
+    props.setProperty("engine.version", ClientContext.getInstance().engineVersion().getVersion().toString());
   }
 }

--- a/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
@@ -60,6 +60,6 @@ class DownloadFileProperties {
     props.setProperty("map.url", selected.getUrl());
     props.setProperty("download.time", new Date().toString());
     props.setProperty("download.hostedBy", selected.getHostedUrl());
-    props.setProperty("engine.version", ClientContext.getInstance().engineVersion().getVersion().toString());
+    props.setProperty("engine.version", ClientContext.engineVersion().getVersion().toString());
   }
 }

--- a/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
@@ -60,6 +60,6 @@ class DownloadFileProperties {
     props.setProperty("map.url", selected.getUrl());
     props.setProperty("download.time", new Date().toString());
     props.setProperty("download.hostedBy", selected.getHostedUrl());
-    props.setProperty("engine.version", ClientContext.engineVersion().getVersion().toString());
+    props.setProperty("engine.version", ClientContext.engineVersion().toString());
   }
 }

--- a/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadFileProperties.java
@@ -60,6 +60,6 @@ class DownloadFileProperties {
     props.setProperty("map.url", selected.getUrl());
     props.setProperty("download.time", new Date().toString());
     props.setProperty("download.hostedBy", selected.getHostedUrl());
-    props.setProperty("engine.version", ClientContext.engineVersion().getCompatabilityVersion().toString());
+    props.setProperty("engine.version", ClientContext.engineVersion().getVersion().toString());
   }
 }

--- a/src/games/strategy/engine/framework/mapDownload/DownloadRunnable.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadRunnable.java
@@ -12,8 +12,7 @@ import java.nio.file.Files;
 import java.util.List;
 
 import games.strategy.debug.ClientLogger;
-import games.strategy.engine.ClientContext;
-import games.strategy.engine.framework.GameRunner2;
+import games.strategy.engine.ClientFileSystemHelper;
 
 public class DownloadRunnable implements Runnable {
   private final String urlString;
@@ -113,7 +112,7 @@ public class DownloadRunnable implements Runnable {
   }
 
   private void readLocalFile() {
-    File targetFile = new File(ClientContext.getRootFolder(), urlString);
+    File targetFile = new File(ClientFileSystemHelper.getRootFolder(), urlString);
     try {
       contents = Files.readAllBytes(targetFile.toPath());
       downloads = DownloadFileParser.parse(new ByteArrayInputStream(getContents()), urlString);

--- a/src/games/strategy/engine/framework/mapDownload/DownloadRunnable.java
+++ b/src/games/strategy/engine/framework/mapDownload/DownloadRunnable.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.util.List;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner2;
 
 public class DownloadRunnable implements Runnable {
@@ -112,7 +113,7 @@ public class DownloadRunnable implements Runnable {
   }
 
   private void readLocalFile() {
-    File targetFile = new File(GameRunner2.getRootFolder(), urlString);
+    File targetFile = new File(ClientContext.getRootFolder(), urlString);
     try {
       contents = Files.readAllBytes(targetFile.toPath());
       downloads = DownloadFileParser.parse(new ByteArrayInputStream(getContents()), urlString);

--- a/src/games/strategy/engine/framework/mapDownload/InstallMapDialog.java
+++ b/src/games/strategy/engine/framework/mapDownload/InstallMapDialog.java
@@ -42,7 +42,7 @@ import javax.swing.event.ListSelectionListener;
 
 import com.google.common.io.Files;
 
-import games.strategy.engine.framework.GameRunner2;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import games.strategy.ui.Util;
@@ -96,7 +96,7 @@ public class InstallMapDialog extends JDialog {
     listingToBeAddedTo.clear();
     for (final DownloadFileDescription d : gamesDownloadFileDescriptions) {
       if (d != null && !d.isDummyUrl()) {
-        File installed = new File(GameRunner2.getUserMapsFolder(), d.getMapName() + ".zip");
+        File installed = new File(ClientFileSystemHelper.getUserMapsFolder(), d.getMapName() + ".zip");
         if (installed == null || !installed.exists()) {
           installed = new File(GameSelectorModel.DEFAULT_MAP_DIRECTORY, d.getMapName() + ".zip");
         }
@@ -127,7 +127,7 @@ public class InstallMapDialog extends JDialog {
       gameMap.put(d.getMapName(), d);
       gameNames.add(d.getMapName());
       if (d != null && !d.isDummyUrl()) {
-        File installed = new File(GameRunner2.getUserMapsFolder(), d.getMapName() + ".zip");
+        File installed = new File(ClientFileSystemHelper.getUserMapsFolder(), d.getMapName() + ".zip");
         if (installed == null || !installed.exists()) {
           installed = new File(GameSelectorModel.DEFAULT_MAP_DIRECTORY, d.getMapName() + ".zip");
         }
@@ -152,7 +152,7 @@ public class InstallMapDialog extends JDialog {
         } else {
           final DownloadFileDescription description = gameMap.get(mapName);
           if (!description.isDummyUrl()) {
-            File installed = new File(GameRunner2.getUserMapsFolder(), mapName + ".zip");
+            File installed = new File(ClientFileSystemHelper.getUserMapsFolder(), mapName + ".zip");
             if (installed == null || !installed.exists()) {
               installed = new File(GameSelectorModel.DEFAULT_MAP_DIRECTORY, mapName + ".zip");
             }
@@ -231,7 +231,7 @@ public class InstallMapDialog extends JDialog {
           if (map.isDummyUrl()) {
             continue;
           }
-          final File destination = new File(GameRunner2.getUserMapsFolder(), map.getMapName() + ".zip");
+          final File destination = new File(ClientFileSystemHelper.getUserMapsFolder(), map.getMapName() + ".zip");
           if (destination.exists()) {
             final String msg = "<html>Replace map: " + map.getMapName() + " ?" + "<br>You have version "
                 + getVersionString(getVersion(destination)) + " installed, replace with version "
@@ -282,7 +282,7 @@ public class InstallMapDialog extends JDialog {
 
   private void install(final DownloadFileDescription selected, final int count, final int total) {
     String destinationFileName = Files.getNameWithoutExtension(selected.getUrl()) + ".zip";
-    final File destination = new File(GameRunner2.getUserMapsFolder(), destinationFileName);
+    final File destination = new File(ClientFileSystemHelper.getUserMapsFolder(), destinationFileName);
 
     if (destination.exists()) {
       if (!destination.delete()) {
@@ -378,7 +378,7 @@ public class InstallMapDialog extends JDialog {
         if (!map.isDummyUrl()) {
           m_urlLabel.setText(DOWNLOAD_URL_PREFIX + map.getUrl());
           String currentVersion = "";
-          final File destination = new File(GameRunner2.getUserMapsFolder(), map.getMapName() + ".zip");
+          final File destination = new File(ClientFileSystemHelper.getUserMapsFolder(), map.getMapName() + ".zip");
           if (destination.exists()) {
             currentVersion = "   (installed version: " + getVersionString(getVersion(destination)) + ")";
           }

--- a/src/games/strategy/engine/framework/mapDownload/MapDownloadController.java
+++ b/src/games/strategy/engine/framework/mapDownload/MapDownloadController.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework.mapDownload;
 
 import java.awt.Frame;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -24,9 +23,8 @@ public class MapDownloadController {
   private static final String TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES = "triplea.lastCheckForMapUpdates";
   private final MapListingSource mapDownloadProperties;
 
-  public MapDownloadController() {
-    File mapDownloadPropertiesFile = new File(GameRunner2.getRootFolder(), "mapDownload.properties");
-    mapDownloadProperties = new MapListingSource(mapDownloadPropertiesFile);
+  public MapDownloadController(final MapListingSource mapSource) {
+    mapDownloadProperties = mapSource;
   }
 
   /** Opens a new window dialog where a user can select maps to download or update */

--- a/src/games/strategy/engine/framework/mapDownload/MapListingSource.java
+++ b/src/games/strategy/engine/framework/mapDownload/MapListingSource.java
@@ -1,15 +1,9 @@
 package games.strategy.engine.framework.mapDownload;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.Properties;
-
-import games.strategy.debug.ClientLogger;
+import games.strategy.engine.config.GameEngineProperty;
+import games.strategy.engine.config.PropertyReader;
 
 
 /**
@@ -20,30 +14,12 @@ import games.strategy.debug.ClientLogger;
  * Can be used to create a <code>MapDownloadAction</code>
  */
 public class MapListingSource {
-
-  public static final String MAP_LIST_DOWNLOAD_SITE_PROPERTY_KEY = "Map_List_File";
   private final String mapListDownloadSite;
 
-
-  public MapListingSource(File mapDownloadPropertiesFile) {
-    checkState(checkNotNull(mapDownloadPropertiesFile).isFile());
-    mapListDownloadSite = readMapListDownloadSitePropertyValue(mapDownloadPropertiesFile);
+  public MapListingSource(PropertyReader propertyReader) {
+    checkNotNull(propertyReader);
+    mapListDownloadSite = propertyReader.readProperty(GameEngineProperty.MAP_LISTING_SOURCE_FILE);
   }
-
-  private static String readMapListDownloadSitePropertyValue(File mapDownloadPropertiesFile) {
-    String propertyValue = null;
-    try (FileInputStream inputStream = new FileInputStream(mapDownloadPropertiesFile)) {
-      Properties props = new Properties();
-      props.load(inputStream);
-      propertyValue = props.getProperty(MAP_LIST_DOWNLOAD_SITE_PROPERTY_KEY);
-    } catch (FileNotFoundException e) {
-      // Exception should not happen, already checked by the Checkstate call during construction
-    } catch (IOException e) {
-      ClientLogger.logError("failed to load property file: " + mapDownloadPropertiesFile.getAbsolutePath(), e);
-    }
-    return propertyValue;
-  }
-
 
   /** Return the URL where we can download a file that lists each map that is available */
   protected String getMapListDownloadSite() {

--- a/src/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -35,7 +35,7 @@ public class ClientLogin implements IConnectionLogin {
       final String password = new String(passwordField.getPassword());
       rVal.put(PASSWORD_PROPERTY, MD5Crypt.crypt(password, challengProperties.get(ClientLoginValidator.SALT_PROPERTY)));
     }
-    rVal.put(ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getVersion().toString());
+    rVal.put(ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getCompatabilityVersion().toString());
     rVal.put(JDK_VERSION_PROPERTY, System.getProperty("java.runtime.version"));
     return rVal;
   }

--- a/src/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -35,7 +35,7 @@ public class ClientLogin implements IConnectionLogin {
       final String password = new String(passwordField.getPassword());
       rVal.put(PASSWORD_PROPERTY, MD5Crypt.crypt(password, challengProperties.get(ClientLoginValidator.SALT_PROPERTY)));
     }
-    rVal.put(ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getVersion().toString());
+    rVal.put(ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().toString());
     rVal.put(JDK_VERSION_PROPERTY, System.getProperty("java.runtime.version"));
     return rVal;
   }

--- a/src/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -35,7 +35,7 @@ public class ClientLogin implements IConnectionLogin {
       final String password = new String(passwordField.getPassword());
       rVal.put(PASSWORD_PROPERTY, MD5Crypt.crypt(password, challengProperties.get(ClientLoginValidator.SALT_PROPERTY)));
     }
-    rVal.put(ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getCompatabilityVersion().toString());
+    rVal.put(ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getVersion().toString());
     rVal.put(JDK_VERSION_PROPERTY, System.getProperty("java.runtime.version"));
     return rVal;
   }

--- a/src/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -35,7 +35,7 @@ public class ClientLogin implements IConnectionLogin {
       final String password = new String(passwordField.getPassword());
       rVal.put(PASSWORD_PROPERTY, MD5Crypt.crypt(password, challengProperties.get(ClientLoginValidator.SALT_PROPERTY)));
     }
-    rVal.put(ENGINE_VERSION_PROPERTY, ClientContext.getInstance().engineVersion().getVersion().toString());
+    rVal.put(ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getVersion().toString());
     rVal.put(JDK_VERSION_PROPERTY, System.getProperty("java.runtime.version"));
     return rVal;
   }

--- a/src/games/strategy/engine/framework/startup/login/ClientLogin.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLogin.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import javax.swing.JOptionPane;
 import javax.swing.JPasswordField;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.net.IConnectionLogin;
 import games.strategy.util.CountDownLatchHandler;
@@ -34,7 +35,7 @@ public class ClientLogin implements IConnectionLogin {
       final String password = new String(passwordField.getPassword());
       rVal.put(PASSWORD_PROPERTY, MD5Crypt.crypt(password, challengProperties.get(ClientLoginValidator.SALT_PROPERTY)));
     }
-    rVal.put(ENGINE_VERSION_PROPERTY, EngineVersion.VERSION.toString());
+    rVal.put(ENGINE_VERSION_PROPERTY, ClientContext.getInstance().engineVersion().getVersion().toString());
     rVal.put(JDK_VERSION_PROPERTY, System.getProperty("java.runtime.version"));
     return rVal;
   }

--- a/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -42,7 +42,7 @@ public class ClientLoginValidator implements ILoginValidator {
   @Override
   public Map<String, String> getChallengeProperties(final String userName, final SocketAddress remoteAddress) {
     final Map<String, String> challengeProperties = new HashMap<String, String>();
-    challengeProperties.put("Sever Version", ClientContext.engineVersion().getCompatabilityVersion().toString());
+    challengeProperties.put("Sever Version", ClientContext.engineVersion().getVersion().toString());
     if (m_password != null) {
       /**
        * Get a new random salt.
@@ -66,8 +66,8 @@ public class ClientLoginValidator implements ILoginValidator {
     }
     // check for version
     final Version clientVersion = new Version(versionString);
-    if (!ClientContext.engineVersion().getCompatabilityVersion().equals(clientVersion, false)) {
-      final String error = "Client is using " + clientVersion + " but server requires version " + ClientContext.engineVersion().getCompatabilityVersion();
+    if (!ClientContext.engineVersion().getVersion().equals(clientVersion, false)) {
+      final String error = "Client is using " + clientVersion + " but server requires version " + ClientContext.engineVersion().getVersion();
       return error;
     }
     final String realName = clientName.split(" ")[0];

--- a/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -42,7 +42,7 @@ public class ClientLoginValidator implements ILoginValidator {
   @Override
   public Map<String, String> getChallengeProperties(final String userName, final SocketAddress remoteAddress) {
     final Map<String, String> challengeProperties = new HashMap<String, String>();
-    challengeProperties.put("Sever Version", ClientContext.engineVersion().getVersion().toString());
+    challengeProperties.put("Sever Version", ClientContext.engineVersion().toString());
     if (m_password != null) {
       /**
        * Get a new random salt.

--- a/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import games.strategy.engine.ClientContext;
-import games.strategy.engine.EngineVersion;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.IServerMessenger;
 import games.strategy.util.MD5Crypt;
@@ -43,7 +42,7 @@ public class ClientLoginValidator implements ILoginValidator {
   @Override
   public Map<String, String> getChallengeProperties(final String userName, final SocketAddress remoteAddress) {
     final Map<String, String> challengeProperties = new HashMap<String, String>();
-    challengeProperties.put("Sever Version", ClientContext.getInstance().engineVersion().getVersion().toString());
+    challengeProperties.put("Sever Version", ClientContext.engineVersion().getVersion().toString());
     if (m_password != null) {
       /**
        * Get a new random salt.
@@ -67,8 +66,8 @@ public class ClientLoginValidator implements ILoginValidator {
     }
     // check for version
     final Version clientVersion = new Version(versionString);
-    if (!ClientContext.getInstance().engineVersion().getVersion().equals(clientVersion, false)) {
-      final String error = "Client is using " + clientVersion + " but server requires version " + ClientContext.getInstance().engineVersion().getVersion();
+    if (!ClientContext.engineVersion().getVersion().equals(clientVersion, false)) {
+      final String error = "Client is using " + clientVersion + " but server requires version " + ClientContext.engineVersion().getVersion();
       return error;
     }
     final String realName = clientName.split(" ")[0];

--- a/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -42,7 +42,7 @@ public class ClientLoginValidator implements ILoginValidator {
   @Override
   public Map<String, String> getChallengeProperties(final String userName, final SocketAddress remoteAddress) {
     final Map<String, String> challengeProperties = new HashMap<String, String>();
-    challengeProperties.put("Sever Version", ClientContext.engineVersion().getVersion().toString());
+    challengeProperties.put("Sever Version", ClientContext.engineVersion().getCompatabilityVersion().toString());
     if (m_password != null) {
       /**
        * Get a new random salt.
@@ -66,8 +66,8 @@ public class ClientLoginValidator implements ILoginValidator {
     }
     // check for version
     final Version clientVersion = new Version(versionString);
-    if (!ClientContext.engineVersion().getVersion().equals(clientVersion, false)) {
-      final String error = "Client is using " + clientVersion + " but server requires version " + ClientContext.engineVersion().getVersion();
+    if (!ClientContext.engineVersion().getCompatabilityVersion().equals(clientVersion, false)) {
+      final String error = "Client is using " + clientVersion + " but server requires version " + ClientContext.engineVersion().getCompatabilityVersion();
       return error;
     }
     final String realName = clientName.split(" ")[0];

--- a/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -5,6 +5,7 @@ import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.IServerMessenger;
@@ -42,7 +43,7 @@ public class ClientLoginValidator implements ILoginValidator {
   @Override
   public Map<String, String> getChallengeProperties(final String userName, final SocketAddress remoteAddress) {
     final Map<String, String> challengeProperties = new HashMap<String, String>();
-    challengeProperties.put("Sever Version", EngineVersion.VERSION.toString());
+    challengeProperties.put("Sever Version", ClientContext.getInstance().engineVersion().getVersion().toString());
     if (m_password != null) {
       /**
        * Get a new random salt.
@@ -66,8 +67,8 @@ public class ClientLoginValidator implements ILoginValidator {
     }
     // check for version
     final Version clientVersion = new Version(versionString);
-    if (!EngineVersion.VERSION.equals(clientVersion, false)) {
-      final String error = "Client is using " + clientVersion + " but server requires version " + EngineVersion.VERSION;
+    if (!ClientContext.getInstance().engineVersion().getVersion().equals(clientVersion, false)) {
+      final String error = "Client is using " + clientVersion + " but server requires version " + ClientContext.getInstance().engineVersion().getVersion();
       return error;
     }
     final String realName = clientName.split(" ")[0];

--- a/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -14,7 +14,7 @@ import java.util.prefs.Preferences;
 
 import javax.swing.JOptionPane;
 
-import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
@@ -33,7 +33,7 @@ public class GameSelectorModel extends Observable {
    */
   public static final String DEFAULT_GAME_XML_DIRECTORY_NAME = "games";
   /** Returns the folder where maps are held, example: "/maps" */
-  public static final File DEFAULT_MAP_DIRECTORY = new File(ClientContext.getRootFolder(), "maps");
+  public static final File DEFAULT_MAP_DIRECTORY = new File(ClientFileSystemHelper.getRootFolder(), "maps");
   private static final String DEFAULT_GAME_NAME_PREF = "DefaultGameName2";
   private static final String DEFAULT_GAME_NAME = "Big World : 1942";
   private static final String DEFAULT_GAME_URI_PREF = "DefaultGameURI";
@@ -71,7 +71,7 @@ public class GameSelectorModel extends Observable {
     // and then start a game with an older jar when they should be using the newest jar (we want user to be using the
     // normal default
     // [newest] triplea.jar for new games)
-    if (ClientContext.areWeOldExtraJar()) {
+    if (ClientFileSystemHelper.areWeOldExtraJar()) {
       return;
     }
     m_fileName = entry.getLocation();
@@ -316,7 +316,7 @@ public class GameSelectorModel extends Observable {
     // version of triplea
     // was using running a game within its root folder, we shouldn't open it)
     final String user = GameRunner2.getUserRootFolder().toURI().toString();
-    final String root = ClientContext.getRootFolder().toURI().toString();
+    final String root = ClientFileSystemHelper.getRootFolder().toURI().toString();
     if (!forceFactoryDefault && userPreferredDefaultGameURI != null && userPreferredDefaultGameURI.length() > 0
         && (userPreferredDefaultGameURI.contains(root) || userPreferredDefaultGameURI.contains(user))) {
       // if the user has a preferred URI, then we load it, and don't bother parsing or doing anything with the whole

--- a/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -315,7 +315,7 @@ public class GameSelectorModel extends Observable {
     // we don't want to load a game file by default that is not within the map folders we can load. (ie: if a previous
     // version of triplea
     // was using running a game within its root folder, we shouldn't open it)
-    final String user = GameRunner2.getUserRootFolder().toURI().toString();
+    final String user = ClientFileSystemHelper.getUserRootFolder().toURI().toString();
     final String root = ClientFileSystemHelper.getRootFolder().toURI().toString();
     if (!forceFactoryDefault && userPreferredDefaultGameURI != null && userPreferredDefaultGameURI.length() > 0
         && (userPreferredDefaultGameURI.contains(root) || userPreferredDefaultGameURI.contains(user))) {

--- a/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -14,6 +14,7 @@ import java.util.prefs.Preferences;
 
 import javax.swing.JOptionPane;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
@@ -32,7 +33,7 @@ public class GameSelectorModel extends Observable {
    */
   public static final String DEFAULT_GAME_XML_DIRECTORY_NAME = "games";
   /** Returns the folder where maps are held, example: "/maps" */
-  public static final File DEFAULT_MAP_DIRECTORY = new File(GameRunner2.getRootFolder(), "maps");
+  public static final File DEFAULT_MAP_DIRECTORY = new File(ClientContext.getRootFolder(), "maps");
   private static final String DEFAULT_GAME_NAME_PREF = "DefaultGameName2";
   private static final String DEFAULT_GAME_NAME = "Big World : 1942";
   private static final String DEFAULT_GAME_URI_PREF = "DefaultGameURI";
@@ -70,7 +71,7 @@ public class GameSelectorModel extends Observable {
     // and then start a game with an older jar when they should be using the newest jar (we want user to be using the
     // normal default
     // [newest] triplea.jar for new games)
-    if (GameRunner2.areWeOldExtraJar()) {
+    if (ClientContext.areWeOldExtraJar()) {
       return;
     }
     m_fileName = entry.getLocation();
@@ -315,7 +316,7 @@ public class GameSelectorModel extends Observable {
     // version of triplea
     // was using running a game within its root folder, we shouldn't open it)
     final String user = GameRunner2.getUserRootFolder().toURI().toString();
-    final String root = GameRunner2.getRootFolder().toURI().toString();
+    final String root = ClientContext.getRootFolder().toURI().toString();
     if (!forceFactoryDefault && userPreferredDefaultGameURI != null && userPreferredDefaultGameURI.length() > 0
         && (userPreferredDefaultGameURI.contains(root) || userPreferredDefaultGameURI.contains(user))) {
       // if the user has a preferred URI, then we load it, and don't bother parsing or doing anything with the whole

--- a/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -32,6 +32,7 @@ import javax.swing.border.EmptyBorder;
 import games.strategy.common.ui.BasicGameMenuBar;
 import games.strategy.debug.ErrorConsole;
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.NumberProperty;
 import games.strategy.engine.data.properties.PropertiesUI;
@@ -443,7 +444,7 @@ public class EnginePreferences extends JDialog {
       @Override
       public void actionPerformed(final ActionEvent e) {
         try {
-          DesktopUtilityBrowserLauncher.openFile(ClientContext.getRootFolder());
+          DesktopUtilityBrowserLauncher.openFile(ClientFileSystemHelper.getRootFolder());
         } catch (final Exception e1) {
           e1.printStackTrace();
         }
@@ -455,7 +456,7 @@ public class EnginePreferences extends JDialog {
       @Override
       public void actionPerformed(final ActionEvent e) {
         try {
-          DesktopUtilityBrowserLauncher.openFile(new File(ClientContext.getRootFolder(), "readme.html"));
+          DesktopUtilityBrowserLauncher.openFile(new File(ClientFileSystemHelper.getRootFolder(), "readme.html"));
         } catch (final Exception e1) {
           e1.printStackTrace();
         }

--- a/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -31,6 +31,7 @@ import javax.swing.border.EmptyBorder;
 
 import games.strategy.common.ui.BasicGameMenuBar;
 import games.strategy.debug.ErrorConsole;
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.NumberProperty;
 import games.strategy.engine.data.properties.PropertiesUI;
@@ -442,7 +443,7 @@ public class EnginePreferences extends JDialog {
       @Override
       public void actionPerformed(final ActionEvent e) {
         try {
-          DesktopUtilityBrowserLauncher.openFile(GameRunner2.getRootFolder());
+          DesktopUtilityBrowserLauncher.openFile(ClientContext.getRootFolder());
         } catch (final Exception e1) {
           e1.printStackTrace();
         }
@@ -454,7 +455,7 @@ public class EnginePreferences extends JDialog {
       @Override
       public void actionPerformed(final ActionEvent e) {
         try {
-          DesktopUtilityBrowserLauncher.openFile(new File(GameRunner2.getRootFolder(), "readme.html"));
+          DesktopUtilityBrowserLauncher.openFile(new File(ClientContext.getRootFolder(), "readme.html"));
         } catch (final Exception e1) {
           e1.printStackTrace();
         }

--- a/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -432,7 +432,7 @@ public class EnginePreferences extends JDialog {
       @Override
       public void actionPerformed(final ActionEvent e) {
         try {
-          DesktopUtilityBrowserLauncher.openFile(GameRunner2.getUserRootFolder());
+          DesktopUtilityBrowserLauncher.openFile(ClientFileSystemHelper.getUserRootFolder());
         } catch (final Exception e1) {
           e1.printStackTrace();
         }

--- a/src/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/src/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -11,9 +11,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.properties.IEditableProperty;
-import games.strategy.engine.framework.GameRunner2;
 
 /**
  * A game options cache that uses files to store the game options
@@ -89,8 +89,8 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
    *        the game data
    * @return the File where the cached game options should be stored or read from
    */
-  private File getCacheFile(final GameData gameData) {
-    final File cacheDir = new File(GameRunner2.getUserRootFolder(), "optionCache");
+  private static File getCacheFile(final GameData gameData) {
+    final File cacheDir = new File(ClientFileSystemHelper.getUserRootFolder(), "optionCache");
     return new File(cacheDir, getFileName(gameData.getGameName()));
   }
 
@@ -101,7 +101,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
    *        the name of the game
    * @return the fileName on disk
    */
-  private String getFileName(final String gameName) {
+  private static String getFileName(final String gameName) {
     final StringBuilder sb = new StringBuilder();
     for (int i = 0, charArrayLength = gameName.length(); i < charArrayLength; i++) {
       final char c = gameName.charAt(i);

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -142,8 +142,8 @@ public class GameSelectorPanel extends JPanel implements Observer {
     String version = ClientContext.getInstance().engineVersion().getExactVersion();
     m_engineVersionText = new JLabel(version);
     m_nameLabel = new JLabel("Game Name:");
-    m_versionLabel = new JLabel("Game Version:");
-    m_roundLabel = new JLabel("Game Round:");
+    m_versionLabel = new JLabel("Map Version:");
+    m_roundLabel = new JLabel("Map Round:");
     m_fileNameLabel = new JLabel("File Name:");
     m_nameText = new JLabel();
     m_versionText = new JLabel();

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -163,25 +163,27 @@ public class GameSelectorPanel extends JPanel implements Observer {
 
   private void layoutComponents() {
     setLayout(new GridBagLayout());
+    add(m_engineVersionLabel, buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
+    add(m_engineVersionText, buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
 
-    add(m_nameLabel, buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
-    add(m_nameText, buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
+    add(m_nameLabel, buildGridCell(0, 1, new Insets(0, 10, 3, 5)));
+    add(m_nameText, buildGridCell(1, 1, new Insets(0, 0, 3, 0)));
 
-    add(m_versionLabel, buildGridCell(0, 1, new Insets(0, 10, 3, 5)));
-    add(m_versionText, buildGridCell(1, 1, new Insets(0, 0, 3, 0)));
+    add(m_versionLabel, buildGridCell(0, 2, new Insets(0, 10, 3, 5)));
+    add(m_versionText, buildGridCell(1, 2, new Insets(0, 0, 3, 0)));
 
-    add(m_roundLabel, buildGridCell(0, 2, new Insets(0, 10, 3, 5)));
-    add(m_roundText, buildGridCell(1, 2, new Insets(0, 0, 3, 0)));
+    add(m_roundLabel, buildGridCell(0, 3, new Insets(0, 10, 3, 5)));
+    add(m_roundText, buildGridCell(1, 3, new Insets(0, 0, 3, 0)));
 
-    add(m_fileNameLabel, buildGridCell(0, 3, new Insets(20, 10, 3, 5)));
+    add(m_fileNameLabel, buildGridCell(0, 4, new Insets(20, 10, 3, 5)));
 
-    add(m_fileNameText, buildGridRow(0, 4, new Insets(0, 10, 3, 5)));
+    add(m_fileNameText, buildGridRow(0, 5, new Insets(0, 10, 3, 5)));
 
-    add(m_loadNewGame, buildGridRow(0, 5, new Insets(25, 10, 10, 10)));
+    add(m_loadNewGame, buildGridRow(0, 6, new Insets(25, 10, 10, 10)));
 
-    add(m_loadSavedGame, buildGridRow(0, 6, new Insets(0, 10, 10, 10)));
+    add(m_loadSavedGame, buildGridRow(0, 7, new Insets(0, 10, 10, 10)));
 
-    add(m_gameOptions, buildGridRow(0, 7, new Insets(25, 10, 10, 10)));
+    add(m_gameOptions, buildGridRow(0, 8, new Insets(25, 10, 10, 10)));
 
     // spacer
     add(new JPanel(), new GridBagConstraints(0, 8, 2, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH,

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -36,7 +36,6 @@ import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUI;
 import games.strategy.engine.framework.GameRunner;
-import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.ui.NewGameChooser;
@@ -115,7 +114,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
    *        maximum number of characters per line
    * @return filename formatted file name - in case it is too long (> maxLength) to two lines
    */
-  private String getFormattedFileNameText(final String fileName, final int maxLength) {
+  private static String getFormattedFileNameText(final String fileName, final int maxLength) {
     if (fileName.length() <= maxLength) {
       return fileName;
     }
@@ -165,9 +164,6 @@ public class GameSelectorPanel extends JPanel implements Observer {
   private void layoutComponents() {
     setLayout(new GridBagLayout());
 
-    add(m_engineVersionLabel, buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
-    add(m_engineVersionText, buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
-
     add(m_nameLabel, buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
     add(m_nameText, buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
 
@@ -185,7 +181,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
 
     add(m_loadSavedGame, buildGridRow(0, 6, new Insets(0, 10, 10, 10)));
 
-    add(m_gameOptions, buildGridRow(0, 7,new Insets(25, 10, 10, 10)));
+    add(m_gameOptions, buildGridRow(0, 7, new Insets(25, 10, 10, 10)));
 
     // spacer
     add(new JPanel(), new GridBagConstraints(0, 8, 2, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH,

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -139,7 +139,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
 
   private void createComponents() {
     m_engineVersionLabel = new JLabel("Engine Version:");
-    String version = ClientContext.getInstance().engineVersion().getExactVersion();
+    String version = ClientContext.engineVersion().getExactVersion();
     m_engineVersionText = new JLabel(version);
     m_nameLabel = new JLabel("Map Name:");
     m_versionLabel = new JLabel("Map Version:");

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -29,6 +29,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.properties.IEditableProperty;
@@ -311,7 +312,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
       m_gameOptions.setEnabled(false);
     }
     // we don't want them starting new games if we are an old jar
-    if (GameRunner2.areWeOldExtraJar()) {
+    if (ClientContext.areWeOldExtraJar()) {
       m_loadNewGame.setEnabled(false);
       m_loadNewGame.setToolTipText(
           "This is disabled on older engine jars, please start new games with the latest version of TripleA.");

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -139,7 +139,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
 
   private void createComponents() {
     m_engineVersionLabel = new JLabel("Engine Version:");
-    String version = ClientContext.engineVersion().getExactVersion();
+    String version = ClientContext.engineVersion().getFullVersion();
     m_engineVersionText = new JLabel(version);
     m_nameLabel = new JLabel("Map Name:");
     m_versionLabel = new JLabel("Map Version:");

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -141,9 +141,9 @@ public class GameSelectorPanel extends JPanel implements Observer {
     m_engineVersionLabel = new JLabel("Engine Version:");
     String version = ClientContext.getInstance().engineVersion().getExactVersion();
     m_engineVersionText = new JLabel(version);
-    m_nameLabel = new JLabel("Game Name:");
+    m_nameLabel = new JLabel("Map Name:");
     m_versionLabel = new JLabel("Map Version:");
-    m_roundLabel = new JLabel("Map Round:");
+    m_roundLabel = new JLabel("Game Round:");
     m_fileNameLabel = new JLabel("File Name:");
     m_nameText = new JLabel();
     m_versionText = new JLabel();

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -45,6 +45,9 @@ import games.strategy.engine.framework.ui.SaveGameFileChooser;
 
 public class GameSelectorPanel extends JPanel implements Observer {
   private static final long serialVersionUID = -4598107601238030020L;
+
+  private JLabel m_engineVersionLabel;
+  private JLabel m_engineVersionText;
   private JLabel m_nameText;
   private JLabel m_versionText;
   private JLabel m_fileNameLabel;
@@ -136,6 +139,9 @@ public class GameSelectorPanel extends JPanel implements Observer {
   }
 
   private void createComponents() {
+    m_engineVersionLabel = new JLabel("Engine Version:");
+    String version = ClientContext.getInstance().engineVersion().getExactVersion();
+    m_engineVersionText = new JLabel(version);
     m_nameLabel = new JLabel("Game Name:");
     m_versionLabel = new JLabel("Game Version:");
     m_roundLabel = new JLabel("Game Round:");
@@ -158,16 +164,27 @@ public class GameSelectorPanel extends JPanel implements Observer {
 
   private void layoutComponents() {
     setLayout(new GridBagLayout());
+
+    add(m_engineVersionLabel, buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
+    add(m_engineVersionText, buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
+
     add(m_nameLabel, buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
     add(m_nameText, buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
+
     add(m_versionLabel, buildGridCell(0, 1, new Insets(0, 10, 3, 5)));
     add(m_versionText, buildGridCell(1, 1, new Insets(0, 0, 3, 0)));
+
     add(m_roundLabel, buildGridCell(0, 2, new Insets(0, 10, 3, 5)));
     add(m_roundText, buildGridCell(1, 2, new Insets(0, 0, 3, 0)));
+
     add(m_fileNameLabel, buildGridCell(0, 3, new Insets(20, 10, 3, 5)));
+
     add(m_fileNameText, buildGridRow(0, 4, new Insets(0, 10, 3, 5)));
+
     add(m_loadNewGame, buildGridRow(0, 5, new Insets(25, 10, 10, 10)));
+
     add(m_loadSavedGame, buildGridRow(0, 6, new Insets(0, 10, 10, 10)));
+
     add(m_gameOptions, buildGridRow(0, 7,new Insets(25, 10, 10, 10)));
 
     // spacer

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -154,34 +154,49 @@ public class GameSelectorPanel extends JPanel implements Observer {
         "<html>Set options for the currently selected game, <br>such as enabling/disabling Low Luck, or Technology, etc.</html>");
   }
 
+
+
   private void layoutComponents() {
     setLayout(new GridBagLayout());
-    add(m_nameLabel, new GridBagConstraints(0, 0, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(10, 10, 3, 5), 0, 0));
-    add(m_nameText, new GridBagConstraints(1, 0, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(10, 0, 3, 0), 0, 0));
-    add(m_versionLabel, new GridBagConstraints(0, 1, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(0, 10, 3, 5), 0, 0));
-    add(m_versionText, new GridBagConstraints(1, 1, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(0, 0, 3, 0), 0, 0));
-    add(m_roundLabel, new GridBagConstraints(0, 2, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(0, 10, 3, 5), 0, 0));
-    add(m_roundText, new GridBagConstraints(1, 2, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(0, 0, 3, 0), 0, 0));
-    add(m_fileNameLabel, new GridBagConstraints(0, 3, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(20, 10, 3, 5), 0, 0));
-    add(m_fileNameText, new GridBagConstraints(0, 4, 2, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(0, 10, 3, 5), 0, 0));
-    add(m_loadNewGame, new GridBagConstraints(0, 5, 2, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(25, 10, 10, 10), 0, 0));
-    add(m_loadSavedGame, new GridBagConstraints(0, 6, 2, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(0, 10, 10, 10), 0, 0));
-    add(m_gameOptions, new GridBagConstraints(0, 7, 2, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(25, 10, 10, 10), 0, 0));
+    add(m_nameLabel, buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
+    add(m_nameText, buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
+    add(m_versionLabel, buildGridCell(0, 1, new Insets(0, 10, 3, 5)));
+    add(m_versionText, buildGridCell(1, 1, new Insets(0, 0, 3, 0)));
+    add(m_roundLabel, buildGridCell(0, 2, new Insets(0, 10, 3, 5)));
+    add(m_roundText, buildGridCell(1, 2, new Insets(0, 0, 3, 0)));
+    add(m_fileNameLabel, buildGridCell(0, 3, new Insets(20, 10, 3, 5)));
+    add(m_fileNameText, buildGridRow(0, 4, new Insets(0, 10, 3, 5)));
+    add(m_loadNewGame, buildGridRow(0, 5, new Insets(25, 10, 10, 10)));
+    add(m_loadSavedGame, buildGridRow(0, 6, new Insets(0, 10, 10, 10)));
+    add(m_gameOptions, buildGridRow(0, 7,new Insets(25, 10, 10, 10)));
+
     // spacer
     add(new JPanel(), new GridBagConstraints(0, 8, 2, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH,
         new Insets(0, 0, 0, 0), 0, 0));
   }
+
+
+  private static GridBagConstraints buildGridCell(int x, int y, Insets insets) {
+    return buildGrid(x, y, insets, 1);
+  }
+
+  private static GridBagConstraints buildGridRow(int x, int y, Insets insets) {
+    return buildGrid(x, y, insets, 2);
+  }
+
+  private static GridBagConstraints buildGrid(int x, int y, Insets insets, int width) {
+    int gridWidth = width;
+    int gridHeight = 1;
+    double weigthX = 0;
+    double weigthY = 0;
+    int anchor = GridBagConstraints.WEST;
+    int fill = GridBagConstraints.NONE;
+    int ipadx = 0;
+    int ipady = 0;
+
+    return new GridBagConstraints(x, y, gridWidth, gridHeight, weigthX, weigthY, anchor, fill, insets, ipadx, ipady);
+  }
+
 
   private void setupListeners() {
     m_loadNewGame.addActionListener(new ActionListener() {

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -30,6 +30,7 @@ import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.properties.IEditableProperty;
@@ -312,7 +313,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
       m_gameOptions.setEnabled(false);
     }
     // we don't want them starting new games if we are an old jar
-    if (ClientContext.areWeOldExtraJar()) {
+    if (ClientFileSystemHelper.areWeOldExtraJar()) {
       m_loadNewGame.setEnabled(false);
       m_loadNewGame.setToolTipText(
           "This is disabled on older engine jars, please start new games with the latest version of TripleA.");

--- a/src/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -188,7 +188,7 @@ public class InGameLobbyWatcher {
             ? "-" : oldWatcher.m_gameDescription.getRound();
     m_gameDescription = new GameDescription(m_messenger.getLocalNode(), m_gameMessenger.getLocalNode().getPort(),
         startDateTime, "???", playerCount, gameStatus, gameRound, m_gameMessenger.getLocalNode().getName(),
-        System.getProperty(GameRunner2.LOBBY_GAME_COMMENTS), passworded, ClientContext.engineVersion().getVersion().toString(), "0");
+        System.getProperty(GameRunner2.LOBBY_GAME_COMMENTS), passworded, ClientContext.engineVersion().getCompatabilityVersion().toString(), "0");
     final ILobbyGameController controller =
         (ILobbyGameController) m_remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE);
     synchronized (m_mutex) {

--- a/src/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -188,7 +188,7 @@ public class InGameLobbyWatcher {
             ? "-" : oldWatcher.m_gameDescription.getRound();
     m_gameDescription = new GameDescription(m_messenger.getLocalNode(), m_gameMessenger.getLocalNode().getPort(),
         startDateTime, "???", playerCount, gameStatus, gameRound, m_gameMessenger.getLocalNode().getName(),
-        System.getProperty(GameRunner2.LOBBY_GAME_COMMENTS), passworded, ClientContext.getInstance().engineVersion().getVersion().toString(), "0");
+        System.getProperty(GameRunner2.LOBBY_GAME_COMMENTS), passworded, ClientContext.engineVersion().getVersion().toString(), "0");
     final ILobbyGameController controller =
         (ILobbyGameController) m_remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE);
     synchronized (m_mutex) {

--- a/src/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -188,7 +188,7 @@ public class InGameLobbyWatcher {
             ? "-" : oldWatcher.m_gameDescription.getRound();
     m_gameDescription = new GameDescription(m_messenger.getLocalNode(), m_gameMessenger.getLocalNode().getPort(),
         startDateTime, "???", playerCount, gameStatus, gameRound, m_gameMessenger.getLocalNode().getName(),
-        System.getProperty(GameRunner2.LOBBY_GAME_COMMENTS), passworded, ClientContext.engineVersion().getVersion().toString(), "0");
+        System.getProperty(GameRunner2.LOBBY_GAME_COMMENTS), passworded, ClientContext.engineVersion().toString(), "0");
     final ILobbyGameController controller =
         (ILobbyGameController) m_remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE);
     synchronized (m_mutex) {

--- a/src/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -188,7 +188,7 @@ public class InGameLobbyWatcher {
             ? "-" : oldWatcher.m_gameDescription.getRound();
     m_gameDescription = new GameDescription(m_messenger.getLocalNode(), m_gameMessenger.getLocalNode().getPort(),
         startDateTime, "???", playerCount, gameStatus, gameRound, m_gameMessenger.getLocalNode().getName(),
-        System.getProperty(GameRunner2.LOBBY_GAME_COMMENTS), passworded, ClientContext.engineVersion().getCompatabilityVersion().toString(), "0");
+        System.getProperty(GameRunner2.LOBBY_GAME_COMMENTS), passworded, ClientContext.engineVersion().getVersion().toString(), "0");
     final ILobbyGameController controller =
         (ILobbyGameController) m_remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE);
     synchronized (m_mutex) {

--- a/src/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -12,6 +12,7 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
 import games.strategy.debug.HeartBeat;
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.events.GameStepListener;
@@ -187,7 +188,7 @@ public class InGameLobbyWatcher {
             ? "-" : oldWatcher.m_gameDescription.getRound();
     m_gameDescription = new GameDescription(m_messenger.getLocalNode(), m_gameMessenger.getLocalNode().getPort(),
         startDateTime, "???", playerCount, gameStatus, gameRound, m_gameMessenger.getLocalNode().getName(),
-        System.getProperty(GameRunner2.LOBBY_GAME_COMMENTS), passworded, EngineVersion.VERSION.toString(), "0");
+        System.getProperty(GameRunner2.LOBBY_GAME_COMMENTS), passworded, ClientContext.getInstance().engineVersion().getVersion().toString(), "0");
     final ILobbyGameController controller =
         (ILobbyGameController) m_remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE);
     synchronized (m_mutex) {

--- a/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -31,8 +31,6 @@ import javax.swing.ScrollPaneConstants;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.EngineVersion;
-import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.mapDownload.MapDownloadController;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
 import games.strategy.engine.framework.ui.NewGameChooser;
@@ -47,7 +45,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private static final long serialVersionUID = 3926503672972937677L;
   private static final Logger s_logger = Logger.getLogger(MetaSetupPanel.class.getName());
-  private static String s_serverPropertiesName = "server_" + ClientContext.engineVersion().getCompatabilityVersion().toString() + ".properties";
+  private static String s_serverPropertiesName = "server_" + ClientContext.engineVersion().getCompatabilityVersion() + ".properties";
   private JButton m_startLocal;
   private JButton m_startPBEM;
   private JButton m_hostGame;
@@ -232,7 +230,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private void about() {
     final String text =
-        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion().toString()
+        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + ClientContext.engineVersion().getCompatabilityVersion()
             + "<br><b>Authors:</b> Sean Bridges, and many others. Current Developers: Veqryn (Chris Duncan)."
             + "<br>TripleA is an open-source game engine, allowing people to play many different games and maps."
             + "<br>For more information please visit:<br>"

--- a/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -47,7 +47,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private static final long serialVersionUID = 3926503672972937677L;
   private static final Logger s_logger = Logger.getLogger(MetaSetupPanel.class.getName());
-  private static String s_serverPropertiesName = "server_" + ClientContext.engineVersion().getVersion().toString() + ".properties";
+  private static String s_serverPropertiesName = "server_" + ClientContext.engineVersion().getCompatabilityVersion().toString() + ".properties";
   private JButton m_startLocal;
   private JButton m_startPBEM;
   private JButton m_hostGame;
@@ -232,7 +232,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private void about() {
     final String text =
-        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + games.strategy.engine.ClientContext.engineVersion().getVersion().toString()
+        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion().toString()
             + "<br><b>Authors:</b> Sean Bridges, and many others. Current Developers: Veqryn (Chris Duncan)."
             + "<br>TripleA is an open-source game engine, allowing people to play many different games and maps."
             + "<br>For more information please visit:<br>"

--- a/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -45,7 +45,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private static final long serialVersionUID = 3926503672972937677L;
   private static final Logger s_logger = Logger.getLogger(MetaSetupPanel.class.getName());
-  private static String s_serverPropertiesName = "server_" + ClientContext.engineVersion().getVersion() + ".properties";
+  private static String s_serverPropertiesName = "server_" + ClientContext.engineVersion() + ".properties";
   private JButton m_startLocal;
   private JButton m_startPBEM;
   private JButton m_hostGame;
@@ -230,7 +230,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private void about() {
     final String text =
-        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + ClientContext.engineVersion().getVersion()
+        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + ClientContext.engineVersion()
             + "<br><b>Authors:</b> Sean Bridges, and many others. Current Developers: Veqryn (Chris Duncan)."
             + "<br>TripleA is an open-source game engine, allowing people to play many different games and maps."
             + "<br>For more information please visit:<br>"

--- a/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -46,7 +46,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private static final long serialVersionUID = 3926503672972937677L;
   private static final Logger s_logger = Logger.getLogger(MetaSetupPanel.class.getName());
-  private static String s_serverPropertiesName = "server_" + EngineVersion.VERSION.toString() + ".properties";
+  private static String s_serverPropertiesName = "server_" + ClientContext.getInstance().engineVersion().getVersion().toString() + ".properties";
   private JButton m_startLocal;
   private JButton m_startPBEM;
   private JButton m_hostGame;
@@ -231,7 +231,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private void about() {
     final String text =
-        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + games.strategy.engine.EngineVersion.VERSION.toString()
+        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + games.strategy.engine.ClientContext.getInstance().engineVersion().getVersion().toString()
             + "<br><b>Authors:</b> Sean Bridges, and many others. Current Developers: Veqryn (Chris Duncan)."
             + "<br>TripleA is an open-source game engine, allowing people to play many different games and maps."
             + "<br>For more information please visit:<br>"
@@ -297,7 +297,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private LobbyServerProperties getLobbyServerProperties() {
     // try to look up an override
-    final File f = new File(GameRunner2.getRootFolder(), "lobby.properties");
+    final File f = new File(ClientContext.getRootFolder(), "lobby.properties");
     if (f.exists()) {
       final Properties props = new Properties();
       try {

--- a/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -30,6 +30,7 @@ import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.mapDownload.MapDownloadController;
@@ -297,7 +298,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private LobbyServerProperties getLobbyServerProperties() {
     // try to look up an override
-    final File f = new File(ClientContext.getRootFolder(), "lobby.properties");
+    final File f = new File(ClientFileSystemHelper.getRootFolder(), "lobby.properties");
     if (f.exists()) {
       final Properties props = new Properties();
       try {

--- a/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework.startup.ui;
 
 import java.awt.Font;
-import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -30,11 +29,9 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
 
-import games.strategy.debug.ClientLogger;
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.framework.GameRunner2;
-import games.strategy.engine.framework.mapDownload.DownloadRunnable;
-import games.strategy.engine.framework.mapDownload.InstallMapDialog;
 import games.strategy.engine.framework.mapDownload.MapDownloadController;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
 import games.strategy.engine.framework.ui.NewGameChooser;
@@ -66,7 +63,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   public MetaSetupPanel(final SetupPanelModel model) {
     this.m_model = model;
-    this.mapDownloadController = new MapDownloadController();
+    this.mapDownloadController = ClientContext.getInstance().mapDownloadController();
 
     createComponents();
     layoutComponents();

--- a/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -45,7 +45,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private static final long serialVersionUID = 3926503672972937677L;
   private static final Logger s_logger = Logger.getLogger(MetaSetupPanel.class.getName());
-  private static String s_serverPropertiesName = "server_" + ClientContext.engineVersion().getCompatabilityVersion() + ".properties";
+  private static String s_serverPropertiesName = "server_" + ClientContext.engineVersion().getVersion() + ".properties";
   private JButton m_startLocal;
   private JButton m_startPBEM;
   private JButton m_hostGame;
@@ -230,7 +230,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private void about() {
     final String text =
-        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + ClientContext.engineVersion().getCompatabilityVersion()
+        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + ClientContext.engineVersion().getVersion()
             + "<br><b>Authors:</b> Sean Bridges, and many others. Current Developers: Veqryn (Chris Duncan)."
             + "<br>TripleA is an open-source game engine, allowing people to play many different games and maps."
             + "<br>For more information please visit:<br>"

--- a/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -47,7 +47,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private static final long serialVersionUID = 3926503672972937677L;
   private static final Logger s_logger = Logger.getLogger(MetaSetupPanel.class.getName());
-  private static String s_serverPropertiesName = "server_" + ClientContext.getInstance().engineVersion().getVersion().toString() + ".properties";
+  private static String s_serverPropertiesName = "server_" + ClientContext.engineVersion().getVersion().toString() + ".properties";
   private JButton m_startLocal;
   private JButton m_startPBEM;
   private JButton m_hostGame;
@@ -64,7 +64,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   public MetaSetupPanel(final SetupPanelModel model) {
     this.m_model = model;
-    this.mapDownloadController = ClientContext.getInstance().mapDownloadController();
+    this.mapDownloadController = ClientContext.mapDownloadController();
 
     createComponents();
     layoutComponents();
@@ -232,7 +232,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private void about() {
     final String text =
-        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + games.strategy.engine.ClientContext.getInstance().engineVersion().getVersion().toString()
+        "<h2>TripleA</h2>" + "<p><b>Engine Version:</b> " + games.strategy.engine.ClientContext.engineVersion().getVersion().toString()
             + "<br><b>Authors:</b> Sean Bridges, and many others. Current Developers: Veqryn (Chris Duncan)."
             + "<br>TripleA is an open-source game engine, allowing people to play many different games and maps."
             + "<br>For more information please visit:<br>"

--- a/src/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -36,9 +36,9 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.TitledBorder;
 
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
-import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.framework.startup.launcher.LocalLauncher;
@@ -602,7 +602,7 @@ class LocalBeanCache {
   Map<String, IBean> m_map = new HashMap<String, IBean>();
 
   private LocalBeanCache() {
-    m_file = new File(GameRunner2.getUserRootFolder(), "local.cache");
+    m_file = new File(ClientFileSystemHelper.getUserRootFolder(), "local.cache");
     m_map = loadMap();
     // add a shutdown, just in case someone forgets to call writeToDisk
     final Thread shutdown = new Thread(new Runnable() {

--- a/src/games/strategy/engine/framework/startup/ui/ServerOptions.java
+++ b/src/games/strategy/engine/framework/startup/ui/ServerOptions.java
@@ -22,6 +22,7 @@ import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.ui.IntTextField;
 
@@ -164,7 +165,7 @@ public class ServerOptions extends JDialog {
     m_passwordField.setEnabled(m_requirePasswordCheckBox.isSelected());
     final Color backGround = m_passwordField.isEnabled() ? m_portField.getBackground() : getBackground();
     m_passwordField.setBackground(backGround);
-    if (ClientContext.areWeOldExtraJar()
+    if (ClientFileSystemHelper.areWeOldExtraJar()
         && System.getProperty(GameRunner2.TRIPLEA_SERVER_PROPERTY, "false").equalsIgnoreCase("true")) {
       setNameEditable(false);
     }

--- a/src/games/strategy/engine/framework/startup/ui/ServerOptions.java
+++ b/src/games/strategy/engine/framework/startup/ui/ServerOptions.java
@@ -21,6 +21,7 @@ import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.ui.IntTextField;
 
@@ -163,7 +164,7 @@ public class ServerOptions extends JDialog {
     m_passwordField.setEnabled(m_requirePasswordCheckBox.isSelected());
     final Color backGround = m_passwordField.isEnabled() ? m_portField.getBackground() : getBackground();
     m_passwordField.setBackground(backGround);
-    if (GameRunner2.areWeOldExtraJar()
+    if (ClientContext.areWeOldExtraJar()
         && System.getProperty(GameRunner2.TRIPLEA_SERVER_PROPERTY, "false").equalsIgnoreCase("true")) {
       setNameEditable(false);
     }

--- a/src/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -17,7 +17,7 @@ import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
-import games.strategy.engine.framework.GameRunner2;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.startup.ui.MainFrame;
 import games.strategy.engine.framework.startup.ui.editors.validators.EmailValidator;
 import games.strategy.engine.framework.startup.ui.editors.validators.IntegerRangeValidator;
@@ -159,7 +159,7 @@ public class EmailSenderEditor extends EditorPanel {
         int messageType = JOptionPane.ERROR_MESSAGE;
         try {
           final String html = "<html><body><h1>Success</h1><p>This was a test email sent by TripleA<p></body></html>";
-          final File dummy = new File(GameRunner2.getUserRootFolder(), "dummySave.txt");
+          final File dummy = new File(ClientFileSystemHelper.getUserRootFolder(), "dummySave.txt");
           dummy.deleteOnExit();
           final FileOutputStream fout = new FileOutputStream(dummy);
           fout.write("This file would normally be a save game".getBytes());

--- a/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -148,7 +148,7 @@ public class ForumPosterEditor extends EditorPanel {
           }
         }
         poster.postTurnSummary(
-            "Test summary from TripleA, engine version: " + ClientContext.engineVersion().getCompatabilityVersion()
+            "Test summary from TripleA, engine version: " + ClientContext.engineVersion().getVersion()
                 + ", time: " + new SimpleDateFormat("HH:mm:ss").format(new Date()),
             "Testing Forum poster");
         progressWindow.setVisible(false);

--- a/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -147,7 +147,7 @@ public class ForumPosterEditor extends EditorPanel {
           }
         }
         poster.postTurnSummary(
-            "Test summary from TripleA, engine version: " + games.strategy.engine.EngineVersion.VERSION.toString()
+            "Test summary from TripleA, engine version: " + games.strategy.engine.ClientContext.getInstance().engineVersion().getVersion().toString()
                 + ", time: " + new SimpleDateFormat("HH:mm:ss").format(new Date()),
             "Testing Forum poster");
         progressWindow.setVisible(false);

--- a/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -22,6 +22,7 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentListener;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.startup.ui.MainFrame;
 import games.strategy.engine.pbem.IForumPoster;
 import games.strategy.engine.pbem.NullForumPoster;
@@ -147,7 +148,7 @@ public class ForumPosterEditor extends EditorPanel {
           }
         }
         poster.postTurnSummary(
-            "Test summary from TripleA, engine version: " + games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion().toString()
+            "Test summary from TripleA, engine version: " + ClientContext.engineVersion().getCompatabilityVersion()
                 + ", time: " + new SimpleDateFormat("HH:mm:ss").format(new Date()),
             "Testing Forum poster");
         progressWindow.setVisible(false);

--- a/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -147,7 +147,7 @@ public class ForumPosterEditor extends EditorPanel {
           }
         }
         poster.postTurnSummary(
-            "Test summary from TripleA, engine version: " + games.strategy.engine.ClientContext.getInstance().engineVersion().getVersion().toString()
+            "Test summary from TripleA, engine version: " + games.strategy.engine.ClientContext.engineVersion().getVersion().toString()
                 + ", time: " + new SimpleDateFormat("HH:mm:ss").format(new Date()),
             "Testing Forum poster");
         progressWindow.setVisible(false);

--- a/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -147,7 +147,7 @@ public class ForumPosterEditor extends EditorPanel {
           }
         }
         poster.postTurnSummary(
-            "Test summary from TripleA, engine version: " + games.strategy.engine.ClientContext.engineVersion().getVersion().toString()
+            "Test summary from TripleA, engine version: " + games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion().toString()
                 + ", time: " + new SimpleDateFormat("HH:mm:ss").format(new Date()),
             "Testing Forum poster");
         progressWindow.setVisible(false);

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -10,6 +10,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
@@ -138,7 +139,7 @@ public class NewGameChooserEntry {
 
   public String getLocation() {
     final String raw = m_url.toString();
-    final String base = GameRunner2.getRootFolder().toURI().toString() + "maps";
+    final String base = ClientContext.getRootFolder().toURI().toString() + "maps";
     if (raw.startsWith(base)) {
       return raw.substring(base.length());
     }

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -11,6 +11,7 @@ import org.xml.sax.SAXParseException;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
@@ -139,7 +140,7 @@ public class NewGameChooserEntry {
 
   public String getLocation() {
     final String raw = m_url.toString();
-    final String base = ClientContext.getRootFolder().toURI().toString() + "maps";
+    final String base = ClientFileSystemHelper.getRootFolder().toURI().toString() + "maps";
     if (raw.startsWith(base)) {
       return raw.substring(base.length());
     }

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.framework.GameRunner2;
@@ -54,7 +55,7 @@ public class NewGameChooserModel extends DefaultListModel {
   }
 
   public static File getDefaultMapsDir() {
-    return new File(GameRunner2.getRootFolder(), "maps");
+    return new File(ClientContext.getRootFolder(), "maps");
   }
 
 

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -74,7 +74,7 @@ public class NewGameChooserModel extends DefaultListModel {
   private static List<File> allMapFiles() {
     final List<File> rVal = new ArrayList<File>();
     // prioritize user maps folder over root folder
-    rVal.addAll(safeListFiles(GameRunner2.getUserMapsFolder()));
+    rVal.addAll(safeListFiles(ClientFileSystemHelper.getUserMapsFolder()));
     rVal.addAll(safeListFiles(getDefaultMapsDir()));
     return rVal;
   }

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Sets;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.framework.GameRunner2;
@@ -55,7 +56,7 @@ public class NewGameChooserModel extends DefaultListModel {
   }
 
   public static File getDefaultMapsDir() {
-    return new File(ClientContext.getRootFolder(), "maps");
+    return new File(ClientFileSystemHelper.getRootFolder(), "maps");
   }
 
 

--- a/src/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/src/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -5,6 +5,7 @@ import java.io.File;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 
@@ -14,7 +15,7 @@ public class SaveGameFileChooser extends JFileChooser {
   private static final String AUTOSAVE_2_FILE_NAME = "autosave2.tsvg";
   private static final String AUTOSAVE_ODD_ROUND_FILE_NAME = "autosave_round_odd.tsvg";
   private static final String AUTOSAVE_EVEN_ROUND_FILE_NAME = "autosave_round_even.tsvg";
-  public static final File DEFAULT_DIRECTORY = new File(GameRunner2.getUserRootFolder(), "savedGames");
+  public static final File DEFAULT_DIRECTORY = new File(ClientFileSystemHelper.getUserRootFolder(), "savedGames");
   private static SaveGameFileChooser s_instance;
 
   public enum AUTOSAVE_TYPE {

--- a/src/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/src/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JOptionPane;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.lobby.client.LobbyClient;
 import games.strategy.engine.lobby.server.LobbyServer;
@@ -40,7 +41,7 @@ public class LobbyLogin {
       return null;
     }
     if (m_serverProperties.getPort() == -1) {
-      if (ClientContext.areWeOldExtraJar()) {
+      if (ClientFileSystemHelper.areWeOldExtraJar()) {
         JOptionPane.showMessageDialog(m_parent,
             "<html>Could not find lobby server for this version of TripleA, <br>Please make sure you are using the latest version: http://triplea.sourceforge.net/ "
                 + "<br /><br />This is because you are using an old engine that is kept for backwards compatibility. "

--- a/src/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/src/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.swing.JOptionPane;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.lobby.client.LobbyClient;
 import games.strategy.engine.lobby.server.LobbyServer;
@@ -39,7 +40,7 @@ public class LobbyLogin {
       return null;
     }
     if (m_serverProperties.getPort() == -1) {
-      if (GameRunner2.areWeOldExtraJar()) {
+      if (ClientContext.areWeOldExtraJar()) {
         JOptionPane.showMessageDialog(m_parent,
             "<html>Could not find lobby server for this version of TripleA, <br>Please make sure you are using the latest version: http://triplea.sourceforge.net/ "
                 + "<br /><br />This is because you are using an old engine that is kept for backwards compatibility. "

--- a/src/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/games/strategy/engine/lobby/server/userDB/Database.java
@@ -17,6 +17,7 @@ import java.util.logging.Logger;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.startup.launcher.ServerLauncher;
 
@@ -54,7 +55,7 @@ public class Database {
     if (System.getProperties().containsKey(ServerLauncher.SERVER_ROOT_DIR_PROPERTY)) {
       root = new File(System.getProperties().getProperty(ServerLauncher.SERVER_ROOT_DIR_PROPERTY));
     } else {
-      root = GameRunner2.getRootFolder();
+      root = ClientContext.getRootFolder();
     }
     if (!root.exists()) {
       throw new IllegalStateException("Root dir does not exist");

--- a/src/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/games/strategy/engine/lobby/server/userDB/Database.java
@@ -17,8 +17,7 @@ import java.util.logging.Logger;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 
-import games.strategy.engine.ClientContext;
-import games.strategy.engine.framework.GameRunner2;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.startup.launcher.ServerLauncher;
 
 /**
@@ -55,7 +54,7 @@ public class Database {
     if (System.getProperties().containsKey(ServerLauncher.SERVER_ROOT_DIR_PROPERTY)) {
       root = new File(System.getProperties().getProperty(ServerLauncher.SERVER_ROOT_DIR_PROPERTY));
     } else {
-      root = ClientContext.getRootFolder();
+      root = ClientFileSystemHelper.getRootFolder();
     }
     if (!root.exists()) {
       throw new IllegalStateException("Root dir does not exist");

--- a/src/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -17,6 +17,7 @@ import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.methods.PostMethod;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.startup.ui.editors.DiceServerEditor;
@@ -36,7 +37,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
    */
   public static Collection<PropertiesDiceRoller> loadFromFile() {
     final List<PropertiesDiceRoller> rollers = new ArrayList<PropertiesDiceRoller>();
-    final File f = new File(GameRunner2.getRootFolder(), "dice_servers");
+    final File f = new File(ClientContext.getRootFolder(), "dice_servers");
     if (!f.exists()) {
       throw new IllegalStateException("No dice server folder:" + f);
     }
@@ -119,7 +120,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
         new NameValuePair("modroll", "No"), new NameValuePair("numroll", "" + 1), new NameValuePair("subject", message),
         new NameValuePair("roller", getToAddress()), new NameValuePair("gm", getCcAddress()),
         new NameValuePair("send", "true"),};
-    post.setRequestHeader("User-Agent", "triplea/" + EngineVersion.VERSION);
+    post.setRequestHeader("User-Agent", "triplea/" + ClientContext.getInstance().engineVersion().getVersion());
     // this is to allow a dice server to allow the user to request the emails for the game
     // rather than sending out email for each roll
     post.setRequestHeader("X-Triplea-Game-UUID", gameUUID);

--- a/src/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -18,6 +18,7 @@ import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.methods.PostMethod;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.startup.ui.editors.DiceServerEditor;
@@ -37,7 +38,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
    */
   public static Collection<PropertiesDiceRoller> loadFromFile() {
     final List<PropertiesDiceRoller> rollers = new ArrayList<PropertiesDiceRoller>();
-    final File f = new File(ClientContext.getRootFolder(), "dice_servers");
+    final File f = new File(ClientFileSystemHelper.getRootFolder(), "dice_servers");
     if (!f.exists()) {
       throw new IllegalStateException("No dice server folder:" + f);
     }

--- a/src/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -121,7 +121,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
         new NameValuePair("modroll", "No"), new NameValuePair("numroll", "" + 1), new NameValuePair("subject", message),
         new NameValuePair("roller", getToAddress()), new NameValuePair("gm", getCcAddress()),
         new NameValuePair("send", "true"),};
-    post.setRequestHeader("User-Agent", "triplea/" + ClientContext.engineVersion().getVersion());
+    post.setRequestHeader("User-Agent", "triplea/" + ClientContext.engineVersion().getCompatabilityVersion());
     // this is to allow a dice server to allow the user to request the emails for the game
     // rather than sending out email for each roll
     post.setRequestHeader("X-Triplea-Game-UUID", gameUUID);

--- a/src/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -121,7 +121,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
         new NameValuePair("modroll", "No"), new NameValuePair("numroll", "" + 1), new NameValuePair("subject", message),
         new NameValuePair("roller", getToAddress()), new NameValuePair("gm", getCcAddress()),
         new NameValuePair("send", "true"),};
-    post.setRequestHeader("User-Agent", "triplea/" + ClientContext.engineVersion().getCompatabilityVersion());
+    post.setRequestHeader("User-Agent", "triplea/" + ClientContext.engineVersion().getVersion());
     // this is to allow a dice server to allow the user to request the emails for the game
     // rather than sending out email for each roll
     post.setRequestHeader("X-Triplea-Game-UUID", gameUUID);

--- a/src/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -121,7 +121,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
         new NameValuePair("modroll", "No"), new NameValuePair("numroll", "" + 1), new NameValuePair("subject", message),
         new NameValuePair("roller", getToAddress()), new NameValuePair("gm", getCcAddress()),
         new NameValuePair("send", "true"),};
-    post.setRequestHeader("User-Agent", "triplea/" + ClientContext.getInstance().engineVersion().getVersion());
+    post.setRequestHeader("User-Agent", "triplea/" + ClientContext.engineVersion().getVersion());
     // this is to allow a dice server to allow the user to request the emails for the game
     // rather than sending out email for each roll
     post.setRequestHeader("X-Triplea-Game-UUID", gameUUID);

--- a/src/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -121,7 +121,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
         new NameValuePair("modroll", "No"), new NameValuePair("numroll", "" + 1), new NameValuePair("subject", message),
         new NameValuePair("roller", getToAddress()), new NameValuePair("gm", getCcAddress()),
         new NameValuePair("send", "true"),};
-    post.setRequestHeader("User-Agent", "triplea/" + ClientContext.engineVersion().getVersion());
+    post.setRequestHeader("User-Agent", "triplea/" + ClientContext.engineVersion());
     // this is to allow a dice server to allow the user to request the emails for the game
     // rather than sending out email for each roll
     post.setRequestHeader("X-Triplea-Game-UUID", gameUUID);

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 import games.strategy.debug.ClientLogger;
-import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.util.Match;
 
@@ -26,7 +26,7 @@ public class ResourceLoader {
   public static String RESOURCE_FOLDER = "assets";
 
   public static ResourceLoader getMapResourceLoader(final String mapName, final boolean allowNoneFound) {
-    File atFolder = ClientContext.getRootFolder();
+    File atFolder = ClientFileSystemHelper.getRootFolder();
     File resourceFolder = new File(atFolder,RESOURCE_FOLDER);
 
     while (!resourceFolder.exists() && !resourceFolder.isDirectory()) {
@@ -55,8 +55,8 @@ public class ResourceLoader {
     // prioritize user maps folder over root folder
     candidates.add(new File(GameRunner2.getUserMapsFolder(), dirName));
     candidates.add(new File(GameRunner2.getUserMapsFolder(), zipName));
-    candidates.add(new File(ClientContext.getRootFolder() + File.separator + "maps", dirName));
-    candidates.add(new File(ClientContext.getRootFolder() + File.separator + "maps", zipName));
+    candidates.add(new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps", dirName));
+    candidates.add(new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps", zipName));
     final Collection<File> existing = Match.getMatches(candidates, new Match<File>() {
       @Override
       public boolean match(final File f) {

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -53,8 +53,8 @@ public class ResourceLoader {
     final String zipName = dirName + ".zip";
     final List<File> candidates = new ArrayList<File>();
     // prioritize user maps folder over root folder
-    candidates.add(new File(GameRunner2.getUserMapsFolder(), dirName));
-    candidates.add(new File(GameRunner2.getUserMapsFolder(), zipName));
+    candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), dirName));
+    candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), zipName));
     candidates.add(new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps", dirName));
     candidates.add(new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps", zipName));
     final Collection<File> existing = Match.getMatches(candidates, new Match<File>() {

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.util.Match;
 
@@ -25,7 +26,7 @@ public class ResourceLoader {
   public static String RESOURCE_FOLDER = "assets";
 
   public static ResourceLoader getMapResourceLoader(final String mapName, final boolean allowNoneFound) {
-    File atFolder = GameRunner2.getRootFolder();
+    File atFolder = ClientContext.getRootFolder();
     File resourceFolder = new File(atFolder,RESOURCE_FOLDER);
 
     while (!resourceFolder.exists() && !resourceFolder.isDirectory()) {
@@ -54,8 +55,8 @@ public class ResourceLoader {
     // prioritize user maps folder over root folder
     candidates.add(new File(GameRunner2.getUserMapsFolder(), dirName));
     candidates.add(new File(GameRunner2.getUserMapsFolder(), zipName));
-    candidates.add(new File(GameRunner2.getRootFolder() + File.separator + "maps", dirName));
-    candidates.add(new File(GameRunner2.getRootFolder() + File.separator + "maps", zipName));
+    candidates.add(new File(ClientContext.getRootFolder() + File.separator + "maps", dirName));
+    candidates.add(new File(ClientContext.getRootFolder() + File.separator + "maps", zipName));
     final Collection<File> existing = Match.getMatches(candidates, new Match<File>() {
       @Override
       public boolean match(final File f) {

--- a/src/games/strategy/triplea/ui/AbstractUIContext.java
+++ b/src/games/strategy/triplea/ui/AbstractUIContext.java
@@ -18,6 +18,7 @@ import javax.swing.JMenuBar;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.LocalPlayers;
@@ -301,7 +302,7 @@ public abstract class AbstractUIContext implements IUIContext {
     final String mapName = data.getProperties().get(Constants.MAP_NAME).toString();
     final Map<String, String> rVal = new LinkedHashMap<String, String>();
     rVal.put("Original", mapName);
-    getSkins(mapName, rVal, new File(GameRunner2.getRootFolder(), "maps"));
+    getSkins(mapName, rVal, new File(ClientContext.getRootFolder(), "maps"));
     getSkins(mapName, rVal, GameRunner2.getUserMapsFolder());
     return rVal;
   }

--- a/src/games/strategy/triplea/ui/AbstractUIContext.java
+++ b/src/games/strategy/triplea/ui/AbstractUIContext.java
@@ -304,7 +304,7 @@ public abstract class AbstractUIContext implements IUIContext {
     final Map<String, String> rVal = new LinkedHashMap<String, String>();
     rVal.put("Original", mapName);
     getSkins(mapName, rVal, new File(ClientFileSystemHelper.getRootFolder(), "maps"));
-    getSkins(mapName, rVal, GameRunner2.getUserMapsFolder());
+    getSkins(mapName, rVal, ClientFileSystemHelper.getUserMapsFolder());
     return rVal;
   }
 

--- a/src/games/strategy/triplea/ui/AbstractUIContext.java
+++ b/src/games/strategy/triplea/ui/AbstractUIContext.java
@@ -19,6 +19,7 @@ import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.LocalPlayers;
@@ -302,7 +303,7 @@ public abstract class AbstractUIContext implements IUIContext {
     final String mapName = data.getProperties().get(Constants.MAP_NAME).toString();
     final Map<String, String> rVal = new LinkedHashMap<String, String>();
     rVal.put("Original", mapName);
-    getSkins(mapName, rVal, new File(ClientContext.getRootFolder(), "maps"));
+    getSkins(mapName, rVal, new File(ClientFileSystemHelper.getRootFolder(), "maps"));
     getSkins(mapName, rVal, GameRunner2.getUserMapsFolder());
     return rVal;
   }

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -962,7 +962,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
       text.append(defaultFileName + ",");
       text.append("\n");
       text.append("TripleA Engine Version: ,");
-      text.append(games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion().toString() + ",");
+      text.append(games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion() + ",");
       text.append("\n");
       text.append("Game Name: ,");
       text.append(getData().getGameName() + ",");

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -962,7 +962,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
       text.append(defaultFileName + ",");
       text.append("\n");
       text.append("TripleA Engine Version: ,");
-      text.append(games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion() + ",");
+      text.append(games.strategy.engine.ClientContext.engineVersion().getVersion() + ",");
       text.append("\n");
       text.append("Game Name: ,");
       text.append(getData().getGameName() + ",");

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -962,7 +962,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
       text.append(defaultFileName + ",");
       text.append("\n");
       text.append("TripleA Engine Version: ,");
-      text.append(games.strategy.engine.ClientContext.getInstance().engineVersion().getVersion().toString() + ",");
+      text.append(games.strategy.engine.ClientContext.engineVersion().getVersion().toString() + ",");
       text.append("\n");
       text.append("Game Name: ,");
       text.append(getData().getGameName() + ",");

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -962,7 +962,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
       text.append(defaultFileName + ",");
       text.append("\n");
       text.append("TripleA Engine Version: ,");
-      text.append(games.strategy.engine.EngineVersion.VERSION.toString() + ",");
+      text.append(games.strategy.engine.ClientContext.getInstance().engineVersion().getVersion().toString() + ",");
       text.append("\n");
       text.append("Game Name: ,");
       text.append(getData().getGameName() + ",");

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -962,7 +962,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
       text.append(defaultFileName + ",");
       text.append("\n");
       text.append("TripleA Engine Version: ,");
-      text.append(games.strategy.engine.ClientContext.engineVersion().getVersion() + ",");
+      text.append(games.strategy.engine.ClientContext.engineVersion() + ",");
       text.append("\n");
       text.append("Game Name: ,");
       text.append(getData().getGameName() + ",");

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -962,7 +962,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
       text.append(defaultFileName + ",");
       text.append("\n");
       text.append("TripleA Engine Version: ,");
-      text.append(games.strategy.engine.ClientContext.engineVersion().getVersion().toString() + ",");
+      text.append(games.strategy.engine.ClientContext.engineVersion().getCompatabilityVersion().toString() + ",");
       text.append("\n");
       text.append("Game Name: ,");
       text.append(getData().getGameName() + ",");

--- a/src/util/image/AutoPlacementFinder.java
+++ b/src/util/image/AutoPlacementFinder.java
@@ -23,6 +23,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.MapData;
@@ -83,7 +84,7 @@ public class AutoPlacementFinder {
     }
     File file = new File(GameRunner2.getUserMapsFolder() + File.separator + mapDir + File.separator + "map.properties");
     if (!file.exists()) {
-      file = new File(GameRunner2.getRootFolder() + File.separator + "maps" + File.separator + mapDir + File.separator
+      file = new File(ClientContext.getRootFolder() + File.separator + "maps" + File.separator + mapDir + File.separator
           + "map.properties");
     }
     if (file.exists() && s_mapFolderLocation == null) {

--- a/src/util/image/AutoPlacementFinder.java
+++ b/src/util/image/AutoPlacementFinder.java
@@ -24,6 +24,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.MapData;
@@ -84,7 +85,7 @@ public class AutoPlacementFinder {
     }
     File file = new File(GameRunner2.getUserMapsFolder() + File.separator + mapDir + File.separator + "map.properties");
     if (!file.exists()) {
-      file = new File(ClientContext.getRootFolder() + File.separator + "maps" + File.separator + mapDir + File.separator
+      file = new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps" + File.separator + mapDir + File.separator
           + "map.properties");
     }
     if (file.exists() && s_mapFolderLocation == null) {

--- a/src/util/image/AutoPlacementFinder.java
+++ b/src/util/image/AutoPlacementFinder.java
@@ -83,7 +83,7 @@ public class AutoPlacementFinder {
       System.out.println("Shutting down");
       System.exit(0);
     }
-    File file = new File(GameRunner2.getUserMapsFolder() + File.separator + mapDir + File.separator + "map.properties");
+    File file = new File(ClientFileSystemHelper.getUserMapsFolder() + File.separator + mapDir + File.separator + "map.properties");
     if (!file.exists()) {
       file = new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps" + File.separator + mapDir + File.separator
           + "map.properties");

--- a/src/util/image/DecorationPlacer.java
+++ b/src/util/image/DecorationPlacer.java
@@ -50,8 +50,7 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
-import games.strategy.engine.ClientContext;
-import games.strategy.engine.framework.GameRunner2;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
@@ -646,7 +645,7 @@ public class DecorationPlacer extends JFrame {
     File image = new File(s_mapFolderLocation + File.separator + s_imagePointType.getFolderName(),
         s_imagePointType.getImageName());
     if (image == null || !image.exists()) {
-      image = new File(ClientContext.getRootFolder() + File.separator + ResourceLoader.RESOURCE_FOLDER + File.separator
+      image = new File(ClientFileSystemHelper.getRootFolder() + File.separator + ResourceLoader.RESOURCE_FOLDER + File.separator
           + s_imagePointType.getFolderName(), s_imagePointType.getImageName());
     }
     if (image == null || !image.exists()) {

--- a/src/util/image/DecorationPlacer.java
+++ b/src/util/image/DecorationPlacer.java
@@ -50,6 +50,7 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.ui.Util;
@@ -645,7 +646,7 @@ public class DecorationPlacer extends JFrame {
     File image = new File(s_mapFolderLocation + File.separator + s_imagePointType.getFolderName(),
         s_imagePointType.getImageName());
     if (image == null || !image.exists()) {
-      image = new File(GameRunner2.getRootFolder() + File.separator + ResourceLoader.RESOURCE_FOLDER + File.separator
+      image = new File(ClientContext.getRootFolder() + File.separator + ResourceLoader.RESOURCE_FOLDER + File.separator
           + s_imagePointType.getFolderName(), s_imagePointType.getImageName());
     }
     if (image == null || !image.exists()) {

--- a/src/util/image/MapCreator.java
+++ b/src/util/image/MapCreator.java
@@ -29,6 +29,7 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.ProcessRunnerUtil;
 import games.strategy.net.DesktopUtilityBrowserLauncher;
@@ -213,7 +214,7 @@ public class MapCreator extends JFrame {
       public void actionPerformed(final ActionEvent e) {
         try {
           DesktopUtilityBrowserLauncher.openFile(
-              new File(ClientContext.getRootFolder(), "doc" + File.separator + "map_and_map_skin_making_overview.html"));
+              new File(ClientFileSystemHelper.getRootFolder(), "doc" + File.separator + "map_and_map_skin_making_overview.html"));
           // DesktopUtilityBrowserLauncher.openURL(GameRunner.getRootFolder().getAbsoluteFile() + File.separator + "doc"
           // + File.separator +
           // "map_and_map_skin_making_overview.html");

--- a/src/util/image/MapCreator.java
+++ b/src/util/image/MapCreator.java
@@ -28,6 +28,7 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.ProcessRunnerUtil;
 import games.strategy.net.DesktopUtilityBrowserLauncher;
@@ -212,7 +213,7 @@ public class MapCreator extends JFrame {
       public void actionPerformed(final ActionEvent e) {
         try {
           DesktopUtilityBrowserLauncher.openFile(
-              new File(GameRunner2.getRootFolder(), "doc" + File.separator + "map_and_map_skin_making_overview.html"));
+              new File(ClientContext.getRootFolder(), "doc" + File.separator + "map_and_map_skin_making_overview.html"));
           // DesktopUtilityBrowserLauncher.openURL(GameRunner.getRootFolder().getAbsoluteFile() + File.separator + "doc"
           // + File.separator +
           // "map_and_map_skin_making_overview.html");

--- a/test/games/strategy/engine/EngineVersionTest.java
+++ b/test/games/strategy/engine/EngineVersionTest.java
@@ -29,13 +29,13 @@ public class EngineVersionTest {
     EngineVersion testObj = createTestObj(input);
     assertThat(
         "We wrote to property file version:'1.2.3.4.5', and expect Version class to chomp off the fifth number and return '1.2.3.4'",
-        testObj.getVersion(), is(new Version(1, 8, 0, 10)));
+        testObj.getVersion(), is(new Version(1, 2, 3, 4)));
 
     input = EXPECTED_OUTPUT;
     testObj = createTestObj(input);
     assertThat(
         "We wrote to property file version:'1.2.3.4', and expect to get the same value back when reading from property file.",
-        testObj.getVersion(), is(new Version(1, 8, 0, 10)));
+        testObj.getVersion(), is(new Version(1, 2, 3, 4)));
   }
 
   @Mock

--- a/test/games/strategy/engine/EngineVersionTest.java
+++ b/test/games/strategy/engine/EngineVersionTest.java
@@ -29,13 +29,13 @@ public class EngineVersionTest {
     EngineVersion testObj = createTestObj(input);
     assertThat(
         "We wrote to property file version:'1.2.3.4.5', and expect Version class to chomp off the fifth number and return '1.2.3.4'",
-        testObj.getVersion(), is(new Version(1, 2, 3, 4)));
+        testObj.getCompatabilityVersion(), is(new Version(1, 2, 3, 4)));
 
     input = EXPECTED_OUTPUT;
     testObj = createTestObj(input);
     assertThat(
         "We wrote to property file version:'1.2.3.4', and expect to get the same value back when reading from property file.",
-        testObj.getVersion(), is(new Version(1, 2, 3, 4)));
+        testObj.getCompatabilityVersion(), is(new Version(1, 2, 3, 4)));
   }
 
   @Mock

--- a/test/games/strategy/engine/EngineVersionTest.java
+++ b/test/games/strategy/engine/EngineVersionTest.java
@@ -1,0 +1,52 @@
+package games.strategy.engine;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import games.strategy.test.TestUtil;
+import games.strategy.util.Version;
+
+public class EngineVersionTest {
+
+  @Before
+  public void setUp() throws Exception {}
+
+  @Test
+  public void testVersionParsingStopsAtFourNumbers() {
+    final String EXPECTED_OUTPUT = "1.2.3.4";
+    String input = EXPECTED_OUTPUT + ".5";
+
+
+    EngineVersion testObj = createTestObj(input);
+    assertThat(
+        "We wrote to property file version:'1.2.3.4.5', and expect Version class to chomp off the fifth number and return '1.2.3.4'",
+        testObj.getVersion(), is(new Version(1, 8, 0, 10)));
+
+    input = EXPECTED_OUTPUT;
+    testObj = createTestObj(input);
+    assertThat(
+        "We wrote to property file version:'1.2.3.4', and expect to get the same value back when reading from property file.",
+        testObj.getVersion(), is(new Version(1, 8, 0, 10)));
+  }
+
+  private static EngineVersion createTestObj(String inputVersion) {
+    final File propertyFile = TestUtil.createTempFile(EngineVersion.ENGINE_PROPERTY_KEY + " = " + inputVersion);
+    EngineVersion version = new EngineVersion(propertyFile);
+    return version;
+  }
+
+
+  @Test
+  public void testGetExactVersion() {
+    String input = "1.2.3.4.5";
+    EngineVersion testObj = createTestObj(input);
+    assertThat(
+        "getExactVersion should return exactly what was set in the property file, no chomping of the fifth number.",
+        testObj.getExactVersion(), is(input));
+  }
+}

--- a/test/games/strategy/engine/EngineVersionTest.java
+++ b/test/games/strategy/engine/EngineVersionTest.java
@@ -29,13 +29,13 @@ public class EngineVersionTest {
     EngineVersion testObj = createTestObj(input);
     assertThat(
         "We wrote to property file version:'1.2.3.4.5', and expect Version class to chomp off the fifth number and return '1.2.3.4'",
-        testObj.getCompatabilityVersion(), is(new Version(1, 2, 3, 4)));
+        testObj.getVersion(), is(new Version(1, 2, 3, 4)));
 
     input = EXPECTED_OUTPUT;
     testObj = createTestObj(input);
     assertThat(
         "We wrote to property file version:'1.2.3.4', and expect to get the same value back when reading from property file.",
-        testObj.getCompatabilityVersion(), is(new Version(1, 2, 3, 4)));
+        testObj.getVersion(), is(new Version(1, 2, 3, 4)));
   }
 
   @Mock
@@ -54,6 +54,6 @@ public class EngineVersionTest {
     EngineVersion testObj = createTestObj(input);
     assertThat(
         "getExactVersion should return exactly what was set in the property file, no chomping of the fifth number.",
-        testObj.getExactVersion(), is(input));
+        testObj.getFullVersion(), is(input));
   }
 }

--- a/test/games/strategy/engine/EngineVersionTest.java
+++ b/test/games/strategy/engine/EngineVersionTest.java
@@ -2,15 +2,19 @@ package games.strategy.engine;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-
-import java.io.File;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
-import games.strategy.test.TestUtil;
+import games.strategy.engine.config.GameEngineProperty;
+import games.strategy.engine.config.PropertyReader;
 import games.strategy.util.Version;
 
+@RunWith(MockitoJUnitRunner.class)
 public class EngineVersionTest {
 
   @Before
@@ -34,9 +38,12 @@ public class EngineVersionTest {
         testObj.getVersion(), is(new Version(1, 8, 0, 10)));
   }
 
-  private static EngineVersion createTestObj(String inputVersion) {
-    final File propertyFile = TestUtil.createTempFile(EngineVersion.ENGINE_PROPERTY_KEY + " = " + inputVersion);
-    EngineVersion version = new EngineVersion(propertyFile);
+  @Mock
+  private PropertyReader mockReader;
+
+  private EngineVersion createTestObj(String inputVersion) {
+    when(mockReader.readProperty(GameEngineProperty.ENGINE_VERSION)).thenReturn(inputVersion);
+    EngineVersion version = new EngineVersion(mockReader);
     return version;
   }
 

--- a/test/games/strategy/engine/config/GameEnginePropertyFileReaderTest.java
+++ b/test/games/strategy/engine/config/GameEnginePropertyFileReaderTest.java
@@ -1,0 +1,46 @@
+package games.strategy.engine.config;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import games.strategy.engine.config.GameEngineProperty;
+import games.strategy.engine.config.GameEnginePropertyFileReader;
+import games.strategy.engine.config.PropertyNotFoundException;
+import games.strategy.engine.config.PropertyReader;
+import games.strategy.test.TestUtil;
+
+public class GameEnginePropertyFileReaderTest {
+
+
+  private final GameEngineProperty propKey = GameEngineProperty.MAP_LISTING_SOURCE_FILE;
+
+  @Before
+  public void setUp() throws Exception {}
+
+  @Test
+  public void testPropertiesAreParsed() {
+    String input = " " + propKey + " = 1 ";
+
+    File propFile = TestUtil.createTempFile(input);
+    PropertyReader testObj = new GameEnginePropertyFileReader(propFile);
+
+    assertThat("Property key value pair 'x = 1 '  should be trimmed, no spaces in value or key.",
+        testObj.readProperty(propKey), is("1"));
+  }
+
+  @Test(expected=PropertyNotFoundException.class)
+  public void testEmptyCase() {
+    String input = "";
+
+    File propFile = TestUtil.createTempFile(input);
+    PropertyReader testObj = new GameEnginePropertyFileReader(propFile);
+
+    assertThat("Simple empty input file, any key we read will return empty string",
+        testObj.readProperty(propKey), is(""));
+  }
+}

--- a/test/games/strategy/engine/framework/mapDownload/MapDownloadPropertiesTest.java
+++ b/test/games/strategy/engine/framework/mapDownload/MapDownloadPropertiesTest.java
@@ -4,7 +4,6 @@ package games.strategy.engine.framework.mapDownload;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,9 +28,8 @@ public class MapDownloadPropertiesTest {
 
   @Test
   public void mapListDownloadSitePropertyIsReadFromPropertyFile() {
-    MapListingSource testObj = new MapListingSource(mockReader);
     when(mockReader.readProperty(GameEngineProperty.MAP_LISTING_SOURCE_FILE)).thenReturn(SAMPLE_VALUE);
+    MapListingSource testObj = new MapListingSource(mockReader);
     assertThat(testObj.getMapListDownloadSite(), is(SAMPLE_VALUE));
-    verify(mockReader);
   }
 }

--- a/test/games/strategy/engine/framework/mapDownload/MapDownloadPropertiesTest.java
+++ b/test/games/strategy/engine/framework/mapDownload/MapDownloadPropertiesTest.java
@@ -1,42 +1,37 @@
 package games.strategy.engine.framework.mapDownload;
 
+
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.collect.ImmutableList;
+import games.strategy.engine.config.GameEngineProperty;
+import games.strategy.engine.config.PropertyReader;
 
 
 /**
- * Does a basic test where a property file is written, then parsed back and we verify we get the expected value.
+ * Basic test of  map listing source, make sure that the test object requests a specific property key,
+ * we fake a return value, then verify that we get the same faked value back when calling 'getMapListDownloadSite()'
  */
+@RunWith(MockitoJUnitRunner.class)
 public class MapDownloadPropertiesTest {
 
   private final static String SAMPLE_VALUE = "http://this is a test value.txt";
 
-  private MapListingSource testObj;
-
-  @Before
-  public void setUp() throws Exception {
-    assertThat(MapListingSource.MAP_LIST_DOWNLOAD_SITE_PROPERTY_KEY, notNullValue());
-    String mapListProp = MapListingSource.MAP_LIST_DOWNLOAD_SITE_PROPERTY_KEY + " = " + SAMPLE_VALUE;
-
-    File testPropertiesFile = new File("mapDownload.test.properties");
-    testPropertiesFile.deleteOnExit();
-    Files.write(Paths.get(testPropertiesFile.getPath()), ImmutableList.of(mapListProp));
-
-    testObj = new MapListingSource(testPropertiesFile);
-  }
+  @Mock
+  private PropertyReader mockReader;
 
   @Test
   public void mapListDownloadSitePropertyIsReadFromPropertyFile() {
+    MapListingSource testObj = new MapListingSource(mockReader);
+    when(mockReader.readProperty(GameEngineProperty.MAP_LISTING_SOURCE_FILE)).thenReturn(SAMPLE_VALUE);
     assertThat(testObj.getMapListDownloadSite(), is(SAMPLE_VALUE));
+    verify(mockReader);
   }
 }

--- a/test/games/strategy/net/MessengerLoginTest.java
+++ b/test/games/strategy/net/MessengerLoginTest.java
@@ -119,7 +119,7 @@ public class MessengerLoginTest extends TestCase {
         final String salt = challengProperties.get(ClientLoginValidator.SALT_PROPERTY);
         final HashMap<String, String> rVal = new HashMap<String, String>();
         rVal.put(ClientLogin.PASSWORD_PROPERTY, MD5Crypt.crypt("foo", salt));
-        rVal.put(ClientLogin.ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getVersion().toString());
+        rVal.put(ClientLogin.ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().toString());
         return rVal;
       }
     };

--- a/test/games/strategy/net/MessengerLoginTest.java
+++ b/test/games/strategy/net/MessengerLoginTest.java
@@ -119,7 +119,7 @@ public class MessengerLoginTest extends TestCase {
         final String salt = challengProperties.get(ClientLoginValidator.SALT_PROPERTY);
         final HashMap<String, String> rVal = new HashMap<String, String>();
         rVal.put(ClientLogin.PASSWORD_PROPERTY, MD5Crypt.crypt("foo", salt));
-        rVal.put(ClientLogin.ENGINE_VERSION_PROPERTY, ClientContext.getInstance().engineVersion().getVersion().toString());
+        rVal.put(ClientLogin.ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getVersion().toString());
         return rVal;
       }
     };

--- a/test/games/strategy/net/MessengerLoginTest.java
+++ b/test/games/strategy/net/MessengerLoginTest.java
@@ -119,7 +119,7 @@ public class MessengerLoginTest extends TestCase {
         final String salt = challengProperties.get(ClientLoginValidator.SALT_PROPERTY);
         final HashMap<String, String> rVal = new HashMap<String, String>();
         rVal.put(ClientLogin.PASSWORD_PROPERTY, MD5Crypt.crypt("foo", salt));
-        rVal.put(ClientLogin.ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getCompatabilityVersion().toString());
+        rVal.put(ClientLogin.ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getVersion().toString());
         return rVal;
       }
     };

--- a/test/games/strategy/net/MessengerLoginTest.java
+++ b/test/games/strategy/net/MessengerLoginTest.java
@@ -119,7 +119,7 @@ public class MessengerLoginTest extends TestCase {
         final String salt = challengProperties.get(ClientLoginValidator.SALT_PROPERTY);
         final HashMap<String, String> rVal = new HashMap<String, String>();
         rVal.put(ClientLogin.PASSWORD_PROPERTY, MD5Crypt.crypt("foo", salt));
-        rVal.put(ClientLogin.ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getVersion().toString());
+        rVal.put(ClientLogin.ENGINE_VERSION_PROPERTY, ClientContext.engineVersion().getCompatabilityVersion().toString());
         return rVal;
       }
     };

--- a/test/games/strategy/net/MessengerLoginTest.java
+++ b/test/games/strategy/net/MessengerLoginTest.java
@@ -4,6 +4,7 @@ import java.net.SocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.framework.startup.login.ClientLogin;
 import games.strategy.engine.framework.startup.login.ClientLoginValidator;
@@ -118,7 +119,7 @@ public class MessengerLoginTest extends TestCase {
         final String salt = challengProperties.get(ClientLoginValidator.SALT_PROPERTY);
         final HashMap<String, String> rVal = new HashMap<String, String>();
         rVal.put(ClientLogin.PASSWORD_PROPERTY, MD5Crypt.crypt("foo", salt));
-        rVal.put(ClientLogin.ENGINE_VERSION_PROPERTY, EngineVersion.VERSION.toString());
+        rVal.put(ClientLogin.ENGINE_VERSION_PROPERTY, ClientContext.getInstance().engineVersion().getVersion().toString());
         return rVal;
       }
     };

--- a/test/games/strategy/test/TestUtil.java
+++ b/test/games/strategy/test/TestUtil.java
@@ -1,12 +1,31 @@
 package games.strategy.test;
 
 import java.awt.event.WindowEvent;
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
+import com.google.common.base.Throwables;
+import com.google.common.io.Files;
+
 public class TestUtil {
+
+  /** Create and returns a simple delete on exit temp file with contents equal to the String parameter. */
+  public static File createTempFile(String contents) {
+    File file;
+    try {
+      file = File.createTempFile("testFile", ".tmp");
+      file.deleteOnExit();
+      Files.write(contents, file, java.nio.charset.StandardCharsets.UTF_8);
+      return file;
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
   /**
    * A server socket has a time to live after it is closed in which it is still
    * bound to its port. For testing, we need to use a new port each time

--- a/test/games/strategy/triplea/xml/LoadGameUtil.java
+++ b/test/games/strategy/triplea/xml/LoadGameUtil.java
@@ -81,7 +81,7 @@ public class LoadGameUtil {
    */
   private static File getFile(final String game, final String[] possibleFolders) {
     for (final String possibleFolder : possibleFolders) {
-      final File start = ClientContext.getRootFolder();
+      final File start = ClientFileSystemHelper.getRootFolder();
       if (folderContainsFolderAndFile(start, possibleFolder, game)) {
         return new File(new File(start, possibleFolder), game);
       }

--- a/test/games/strategy/triplea/xml/LoadGameUtil.java
+++ b/test/games/strategy/triplea/xml/LoadGameUtil.java
@@ -4,12 +4,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
-import games.strategy.engine.framework.GameRunner2;
 
 public class LoadGameUtil {
 
@@ -49,7 +50,7 @@ public class LoadGameUtil {
   private static InputStream openInputStream(final String game, String[] possibleFolders) {
     InputStream is = LoadGameUtil.class.getResourceAsStream(game);
     if (is == null) {
-      final File f = ClientContext.getFile(game, possibleFolders);
+      final File f = getFile(game, possibleFolders);
       if (f.exists()) {
         try {
           is = new FileInputStream(f);
@@ -60,4 +61,69 @@ public class LoadGameUtil {
     }
     return is;
   }
+
+
+  /**
+   * Search for a file that may be contained in one of multiple folders.
+   *
+   * The file to search for is given by first parameter, second is the list of folders.
+   * We will search all possible paths of the first folder before moving on to the next,
+   * so ordering of the possible folders is more important than the ordering of search paths.
+   *
+   * The search paths vary by if this class is being run from a class file instance,
+   * or a copy compiled into a jar.
+   *
+   * @param game The name of the file to find
+   * @param possibleFolders An array containing a sequence of possible folders that may contain
+   *        the search file.
+   * @return Throws illegal state if not found. Otherwise returns a file reference whose name
+   *         matches the first parameter and parent folder matches an element of "possibleFolders"
+   */
+  private static File getFile(final String game, final String[] possibleFolders) {
+    for (final String possibleFolder : possibleFolders) {
+      final File start = ClientContext.getRootFolder();
+      if (folderContainsFolderAndFile(start, possibleFolder, game)) {
+        return new File(new File(start, possibleFolder), game);
+      }
+
+      final File secondStart = getParentFolder(possibleFolder);
+      if (folderContainsFolderAndFile(secondStart, possibleFolder, game)) {
+        return new File(new File(secondStart, possibleFolder), game);
+      }
+
+    }
+    throw new IllegalStateException(
+        "Could not find any of these folders: " + Arrays.asList(possibleFolders) + ", containing game file: " + game);
+  }
+
+
+  /* From the Game Runner root location, walk up directories until we find a given folder */
+  private static File getParentFolder(final String folderToFind) {
+    File f = new File(ClientFileSystemHelper.getGameRunnerFileLocation("GameRunner2.class"));
+
+    while (f != null && f.exists() && !folderContains(f, folderToFind)) {
+      f = f.getParentFile();
+    }
+    return f;
+  }
+
+  /* Check if a given folder contains another folder that in turn contains a given file */
+  private static boolean folderContainsFolderAndFile(final File f, final String childFolder, final String child) {
+    if (folderContains(f, childFolder)) {
+      final File possibleParent = new File(f, childFolder);
+      if (folderContains(possibleParent, child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /* Check if a folder contains another folder or file */
+  private static boolean folderContains(final File folder, final String childToFind) {
+    if (folder == null || folder.list() == null || folder.list().length == 0) {
+      return false;
+    }
+    return Arrays.asList(folder.list()).contains(childToFind);
+  }
+
 }

--- a/test/games/strategy/triplea/xml/LoadGameUtil.java
+++ b/test/games/strategy/triplea/xml/LoadGameUtil.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicReference;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
 import games.strategy.engine.framework.GameRunner2;
@@ -48,7 +49,7 @@ public class LoadGameUtil {
   private static InputStream openInputStream(final String game, String[] possibleFolders) {
     InputStream is = LoadGameUtil.class.getResourceAsStream(game);
     if (is == null) {
-      final File f = GameRunner2.getFile(game, possibleFolders);
+      final File f = ClientContext.getFile(game, possibleFolders);
       if (f.exists()) {
         try {
           is = new FileInputStream(f);


### PR DESCRIPTION
### Changes:
- Parse the game engine version from a config file instead of hardcoded
- Convert the mapDownload.properties file into a generic config file 'game_engine.properties'
- Display the game engine version on the UI
- Update Travis to read and update the game version in 'game_engine.properties'

### Before / Context:
-  `EngineVersion.java` stored the game engine version in statically initialized singleton instance
- Travis also stored the game engine version redundantly as an environment variable (this can be removed after this PR)
- MapDownloadController.java reads from the 'mapDownload.properties' to know where the triplea_maps.xml file is

### General Approach
- Have just one configuration file rather than many: 'game_engine.properties'
- Have the EngineVersion parse the file and ignore the fifth digit, yet still store it so we can display it on the UI.
- Push the game engine config parsing code 'up' so that it is not duplicated by anything that loads a value from config.
- The code to parse the property file needs a home. It is consolidated into a `PropertyReader` implementation, which is then needed to use an `EngineVersion` or a `MapDownloadController`. The next key problem is that `EngineVersion` is used in 30+ places, so wiring that data through to use EngineVersion each time is not very practical. So to solve this we consolidate the initialization code to a `ClientContext` object. Then the old code that used to get an EngineVersion via singleton, it gets it through the ClientContext singleton now instead which can return an initialized EngineVersion.
- ClientContext is modeled after Spring IOC containers. In this case it helps since we can conslidate initialization logic, and not pass around objects needed for initialization in 31+ places. (See bottom of this summary for an architecture diagram, showing these transformations/reorganization)


### Comments on the  IOC container `ClientContext`:
- `ClientContext` is reinventing the wheel..  But for now it helps a lot, and we don't have to go through the hurdle yet of picking and using a full blown IOC container.
- The test infrastructure for the IOC is not complete. There for now is no way to prevent normal IOC container initialization when running tests. A hook has been left in so at least IOC container objects can be mocked, but to really go the distance we would want to stop the normal initialization completely.

### Circular Dependency Note When reading Game engine version from Config file
- The game engine version was moved to a config file, at the root folder
- To find the root folder, we need the engine version
- To read the config file, to get the engine versoin, we need the root folder..

To break this circular loop it wasn't too hard to drop the need for the engine version when finding the root folder. A regex could match any version number, and there is a specific prefix and suffix that we were looking for before, so the actual version number was not important. By removing that we no longer had the circular call loop.

### Methods moved from GameRunner2 to ClientFileSystemHelper
- While trying to resolve the circular call loop I moved stuff out of GameRunner2 to ClientContext. Then eventually this stuff moved to `ClientFileSystemHelper`. The goal there is to place a lot of the procedural utility code somewhere that is not GameRunner2 and not ClientContext. 

### UI  Screenshots
Before:
![before](https://cloud.githubusercontent.com/assets/12397753/12775315/daa40136-ca01-11e5-9bae-e18ca8994970.png)

After with game engine version:
![after](https://cloud.githubusercontent.com/assets/12397753/12775316/daa4249a-ca01-11e5-847c-7e3661e276c0.png)

Final with renamed "game name" and "game version" labels:
![after_after](https://cloud.githubusercontent.com/assets/12397753/12775380/3cf6e47a-ca02-11e5-8b3d-bb09885e2172.png)


### High level Change Diagram

Goal: share the data pulled from the config file between MapDownloadController and EngineVersion. To do this they will share the `congFileParser` , and a ClientContext object will create the common dependencies and then instantiate objects that need them. 

![arch_diagram_for_ioc](https://cloud.githubusercontent.com/assets/12397753/12776663/c828d828-ca0c-11e5-90f4-c94f3176b9db.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/426)
<!-- Reviewable:end -->
