### PR TITLE
Add timing to how long it takes to parse maps from disk

### DIFF
--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -22,6 +22,8 @@ import javax.swing.DefaultListModel;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
+import games.strategy.performance.Perf;
+import games.strategy.performance.PerfTimer;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
@@ -88,18 +90,20 @@ public class NewGameChooserModel extends DefaultListModel {
 
 
   private Set<NewGameChooserEntry> parseMapFiles() {
-    final Set<NewGameChooserEntry> parsedMapSet = Sets.newHashSet();
-    for (final File map : allMapFiles()) {
-      if (clearCacheMessenger.isCancelled()) {
-        return ImmutableSet.of();
+    try(PerfTimer timer = Perf.startTimer("Parse map files")) {
+      final Set<NewGameChooserEntry> parsedMapSet = Sets.newHashSet();
+      for (final File map : allMapFiles()) {
+        if (clearCacheMessenger.isCancelled()) {
+          return ImmutableSet.of();
+        }
+        if (map.isDirectory()) {
+          parsedMapSet.addAll(populateFromDirectory(map));
+        } else if (map.isFile() && map.getName().toLowerCase().endsWith(".zip")) {
+          parsedMapSet.addAll(populateFromZip(map));
+        }
       }
-      if (map.isDirectory()) {
-        parsedMapSet.addAll(populateFromDirectory(map));
-      } else if (map.isFile() && map.getName().toLowerCase().endsWith(".zip")) {
-        parsedMapSet.addAll(populateFromZip(map));
-      }
+      return parsedMapSet;
     }
-    return parsedMapSet;
   }
 
 


### PR DESCRIPTION
Effectively a one line change to add a timer around how long it takes to parse map files.


I downloaded every map available, and obtained the following results:
```
2847.4 ms - Parse map files
2357.2 ms - Parse map files
2202.3 ms - Parse map files
2257.1 ms - Parse map files
2200.6 ms - Parse map files
2184.8 ms - Parse map files
```
My hard disk was upgraded to a relatively fast SSD less than a year ago, I'm curious what timings other people see.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/584)
<!-- Reviewable:end -->
