### PR TITLE
Triplea maps yaml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 	compile 'com.github.insubstantial:substance-flamingo:7.3'
 	compile 'com.github.insubstantial:trident:7.3'
 
+	compile 'org.yaml:snakeyaml:1.17'
 	compile 'org.swinglabs.swingx:swingx-all:1.6.5-1'
 	compile 'com.sun.mail:mailapi:1.5.5'
 	compile 'com.sun.mail:smtp:1.5.5'

--- a/game_engine.properties
+++ b/game_engine.properties
@@ -3,5 +3,5 @@ engine_version = 1.8.0.10
 ## Map_List_File
 # URL if the value begins with http, otherwise assumed to be a file. This file lists which maps are available
 # to tripleA for download.
-#Map_List_File = triplea_maps.xml
-Map_List_File = http://raw.githubusercontent.com/triplea-game/triplea/master/triplea_maps.xml?raw=true
+#Map_List_File = triplea_maps.yaml
+Map_List_File = http://raw.githubusercontent.com/triplea-game/triplea/master/triplea_maps.yaml?raw=true

--- a/src/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -15,7 +15,6 @@ import games.strategy.util.Version;
  * version, etc..
  */
 public class DownloadFileDescription {
-  protected static final String DUMMY_URL = "!";
   private final String url;
   private final String description;
   private final String mapName;
@@ -27,7 +26,7 @@ public class DownloadFileDescription {
   }
 
   public static final DownloadFileDescription PLACE_HOLDER =
-      new DownloadFileDescription(DUMMY_URL, " ", " ", new Version("0"), DownloadType.DISPLAY_HEADER);
+      new DownloadFileDescription(null, " ", " ", new Version("0"), DownloadType.DISPLAY_HEADER);
 
   public DownloadFileDescription(final String url, final String description, final String mapName,
       final Version version, DownloadType downloadType) {
@@ -51,7 +50,7 @@ public class DownloadFileDescription {
   }
 
   public boolean isDummyUrl() {
-    return url.startsWith(DUMMY_URL);
+    return url == null;
   }
 
   public Version getVersion() {

--- a/test/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
+++ b/test/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
@@ -73,92 +73,35 @@ public class DownloadFileParserTest {
 
 
   private static String createTypeTag(DownloadFileParser.ValueType type) {
-    return "<" + DownloadFileParser.Tags.mapType + ">" + type + "</" + DownloadFileParser.Tags.mapType + ">";
+    return "  " + DownloadFileParser.Tags.mapType + ": " + type + "\n";
   }
 
   private static byte[] buildTestXml() {
     String xml = "";
-    xml += "<games>\n";
-    xml += "  <game>\n";
-    xml += "    <url>http://example.com/games/game.zip</url>\n";
-    xml += "    <mapName>" + GAME_NAME + "</mapName>\n";
+    xml += "- url: http://example.com/games/game.zip\n";
+    xml += "  mapName: " + GAME_NAME + "\n";
     xml += createTypeTag(DownloadFileParser.ValueType.MAP);
-    xml += "    <description><![CDATA[\n";
-    xml += "	<pre>Some notes about the game, simple html allowed.\n";
-    xml += "	</pre>\n";
-    xml += "    ]]></description>\n";
-    xml += "  </game>\n";
-    xml += "  <game>\n";
-    xml += "    <url>http://example.com/games/mod.zip</url>\n";
-    xml += "    <mapName>mapModName</mapName>\n";
+    xml += "  description: |\n";
+    xml += "     <pre>Some notes about the game, simple html allowed.\n";
+    xml += "     </pre>\n";
+    xml += "- url: http://example.com/games/mod.zip\n";
+    xml += "  mapName: mapModName\n";
     xml += createTypeTag(DownloadFileParser.ValueType.MAP_MOD);
-    xml += "    <description><![CDATA[\n";
+    xml += "  description: |\n";
     xml += "      map mod\n";
-    xml += "	</pre>\n";
-    xml += "    ]]></description>\n";
-    xml += "  </game>\n";
-    xml += "  <game>\n";
-    xml += "    <url>http://example.com/games/skin.zip</url>\n";
-    xml += "    <mapName>mapSkinName</mapName>\n";
+    xml += "- url: http://example.com/games/skin.zip\n";
+    xml += "  mapName: skin\n";
     xml += createTypeTag(DownloadFileParser.ValueType.MAP_SKIN);
-    xml += "    <description><![CDATA[\n";
+    xml += "  description: |\n";
     xml += "      map skin\n";
-    xml += "    ]]></description>\n";
-    xml += "  </game>\n";
-    xml += "  <game>\n";
-    xml += "    <url>http://example.com/games/tool.zip</url>\n";
-    xml += "    <mapName>mapToolName</mapName>\n";
+    xml += "- url: http://example.com/games/tool.zip\n";
+    xml += "  mapName: mapToolName\n";
     xml += createTypeTag(DownloadFileParser.ValueType.MAP_TOOL);
-    xml += "    <description><![CDATA[\n";
+    xml += "  description: |\n";
+    xml += "       <pre>\n";
     xml += "       this is a map tool";
     xml += "    </pre>\n";
-    xml += "    ]]></description>\n";
-    xml += "  </game>\n";
-    xml += "</games>\n";
     return xml.getBytes();
-  }
-
-
-  // TODO we probably should do clientLogger.logError( ) to handle this, show an error
-  // to the user and abort, rather than sending a stack trace and exception to the user.
-  @Test(expected = IllegalStateException.class)
-  public void testParseBadData() {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildBadTestXml());
-    DownloadFileParser.parse(inputStream);
-  }
-
-  private static byte[] buildBadTestXml() {
-    String xml = "";
-    xml += "<games>\n";
-    return xml.getBytes();
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void testDuplicateMapNames() {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildDuplicateMapNameTestXml().getBytes());
-    DownloadFileParser.parse(inputStream);
-  }
-
-  private static String buildDuplicateMapNameTestXml() {
-    String xml = "";
-    xml += "<games>\n";
-      xml += createGameXml( );
-      xml += createGameXml( );
-    xml += "</games>\n";
-    return xml;
-  }
-
-  private static String createGameXml( ) {
-    String xml = "";
-    xml += "  <game>\n";
-    xml += "    <url>http://example.com/games/mod.zip</url>\n";
-    xml += "    <mapName>" + GAME_NAME + "</mapName>\n";
-    xml += createTypeTag(DownloadFileParser.ValueType.MAP_MOD);
-    xml += "    <description><![CDATA[\n";
-    xml += "      description\n";
-    xml += "    ]]></description>\n";
-    xml += "  </game>\n";
-    return xml;
   }
 
 
@@ -177,13 +120,10 @@ public class DownloadFileParserTest {
 
   private static byte[] createSimpleGameXmlWithNoTypeTag( ) {
     String xml = "";
-    xml += "  <game>\n";
-    xml += "    <url>http://example.com/games/mod.zip</url>\n";
-    xml += "    <mapName>" + GAME_NAME + "</mapName>\n";
-    xml += "    <description><![CDATA[\n";
+    xml += "- url: http://example.com/games/mod.zip\n";
+    xml += "  mapName: " + GAME_NAME + "\n";
+    xml += "  description: |\n";
     xml += "      description\n";
-    xml += "    ]]></description>\n";
-    xml += "  </game>\n";
     return xml.getBytes();
   }
 

--- a/test/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
+++ b/test/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
@@ -4,14 +4,11 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.Test;
 
 import com.google.common.collect.Lists;
 
-import games.strategy.engine.framework.map.download.DownloadFileDescription;
-import games.strategy.engine.framework.map.download.MapDownloadListSort;
 import games.strategy.util.Version;
 
 public class MapDownloadListSortTest {
@@ -21,7 +18,7 @@ public class MapDownloadListSortTest {
                                                                                    // insensitive sorting
   private static final DownloadFileDescription MAP_C = createDownload("c", "url");
   private static final DownloadFileDescription MAP_D = createDownload("d", "url");
-  private static final DownloadFileDescription HEADER = createDownload("header", DownloadFileDescription.DUMMY_URL);
+  private static final DownloadFileDescription HEADER = createDownload("header", null);
 
 
   private static DownloadFileDescription createDownload(String mapName, String url) {

--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -1,0 +1,1623 @@
+- mapName: ==HIGH QUALITY MAPS==
+  description: |
+    <br>Maps here feature good to excellent balance, high replay value, good documentation and good visuals.
+    <br>
+    <br>Maps failing in any of the above are thus not included here. 
+    <br>However, since we -  by far - have not checked all the available maps, not being listed at the top doesnt mean anything for a given map.
+    <br>New sections featuring untested but very promising candidates have been added below.
+    <br>The WW2 maps are in the list now too.
+    <br>
+    <br>Again, Only Maps meeting all above listed high quality requirements and having undergone extensive testing are located here. Maps from this section can be 
+             considered classics, and it should usually be no problem finding an opponent for any of them.
+- url: https://github.com/triplea-maps/total_world_war/releases/download/0.1/total_world_war.zip
+  mapName: Total_World_War
+  version: 2.7.7.2
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_total_world_war_mini.png" />
+    <br>
+    <br>
+        <b><font size="12"> Total World War </font></b>
+    <br>
+    <br>
+    <br> </CENTER>
+    <br> <em><b><font size="6">Created by Rolf Larsson and Hepster</font></b></em>
+    <br>
+    <br> <em><b><font size="5">Map and Mechanics by Rolf Larsson</font></b></em>
+    <br> <em><b><font size="5">Graphics by Hepster</font></b></em>
+    <br>
+    <br>
+        <p>
+    <br><b><em>December 1941</em></b>
+    <br><b>The winter has stopped all actions of the Wehrmacht in front of Moscow. Russian elite troops from Siberia prepare for a conterattack.
+    <br>Japan is determined to rule the Pacific and gain the ressorces needed by force. The Imperial Fleet is on its way to attack Pearl Harbour.
+    <br>Roosevelt eager to enter the war for the Allies, will get his Casus Belli. China is fighting to survive a Japanese assault on its mainland.
+    <br>Italy is determined to restore a Roman like dominion in the Mediterranean Sea, while British forces try to hold on to their territory all
+    <br>over the globe.The events in December 1941 turn the conflicts into a total World War for the 2nd time.
+        </b>
+    <br>
+    <br><b>There is a very good manual included within the zip. If you do not know how to get to it, you can download it here:
+    <br>http://sourceforge.net/projects/tripleamaps/files/rules/TotalWorldWarManual.pdf</b>
+    <br>
+    <br><b>Triplea 1.6.1.4 is required at least for the included Tournament Edition.</b>
+    <br><b>Triplea 1.7.0.3 is required at least.</b>
+    <br>
+        <p> <a name="Features"><font size="6"><b><em>Features</em></b></font></a></p>
+    <br>
+        <ul>
+        <li><b>Terrain - modifications for unitvalues and -abilities</b></li>
+        <li><b>A real Technologytree and Researchsystem</b></li>
+        <li><b>A 12 sided Dice based Unitsystem</b></li>
+        <li><b>New units like Heavy Tanks unlocked by technologies</b></li>
+        <li><b>Beautiful ingame newspaper images</b></li>
+        <li><b>Advanced Minor concept/use of local resources</b></li>
+        <li><b>Optional Politics ( ever wanted to be allied with Spain in a ww2 scenario? )</b></li>
+        <li><b>Advanced Productionsystem</b></li>
+        <li><b>Advanced Constructionsystem with Material and Engineers</b></li>
+        <li><b>Scorched Earth - Production buildings get reduced or destroyed</b></li>
+        <li><b>Freedom of play - no rewards/national objectives needed to force a player into any direction</b></li>
+        <li><b>Advanced Infrastructure( destroy your enemies Buildings by Bombing Raids)</b></li>
+        <li><b>Custom Options like National Technolgy advantages</b></li>
+        <li><b>Historical events( Pearl Harbour, Battle of Java Sea,...) and historical accurate setup as much as possible!</b></li>
+        <li><b>and many more...</b></li>
+        </UL><br/>
+        <p> <a name="Nations and Turn order"><font size="6"><b><em>Nations and Turn order</em></b></font></a></p>
+    <br>
+        <ul>
+        <li><b>Germany</b> ( Vichy France, Danube Axis, Finnland)</li>
+        <li><b>Russia</b></li>
+        <li><b>Brazil</b> (Neutral-AI as long as not allied)</li>
+        <li><b>Japan</b> ( Manchuria, Thailand)</li>
+        <li><b>China</b></li>
+        <li><b>Spain</b> (Neutral-AI as long as not allied)</li>
+        <li><b>Britain</b> ( Canada, Egypt, South Africa, India, Australia)</li>
+        <li><b>Sweden</b> (Neutral-AI as long as not allied)</li>
+        <li><b>Italy</b></li>
+        <li><b>Usa</b></li>
+        <li><b>Turkey</b> (Neutral-AI as long as not allied)</li>
+        </UL><br/>
+    <br><b>Smaller Nations ( those in brackets like Finnland) have their own territory, income and production, but their forces are beeing controlled and moved by their major power.<b>
+    <br><b>This allows to play only the majorpowers without having too many nations to be played, but have a realistic use of local resources.<b>
+    <br>
+- url: https://github.com/triplea-maps/270bc/releases/download/0.1/270bc.zip
+  mapName: 270BC
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_270BC_mini.png" />
+    <br>
+    <br>270BC
+    <br> by Dr.Che
+    <br>
+    <br>270BC is a beautifully made fun map. With its slow and few units, and no air, but a very dynamic income situation, as well as nicely interlinked theaters of war, it plays refreshingly different.
+  version: 1.6
+- url: https://github.com/triplea-maps/civil_war/releases/download/0.1/civil_war.zip
+  mapName: Civil_War
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_civil_war_mini.png" />
+    <br>Civil_War
+    <br>by Pulicat
+    <br>
+    <br>In the summer of 1861, some boys wore blue, some wore gray, but all prayed to the same God for victory.
+    <br>Play either the Union or the Confederacy to determine the fate of the American Republic.
+    <br>
+    <br>
+    <br><b>A House Divided (primary game):</b><ul>
+          <li>Operational scale map, spanning 3 campaign theaters.</li>
+          <li>Heavy focus on economic, geography, and logistics.</li>
+          <li>12 sided dice.</li>
+          <li>Fully functional and cuttable railroad lines.</li>
+          <li>Deep, upgradable infrastructure tree.</li>
+          <li>5 resource types, collected from upgradable economic infrastructure, not territory value.</li>
+          <li>Assymmetric victory conditions.</li>
+          <li>Manpower limitations keeps size of armies under realistic control.</li>
+          <li>Only 2 rounds of combat per battle, instead of fight to the death.</li>
+          <li>Can take loans and repay with interest.</li>
+          <li>Unit upkeep costs: troops consume supplies every turn.</li>
+          <li>Unit fuel costs: troops consume require supplies to campaign.</li>
+          <li>Blockade causes inflation and reduces resource production.</li>
+          <li>Low force-to-space-ratio: relatively small stacks roaming the vast American lands, especially in the West.</li>
+          <li>Confederate "Forced March": extra non combat move resets movement counters.</li>
+          <li>"Union logistics": supply depots, shipyards, and railyards provide additional movement.</li>
+          <li>River forts control waterway navigation.</li>
+          <li>Offensive and defensive bonuses and penalties from leadership and constructed fieldworks.</li>
+          <li>Leadership points gained from battlefield experience.</li>
+          <li>Optional commander labels for additional immersion.</li>
+          </ul>
+    <br>
+    <br>Also includes--<b>Eastern Campaigns:</b><ul>
+          <li>Most of the features of A House Divided, but on the smaller Eastern Theater only.</li>
+          <li>An "entry-level" way for new players to learn the game mechanics.</li>
+          </ul>
+    <br>
+    <br>
+  version: 3.2.4
+- url: https://github.com/triplea-maps/world_at_war/releases/download/0.1/world_at_war.zip
+  mapName: World_At_War
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_world_at_war_mini.png" />
+    <br>
+    <br>=WORLD AT WAR=
+    <br> by sieg
+    <br>
+    <br>Very large file, over 40mb, download could take a while.
+    <br>If link does not work, download manually from:
+    <br>https://sourceforge.net/projects/tripleamaps/files/
+    <br>
+    <br>Includes World at War 1940 Mod by Ice, version: 1.2.1 .
+  version: 1.1.9
+- url: https://github.com/triplea-maps/the_rising_sun/releases/download/0.1/the_rising_sun.zip
+  mapName: The_Rising_Sun
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_the_rising_sun_mini.png" />
+    <br>
+    <br>=THE RISING SUN=
+    <br> by sieg
+    <br>
+    <br>Excellent large WW2 maps sited in the pacific, using mostly the NWO unit structure.
+    <br>   NWO in the Pacific
+    <br>
+    <br>If link does not work, download manually from:
+    <br>https://sourceforge.net/projects/tripleamaps/files/
+    <br>
+  version: 1.9.3
+- url: https://github.com/triplea-maps/diplomacy/releases/download/0.1/diplomacy.zip
+  mapName: Diplomacy
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_diplomacy_mini.png" />
+    <br>An adaptation of the game "Diplomacy" for TripleA.
+    <br>Includes 3 Free-For-All (ffa) games, and 1 normal 
+    <br>
+    <br>1) Diplomacy
+    <br>This is as close as TripleA lets us come to the real Diplomacy board game. Uses some complex rules, be sure to read the game notes.
+    <br>
+    <br>2) Diplomacy: FFA V3 Rules
+    <br>This is the Diplomacy map of Europe, with ww2v3 units and rules.  Easy to learn.
+    <br>
+    <br>3) Diplomacy: FFA Great War Style
+    <br>This is the Diplomacy map of Europe, with "Great War" units.  Also very easy to learn.
+    <br>
+    <br>4) Diplomacy: WW1
+    <br>Unlike the other 3, this is a normal non-ffa game.  It pits Germany, Austria, and Turkey, against France, England, and Russia.  (Italy is neutral)  
+        It uses Diplomacy style units, Armies and Navies, with 3 territory types: Land, Sea, and Coastal.
+    <br>
+    <br>
+    <br>Be sure to download some of the map skins for this game.
+    <br>
+    <br>by Veqryn
+    <br>With help from Pulicat and Bung
+  version: 2.2
+- url: https://github.com/triplea-maps/world_war_ii_classic/releases/download/0.1/world_war_ii_classic.zip
+  mapName: World War II Classic
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v1_classic_mini.png" />
+    <br>
+    <br>A classic edition of World War II
+    <br>Includes:
+    <br>Classic 2nd Edition
+    <br>Classic 3rd Edition
+    <br>Iron Blitz (3rd Edition)
+    <br>
+  version: 2.0
+- url: https://github.com/triplea-maps/world_war_ii_revised/releases/download/0.1/world_war_ii_revised.zip
+  mapName: World War II Revised
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v2_revised_mini.png" />
+    <br>
+    <br>A revised edition of World War II, including artillery support, and destroyer capabilities.
+    <br>Includes:
+    <br>1. Revised game as released.
+    <br>2. LHTR (Larry Harris Tournament Rules) version, which is the way the game was meant to be played for all tournaments.
+    <br>
+    <br>The Variations Zip includes a 6 Army Free For All variant, but you will need to download that zip separately.
+  version: 1.4.1
+- url: https://github.com/triplea-maps/world_war_ii_v3/releases/download/0.1/world_war_ii_v3.zip
+  mapName: World War II v3
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v3_1941_mini.png" />
+    <br>
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v3_1942_mini.png" />
+    <br>
+    <br>A new edition of World War II with new tech and units. Includes the two starting scenarios 1941 and 1942.
+  version: 1.7
+- url: https://github.com/triplea-maps/world_war_ii_v4/releases/download/0.1/world_war_ii_v4.zip
+  mapName: World War II v4
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v4_1942_mini.png" />
+    <br>
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v4_ffa_mini.png" />
+    <br>
+    <br>The latest edition of World War II. Starting in 1942 with the World War II v3 rule set and a map similar to World War II v2 Revised.
+    <br>Includes two 6-Army-Free-For-All variants.
+  version: 2.8
+- url: https://github.com/triplea-maps/world_war_ii_pacific/releases/download/0.1/world_war_ii_pacific.zip
+  mapName: World War II Pacific
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2_pacific_1940_mini.png" />
+    <br>
+    <br>World War II Pacific 1940
+    <br>
+    <br>Includes both Original version, and Second Edition version.
+    <br>
+    <br>Now working fully according to official rules.
+    <br>
+    <br>XML & files by Veqryn, Unit art by CrystalCT & Veqryn, Relief tiles by Gudkarma
+    <br>Engine code to get this game to work by Veqryn, SquidDaddy, Edwin
+    <br>
+    <br>A second TripleA adaption of WW2 Pacific.
+    <br>Check out the forum thread here:
+    <br>http://tripleadev.1671093.n2.nabble.com/World-War-II-Pacific-1940-tp4225367p4225367.html
+    <br>
+  version: 3.1
+- url: https://github.com/triplea-maps/world_war_ii_europe/releases/download/0.1/world_war_ii_europe.zip
+  mapName: World War II Europe
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2_europe_1940_mini.png" />
+    <br>
+    <br>World War II Europe 1940
+    <br>
+    <br>Now working fully according to official rules.
+    <br>
+    <br>Map and XML by Bung, XML conditions, objectives, triggers and special code by Veqryn
+    <br>Engine code to get this game to work by Veqryn
+    <br>
+    <br>A second TripleA adaption of WW2 Europe.
+    <br>Check out the forum thread here:
+    <br>http://tripleadev.1671093.n2.nabble.com/World-War-II-Europe-1940-tp7283373p7283373.html
+    <br>
+  version: 3.0
+- url: https://github.com/triplea-maps/world_war_ii_global/releases/download/0.1/world_war_ii_global.zip
+  mapName: World War II Global
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2_global_1940_mini.png" />
+    <br>
+    <br>World War II Global 1940
+    <br>
+    <br>Includes: Original/OOB and Alpha+3 and Second Edition and a Global 1942 mod.
+    <br>
+    <br>Now working fully according to official rules.
+    <br>
+    <br>Map and XML by Bung, XML conditions, objectives, triggers and special code by Veqryn
+    <br>Engine code to get this game to work by Veqryn
+    <br>
+    <br>A fifth TripleA adaption of World War II.
+    <br>Check out the forum threads here:
+    <br>http://tripleadev.1671093.n2.nabble.com/World-War-II-Global-1940-Alpha-3-tp7399456p7399456.html
+    <br>http://tripleadev.1671093.n2.nabble.com/World-War-II-Global-1940-Original-tp7314662p7314662.html
+    <br>
+  version: 3.9
+- url: https://github.com/triplea-maps/world_war_ii_v5_1942/releases/download/0.1/world_war_ii_v5_1942.zip
+  mapName: World War II v5 1942
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v5_1942_mini.png" />
+    <br>
+    <br><b>World War II v5 1942 Second Edition</b>
+    <br>
+    <br>An update of the popular "Spring 1942" game (ww2v4), which itself was an update of "Revised" (ww2v2).
+    <br>
+    <br>Changes:
+    <br>1. Several territories/SZs added or modified.
+    <br>2. More initial starting units (including new Factories on Karelia and India).
+    <br>3. Armor cost increased to 6 PUs.
+    <br>4. AA Guns now cost 5 PUs and each can fire at a maximum of 3 planes, each plane being only fired upon once, and they can be combat casualties.
+    <br>5. Factories now have their own AA to defend during strategic bombing.
+    <br>6. Honolulu is now a Victory City.
+    <br>
+  version: 1.9
+- url: https://github.com/triplea-maps/world_war_ii_v6_1941/releases/download/0.1/world_war_ii_v6_1941.zip
+  mapName: World War II v6 1941
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v6_1941_mini.png" />
+    <br><b>World War II v6 1941</b>
+    <br>
+    <br>Simplified version of the WWIIv5 1942 scenario, with fewer territories, starting units and income.
+    <br>Good for an easy game, and great for beginners.
+    <br>
+    <br>Changes:
+    <br>1. No strategic bombing.
+    <br>2. No AA Guns / Artillery / Cruisers.
+    <br>3. No shore bombardment.
+    <br>4. Cannot build new factories.
+    <br>5. Carrier and battleship costs decreased to 12 and 16 PUs.
+    <br>6. SZ18 (Black Sea) can't be accessed by ships.
+    <br>
+  version: 1.7
+- mapName: ==QUALITY MAPS==
+  description: |
+    <br>Maps that make it into this category are of high general quality, mostly even awesome, only coming short in one or two of the requirements.
+    <br>Maps here must have a decent level of popularity and/or very good art and polish.
+    <br>Balance might need some fine tuning, Game notes might be incomplete, or they simply have to establish fan base at the moment - minor issues like this.
+    <br>Feedback highly welcome, if played.
+    <br>Leave feedback at the forums: http://triplea.sourceforge.net/mywiki/Community
+    <br>or at the Depot: http://sites.google.com/site/tripleaerniebommel/
+- url: https://github.com/triplea-maps/big_world_2/releases/download/0.1/big_world_2.zip
+  mapName: big_world_2
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_big_world2_mini.png" />
+    <br>
+    <br>Big World 2 
+    <br>Version 6.1.2, last update 2015.1.2 for engine 1.8.0.5 
+    <br>Mod done by Prussia. 
+    <br>Suggestions to y3364andy@hotmail.com
+    <br>
+    <br>a.) Content: 
+    <br>Includes 2 scenarios of Big World 2 
+    <br>Big World 2 : Balance of Power 
+    <br>Big World 2 : Rise of the Axis 
+    <br>
+    <br>b.) Rough overview: 
+    <br>This is a World War 2 themed global map like ww2v3, ww2 revised, Big World 1942 and TWW. This is an averaged sized map. The game play is slower than ww2v3 and ww2 revised, but far faster than NWO and TWW. The game can be decided as quickly as round 6 (appromimately 3 hours) but could sometimes drag on to rounds 10+ between experienced players. 
+    <br>
+    <br>Features common in both scenarios 
+    <br>- give players a choice of v3 style or NWO/revised style transport and submarine rules. 
+    <br>- automatically balances starting position under either v3 style or revised rules 
+    <br>- optional national objectives for extra income 
+    <br>- optional national advatages for unique units or abilities 
+    <br>- optional balanced techs. Each tech is more-or-less balanced so that no single tech is overpowered. 
+    <br>- been in development since 2011, playtested over 4 years for balance. 
+    <br>
+    <br>Big World 2 : Balance of Power 
+    <br>This map develops from Big World : 1942 v3 rules by Prussia, Veqryn, Bung, Pulicat et al. The scenario is set at the turning point of WW2 with the battles of Stalingrad and Midway imminent. Experienced players on Big World : 1942 or its variants should have very little problem playing this map. Playable nations are Russia, Germany, Britain, Italy, China, Japan and USA. 
+    <br>
+    <br>Big World 2: Rise of the Axis 
+    <br>This is a 1939 scenario. One Unique feature is the inclusion of the French, who are likely to survive until at least the second round. It is more cost-efficient for Germany to capture Poland before France. Other historical events such as Germany's Axis alliance, Vichy France Surrender and Pearl Harbor are also depicted. This map offers a great variety of strategies for the Axis. 
+    <br>
+    <br>c.) General tips: 
+    <br>Refer to game notes.
+    <br>
+  version: 6.1.2
+- url: https://github.com/triplea-maps/ultimate_world/releases/download/0.1/ultimate_world.zip
+  mapName: Ultimate_World
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ultimate_world_mini.png" />
+    <br>
+    Ultimate World
+    <br>Created by Rod the God
+    <br>Converted up to TripleA1.2.x.x and v3 version both by Veqryn, many thanks to Ice for balancing suggestions.
+    <br>Also thanks to Talibush and Joey Pants for their mods (see the "Variants" file below).
+    <br>
+    <br>Includes Ultimate World Revised Mod by Ice.
+  version: 1.7.8
+- url: https://github.com/triplea-maps/battle_of_jutland/releases/download/0.1/battle_of_jutland.zip
+  mapName: Battle_of_Jutland
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_battle_of_jutland_mini.png" />
+    <br><b><em>The Battle of Jutland
+    <br> by Veqryn</em></b>
+    <br>
+    <br>May 31, 1916, the two greatest navies in the world set sail to meet in the greatest and only full-scale clash of battleships in history.
+    <br>The German High Seas Fleet planned to use its scouting battlecruisers to draw the Royal Navy's battlecruiser group of the Grand Fleet into a trap and 
+        destroy it before the rest of the Grand Fleet could arrive.  The Royal Navy seeked to cut the germans off from their port, then use their numerical 
+        advantage to annihilate the Germans.  
+    <br>
+    <br><b>TO WIN:</b>
+    <br>Move an Admiral (your flag) into the enemy's capital.
+    <br>You can do this by defeating your enemy's navy, or by sneaking around it with a fast task force.
+    <br>Conquer the convoy zones to slowly turn the tide against your enemy (most worth 10 PUs each, some worth 20 PUs).
+    <br>
+    <br><b>HOW TO PLAY:</b>
+    <br>This is a tactical game, which means each piece represents a single ship, instead of a navy.
+    <br>Each nation is broken up into 2 players: Movement and Armament (Attack).
+    <br>The Movement player first moves all of that nations ships around, as well as buying and placing any new ships, Then the Attack player moves 
+        the Shells, Torpedos, and Depth Charges to attack the enemy ships.  The Attack player is simulating the ships firing their weapons at the enemy.
+    <br>The armament (ammunition) used to attack the enemy is used up in the first round of battle and 'dies'.  
+    <br>Then, the Armament player then simulates the ships reloading their weapons, by placing new ammunition on each ship.
+    <br>
+    <br>In order to make this a tactical game, we need to give players a good reason to spread out their fleets.  
+        Here are 2 very good reasons to spread out your ships:
+    <br>1. You can only Reload (Place) up to 2 new shells/ammunition per turn PER HEX (any, every, and all hexes).
+    <br>2. You may have NO MORE THAN 4 ships per hex, (Max of 4 ships per hex. Only applies to ships, does NOT apply to ammunition).
+    <br>So this means that if you have 4 ships in a hex, and all of them fire at the enemy, you will only be able to 'reload' 2 of the ships. 
+        So next round, the 2 you did not reload will not be able to fire at the enemy.
+    <br>Both rules are enforced by the game engine.
+    <br>
+    <br>
+    <br><b>RULES:</b>
+    <br><b>1)</b> You can Place up to 2 new shells per turn PER HEX (any and all hex), so you may wish to keep your units spread out.
+    <br><b>2)</b> You may have NO MORE THAN 4 ships per hex, (max of 4 ships per hex).
+    <br><b>3)</b> You can ONLY attack submarines with Depth Charges.
+    <br><b>4)</b> Only Submarines may carry Torpedos, and Torpedos may not travel through targets to get to a further target (Torpedos hit the first target in their 
+        path, while shells can fly over targets to reach further targets).
+    <br><b>5)</b> Battleships have 2 hit points, but do <b>NOT repair</b>.  All other ships have 1 hit point.
+    <br>
+    <br><b>AMMUNITION UNIT STATS:</b>
+    <br>Battleship_Shell (big) = 4 attack / 4 movement max to a target (used by both battlecruisers and battleships)
+    <br>Cruiser_Shell (medium) = 3 attack / 3 movement max to a target
+    <br>Destroyer_Shell (small) = 2 attack / 2 movement max to a target
+    <br>Torpedo = 4 attack / 2 movement max to a target
+    <br>Depth_Charge = 4 attack / 1 movement max to a target
+    <br>
+    <br>
+    <br><b>TIPS:</b>
+    <br><b>*</b> To switch between a Shell and a Depth Charge, just fire your shell/charge into the ocean during the combat-move phase, then place the new 
+        shell/charge onto the ship during the placement phase.
+    <br><b>*</b> You may Attack a sea hex with as many shells/charges/torpedoes as you want, (The stack limit is only on "Placing", which is basically just "reloading").
+    <br><b>*</b> Ramming into ships is pointless, your ramming ship will die and not do any damage to the rammed ship (This is intentional).
+    <br><b>*</b> Cruisers and Battlecruisers are the most effective means of hunting subs.  Destroyers can not carry Depth Charges (in ww1 destroyers were 
+        anti-tboat units, not anti-sub units, destroyers did not become anti-sub units until ww2).
+    <br><b>*</b> You get +1 movement when moving away from your factory / naval base.
+    <br><b>*</b> To see the big picture, try using "Map Zoom" from the View menu at the top of the screen.
+    <br>
+    <br>
+    <br>
+    <br>Use of Edit Mode (not necessary):
+    <br>You do not need to use edit mode to play. You can follow all the rules and never have to use edit mode once.
+    <br>
+    <br>* To move subborn ships with the correct shells attached.  Example: sometimes when you have multiple ship types and multiple shell types in the same hex, and you try to 
+        move a ship, the game grabs the wrong shell to go with it.  If this happens, undo and try again moving just 1 ship at a time.  If this still does not work, use 
+        edit mode's movement feature to move what you want where it is allowed to go.  (To do this, go into edit mode, then click the action tab on the right by 
+        the stats tab, then edit mode will allow you to move units).  This is very rare, as moving ships 1 at a time solves the problem most of the time.
+    <br>
+    <br>* To switch from a Shell to a Depth Charge, or from a Depth Charge to a Shell.  The preferred method is to fire your shells/charges into the ocean and let 
+        them die, then place a new shell/depth charge on the ship during the placement phase (therefore it is not needed to use edit mode).
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>Detailed Unit Stats:
+    <br>2 movement: Battleships (bb) have 12 capacity.
+    <br>3 movement: Battlecruisers (bc) have 12 capacity.
+    <br>2 movement: Cruisers (cc) have 7 capacity.
+    <br>1 movement: Submarines (ss) have 5 capacity.
+    <br>3 movement: Destroyers (dd) have 3 capacity.
+    <br>
+    <br>bb_shell takes up 12 capacity.
+    <br>cc_shell takes up 6 capacity.
+    <br>depth charge takes up 7 capacity (only thing that can attack subs).
+    <br>torpedo takes up 5 capacity.
+    <br>dd_shell takes up 3 capacity.
+    <br>
+  version: 1.8
+- url: https://github.com/triplea-maps/red_sun_over_china/releases/download/0.1/red_sun_over_china.zip
+  mapName: Red_Sun_Over_China
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_red_sun_over_china_mini.png" />
+    <br>This is a mod based on the Second Sino-Japanese War, starting in January 1938. 
+    <br>Will the Japanese and their allies push into the interior of China or will the Nationalist and Communist Chinese and their allies resist the onslaught?
+    <br>Red Sun Over China 
+    <br> by Pulicat
+    <br>
+    <br>Alson contains a second  Warlords FFA
+    <br>A free for all, with 6 players.
+  version: 2.3.1
+- url: https://github.com/triplea-maps/feudal_japan/releases/download/0.1/feudal_japan.zip
+  mapName: FeudalJapan
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_feudal_japan_mini.png" />
+    <br>
+        <CENTER>
+        <b><font size="12"> Feudal Japan </font></b>
+    <br>
+    <br> </CENTER>
+    <br> <em><b><font size="3">Designed by Rolf Larsson</font></b></em>
+    <br>
+        <p>
+    <br><b>Japan, in the 16th century, faced one of the longest and bloodiest civil wars in history, called the Sengoku Era or Warring States period.
+    <br>In this game (inspired by the Shogun/Samurai Swords board game) you control one of 17 historical clans struggling for the domination of Japan.
+    <br>The map expands the ideas of the board game with: Cavalry, Ships, Objectives and Alliances.
+    <br>Each clan starts with only his captial and claims more and more territories from his foe.
+    <br>After a few rounds of easy expanding into passive minor Clan territories, the real fight for domination starts.
+    <br>Each Clan fights for its own and most of them will be controlled by the AI to make it lively and every game unique.
+    <br>The AI gets many useful boni (all optional) and is challenging for a single player match, too.
+    <br>Defeat your rivals and claim the title of Shogun for your clan! There is much to be conquered!</b>
+    <br>
+    <br>Requires Triplea 1.6.1 or higher
+        </p>
+  version: 4.2
+- url: https://github.com/triplea-maps/battle_of_aventurica/releases/download/0.1/battle_of_aventurica.zip
+  mapName: Battle of Aventurica
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_battle_of_aventurica_mini2.png" />
+    <br>
+    <br>Battle of Aventurica
+    <br> by Nick Taylor
+    <br>
+    <br>Battle of Aventurica is a well done adaption of a fantasy boardgame. The map is fast, thanks to its small size, and appears to have decent balance.
+    <br>if you play it, help it be perfected by giving feedback!
+  version: 1.1.2
+- url: https://github.com/triplea-maps/greyhawk_wars/releases/download/0.1/greyhawk_wars.zip
+  mapName: Greyhawk_Wars
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_greyhawk_wars_mini.png" />
+    <br>
+    <br>Greyhawk Wars 
+    <br>by Panguitch 
+    <br>Version 1.0 for TripleA 1.8.0.5 
+    <br>Suggestions to ghpanguitch@gmail.com 
+    <br>
+    <br>a.) Content 
+    <br>Contains one xml (Greyhawk Wars) with 10 factions, 3 alliances, and a built in free-for-all option. 
+    <br>
+    <br>b.) Rough overview: 
+    <br>Greyhawk Wars is an immersive strategy game based on the World of Greyhawk, the classic setting of Dungeons & Dragons. Inspired by an out-of-print tabletop wargame and built on the TripleA engine, Greyhawk Wars offers world-spanning conflict, diverse factions, and flexible opportunities for conquest and diplomacy. Central to the game are the individual personalities who lead each faction, recruiting mercenaries and seeking magical artifacts to tilt the balance of power in their favor. 
+    <br>
+    <br>c.) General tips: 
+    <br>Hard AI is recommended. Human players must select the "I am Human" option to enable certain features for their faction. Consult the game notes for further tips, rules, and details, or visit the development forum: http://tinyurl.com/ghwars 
+    <br>    
+  version: 1.0
+- url: https://github.com/triplea-maps/greyhawk/releases/download/0.3/greyhawk.zip
+  mapName: Greyhawk
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_greyhawk_mini.png" />
+    <br>
+    <br>Greyhawk 
+    <br>by Panguitch 
+    <br>Version 0.9.9 
+    <br>Suggestions to ghpanguitch@gmail.com 
+    <br>
+    <br>This version of Greyhawk continues to function, but is being deprecated. Please install the new, massively revised Greyhawk Wars: http://tinyurl.com/ghwars
+    <br>
+  version: 0.9.9
+- url: https://github.com/triplea-maps/domination/releases/download/0.1/domination.zip
+  mapName: domination
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_domination_mini.png" />
+    <br>
+        An Anachronistic 20th century scenario based roughly on the years 1890-1914.
+        3 Player version - First team to achieve 500 production wins.     
+        All territories have production capacity and units can be placed in any territory that you control. Each faction has a starting bid, with placement capped at the 
+        territories production value.     
+        In an AI game, the human player should save their bid as the computer.      Ships must be placed in sea zones that are adjacent to a controlled territory or island.      
+        This is a full alliance set up, but the map is designed to be edited.    Some friendly factions can be left to the AI if desired.   
+        More to come later.     
+               -Triplelk (Jason Clark) and Surtur  
+  version: 1.6
+- url: https://github.com/triplea-maps/twilight_imperium/releases/download/0.1/twilight_imperium.zip
+  mapName: twilight_imperium
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_twilight_imperium_mini2.png" />
+    <br>
+    <br>Twilight Imperium
+    <br> by Geno33 (bpbull@shaw.ca)
+    <br>
+    <br>From the creator: "This is an adaptation of the board game Twilight Imperium and it plays quite a bit differently from Axis and Allies. I primarily made this as an 
+        alternative for the HTML PBEM TI systems that exist, and allow groups of people to play real TI long distance with only one copy of the game.
+    <br>But, even without all the cards that come with the game, it stands alone just fine as a good game by it's own right."
+    <br>
+    <br>EB: "I am taking a risk here, putting it in the main section right away, since I did not test this mod. But it is so awesomely well done, looking great, perfect documention, 
+        and it is also based on an established board game, that I trust it in terms of balance and mechanics."
+    <br>
+    <br>if you play it, help it be perfected by giving feedback!
+  version: 1.2
+- url: https://github.com/triplea-maps/star_wars_galactic_war/releases/download/0.1/star_wars_galactic_war.zip
+  mapName: StarWarsGalacticWar
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_starwars_galactic_war_mini.png" />
+    <br>created by Frostion 
+    <br>
+    <br>Set in the Star Wars universe _ A long time ago in a galaxy far, far away...  Some years after the death of Emperor Palpatine and after the rise of the New Republic, a new civil war breaks out. Now 8 Star Wars universe factions will battle for control over the entire galaxy. 
+    <br>
+    <br>All 8 factions have different unit types and starting conditions, therefore they must rely on different tactics to prevail. The map has neutrals, pirates, local forces and other hazards that can obstruct the battle plans of the factions. (These are not meant to be played. They are meant to be under AI control.) Galactic War is a 4v4 map, but 2v2 and Free-for-all versions are included, designed to be played separately or along with StarWarsTatooineWar.  
+  version: 1.2
+- url: https://github.com/triplea-maps/star_wars_tatooine_war/releases/download/0.1/star_wars_tatooine_war.zip
+  mapName: StarWarsTatooineWar
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_starwars_tatooine_war_mini.png" />
+    <br>created by Frostion 
+    <br>
+    <br>Set in the Star Wars universe _ A long time ago in a galaxy far, far away... 
+    <br>Some years after the death of Emperor Palpatine and after the rise of the New Republic, a new civil war breaks out. Now 8 Star Wars universe factions battle for control of the planet Tatooine, in the midst of a galactic war.
+    <br>
+    <br>All 8 factions have different unit types and starting conditions, therefore they must rely on different tactics to prevail. The map has neutrals, pirates, local forces and other hazards that can obstruct the battle plans of the factions. (These are not meant to be played. They are meant to be under AI control.) StarWars Tatooine War is a 4v4 map, but 2v2 and Free-for-all versions are included, designed to be played separately or along with StarWarsGalacticWar.
+  version: 1.2
+- url: https://github.com/triplea-maps/pacific_challenge/releases/download/0.1/pacific_challenge.zip
+  mapName: Pacific_Challenge
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_pacific_challenge_mini.png" />
+    <br>
+    <br><b>Pacific_Theater_Solo_Challenge by Zim Xero </b>
+    <br>
+    <br>Updated single-player variant of the WW2 Pacific conflict using a modded map created by Triple_Elk, iron__cross, and ComradeKev.  This map features AI interactivity, diverging timelines, a unique technology system, nontraditional unit statistics, resources, a  'quick-to-learn hard-to-master' play style, and built-in difficulty selection.  Designed for challenging human play as Japan versus the AI.
+    <br>
+  version: 4.3
+- mapName: == MAP MODS ==
+  mapType: MAP_MOD
+  description: |
+- url: https://github.com/triplea-maps/big_world_variations/releases/download/0.1/big_world_variations.zip
+  mapName: big_world_variations
+  mapType: MAP_MOD
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_big_world_mini.png" />
+    <br>Variations of BigWorld. 
+    <br>
+    <br>1. June 1942, by Prussia, with a focus on implementing the new technology from v3, as well as national objectives, and new units.
+    <br>
+    <br>2. Small's 1939, by Smallman, has many neutrals to consider taking over for extra income. Mod balanced for dice and ll, with good strategy variety. 
+        Has been around for years and balanced tested over 100 times, was edited from Nekahnets original 1939 version.
+    <br>
+    <br>3. NekahNet's 1939, by NekahNet, with increased territory income and a focus on historical accuracy and balance.
+    <br>
+  version: 3.6.6
+- url: https://github.com/triplea-maps/nwo_variants/releases/download/0.1/nwo_variants.zip
+  mapName: NWO_Variants
+  mapType: MAP_MOD
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_new_world_order_mini.png" />
+    <br>
+    <br>Includes 3 variants of New World Order
+    <br>
+    <br>1) NWO by Smallman.
+    <br>Map is designed to promote the faster units resulting in less stagnant stacks, and increased variety each game.
+    <br>Changes: Infantry, Transports, Submarines cost 1 more, Elites and Artillery 0.5 more, Mech.Inf and Katyusha cost 1 less.
+    <br>Finnland has 2 more EarlyFighters, Stalingrad 5 more Armour, and Paris has 1 more Bunker.
+    <br>
+    <br>2) NWO 5 Nation
+    <br>Same units as normal NWO, but with slightly changed territory values and only 5 nations: Germany and Italy against Russia, the UK, and USA.
+    <br>
+    <br>3) NWO Eastern Front by Penguins
+    <br>Fewer nations and fewer units than regular NWO, and the territories that were neutral in World War 2 are now impassible.
+    <br>
+    <br>You must have TripleA 1.5.x.x or later installed in order to use these game variants, as only triplea 1.5 or later come with "new_world_order" and the needed unit images.
+  version: 2.4.1
+- url: https://github.com/triplea-maps/pact_of_steel_variations/releases/download/0.1/pact_of_steel_variations.zip
+  mapName: pact_of_steel_variations
+  mapType: MAP_MOD
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_pact_of_steel_china_added_mini.png" />
+    <br>
+    <br>1. adoy's version of PoS with China added.
+    <br>   This is a variation of Pact of Steel. China has been made its own seperate power, and it has been attempted to rebalance the game accordingly. Their capital is on 
+        Sinkiang. Sinkiang is now a Victory City and is worth 3 PU's. Central United States is now worth 5 PU's. China goes after Japan and before the United States. Enjoy!
+    <br>
+    <br>2. Pact of Steel China Added game with WWII v3 rules. 
+    <br>   This mod uses the Pact of Steel map with the new rule structure from World War II v3 and China as an additional Ally.  Original POS by: Black Elk, Madmat, Beagle and 
+            Cousin Joe POS China Added by: Adoya http://adoyaaa.blogspot.com WWIIv3 Rules update by SirAdamTheGreat Last edited Dec29, 2009.
+    <br>
+  version: 1.3
+- url: https://github.com/triplea-maps/world_war_ii_revised_variations/releases/download/0.1/world_war_ii_revised_variations.zip
+  mapName: World War II Revised Variations
+  description: |
+    <br>6 army ffa
+    <br><img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v2_ffa_mini.png" />
+    <br>
+    <br>7 power ww2v2
+    <br><img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v2_7power_mini.png" />
+    <br>
+    <br>
+    <br>1. Free-For-All for 6 players
+    <br>
+    <br>2. hoshi head's seven powers version of WW-II-Revised.
+    <br>
+    <br>3. Barbarossa
+    <br>
+    <br>
+    <br>About the mods:
+    <br>
+    <br>   Hoshi Head: The Chinese and an Italian player were added to old WW-2-Revised map.
+    <br>
+    <br>   additional changes to Hoshi Head version:
+    <br>   - WW2v3 rules were added.
+    <br>   - all have paratroopers from the beginning on (how can that be a new technology?).
+    <br>   - Western Russia and Belorussia will be Russian after freed by any allies (because both belong to Russia and cannot be British or American).
+    <br>   - some territory's PU's were changed due to historical reasons.
+    <br>   Belorus: from 2 to 1 (what is there but villages and Minsk..?)
+    <br>   Archangelsk: from 2 to 1 (nothing but cold temperatures)
+    <br>   Borneo and East Indies: from 4 to 3 (Borneo cannot bring in more than India)
+    <br>   Novosibirsk: from 2 to 3 (very important industry region during WW2)
+    <br>   As a result, German starting PU's decreased from 30 to 29 and Japanese from 30 to 28.
+    <br>
+  version: 1.3.5
+- url: https://github.com/triplea-maps/classic_variations/releases/download/0.1/classic_variations.zip
+  mapName: Classic_variations
+  mapType: MAP_MOD
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v1_classic_mini.png" />
+    <br>
+    <br>The mod pack is for the "World War II Classic" map, and you must have that map already installed to be able to use these mods and variants.
+    <br>
+    <br>Included Mods:
+    <br>Omaha
+    <br>Kremlin
+    <br>Utah
+    <br>Gold
+    <br>Sword
+    <br>Anzio
+    <br>Iron Blitz (2nd Edition version)
+    <br>Iron Blitz 1939A Historical
+    <br>Iron Blitz 1939B Russia In The Axis
+    <br>Iron Blitz 1939C US Stands Apart
+    <br>Iron Blitz 1942A Russia Neutral
+    <br>Iron Blitz 1945A Russia And Japan
+    <br>Iron Blitz 1945B Aggressive Russia
+    <br>Iron Blitz Cold War
+    <br>Battleship Row
+    <br>Four If By Sea
+    <br>
+  version: 1.9
+- mapName: ==HOW TO USE MAP SKINS==
+  mapType: MAP_SKIN 
+  description: |
+    <br>To use a map skin, you MUST HAVE THE ORIGINAL MAP.
+    <br>This means that any map ending in "<MapName>-<SkinName>" you must have the map that is the <MapName> part in order to use the skin.
+    <br>
+    <br>To use the skin, start a game and go to the top of the screen.  Click "view" then click "map skins", and then select the skin you want.
+- url: https://github.com/triplea-maps/world_war_ii_global-battlemap_skin/releases/download/0.1/world_war_ii_global-battlemap_skin.zip
+  mapName: World War II Global-battlemap_skin
+  mapType: MAP_SKIN
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2_global_1940_battlemap_skin_mini.png" />
+    <br>
+    <br>World War II Global 1940 Battle Map Skin
+    <br>
+    <br>An alternative skin based on the ABattleMap program.
+    <br>
+    <br>Just install them like a map, by selecting them for downloading. Once installed, the alternative relief Tiles are available from the TripleA menu under "View"/"Map Skins".
+  version: 3.6
+- url: https://github.com/triplea-maps/new_world_order-skin_sieg_2/releases/download/0.1/new_world_order-skin_sieg_2.zip
+  mapName: new_world_order-skin_sieg_2
+  mapType: MAP_SKIN
+  description: |
+    <div style="text-align: left;">     
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_new_world_order_siegSkin2_mini.png" />
+    <br>
+    <h1 style="text-align: left;font-size:120%;color:000000">#NEW WORLD ORDER#</h1>
+    <br>Alternative Relief Tiles for NWO
+    <br>by sieg
+    <br>
+    <div style="text-align: left;">
+    <br>Just install them like a map, by selecting them for downloading. Once installed, the alternative relief Tiles are available from the TripleA menu under "View"/"Map Skins".
+  version: 1.8.6
+- url: https://github.com/triplea-maps/new_world_order-skin_pulicat_1/releases/download/0.1/new_world_order-skin_pulicat_1.zip
+  mapName: new_world_order-skin_pulicat_1
+  mapType: MAP_SKIN
+  description: |
+    <div style="text-align: left;">
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_new_world_order_pulicatSkin_mini.png" />
+    <br>
+    <h1 style="text-align: left;font-size:120%;color:000000">#NEW WORLD ORDER#</h1>
+    <br>Alternative Relief Tiles for NWO
+    <br>by pulicat
+    <br>
+    <div style="text-align: left;">
+    <br>Just install them like a map, by selecting them for downloading. Once installed, the alternative relief Tiles are available from the TripleA menu under "View"/"Map Skins".
+  version: 1.8.6
+- url: https://github.com/triplea-maps/diplomacy-map_skin1/releases/download/0.1/diplomacy-map_skin1.zip
+  mapName: Diplomacy-MapSkin1
+  mapType: MAP_SKIN
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_diplomacy_mapskin1_mini.png" />
+    <br>This is a MAP SKIN for "Diplomacy"
+    <br>The original relief tiles, in all their glory, made by Veqryn.
+  version: 2.0
+- url: https://github.com/triplea-maps/diplomacy-map_skin2/releases/download/0.1/diplomacy-map_skin2.zip
+  mapName: Diplomacy-MapSkin2
+  mapType: MAP_SKIN
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_diplomacy_mapskin2_mini.png" />
+    <br>This is a MAP SKIN for "Diplomacy"
+    <br>Similar style to ww2v3 relief tiles, made by Bung, Veqryn, TripleElk, and Imperious Leader
+  version: 2.0
+- url: https://github.com/triplea-maps/diplomacy-map_skin3/releases/download/0.1/diplomacy-map_skin3.zip
+  mapName: Diplomacy-MapSkin3
+  mapType: MAP_SKIN
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_diplomacy_mapskin3_mini.png" />
+    <br>This is a MAP SKIN for "Diplomacy"
+    <br>A very basic style.  I made this one for people who hate the cursive writing of the other 3 skins.  It has a simple font, no textures, and no cursive.
+  version: 2.0
+- mapName: ==ALL OTHER MAPS / EXPERIMENTAL==
+  description: |
+    <br>This section is for all maps that dont fit into the other sections.
+    <br>From good maps that didnt become popular yet, to maps which may need an extra hand to be finished, to maps which may have gameplay design flaws are found here.
+    <br>Excellent place to look for ideas or discovering something that others have not yet found.
+    <br>If you would like to help balance or polish or fix these maps, be sure to let us know.
+- url: https://github.com/triplea-maps/world_at_war_variants/releases/download/0.1/world_at_war_variants.zip
+  mapName: World_At_War_Variants
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_world_at_war_mini.png" />
+    <br>
+    <br>v3 Variants of World At War (original map by Sieg) 
+    <br>Version 1.4.9, last update 2014.12.20 for engine 1.8.0.3 
+    <br>Mod done by sneakingcoward. 
+    <br>Suggestions to wgbt@gmx.at 
+    <br>Game is continuously played by PBEM. Gamers state, that it is one of the best games listed at the depot. 
+    <br>
+    <br>a.) Content: 
+    <br>Includes 2 Mods of WAW. 
+    <br>World at War - v3 Variant ... (with Japan as 2 parties Yamamoto and Hisaichi) 
+    <br>World at War - v3 Variant FUEL-AA-Range ... (with Japanese as only 1 combined party) 
+    <br>
+    <br>b.) Rough overview: 
+    <br>Detailed description inside game notes, following is a rough overview. 
+    <br>
+    <br>Both v3 Variants use v3 rules and include: 
+    <br>- paratroopers 
+    <br>- air+sea+land transports, also landing boats, generally proper transport concept 
+    <br>- construction unit 
+    <br>- ability to destroy structures with strategic bombing raid (SBR) 
+    <br>- destroy structures at a retreat 
+    <br>- fighter escorting+intercepting and air battle before normal battle 
+    <br>- battle rounds limit 
+    <br>- multiple hitPoints 
+    <br>- Turn order, which combines axis+allies parties and is therefore perfect for PBEM. 
+    <br>
+    <br>The FUEL-AA-Range mod uses additional: 
+    <br>- "Change unit owners" from Brit&US to Rus&CN and Rus to CN 
+    <br>- Fighter scrambling with radar 
+    <br>- Fighter can also do SBR to train, radar, construction and not intercepted planes 
+    <br>- Fuel consumption for production+movement, incl. refineries 
+    <br>- AntiAir (AA) separated to combat- (hit 1 of 6) and bombing raid- (hit 1 of 12) AA 
+    <br>- Airbase enables full range for planes 
+    <br>
+    <br>c.) General tips: 
+    <br>Due to the wide range of possibilities its more a game for experienced players (typical rounds 30). 
+    <br>Specially the supply strategy is crucial for this mod with air+sea+land transport units. 
+    <br>The combination of all possible features enables almost a real handling of warfare. 
+    <br>The fuel mod opens a totally new strategy setup. Big unit groups can't move forever, so use your fuel wisely. 
+    <br>Historical: http://histclo.com/essay/war/ww2/stra/w2j-oil.html
+    <br>
+  version: 1.4.9
+- url: https://github.com/triplea-maps/world_war2010/releases/download/0.1/world_war2010.zip
+  mapName: WorldWar2010
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_world_war_2010_mini.png" />
+    <br>The year is 2010.
+    <br>
+    <br>The nations of the Shanghai Cooperation Organization (SCO) have moved their troops towards the borders with the North Atlantic Treaty Organization (NATO).
+    <br>
+    <br>A minor conflict between their respective allies, the Peace and Security Council (PSC) of the African Union and the Union of South American Nations (USAN), will set the 
+        world on fire...
+    <br>
+    <br>Map designed and created by: Bas71.
+    <br>
+    <br>About this map:
+    <br>
+    <br>* This map is based on the WW2V3 ruleset and units.
+    <br>* The alliance organizations in this map, are actual alliances.
+    <br>* The production-value per territory is based on the actual GDP, the natural resources, and the size and growth of their populations.
+    <br>* The starting units are based on the actual military strength of each territory.
+    <br>* Neutral territories are powerful, yet interesting to conquer due to their strategic positions and/or production-values. 
+    <br>
+  version: 1.3.0
+- url: https://github.com/triplea-maps/global_war/releases/download/0.1/global_war.zip
+  mapName: Global_War
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_global_war_mini.png" />
+    <br>Global War
+    <br>Created by Dagon81
+    <br>
+    <br>This has to be one of the best looking world maps I've seen.  Scale is a bit bigger than Big World and Ultimate World, but smaller than Domination.  Includes a v3 
+        rules version by veqryn.
+    <br>
+    <br>Filesize is huge, 33mb, so may take a while to download. External sf.net link used. If download does not work, please visit this website:
+    <br>http://www.mediafire.com/file/z0zmzqz1umm/Global_War.zip
+    <br>
+    <br>Converted up to TripleA 1.2.x.x by Veqryn
+  version: 1.3
+- url: https://github.com/triplea-maps/global_war2/releases/download/0.1/global_war2.zip
+  mapName: Global_War2
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_global_war_2_mini.png" />
+    <br>Global War 2
+    <br>Created by Dagon81
+    <br>
+    <br>Filesize is huge, at 64mb, so it may take a while to download.  Now comes with relief tiles, thx dagon.
+    <br>
+    <br>Converted up to TripleA 1.2.x.x by Veqryn
+  version: 2.1.2
+- url: https://github.com/triplea-maps/new_world_order_lebowski_edition/releases/download/0.1/new_world_order_lebowski_edition.zip
+  mapName: New World Order LebowskiEdition
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_nwo_1939_lebowski_mini.png" />
+    <br>
+    <br>A version of NWO by Lebowski.
+    <br>Update by Ice
+  version: 2.0.3
+- url: https://github.com/triplea-maps/ww2v3_11n/releases/download/0.1/ww2v3_11n.zip
+  mapName: WW2v3_11N
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v3_11nation_mini.png" />
+    <br>World War II v3 11 Nation Mod
+    <br>A mod of ww2v3 by Furyisback
+    <br>
+    <br>The new nations are Sowjets Puppet States (Soviet), Minor Axis Powers, French, and Dutch
+    <br>
+    <br>4 different starting date: 1939, 1940, 1941, 1942
+    <br>
+  version: 1.1.0
+- url: https://github.com/triplea-maps/ww2v3_variants/releases/download/0.1/ww2v3_variants.zip
+  mapName: WW2v3_Variants
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ww2v3_11nation_mini.png" />
+    <br>7 Variants of World War II v3
+    <br> (you must have World War II v3 install already to be able to play these)
+    <br>
+    <br>WWIIv3 China Mod  (by Veqryn)
+    <br>  A rebalancing of v3 where China's turn is with the USSR.  (china goes before japan)
+    <br>
+    <br>WWIIv3 UK Factory (by Veqryn)
+    <br>  A rebalancing of v3 where UK starts with a bid of a factory + infantry (they can place the factory anywhere before game begins).
+    <br>
+    <br>WWIIv3 1941 - Combat-Move Before Purchasing  (by Talibush)
+    <br>  1941 except where you do your combat movement before making purchases.
+    <br>
+    <br>WWIIv3 1942 - Combat-Move Before Purchasing  (by Talibush)
+    <br>  1942 except where you do your combat movement before making purchases.
+    <br>
+    <br>WWIIv3 FFA  (by Talibush)
+    <br>  1941 Free-For-All Version.
+    <br>
+    <br>WWIIv3 3Teams  (by Talibush)
+    <br>  1941 With 3 Sides instead of 2.  The sides are: Nazi, Anglo, Asia.
+    <br>
+    <br>WWIIv3 Free Tech  (by Zlefin)
+    <br>  1941 With some Free Technology given to each player, based on historical tendencies.
+    <br>
+  version: 1.4
+- url: https://github.com/triplea-maps/atari/releases/download/0.1/atari.zip
+  mapName: Atari
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_atari_mini2.png" />
+    <br>
+    <br>Atari - War in the Pacific
+    <br> by sieg
+    <br>
+    <br>Beautiful large pacific map. According to the creator, the game would need some balancing and polishing, as well as better adaption to the new TripleA, but it runs as it is.
+    <br>
+  version: 1.3.2
+- url: https://github.com/triplea-maps/ww2_phillipines/releases/download/0.1/ww2_phillipines.zip
+  mapName: WW2 Phillipines
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_atari_mini2.png" />
+    <br>Created by Marshal
+    <br>
+    <br>A mod of ATARI
+    <br>Hybrid rules.
+    <br>
+  version: 1.3.2
+- url: https://github.com/triplea-maps/eastern_front/releases/download/0.1/eastern_front.zip
+  mapName: Eastern_Front
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_eastern_front_mini.png" />
+    <br>Eastern Front by RODTHEGOD
+    <br>with some help by Veqryn
+    <br>Converted up to TripleA1.2.x.x by Veqryn
+  version: 1.3.3
+- url: https://github.com/triplea-maps/d-day/releases/download/0.1/d-day.zip
+  mapName: D-Day
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_d-day_mini.png" />
+    <br>A map of Normandy on D-Day.
+    <br>D-Day Created by Dagon81
+    <br>D-Day 2 mod created by Dagon81 and ZjelcoP
+    <br>
+    <br>External sf link used, if download does not work please download manually from:
+    <br>http://www.mediafire.com/file/nt2ne2z2mxz/D-Day.zip
+    <br>
+    <br>Converted up to TripleA1.2.x.x by Veqryn.
+  version: 2.1
+- url: https://github.com/triplea-maps/d-day2/releases/download/0.1/d-day2.zip
+  mapName: D-Day2
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_d-day_mini.png" />
+    <br>A map of Normandy on D-Day.
+    <br>D-Day 2 created by Dagon81 and ZjelcoP
+    <br>
+    <br>A tactical map.
+    <br>
+  version: 2.2
+- url: https://github.com/triplea-maps/arnhem/releases/download/0.1/arnhem.zip
+  mapName: Arnhem
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_arnhem_mini2.png" />
+    <br>A map of Arnhem
+    <br>Created by Dagon81
+    <br>
+    <br>Converted up to TripleA1.2.x.x by Veqryn.
+  version: 1.1.1
+- url: https://github.com/triplea-maps/tactics_campaign/releases/download/0.1/tactics_campaign.zip
+  mapName: Tactics_Campaign
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_tactics_campaign_mini2.png" />
+    <br>
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_tactics_campaign_alt_mini2.png" />
+    <br>
+    <br>Tactics - Campaign
+    <br> by sieg
+    <br>
+    <br>Very flexible package of small tactical hex-maps. Both good for fast games as well as well suited for modding. Only needs better adaption to the new TripleA to be 
+        elevated, but runs well as it is and was already popular.
+    <br>
+  version: 1.1
+- url: https://github.com/triplea-maps/neuschwabenland/releases/download/0.1/neuschwabenland.zip
+  mapName: Neuschwabenland
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_neuschwabenland_mini.png" />
+    <br>A simple map created by Sieg.
+    <br>Comes with 4 games, (including 1 mod by DH).
+    <br>All but starting territory are undefended neutrals.  Conquer your way to victory.
+    <br>
+    <br>Converted up to TripleA1.2.x.x by Veqryn.
+  version: 0.4
+- url: https://github.com/triplea-maps/cold_war_asia1948/releases/download/0.1/cold_war_asia1948.zip
+  mapName: ColdWarAsia1948
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_cold_war_asia_1948_mini.png" />
+    <br>created by demagogue
+    <br>
+    <br>Cold War Asia (1948) covers three interconnected civil wars between pro-democracy and pro-communist forces following the end of WWII, circa 1947 to 1948 and extending past the 1950 Chinese Revolution, the Korean War, and the First Indochina War. Victory Condition... An alliance occupies 10 of the 11 Victory Cities. 
+    <br>
+    <br>A second alternate history variant adds a hypothetical where the US did not drop nuclear weapons on Japan in 1945 and Japan was occupied by the US and USSR following WWII. This variant covers four interconnected civil wars, the three mentioned above plus an alternative history Japan civil war. Victory Condition... An alliance occupies 15 of the 16 Victory Cities. 
+  version: 1.0
+- url: https://github.com/triplea-maps/camp_david/releases/download/0.1/camp_david.zip
+  mapName: CampDavid
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_camp_david_mini2.png" />
+    <br>By Bas71
+    <br>
+    <br>On 29 November 1947 the United Nations General Assembly approved a plan to resolve the Arab-Jewish conflict by 
+        partitioning Palestine into two states, one Jewish and one Arab. After the Arab rejection of this plan, Egypt, Iraq, Jordan, Lebanon 
+        and Syria invaded the territory of the former British Mandate of Palestine. The war concluded with the 1949 Armistice Agreements, but it 
+        did not mark the end of the Arab-Israeli conflict. Three more wars would follow.
+    <br>
+    <br>The Camp David map consists of the four Arab - Israeli wars:
+    <br>
+    <br>* 1948 Arab-Israeli War
+    <br>* 1956 Suez Crisis
+    <br>* 1967 Six-Day War
+    <br>* 1973 Yom Kippur War
+    <br>
+  version: 0.6.2
+- url: https://github.com/triplea-maps/cold_war/releases/download/0.1/cold_war.zip
+  mapName: cold_war
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_cold_war_mini.png" />
+    <br>October 1962: Cuban Missle Crisis
+    <br>
+    <br>Instead of following demands by the U.S. to remove missles in Cuba, Cuba is alligned with the United Soviet Socialist Republics(USSR) to not follow those orders, 
+        which then leads to war between the North Atlantic Trade Organisation(NATO) members and the Warsaw-Pact members including Cuba.
+    <br>
+    <br>created by ???
+    <br>
+    <br>Converted up to TripleA1.2.x.x by Veqryn
+  version: 0.1
+- url: https://github.com/triplea-maps/the_great_northern_war/releases/download/0.1/the_great_northern_war.zip
+  mapName: TheGreatNorthernWar
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_the_great_northern_war_mini.png" />
+    <br>Created by Doctor Che
+    <br>
+    <br>The Great Northern War (1700-21) ended the Swedish Empire, leaving Russia dominant in the Baltic Sea and a major 
+        player in European politics. The war began as a coordinated attack on Sweden by the coalition in 1700 and ended
+        in 1721 with the Treaty of Nystad and the Stockholm treaties. It was fought between a coalition of Russia, Denmark-Norway, 
+        and Saxony (also the Polish-Lithuanian Commonwealth from 1701 and Prussia and Hanover from 1715) and many smaller 
+        northgerman states on one side and Sweden, which was partially helped by the Ottoman Empire (who later left the war) on the other.
+    <br>
+    <br>Converted up to TripleA1.2.x.x by Veqryn
+  version: 0.3.1
+- url: https://github.com/triplea-maps/age_of_the_sturlungs/releases/download/0.1/age_of_the_sturlungs.zip
+  mapName: Age_Of_The_Sturlungs
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_age_of_the_sturlungs_mini.png" />
+    <br>
+        this scenario loosely based somewhere around  the year 1226.   
+        it is in  an early part of a bloody civil war in Iceland.     
+        In 1218 Snorri Sturluson (chieftain of the vestur-Sturlugar) became a vassal of King Hakon of Norway.    
+        After Snorri returned  home to Iceland he quickly began, expending his rule of domain and/or trying to bring Iceland under the sovereignty of the king of Norway.
+  version: 0.0.2
+- url: https://github.com/triplea-maps/first_punic_war/releases/download/0.1/first_punic_war.zip
+  mapName: FirstPunicWar
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_first_punic_war_mini.png" />
+    <br>
+        A map of the First Punic War between Rome and Carthage.
+  version: 1.0.1
+- url: https://github.com/triplea-maps/ancient_times/releases/download/0.1/ancient_times.zip
+  mapName: Ancient Times
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ancient_times_mini.png" />
+    <br>
+    Make War to control ancient europe.
+  version: 2.0
+- url: https://github.com/triplea-maps/war_of_the_lance/releases/download/0.1/war_of_the_lance.zip
+  mapName: War of the Lance
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_war_of_the_lance_mini.png" />
+    <br>
+    <br>War of the Lance
+    <br> by AmericaLex
+    <br>
+    <br>Fantasy themed map featuring dragons as evil uber-units. In Alpha stage.
+    <br>
+  version: 1.2
+- url: https://github.com/triplea-maps/rome_total_war/releases/download/0.1/rome_total_war.zip
+  mapName: Rome_Total_War
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_rome_total_war_mini.png" />
+    <br>
+    <br>Rome Total War
+    <br> by ice
+    <br>
+    <br>This map simulates the expansion of the roman empire unlike 270 BC ROME WILL GROW LARGE HERE.
+    <br>
+  version: 1.0.4
+- url: https://github.com/triplea-maps/large_middle_earth/releases/download/0.1/large_middle_earth.zip
+  mapName: Large_Middle_Earth
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_large_middle_earth_mini.png" />
+    <br>
+    <br>Large_Middle_Earth 
+    <br>Version 1.0, last update 2014.12.29 for engine 1.8.0.3 
+    <br>Game done by alkexr 
+    <br>Suggestions to kovvaszilij@gmail.com 
+    <br>
+    <br>a.) Content: 
+    <br>1 Game 
+    <br>Large_Middle_Earth 
+    <br>
+    <br>b.) Rough overview: 
+    <br>A game about a war in Tolkien's Middle Earth where the mightiest realms of the Third Age fight for the victory in the struggle between Good and Evil. 
+    <br>
+    <br>The game features 
+    <br>- a large map with hundreds of territories and many factions 
+    <br>- different territory effects with major impact on battles 
+    <br>- various unit abilities: there is more difference between units than just attack/defense/movement stats 
+    <br>- Free For All game option 
+    <br>
+    <br>c.) General tips: 
+    <br>Read game notes before playing, unless you want to have your strongest units killed by some unexpected enemy ability.
+  version: 1.0
+- url: https://github.com/triplea-maps/1914-cow-empires/releases/download/0.1/1914-cow-empires.zip
+  mapName: 1914-COW-Empires
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_1914_cow_empires_mini.png" />
+    <br>
+    <br>1914-COW-Empires 
+    <br>Version 1.0, last update 2014.12.07 for engine 1.8.0.3 
+    <br>Game done by RogerCooper 
+    <br>Suggestions to RogerCoop@aol.com 
+    <br>
+    <br>a.) Content: 
+    <br>1 Game 
+    <br>1914-COW-Empires 
+    <br>
+    <br>b.) Rough overview: 
+    <br>A WW1 scenario using the Napoleonic Empires map and military/economic data from the Correlates of War database. 
+    <br>
+    <br>c.) General tips: 
+    <br>Read game notes before playing. 
+    <br>
+  version: 1.0
+- url: https://github.com/triplea-maps/blue_vs_gray/releases/download/0.1/blue_vs_gray.zip
+  mapName: blue_vs_gray
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_blue_vs_gray_mini.png" />
+    <br>
+    <br>Blue vs. Gray 
+    <br>Version 1.0.4, last update 2015.01.03 for engine 1.8.0.5 
+    <br>Game done by humbabba 
+    <br>Suggestions to humbabba@gmail.com 
+    <br>
+    <br>a.) Content: 
+    <br>1 Game 
+    <br>Blue vs. Gray 
+    <br>
+    <br>b.) Rough overview: 
+    <br>A strategic-level Civil War scenario adapted from a simple-yet-elegant 
+    <br>board game. Two players face off as the North and the South in the 
+    <br>American Civil War of 1861-65. Each has control of infantry and 
+    <br>cavalry units, which can be upgraded to stronger versions after 
+    <br>winning battles. Three generals -- Lee, Grant, and Sherman -- are also 
+    <br>featured. Players fight for control of territory with very different 
+    <br>victory objectives. 
+    <br>
+    <br>Much of the game is about maneuvering, as better position can trump 
+    <br>superior firepower, and things evolve in surprising ways. A system for 
+    <br>rail and river movement really mixes things up, and cavalry can jump 
+    <br>over defenders to wreak havoc behind enemy lines. 
+    <br>
+    <br>The North has lots of advantages, but the South has more ways to win, 
+    <br>giving each side a distinct flavor. 
+    <br>
+    <br>c) General tips: 
+    <br>AI play is not possible; human-vs.-human play only, online or via email. 
+    <br>
+  version: 1.0.4
+- url: https://github.com/triplea-maps/caribbean_trade_war/releases/download/0.1/caribbean_trade_war.zip
+  mapName: Caribbean_Trade_War
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_caribbean_trade_war_mini.png" />
+    <br>
+    <br>Caribbean Trade War 
+    <br>Version 1.1, last update 2015.06.21 for engine 1.8.0.4
+    <br>Game done by Frostion 
+    <br>
+    <br>a.) Content: 
+    <br>1 Game 
+    <br>Caribbean Trade War 
+    <br>
+    <br>b.) Rough overview: 
+    <br>This map is set in the 1700s Caribbean. Two 3-player alliances fight over control of money, land and sea territories. The first alliance is the Franco-Dutch-Danish and the second is the Anglo-Spanish-Swedish. 
+    <br>
+    <br>The game features 
+    <br>- A 3 vs 3 player scenario that is AI compatible. 
+    <br>- Pirates and Indians (Two additional AI controlled players that are meant as weak harassing elements). 
+    <br>- Timed triggers that regularly provide all players with extra military units and money. 
+    <br>- A lot of interesting land and sea units that also include several support types. 
+    <br>- An approximately 50/50 focus on land and sea. 
+    <br>- Two victory conditions (Economic and Total Victory). 
+    <br>
+    <br>c.) General tips: 
+    <br>Read the map notes for more detailed information and game conditions.  
+    <br>
+  version: 1.1
+- url: https://github.com/triplea-maps/ur_quan_war_masters_edition/releases/download/0.1/ur_quan_war_masters_edition.zip
+  mapName: UrQuanWarMastersEdition
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_ur-quan_slave_war_masters_edition_mini.png" /> 
+    <br>
+    <br>Ur-Quan Slave War: Masters Edition 
+    <br>Version 1.0, last update 2015.4.12 for engine 1.8.0.5 
+    <br>Game done by DrSeptapus 
+    <br>Suggestions to gontoben@hotmail.com 
+    <br>
+    <br>a.) Content: 
+    <br>Includes 1 Game. 
+    <br>Ur-Quan Slave War: Masters Edition 
+    <br>
+    <br>b.) Rough overview: 
+    <br>If you are a fan of Star Control you will quickly notice this map is made with love from a fanboi. You will see every ship featured in Star Control 2, including the ones only available in super melee like the Androsynth Guardian. This map does play differently than most space maps however in that every tile is a land tile and all ships are considered land units(except 2 air units). This may seem odd but is mostly canonical since in Star Control 2 you knew a system was owned by a specific race because they had ships in the system, not because of soldiers on the planets. 
+    <br>
+    <br>The game features 
+    <br>- 15 major factions and 3 minor factions available 
+    <br>- 218 tiles(one for each solar system featured in Star Control 2's galaxy map) 
+    <br>- and 34 units including special one time use ships like the Sa-Matra 
+    <br>
+    <br>c.) General tips: 
+    <br>Read game notes before playing. 
+    <br>
+  version: 1.0
+- url: https://github.com/triplea-maps/steampunk/releases/download/0.1/steampunk.zip
+  mapName: Steampunk
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_Steampunk_mini.png" /> 
+    <br>
+    <br>Large Map of 1915 Earth with some fictional locations. 
+    <br>Version 1.1, last update May 2015 for engine 1.8.0.5 
+    <br>Game done by Patrick Brady 
+    <br>Suggestions to Tekumel1@yahoo.com 
+    <br>a.) Content: 
+    <br>Includes 1 Game. 
+    <br>Steampunk 1915 
+    <br>
+    <br>b.) Rough overview: 
+    <br>This is the First World War with added Martians. Every nation has special units, map altered in line with fictional locations from period literature.  This has Captain Nemo’s Nautilus and Martian Tripods. 
+    <br>
+    <br>The game features 
+    <br>- a large map with hundreds of territories and many factions   
+    <br>- various unit abilities and special units.   
+    <br>
+    <br>c.) General tips: 
+    <br>An extensive manual is provided in the .zip file. Special units can be powerful.
+    <br>
+  version: 1.1
+- url: https://github.com/triplea-maps/domination_1914_blood_and_steel/releases/download/0.1/domination_1914_blood_and_steel.zip
+  mapName: Domination_1914_Blood_And_Steel
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_domination_1914_blood_and_steel_mini.png" /> 
+    <br>
+    <br>Domination_1914_Blood_And_Steel 
+    <br>by Navalland 
+    <br>Version 1.0 for TripleA 1.8.0.5 
+    <br>Suggestions to anillyuksell@hotmail.com 
+    <br>
+    <br>"Domination 1914 Blood And Steel" is a realistic First World War immersive grand strategy wargame, based on the military conflict between two opposite sides. Germany, Austria, Ottomans, Bulgaria and Bolsheviks are Central Powers. Americans, British, French, Russia, Serbia, Romania, Greece and Japan are Allied. The various countries join the war at different times. Italy can join Central Powers or Allied, depending on Central Powers' achievements. 
+    <br>
+    <br>Available politic panel and actions to declare war on some neutral countries. Different units for different countries. And different technologies for different countries. Featuring convoy zones, harbours, airfields and dogfighting. 
+    <br>
+    <br>Highly dynamic gameplay. The war extending over the immense spaces of Africa, East Asia and Pacific, yet of scarce or no economic value. Europe is where the future of the World shall be forged, with steel and blood... 
+    <br>        
+  version: 1.0
+- mapName: ==IN DEVELOPMENT==
+  description: |
+    <br>Located in this section are maps that are a "work in progress".  
+        Thus good Maps which are in the state of development and thus not completed yet, may it be functionally, bugs, art, or in terms of basic balance.
+    <br>These maps are usually updated often, so check back.
+    <br>Technically, all maps are still usually getting updates here and there, but maps in this category are usually very new (2-6 weeks), or have bugs, 
+        or the map maker does not consider them to be ready for release.
+- url: https://github.com/triplea-maps/feudal_japan_warlords/releases/download/0.1/feudal_japan_warlords.zip
+  mapName: FeudalJapanWarlords
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_feudal_japan_warlords_mini.png" />
+    <br>
+    <br><b><font size="12"> Feudal Japan Warlords </font></b>
+    <br>
+    <br> </CENTER>
+    <br> <em><b><font size="6">Created by Rolf Larsson </font></b></em>
+    <br>
+    <br><b>Inspired by Shogun, Samurai Swords, Ikusa boardgames, this map is done in tripleastyle, adding
+    <br>Ships, Seazones, Cavalry and changes a few other things.</b>
+    <br>
+    <p> <a name="Features"><font size="6"><b><em>Features</em></b></font></a></p>
+    <br>
+        <ul>
+        <li><b>2, 3, 4 or 5 players, free for all</b></li>
+        <li><b>Rotating turnorder</b></li>
+        <li><b>Ninjas and Ronins</b></li>
+        <li><b>Daimyo experience</b></li>
+        <li><b>Guardvalues vs. assassination attempts</b></li>
+        <li><b>Boardgame like maximums for units</b></li>
+        <li><b>Random dealt territories or picked from start</b></li>
+        <li><b>and some more...</b></li>
+        </UL><br/>
+  version: 1.5
+- url: https://github.com/triplea-maps/war_of_the_relics/releases/download/0.1/war_of_the_relics.zip
+  mapName: war_of_the_relics
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_war_of_the_relics_mini.png" />
+    <br>
+    <br>War of the Relics
+    <br>
+    <br>The War of the Relics is complex medieval-themed strategy game in which two players build factions of noble lords who use powerful titles and offices to gain strength and crush the opposition. 
+    <br>Each lord can recruit sworn troops, mercenaries, druids, and ships to his cause, taking over castles and towns via title or conquest.
+    <br>Three sacred relics must be gathered to a player's faction to anoint one of its nobles as the new king.
+    <br>A system of random events can thwart the best-laid plans at the most inconvenient times.
+    <br>
+    <br>by humbabba
+    <br>
+  version: 2.0.3
+- url: https://github.com/triplea-maps/empire/releases/download/0.1/empire.zip
+  mapName: Empire
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_empire_mini.png" />
+    <br>
+    <br>Empire
+    <br>
+    <br>Empire is a free-for-all strategy game set in the late Roman Empire as various caesars take the field to win dominance. Inspired by a once-popular board game. 
+    <br>Each caesar starts off in one of six provinces of the empire with a small army and a fortified city.
+    <br>Using his limited supply of generals to lead his troops, each expands and tries to outdo and eliminate the competition - conquer a rival caesar, and you get all his territory and troops as well.
+    <br>Along the way, build and fortify cities, send war galleys across the Mediterranean, ransom or execute captive generals, and cope with rampant inflation as the cost of war doubles and triples.
+    <br>
+    <br>by humbabba
+    <br>
+  version: 2.0
+- url: https://github.com/triplea-maps/total_ancient_war/releases/download/0.1/total_ancient_war.zip
+  mapName: Total_Ancient_War
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_total_ancient_war_mini.png" />
+    <br>
+    <br>Make yourself an empire around the Mediterranean Ocean (the known world), in the era when hellenes, romans and phoenicians ruled.
+    <br>Choose from an arsenal of legionaires, hoplites, catapults, cataphracts, quadriremes, warelephants and many more.
+    <br>
+    <br>11 faction PvP map including two solo player campaigns
+    <br>2x map and units larger than 270 BC.
+    <br>Unit maintenace costs.
+    <br>Uses real seige warfare.
+    <br>12 ancient technologies to develop.
+    <br>Each faction has a unique selection of units.
+    <br>Pit armies with leaders and navies with flagships against your opponent.
+    <br>Deep unit support system defending and attacking.
+    <br>Winning though Victory City points.
+    <br>Factions survive after their capital is taken.
+    <br>4 neutral barbarian strongholds: Gauls, Moors, Iber-Celts, Germanic-Dacian-Scythians.
+    <br>
+    <br>A 270BC mod by Zim Xero.
+    <br>
+  version: 1.0
+- url: https://github.com/triplea-maps/elemental_forces/releases/download/0.1/elemental_forces.zip
+  mapName: Elemental_Forces
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_elemental_forces_mini.png" />
+    <br>
+    <br>An FFA map with a lot of features, like: terrain, unit classes, regional elements etc.
+    <br>2-8 players.
+    <br>Original fantasy-based strategy game. Fully compatible with AI and player versus player.
+    <br>Music by Torley Wong, edited by Zim Xero.
+    <br>
+    <br>To enjoy all the custom sounds the designer had choosen,
+    <br>go to maps folder( engine prefrences, open user maps and savegames folder) and
+    <br>unpack Elemental_Forces.zip. Download sounds.zip from:
+    <br>http://www.mediafire.com/download/y7gj9t6afna4ijm/sounds.zip (manually, browser download)
+    <br>and simply unpack those into your new Elemental_Forces folder from above. Delete
+    <br>Elemental_Forces.zip when ready.
+    <br>
+  version: 1.0
+- url: https://github.com/triplea-maps/game_of_thrones/releases/download/0.1/game_of_thrones.zip
+  mapName: Game_of_Thrones
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_game_of_thrones_mini.png" />
+    <br>
+    <br>An FFA map with the background of George R. R. Martins novel: A Song of Ice and Fire.
+    <br>
+    <br>Alpha stage.
+    <br>Modified to work, by Rolf Larsson.
+    <br>abandoned? Excellent map already, needs a little work, feel free to take over.
+    <br>
+  version: 1.3
+- url: https://github.com/triplea-maps/new_world_order1915lebowski/releases/download/0.1/new_world_order1915lebowski.zip
+  mapName: NewWorldOrder1915Lebowski
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_nwo_1915_lebowski_mini.png" />
+    <br>
+    <br>WW1 map by Lebowski, based on Siegs New World Order map.
+    <br>
+    <br>Brought back to life by Ajmdeman and Rolf Larsson.
+    <br>
+  version: 1.1
+- url: https://github.com/triplea-maps/stellar_forces/releases/download/0.1/stellar_forces.zip
+  mapName: Stellar_Forces
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_stellar_forces_mini.png" />
+    <br>
+    <br>A 4 Player FFA map about populating the Galaxy by Zim Xero.
+    <br>
+    <br>Many nice features like a random planetary setup. Alpha stage.
+    <br>
+    <br>
+  version: 0.8.3
+- url: https://github.com/triplea-maps/pacific/releases/download/0.1/pacific.zip
+  mapName: pacific
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_pacific_mini.png" />
+    <br>
+    <br>WW2 Pacific (WW2 Revised era)
+    <br>
+    <br>Created by Triplelk and ComradeKev
+    <br>TripleA adaption of WW2 Pacific (from the WW2 Revised era). Alpha stage.
+    <br>
+    <br>abandoned
+    <br>
+  version: 1.4
+- url: https://github.com/triplea-maps/europe/releases/download/0.1/europe.zip
+  mapName: europe
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_europe_mini.png" />
+    <br>
+    <br>Original Europe Edition.
+    <br>
+    <br>Includes default version following original europe rules (similar to ww2v2 but not exact), and a version following ww2v3 type rules
+    <br>
+    <br><i>Credits: Triple_Elk (base-line), iron__cross (integration), Adam (convoy center code), and the rest of the team...
+    <br>Converted to TripleA 1.2.x.x, and additional rules properties and fixes by Veqryn</i>
+  version: 1.3
+- url: https://github.com/triplea-maps/pacific_1942/releases/download/0.1/pacific_1942.zip
+  mapName: pacific_1942
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_pacific_1942_mini.png" />
+    <br>Mod by Pulicat
+    <br>Historical scenario based on the original Pacific map.
+    <br>Six months after Pearl Harbor, the Japanese Empire reached its greatest extent. The question is: how long will they keep it?
+    <br>
+    <br>abandoned
+    <br>
+  version: 1.0.1
+- url: https://github.com/triplea-maps/zombieland/releases/download/0.1/zombieland.zip
+  mapName: Zombieland
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_zombieland_mini.png" />
+    <br>Created by Pulicat
+    <br>The zombie apocalypse has arrived!
+    <br>Zombies have spread to most of the main population centers in the United States and are threatening to take over the rest. 
+        Can the US military and bands of survivalist militias contain and exterminate the zombie plague, or will this be the end of civilization as we know it?
+    <br>
+    <br>abandoned
+    <br>
+  version: 1.2.1
+- url: https://github.com/triplea-maps/caravan/releases/download/0.1/caravan.zip
+  mapName: Caravan
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_caravan_mini2.png" />
+    <br>Caravan
+    <br>by Pulicat
+    <br>
+    <br>In the deep, dark woods, a trade route is under threat from armed brigands. Can the town merchants get their goods through the forest paths safely?
+    <br>
+    <br>abandoned
+    <br>
+  version: 1.0
+- url: https://github.com/triplea-maps/hex_globe10/releases/download/0.1/hex_globe10.zip
+  mapName: HexGlobe10
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_hexglobe_mini2.png" />
+    <br>HexGlobe10 is a 4 player game with no alliances.
+    <br>
+  version: 2.5
+- url: https://github.com/triplea-maps/domination_1914_no_mans_land/releases/download/0.1/domination_1914_no_mans_land.zip
+  mapName: Domination_1914_No_Mans_Land
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_domination_1914_mini.png" />
+    <br>Domination_1914_No_Mans_Land
+    <br>by Imbaked
+    <br>
+    <br>WW1 mod of Domination map.
+    <br>
+    <br>
+  version: 1.0
+- url: https://github.com/triplea-maps/jurassic/releases/download/0.1/jurassic.zip
+  mapName: Jurassic
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_jurassic_mini.png" />
+    <br>
+    <p><b>Welcome to the world of dead reptiles and avian ancestors.</b>
+        <p><br>The map is a low resolution image produced from NASA topological data.
+    <br>The globe was rotated to center Iceland on the equator before slicing it open and laying it flat.
+    <br>This reduces distortions for all land, since only water remains at the poles.
+    <br>A small section of turf around Greenland is used for JURASSIC.  Greenland's massive ice block makes it the perfect volcano for the Dimorphodon, one of the first Pterosaurs.
+    <br>This location is impassable and the capital of Tithonia.
+    <br>The players are named after the eleven periods of the Jurassic era.
+    <br>Their positions on the board make game play more or less difficult.
+    <br>This is reflected in the player list order with easiest on the bottom.
+    <br>The top player is unique with a special dinosaur; Dimorphodon.
+    <br>All other players have a full list of other dinosaurs from the Jurassic Period.
+    <br>The first player is meant to be a nuisance; a leftover from the Triassic.
+    <br>Even though the capital is impassable, you can still create but cannot return; like deamons emerging from the pit of Hell.
+    <br>
+    <br>The map is colored for topologic elevation and not actual vegetation conditions. Sea level after the last Ice Age, ten-thousand years ago, was nearly 400-feet lower than today.
+    <br>This is easy to see as the continental shelves (light blue areas). Sadly, all that topology has been washed clean.
+    <br>Territory Effects are employed to allow land reptiles to swim, and ocean dwellers to flop around on land.
+    <br>Study the Effects chart in the NOTES, or snap a screen shot and place it on your desktop for reference.
+    <br>Territories are labeled with a Terrain Tag. Combat is based on 12-sided dice.
+    <br>All creatures looking right are defense oriented.
+    <br>Each dinosaur has advantages, and the project purpose is to bring dinosaurs into the Triple-A family.
+    <br>
+    <br>by Gregorek
+  version: 1.0
+- mapName: ==DEVELOPER RESOURCES==
+  mapType: MAP_TOOL
+  description: |
+    <br>Located in this section are resources such as the map maker by Wisconsin (be sure to check the .txt files that come with it before using it), 
+        as well as map files or art files that could be used for future maps.
+    <br>
+- url: http://downloads.sourceforge.net/project/tripleamaps/developer%20resources/map%20makers/TripleA_Map_Creator.zip
+  mapName: TripleA_Map_Creator
+  mapType: MAP_TOOL
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_Map_Creator_mini.png" />
+    <br>By Wisconsin, SGB, and ComradeKev
+    <br>The TripleA Map Creator zip file should contain the following items:
+    <br>(suggest you unzip everything to a folder)
+    <br>
+    <br>    readme.txt
+    <br>    changelog.txt
+    <br>    Map Creation Guide.txt
+    <br>    Mod Creation Guide.txt
+    <br>    Settings.inf
+    <br>    TripleA Map Creator Part 1.exe
+    <br>    TripleA Map Creator Part 2.exe
+    <br>    A folder named 'Additional Utilities' containing some extra utilities.
+    <br>
+    <br>
+    <br>If you would like to make a completely new map, open the Map Creation Guide file and follow the instructions carefully.
+    <br>If you want to create a mod based off of an already created map, open the Mod Creation Guide and follow those instructions.
+    <br>
+    <br>
+    <br>Useful links:
+    <br>A Complete List of the Correct Properties / Game Settings to use:
+    <br>http://tripleadev.1671093.n2.nabble.com/Correct-Properties-list-for-reference-and-Better-XMLs-Please-tp4488213p4488213.html
+    <br>http://n2.nabble.com/Correct-Properties-list-for-reference-and-Better-XMLs-Please-tp4488213p4488213.html
+    <br>
+    <br>General How to:
+    <br>http://bit.ly/aTuuyA
+    <br>http://n2.nabble.com/Download-Maps-Links-Hosting-Games-General-Information-tp4074312p4074312.html
+    <br>http://tripleadev.1671093.n2.nabble.com/Download-Maps-Links-Hosting-Games-General-Information-tp4074312p4074312.html
+    <br>
+    <br>TripleA forum:
+    <br>http://triplea.sourceforge.net/mywiki/Forum
+    <br>
+    <br>Latest Version of TripleA:
+    <br>https://sourceforge.net/projects/triplea/files/
+    <br>
+    <br>
+    <br>
+    <br>The TripleA Map Image Extractor found in the 'Additional Utilities' folder can be used to re-create the map image by using the map's base tiles and 
+        pasting them together. Having the map image can help you later on when you are making a mod.
+    <br>The TripleA Map Resizer And Shifter found in the 'Additional Utilities' folder can be used to resize any map you choose by simply choosing the map, 
+        setting the scale amount or new dimensions, and having the program do the rest. You can also use it to shift the map by a specified amount.
+    <br>
+    <br>Please report any errors that you find at http://code.google.com/p/tmapc/issues/list
+    <br>Feel free to post any questions or suggestions you have on the TripleA forum at http://triplea.sourceforge.net/mywiki/Forum#nabble-td2578942
+    <br>If you would like to download the latest version of the program, visit http://code.google.com/p/tmapc/downloads/list
+    <br>You can also view the source code for the program at http://code.google.com/p/tmapc/source/browse/
+  version: 1.0.1.6
+- url: http://downloads.sourceforge.net/project/tripleamaps/developer%20resources/map%20makers/Map_Making_Tutorial_Map.zip
+  mapName: Map_Making_Tutorial_Map
+  mapType: MAP_TOOL
+  description: |
+    <img src="http://tripleamaps.sourceforge.net/images/TripleA_map_making_tutorial_map_mini.png" />
+    <br>A VERY simple map.
+    <br>Purpose: use these files to make your first map.  If you can make a map out of it, then you can do anything.
+    <br>Basically, many people try to make these big elaborate maps as their very first map, and it often does not turn out well.  They get frustrated, have tons of bugs, and 
+        can't get the game to work (my very first map did not run either...).  
+    <br>So the idea here is that you can take all these files, run them through the map creator, and in 20 minutes you will have a working map.  If you can make it work without bugs, 
+        and it runs, then you better understand the development process for maps and go apply what you learned here to the map you always wanted to make.
+    <br>
+    <br>Created by Veqryn
+    <br>
+  version: 1.0


### PR DESCRIPTION
1 commit: 0ef429d, based on: #449

Converts triplea_maps.xml from a XML to a yaml file. Benefits:
- simpler code to parse, both in Java and with other tools.
- will be consumed by the website, parsed by javascript to summarize the maps we have available (relates to: #479)
- simpler syntax in the file, no more CDATA tags, no more "game" or "games" tags either



Only gotchya I ran into while working with  the YAML is to make sure the indentation stays good on the description block. For exampe:
```
  description: |
          <firstrow>
      <the above is bad, nto in line>
  version: 0.1
```
vs
```
  description: |
       <firstrow>
       <this is lined up, good>
            <indent is okay>
  version: 0.1
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/498)
<!-- Reviewable:end -->
