### PR TITLE
prerelease Lobby automated deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,10 @@ deploy:
     branches:
       only:
         - master
+after_deploy:
+- DEPLOY_DEST="$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PATH"
+- LOBBY_ARTIFACT="triplea-${TAGGED_VERSION}-server.zip"
+- export SSHPASS=$DEPLOY_PASS
+- sshpass -e scp build/distributions/$LOBBY_ARTIFACT $DEPLOY_DEST
+- sshpass -e scp .travis/prerelease_lobby_install.sh $DEPLOY_DEST
+- sshpass -e ssh $DEPLOY_USER@$DEPLOY_HOST $DEPLOY_PATH/rerelease_lobby_install.sh $LOBBY_ARTIFACT

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,13 @@ install: true
 script:
 - gradle test -i
 before_deploy:
-- wget -O setup https://github.com/triplea-game/triplea/blob/master/.travis/setup?raw=true
-- chmod +x setup && ./setup
+- chmod +x ./travis/setup && ./travis/setup
 - GAME_CONFIG=game_engine.properties
 - ENGINE_VERSION=$(grep "engine_version" $GAME_CONFIG | sed 's/.*= *//g')
 - export TAGGED_VERSION="$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER"
 - sed -i "s/engine_version.*/engine_version = $TAGGED_VERSION/" $GAME_CONFIG
 - gradle release
-- wget -O push_tag https://github.com/triplea-game/triplea/blob/master/.travis/push_tag?raw=true
-- chmod +x push_tag && ./push_tag
+- chmod +x push_tag && ./.travis/push_tag
 deploy:
   provider: releases
   api_key:

--- a/.travis/prerelease_lobby_install
+++ b/.travis/prerelease_lobby_install
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+## Installs the lobby using a build artifact passed as command line into a folder called "triplea_prerelease_lobby"
+
+LOBBY_ARTIFACT=$1
+INSTALL_DIR=triplea_prerelease_lobby
+
+PID_FILE="$INSTALL_DIR/.prereleases_lobby_running.pid"
+if [ -f $PID_FILE ]; then
+  PID=$(cat $PID_FILE)
+  if [ ! -z "$PID" ]; then
+    kill $PID
+    sleep 1
+  fi
+  rm $PID_FILE
+fi
+
+unzip -d $INSTALL_DIR $LOBBY_ARTIFACT
+cd $INSTALL_DIR
+nohup java -server  -Xmx192m -classpath bin/triplea.jar:lib/derby-10.10.1.1.jar -Dtriplea.lobby.port=33333 -Dtriplea.lobby.console=true games.strategy.engine.lobby.server.LobbyServer &
+
+NEW_PID=$!
+if [ ! -z $NEW_PID ]; then
+  echo $NEW_PID > $PID_FILE
+fi
+rm $LOBBY_ARTIFACT

--- a/.travis/prerelease_lobby_install
+++ b/.travis/prerelease_lobby_install
@@ -9,7 +9,10 @@ PID_FILE="$INSTALL_DIR/.prereleases_lobby_running.pid"
 if [ -f $PID_FILE ]; then
   PID=$(cat $PID_FILE)
   if [ ! -z "$PID" ]; then
-    kill $PID
+    if  ! kill $PID > /dev/null 2>&1; then
+      echo "Could not send SIGTERM to process $PID" >&2
+      exit 1
+    fi
     sleep 1
   fi
   rm $PID_FILE
@@ -23,4 +26,14 @@ NEW_PID=$!
 if [ ! -z $NEW_PID ]; then
   echo $NEW_PID > $PID_FILE
 fi
+
+## wait for a little bit and then check if the lobby is still running
+sleep 5
+if  ! kill -0 $NEW_PID > /dev/null 2>&1; then
+   echo "Lobby crashed shortly after startup, $NEW_PID is no longer running." >&2
+   exit 2
+fi
+
 rm $LOBBY_ARTIFACT
+
+exit 0


### PR DESCRIPTION
Add travis config and install script to deploy the lobby to the lobby server on each update of master. The second lobby is running on port 33333, rather than port 3303, and will be installed to: /home/triplea/triplea_prerelease_lobby

The install script also drops a pid file into the same folder, which it uses to identify and kill any previous running instances.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/458)
<!-- Reviewable:end -->
