### PR TITLE
Fix NPE on game launch, a missing getUserActions() update did not convert the null return value to an  empty list

### DIFF
--- a/src/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -7,6 +7,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.Action;
 import javax.swing.JPanel;
 
+import com.google.common.collect.Lists;
+
 import games.strategy.engine.chat.IChatPanel;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 
@@ -67,6 +69,6 @@ public abstract class SetupPanel extends JPanel implements ISetupPanel {
 
   @Override
   public List<Action> getUserActions() {
-    return null;
+    return Lists.newArrayList();
   }
 }


### PR DESCRIPTION
Break fix, missed a getUserAction() on a previous commit.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/512)
<!-- Reviewable:end -->
