### PR TITLE
Added setUndecorated(true); to WaitDialog.java

### DIFF
--- a/src/games/strategy/engine/framework/ui/background/WaitDialog.java
+++ b/src/games/strategy/engine/framework/ui/background/WaitDialog.java
@@ -18,13 +18,14 @@ public class WaitDialog extends JDialog {
   public WaitDialog(final Component parent, final String waitMessage, final Action cancelAction) {
     super(JOptionPane.getFrameForComponent(parent), "Please Wait", true);
     setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+    setUndecorated(true);
     final WaitPanel panel = new WaitPanel(waitMessage);
-    setLayout(new BorderLayout());
-    add(panel, BorderLayout.CENTER);
+    getContentPane().setLayout(new BorderLayout());
+    getContentPane().add(panel, BorderLayout.CENTER);
     if (cancelAction != null) {
       final JButton cancelButton = new JButton("Cancel");
       cancelButton.addActionListener(cancelAction);
-      add(cancelButton, BorderLayout.SOUTH);
+      getContentPane().add(cancelButton, BorderLayout.SOUTH);
     }
   }
 }


### PR DESCRIPTION
because the loading window is not closable and for style

If you wonder, why the getContentPane thing got added, then ask eclipse why it inserted these lines automatically. As far as I know these should be used - clean coding
I did this because @DanVanAtta wanted it to be like this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/570)
<!-- Reviewable:end -->
