### PR TITLE
[Image Loading Fix] Fix so images are loaded from Maps first

### DIFF
--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -6,15 +6,14 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.StringTokenizer;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.framework.GameRunner2;
 import games.strategy.util.Match;
 
 /**
@@ -25,9 +24,9 @@ public class ResourceLoader {
   private final URLClassLoader m_loader;
   public static String RESOURCE_FOLDER = "assets";
 
-  public static ResourceLoader getMapResourceLoader(final String mapName, final boolean allowNoneFound) {
+  public static ResourceLoader getMapResourceLoader(final String mapName,final boolean allowNoneFound) {
     File atFolder = ClientFileSystemHelper.getRootFolder();
-    File resourceFolder = new File(atFolder,RESOURCE_FOLDER);
+    File resourceFolder = new File(atFolder, RESOURCE_FOLDER);
 
     while (!resourceFolder.exists() && !resourceFolder.isDirectory()) {
       atFolder = atFolder.getParentFile();
@@ -137,6 +136,9 @@ public class ResourceLoader {
         throw new IllegalStateException(e.getMessage());
       }
     }
+    // Note: URLClassLoader does not always respect the ordering of the search URLs
+    // To solve this we will get all matching paths and then filter by what matched
+    // the assets folder.
     m_loader = new URLClassLoader(urls);
   }
 
@@ -146,29 +148,41 @@ public class ResourceLoader {
   }
 
   /**
-   * @param pathURL
+   * @param path
    *        (The name of a resource is a '/'-separated path name that identifies the resource. Do not use '\' or
    *        File.separator)
    */
-  public URL getResource(final String pathURL) {
-    final URL rVal = m_loader.getResource(pathURL);
-    if (rVal == null) {
-      return null;
+  public URL getResource(final String path) {
+    URL defaultUrl = null;
+    // Return first any match that is not in the assets folder (we expect that to be the users maps folder (loading from map.zip))
+    // If we don't have any matches, then return any matches we had from the assets folder
+    for (URL element : getMatchingResources(path)) {// Collections.list(m_loader.getResources(path))) {
+      if (element.toString().contains(RESOURCE_FOLDER)) {
+        defaultUrl = element;
+      } else {
+        return element;
+      }
     }
-    String fileName;
+    return defaultUrl;
+  }
+
+  private List<URL> getMatchingResources(final String path ) {
     try {
-      fileName = URLDecoder.decode(rVal.getFile(), "UTF-8");
-    } catch (final IOException e) {
+      return Collections.list(m_loader.getResources(path));
+    } catch (IOException e) {
       throw new IllegalStateException(e);
     }
-    if (!fileName.endsWith(pathURL)) {
-      throw new IllegalStateException("The file:" + fileName
-          + "  does not have the correct case.  It must match the case declared in the xml:" + pathURL);
-    }
-    return rVal;
   }
 
   public InputStream getResourceAsStream(final String path) {
-    return m_loader.getResourceAsStream(path);
+    URL url = getResource(path);
+    if (url == null) {
+      return null;
+    }
+    try {
+      return url.openStream();
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }


### PR DESCRIPTION
When images are present with both the game engine, and also a map, then prefer to use the one bundled with the map. Before we would use URLClassLoader and pass it base search paths in a specific folder. It URLClassloader is now no longer deterministic when there are multiple matches, which one it will find is no longer deterministic (java8 upgrade? - who knows. I set up a URLClassLoader that only had the map zip path, and it still returned the wrong one, I was left puzzled why URLClassloader also searched the current path rather than the single one I specified).

To get around this problem we instead ask URLClassloader to return all matching paths and then return any that are in map zip folder first.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/454)
<!-- Reviewable:end -->
