### PR TITLE
[Remove Delay on the Startup Map and Engine Version Checks]

### DIFF
--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -710,11 +710,6 @@ public class GameRunner2 {
         if (areWeOldExtraJar()) {
           return;
         }
-        // if we are joining a game online, or hosting, or loading straight into a savegame, do not check
-        final String fileName = System.getProperty(GameRunner2.TRIPLEA_GAME_PROPERTY, "");
-        if (fileName.trim().length() > 0) {
-          return;
-        }
         if (System.getProperty(GameRunner2.TRIPLEA_SERVER_PROPERTY, "false").equalsIgnoreCase("true")) {
           return;
         }
@@ -724,19 +719,13 @@ public class GameRunner2 {
         if (System.getProperty(GameRunner2.TRIPLEA_DO_NOT_CHECK_FOR_UPDATES, "false").equalsIgnoreCase("true")) {
           return;
         }
-        if (s_countDownLatch != null) {
-          try {
-            // wait til the main screen has shown.
-            s_countDownLatch.await();
-          } catch (final InterruptedException e) {
-          }
+
+        // if we are joining a game online, or hosting, or loading straight into a savegame, do not check
+        final String fileName = System.getProperty(GameRunner2.TRIPLEA_GAME_PROPERTY, "");
+        if (fileName.trim().length() > 0) {
+          return;
         }
-        // the main screen may take just a little bit longer after releasing the latch,
-        // so sleep for just a little bit.
-        try {
-          Thread.sleep(500);
-        } catch (final InterruptedException e) {
-        }
+
         boolean busy = false;
         busy = checkForLatestEngineVersionOut();
         if (!busy) {


### PR DESCRIPTION
Remove the wait for the main window to be visible before checking the game engine and if maps are up to date. We do the up to date checks in a background thread, so its better to go ahead and get a start on them. Particularly when a check is done the UI becomes blocked by the DownloadRunner execution, so part of the idea is to get as early of a start and finish as we can on these background checks.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/470)
<!-- Reviewable:end -->
