### PR TITLE
[Default Politics Action is No]

### DIFF
--- a/src/games/strategy/util/EventThreadJOptionPane.java
+++ b/src/games/strategy/util/EventThreadJOptionPane.java
@@ -199,7 +199,14 @@ public class EventThreadJOptionPane {
     SwingUtilities.invokeLater(new Runnable() {
       @Override
       public void run() {
-        rVal.set(JOptionPane.showConfirmDialog(parentComponent, message, title, optionType));
+        String noOption = "No";
+        Object initialValue = noOption;
+        Icon icon = null;
+        Object[] options = {noOption, "Yes"};
+        int selectionValue = JOptionPane.showOptionDialog(parentComponent, message, title , JOptionPane.YES_NO_OPTION,  JOptionPane.QUESTION_MESSAGE,  icon, options, initialValue);
+        // we swapped the meaning of No and Yes, typically it is the other way round, thus we should shift rVal from: 1->0, or: 0->1
+        int correctedValue = (selectionValue + 1) % 2;
+        rVal.set(correctedValue);
         latch.countDown();
       }
     });


### PR DESCRIPTION
To help address: "Space bar does not confirm politics #415"

Instead of by default confirming a political proposal, instead reject it. This is a problem since the pop-up comes up without warning and takes the keyboard focus. If the player is typing, they can easily hit space bar and confirm the default option. For now we set that to 'no' so at least the consequenes are less severe. More ideally we would add an option to look around at the map, and have that be the default. Thus this is a bit of a bandaid fix.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/497)
<!-- Reviewable:end -->
