### PR TITLE
Revert "[Default Politics Action is No]"

### DIFF
--- a/src/games/strategy/util/EventThreadJOptionPane.java
+++ b/src/games/strategy/util/EventThreadJOptionPane.java
@@ -199,14 +199,7 @@ public class EventThreadJOptionPane {
     SwingUtilities.invokeLater(new Runnable() {
       @Override
       public void run() {
-        String noOption = "No";
-        Object initialValue = noOption;
-        Icon icon = null;
-        Object[] options = {noOption, "Yes"};
-        int selectionValue = JOptionPane.showOptionDialog(parentComponent, message, title , JOptionPane.YES_NO_OPTION,  JOptionPane.QUESTION_MESSAGE,  icon, options, initialValue);
-        // we swapped the meaning of No and Yes, typically it is the other way round, thus we should shift rVal from: 1->0, or: 0->1
-        int correctedValue = (selectionValue + 1) % 2;
-        rVal.set(correctedValue);
+        rVal.set(JOptionPane.showConfirmDialog(parentComponent, message, title, optionType));
         latch.countDown();
       }
     });


### PR DESCRIPTION
Reverts triplea-game/triplea#497

Swapping default dialog action is causing too many downstream effects... Likely a better solution will be to display a piece of 'toast' (custom JFrame pop-above window). Then we can control were the keyboard focus will land, with JDialog we are just stuck with the first button have keyboard focus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/539)
<!-- Reviewable:end -->
