### PR TITLE
Fixes "duplicate" Map error

### DIFF
--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -87,8 +87,10 @@ public class ResourceLoader {
     candidates.add(new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps", zipName));
 
     String normalizedZipName = normalizeMapZipName(zipName);
-    candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), normalizedZipName));
-
+    
+    if(!normalizedZipName.equals(zipName)){
+      candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), normalizedZipName));
+    }
 
     final Collection<File> existing = Match.getMatches(candidates, new Match<File>() {
       @Override


### PR DESCRIPTION
When a Map name was "normalized" - it was writte lowercase and without spaces normalizedzipname would be equals zipname causing candidates to have duplicate files with the exact same name.

Checking if normalizedZipName.equals(zipname) avoids this, so that the normalized zip name is only added, when the to strings differ.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/620)
<!-- Reviewable:end -->
