### PR TITLE
Swing action invoke and wait

### DIFF
--- a/src/games/strategy/common/swing/SwingAction.java
+++ b/src/games/strategy/common/swing/SwingAction.java
@@ -1,8 +1,12 @@
 package games.strategy.common.swing;
 
 import java.awt.event.ActionEvent;
+import java.lang.reflect.InvocationTargetException;
 import java.util.function.Consumer;
 import javax.swing.AbstractAction;
+import javax.swing.SwingUtilities;
+
+import games.strategy.debug.ClientLogger;
 
 
 /**
@@ -48,5 +52,15 @@ public class SwingAction {
         swingAction.accept(e);
       }
     };
+  }
+
+  public static void invokeAndWait(Runnable action) {
+    try {
+      SwingUtilities.invokeAndWait(() -> action.run());
+    } catch (InvocationTargetException e) {
+      ClientLogger.logError(e);
+    } catch (InterruptedException e) {
+      ClientLogger.logQuietly(e);
+    }
   }
 }

--- a/src/games/strategy/common/swing/SwingAction.java
+++ b/src/games/strategy/common/swing/SwingAction.java
@@ -3,8 +3,7 @@ package games.strategy.common.swing;
 import java.awt.event.ActionEvent;
 import java.lang.reflect.InvocationTargetException;
 import java.util.function.Consumer;
-import javax.swing.AbstractAction;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 
 import games.strategy.debug.ClientLogger;
 
@@ -56,7 +55,11 @@ public class SwingAction {
 
   public static void invokeAndWait(Runnable action) {
     try {
-      SwingUtilities.invokeAndWait(() -> action.run());
+      if( SwingUtilities.isEventDispatchThread()) {
+        action.run();
+      } else {
+        SwingUtilities.invokeAndWait(() -> action.run());
+      }
     } catch (InvocationTargetException e) {
       ClientLogger.logError(e);
     } catch (InterruptedException e) {

--- a/src/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/src/games/strategy/engine/chat/ChatMessagePanel.java
@@ -5,7 +5,6 @@ import java.awt.Container;
 import java.awt.Insets;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.lang.reflect.InvocationTargetException;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
@@ -89,18 +88,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
 
   public void setChat(final Chat chat) {
     if (!SwingUtilities.isEventDispatchThread()) {
-      try {
-        SwingUtilities.invokeAndWait(new Runnable() {
-          @Override
-          public void run() {
-            setChat(chat);
-          }
-        });
-      } catch (final InterruptedException e) {
-        e.printStackTrace();
-      } catch (final InvocationTargetException e) {
-        e.printStackTrace();
-      }
+      SwingAction.invokeAndWait(() -> setChat(chat));
       return;
     }
     if (m_chat != null) {

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -150,19 +150,6 @@ public class GameRunner2 {
       ErrorHandler.registerExceptionHandler();
     })).start();
 
-    s_countDownLatch = new CountDownLatch(1);
-    try {
-      SwingUtilities.invokeAndWait(new Runnable() {
-        @Override
-        public void run() {
-          s_waitWindow = new WaitWindow("TripleA is starting...");
-          s_waitWindow.setVisible(true);
-          s_waitWindow.showWait();
-        }
-      });
-    } catch (final Exception e) {
-      // just don't show the wait window
-    }
     setupProxies();
     (new Thread(() -> checkForUpdates())).start();
     handleCommandLineArgs(args);

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -25,6 +25,7 @@ import javax.swing.UIManager;
 
 import org.apache.commons.httpclient.HostConfiguration;
 
+import games.strategy.common.swing.SwingAction;
 import games.strategy.common.ui.BasicGameMenuBar;
 import games.strategy.debug.ClientLogger;
 import games.strategy.debug.ErrorConsole;
@@ -149,6 +150,19 @@ public class GameRunner2 {
       ErrorHandler.registerExceptionHandler();
     })).start();
 
+    s_countDownLatch = new CountDownLatch(1);
+    try {
+      SwingUtilities.invokeAndWait(new Runnable() {
+        @Override
+        public void run() {
+          s_waitWindow = new WaitWindow("TripleA is starting...");
+          s_waitWindow.setVisible(true);
+          s_waitWindow.showWait();
+        }
+      });
+    } catch (final Exception e) {
+      // just don't show the wait window
+    }
     setupProxies();
     (new Thread(() -> checkForUpdates())).start();
     handleCommandLineArgs(args);
@@ -241,23 +255,24 @@ public class GameRunner2 {
   }
 
   public static void setupLookAndFeel() {
-    try {
-      UIManager.setLookAndFeel(getDefaultLookAndFeel());
-      // FYI if you are getting a null pointer exception in Substance, like this:
-      // org.pushingpixels.substance.internal.utils.SubstanceColorUtilities
-      // .getDefaultBackgroundColor(SubstanceColorUtilities.java:758)
-      // Then it is because you included the swingx substance library without including swingx.
-      // You can solve by including both swingx libraries or removing both,
-      // or by setting the look and feel twice in a row.
-    } catch (final Throwable t) {
-      System.out.println("LOOK AND FEEL exception: " + t.getMessage());
-      if (!GameRunner.isMac()) {
-        try {
-          UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-        } catch (final Exception e) {
+    SwingAction.invokeAndWait(() -> {
+      try {
+        UIManager.setLookAndFeel(getDefaultLookAndFeel());
+        // FYI if you are getting a null pointer exception in Substance, like this:
+        // org.pushingpixels.substance.internal.utils.SubstanceColorUtilities
+        // .getDefaultBackgroundColor(SubstanceColorUtilities.java:758)
+        // Then it is because you included the swingx substance library without including swingx.
+        // You can solve by including both swingx libraries or removing both,
+        // or by setting the look and feel twice in a row.
+      } catch (final Throwable t) {
+        if (!GameRunner.isMac()) {
+          try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+          } catch (final Exception e) {
+          }
         }
       }
-    }
+    });
   }
 
   public static void setupLogging() {

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServerUI.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServerUI.java
@@ -160,19 +160,7 @@ public class HeadlessGameServerUI extends MainGameFrame {
     // change, we need to ensure that no further history
     // events are run until our historySynchronizer is set up
     if (!SwingUtilities.isEventDispatchThread()) {
-      try {
-        SwingUtilities.invokeAndWait(new Runnable() {
-          @Override
-          public void run() {
-            updateStep();
-          }
-        });
-      } catch (final InterruptedException e) {
-        e.printStackTrace();
-      } catch (final InvocationTargetException e) {
-        e.getCause().printStackTrace();
-        throw new IllegalStateException(e.getCause().getMessage());
-      }
+      SwingAction.invokeAndWait(() -> updateStep());
       return;
     }
     int round;

--- a/src/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -21,6 +21,7 @@ import javax.swing.Action;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
+import games.strategy.common.swing.SwingAction;
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.ChatPanel;
 import games.strategy.engine.chat.IChatPanel;
@@ -243,12 +244,7 @@ public class ClientModel implements IMessengerErrorListener {
     @Override
     public void gameReset() {
       m_objectStreamFactory.setData(null);
-      Util.runInSwingEventThread(new Runnable() {
-        @Override
-        public void run() {
-          MainFrame.getInstance().setVisible(true);
-        }
-      });
+      SwingAction.invokeAndWait(() -> MainFrame.getInstance().setVisible(true));
     }
 
     @Override

--- a/src/games/strategy/engine/framework/startup/ui/MainFrame.java
+++ b/src/games/strategy/engine/framework/startup/ui/MainFrame.java
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
+import games.strategy.common.swing.SwingAction;
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
@@ -102,18 +103,7 @@ public class MainFrame extends JFrame {
    */
   public void clientLeftGame() {
     if (!SwingUtilities.isEventDispatchThread()) {
-      try {
-        SwingUtilities.invokeAndWait(new Runnable() {
-          @Override
-          public void run() {
-            clientLeftGame();
-          }
-        });
-      } catch (final InterruptedException e) {
-        throw new IllegalStateException(e);
-      } catch (final InvocationTargetException e) {
-        throw new IllegalStateException(e);
-      }
+      SwingAction.invokeAndWait(() -> clientLeftGame());
       return;
     }
       // having an oddball issue with the zip stream being closed while parsing to load default game. might be caused by

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -152,7 +152,7 @@ public class NewGameChooserModel extends DefaultListModel {
    * Open up a confirmation dialog, if user says yes, delete the map specified by
    * parameter, then show confirmation of deletion.
    */
-  private static void confirmWithUserAndThenDeleteCorruptZipFile(final File map) {
+  private static void confirmWithUserAndThenDeleteCorruptZipFile(final File map, Optional<String> errorDetails) {
     Runnable deleteMapRunnable = () -> {
       final Component parentComponent = MainFrame.getInstance();
       String message = "Could not parse map file correctly, would you like to remove it?\n" + map.getAbsolutePath()
@@ -167,7 +167,11 @@ public class NewGameChooserModel extends DefaultListModel {
           messageType = JOptionPane.INFORMATION_MESSAGE;
           message = "File was deleted successfully.";
         } else if (!deleted && map.exists()) {
-          message = "Unable to delete file, please remove it by hand:\n" + map.getAbsolutePath();
+          message = "Unable to delete file, please remove it in the file system and restart tripleA:\n" + map
+              .getAbsolutePath();
+          if (errorDetails.isPresent()) {
+            message += "\nError details: " + errorDetails;
+          }
         }
         title = "File Removal Result";
         JOptionPane.showMessageDialog(parentComponent, message, title, messageType);

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -29,10 +29,13 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+import games.strategy.common.swing.SwingAction;
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.ClientContext;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameParseException;
+import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.startup.ui.MainFrame;
 
 public class NewGameChooserModel extends DefaultListModel {
@@ -149,45 +152,29 @@ public class NewGameChooserModel extends DefaultListModel {
    * Open up a confirmation dialog, if user says yes, delete the map specified by
    * parameter, then show confirmation of deletion.
    */
-  private static void confirmWithUserAndThenDeleteCorruptZipFile(final File map, Optional<String> details) {
-    try {
-      Runnable deleteMapRunnable = new Runnable() {
-        @Override
-        public void run() {
-          final Component parentComponent = MainFrame.getInstance();
-          String message = "Could not parse map file correctly, would you like to remove it?\n" + map.getAbsolutePath()
-              + "\n(You may see this error message again if you keep the file)";
-          if( details.isPresent()) {
-            message += "\nError message encountered: " + details.get();
-          }
-          String title = "Corrup Map File Found";
-          final int optionType = JOptionPane.YES_NO_OPTION;
-          int messageType = JOptionPane.WARNING_MESSAGE;
-          final int result = JOptionPane.showConfirmDialog(parentComponent, message, title, optionType, messageType);
-          if (result == JOptionPane.YES_OPTION) {
-            final boolean deleted = map.delete();
-            if (deleted) {
-              messageType = JOptionPane.INFORMATION_MESSAGE;
-              message = "File was deleted successfully.";
-            } else if (!deleted && map.exists()) {
-              message = "Unable to delete file, please remove it by hand:\n" + map.getAbsolutePath();
-            }
-            title = "File Removal Result";
-            JOptionPane.showMessageDialog(parentComponent, message, title, messageType);
-          }
+  private static void confirmWithUserAndThenDeleteCorruptZipFile(final File map) {
+    Runnable deleteMapRunnable = () -> {
+      final Component parentComponent = MainFrame.getInstance();
+      String message = "Could not parse map file correctly, would you like to remove it?\n" + map.getAbsolutePath()
+          + "\n(You may see this error message again if you keep the file)";
+      String title = "Corrup Map File Found";
+      final int optionType = JOptionPane.YES_NO_OPTION;
+      int messageType = JOptionPane.WARNING_MESSAGE;
+      final int result = JOptionPane.showConfirmDialog(parentComponent, message, title, optionType, messageType);
+      if (result == JOptionPane.YES_OPTION) {
+        final boolean deleted = map.delete();
+        if (deleted) {
+          messageType = JOptionPane.INFORMATION_MESSAGE;
+          message = "File was deleted successfully.";
+        } else if (!deleted && map.exists()) {
+          message = "Unable to delete file, please remove it by hand:\n" + map.getAbsolutePath();
         }
-      };
-
-      if (SwingUtilities.isEventDispatchThread()) {
-        deleteMapRunnable.run();
-      } else {
-        SwingUtilities.invokeAndWait(deleteMapRunnable);
+        title = "File Removal Result";
+        JOptionPane.showMessageDialog(parentComponent, message, title, messageType);
       }
-    } catch (final InvocationTargetException e) {
-      ClientLogger.logError(e);
-    } catch (final InterruptedException e) {
-      ClientLogger.logQuietly(e);
-    }
+    };
+
+    SwingAction.invokeAndWait(deleteMapRunnable);
   }
 
   /**
@@ -205,8 +192,8 @@ public class NewGameChooserModel extends DefaultListModel {
     } catch (final EngineVersionException e) {
       System.out.println(e.getMessage());
     } catch (final SAXParseException e) {
-      System.err
-          .println("Could not parse:" + uri + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber());
+      String msg = "Could not parse:" + uri + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber();
+      System.err.println(msg);
       e.printStackTrace();
     } catch (final Exception e) {
       System.err.println("Could not parse:" + uri);

--- a/src/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/src/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -9,6 +9,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 
+import games.strategy.common.swing.SwingAction;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUI;
 
@@ -30,16 +31,7 @@ public class PropertiesSelector {
     if (!SwingUtilities.isEventDispatchThread()) {
       // throw new IllegalStateException("Must run from EventDispatchThread");
       final AtomicReference<Object> rVal = new AtomicReference<Object>();
-      try {
-        SwingUtilities.invokeAndWait(new Runnable() {
-          @Override
-          public void run() {
-            rVal.set(showDialog(parent, title, properties, buttonOptions));
-          }
-        });
-      } catch (final Exception e) {
-        e.printStackTrace();
-      }
+      SwingAction.invokeAndWait(() -> rVal.set(showDialog(parent, title, properties, buttonOptions)));
       return rVal.get();
     } else {
       return showDialog(parent, title, properties, buttonOptions);

--- a/src/games/strategy/engine/random/PBEMDiceRoller.java
+++ b/src/games/strategy/engine/random/PBEMDiceRoller.java
@@ -20,6 +20,8 @@ import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
+import games.strategy.common.swing.SwingAction;
+
 /**
  * Its a bit messy, but the threads are a pain to deal with We want to be able
  * to call this from any thread, and have a dialog that doesnt close until the
@@ -62,18 +64,7 @@ public class PBEMDiceRoller implements IRandomSource {
   public int[] getRandom(final int max, final int count, final String annotation) throws IllegalStateException {
     if (!SwingUtilities.isEventDispatchThread()) {
       final AtomicReference<int[]> result = new AtomicReference<int[]>();
-      try {
-        SwingUtilities.invokeAndWait(new Runnable() {
-          @Override
-          public void run() {
-            result.set(getRandom(max, count, annotation));
-          }
-        });
-      } catch (final InterruptedException e) {
-        throw new IllegalStateException(e);
-      } catch (final InvocationTargetException e) {
-        throw new IllegalStateException(e);
-      }
+      SwingAction.invokeAndWait(() -> result.set(getRandom(max, count, annotation)));
       return result.get();
     }
     final HttpDiceRollerDialog dialog =
@@ -82,7 +73,7 @@ public class PBEMDiceRoller implements IRandomSource {
     return dialog.getDiceRoll();
   }
 
-  private Frame getFocusedFrame() {
+  private static Frame getFocusedFrame() {
     if (s_focusWindow != null) {
       return s_focusWindow;
     }

--- a/src/games/strategy/triplea/TripleA.java
+++ b/src/games/strategy/triplea/TripleA.java
@@ -1,13 +1,11 @@
 package games.strategy.triplea;
 
 import java.awt.Frame;
-import java.lang.reflect.InvocationTargetException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.swing.SwingUtilities;
-
+import games.strategy.common.swing.SwingAction;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.IUnitFactory;
 import games.strategy.engine.data.PlayerID;
@@ -89,7 +87,7 @@ public class TripleA extends AbstractGameLoader implements IGameLoader {
 
 
   @Override
-  public void startGame(final IGame game, final Set<IGamePlayer> players, final boolean headless) throws Exception {
+  public void startGame(final IGame game, final Set<IGamePlayer> players, final boolean headless) {
     super.game = game;
     if (game.getData().getDelegateList().getDelegate("edit") == null) {
       // An evil hack: instead of modifying the XML, force an EditDelegate by adding one here
@@ -126,29 +124,23 @@ public class TripleA extends AbstractGameLoader implements IGameLoader {
         headlessFrameUI.toFront();
       }
     } else {
-      SwingUtilities.invokeAndWait(new Runnable() {
-        @Override
-        public void run() {
-          final TripleAFrame frame;
-          frame = new TripleAFrame(game, localPlayers);
-          display = new TripleaDisplay(frame);
-          game.addDisplay(display);
-          soundChannel = new DefaultSoundChannel(localPlayers);
-          game.addSoundChannel(soundChannel);
-          frame.setSize(700, 400);
-          frame.setVisible(true);
-          ClipPlayer.play(SoundPath.CLIP_GAME_START);
-          connectPlayers(players, frame);
-          SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-              frame.setExtendedState(Frame.MAXIMIZED_BOTH);
-              frame.toFront();
-            }
-          });
-        }
+      SwingAction.invokeAndWait(() -> {
+        final TripleAFrame frame;
+        frame = new TripleAFrame(game, localPlayers);
+        display = new TripleaDisplay(frame);
+        game.addDisplay(display);
+        soundChannel = new DefaultSoundChannel(localPlayers);
+        game.addSoundChannel(soundChannel);
+        frame.setSize(700, 400);
+        frame.setVisible(true);
+        ClipPlayer.play(SoundPath.CLIP_GAME_START);
+        connectPlayers(players, frame);
+        frame.setExtendedState(Frame.MAXIMIZED_BOTH);
+        frame.toFront();
       });
+
     }
+
   }
 
   private static void connectPlayers(final Set<IGamePlayer> players, final TripleAFrame frame) {

--- a/src/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
+++ b/src/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
@@ -398,28 +398,21 @@ public class ProLogWindow extends javax.swing.JDialog {
   }
 
   public void notifyNewRound(final int roundNumber, final String name) {
-    try {
-      SwingUtilities.invokeAndWait(new Runnable() {
-        @Override
-        public void run() {
-          final JPanel newPanel = new JPanel();
-          final JScrollPane newScrollPane = new JScrollPane();
-          final JTextArea newTextArea = new JTextArea();
-          newTextArea.setColumns(20);
-          newTextArea.setRows(5);
-          newTextArea.setFont(new java.awt.Font("Segoe UI", 0, 10));
-          newTextArea.setEditable(false);
-          newScrollPane.getHorizontalScrollBar().setEnabled(true);
-          newScrollPane.setViewportView(newTextArea);
-          newPanel.setLayout(new GridLayout());
-          newPanel.add(newScrollPane);
-          v_logHolderTabbedPane.addTab(Integer.toString(roundNumber) + "-" + name, newPanel);
-          currentLogTextArea = newTextArea;
-        }
-      });
-    } catch (final Exception ex) {
-      System.out.print("Error initializing ProAI settings window: " + ex.toString() + "\r\n");
-    }
+    SwingAction.invokeAndWait(() -> {
+      final JPanel newPanel = new JPanel();
+      final JScrollPane newScrollPane = new JScrollPane();
+      final JTextArea newTextArea = new JTextArea();
+      newTextArea.setColumns(20);
+      newTextArea.setRows(5);
+      newTextArea.setFont(new java.awt.Font("Segoe UI", 0, 10));
+      newTextArea.setEditable(false);
+      newScrollPane.getHorizontalScrollBar().setEnabled(true);
+      newScrollPane.setViewportView(newTextArea);
+      newPanel.setLayout(new GridLayout());
+      newPanel.add(newScrollPane);
+      v_logHolderTabbedPane.addTab(Integer.toString(roundNumber) + "-" + name, newPanel);
+      currentLogTextArea = newTextArea;
+    });
     // Now remove round logging that has 'expired'.
     // Note that this method will also trim all but the first and last log panels if logging is turned off
     // (We always keep first round's log panel, and we keep last because the user might turn logging back on in the
@@ -437,23 +430,16 @@ public class ProLogWindow extends javax.swing.JDialog {
       } else {
         maxHistoryRounds = 1; // If we're not logging, trim to 1
       }
-      try {
-        final Runnable runner = new Runnable() {
-          @Override
-          public void run() {
-            for (int i = 0; i < v_logHolderTabbedPane.getTabCount(); i++) {
-              // Remember, we never remove last tab, in case user turns logging back on in the middle of a round
-              if (i != 0 && i < v_logHolderTabbedPane.getTabCount() - maxHistoryRounds) {
-                // Remove the tab and decrease i by one, so the next component will be checked
-                v_logHolderTabbedPane.removeTabAt(i);
-                i--;
-              }
-            }
+      SwingAction.invokeAndWait(() -> {
+        for (int i = 0; i < v_logHolderTabbedPane.getTabCount(); i++) {
+          // Remember, we never remove last tab, in case user turns logging back on in the middle of a round
+          if (i != 0 && i < v_logHolderTabbedPane.getTabCount() - maxHistoryRounds) {
+            // Remove the tab and decrease i by one, so the next component will be checked
+            v_logHolderTabbedPane.removeTabAt(i);
+            i--;
           }
-        };
-        SwingUtilities.invokeAndWait(runner);
-      } catch (final Exception ex) {
-      }
+        }
+      });
     }
   }
 

--- a/src/games/strategy/triplea/ui/AbstractUIContext.java
+++ b/src/games/strategy/triplea/ui/AbstractUIContext.java
@@ -211,43 +211,40 @@ public abstract class AbstractUIContext implements IUIContext {
 
   protected static void closeWindow(final Window window) {
     window.setVisible(false);
-    SwingUtilities.invokeLater(new Runnable() {
-      @Override
-      public void run() {
-        // Having dispose run on anything but the Swing Event Dispatch Thread is very dangerous.
-        // This is because dispose will call invokeAndWait if it is not on this thread already.
-        // If you are calling this method while holding a lock on an object, while the EDT is separately
-        // waiting for that lock, then you have a deadlock.
-        // A real life example: player disconnects while you have the battle calc open.
-        // Non-EDT thread does shutdown on IGame and UIContext, causing btl calc to shutdown, which calls the
-        // window closed event on the EDT, and waits for the lock on UIContext to removeShutdownWindow, meanwhile
-        // our non-EDT tries to dispose the battle panel, which requires the EDT with a invokeAndWait, resulting in a
-        // deadlock.
-        window.dispose();
-        // there is a bug in java (1.50._06 for linux at least)
-        // where frames are not garbage collected.
-        // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6364875
-        // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6368950
-        // so remove all references to everything
-        // to minimize the damage
-        if (window instanceof JFrame) {
-          final JFrame frame = ((JFrame) window);
-          final JMenuBar menu = frame.getJMenuBar();
-          if (menu != null) {
-            while (menu.getMenuCount() > 0) {
-              menu.remove(0);
-            }
+    SwingUtilities.invokeLater(() -> {
+      // Having dispose run on anything but the Swing Event Dispatch Thread is very dangerous.
+      // This is because dispose will call invokeAndWait if it is not on this thread already.
+      // If you are calling this method while holding a lock on an object, while the EDT is separately
+      // waiting for that lock, then you have a deadlock.
+      // A real life example: player disconnects while you have the battle calc open.
+      // Non-EDT thread does shutdown on IGame and UIContext, causing btl calc to shutdown, which calls the
+      // window closed event on the EDT, and waits for the lock on UIContext to removeShutdownWindow, meanwhile
+      // our non-EDT tries to dispose the battle panel, which requires the EDT with a invokeAndWait, resulting in a
+      // deadlock.
+      window.dispose();
+      // there is a bug in java (1.50._06 for linux at least)
+      // where frames are not garbage collected.
+      // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6364875
+      // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6368950
+      // so remove all references to everything
+      // to minimize the damage
+      if (window instanceof JFrame) {
+        final JFrame frame = ((JFrame) window);
+        final JMenuBar menu = frame.getJMenuBar();
+        if (menu != null) {
+          while (menu.getMenuCount() > 0) {
+            menu.remove(0);
           }
-          frame.setMenuBar(null);
-          frame.setJMenuBar(null);
-          frame.getRootPane().removeAll();
-          frame.getRootPane().setJMenuBar(null);
-          frame.getContentPane().removeAll();
-          frame.getContentPane().setLayout(new BorderLayout());
-          frame.setContentPane(new JPanel());
-          frame.setIconImage(null);
-          clearInputMap(frame.getRootPane());
         }
+        frame.setMenuBar(null);
+        frame.setJMenuBar(null);
+        frame.getRootPane().removeAll();
+        frame.getRootPane().setJMenuBar(null);
+        frame.getContentPane().removeAll();
+        frame.getContentPane().setLayout(new BorderLayout());
+        frame.setContentPane(new JPanel());
+        frame.setIconImage(null);
+        clearInputMap(frame.getRootPane());
       }
     });
   }

--- a/src/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/games/strategy/triplea/ui/BattlePanel.java
@@ -241,61 +241,52 @@ public class BattlePanel extends ActionPanel {
     }
   }
 
-  public void showBattle(final GUID battleID, final Territory location, final String battleTitle,
+  public void showBattle(final GUID battleID, final Territory location,
       final Collection<Unit> attackingUnits, final Collection<Unit> defendingUnits, final Collection<Unit> killedUnits,
       final Collection<Unit> attackingWaitingToDie, final Collection<Unit> defendingWaitingToDie,
-      final Map<Unit, Collection<Unit>> unit_dependents, final PlayerID attacker, final PlayerID defender,
+      final PlayerID attacker, final PlayerID defender,
       final boolean isAmphibious, final BattleType battleType, final Collection<Unit> amphibiousLandAttackers) {
-    try {
-      SwingUtilities.invokeAndWait(new Runnable() {
-        @Override
-        public void run() {
-          if (m_battleDisplay != null) {
-            cleanUpBattleWindow();
-            m_currentBattleDisplayed = null;
-          }
-          if (!getMap().getUIContext().getShowMapOnly()) {
-            m_battleDisplay = new BattleDisplay(getData(), location, attacker, defender, attackingUnits, defendingUnits,
-                killedUnits, attackingWaitingToDie, defendingWaitingToDie, battleID, BattlePanel.this.getMap(),
-                isAmphibious, battleType, amphibiousLandAttackers);
-            m_battleFrame.setTitle(attacker.getName() + " attacks " + defender.getName() + " in " + location.getName());
-            m_battleFrame.getContentPane().removeAll();
-            m_battleFrame.getContentPane().add(m_battleDisplay);
-            m_battleFrame.setSize(800, 600);
-            m_battleFrame.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
-            games.strategy.engine.random.PBEMDiceRoller.setFocusWindow(m_battleFrame);
-            boolean foundHumanInBattle = false;
-            for (final IGamePlayer gamePlayer : getMap().getUIContext().getLocalPlayers().getLocalPlayers()) {
-              if ((gamePlayer.getPlayerID().equals(attacker) && gamePlayer instanceof TripleAPlayer)
-                  || (gamePlayer.getPlayerID().equals(defender) && gamePlayer instanceof TripleAPlayer)) {
-                foundHumanInBattle = true;
-                break;
-              }
-            }
-            if (getMap().getUIContext().getShowBattlesBetweenAIs() || foundHumanInBattle) {
-              m_battleFrame.setVisible(true);
-              m_battleFrame.validate();
-              m_battleFrame.invalidate();
-              m_battleFrame.repaint();
-            } else {
-              m_battleFrame.setVisible(false);
-            }
-            m_battleFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-            m_currentBattleDisplayed = battleID;
-            SwingUtilities.invokeLater(new Runnable() {
-              @Override
-              public void run() {
-                m_battleFrame.toFront();
-              }
-            });
+    SwingAction.invokeAndWait(() -> {
+      if (m_battleDisplay != null) {
+        cleanUpBattleWindow();
+        m_currentBattleDisplayed = null;
+      }
+      if (!getMap().getUIContext().getShowMapOnly()) {
+        m_battleDisplay = new BattleDisplay(getData(), location, attacker, defender, attackingUnits, defendingUnits,
+            killedUnits, attackingWaitingToDie, defendingWaitingToDie, battleID, BattlePanel.this.getMap(),
+            isAmphibious, battleType, amphibiousLandAttackers);
+        m_battleFrame.setTitle(attacker.getName() + " attacks " + defender.getName() + " in " + location.getName());
+        m_battleFrame.getContentPane().removeAll();
+        m_battleFrame.getContentPane().add(m_battleDisplay);
+        m_battleFrame.setSize(800, 600);
+        m_battleFrame.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
+        games.strategy.engine.random.PBEMDiceRoller.setFocusWindow(m_battleFrame);
+        boolean foundHumanInBattle = false;
+        for (final IGamePlayer gamePlayer : getMap().getUIContext().getLocalPlayers().getLocalPlayers()) {
+          if ((gamePlayer.getPlayerID().equals(attacker) && gamePlayer instanceof TripleAPlayer)
+              || (gamePlayer.getPlayerID().equals(defender) && gamePlayer instanceof TripleAPlayer)) {
+            foundHumanInBattle = true;
+            break;
           }
         }
-      });
-    } catch (final InterruptedException e) {
-      e.printStackTrace();
-    } catch (final InvocationTargetException e) {
-      e.printStackTrace();
-    }
+        if (getMap().getUIContext().getShowBattlesBetweenAIs() || foundHumanInBattle) {
+          m_battleFrame.setVisible(true);
+          m_battleFrame.validate();
+          m_battleFrame.invalidate();
+          m_battleFrame.repaint();
+        } else {
+          m_battleFrame.setVisible(false);
+        }
+        m_battleFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+        m_currentBattleDisplayed = battleID;
+        SwingUtilities.invokeLater(new Runnable() {
+          @Override
+          public void run() {
+            m_battleFrame.toFront();
+          }
+        });
+      }
+    });
   }
 
   public FightBattleDetails waitForBattleSelection() {

--- a/src/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/games/strategy/triplea/ui/BattlePanel.java
@@ -28,6 +28,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
+import games.strategy.common.swing.SwingAction;
 import games.strategy.common.swing.SwingComponents;
 import games.strategy.debug.ErrorConsole;
 import games.strategy.engine.data.GameData;

--- a/src/games/strategy/triplea/ui/MapPanel.java
+++ b/src/games/strategy/triplea/ui/MapPanel.java
@@ -101,7 +101,7 @@ public class MapPanel extends ImageScrollerLargeView {
 
   /** Creates new MapPanel */
   public MapPanel(final GameData data, final MapPanelSmallView smallView, final IUIContext uiContext,
-      final ImageScrollModel model) throws IOException {
+      final ImageScrollModel model)  {
     super(uiContext.getMapData().getMapDimensions(), model);
     m_uiContext = uiContext;
     this.setCursor(m_uiContext.getCursor());

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -158,11 +158,7 @@ import games.strategy.triplea.ui.history.HistoryPanel;
 import games.strategy.ui.ImageScrollModel;
 import games.strategy.ui.ScrollableTextField;
 import games.strategy.ui.Util;
-import games.strategy.util.EventThreadJOptionPane;
-import games.strategy.util.IntegerMap;
-import games.strategy.util.LocalizeHTML;
-import games.strategy.util.Match;
-import games.strategy.util.Tuple;
+import games.strategy.util.*;
 
 /**
  * Main frame for the triple a game
@@ -1188,11 +1184,7 @@ public class TripleAFrame extends MainGameFrame {
               dialog.setVisible(false);
               dialog.removeAll();
               dialog.dispose();
-              try {
-                Thread.sleep(500);
-              } catch (final InterruptedException e2) {
-                e2.printStackTrace();
-              }
+              ThreadUtil.sleep(500);
               run();
             }
           }
@@ -1299,11 +1291,7 @@ public class TripleAFrame extends MainGameFrame {
               dialog.setVisible(false);
               dialog.removeAll();
               dialog.dispose();
-              try {
-                Thread.sleep(500);
-              } catch (final InterruptedException e2) {
-                e2.printStackTrace();
-              }
+              ThreadUtil.sleep(500);
               run();
             }
           }
@@ -1396,11 +1384,7 @@ public class TripleAFrame extends MainGameFrame {
               dialog.setVisible(false);
               dialog.removeAll();
               dialog.dispose();
-              try {
-                Thread.sleep(500);
-              } catch (final InterruptedException e2) {
-                e2.printStackTrace();
-              }
+              ThreadUtil.sleep(500);
               run();
             }
           }

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -211,10 +211,12 @@ public class TripleAFrame extends MainGameFrame {
   private Map<PlayerID, Boolean> m_requiredTurnSeries = new HashMap<PlayerID, Boolean>();
   private ThreadPool m_messageAndDialogThreadPool;
   private TripleaMenu m_menu;
+  private LocalPlayers m_localPlayers;
 
   /** Creates new TripleAFrame */
-  public TripleAFrame(final IGame game, final LocalPlayers players) throws IOException {
+  public TripleAFrame(final IGame game, final LocalPlayers players) {
     super("TripleA - " + game.getData().getGameName(), players);
+    m_localPlayers = players;
     m_game = game;
     m_data = game.getData();
     m_messageAndDialogThreadPool = new ThreadPool(1);

--- a/src/games/strategy/triplea/ui/display/TripleaDisplay.java
+++ b/src/games/strategy/triplea/ui/display/TripleaDisplay.java
@@ -31,14 +31,16 @@ public class TripleaDisplay implements ITripleaDisplay {
     m_displayBridge.toString();
   }
 
+  // TODO: unit_dependents and battleTitle are both likely not used, they have been removed
+  // from BattlePane().showBattle( .. ) already
   @Override
   public void showBattle(final GUID battleID, final Territory location, final String battleTitle,
       final Collection<Unit> attackingUnits, final Collection<Unit> defendingUnits, final Collection<Unit> killedUnits,
       final Collection<Unit> attackingWaitingToDie, final Collection<Unit> defendingWaitingToDie,
       final Map<Unit, Collection<Unit>> unit_dependents, final PlayerID attacker, final PlayerID defender,
       final boolean isAmphibious, final BattleType battleType, final Collection<Unit> amphibiousLandAttackers) {
-    m_ui.getBattlePanel().showBattle(battleID, location, battleTitle, attackingUnits, defendingUnits, killedUnits,
-        attackingWaitingToDie, defendingWaitingToDie, unit_dependents, attacker, defender, isAmphibious, battleType,
+    m_ui.getBattlePanel().showBattle(battleID, location, attackingUnits, defendingUnits, killedUnits,
+        attackingWaitingToDie, defendingWaitingToDie, attacker, defender, isAmphibious, battleType,
         amphibiousLandAttackers);
   }
 

--- a/src/games/strategy/ui/Util.java
+++ b/src/games/strategy/ui/Util.java
@@ -14,16 +14,16 @@ import java.awt.Window;
 import java.awt.geom.GeneralPath;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
-import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
+import games.strategy.common.swing.SwingAction;
 import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 
-public class Util {
+public final class Util {
   // all we have is static methods
   private Util() {}
 
@@ -31,37 +31,12 @@ public class Util {
     public T run();
   }
 
-  public static void runInSwingEventThread(final Runnable r) {
-    if (SwingUtilities.isEventDispatchThread()) {
-      r.run();
-    } else {
-      try {
-        SwingUtilities.invokeAndWait(r);
-      } catch (final InterruptedException e) {
-        throw new IllegalStateException(e);
-      } catch (final InvocationTargetException e) {
-        throw new IllegalStateException(e);
-      }
-    }
-  }
-
   public static <T> T runInSwingEventThread(final Task<T> task) {
     if (SwingUtilities.isEventDispatchThread()) {
       return task.run();
     }
     final AtomicReference<T> results = new AtomicReference<T>();
-    try {
-      SwingUtilities.invokeAndWait(new Runnable() {
-        @Override
-        public void run() {
-          results.set(task.run());
-        }
-      });
-    } catch (final InterruptedException e) {
-      throw new IllegalStateException(e);
-    } catch (final InvocationTargetException e) {
-      throw new IllegalStateException(e);
-    }
+    SwingAction.invokeAndWait(() -> results.set(task.run()));
     return results.get();
   }
 

--- a/test/games/strategy/test/TestUtil.java
+++ b/test/games/strategy/test/TestUtil.java
@@ -3,13 +3,13 @@ package games.strategy.test;
 import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 
 import javax.swing.JFrame;
-import javax.swing.SwingUtilities;
 
 import com.google.common.base.Throwables;
 import com.google.common.io.Files;
+
+import games.strategy.common.swing.SwingAction;
 
 public class TestUtil {
 
@@ -56,18 +56,9 @@ public class TestUtil {
    * to the event thread and then blocking until the do-nothing event is done.
    */
   public static void waitForSwingThreads() {
-    try {
-      SwingUtilities.invokeAndWait(new Runnable() {
-        @Override
-        public void run() {
-          // do nothing event, should be at the end of the event queue.
-        }
-      });
-    } catch (InvocationTargetException e) {
-      throw new IllegalStateException(e);
-    } catch (InterruptedException e) {
-      throw new IllegalStateException(e);
-    }
+    // add a no-op action to the end of the swing event queue, and then wait for it
+    SwingAction.invokeAndWait(() -> {
+    });
   }
 
   private static void closeFrame(JFrame frame) {


### PR DESCRIPTION
- Cleanup for TripleA.java
- Add new library method SwingAction.invokeAndWait, simplifies and replaces SwingUtilities.invokeAndWait
- Allow SwingUtilities to check the current thread. We had quite a bit of this pattern:
```
Runnable r = 
if( Swing.eventThread) {
 r.run();
} else {
  SwingUtilities.invokeAndWait(r)
}
```

The cost for a new thread is very cheap these days. So this can be re-written as:
```
Runnable r = ...
SwingUtilities.invokeAndWait(r)
```
Actually, not only is the cost of a new thread expensive, but the current thread check is pretty much what SwingUtilities does, so  wrapping our own is redundant.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/514)
<!-- Reviewable:end -->
