### PR TITLE
Resolved OSX and Move-calculation warnings

### DIFF
--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -50,9 +50,9 @@ import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.plaf.metal.MetalLookAndFeel;
 
+import com.apple.eawt.AboutHandler;
+import com.apple.eawt.AppEvent.AboutEvent;
 import com.apple.eawt.Application;
-import com.apple.eawt.ApplicationAdapter;
-import com.apple.eawt.ApplicationEvent;
 
 import games.strategy.common.swing.SwingAction;
 import games.strategy.common.swing.SwingComponents;
@@ -378,14 +378,13 @@ public class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> extends JMe
     } else
     // On Mac OS X, put the About menu where Mac users expect it to be
     {
-      Application.getApplication().addApplicationListener(new ApplicationAdapter() {
+      Application.getApplication().setAboutHandler(new AboutHandler(){
         @Override
-        public void handleAbout(final ApplicationEvent event) {
-          // otherwise the default About menu will still show appear
-          event.setHandled(true);
+        public void handleAbout(AboutEvent paramAboutEvent) {
           JOptionPane.showMessageDialog(m_frame, editorPane, "About " + m_frame.getGame().getData().getGameName(),
               JOptionPane.PLAIN_MESSAGE);
         }
+        
       });
     }
   }

--- a/src/games/strategy/common/ui/MacWrapper.java
+++ b/src/games/strategy/common/ui/MacWrapper.java
@@ -1,8 +1,9 @@
 package games.strategy.common.ui;
 
+import com.apple.eawt.AppEvent.QuitEvent;
 import com.apple.eawt.Application;
-import com.apple.eawt.ApplicationAdapter;
-import com.apple.eawt.ApplicationEvent;
+import com.apple.eawt.QuitHandler;
+import com.apple.eawt.QuitResponse;
 
 /**
  * Utility class to wrap Mac OS X-specific shutdown handler.
@@ -15,9 +16,10 @@ public class MacWrapper {
   private static MainGameFrame shutdownFrame;
 
   static {
-    Application.getApplication().addApplicationListener(new ApplicationAdapter() {
+    Application.getApplication().setQuitHandler(new QuitHandler(){
+
       @Override
-      public void handleQuit(final ApplicationEvent event) {
+      public void handleQuitRequestWith(QuitEvent arg0, QuitResponse arg1) {
         if (shutdownFrame != null) {
           shutdownFrame.shutdown();
         } else {

--- a/src/games/strategy/engine/data/Route.java
+++ b/src/games/strategy/engine/data/Route.java
@@ -570,4 +570,12 @@ public class Route implements java.io.Serializable, Iterable<Territory> {
     }
     return ownedFightersOnOwnedCarriers;
   }
+
+  public static Route create(List<Route> routes) {
+    Route route = new Route();
+    for(Route r : routes){
+      route = Route.join(route, r);
+    }
+    return route;
+  }
 }

--- a/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -366,7 +366,7 @@ public class DownloadMapsWindow extends JFrame {
   }
 
   private static ActionListener removeAction(JList<String> gamesList, List<DownloadFileDescription> maps,
-      DefaultListModel listModel) {//TODO change FSAS.remove so that it uses DefaultListModel<String> instead.
+      DefaultListModel<String> listModel) {
     return (e) -> {
       final List<String> selectedValues = gamesList.getSelectedValuesList();
       final List<DownloadFileDescription> selectedMaps =

--- a/src/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/src/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -33,14 +33,14 @@ public class FileSystemAccessStrategy {
     }
   }
 
-  public static void remove(List<DownloadFileDescription> toRemove, DefaultListModel<DownloadFileDescription> listModel) {
+  public static void remove(List<DownloadFileDescription> toRemove, DefaultListModel<String> listModel) {
     SwingComponents.promptUser("Remove Maps?",
         "<html>Will remove " + toRemove.size() + " maps, are you sure? <br/>"
             + formatMapList(toRemove, map -> map.getMapName()) + "</html>",
         createRemoveMapAction(toRemove, listModel));
   }
 
-  private static Runnable createRemoveMapAction(List<DownloadFileDescription> maps, DefaultListModel<DownloadFileDescription> listModel) {
+  private static Runnable createRemoveMapAction(List<DownloadFileDescription> maps, DefaultListModel<String> listModel) {
     return () -> {
       List<DownloadFileDescription> fails = Lists.newArrayList();
       List<DownloadFileDescription> deletes = Lists.newArrayList();

--- a/src/games/strategy/engine/lobby/client/ui/MacLobbyWrapper.java
+++ b/src/games/strategy/engine/lobby/client/ui/MacLobbyWrapper.java
@@ -16,7 +16,7 @@ public class MacLobbyWrapper {
     // new Application();
     Application.getApplication().setQuitHandler(new QuitHandler(){
       @Override
-      public void handleQuitRequestWith(QuitEvent arg0, QuitResponse arg1) {
+      public void handleQuitRequestWith(QuitEvent quitEvent, QuitResponse quitResponse) {
         if (frame != null) {
           frame.shutdown();
         } else {

--- a/src/games/strategy/engine/lobby/client/ui/MacLobbyWrapper.java
+++ b/src/games/strategy/engine/lobby/client/ui/MacLobbyWrapper.java
@@ -1,8 +1,9 @@
 package games.strategy.engine.lobby.client.ui;
 
+import com.apple.eawt.AppEvent.QuitEvent;
 import com.apple.eawt.Application;
-import com.apple.eawt.ApplicationAdapter;
-import com.apple.eawt.ApplicationEvent;
+import com.apple.eawt.QuitHandler;
+import com.apple.eawt.QuitResponse;
 
 /**
  * TODO This class should be merged with games.strategy.common.ui.MacWrapper.
@@ -13,10 +14,9 @@ public class MacLobbyWrapper {
   // i think the java validator triggers this
   public static void registerMacShutdownHandler(final LobbyFrame frame) {
     // new Application();
-    final Application application = Application.getApplication();
-    application.addApplicationListener(new ApplicationAdapter() {
+    Application.getApplication().setQuitHandler(new QuitHandler(){
       @Override
-      public void handleQuit(final ApplicationEvent event) {
+      public void handleQuitRequestWith(QuitEvent arg0, QuitResponse arg1) {
         if (frame != null) {
           frame.shutdown();
         } else {

--- a/src/games/strategy/triplea/ai/proAI/ProBidAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProBidAI.java
@@ -1765,11 +1765,11 @@ public class ProBidAI {
             continue;
           }
           for (final Unit u : neighbor.getUnits()) {
-            Route r1 = new Route();
+            Route route1 = new Route();
             for (Route r : routes){
-              r1 = Route.join(r1,r);
+              route1 = Route.join(route1,r);
             }
-            if (unitCondition.match(u) && Matches.UnitHasEnoughMovementForRoute(r1).match(u)) {
+            if (unitCondition.match(u) && Matches.UnitHasEnoughMovementForRoute(route1).match(u)) {
               units.add(u);
             }
           }

--- a/src/games/strategy/triplea/ai/proAI/ProBidAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProBidAI.java
@@ -1765,7 +1765,11 @@ public class ProBidAI {
             continue;
           }
           for (final Unit u : neighbor.getUnits()) {
-            if (unitCondition.match(u) && MoveValidator.hasEnoughMovement(u, dist)) {
+            Route r1 = new Route();
+            for (Route r : routes){
+              r1 = Route.join(r1,r);
+            }
+            if (unitCondition.match(u) && Matches.UnitHasEnoughMovementForRoute(r1).match(u)) {
               units.add(u);
             }
           }
@@ -1837,10 +1841,10 @@ public class ProBidAI {
       }
     }
     for (final Unit u : unitDistance.keySet()) {
-      if (lz != null && MoveValidator.hasEnoughMovement(u, unitDistance.getInt(u) + distance.getInt(lz))) {
+      if (lz != null && Matches.UnitHasEnoughMovementForRoute(new Route(checked)).match(u)) {
         units.add(u);
       } else if (ac != null && Matches.UnitCanLandOnCarrier.match(u)
-          && MoveValidator.hasEnoughMovement(u, unitDistance.getInt(u) + distance.getInt(ac))) {
+          && Matches.UnitHasEnoughMovementForRoute(new Route(checked)).match(u)) {
         units.add(u);
       }
     }

--- a/src/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -429,7 +429,11 @@ public final class ProTechAI {
             continue;
           }
           for (final Unit u : neighbor.getUnits()) {
-            if (unitCondition.match(u) && MoveValidator.hasEnoughMovement(u, dist)) {
+            Route r1 = new Route();
+            for(Route r : routes){
+              r1 = Route.join(r1, r);
+            }
+            if (unitCondition.match(u) && Matches.UnitHasEnoughMovementForRoute(r1).match(u)) {
               units.add(u);
             }
           }
@@ -501,10 +505,10 @@ public final class ProTechAI {
       }
     }
     for (final Unit u : unitDistance.keySet()) {
-      if (lz != null && MoveValidator.hasEnoughMovement(u, unitDistance.getInt(u) + distance.getInt(lz))) {
+      if (lz != null && Matches.UnitHasEnoughMovementForRoute(new Route(checked)).match(u)) {
         units.add(u);
       } else if (ac != null && Matches.UnitCanLandOnCarrier.match(u)
-          && MoveValidator.hasEnoughMovement(u, unitDistance.getInt(u) + distance.getInt(ac))) {
+          && Matches.UnitHasEnoughMovementForRoute(new Route(checked)).match(u)) {
         units.add(u);
       }
     }

--- a/src/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -429,11 +429,7 @@ public final class ProTechAI {
             continue;
           }
           for (final Unit u : neighbor.getUnits()) {
-            Route r1 = new Route();
-            for(Route r : routes){
-              r1 = Route.join(r1, r);
-            }
-            if (unitCondition.match(u) && Matches.UnitHasEnoughMovementForRoute(r1).match(u)) {
+            if (unitCondition.match(u) && Matches.UnitHasEnoughMovementForRoutes(routes).match(u)) {
               units.add(u);
             }
           }
@@ -505,10 +501,10 @@ public final class ProTechAI {
       }
     }
     for (final Unit u : unitDistance.keySet()) {
-      if (lz != null && Matches.UnitHasEnoughMovementForRoute(new Route(checked)).match(u)) {
+      if (lz != null && Matches.UnitHasEnoughMovementForRoute(checked).match(u)) {
         units.add(u);
       } else if (ac != null && Matches.UnitCanLandOnCarrier.match(u)
-          && Matches.UnitHasEnoughMovementForRoute(new Route(checked)).match(u)) {
+          && Matches.UnitHasEnoughMovementForRoute(checked).match(u)) {
         units.add(u);
       }
     }

--- a/src/games/strategy/triplea/delegate/Matches.java
+++ b/src/games/strategy/triplea/delegate/Matches.java
@@ -1735,7 +1735,15 @@ public class Matches {
       }
     };
   }
-
+  
+  public static Match<Unit> UnitHasEnoughMovementForRoutes(List<Route> route) {
+    return UnitHasEnoughMovementForRoute(Route.create(route));
+  }
+  
+  public static Match<Unit> UnitHasEnoughMovementForRoute(List<Territory> territories) {
+    return UnitHasEnoughMovementForRoute(new Route(territories));
+  }
+  
   public static Match<Unit> UnitHasEnoughMovementForRoute(final Route route) {
     return new Match<Unit>() {
       @Override


### PR DESCRIPTION
The only warnings left are because of FileSystemAccessStrategy.remove() and SoftJEditorPane.
If someone told me on what to use instead / how to edit the remove() method I would do this in another pull request...
I'm not sure if these changes work like expected - Someone owning a mac would need to check that part, but I'm mostly concerned about the move calculation part. Since some methods don't seem to be called, I cant check if my changes work - seems to work fine until now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/609)
<!-- Reviewable:end -->
