### PR TITLE
Improve load time of main window

### DIFF
--- a/src/games/strategy/debug/GenericConsole.java
+++ b/src/games/strategy/debug/GenericConsole.java
@@ -14,6 +14,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JToolBar;
 import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 import games.strategy.common.swing.SwingAction;
@@ -40,7 +41,7 @@ public abstract class GenericConsole extends JFrame {
     m_actions.add(m_propertiesAction);
     m_actions.add(m_copyAction);
     m_actions.add(m_clearAction);
-    pack();
+    SwingUtilities.invokeLater(() -> pack());
   }
 
   public abstract GenericConsole getConsoleInstance();

--- a/src/games/strategy/engine/framework/GameRunner.java
+++ b/src/games/strategy/engine/framework/GameRunner.java
@@ -52,8 +52,8 @@ public class GameRunner {
     // we want this class to be executable in older jvm's
     // since we require jdk 1.5, this class delegates to GameRunner2
     // and all we do is check the java version
-    try (PerfTimer timer = Perf.startTimer("GameRunner1 Launch")) {
-      checkJavaVersion();
+    try (PerfTimer timer = Perf.startTimer("GameRunner1 Total Launch")) {
+      (new Thread(() -> checkJavaVersion())).start();
       // do the other interesting stuff here
       GameRunner2.main(args);
     }

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -15,7 +15,6 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
 import java.util.logging.LogManager;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
@@ -34,7 +33,6 @@ import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.map.download.MapDownloadController;
 import games.strategy.engine.framework.startup.ui.MainFrame;
 import games.strategy.engine.framework.systemcheck.LocalSystemChecker;
-import games.strategy.engine.framework.ui.background.WaitWindow;
 import games.strategy.performance.Perf;
 import games.strategy.performance.PerfTimer;
 import games.strategy.triplea.ui.ErrorHandler;
@@ -93,8 +91,6 @@ public class GameRunner2 {
   public static final String TRIPLEA_MEMORY_XMX = "triplea.memory.Xmx";
   public static final String TRIPLEA_MEMORY_USE_DEFAULT = "triplea.memory.useDefault";
   public static final String SYSTEM_INI = "system.ini";
-  private static WaitWindow s_waitWindow;
-  private static CountDownLatch s_countDownLatch;
   public static final int MINIMUM_CLIENT_GAMEDATA_LOAD_GRACE_TIME = 20;
   public static final int DEFAULT_CLIENT_GAMEDATA_LOAD_GRACE_TIME =
       Math.max(MINIMUM_CLIENT_GAMEDATA_LOAD_GRACE_TIME, 25);
@@ -165,12 +161,6 @@ public class GameRunner2 {
         final MainFrame frame = new MainFrame();
         frame.requestFocus();
         frame.toFront();
-        if (s_waitWindow != null) {
-          s_waitWindow.doneWait();
-        }
-        if (s_countDownLatch != null) {
-          s_countDownLatch.countDown();
-        }
         frame.setVisible(true);
       }
     });
@@ -342,12 +332,6 @@ public class GameRunner2 {
       return;
     }
     // the difference is significant enough that we should re-run triplea with a larger number
-    if (s_waitWindow != null) {
-      s_waitWindow.doneWait();
-    }
-    if (s_countDownLatch != null) {
-      s_countDownLatch.countDown();
-    }
     TripleAProcessRunner.startNewTripleA(xmx);
     // must exit now
     System.exit(0);

--- a/src/games/strategy/engine/framework/startup/ui/MainFrame.java
+++ b/src/games/strategy/engine/framework/startup/ui/MainFrame.java
@@ -56,7 +56,31 @@ public class MainFrame extends JFrame {
     // getRootPane().setDefaultButton(mainPanel.getDefaultButton());
     pack();
     setLocationRelativeTo(null);
+    start();
   }
+
+  /**
+   * For displaying on startup.
+   * Only call once!
+   */
+  private void start() {
+    SwingUtilities.invokeLater(new Runnable() {
+      @Override
+      public void run() {
+        final String fileName = System.getProperty(GameRunner2.TRIPLEA_GAME_PROPERTY, "");
+        if (fileName.length() > 0) {
+          loadGameFile(fileName);
+        }
+        setVisible(true);
+        if (System.getProperty(GameRunner2.TRIPLEA_SERVER_PROPERTY, "false").equals("true")) {
+          m_setupPanelModel.showServer(MainFrame.this);
+        } else if (System.getProperty(GameRunner2.TRIPLEA_CLIENT_PROPERTY, "false").equals("true")) {
+          m_setupPanelModel.showClient(MainFrame.this);
+        }
+      }
+    });
+  }
+
 
   /**
    * todo, replace with something better
@@ -113,25 +137,4 @@ public class MainFrame extends JFrame {
     m_gameSelectorModel.load(f, this);
   }
 
-  /**
-   * For displaying on startup.
-   * Only call once!
-   */
-  public void start() {
-    SwingUtilities.invokeLater(new Runnable() {
-      @Override
-      public void run() {
-        final String fileName = System.getProperty(GameRunner2.TRIPLEA_GAME_PROPERTY, "");
-        if (fileName.length() > 0) {
-          loadGameFile(fileName);
-        }
-        setVisible(true);
-        if (System.getProperty(GameRunner2.TRIPLEA_SERVER_PROPERTY, "false").equals("true")) {
-          m_setupPanelModel.showServer(MainFrame.this);
-        } else if (System.getProperty(GameRunner2.TRIPLEA_CLIENT_PROPERTY, "false").equals("true")) {
-          m_setupPanelModel.showClient(MainFrame.this);
-        }
-      }
-    });
-  }
 }

--- a/src/games/strategy/engine/framework/ui/background/WaitWindow.java
+++ b/src/games/strategy/engine/framework/ui/background/WaitWindow.java
@@ -16,12 +16,9 @@ public class WaitWindow extends JWindow {
   private boolean m_finished = false;
 
   public WaitWindow(final String waitMessage) {
-    // super("Game Loading, Please wait");
-    // setIconImage(GameRunner.getGameIcon(this));
     setSize(200, 80);
     final WaitPanel mainPanel = new WaitPanel(waitMessage);
     setLocationRelativeTo(null);
-    // setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
     mainPanel.setBorder(new LineBorder(Color.BLACK));
     setLayout(new BorderLayout());
     add(mainPanel, BorderLayout.CENTER);
@@ -31,14 +28,10 @@ public class WaitWindow extends JWindow {
     final TimerTask task = new TimerTask() {
       @Override
       public void run() {
-        SwingUtilities.invokeLater(new Runnable() {
-          @Override
-          public void run() {
-            toFront();
-          }
-        });
-      }
-    };
+        SwingUtilities.invokeLater(() -> toFront());
+        }
+      };
+
     synchronized (m_mutex) {
       if (m_timer != null) {
         m_timer.schedule(task, 15, 15);
@@ -66,16 +59,5 @@ public class WaitWindow extends JWindow {
 
   public boolean isFinished() {
     return m_finished;
-  }
-
-  public static void main(final String[] args) {
-    SwingUtilities.invokeLater(new Runnable() {
-      @Override
-      public void run() {
-        final WaitWindow window = new WaitWindow("Loading game, please wait.");
-        window.setVisible(true);
-        window.showWait();
-      }
-    });
   }
 }


### PR DESCRIPTION
Decrease the measured time from start of the GameRunner1 main method to after  `pack()` and `setVisible(true)` are called on the main window, from 400ms to 4ms.

- remove the loading wait window and set the look and feel call to 'invokeLater' rather than 'invokeAndWait'. This change got the measured time down to 70ms. Moving the main window load to before setupLogging and everything else got the measured time to less than 5ms.
  - The wait window was blocking the main window, turns out we can spend the same resources to display the main window in the first pass, rather than display the wait window, *start* the main window, dispose of the wait window, *then* show the main window. Now we just start showing the main window and can render it at the same speed as rendering the wait window (the time spent waiting now seems to be ClassLoader, Swing library internals)
- do setuplogging and other nonessential tasks *after* we start rendering the main window.
- setup look and feel is slow, but if we display the main window first then it 'flashes' as it changes color. So keeping the look and feel call before we render the main window to avoid this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/452)
<!-- Reviewable:end -->
