### PR TITLE
Add option to time-delay auto-confirm combat rolls when otherwise no combat decision is needed 

### DIFF
--- a/src/games/strategy/triplea/Constants.java
+++ b/src/games/strategy/triplea/Constants.java
@@ -242,9 +242,6 @@ public interface Constants {
   public static final String PROPERTY_TRUE = "true";
   public static final String PROPERTY_FALSE = "false";
   public static final String PROPERTY_DEFAULT = "default";
-  /*
-   * public static final char VALUE_TRUE = 't';
-   * public static final char VALUE_FALSE = 'f';
-   * public static final char VALUE_DEFAULT = 'd';
-   */
+
+  public static final String CONFIRM_DEFENSIVE_ROLLS = "confirm_defensive_rolls";
 }

--- a/src/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/games/strategy/triplea/ui/BattleDisplay.java
@@ -200,6 +200,17 @@ public class BattleDisplay extends JPanel {
     prefs.putBoolean(Constants.FOCUS_ON_OWN_CASUALTIES_USER_PREF, aVal);
   }
 
+  public static void setConfirmDefensiveRolls(final boolean aVal) {
+    final Preferences prefs = Preferences.userNodeForPackage(BattleDisplay.class);
+    prefs.putBoolean(Constants.CONFIRM_DEFENSIVE_ROLLS, aVal);
+  }
+
+  public static boolean getConfirmDefensiveRolls() {
+    final Preferences prefs = Preferences.userNodeForPackage(BattleDisplay.class);
+    return prefs.getBoolean(Constants.CONFIRM_DEFENSIVE_ROLLS, false);
+  }
+
+
   /**
    * updates the panel content according to killed units for the player
    *
@@ -290,10 +301,27 @@ public class BattleDisplay extends JPanel {
     }
   }
 
-  public void waitForConfirmation(final String message) {
+  protected void waitForConfirmation(final String message) {
     if (SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("This cant be in dispatch thread");
     }
+
+    if (getConfirmDefensiveRolls()) {
+      waitForSpaceBarClick(message);
+    } else {
+      // Sleep for a short period, allows users to see the dice rolls before the game
+      // moves on.
+      // TODO: This value should find its way into a setting. For now it is hardcoded since
+      // just having another confusing value to set would not help very much. Needs to be some
+      // context/explanation around it for a user to really want to set it.
+      try {
+        Thread.sleep(1500);
+      } catch (InterruptedException e) {
+      }
+    }
+  }
+
+  private void waitForSpaceBarClick(final String message) {
     final CountDownLatch continueLatch = new CountDownLatch(1);
     // set the action in the swing thread.
     SwingUtilities.invokeLater(new Runnable() {
@@ -324,6 +352,7 @@ public class BattleDisplay extends JPanel {
       }
     });
   }
+
 
   public void endBattle(final String message, final Window enclosingFrame) {
     m_steps.walkToLastStep();

--- a/src/games/strategy/triplea/ui/TripleaMenu.java
+++ b/src/games/strategy/triplea/ui/TripleaMenu.java
@@ -298,6 +298,7 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
     addPoliticsMenu(menuGame);
     addNotificationSettings(menuGame);
     addFocusOnCasualties(menuGame);
+    addConfirmBattlePhases(menuGame);
     addShowEnemyCasualties(menuGame);
     addShowAIBattles(menuGame);
     addChangeProAISettings(menuGame);
@@ -459,6 +460,14 @@ public class TripleaMenu extends BasicGameMenuBar<TripleAFrame> {
     focusOnCasualties.addActionListener(
         SwingAction.of(e -> BattleDisplay.setFocusOnOwnCasualtiesNotification(focusOnCasualties.isSelected())));
     parentMenu.add(focusOnCasualties);
+  }
+
+  private static void addConfirmBattlePhases(final JMenu parentMenu) {
+    final JCheckBoxMenuItem confirmPhases = new JCheckBoxMenuItem("Confirm Defensive Rolls");
+    confirmPhases.setSelected(BattleDisplay.getConfirmDefensiveRolls());
+    confirmPhases.addActionListener(
+        SwingAction.of(e -> BattleDisplay.setConfirmDefensiveRolls(confirmPhases.isSelected())));
+    parentMenu.add(confirmPhases);
   }
 
   private static void addTabbedProduction(final JMenu parentMenu) {


### PR DESCRIPTION
Add a menu option 'confirm defensive rolls' that will change the behavior of the waitConfirmation in combat. Instead of waiting for a user to click space bar, combat will continue after 1.5 seconds.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/475)
<!-- Reviewable:end -->
