### PR TITLE
[Add a SystemChecker] Add classes that support running local system checks at game launch

### DIFF
--- a/src/games/strategy/debug/ClientLogger.java
+++ b/src/games/strategy/debug/ClientLogger.java
@@ -2,6 +2,8 @@ package games.strategy.debug;
 
 import java.io.PrintStream;
 
+import games.strategy.engine.framework.systemcheck.LocalSystemChecker;
+
 public class ClientLogger {
   private static final PrintStream developerOutputStream = System.out;
   private static final PrintStream userOutputStream = System.err;
@@ -37,5 +39,15 @@ public class ClientLogger {
   public static void logError(final String msg, final Throwable e) {
     logError(msg);
     logError(e);
+  }
+
+  public static void logError(LocalSystemChecker systemCheck) {
+    logError("Warning!! " + systemCheck.getExceptions().size()
+        + " system checks failed. Some game features may not be available or may not work correctly.\n"
+        + systemCheck.getStatusMessage());
+
+    for (Exception e : systemCheck.getExceptions()) {
+      logError(e);
+    }
   }
 }

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -36,6 +36,7 @@ import games.strategy.debug.ErrorConsole;
 import games.strategy.engine.EngineVersion;
 import games.strategy.engine.framework.mapDownload.MapDownloadController;
 import games.strategy.engine.framework.startup.ui.MainFrame;
+import games.strategy.engine.framework.systemcheck.LocalSystemChecker;
 import games.strategy.engine.framework.ui.background.WaitWindow;
 import games.strategy.triplea.ui.ErrorHandler;
 import games.strategy.util.CountDownLatchHandler;
@@ -148,6 +149,13 @@ public class GameRunner2 {
     // do after we handle command line args
     checkForMemoryXMX();
     setupLookAndFeel();
+
+    LocalSystemChecker systemCheck = new LocalSystemChecker();
+    if( !systemCheck.getExceptions().isEmpty() ) {
+      ClientLogger.logError(systemCheck);
+      // Now continue after we have warned the user that some game functionality may not work.
+    }
+
     s_countDownLatch = new CountDownLatch(1);
     try {
       SwingUtilities.invokeAndWait(new Runnable() {

--- a/src/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
+++ b/src/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
@@ -1,0 +1,68 @@
+package games.strategy.engine.framework.systemcheck;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Set;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+/**
+ * This class runs a set of local system checks, like access network, and create a temp file.
+ * Each check is always run, and this class records the results of those checks.
+ */
+public final class LocalSystemChecker {
+
+  private final Set<SystemCheck> systemChecks;
+
+  public LocalSystemChecker() {
+    this(ImmutableSet.of(defaultNetworkCheck(), defaultFileSystemCheck()));
+  }
+
+  private static final SystemCheck defaultNetworkCheck() {
+    return new SystemCheck("Can connect to internet", () -> {
+      try {
+        URL url = new URL("http://www.github.com");
+        url.openConnection();
+      } catch (Exception e) {
+        Throwables.propagate(e);
+      }
+    });
+  }
+
+  private static final SystemCheck defaultFileSystemCheck() {
+    return new SystemCheck("Can create temporary files", () -> {
+      try {
+        File.createTempFile("prefix", "suffix");
+      } catch (IOException e) {
+        Throwables.propagate(e);
+      }
+    });
+  }
+
+
+  protected LocalSystemChecker(Set<SystemCheck> checks) {
+    systemChecks = checks;
+  }
+
+  /** Return any exceptions encountered while running each each check */
+  public Set<Exception> getExceptions() {
+    final Set<Exception> exceptions = Sets.newHashSet();
+    for (SystemCheck systemCheck : systemChecks) {
+      if (systemCheck.getException().isPresent()) {
+        exceptions.add(systemCheck.getException().get());
+      }
+    }
+    return exceptions;
+  }
+
+  public String getStatusMessage() {
+    StringBuilder sb = new StringBuilder();
+    for (SystemCheck systemCheck : systemChecks) {
+      sb.append(systemCheck.getResultMessage()).append("\n");
+    }
+    return sb.toString();
+  }
+}

--- a/src/games/strategy/engine/framework/systemcheck/SystemCheck.java
+++ b/src/games/strategy/engine/framework/systemcheck/SystemCheck.java
@@ -1,0 +1,60 @@
+package games.strategy.engine.framework.systemcheck;
+
+import java.util.Optional;
+
+
+/**
+ * Class that performs a 'check' of some sort (executes an arbitrary Runnable).
+ * If the runnable executes without exception then the check has passed, otherwise
+ * a failure is marked and we remember the exception.
+ *
+ */
+public class SystemCheck {
+  private final boolean result;
+  private final String msg;
+  private final Optional<Exception> exception;
+
+//  /** Constructor for test case usages, use the (String,Runnable) constructor instead */
+//  protected SystemCheck(Runnable r) {
+//    this("dummy msg test", r);
+//  }
+
+  /**
+   * @param msg Message that is printed along with success/fail, should describe what the system check did.
+   * @param r The runnable that represents the system check, should verify that an action can be performed.
+   */
+  protected SystemCheck(String msg, Runnable r) {
+    this.msg = msg;
+    try {
+      r.run();
+    } catch (Exception e) {
+      exception = Optional.of(e);
+      result = false;
+      return;
+    }
+    result = true;
+    exception = Optional.empty();
+  }
+
+  /**
+   * @return True if the system check (Runnable constructor arg) completed without exception.
+   */
+  public boolean wasSuccess() {
+    return result;
+  }
+
+  /**
+   * @return A status message indicating if the system check passed or succeeded.
+   */
+  public String getResultMessage() {
+    return msg + ": " + result;
+  }
+
+  /**
+   * @return Any exceptions that may have happened while executing the system check.
+   */
+  public Optional<Exception> getException() {
+    return exception;
+  }
+
+}

--- a/test/games/strategy/engine/framework/systemcheck/LocalSystemCheckerTest.java
+++ b/test/games/strategy/engine/framework/systemcheck/LocalSystemCheckerTest.java
@@ -1,0 +1,47 @@
+package games.strategy.engine.framework.systemcheck;
+
+import static org.hamcrest.Matchers.is;
+
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
+
+import games.strategy.engine.framework.systemcheck.LocalSystemChecker;
+
+public class LocalSystemCheckerTest {
+
+  private final static SystemCheck PASSING_CHECK = new SystemCheck("no op", () -> {
+  });
+
+  private final static SystemCheck FAILING_CHECK = new SystemCheck("throws exception",() -> {
+    Throwables.propagate(new Exception("test"));
+  });
+
+
+  @Test
+  public void testHappyCase() {
+    LocalSystemChecker checker = new LocalSystemChecker(ImmutableSet.of(PASSING_CHECK));
+    assertThat(checker.getExceptions().size(), is(0));
+  }
+
+  @Test
+  public void testCheckingNetwork() {
+
+    SystemCheck network = new SystemCheck("throws exception",() -> {
+      Throwables.propagate(new Exception("test"));
+    });
+
+    LocalSystemChecker checker = new LocalSystemChecker( ImmutableSet.of(network));
+    assertThat(checker.getExceptions().size(), is(1));
+  }
+
+  @Test
+  public void testMixedCase() {
+    LocalSystemChecker checker = new LocalSystemChecker(ImmutableSet.of(PASSING_CHECK, FAILING_CHECK));
+    assertThat(checker.getExceptions().size(), is(1));
+  }
+
+}

--- a/test/games/strategy/engine/framework/systemcheck/SystemCheckTest.java
+++ b/test/games/strategy/engine/framework/systemcheck/SystemCheckTest.java
@@ -1,0 +1,41 @@
+package games.strategy.engine.framework.systemcheck;
+
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import com.google.common.base.Throwables;
+
+public class SystemCheckTest {
+
+  private final Exception testException = new Exception("Testing");
+
+  @Test
+  public void testPassingSystemCheck() {
+    Runnable noOp = () -> {
+    };
+    SystemCheck check = new SystemCheck("msg", noOp);
+
+    assertThat(check.wasSuccess(), is(true));
+    assertThat(check.getResultMessage(), is("msg: true"));
+    assertThat(check.getException().isPresent(), is(false));
+  }
+
+
+  @Test
+  public void testFailingSystemCheck() {
+    SystemCheck check = new SystemCheck("msg", () -> Throwables.propagate(testException));
+
+    assertThat(check.wasSuccess(), is(false));
+    assertThat(check.getResultMessage(), is("msg: false"));
+  }
+
+
+  @Test
+  public void remembersAndReturnsExceptions() {
+    SystemCheck check = new SystemCheck("msg", () -> Throwables.propagate(testException));
+    assertThat(check.getException().isPresent(), is(true));
+  }
+}


### PR DESCRIPTION
[Add a SystemChecker] Add classes that support running local system checks at game launch. So far we check that we are able to create temporary files and able to connect to the internet. The goal behind this is to let users know earlier rather than later that some features may not work. This then allows us to focus on slightly more detailed error messages up front, and slightly less detailed messages later as we potentially encounter various error scenarios.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/436)
<!-- Reviewable:end -->
