### PR TITLE
ThreadUtils.sleep

### DIFF
--- a/src/games/strategy/common/player/AbstractBaseAI.java
+++ b/src/games/strategy/common/player/AbstractBaseAI.java
@@ -1,6 +1,7 @@
 package games.strategy.common.player;
 
 import games.strategy.triplea.ui.AbstractUIContext;
+import games.strategy.util.ThreadUtil;
 
 /**
  * As a rule, nothing that changes GameData should be in here (it should be in a delegate, and done through an IDelegate
@@ -20,10 +21,9 @@ public abstract class AbstractBaseAI extends AbstractBasePlayer {
    */
   protected void pause() {
     try {
-      Thread.sleep(AbstractUIContext.getAIPauseDuration());
-    } catch (final InterruptedException e) {
-      e.printStackTrace();
+      ThreadUtil.sleep(AbstractUIContext.getAIPauseDuration());
     } catch (final Exception ex) {
+      ex.printStackTrace();
     }
   }
 }

--- a/src/games/strategy/common/player/AbstractBasePlayer.java
+++ b/src/games/strategy/common/player/AbstractBasePlayer.java
@@ -4,6 +4,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.engine.gamePlayer.IPlayerBridge;
+import games.strategy.util.ThreadUtil;
 
 /**
  * As a rule, nothing that changes GameData should be in here (it should be in a delegate, and done through an IDelegate
@@ -87,27 +88,24 @@ public abstract class AbstractBasePlayer implements IGamePlayer {
       int i = 0;
       boolean shownErrorMessage = false;
       while (!stepName.equals(bridgeStep)) {
-        try {
-          Thread.sleep(100);
-          i++;
-          if (i > 30 && !shownErrorMessage) {
-            System.out.println("Start step: " + stepName + " does not match player bridge step: " + bridgeStep
-                + ". Player Bridge GameOver=" + getPlayerBridge().isGameOver() + ", PlayerID: "
-                + getPlayerID().getName() + ", Game: " + getGameData().getGameName()
-                + ". Something wrong or very laggy. Will keep trying for 30 more seconds. ");
-            shownErrorMessage = true;
-          }
-          // TODO: what is the right amount of time to wait before we give up?
-          if (i > 310) {
-            System.err.println("Start step: " + stepName + " still does not match player bridge step: " + bridgeStep
-                + " even after waiting more than 30 seconds. This will probably result in a ClassCastException very soon. Player Bridge GameOver="
-                + getPlayerBridge().isGameOver() + ", PlayerID: " + getPlayerID().getName() + ", Game: "
-                + getGameData().getGameName());
-            // getPlayerBridge().printErrorStatus();
-            // waited more than 30 seconds, so just let stuff run (an error will pop up surely...)
-            break;
-          }
-        } catch (final InterruptedException e) {
+        ThreadUtil.sleep(100);
+        i++;
+        if (i > 30 && !shownErrorMessage) {
+          System.out.println("Start step: " + stepName + " does not match player bridge step: " + bridgeStep
+              + ". Player Bridge GameOver=" + getPlayerBridge().isGameOver() + ", PlayerID: "
+              + getPlayerID().getName() + ", Game: " + getGameData().getGameName()
+              + ". Something wrong or very laggy. Will keep trying for 30 more seconds. ");
+          shownErrorMessage = true;
+        }
+        // TODO: what is the right amount of time to wait before we give up?
+        if (i > 310) {
+          System.err.println("Start step: " + stepName + " still does not match player bridge step: " + bridgeStep
+              + " even after waiting more than 30 seconds. This will probably result in a ClassCastException very soon. Player Bridge GameOver="
+              + getPlayerBridge().isGameOver() + ", PlayerID: " + getPlayerID().getName() + ", Game: "
+              + getGameData().getGameName());
+          // getPlayerBridge().printErrorStatus();
+          // waited more than 30 seconds, so just let stuff run (an error will pop up surely...)
+          break;
         }
         bridgeStep = getPlayerBridge().getStepName();
       }

--- a/src/games/strategy/debug/GenericConsole.java
+++ b/src/games/strategy/debug/GenericConsole.java
@@ -17,6 +17,7 @@ import javax.swing.SwingConstants;
 import javax.swing.WindowConstants;
 
 import games.strategy.common.swing.SwingAction;
+import games.strategy.util.ThreadUtil;
 
 public abstract class GenericConsole extends JFrame {
   private static final long serialVersionUID = 5754914217052820386L;
@@ -120,11 +121,7 @@ class ThreadReader implements Runnable {
       if (m_displayConsoleOnWrite && !parentConsole.isVisible()) {
         parentConsole.setVisible(true);
       }
-      try {
-        Thread.sleep(CONSOLE_UPDATE_INTERVAL_MS);
-      } catch (final InterruptedException e) {
-        ClientLogger.logQuietly(e);
-      }
+      ThreadUtil.sleep(CONSOLE_UPDATE_INTERVAL_MS);
     }
   }
 }

--- a/src/games/strategy/engine/framework/ClientGame.java
+++ b/src/games/strategy/engine/framework/ClientGame.java
@@ -17,6 +17,7 @@ import games.strategy.engine.random.IRemoteRandom;
 import games.strategy.engine.random.RemoteRandom;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
+import games.strategy.util.ThreadUtil;
 
 public class ClientGame extends AbstractGame {
   public static final RemoteName getRemoteStepAdvancerName(final INode node) {
@@ -168,18 +169,14 @@ public class ClientGame extends AbstractGame {
           } finally {
             m_data.releaseReadLock();
           }
-          try {
-            Thread.sleep(100);
-            i++;
-            if (i > 300 && !shownErrorMessage) {
-              System.err.println("Waited more than 30 seconds for step to update. Something wrong.");
-              shownErrorMessage = true;
-              // TODO: should we throw an illegal state error? or just return? or a game over exception? should we
-              // request the server to
-              // send the step update again or something?
-            }
-          } catch (final InterruptedException e) {
-            // no worries mate
+          ThreadUtil.sleep(100);
+          i++;
+          if (i > 300 && !shownErrorMessage) {
+            System.err.println("Waited more than 30 seconds for step to update. Something wrong.");
+            shownErrorMessage = true;
+            // TODO: should we throw an illegal state error? or just return? or a game over exception? should we
+            // request the server to
+            // send the step update again or something?
           }
         }
       }

--- a/src/games/strategy/engine/framework/GameDataManager.java
+++ b/src/games/strategy/engine/framework/GameDataManager.java
@@ -24,6 +24,7 @@ import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Version;
 
 /**
@@ -106,10 +107,7 @@ public class GameDataManager {
           final boolean closeCurrentInstance = buttonPressed.equals(yesClose);
           TripleAProcessRunner.startGame(savegamePath, newClassPath, null);
           if (closeCurrentInstance) {
-            try {
-              Thread.sleep(1000);
-            } catch (final InterruptedException e) {
-            }
+            ThreadUtil.sleep(1000);
             System.exit(0);
           }
         } catch (final IOException e) {

--- a/src/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/src/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Version;
 
 /**
@@ -158,11 +159,7 @@ public class ProcessRunnerUtil {
     } catch (final IOException ioe) {
       ioe.printStackTrace();
     }
-    try {
-      Thread.sleep(5000);
-    } catch (final InterruptedException e) {
-      e.printStackTrace();
-    }
+    ThreadUtil.sleep(5000);
     System.out.println("Finished");
   }
 }

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -39,6 +39,7 @@ import games.strategy.sound.ClipPlayer;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.util.LoggingPrintStream;
 import games.strategy.util.MD5Crypt;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Util;
 
 /**
@@ -228,11 +229,7 @@ public class HeadlessGameServer {
         @Override
         public void run() {
           System.out.println("Remote Shutdown Initiated.");
-          try {
-            Thread.sleep(1000);
-          } catch (final InterruptedException e) {
-            e.printStackTrace();
-          }
+          ThreadUtil.sleep(1000);
           System.exit(0);
         }
       })).start();
@@ -530,10 +527,7 @@ public class HeadlessGameServer {
         try {
           restartLobbyWatcher(m_setupPanelModel, m_iGame);
         } catch (final Exception e) {
-          try {
-            Thread.sleep(10 * 60 * 1000);
-          } catch (final InterruptedException e1) {
-          }
+          ThreadUtil.sleep(10 * 60 * 1000);
           // try again, but don't catch it this time
           restartLobbyWatcher(m_setupPanelModel, m_iGame);
         }
@@ -654,10 +648,7 @@ public class HeadlessGameServer {
       @Override
       public void run() {
         while (!m_shutDown) {
-          try {
-            Thread.sleep(8000);
-          } catch (final InterruptedException e) {
-          }
+          ThreadUtil.sleep(8000);
           if (m_setupPanelModel != null && m_setupPanelModel.getPanel() != null
               && m_setupPanelModel.getPanel().canGameStart()) {
             final boolean started = startHeadlessGame(m_setupPanelModel);

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServerConsole.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServerConsole.java
@@ -5,6 +5,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 
+import games.strategy.util.ThreadUtil;
+
 /**
  * Terminal line console.
  */
@@ -59,12 +61,7 @@ public class HeadlessGameServerConsole {
         t.printStackTrace(out);
       }
 
-      try {
-        Thread.sleep(LOOP_SLEEP_MS);
-      } catch (final InterruptedException e) {
-        out.print("Interrupted exception: " + e);
-        e.printStackTrace(out);
-      }
+      ThreadUtil.sleep(LOOP_SLEEP_MS);
     }
   }
 

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -19,6 +19,7 @@ import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.ISetupPanel;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcher;
 import games.strategy.engine.pbem.PBEMMessagePoster;
+import games.strategy.util.ThreadUtil;
 
 /**
  * Server setup model.
@@ -57,10 +58,7 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     }
     System.out.println("Restarting lobby watcher");
     shutDownLobbyWatcher();
-    try {
-      Thread.sleep(3000);
-    } catch (final InterruptedException e) {
-    }
+    ThreadUtil.sleep(3000);
     HeadlessGameServer.resetLobbyHostOldExtensionProperties();
     createLobbyWatcher();
   }

--- a/src/games/strategy/engine/framework/map/download/DownloadCoordinator.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadCoordinator.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import games.strategy.common.swing.SwingComponents;
+import games.strategy.util.ThreadUtil;
 
 /**
  * Class that accepts and queues download requests. Download requests are started in background
@@ -38,10 +39,7 @@ public class DownloadCoordinator {
         try {
           startNextDownloads();
           // pause for a brief while before the next iteration
-          try {
-            Thread.sleep(50);
-          } catch (InterruptedException e) {
-          }
+          ThreadUtil.sleep(50);
 
           if (shouldShowDownloadsFinishedPrompt()) {
 

--- a/src/games/strategy/engine/framework/map/download/FileSizeWatcher.java
+++ b/src/games/strategy/engine/framework/map/download/FileSizeWatcher.java
@@ -3,6 +3,8 @@ package games.strategy.engine.framework.map.download;
 import java.io.File;
 import java.util.function.Consumer;
 
+import games.strategy.util.ThreadUtil;
+
 /**
  * A class that will monitor the size of a file. Inputs are a file and a consumer,
  * the file is polled in a new thread for its file size which is then passed to the
@@ -28,10 +30,7 @@ public class FileSizeWatcher {
     return () -> {
       while (!stop) {
         progressListener.accept((int) fileToWatch.length());
-        try {
-          Thread.sleep(50);
-        } catch (InterruptedException e) {
-        }
+        ThreadUtil.sleep(50);
       }
     };
   }

--- a/src/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/src/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -18,6 +18,7 @@ import games.strategy.engine.random.ScriptedRandomSource;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
+import games.strategy.util.ThreadUtil;
 
 public class LocalLauncher extends AbstractLauncher {
   private static final Logger s_logger = Logger.getLogger(ILauncher.class.getName());
@@ -76,12 +77,9 @@ public class LocalLauncher extends AbstractLauncher {
       }
     } finally {
       // todo(kg), this does not occur on the swing thread, and this notifies setupPanel observers
-      try {
         // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused
         // by closing of stream while unloading map resources.
-        Thread.sleep(100);
-      } catch (final InterruptedException e) {
-      }
+        ThreadUtil.sleep(100);
       m_gameSelectorModel.loadDefaultGame(parent);
       SwingUtilities.invokeLater(new Runnable() {
         @Override

--- a/src/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -43,6 +43,7 @@ import games.strategy.engine.random.CryptoRandomSource;
 import games.strategy.net.IMessenger;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
+import games.strategy.util.ThreadUtil;
 
 public class ServerLauncher extends AbstractLauncher {
   private static final Logger s_logger = Logger.getLogger(ServerLauncher.class.getName());
@@ -254,12 +255,9 @@ public class ServerLauncher extends AbstractLauncher {
             }
             stopGame();
           }
-          try {
-            // having an oddball issue with the zip stream being closed while parsing to load default game. might be
-            // caused by closing of stream while unloading map resources.
-            Thread.sleep(200);
-          } catch (final InterruptedException e) {
-          }
+          // having an oddball issue with the zip stream being closed while parsing to load default game. might be
+          // caused by closing of stream while unloading map resources.
+          ThreadUtil.sleep(200);
           // either game ended, or aborted, or a player left or disconnected
           if (m_headless) {
             try {

--- a/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -9,6 +9,7 @@ import games.strategy.engine.ClientContext;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.IServerMessenger;
 import games.strategy.util.MD5Crypt;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Version;
 
 /**
@@ -95,14 +96,9 @@ public class ClientLoginValidator implements ILoginValidator {
         return "No password";
       }
       if (!readPassword.equals(MD5Crypt.crypt(m_password, propertiesSentToClient.get(SALT_PROPERTY)))) {
-        try {
-          // sleep on average 2 seconds
-          // try to prevent flooding to guess the
-          // password
-          Thread.sleep((int) (4000 * Math.random()));
-        } catch (final InterruptedException e) {
-          // ignore
-        }
+        // sleep on average 2 seconds
+        // try to prevent flooding to guess the password
+        ThreadUtil.sleep((int) (4000 * Math.random()));
         return "Invalid password";
       }
     }

--- a/src/games/strategy/engine/framework/startup/ui/MainFrame.java
+++ b/src/games/strategy/engine/framework/startup/ui/MainFrame.java
@@ -11,6 +11,7 @@ import games.strategy.engine.chat.Chat;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
+import games.strategy.util.ThreadUtil;
 
 /**
  * arguments
@@ -91,12 +92,9 @@ public class MainFrame extends JFrame {
       }
       return;
     }
-    try {
       // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused by
       // closing of stream while unloading map resources.
-      Thread.sleep(100);
-    } catch (final InterruptedException e) {
-    }
+    ThreadUtil.sleep(100);
     m_gameSelectorModel.loadDefaultGame(this);
     m_setupPanelModel.showSelectType();
     setVisible(true);

--- a/src/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -45,6 +45,7 @@ import games.strategy.engine.lobby.client.ui.action.EditGameCommentAction;
 import games.strategy.engine.lobby.client.ui.action.RemoveGameFromLobbyAction;
 import games.strategy.engine.pbem.PBEMMessagePoster;
 import games.strategy.net.IServerMessenger;
+import games.strategy.util.ThreadUtil;
 
 /** Setup panel displayed for hosting a non-lobby network game (using host option from main panel) */
 public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener {
@@ -88,10 +89,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     }
     System.out.println("Restarting lobby watcher");
     shutDownLobbyWatcher();
-    try {
-      Thread.sleep(1000);
-    } catch (final InterruptedException e) {
-    }
+    ThreadUtil.sleep(1000);
     HeadlessGameServer.resetLobbyHostOldExtensionProperties();
     createLobbyWatcher();
   }

--- a/src/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/games/strategy/engine/lobby/server/userDB/Database.java
@@ -19,6 +19,7 @@ import javax.swing.JOptionPane;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.startup.launcher.ServerLauncher;
+import games.strategy.util.ThreadUtil;
 
 /**
  * Utility to get connections to the database.
@@ -196,11 +197,7 @@ public class Database {
       public void run() {
         while (true) {
           // wait 7 days
-          try {
-            Thread.sleep(7 * 24 * 60 * 60 * 1000);
-          } catch (final InterruptedException e) {
-            e.printStackTrace();
-          }
+          ThreadUtil.sleep(7 * 24 * 60 * 60 * 1000);
           backup();
         }
       }

--- a/src/games/strategy/engine/message/UnifiedMessenger.java
+++ b/src/games/strategy/engine/message/UnifiedMessenger.java
@@ -24,6 +24,7 @@ import games.strategy.net.IMessageListener;
 import games.strategy.net.IMessenger;
 import games.strategy.net.IMessengerErrorListener;
 import games.strategy.net.INode;
+import games.strategy.util.ThreadUtil;
 
 /**
  * A messenger general enough that both Channel and Remote messenger can be
@@ -240,11 +241,7 @@ public class UnifiedMessenger {
     }
     final long endTime = timeoutMS + System.currentTimeMillis();
     while (System.currentTimeMillis() < endTime && !hasLocalEndPoint(endPointName)) {
-      try {
-        Thread.sleep(50);
-      } catch (final InterruptedException e) {
-        // whats a devloper to do
-      }
+      ThreadUtil.sleep(50);
     }
   }
 

--- a/src/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/src/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -16,6 +16,7 @@ import games.strategy.net.IMessageListener;
 import games.strategy.net.IMessenger;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
+import games.strategy.util.ThreadUtil;
 
 public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeListener {
   private final static Logger s_logger = Logger.getLogger(UnifiedMessengerHub.class.getName());
@@ -163,11 +164,7 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
     }
     final long endTime = timeoutMS + System.currentTimeMillis();
     while (System.currentTimeMillis() < endTime && !hasImplementors(endPointName)) {
-      try {
-        Thread.sleep(50);
-      } catch (final InterruptedException e) {
-        // whats a devloper to do
-      }
+      ThreadUtil.sleep(50);
     }
   }
 

--- a/src/games/strategy/net/ClientMessenger.java
+++ b/src/games/strategy/net/ClientMessenger.java
@@ -24,6 +24,7 @@ import games.strategy.net.nio.NIOSocket;
 import games.strategy.net.nio.NIOSocketListener;
 import games.strategy.net.nio.QuarantineConversation;
 import games.strategy.util.ListenerList;
+import games.strategy.util.ThreadUtil;
 
 public class ClientMessenger implements IClientMessenger, NIOSocketListener {
   private INode m_node;
@@ -84,11 +85,8 @@ public class ClientMessenger implements IClientMessenger, NIOSocketListener {
         if (m_socketChannel.finishConnect()) {
           break;
         }
-        try {
-          Thread.sleep(50);
-          waitTimeMilliseconds += 50;
-        } catch (final InterruptedException e) {
-        }
+        ThreadUtil.sleep(50);
+        waitTimeMilliseconds += 50;
       }
     }
     final Socket socket = m_socketChannel.socket();

--- a/src/games/strategy/thread/ThreadPool.java
+++ b/src/games/strategy/thread/ThreadPool.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.util.ThreadUtil;
 
 /**
  * An ExecutorService backed thread pool.
@@ -38,16 +39,12 @@ public class ThreadPool {
    * Returns when all tasks run through the runTask method have finished.
    */
   public void waitForAll() {
-    try {
-      while (!futuresStack.isEmpty()) {
-        if (futuresStack.peek().isDone()) {
-          futuresStack.pop();
-        } else {
-          Thread.sleep(5);
-        }
+    while (!futuresStack.isEmpty()) {
+      if (futuresStack.peek().isDone()) {
+        futuresStack.pop();
+      } else {
+        ThreadUtil.sleep(5);
       }
-    } catch (InterruptedException e) {
-      ClientLogger.logQuietly(e);
     }
   }
 

--- a/src/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -21,6 +21,7 @@ import games.strategy.triplea.attatchments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.AbstractUIContext;
 import games.strategy.util.Match;
+import games.strategy.util.ThreadUtil;
 
 /**
  * Pro AI utilities (these are very general and maybe should be moved into delegate or engine).
@@ -262,9 +263,7 @@ public class ProUtils {
    */
   public static void pause() {
     try {
-      Thread.sleep(AbstractUIContext.getAIPauseDuration());
-    } catch (final InterruptedException e) {
-      e.printStackTrace();
+      ThreadUtil.sleep(AbstractUIContext.getAIPauseDuration());
     } catch (final Exception e) {
       e.printStackTrace();
     }

--- a/src/games/strategy/triplea/attatchments/AbstractTriggerAttachment.java
+++ b/src/games/strategy/triplea/attatchments/AbstractTriggerAttachment.java
@@ -17,6 +17,7 @@ import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.ITripleaPlayer;
 import games.strategy.util.Match;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Tuple;
 
 public abstract class AbstractTriggerAttachment extends AbstractConditionsAttachment implements ICondition {
@@ -211,15 +212,10 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
       return false;
     }
     // there is an issue with maps using thousands of chance triggers: they are causing the cypted random source (ie:
-    // live and pbem games)
-    // to lock up or error out
+    // live and pbem games) to lock up or error out
     // so we need to slow them down a bit, until we come up with a better solution (like aggregating all the chances
-    // together, then getting
-    // a ton of random numbers at once instead of one at a time)
-    try {
-      Thread.sleep(100);
-    } catch (final InterruptedException e) {
-    }
+    // together, then getting a ton of random numbers at once instead of one at a time)
+    ThreadUtil.sleep(100);
     final int rollResult = aBridge.getRandom(diceSides, null, DiceType.ENGINE,
         "Attempting the Trigger: " + MyFormatter.attachmentNameToText(this.getName())) + 1;
     final boolean testChance = rollResult <= hitTarget;

--- a/src/games/strategy/triplea/attatchments/RulesAttachment.java
+++ b/src/games/strategy/triplea/attatchments/RulesAttachment.java
@@ -38,6 +38,7 @@ import games.strategy.triplea.player.ITripleaPlayer;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Tuple;
 
 public class RulesAttachment extends AbstractPlayerRulesAttachment implements ICondition {
@@ -868,10 +869,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment implements IC
         // so we need to slow them down a bit, until we come up with a better solution (like aggregating all the chances
         // together, then
         // getting a ton of random numbers at once instead of one at a time)
-        try {
-          Thread.sleep(100);
-        } catch (final InterruptedException e) {
-        }
+        ThreadUtil.sleep(100);
         final int rollResult = aBridge.getRandom(diceSides, null, DiceType.ENGINE,
             "Attempting the Condition: " + MyFormatter.attachmentNameToText(this.getName())) + 1;
         objectiveMet = rollResult <= hitTarget;

--- a/src/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -37,6 +37,7 @@ import games.strategy.triplea.player.ITripleaPlayer;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Tuple;
 
 /**
@@ -397,10 +398,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
           // so we need to slow them down a bit, until we come up with a better solution (like aggregating all the
           // chances together, then
           // getting a ton of random numbers at once instead of one at a time)
-          try {
-            Thread.sleep(100);
-          } catch (final InterruptedException e) {
-          }
+          ThreadUtil.sleep(100);
           final String transcript = "Rolling for Convoy Blockade Damage in " + b.getName();
           final int[] dice = aBridge.getRandom(CONVOY_BLOCKADE_DICE_SIDES, numberOfDice,
               enemies.iterator().next().getOwner(), DiceType.BOMBING, transcript);

--- a/src/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -36,6 +36,7 @@ import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.CompositeMatchOr;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
+import games.strategy.util.ThreadUtil;
 
 /**
  * At the end of the turn collect income.
@@ -153,10 +154,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     // so we need to slow them down a bit, until we come up with a better solution (like aggregating all the chances
     // together, then getting
     // a ton of random numbers at once instead of one at a time)
-    try {
-      Thread.sleep(100);
-    } catch (final InterruptedException e) {
-    }
+    ThreadUtil.sleep(100);
     final List<Territory> list = new ArrayList<Territory>(territories);
     final int random =
         // ZERO BASED

--- a/src/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -23,6 +23,7 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Tuple;
 
 /**
@@ -98,10 +99,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
       if (m_currentPickingPlayer == null || !playersCanPick.contains(m_currentPickingPlayer)) {
         m_currentPickingPlayer = playersCanPick.get(0);
       }
-      try {
-        Thread.sleep(250);
-      } catch (final InterruptedException e) {
-      }
+      ThreadUtil.sleep(250);
       Territory picked;
       if (randomTerritories) {
         pos += hitRandom[i];

--- a/src/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
+++ b/src/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
@@ -23,6 +23,7 @@ import games.strategy.engine.pbem.AbstractForumPoster;
 import games.strategy.engine.pbem.IForumPoster;
 import games.strategy.net.DesktopUtilityBrowserLauncher;
 import games.strategy.triplea.help.HelpSupport;
+import games.strategy.util.ThreadUtil;
 
 /**
  * Post turn summary to www.axisandallies.org to the thread identified by the forumId
@@ -180,13 +181,8 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
           post.addRequestHeader("Referer", "http://www.axisandallies.org/forums/index.php?action=post;topic="
               + m_topicId + ".0;num_replies=" + numReplies);
           post.addRequestHeader("Accept", "*/*");
-          try {
             // the site has spam prevention which means you can't post until 15 seconds after login
-            Thread.sleep(15 * 1000);
-          } catch (final InterruptedException ie) {
-            // this should never happen
-            ie.printStackTrace();
-          }
+          ThreadUtil.sleep(15 * 1000);
           post.setFollowRedirects(false);
           status = m_client.executeMethod(m_hostConfiguration, post, m_httpState);
           body = post.getResponseBodyAsString();

--- a/src/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/games/strategy/triplea/ui/BattlePanel.java
@@ -46,6 +46,7 @@ import games.strategy.triplea.delegate.dataObjects.FightBattleDetails;
 import games.strategy.ui.Util;
 import games.strategy.ui.Util.Task;
 import games.strategy.util.EventThreadJOptionPane;
+import games.strategy.util.ThreadUtil;
 
 /**
  * UI for fighting battles.
@@ -199,12 +200,8 @@ public class BattlePanel extends ActionPanel {
     GUID displayed = m_currentBattleDisplayed;
     int count = 0;
     while (displayed == null || !battleID.equals(displayed)) {
-      try {
-        count++;
-        Thread.sleep(count);
-      } catch (final InterruptedException e) {
-        return false;
-      }
+      count++;
+      ThreadUtil.sleep(count);
       // something is wrong, we shouldnt have to wait this long
       if (count > 200) {
         ErrorConsole.getConsole().dumpStacks();

--- a/src/games/strategy/triplea/ui/MemoryLabel.java
+++ b/src/games/strategy/triplea/ui/MemoryLabel.java
@@ -11,6 +11,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 
 import games.strategy.common.swing.SwingAction;
+import games.strategy.util.ThreadUtil;
 
 public class MemoryLabel extends JLabel {
   private static final long serialVersionUID = -6011470050936617333L;
@@ -98,9 +99,6 @@ class Updater implements Runnable {
   }
 
   private static void sleep() {
-    try {
-      Thread.sleep(2000);
-    } catch (final InterruptedException e) {
-    }
+    ThreadUtil.sleep(2000);
   }
 }

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -161,6 +161,7 @@ import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.LocalizeHTML;
 import games.strategy.util.Match;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Tuple;
 
 /**
@@ -1203,11 +1204,7 @@ public class TripleAFrame extends MainGameFrame {
               dialog.setVisible(false);
               dialog.removeAll();
               dialog.dispose();
-              try {
-                Thread.sleep(500);
-              } catch (final InterruptedException e2) {
-                e2.printStackTrace();
-              }
+              ThreadUtil.sleep(500);
               run();
             }
           }
@@ -1314,11 +1311,7 @@ public class TripleAFrame extends MainGameFrame {
               dialog.setVisible(false);
               dialog.removeAll();
               dialog.dispose();
-              try {
-                Thread.sleep(500);
-              } catch (final InterruptedException e2) {
-                e2.printStackTrace();
-              }
+              ThreadUtil.sleep(500);
               run();
             }
           }
@@ -1411,11 +1404,7 @@ public class TripleAFrame extends MainGameFrame {
               dialog.setVisible(false);
               dialog.removeAll();
               dialog.dispose();
-              try {
-                Thread.sleep(500);
-              } catch (final InterruptedException e2) {
-                e2.printStackTrace();
-              }
+              ThreadUtil.sleep(500);
               run();
             }
           }
@@ -1650,10 +1639,7 @@ public class TripleAFrame extends MainGameFrame {
       return;
     }
     try {
-      try {
-        Thread.sleep(300);
-      } catch (final InterruptedException e1) {
-      }
+      ThreadUtil.sleep(300);
       SwingUtilities.invokeAndWait(new Runnable() {
         @Override
         public void run() {
@@ -1783,10 +1769,7 @@ public class TripleAFrame extends MainGameFrame {
             final Runnable disposePopup = new Runnable() {
               @Override
               public void run() {
-                try {
-                  Thread.sleep(5000);
-                } catch (final InterruptedException e) {
-                }
+                ThreadUtil.sleep(5000);
                 popup.hide();
               }
             };

--- a/src/games/strategy/util/ThreadUtil.java
+++ b/src/games/strategy/util/ThreadUtil.java
@@ -7,7 +7,7 @@ public class ThreadUtil {
     try {
       Thread.sleep(millis);
     } catch (InterruptedException e) {
-
+      // ignore, general cause is the user sent an interrupt (killed the program)
     }
   }
 }

--- a/src/games/strategy/util/TimerClock.java
+++ b/src/games/strategy/util/TimerClock.java
@@ -93,12 +93,8 @@ public class TimerClock<T> extends Observable {
       // notify listeners
       setChanged();
       notifyObservers(new TimerClockNotification(0, true));
-      try {
-        // wait a second to gracefully allow a remote player to receive the notice that they are out of time
-        Thread.sleep(1000);
-      } catch (final InterruptedException e1) {
-        e1.printStackTrace();
-      }
+      // wait a second to gracefully allow a remote player to receive the notice that they are out of time
+      ThreadUtil.sleep(1000);
       interrupted = true;
       t.interrupt();
       try {

--- a/src/games/strategy/util/Util.java
+++ b/src/games/strategy/util/Util.java
@@ -136,10 +136,7 @@ public class Util {
   public static String createUniqueTimeStamp() {
     final long time = System.currentTimeMillis();
     while (time == System.currentTimeMillis()) {
-      try {
-        Thread.sleep(1);
-      } catch (final InterruptedException e) {
-      }
+      ThreadUtil.sleep(1);
     }
     return "" + System.currentTimeMillis();
   }

--- a/test/games/strategy/engine/chat/ChatTest.java
+++ b/test/games/strategy/engine/chat/ChatTest.java
@@ -17,6 +17,7 @@ import games.strategy.net.MacFinder;
 import games.strategy.net.ServerMessenger;
 import games.strategy.sound.SoundPath;
 import games.strategy.test.TestUtil;
+import games.strategy.util.ThreadUtil;
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
 
@@ -108,7 +109,7 @@ public class ChatTest extends TestCase {
         assertEquals(m_serverChatListener.m_players.size(), 3);
         break;
       } catch (final AssertionFailedError afe) {
-        Thread.sleep(25);
+        ThreadUtil.sleep(25);
       }
     }
     assertEquals(m_client1ChatListener.m_players.size(), 3);
@@ -149,7 +150,7 @@ public class ChatTest extends TestCase {
         assertEquals(m_serverChatListener.m_messages.size(), 3 * messageCount);
         break;
       } catch (final AssertionFailedError afe) {
-        Thread.sleep(25);
+        ThreadUtil.sleep(25);
       }
     }
     assertEquals(m_client1ChatListener.m_messages.size(), 3 * messageCount);
@@ -163,7 +164,7 @@ public class ChatTest extends TestCase {
         assertEquals(m_serverChatListener.m_players.size(), 1);
         break;
       } catch (final AssertionFailedError afe) {
-        Thread.sleep(25);
+        ThreadUtil.sleep(25);
       }
     }
     assertEquals(m_serverChatListener.m_players.size(), 1);
@@ -173,7 +174,7 @@ public class ChatTest extends TestCase {
         assertEquals(m_serverChatListener.m_players.size(), 0);
         break;
       } catch (final AssertionFailedError afe) {
-        Thread.sleep(25);
+        ThreadUtil.sleep(25);
       }
     }
     assertEquals(m_serverChatListener.m_players.size(), 0);

--- a/test/games/strategy/engine/chat/StatusTest.java
+++ b/test/games/strategy/engine/chat/StatusTest.java
@@ -2,6 +2,7 @@ package games.strategy.engine.chat;
 
 import games.strategy.engine.message.DummyMessenger;
 import games.strategy.net.Messengers;
+import games.strategy.util.ThreadUtil;
 import junit.framework.TestCase;
 
 public class StatusTest extends TestCase {
@@ -11,7 +12,7 @@ public class StatusTest extends TestCase {
     final StatusManager manager = new StatusManager(messengers);
     assertNull(manager.getStatus(messenger.getLocalNode()));
     manager.setStatus("test");
-    Thread.sleep(200);
+    ThreadUtil.sleep(200);
     assertEquals("test", manager.getStatus(messenger.getLocalNode()));
     assertEquals("test", new StatusManager(messengers).getStatus(messenger.getLocalNode()));
   }

--- a/test/games/strategy/engine/framework/headlessGameServer/HeadlessGameServerConsoleTest.java
+++ b/test/games/strategy/engine/framework/headlessGameServer/HeadlessGameServerConsoleTest.java
@@ -14,6 +14,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import games.strategy.util.ThreadUtil;
+
 @RunWith(MockitoJUnitRunner.class)
 public class HeadlessGameServerConsoleTest {
 
@@ -48,12 +50,8 @@ public class HeadlessGameServerConsoleTest {
     }
     testObj.start();
 
-    try {
-      // console thread reads on another thread, sleep for a bit to give it a chance to read.
-      Thread.sleep(HeadlessGameServerConsole.LOOP_SLEEP_MS * 5);
-    } catch (InterruptedException e) {
-      throw new IllegalStateException(e);
-    }
+    // console thread reads on another thread, sleep for a bit to give it a chance to read.
+    ThreadUtil.sleep(HeadlessGameServerConsole.LOOP_SLEEP_MS * 5);
     verify( mockHeadlessConsoleController,times(1)).process(testValueToSendThru.trim());
   }
 

--- a/test/games/strategy/engine/lobby/server/userDB/DBUserControllerTest.java
+++ b/test/games/strategy/engine/lobby/server/userDB/DBUserControllerTest.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 
 import games.strategy.util.MD5Crypt;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Util;
 import junit.framework.TestCase;
 
@@ -61,10 +62,7 @@ public class DBUserControllerTest extends TestCase {
     // advance the clock so we can see the login time
     long loginTimeMustBeAfter = System.currentTimeMillis();
     while (loginTimeMustBeAfter == System.currentTimeMillis()) {
-      try {
-        Thread.sleep(1);
-      } catch (final InterruptedException e) {
-      }
+      ThreadUtil.sleep(1);
     }
     loginTimeMustBeAfter = System.currentTimeMillis();
     assertTrue(controller.login(name, password));

--- a/test/games/strategy/engine/message/ChannelMessengerTest.java
+++ b/test/games/strategy/engine/message/ChannelMessengerTest.java
@@ -8,6 +8,7 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
 import games.strategy.net.ServerMessenger;
 import games.strategy.test.TestUtil;
+import games.strategy.util.ThreadUtil;
 import junit.framework.TestCase;
 
 public class ChannelMessengerTest extends TestCase {
@@ -116,12 +117,7 @@ public class ChannelMessengerTest extends TestCase {
   private void assertHasChannel(final RemoteName descriptor, final UnifiedMessengerHub hub) {
     int waitCount = 0;
     while (waitCount < 10 && !hub.hasImplementors(descriptor.getName())) {
-      try {
-        Thread.sleep(100);
-      } catch (final InterruptedException e) {
-        // like, whatever man
-        e.printStackTrace();
-      }
+      ThreadUtil.sleep(100);
       waitCount++;
     }
     assertTrue(hub.hasImplementors(descriptor.getName()));
@@ -132,11 +128,7 @@ public class ChannelMessengerTest extends TestCase {
     // wait for the call to go through, but dont wait too long
     int waitCount = 0;
     while (waitCount < 20 && expected != subscribor.getCallCount()) {
-      try {
-        Thread.sleep(50);
-      } catch (final InterruptedException e) {
-        e.printStackTrace();
-      }
+      ThreadUtil.sleep(50);
       waitCount++;
     }
     assertEquals(expected, subscribor.getCallCount());

--- a/test/games/strategy/engine/message/RemoteMessengerTest.java
+++ b/test/games/strategy/engine/message/RemoteMessengerTest.java
@@ -9,6 +9,7 @@ import games.strategy.net.INode;
 import games.strategy.net.MacFinder;
 import games.strategy.net.ServerMessenger;
 import games.strategy.test.TestUtil;
+import games.strategy.util.ThreadUtil;
 import junit.framework.TestCase;
 
 public class RemoteMessengerTest extends TestCase {
@@ -122,7 +123,7 @@ public class RemoteMessengerTest extends TestCase {
       int waitCount = 0;
       while (!m_hub.hasImplementors(test.getName()) && waitCount < 20) {
         waitCount++;
-        Thread.sleep(50);
+        ThreadUtil.sleep(50);
       }
       // call it on the client
       final int rVal = ((ITestRemote) clientRM.getRemote(test)).increment(1);
@@ -166,13 +167,6 @@ public class RemoteMessengerTest extends TestCase {
     }
   }
 
-  private void sleep(final int ms) {
-    try {
-      Thread.sleep(ms);
-    } catch (final InterruptedException e) {
-    }
-  }
-
   public void testShutDownClient() throws Exception {
     // when the client shutdown, remotes created
     // on the client should not be visible on server
@@ -190,7 +184,7 @@ public class RemoteMessengerTest extends TestCase {
       serverUM.getHub().waitForNodesToImplement(test.getName(), 200);
       assertTrue(serverUM.getHub().hasImplementors(test.getName()));
       client.shutDown();
-      sleep(200);
+      ThreadUtil.sleep(200);
       assertTrue(!serverUM.getHub().hasImplementors(test.getName()));
     } finally {
       shutdownServerAndClient(server, client);
@@ -245,9 +239,9 @@ public class RemoteMessengerTest extends TestCase {
       t.start();
       // wait for the thread to start
       while (started.get() == false) {
-        sleep(1);
+        ThreadUtil.sleep(1);
       }
-      sleep(20);
+      ThreadUtil.sleep(20);
       // TODO: we are getting a RemoteNotFoundException because the client is disconnecting before the invoke goes out
       // completely
       // Perhaps this situation should be changed to a ConnectionLostException or something else?

--- a/test/games/strategy/net/MessengerTest.java
+++ b/test/games/strategy/net/MessengerTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import games.strategy.test.TestUtil;
+import games.strategy.util.ThreadUtil;
 import junit.framework.TestCase;
 
 public class MessengerTest extends TestCase {
@@ -41,11 +42,7 @@ public class MessengerTest extends TestCase {
     assertEquals(m_server.getServerNode(), m_server.getLocalNode());
     for (int i = 0; i < 100; i++) {
       if (m_server.getNodes().size() != 3) {
-        try {
-          Thread.sleep(1);
-        } catch (final InterruptedException e) {
-          throw new IllegalStateException(e);
-        }
+        ThreadUtil.sleep(1);
       } else {
         break;
       }
@@ -193,10 +190,7 @@ public class MessengerTest extends TestCase {
       if (m_server.getNodes().size() == 3) {
         break;
       }
-      try {
-        Thread.sleep(10);
-      } catch (final InterruptedException e) {
-      }
+      ThreadUtil.sleep(10);
     }
     final AtomicInteger m_serverCount = new AtomicInteger(3);
     m_server.addConnectionChangeListener(new IConnectionChangeListener() {
@@ -213,10 +207,10 @@ public class MessengerTest extends TestCase {
     m_client1.shutDown();
     for (int i = 0; i < 100; i++) {
       if (m_server.getNodes().size() == 2) {
-        Thread.sleep(10);
+        ThreadUtil.sleep(10);
         break;
       }
-      Thread.sleep(10);
+      ThreadUtil.sleep(10);
     }
     assertEquals(2, m_serverCount.get());
   }
@@ -226,17 +220,17 @@ public class MessengerTest extends TestCase {
       if (m_server.getNodes().size() == 3) {
         break;
       }
-      Thread.sleep(10);
+      ThreadUtil.sleep(10);
     }
     assertEquals(3, m_server.getNodes().size());
     m_client1.shutDown();
     m_client2.shutDown();
     for (int i = 0; i < 100; i++) {
       if (m_server.getNodes().size() == 1) {
-        Thread.sleep(10);
+        ThreadUtil.sleep(10);
         break;
       }
-      Thread.sleep(1);
+      ThreadUtil.sleep(1);
     }
     assertEquals(m_server.getNodes().size(), 1);
   }
@@ -252,10 +246,10 @@ public class MessengerTest extends TestCase {
     m_server.removeConnection(m_client1.getLocalNode());
     int waitCount = 0;
     while (!closed.get() && waitCount < 10) {
-      Thread.sleep(40);
+      ThreadUtil.sleep(40);
       waitCount++;
     }
-    assert(closed.get());
+    assert (closed.get());
   }
 
   public void testManyClients() throws UnknownHostException, CouldNotLogInException, IOException, InterruptedException {

--- a/test/games/strategy/thread/ThreadPoolTest.java
+++ b/test/games/strategy/thread/ThreadPoolTest.java
@@ -104,8 +104,8 @@ class Task implements Runnable {
   public void run() {
     try {
       Thread.sleep(0, 1);
-    } catch (final InterruptedException e) {
-      e.printStackTrace();
+    } catch (InterruptedException e) {
+      throw new IllegalStateException(e);
     }
     done = true;
   }


### PR DESCRIPTION
Use ThreadUtils.sleep instead of Thread.sleep

ThreadUtil is a new utility class, allows us to call Thread.sleep() without having to catch interrupted exception. Interrupted exception would be thrown most likely by the user sending a kill signal in to the process. Logging this is not very useful, so most of the time the handling of the interrupted exception is arbitrary (from formal error handling of logging error and stack trace, to funny comments about "what is a developer to do?")

So with this change we uniformly handle the interrupted exception (just ignore it), and we simplify the code a bit so we don't have to have the extra 'try/catch' block. whenever we sleep.

(Based on prior PRs)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/450)
<!-- Reviewable:end -->
