### PR TITLE
Travis updates - experiment to see if we can also build a 'stable' do…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_deploy:
 - chmod +x ./.travis/setup && ./.travis/setup
 - GAME_CONFIG=game_engine.properties
 - ENGINE_VERSION=$(grep "engine_version" $GAME_CONFIG | sed 's/.*= *//g')
-- export TAGGED_VERSION="$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER"
+- if [ $TRAVIS_BRANCH == master ]; then export TAGGED_VERSION="$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER"; else export TAGGED_VERSION="stable"; fi
 - sed -i "s/engine_version.*/engine_version = $TAGGED_VERSION/" $GAME_CONFIG
 - gradle release
 - chmod +x ./.travis/push_tag && ./.travis/push_tag
@@ -40,7 +40,8 @@ deploy:
   skip_cleanup: true
   prerelease: true
   on:
-    repo: triplea-game/triplea
-    tags: true
-    all_branches: true
-    condition: "$TRAVIS_TAG == stable || $TRAVIS_BRANCH == master"
+    tags: false
+    branches:
+      only:
+        - master
+        - stable

--- a/.travis/push_tag
+++ b/.travis/push_tag
@@ -8,5 +8,6 @@ echo "Delete previous tag if it exists, this way we can restart builds and regen
 git tag -d "$TAGGED_VERSION"
 git push origin ":refs/tags/$TAGGED_VERSION"
 
+echo "Push a tag to trigger github releases deployment"
 git tag $TAGGED_VERSION -a -m "$TAGGED_VERSION"
 git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags 2>&1 | sed 's|https://.*github|https://[secure]@github|'


### PR DESCRIPTION
…wnload URL:

- Add echo to travis script to document where/why we are pushing a tag, namely to trigger a github release
- Update .travis.yml to also build a 'stable' branch, which will default the tag pushed to read 'stable'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/524)
<!-- Reviewable:end -->
