### PR TITLE
Added Look and Feel Suport for Map Creator

### DIFF
--- a/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -25,7 +25,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
-import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 
 import games.strategy.common.swing.SwingAction;
@@ -369,7 +368,6 @@ public class EnginePreferences extends JDialog {
         ProcessRunnerUtil.populateBasicJavaArgs(commands);
         final String javaClass = "util.image.MapCreator";
         commands.add(javaClass);
-        commands.add(UIManager.getLookAndFeel().getClass().getName());
         ProcessRunnerUtil.exec(commands);
 
     }));

--- a/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -25,6 +25,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
+import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 
 import games.strategy.common.swing.SwingAction;
@@ -368,6 +369,7 @@ public class EnginePreferences extends JDialog {
         ProcessRunnerUtil.populateBasicJavaArgs(commands);
         final String javaClass = "util.image.MapCreator";
         commands.add(javaClass);
+        commands.add(UIManager.getLookAndFeel().getClass().getName());
         ProcessRunnerUtil.exec(commands);
 
     }));

--- a/src/util/image/MapCreator.java
+++ b/src/util/image/MapCreator.java
@@ -31,6 +31,7 @@ import javax.swing.UnsupportedLookAndFeelException;
 
 import games.strategy.common.swing.SwingAction;
 import games.strategy.common.swing.SwingComponents;
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.ProcessRunnerUtil;
 import games.strategy.net.DesktopUtilityBrowserLauncher;

--- a/src/util/image/MapCreator.java
+++ b/src/util/image/MapCreator.java
@@ -26,13 +26,11 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 
 import games.strategy.common.swing.SwingAction;
 import games.strategy.common.swing.SwingComponents;
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.engine.framework.GameRunner2;
 import games.strategy.engine.framework.ProcessRunnerUtil;
 import games.strategy.net.DesktopUtilityBrowserLauncher;
 import games.strategy.triplea.UrlConstants;
@@ -69,14 +67,7 @@ public class MapCreator extends JFrame {
   }
 
   public static void main(final String[] args) {
-      try {
-        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());//Fallback Look and Feel
-      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-          | UnsupportedLookAndFeelException e) {
-        ClientLogger.logError("Default Look and Feel could not be applied:" + e.getMessage());
-      }
-    
-    handleCommandLineArgs(args);
+    GameRunner2.setupLookAndFeel();
     final MapCreator creator = new MapCreator();
     creator.setSize(800, 600);
     creator.setLocationRelativeTo(null);
@@ -542,16 +533,5 @@ public class MapCreator extends JFrame {
     commands.add(javaClass);
     ProcessRunnerUtil.exec(commands);
     // example: java -classpath triplea.jar -Dtriplea.map.folder="C:/Users" util/image/CenterPicker
-  }
-
-  private static void handleCommandLineArgs(final String[] args) {
-    if(args.length == 1){
-      try {
-        UIManager.setLookAndFeel(args[0]);
-      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-          | UnsupportedLookAndFeelException e) {
-        ClientLogger.logError("Look and feel could not be applied to the Map Creator:" + e.getMessage());
-      }
-    }
   }
 }

--- a/src/util/image/MapCreator.java
+++ b/src/util/image/MapCreator.java
@@ -26,6 +26,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
 import games.strategy.common.swing.SwingAction;
 import games.strategy.common.swing.SwingComponents;
@@ -544,7 +546,29 @@ public class MapCreator extends JFrame {
 
   private static void handleCommandLineArgs(final String[] args) {
     final String[] properties = getProperties();
-    if (args.length == 1) {
+    
+      try {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());//Fallback Look and Feel
+      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+          | UnsupportedLookAndFeelException e) {
+        ClientLogger.logError("Default Look and Feel could not be applied", e);
+      }
+    
+    boolean laf = false;
+    
+    if(args.length == 1){
+      try {
+        UIManager.setLookAndFeel(args[0]);
+        laf = true;
+      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+          | UnsupportedLookAndFeelException e) {
+        ClientLogger.logError("Look and feel could not be applied to the Map Creator", e);
+      } catch(ClassCastException e){
+        ClientLogger.logQuietly("Argument is not a Look and Feel");
+      }
+    }
+    
+    if (args.length == 1 && !laf) {
       String value;
       if (args[0].startsWith(TRIPLEA_MAP_FOLDER)) {
         value = getValue(args[0]);

--- a/src/util/image/MapCreator.java
+++ b/src/util/image/MapCreator.java
@@ -555,7 +555,6 @@ public class MapCreator extends JFrame {
       }
     
     boolean laf = false;
-    
     if(args.length == 1){
       try {
         UIManager.setLookAndFeel(args[0]);

--- a/src/util/image/MapCreator.java
+++ b/src/util/image/MapCreator.java
@@ -69,6 +69,13 @@ public class MapCreator extends JFrame {
   }
 
   public static void main(final String[] args) {
+      try {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());//Fallback Look and Feel
+      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+          | UnsupportedLookAndFeelException e) {
+        ClientLogger.logError("Default Look and Feel could not be applied", e);
+      }
+    
     handleCommandLineArgs(args);
     final MapCreator creator = new MapCreator();
     creator.setSize(800, 600);
@@ -547,14 +554,6 @@ public class MapCreator extends JFrame {
 
   private static void handleCommandLineArgs(final String[] args) {
     final String[] properties = getProperties();
-    
-      try {
-        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());//Fallback Look and Feel
-      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
-          | UnsupportedLookAndFeelException e) {
-        ClientLogger.logError("Default Look and Feel could not be applied", e);
-      }
-    
     boolean laf = false;
     if(args.length == 1){
       try {

--- a/src/util/image/MapCreator.java
+++ b/src/util/image/MapCreator.java
@@ -544,104 +544,13 @@ public class MapCreator extends JFrame {
     // example: java -classpath triplea.jar -Dtriplea.map.folder="C:/Users" util/image/CenterPicker
   }
 
-  private static String getValue(final String arg) {
-    final int index = arg.indexOf('=');
-    if (index == -1) {
-      return "";
-    }
-    return arg.substring(index + 1);
-  }
-
   private static void handleCommandLineArgs(final String[] args) {
-    final String[] properties = getProperties();
-    boolean laf = false;
     if(args.length == 1){
       try {
         UIManager.setLookAndFeel(args[0]);
-        laf = true;
       } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
           | UnsupportedLookAndFeelException e) {
-        ClientLogger.logError("Look and feel could not be applied to the Map Creator", e);
-      } catch(ClassCastException e){
-        ClientLogger.logQuietly("Argument is not a Look and Feel");
-      }
-    }
-    
-    if (args.length == 1 && !laf) {
-      String value;
-      if (args[0].startsWith(TRIPLEA_MAP_FOLDER)) {
-        value = getValue(args[0]);
-      } else {
-        value = args[0];
-      }
-      final File mapFolder = new File(value);
-      if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
-      } else {
-        System.out.println("Could not find directory: " + value);
-      }
-    }
-    boolean usagePrinted = false;
-    for (final String arg2 : args) {
-      boolean found = false;
-      String arg = arg2;
-      final int indexOf = arg.indexOf('=');
-      if (indexOf > 0) {
-        arg = arg.substring(0, indexOf);
-        for (final String propertie : properties) {
-          if (arg.equals(propertie)) {
-            final String value = getValue(arg2);
-            System.getProperties().setProperty(propertie, value);
-            System.out.println(propertie + ":" + value);
-            found = true;
-            break;
-          }
-        }
-      }
-      if (!found) {
-        System.out.println("Unrecogized:" + arg2);
-        if (!usagePrinted) {
-          usagePrinted = true;
-          System.out.println("Arguments\r\n" + "   " + TRIPLEA_MAP_FOLDER + "=<FILE_PATH>\r\n" + "   "
-              + TRIPLEA_UNIT_ZOOM + "=<UNIT_ZOOM_LEVEL>\r\n" + "   " + TRIPLEA_UNIT_WIDTH + "=<UNIT_WIDTH>\r\n" + "   "
-              + TRIPLEA_UNIT_HEIGHT + "=<UNIT_HEIGHT>\r\n");
-        }
-      }
-    }
-    final String folderString = System.getProperty(TRIPLEA_MAP_FOLDER);
-    if (folderString != null && folderString.length() > 0) {
-      final File mapFolder = new File(folderString);
-      if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
-      } else {
-        System.out.println("Could not find directory: " + folderString);
-      }
-    }
-    final String zoomString = System.getProperty(TRIPLEA_UNIT_ZOOM);
-    if (zoomString != null && zoomString.length() > 0) {
-      try {
-        s_unit_zoom = Double.parseDouble(zoomString);
-        System.out.println("Unit Zoom Percent to use: " + s_unit_zoom);
-      } catch (final Exception ex) {
-        System.err.println("Not a decimal percentage: " + zoomString);
-      }
-    }
-    final String widthString = System.getProperty(TRIPLEA_UNIT_WIDTH);
-    if (widthString != null && widthString.length() > 0) {
-      try {
-        s_unit_width = Integer.parseInt(widthString);
-        System.out.println("Unit Width to use: " + s_unit_width);
-      } catch (final Exception ex) {
-        System.err.println("Not an integer: " + widthString);
-      }
-    }
-    final String heightString = System.getProperty(TRIPLEA_UNIT_HEIGHT);
-    if (heightString != null && heightString.length() > 0) {
-      try {
-        s_unit_height = Integer.parseInt(heightString);
-        System.out.println("Unit Height to use: " + s_unit_height);
-      } catch (final Exception ex) {
-        System.err.println("Not an integer: " + heightString);
+        ClientLogger.logError("Look and feel could not be applied to the Map Creator" + e.getMessage());
       }
     }
   }

--- a/src/util/image/MapCreator.java
+++ b/src/util/image/MapCreator.java
@@ -73,7 +73,7 @@ public class MapCreator extends JFrame {
         UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());//Fallback Look and Feel
       } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
           | UnsupportedLookAndFeelException e) {
-        ClientLogger.logError("Default Look and Feel could not be applied", e);
+        ClientLogger.logError("Default Look and Feel could not be applied:" + e.getMessage());
       }
     
     handleCommandLineArgs(args);
@@ -550,7 +550,7 @@ public class MapCreator extends JFrame {
         UIManager.setLookAndFeel(args[0]);
       } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
           | UnsupportedLookAndFeelException e) {
-        ClientLogger.logError("Look and feel could not be applied to the Map Creator" + e.getMessage());
+        ClientLogger.logError("Look and feel could not be applied to the Map Creator:" + e.getMessage());
       }
     }
   }


### PR DESCRIPTION
One thing I realized... the Map creator is accepting arguments on startup, but the class firing the start of the map Crator passes no  arguments -> the only way passing those arguments is by manually starting the Map Creator class via command line (once the final jar file is built) which is not likely to be done by an user.

If you agree, I could simply remove this argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/621)
<!-- Reviewable:end -->
