### PR TITLE
[PropertyUtil XML Property Loading]  Don't always assume properties begin with 'm_'

### DIFF
--- a/src/games/strategy/util/PropertyUtil.java
+++ b/src/games/strategy/util/PropertyUtil.java
@@ -70,23 +70,29 @@ public class PropertyUtil {
   }
 
   public static Object getPropertyFieldObject(final String propertyName, final Object subject) {
-    Object rVal = null;
-    Field field = null;
     try {
-      field = getFieldIncludingFromSuperClasses(subject.getClass(), "m_" + propertyName, false);
-    } catch (final Exception e) {
-      throw new IllegalStateException(
-          "No such Property Field: " + "m_" + propertyName + " for Subject: " + subject.toString(), e);
-    }
-    try {
+      Field field = getPropertyField(propertyName, subject);
       field.setAccessible(true);
-      rVal = field.get(subject);
+      return field.get(subject);
     } catch (final Exception e) {
-      throw new IllegalStateException(
-          "No such Property Field: " + "m_" + propertyName + " for Subject: " + subject.toString(), e);
+      String msg = "No such Property Field named: " + "m_" + propertyName + ", or: " + propertyName + ", for Subject: "
+          + subject.toString();
+      throw new IllegalStateException(msg, e);
     }
-    return rVal;
   }
+
+  private static Field getPropertyField(final String propertyName, final Object subject) {
+    try {
+      return getFieldIncludingFromSuperClasses(subject.getClass(), "m_" + propertyName, false);
+    } catch (final Exception e) {
+      try {
+        return getFieldIncludingFromSuperClasses(subject.getClass(), propertyName, false);
+      } catch (final Exception exception) {
+        throw exception;
+      }
+    }
+  }
+
 
   private static String capitalizeFirstLetter(final String aString) {
     char first = aString.charAt(0);

--- a/test/games/strategy/util/PropertyUtilTest.java
+++ b/test/games/strategy/util/PropertyUtilTest.java
@@ -1,20 +1,120 @@
 package games.strategy.util;
 
-import games.strategy.triplea.attatchments.RulesAttachment;
-import junit.framework.TestCase;
 
-public class PropertyUtilTest extends TestCase {
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import games.strategy.triplea.attatchments.RulesAttachment;
+
+
+/**
+ * PropertyUtil test sets / gets variables via reflection.
+ *
+ * The set in PropertyUtil done through a setter method, the get is done by reading the private variable value directly.
+ *
+ * To test we set up some sample test objects and do read/set property operations on them.
+ */
+public class PropertyUtilTest {
+  @Test
   public void testGetFieldObject() {
-    final RulesAttachment at = new RulesAttachment("test", null, null);
-    int uses = (Integer) PropertyUtil.getPropertyFieldObject("uses", at);
+    final RulesAttachment testClass = new RulesAttachment("test", null, null);
+    int uses = (Integer) PropertyUtil.getPropertyFieldObject("uses", testClass);
     // default value should be -1
-    assertEquals(-1, uses);
-    PropertyUtil.set("uses", "3", at);
-    uses = (Integer) PropertyUtil.getPropertyFieldObject("uses", at);
-    assertEquals(3, uses);
+    assertThat(uses, is(-1));
+    PropertyUtil.set("uses", "3", testClass);
+    uses = (Integer) PropertyUtil.getPropertyFieldObject("uses", testClass);
+    assertThat(uses, is(3));
     final IntegerMap<String> unitPresence = new IntegerMap<String>();
     unitPresence.add("Blah", 3);
-    PropertyUtil.set("unitPresence", unitPresence, at);
-    assertEquals(unitPresence, PropertyUtil.getPropertyFieldObject("unitPresence", at));
+    PropertyUtil.set("unitPresence", unitPresence, testClass);
+    assertThat(PropertyUtil.getPropertyFieldObject("unitPresence", testClass), is(unitPresence));
+  }
+
+  private static final String NEW_VALUE = "newValue";
+  private static final String BAR = "bar";
+  protected static final String DEFAULT = "default";
+
+  @Test
+  public void testHappyCaseWithGetAndSetFields() {
+    PropertyClass testClass = new PropertyClass();
+    PropertyUtil.set("bar", NEW_VALUE, testClass);
+    assertThat(testClass.bar, is(NEW_VALUE));
+
+    assertThat((String) PropertyUtil.getPropertyFieldObject(BAR, testClass), is(NEW_VALUE));
+  }
+
+  @Test
+  public void testGetField() {
+    assertThat((String) PropertyUtil.getPropertyFieldObject("bar", new PropertyClass()), is(DEFAULT));
+  }
+
+  @Test
+  public void testGetFieldWithPrefixedPropertyNames() {
+    assertThat((String) PropertyUtil.getPropertyFieldObject(BAR, new mUnderBarClass() ), is(DEFAULT));
+  }
+
+
+
+  @Test(expected = IllegalStateException.class)
+  public void testErrorCaseWithNoSetterMethod() {
+    PropertyUtil.set(BAR, NEW_VALUE, new NoSetterClass());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testErrorCaseWithInvalidSetterMethod() {
+    PropertyUtil.set(BAR, NEW_VALUE, new InvalidSetterClass());
+  }
+
+  @Test
+  public void testNoOpSetterMethod() {
+    NoOpSetterClass testClass = new NoOpSetterClass();
+    PropertyUtil.set(BAR, NEW_VALUE, testClass);
+    assertThat(
+        "we are only really checking that the setter method was called, which did not do anything, thus we shoudl still have a default value.",
+        testClass.bar, is("default"));
+  }
+
+
+}
+
+
+class NoSetterClass {
+  @SuppressWarnings("unused")
+  private String bar = PropertyUtilTest.DEFAULT;
+}
+
+
+class InvalidSetterClass {
+  @SuppressWarnings("unused")
+  private String bar = PropertyUtilTest.DEFAULT;
+
+  public void setBar() {}
+}
+
+
+class NoOpSetterClass {
+  protected String bar = PropertyUtilTest.DEFAULT;
+
+  public void setBar(@SuppressWarnings("unused") String value) {}
+}
+
+
+class PropertyClass {
+  protected String bar = PropertyUtilTest.DEFAULT;
+
+  public void setBar(String newValue) {
+    bar = newValue;
+  }
+}
+
+
+class mUnderBarClass {
+  @SuppressWarnings("unused")
+  private String m_bar = PropertyUtilTest.DEFAULT;
+
+  public void setBar(String newValue) {
+    m_bar = newValue;
   }
 }


### PR DESCRIPTION
Update PropertyUtil to check for a second Java class property name based on what is coming from XML. Rather than always prepending 'm_', we will also check if the non 'm_' version of the property name exists

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/465)
<!-- Reviewable:end -->
