### PR TITLE
Improve Territory Name Placement

### DIFF
--- a/src/games/strategy/triplea/ui/MapData.java
+++ b/src/games/strategy/triplea/ui/MapData.java
@@ -8,7 +8,6 @@ import games.strategy.util.PointFileReaderWriter;
 
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
@@ -698,50 +697,6 @@ public class MapData {
       boundingRect.translate(0, mapHeight);
     }
     return boundingRect;
-  }
-
-  /**
-   * Find the best rectangle inside the territory to place the name in. Finds the rectangle
-   * that can fit the name, that is the closest to the vertical center, and has a large width at
-   * that location. If there isn't any rectangles that can fit the name then default back to the
-   * bounding rectangle.
-   */
-  public Rectangle getBestTerritoryNameRect(final Territory territory, final FontMetrics fontMetrics) {
-    final Rectangle territoryBounds = getBoundingRect(territory);
-    Rectangle maxRectangle = territoryBounds;
-    final int minX = territoryBounds.x;
-    final int minY = territoryBounds.y;
-    final int maxX = minX + territoryBounds.width;
-    final int maxY = minY + territoryBounds.height;
-    final int centerY = minY + territoryBounds.height / 2;
-    final List<Polygon> polygons = m_polys.get(territory.getName());
-    final int minWidth = fontMetrics.stringWidth(territory.getName());
-    final int increment = fontMetrics.getAscent();
-    int maxScore = 0;
-    for (int startX = minX; startX < maxX - increment; startX += increment) {
-      for (int startY = minY; startY < maxY - increment; startY += increment) {
-        for (int endX = maxX; endX > startX; endX -= increment) {
-          final Rectangle current = new Rectangle(startX, startY, endX - startX, increment);
-          final int verticalFromEdge = territoryBounds.height / 2 - Math.abs(centerY - (startY + increment));
-          final int score = verticalFromEdge * current.width;
-          if (current.width > minWidth && score > maxScore) {
-            boolean isContained = false;
-            for (final Polygon polygon : polygons) {
-              if (polygon.contains(current)) {
-                maxScore = score;
-                maxRectangle = current;
-                isContained = true;
-                break;
-              }
-            }
-            if (isContained) {
-              break;
-            }
-          }
-        }
-      }
-    }
-    return maxRectangle;
   }
 
   /**

--- a/src/games/strategy/triplea/ui/MapData.java
+++ b/src/games/strategy/triplea/ui/MapData.java
@@ -706,17 +706,17 @@ public class MapData {
    * that location. If there isn't any rectangles that can fit the name then default back to the
    * bounding rectangle.
    */
-  public Rectangle getBestTerritoryNameRect(final Territory t, final FontMetrics fm) {
-    final Rectangle territoryBounds = getBoundingRect(t);
+  public Rectangle getBestTerritoryNameRect(final Territory territory, final FontMetrics fontMetrics) {
+    final Rectangle territoryBounds = getBoundingRect(territory);
     Rectangle maxRectangle = territoryBounds;
     final int minX = territoryBounds.x;
     final int minY = territoryBounds.y;
     final int maxX = minX + territoryBounds.width;
     final int maxY = minY + territoryBounds.height;
     final int centerY = minY + territoryBounds.height / 2;
-    final List<Polygon> polygons = m_polys.get(t.getName());
-    final int minWidth = fm.stringWidth(t.getName());
-    final int increment = fm.getAscent();
+    final List<Polygon> polygons = m_polys.get(territory.getName());
+    final int minWidth = fontMetrics.stringWidth(territory.getName());
+    final int increment = fontMetrics.getAscent();
     int maxScore = 0;
     for (int startX = minX; startX < maxX - increment; startX += increment) {
       for (int startY = minY; startY < maxY - increment; startY += increment) {

--- a/src/games/strategy/triplea/ui/MapData.java
+++ b/src/games/strategy/triplea/ui/MapData.java
@@ -90,8 +90,7 @@ public class MapData {
   public static final String DECORATIONS_FILE = "decorations.txt";
   // default colour if none is defined.
   private final List<Color> m_defaultColours = new ArrayList<Color>(Arrays.asList(new Color[] {Color.RED,
-      Color.MAGENTA,
-      Color.YELLOW, Color.ORANGE, Color.CYAN, Color.GREEN, Color.PINK, Color.GRAY}));
+      Color.MAGENTA, Color.YELLOW, Color.ORANGE, Color.CYAN, Color.GREEN, Color.PINK, Color.GRAY}));
   // maps PlayerName as String to Color
   private final Map<String, Color> m_playerColors = new HashMap<String, Color>();
   // maps String -> List of points

--- a/src/games/strategy/triplea/ui/screen/IDrawable.java
+++ b/src/games/strategy/triplea/ui/screen/IDrawable.java
@@ -201,10 +201,12 @@ class TerritoryNameDrawable implements IDrawable {
     for (int x = territoryBounds.x; x < maxX - increment; x += increment) {
       for (int y = territoryBounds.y; y < maxY - increment; y += increment) {
         for (int endX = maxX; endX > x; endX -= increment) {
-
-          // Find current rectangle then 'score' based on how close to vertical center and width
           final Rectangle current = new Rectangle(x, y, endX - x, increment);
+
+          // Ranges from 0 when at very top or bottom of territory to height/2 when at vertical center
           final int verticalDistanceFromEdge = territoryBounds.height / 2 - Math.abs(centerY - y - increment);
+
+          // Score rectangle based on how close to vertical center and territory width at location
           final int score = verticalDistanceFromEdge * current.width;
           if (current.width > minWidth && score > maxScore) {
 

--- a/src/games/strategy/triplea/ui/screen/IDrawable.java
+++ b/src/games/strategy/triplea/ui/screen/IDrawable.java
@@ -192,28 +192,26 @@ class TerritoryNameDrawable implements IDrawable {
   private Rectangle getBestTerritoryNameRect(final MapData mapData, final Territory territory,
       final FontMetrics fontMetrics) {
     final Rectangle territoryBounds = mapData.getBoundingRect(territory);
-    Rectangle maxRectangle = territoryBounds;
-    final int minX = territoryBounds.x;
-    final int minY = territoryBounds.y;
-    final int maxX = minX + territoryBounds.width;
-    final int maxY = minY + territoryBounds.height;
-    final int centerY = minY + territoryBounds.height / 2;
-    final List<Polygon> polygons = mapData.getPolygons(territory.getName());
+    Rectangle result = territoryBounds;
+    final int maxX = territoryBounds.x + territoryBounds.width;
+    final int maxY = territoryBounds.y + territoryBounds.height;
+    final int centerY = territoryBounds.y + territoryBounds.height / 2;
     final int minWidth = fontMetrics.stringWidth(territory.getName());
     final int increment = fontMetrics.getAscent();
     int maxScore = 0;
-    for (int startX = minX; startX < maxX - increment; startX += increment) {
-      for (int startY = minY; startY < maxY - increment; startY += increment) {
+    for (int startX = territoryBounds.x; startX < maxX - increment; startX += increment) {
+      for (int startY = territoryBounds.y; startY < maxY - increment; startY += increment) {
         for (int endX = maxX; endX > startX; endX -= increment) {
           final Rectangle current = new Rectangle(startX, startY, endX - startX, increment);
           final int verticalFromEdge = territoryBounds.height / 2 - Math.abs(centerY - (startY + increment));
           final int score = verticalFromEdge * current.width;
           if (current.width > minWidth && score > maxScore) {
             boolean isContained = false;
+            final List<Polygon> polygons = mapData.getPolygons(territory.getName());
             for (final Polygon polygon : polygons) {
               if (polygon.contains(current)) {
                 maxScore = score;
-                maxRectangle = current;
+                result = current;
                 isContained = true;
                 break;
               }
@@ -225,7 +223,7 @@ class TerritoryNameDrawable implements IDrawable {
         }
       }
     }
-    return maxRectangle;
+    return result;
   }
 
   private void draw(final Rectangle bounds, final Graphics2D graphics, final int x, final int y, final Image img,

--- a/src/games/strategy/triplea/ui/screen/IDrawable.java
+++ b/src/games/strategy/triplea/ui/screen/IDrawable.java
@@ -191,6 +191,8 @@ class TerritoryNameDrawable implements IDrawable {
    */
   private Rectangle getBestTerritoryNameRect(final MapData mapData, final Territory territory,
       final FontMetrics fontMetrics) {
+
+    // Find bounding rectangle and use to create parameters for a grid across the territory
     final Rectangle territoryBounds = mapData.getBoundingRect(territory);
     Rectangle result = territoryBounds;
     final int maxX = territoryBounds.x + territoryBounds.width;
@@ -199,13 +201,19 @@ class TerritoryNameDrawable implements IDrawable {
     final int minWidth = fontMetrics.stringWidth(territory.getName());
     final int increment = fontMetrics.getAscent();
     int maxScore = 0;
+
+    // Loop through the grid moving the starting point and determining max width at that point
     for (int startX = territoryBounds.x; startX < maxX - increment; startX += increment) {
       for (int startY = territoryBounds.y; startY < maxY - increment; startY += increment) {
         for (int endX = maxX; endX > startX; endX -= increment) {
+
+          // Find current rectangle and the 'score' based on how close to vertical center and width
           final Rectangle current = new Rectangle(startX, startY, endX - startX, increment);
           final int verticalFromEdge = territoryBounds.height / 2 - Math.abs(centerY - (startY + increment));
           final int score = verticalFromEdge * current.width;
           if (current.width > minWidth && score > maxScore) {
+
+            // Check to make sure rectangle is contained in the territory
             boolean isContained = false;
             final List<Polygon> polygons = mapData.getPolygons(territory.getName());
             for (final Polygon polygon : polygons) {

--- a/src/games/strategy/triplea/ui/screen/IDrawable.java
+++ b/src/games/strategy/triplea/ui/screen/IDrawable.java
@@ -1,5 +1,19 @@
 package games.strategy.triplea.ui.screen;
 
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.TerritoryEffect;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.TripleAUnit;
+import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.formatter.MyFormatter;
+import games.strategy.triplea.image.MapImage;
+import games.strategy.triplea.image.TileImageFactory;
+import games.strategy.triplea.ui.IUIContext;
+import games.strategy.triplea.ui.MapData;
+import games.strategy.triplea.util.Stopwatch;
+
 import java.awt.Color;
 import java.awt.FontMetrics;
 import java.awt.GradientPaint;
@@ -18,20 +32,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.PlayerID;
-import games.strategy.engine.data.Territory;
-import games.strategy.engine.data.TerritoryEffect;
-import games.strategy.engine.data.Unit;
-import games.strategy.triplea.TripleAUnit;
-import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.triplea.image.MapImage;
-import games.strategy.triplea.image.TileImageFactory;
-import games.strategy.triplea.ui.IUIContext;
-import games.strategy.triplea.ui.MapData;
-import games.strategy.triplea.util.Stopwatch;
 
 public interface IDrawable {
   public Logger s_logger = Logger.getLogger(IDrawable.class.getName());
@@ -128,26 +128,29 @@ class TerritoryNameDrawable implements IDrawable {
         return;
       }
     }
-    final Rectangle territoryBounds = mapData.getBoundingRect(territory);
+
+    // get font metrics
     graphics.setFont(MapImage.getPropertyMapFont());
     graphics.setColor(MapImage.getPropertyTerritoryNameAndPUAndCommentcolor());
     final FontMetrics fm = graphics.getFontMetrics();
+
+    // if we specify a placement point, use it otherwise try to center it
     int x;
     int y;
-    // if we specify a placement point, use it
-    // otherwise, put it in the center
     final Point namePlace = mapData.getNamePlacementPoint(territory);
     if (namePlace == null) {
+      final Rectangle territoryBounds = mapData.getBestTerritoryNameRect(territory, fm);
       x = territoryBounds.x;
       y = territoryBounds.y;
-      x += (int) territoryBounds.getWidth() >> 1;
-      y += (int) territoryBounds.getHeight() >> 1;
-      x -= fm.stringWidth(territory.getName()) >> 1;
-      y += fm.getAscent() >> 1;
+      x += (int) territoryBounds.getWidth() / 2;
+      y += (int) territoryBounds.getHeight() / 2;
+      x -= fm.stringWidth(territory.getName()) / 2;
+      y += fm.getAscent() / 2;
     } else {
       x = namePlace.x;
       y = namePlace.y;
     }
+
     // draw comments above names
     if (showComments && drawComments && commentText != null) {
       final Point place = mapData.getCommentMarkerLocation(territory);

--- a/src/games/strategy/triplea/ui/screen/IDrawable.java
+++ b/src/games/strategy/triplea/ui/screen/IDrawable.java
@@ -129,7 +129,6 @@ class TerritoryNameDrawable implements IDrawable {
       }
     }
 
-    // get font metrics
     graphics.setFont(MapImage.getPropertyMapFont());
     graphics.setColor(MapImage.getPropertyTerritoryNameAndPUAndCommentcolor());
     final FontMetrics fm = graphics.getFontMetrics();
@@ -140,12 +139,8 @@ class TerritoryNameDrawable implements IDrawable {
     final Point namePlace = mapData.getNamePlacementPoint(territory);
     if (namePlace == null) {
       final Rectangle territoryBounds = getBestTerritoryNameRect(mapData, territory, fm);
-      x = territoryBounds.x;
-      y = territoryBounds.y;
-      x += (int) territoryBounds.getWidth() / 2;
-      y += (int) territoryBounds.getHeight() / 2;
-      x -= fm.stringWidth(territory.getName()) / 2;
-      y += fm.getAscent() / 2;
+      x = territoryBounds.x + (int) territoryBounds.getWidth() / 2 - fm.stringWidth(territory.getName()) / 2;
+      y = territoryBounds.y + (int) territoryBounds.getHeight() / 2 + fm.getAscent() / 2;
     } else {
       x = namePlace.x;
       y = namePlace.y;
@@ -203,14 +198,14 @@ class TerritoryNameDrawable implements IDrawable {
     int maxScore = 0;
 
     // Loop through the grid moving the starting point and determining max width at that point
-    for (int leftX = territoryBounds.x; leftX < maxX - increment; leftX += increment) {
-      for (int topY = territoryBounds.y; topY < maxY - increment; topY += increment) {
-        for (int rightX = maxX; rightX > leftX; rightX -= increment) {
+    for (int x = territoryBounds.x; x < maxX - increment; x += increment) {
+      for (int y = territoryBounds.y; y < maxY - increment; y += increment) {
+        for (int endX = maxX; endX > x; endX -= increment) {
 
-          // Find current rectangle and the 'score' based on how close to vertical center and width
-          final Rectangle current = new Rectangle(leftX, topY, rightX - leftX, increment);
-          final int verticalFromEdge = territoryBounds.height / 2 - Math.abs(centerY - (topY + increment));
-          final int score = verticalFromEdge * current.width;
+          // Find current rectangle then 'score' based on how close to vertical center and width
+          final Rectangle current = new Rectangle(x, y, endX - x, increment);
+          final int verticalDistanceFromEdge = territoryBounds.height / 2 - Math.abs(centerY - y - increment);
+          final int score = verticalDistanceFromEdge * current.width;
           if (current.width > minWidth && score > maxScore) {
 
             // Check to make sure rectangle is contained in the territory

--- a/src/games/strategy/triplea/ui/screen/IDrawable.java
+++ b/src/games/strategy/triplea/ui/screen/IDrawable.java
@@ -203,13 +203,13 @@ class TerritoryNameDrawable implements IDrawable {
     int maxScore = 0;
 
     // Loop through the grid moving the starting point and determining max width at that point
-    for (int startX = territoryBounds.x; startX < maxX - increment; startX += increment) {
-      for (int startY = territoryBounds.y; startY < maxY - increment; startY += increment) {
-        for (int endX = maxX; endX > startX; endX -= increment) {
+    for (int leftX = territoryBounds.x; leftX < maxX - increment; leftX += increment) {
+      for (int topY = territoryBounds.y; topY < maxY - increment; topY += increment) {
+        for (int rightX = maxX; rightX > leftX; rightX -= increment) {
 
           // Find current rectangle and the 'score' based on how close to vertical center and width
-          final Rectangle current = new Rectangle(startX, startY, endX - startX, increment);
-          final int verticalFromEdge = territoryBounds.height / 2 - Math.abs(centerY - (startY + increment));
+          final Rectangle current = new Rectangle(leftX, topY, rightX - leftX, increment);
+          final int verticalFromEdge = territoryBounds.height / 2 - Math.abs(centerY - (topY + increment));
           final int score = verticalFromEdge * current.width;
           if (current.width > minWidth && score > maxScore) {
 

--- a/src/games/strategy/triplea/ui/screen/IDrawable.java
+++ b/src/games/strategy/triplea/ui/screen/IDrawable.java
@@ -5,8 +5,6 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
-import games.strategy.performance.Perf;
-import games.strategy.performance.PerfTimer;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.formatter.MyFormatter;
@@ -140,11 +138,9 @@ class TerritoryNameDrawable implements IDrawable {
     int y;
     final Point namePlace = mapData.getNamePlacementPoint(territory);
     if (namePlace == null) {
-      try (PerfTimer timer = Perf.startTimer("Place land territory name for " + territory.getName())) {
-        final Rectangle territoryBounds = getBestTerritoryNameRect(mapData, territory, fm);
-        x = territoryBounds.x + (int) territoryBounds.getWidth() / 2 - fm.stringWidth(territory.getName()) / 2;
-        y = territoryBounds.y + (int) territoryBounds.getHeight() / 2 + fm.getAscent() / 2;
-      }
+      final Rectangle territoryBounds = getBestTerritoryNameRect(mapData, territory, fm);
+      x = territoryBounds.x + (int) territoryBounds.getWidth() / 2 - fm.stringWidth(territory.getName()) / 2;
+      y = territoryBounds.y + (int) territoryBounds.getHeight() / 2 + fm.getAscent() / 2;
     } else {
       x = namePlace.x;
       y = namePlace.y;


### PR DESCRIPTION
Instead of just finding the bounding rectangle and placing the name in
the center, actually try to find the best location within the territory.
This now finds the rectangle that can fit the name, that is the closest
to the vertical center, and has a large width at that location. If one
isn't found then default back to the bounding rectangle center.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/622)
<!-- Reviewable:end -->
