### PR TITLE
AI - Add support for nations with no capital

### DIFF
--- a/src/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -116,7 +116,6 @@ public class ProNonCombatMoveAI {
       while (true) {
 
         // Add value to territories near capital if necessary
-
         for (final Territory t : territoryManager.getDefendTerritories()) {
           double value = territoryValueMap.get(t);
           final int distance =
@@ -131,7 +130,6 @@ public class ProNonCombatMoveAI {
           }
         }
 
-        // Move units to best territories
         moveUnitsToBestTerritories();
 
         // Check if capital has local land superiority
@@ -148,6 +146,8 @@ public class ProNonCombatMoveAI {
           break;
         }
       }
+    } else {
+      moveUnitsToBestTerritories();
     }
 
     // Determine where to move infra units


### PR DESCRIPTION
Add else that just moves units with no capital defense check for when a nation doesn't have a capital (capital == null). Otherwise if you play a map where nations have no capitals it won't move units in noncombat except when defending territories.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/562)
<!-- Reviewable:end -->
