### PR TITLE
[Improve Planes Can Not Land Warning]

### DIFF
--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -850,11 +850,13 @@ public class TripleAFrame extends MainGameFrame {
       return true;
     }
     m_messageAndDialogThreadPool.waitForAll();
-    final StringBuilder buf = new StringBuilder("Air in following territories cant land: ");
+    final String airUnitPlural = (airCantLand.size() == 1 ) ? "" : "s";
+    final String territoryPlural = (airCantLand.size() == 1 ) ? "y" : "ies";
+    final StringBuilder sb = new StringBuilder("<html>" + airCantLand.size() + " air unit" + airUnitPlural + " cannot land in the following territor" + territoryPlural + ":<ul> ");
     for (final Territory t : airCantLand) {
-      buf.append(t.getName());
-      buf.append(" ");
+      sb.append("<li>" + t.getName() + "</li>");
     }
+    sb.append("</ul></html>");
     final boolean lhtrProd = AirThatCantLandUtil.isLHTRCarrierProduction(m_data)
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(m_data);
     int carrierCount = 0;
@@ -863,7 +865,7 @@ public class TripleAFrame extends MainGameFrame {
     }
     final boolean canProduceCarriersUnderFighter = lhtrProd && carrierCount != 0;
     if (canProduceCarriersUnderFighter && carrierCount > 0) {
-      buf.append("\nYou have " + carrierCount + " " + MyFormatter.pluralize("carrier", carrierCount)
+      sb.append("\nYou have " + carrierCount + " " + MyFormatter.pluralize("carrier", carrierCount)
           + " on which planes can land");
     }
     final String ok = movePhase ? "End Move Phase" : "Kill Planes";
@@ -871,7 +873,7 @@ public class TripleAFrame extends MainGameFrame {
     final String[] options = {cancel, ok};
     this.m_mapPanel.centerOn(airCantLand.iterator().next());
     final int choice =
-        EventThreadJOptionPane.showOptionDialog(this, buf.toString(), "Air cannot land", JOptionPane.YES_NO_OPTION,
+        EventThreadJOptionPane.showOptionDialog(this, sb.toString(), "Air cannot land", JOptionPane.YES_NO_OPTION,
             JOptionPane.WARNING_MESSAGE, null, options, cancel, getUIContext().getCountDownLatchHandler());
     return choice == 1;
   }


### PR DESCRIPTION
 Change the output of the dialog from plain text to HTML, render each territory where a plane will crash as its own list element. This will make it more obvious when the warning applies for multiple territories vs just one. Secondly add to the message dialog the total count of how many planes that can not land.


### Before:
![air_cant_land_warning_message_before](https://cloud.githubusercontent.com/assets/12397753/13304305/b6023240-db08-11e5-9fe8-d3c79134535e.png)

![air_cant_land_multi_sz_warning_before](https://cloud.githubusercontent.com/assets/12397753/13304309/ba7b01f8-db08-11e5-856a-8f53115030f9.png)


### After:
![updated_alert_text__1_carrier_to_land](https://cloud.githubusercontent.com/assets/12397753/13304278/99ac29ac-db08-11e5-9548-872b5d9f1d17.png)

![cant_land_multi_territory_warning_after](https://cloud.githubusercontent.com/assets/12397753/13304315/bed76c82-db08-11e5-85fe-6b0eaf2f5465.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/476)
<!-- Reviewable:end -->
