### PR TITLE
Lobby props file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ triplea_maps.xml eol=lf
 *.sh eol=lf
 *.plist eol=lf
 *.properties eol=lf
+*.yaml eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 
 	compile 'org.yaml:snakeyaml:1.17'
 	compile 'org.swinglabs.swingx:swingx-all:1.6.5-1'
+	compile 'org.yaml:snakeyaml:1.17'
 	compile 'com.sun.mail:mailapi:1.5.5'
 	compile 'com.sun.mail:smtp:1.5.5'
 	compile 'com.google.guava:guava:19.0'
@@ -118,7 +119,7 @@ task allPlatform(type: Zip, group: 'release', dependsOn: [renameShadowJar, updat
 		into('icons')
 		exclude("icon.icns")
 	}
-	['readme.html', 'changelog.txt', 'system.ini', 'game_engine.properties',
+	['readme.html', 'changelog.txt', 'system.ini', 'game_engine.properties', 'lobby_server.yaml',
 	 'run-headless-game-host-mac-os.sh', 'run-headless-game-host.sh', 'run-headless-game-host-windows.bat',
 	 'triplea_unix.sh', 'triplea_windows.bat', 'triplea_mac_os_x.sh'].each { fileName ->
 		from(fileName)
@@ -144,7 +145,7 @@ task bots(type: Zip, group: 'release', dependsOn: [renameShadowJar, updateAssets
 			into(folder)
 		}
 	}
-	['readme.html', 'changelog.txt', 'system.ini', 'game_engine.properties',
+	['readme.html', 'changelog.txt', 'system.ini', 'game_engine.properties', 'lobby_server.yaml',
 	 'run-headless-game-host-mac-os.sh', 'run-headless-game-host.sh', 'run-headless-game-host-windows.bat',
 	 'triplea_unix.sh', 'triplea_windows.bat', 'triplea_mac_os_x.sh'].each { fileName ->
 		from(fileName)

--- a/game_engine.properties
+++ b/game_engine.properties
@@ -5,3 +5,6 @@ engine_version = 1.8.0.10
 # to tripleA for download.
 #Map_List_File = triplea_maps.yaml
 Map_List_File = http://raw.githubusercontent.com/triplea-game/triplea/master/triplea_maps.yaml?raw=true
+
+lobby_properties_file_url = http://raw.githubusercontent.com/triplea-game/triplea/master/lobby_server.yaml?raw=true
+lobby_properties_file_backup = lobby_server.yaml

--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -1,0 +1,16 @@
+- version: 1.8.0.9
+  host: 45.79.144.53
+  port: 3303
+  message: |
+    Veqryn welcomes you to the new Stable Release engine 1.8.0.9
+    To load 1.7.0.x savegames with 1.8.x.x, just start hosting then click 'Load Game' (bots do not load old saves).
+    FAQ/Help\: http\://tinyurl.com/tripleaFAQ
+    Download Maps\: http\://downloads.sourceforge.net/project/tripleamaps/triplea_maps.xml
+    Hosting\: http\://tinyurl.com/tripleaHosting\nLadder/Forum\: http\://tripleawarclub.org/
+    Dev Forum\: http\://triplea.sourceforge.net/mywiki/Forum
+    
+    No talking politics in the lobby\! Take your political comments to a private game\!
+    Please report any bugs to\: https\://sourceforge.net/p/triplea/_list/tickets
+    Try out the new 'automated hosts'\: Join one then select a map. Game starts when all players are taken.
+  error_message:
+  

--- a/src/games/strategy/engine/ClientContext.java
+++ b/src/games/strategy/engine/ClientContext.java
@@ -39,14 +39,19 @@ public final class ClientContext {
   private final MapDownloadController mapDownloadController;
   private final EngineVersion engineVersion;
   private final MapDownloadStrategy downloadStrategy;
+  private final PropertyReader propertyReader;
 
 
   private ClientContext() {
-    PropertyReader reader = new GameEnginePropertyFileReader();
-    MapListingSource listingSource = new MapListingSource(reader);
+    propertyReader = new GameEnginePropertyFileReader();
+    MapListingSource listingSource = new MapListingSource(propertyReader);
     mapDownloadController = new MapDownloadController(listingSource);
-    engineVersion = new EngineVersion(reader);
+    engineVersion = new EngineVersion(propertyReader);
     downloadStrategy = new MapDownloadStrategy();
+  }
+
+  public static PropertyReader propertyReader() {
+    return instance.propertyReader;
   }
 
   public static MapDownloadController mapDownloadController() {

--- a/src/games/strategy/engine/config/GameEngineProperty.java
+++ b/src/games/strategy/engine/config/GameEngineProperty.java
@@ -1,7 +1,9 @@
 package games.strategy.engine.config;
 
 public enum GameEngineProperty {
-  MAP_LISTING_SOURCE_FILE("Map_List_File"), ENGINE_VERSION("engine_version");
+  MAP_LISTING_SOURCE_FILE("Map_List_File"), ENGINE_VERSION("engine_version"),
+  LOBBY_PROPS_URL("lobby_properties_file_url"), LOBBY_PROPS_BACKUP_FILE("lobby_properties_file_backup");
+
 
   private final String value;
 

--- a/src/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -20,7 +20,7 @@ import games.strategy.engine.ClientFileSystemHelper;
 
 /** Used to download triplea_maps.xml */
 public class DownloadRunnable implements Runnable {
-  private static Map<URL, File> downloadCache = Maps.newHashMap();
+  private static Map<String,File> downloadCache = Maps.newHashMap();
   private final String urlString;
   private final boolean parse;
   private volatile byte[] contents;
@@ -54,22 +54,20 @@ public class DownloadRunnable implements Runnable {
     }
   }
 
-  private static boolean beginsWithHttpProtocol(String urlString) {
+  public static boolean beginsWithHttpProtocol(String urlString) {
     return urlString.startsWith("http://") || urlString.startsWith("https://");
   }
 
   private void downloadFile() {
     try {
-      final URL url = getUrlFollowingRedirects(urlString);
-
-      if (!downloadCache.containsKey(url)) {
+      if( !downloadCache.containsKey(urlString)) {
         File tempFile = ClientFileSystemHelper.createTempFile();
-        FileUtils.copyURLToFile(url, tempFile);
-        downloadCache.put(url, tempFile);
+        DownloadUtils.downloadFile(urlString, tempFile);
+        downloadCache.put(urlString, tempFile);
       }
-      File f = downloadCache.get(url);
+      File f = downloadCache.get(urlString);
       contents = Files.readAllBytes(f.toPath());
-    } catch (final Exception e) {
+    } catch (IOException e) {
       error = e.getMessage();
       return;
     }

--- a/src/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -1,9 +1,14 @@
 package games.strategy.engine.framework.map.download;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+
+import org.apache.commons.io.FileUtils;
+
+import com.google.common.base.Throwables;
 
 public class DownloadUtils {
   public static int getDownloadLength(URL url) {
@@ -32,4 +37,28 @@ public class DownloadUtils {
   public static boolean beginsWithHttpProtocol(String urlString) {
     return urlString.startsWith("http://") || urlString.startsWith("https://");
   }
+
+  public static void downloadFile(String urlString, File targetFile) throws IOException {
+    try {
+      final URL url = getUrlFollowingRedirects(urlString);
+
+      FileUtils.copyURLToFile(url, targetFile);
+    } catch (MalformedURLException e) {
+      throw Throwables.propagate(e);
+    }
+
+  }
+
+  private static URL getUrlFollowingRedirects(String possibleRedirectionUrl) throws IOException {
+    URL url = new URL(possibleRedirectionUrl);
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    int status = conn.getResponseCode();
+    if (status == HttpURLConnection.HTTP_MOVED_TEMP || status == HttpURLConnection.HTTP_MOVED_PERM
+        || status == HttpURLConnection.HTTP_SEE_OTHER) {
+      // update the URL if we were redirected
+      url = new URL(conn.getHeaderField("Location"));
+    }
+    return url;
+  }
+
 }

--- a/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -39,8 +39,8 @@ import games.strategy.engine.ClientContext;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.config.GameEngineProperty;
 import games.strategy.engine.config.PropertyReader;
-import games.strategy.engine.framework.mapDownload.DownloadUtils;
-import games.strategy.engine.framework.mapDownload.MapDownloadController;
+import games.strategy.engine.framework.map.download.DownloadUtils;
+import games.strategy.engine.framework.map.download.MapDownloadController;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
 import games.strategy.engine.framework.ui.NewGameChooser;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
@@ -324,7 +324,7 @@ public class MetaSetupPanel extends SetupPanel {
 
   private static Map<String, Object> matchCurrentVersion(List<Map<String, Object>> lobbyProps) {
     checkNotNull(lobbyProps);
-    Version currentVersion = ClientContext.engineVersion().getCompatabilityVersion();
+    Version currentVersion = ClientContext.engineVersion().getVersion();
     for (Map<String, Object> props : lobbyProps) {
       if (props.containsKey("version")) {
         Version otherVersion = new Version((String) props.get("version"));

--- a/src/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/src/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.lobby.client.login;
 
+
 import java.awt.Window;
 import java.io.IOException;
 import java.util.HashMap;
@@ -8,9 +9,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.swing.JOptionPane;
 
-import games.strategy.engine.ClientContext;
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.lobby.client.LobbyClient;
 import games.strategy.engine.lobby.server.LobbyServer;
 import games.strategy.engine.lobby.server.login.LobbyLoginValidator;
@@ -37,11 +36,11 @@ public class LobbyLogin {
    */
   public LobbyClient login() {
     if (!m_serverProperties.isServerAvailable()) {
-      JOptionPane.showMessageDialog(m_parent, m_serverProperties.getServerErrorMessage(), "Could not connect to server",
+      JOptionPane.showMessageDialog(m_parent, m_serverProperties.serverErrorMessage, "Could not connect to server",
           JOptionPane.ERROR_MESSAGE);
       return null;
     }
-    if (m_serverProperties.getPort() == -1) {
+    if (m_serverProperties.port == -1) {
       if (ClientFileSystemHelper.areWeOldExtraJar()) {
         JOptionPane.showMessageDialog(m_parent,
             "<html>Could not find lobby server for this version of TripleA, <br>Please make sure you are using the latest version: " + UrlConstants.SOURCE_FORGE
@@ -75,7 +74,7 @@ public class LobbyLogin {
   private LobbyClient login(final LoginPanel panel) {
     try {
       final String mac = MacFinder.GetHashedMacAddress();
-      final ClientMessenger messenger = new ClientMessenger(m_serverProperties.getHost(), m_serverProperties.getPort(),
+      final ClientMessenger messenger = new ClientMessenger(m_serverProperties.host, m_serverProperties.port,
           panel.getUserName(), mac, new IConnectionLogin() {
             private final AtomicReference<String> m_internalError = new AtomicReference<String>();
 
@@ -134,7 +133,7 @@ public class LobbyLogin {
   private LobbyClient createAccount(final CreateUpdateAccountPanel createAccount) {
     try {
       final String mac = MacFinder.GetHashedMacAddress();
-      final ClientMessenger messenger = new ClientMessenger(m_serverProperties.getHost(), m_serverProperties.getPort(),
+      final ClientMessenger messenger = new ClientMessenger(m_serverProperties.host, m_serverProperties.port,
           createAccount.getUserName(), mac, new IConnectionLogin() {
             @Override
             public void notifyFailedLogin(final String message) {

--- a/src/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/src/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -1,14 +1,6 @@
 package games.strategy.engine.lobby.client.login;
 
-import java.io.ByteArrayInputStream;
-import java.net.URL;
-import java.util.Properties;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.apache.commons.httpclient.HostConfiguration;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.methods.GetMethod;
+import java.util.Map;
 
 /**
  * Server properties.
@@ -22,94 +14,22 @@ import org.apache.commons.httpclient.methods.GetMethod;
  * <p>
  */
 public class LobbyServerProperties {
-  private final static Logger s_logger = Logger.getLogger(LobbyServerProperties.class.getName());
-  private final String m_host;
-  private final int m_port;
-  private final String m_serverErrorMessage;
-  private final String m_serverMessage;
-  private volatile boolean m_done;
+  public final String host;
+  public final int port;
+  public final String serverErrorMessage;
+  public final String serverMessage;
 
-  public LobbyServerProperties(final String host, final int port, final String serverErrorMessage,
-      final String serverMessage) {
-    m_host = host;
-    m_port = port;
-    m_serverErrorMessage = serverErrorMessage;
-    m_serverMessage = serverMessage;
-  }
-
-  public boolean isDone() {
-    return m_done;
-  }
-
-  /**
-   * Read the server properties from a given url.
-   * If an error occurs during read, then ErrorMessage will be populated.
-   */
-  public LobbyServerProperties(final URL url) {
-    this(getProperties(url));
-  }
-
-  public LobbyServerProperties(final Properties props) {
-    m_host = props.getProperty("HOST");
-    m_port = Integer.parseInt(props.getProperty("PORT", "-1"));
-    m_serverErrorMessage = props.getProperty("ERROR_MESSAGE", "");
-    m_serverMessage = props.getProperty("MESSAGE", "");
-    m_done = true;
-  }
-
-  private static Properties getProperties(final URL url) {
-    final Properties props = new Properties();
-    final HttpClient client = new HttpClient();
-    final HostConfiguration config = client.getHostConfiguration();
-    config.setHost(url.getHost());
-
-    final GetMethod method = new GetMethod(url.getPath());
-    // pretend to be ie
-    method.setRequestHeader("User-Agent", "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0)");
-    try {
-      client.executeMethod(method);
-      final String propsString = method.getResponseBodyAsString();
-      props.load(new ByteArrayInputStream(propsString.getBytes()));
-    } catch (final Exception ioe) {
-      s_logger.log(Level.WARNING, ioe.getMessage(), ioe);
-      props.put("ERROR_MESSAGE", ioe.getMessage());
-    } finally {
-      method.releaseConnection();
-    }
-    return props;
-  }
-
-  public String getHost() {
-    return m_host;
-  }
-
-  public int getPort() {
-    return m_port;
-  }
-
-  /**
-   * @return the error message for the server.
-   */
-  public String getServerErrorMessage() {
-    return m_serverErrorMessage;
+  public LobbyServerProperties(Map<String, Object> yamlProps) {
+    this.host = (String) yamlProps.get("host");
+    this.port= (Integer) yamlProps.get("port");
+    this.serverMessage = (String) yamlProps.get("message");
+    this.serverErrorMessage = (String) yamlProps.get("error_message");
   }
 
   /**
    * @return if the server is available. If the server is not available then getServerErrorMessage will give a reason.
    */
   public boolean isServerAvailable() {
-    return m_serverErrorMessage.trim().length() <= 0;
-  }
-
-  public static void main(final String[] args) throws Exception {
-    final URL url = new URL("http://triplea.sourceforge.net/lobby/server.properties");
-    final LobbyServerProperties props = new LobbyServerProperties(url);
-    System.out.println(props.getHost());
-    System.out.println(props.getPort());
-    System.out.println(props.getServerErrorMessage());
-  }
-
-  public String getServerMessage() {
-    return m_serverMessage;
+    return (serverErrorMessage == null) || serverErrorMessage.trim().length() <= 0;
   }
 }

--- a/src/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -98,8 +98,8 @@ public class LobbyFrame extends JFrame {
   }
 
   private void showServerMessage(final LobbyServerProperties props) {
-    if (props.getServerMessage() != null && props.getServerMessage().length() > 0) {
-      m_chatMessagePanel.addServerMessage(props.getServerMessage());
+    if (props.serverMessage != null && props.serverMessage.length() > 0) {
+      m_chatMessagePanel.addServerMessage(props.serverMessage);
     }
   }
 

--- a/src/games/strategy/triplea/UrlConstants.java
+++ b/src/games/strategy/triplea/UrlConstants.java
@@ -1,7 +1,11 @@
 package games.strategy.triplea;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 public enum UrlConstants {
   GITHUB_ISSUES("http://github.com/triplea-game/triplea/issues/new"),
+  LOBBY_PROPS("https://raw.githubusercontent.com/triplea-game/triplea/master/lobby_server.yaml"),
   PAYPAL_DONATE("https://sourceforge.net/donate/index.php?group_id=44492"),
   SOURCE_FORGE("http://triplea.sourceforge.net/"),
   SF_TICKET_LIST("https://sourceforge.net/p/triplea/_list/tickets"),
@@ -28,5 +32,13 @@ public enum UrlConstants {
 
   public String getDescription() {
     return description;
+  }
+
+  public URL toURL() {
+    try {
+      return new URL(urlString);
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException("Invalid URL: "+ urlString, e);
+    }
   }
 }


### PR DESCRIPTION
2 commits  based on #455

Resolves #435 - "source forge property files"

Before:
The game would download from first a sourceforge URL a properties file that would indicate the host, port, and server message of the lobby. Failing that, it would try source forge. Both URLs were hard coded.

After:
- lobby properties file is now a single yaml file. Instead of it being named `lobby_<version>.properties`, it is now always named `lobby_server.yaml`
- the URL of lobby_server.yaml is pulled from game config, failing that we use a local version distributed with the game

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/494)
<!-- Reviewable:end -->
