### PR TITLE
Improve Transports To Load Default

### DIFF
--- a/src/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/games/strategy/triplea/delegate/MoveValidator.java
@@ -935,19 +935,6 @@ public class MoveValidator {
     return route.hasNeutralBeforeEnd();
   }
 
-  public static int getTransportCost(final Collection<Unit> units) {
-    if (units == null) {
-      return 0;
-    }
-    int cost = 0;
-    final Iterator<Unit> iter = units.iterator();
-    while (iter.hasNext()) {
-      final Unit item = iter.next();
-      cost += UnitAttachment.get(item.getType()).getTransportCost();
-    }
-    return cost;
-  }
-
   private static Collection<Unit> getUnitsThatCantGoOnWater(final Collection<Unit> units) {
     final Collection<Unit> retUnits = new ArrayList<Unit>();
     for (final Unit unit : units) {

--- a/src/games/strategy/triplea/delegate/TransportTracker.java
+++ b/src/games/strategy/triplea/delegate/TransportTracker.java
@@ -1,11 +1,5 @@
 package games.strategy.triplea.delegate;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.ChangeFactory;
 import games.strategy.engine.data.CompositeChange;
@@ -16,14 +10,22 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.util.TransportUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Tracks which transports are carrying which units. Also tracks the capacity
  * that has been unloaded. To reset the unloaded call clearUnloadedCapacity().
  */
 public class TransportTracker {
+
   public static int getCost(final Collection<Unit> units) {
-    return MoveValidator.getTransportCost(units);
+    return TransportUtils.getTransportCost(units);
   }
 
   private static void assertTransport(final Unit u) {

--- a/src/games/strategy/triplea/delegate/UnitComparator.java
+++ b/src/games/strategy/triplea/delegate/UnitComparator.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.util.TransportUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -60,7 +61,7 @@ public class UnitComparator {
     final IntegerMap<Unit> capacityMap = new IntegerMap<Unit>(transports.size() + 1, 1);
     for (final Unit transport : transports) {
       final Collection<Unit> transporting = TripleAUnit.get(transport).getTransporting();
-      capacityMap.add(transport, MoveValidator.getTransportCost(transporting));
+      capacityMap.add(transport, TransportUtils.getTransportCost(transporting));
     }
     return new Comparator<Unit>() {
       @Override

--- a/src/games/strategy/triplea/ui/EditPanel.java
+++ b/src/games/strategy/triplea/ui/EditPanel.java
@@ -23,6 +23,7 @@ import games.strategy.triplea.delegate.TechnologyDelegate;
 import games.strategy.triplea.delegate.UnitBattleComparator;
 import games.strategy.triplea.delegate.dataObjects.MustMoveWithDetails;
 import games.strategy.triplea.formatter.MyFormatter;
+import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.util.UnitSeperator;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
@@ -550,8 +551,8 @@ public class EditPanel extends ActionPanel {
           // Sort by decreasing transport capacity
           final Collection<Unit> transporting1 = u1.getTransporting();
           final Collection<Unit> transporting2 = u2.getTransporting();
-          final int cost1 = MoveValidator.getTransportCost(transporting1);
-          final int cost2 = MoveValidator.getTransportCost(transporting2);
+          final int cost1 = TransportUtils.getTransportCost(transporting1);
+          final int cost2 = TransportUtils.getTransportCost(transporting2);
           if (cost1 != cost2) {
             return cost2 - cost1;
           }

--- a/src/games/strategy/triplea/ui/MovePanel.java
+++ b/src/games/strategy/triplea/ui/MovePanel.java
@@ -216,7 +216,7 @@ public class MovePanel extends AbstractMovePanel {
         final IntegerMap<Unit> capacityMap = new IntegerMap<Unit>();
         for (final Unit transport : sortedTransports) {
           final Collection<Unit> transporting = TripleAUnit.get(transport).getTransporting();
-          capacityMap.add(transport, MoveValidator.getTransportCost(transporting));
+          capacityMap.add(transport, TransportUtils.getTransportCost(transporting));
         }
         boolean hasChanged = false;
         final Comparator<Unit> increasingCapacityComparator =

--- a/src/games/strategy/triplea/ui/MovePanel.java
+++ b/src/games/strategy/triplea/ui/MovePanel.java
@@ -637,7 +637,7 @@ public class MovePanel extends AbstractMovePanel {
     capableTransports.removeAll(alliedTransports);
     // First, load capable transports
     final Map<Unit, Unit> unitsToCapableTransports =
-        TransportUtils.mapTransports(route, availableUnits, capableTransports);
+        TransportUtils.mapTransportsToLoadUsingMinTransports(availableUnits, capableTransports);
     for (final Unit unit : unitsToCapableTransports.keySet()) {
       final Unit transport = unitsToCapableTransports.get(unit);
       final int unitCost = UnitAttachment.get(unit.getType()).getTransportCost();
@@ -647,7 +647,7 @@ public class MovePanel extends AbstractMovePanel {
     availableUnits.removeAll(unitsToCapableTransports.keySet());
     // Next, load allied transports
     final Map<Unit, Unit> unitsToAlliedTransports =
-        TransportUtils.mapTransports(route, availableUnits, alliedTransports);
+        TransportUtils.mapTransportsToLoadUsingMinTransports(availableUnits, alliedTransports);
     for (final Unit unit : unitsToAlliedTransports.keySet()) {
       final Unit transport = unitsToAlliedTransports.get(unit);
       final int unitCost = UnitAttachment.get(unit.getType()).getTransportCost();
@@ -661,7 +661,7 @@ public class MovePanel extends AbstractMovePanel {
     // are selected, since it may not be obvious
     if (getSelectedEndpointTerritory() == null) {
       final Map<Unit, Unit> unitsToIncapableTransports =
-          TransportUtils.mapTransports(route, availableUnits, incapableTransports);
+          TransportUtils.mapTransportsToLoadUsingMinTransports(availableUnits, incapableTransports);
       for (final Unit unit : unitsToIncapableTransports.keySet()) {
         final Unit transport = unitsToIncapableTransports.get(unit);
         final int unitCost = UnitAttachment.get(unit.getType()).getTransportCost();

--- a/src/games/strategy/triplea/util/TransportUtils.java
+++ b/src/games/strategy/triplea/util/TransportUtils.java
@@ -35,8 +35,7 @@ public class TransportUtils {
   }
 
   /**
-   * Returns a map of unit -> transport. Unit must already be loaded in the transport. If no units are loaded in the
-   * transports then an empty Map will be returned.
+   * Returns a map of unit -> transport. Unit must already be loaded in the transport.
    */
   private static Map<Unit, Unit> mapTransportsAlreadyLoaded(final Collection<Unit> units,
       final Collection<Unit> transports) {
@@ -61,34 +60,12 @@ public class TransportUtils {
   }
 
   /**
-   * Returns a map of unit -> transport. Tries to find transports to load all units. If it can't succeed returns an
-   * empty Map.
+   * Returns a map of unit -> transport. Tries to find transports to load all units.
    */
   public static Map<Unit, Unit> mapTransportsToLoad(final Collection<Unit> units, final Collection<Unit> transports) {
 
-    // Sort units with the highest transport cost first
-    final Comparator<Unit> transportCostComparator = new Comparator<Unit>() {
-      @Override
-      public int compare(final Unit o1, final Unit o2) {
-        final int cost1 = UnitAttachment.get((o1).getUnitType()).getTransportCost();
-        final int cost2 = UnitAttachment.get((o2).getUnitType()).getTransportCost();
-        return cost2 - cost1;
-      }
-    };
-    final List<Unit> canBeTransported = Match.getMatches(units, Matches.UnitCanBeTransported);
-    Collections.sort(canBeTransported, transportCostComparator);
-
-    // Sort transports with the lowest capacity first
-    final Comparator<Unit> transportCapacityComparator = new Comparator<Unit>() {
-      @Override
-      public int compare(final Unit o1, final Unit o2) {
-        final int capacityLeft1 = TransportTracker.getAvailableCapacity(o1);
-        final int capacityLeft2 = TransportTracker.getAvailableCapacity(o1);
-        return capacityLeft1 - capacityLeft2;
-      }
-    };
-    final List<Unit> canTransport = Match.getMatches(transports, Matches.UnitCanTransport);
-    Collections.sort(canTransport, transportCapacityComparator);
+    final List<Unit> canBeTransported = sortByTransportCostDescending(units);
+    final List<Unit> canTransport = sortByTransportCapacityAscending(transports);
 
     // Add max units to transports
     final Map<Unit, Unit> mapping = new HashMap<Unit, Unit>();
@@ -156,6 +133,34 @@ public class TransportUtils {
       cost += UnitAttachment.get(item.getType()).getTransportCost();
     }
     return cost;
+  }
+
+  private static List<Unit> sortByTransportCapacityAscending(final Collection<Unit> transports) {
+    final Comparator<Unit> transportCapacityComparator = new Comparator<Unit>() {
+      @Override
+      public int compare(final Unit o1, final Unit o2) {
+        final int capacityLeft1 = TransportTracker.getAvailableCapacity(o1);
+        final int capacityLeft2 = TransportTracker.getAvailableCapacity(o1);
+        return capacityLeft1 - capacityLeft2;
+      }
+    };
+    final List<Unit> canTransport = Match.getMatches(transports, Matches.UnitCanTransport);
+    Collections.sort(canTransport, transportCapacityComparator);
+    return canTransport;
+  }
+
+  private static List<Unit> sortByTransportCostDescending(final Collection<Unit> units) {
+    final Comparator<Unit> transportCostComparator = new Comparator<Unit>() {
+      @Override
+      public int compare(final Unit o1, final Unit o2) {
+        final int cost1 = UnitAttachment.get((o1).getUnitType()).getTransportCost();
+        final int cost2 = UnitAttachment.get((o2).getUnitType()).getTransportCost();
+        return cost2 - cost1;
+      }
+    };
+    final List<Unit> canBeTransported = Match.getMatches(units, Matches.UnitCanBeTransported);
+    Collections.sort(canBeTransported, transportCostComparator);
+    return canBeTransported;
   }
 
 }

--- a/src/games/strategy/triplea/util/TransportUtils.java
+++ b/src/games/strategy/triplea/util/TransportUtils.java
@@ -22,11 +22,8 @@ import java.util.Map;
 public class TransportUtils {
 
   /**
-   * This method is static so it can be called from the client side.
-   *
-   * @return a map of unit -> transport (null if no mapping can be
-   *         done either because there is not sufficient transport capacity or because
-   *         a unit is not with its transport)
+   * Returns a map of unit -> transport (null if no mapping can be done either because there is not sufficient transport
+   * capacity or because a unit is not with its transport)
    */
   public static Map<Unit, Unit> mapTransports(final Route route, final Collection<Unit> units,
       final Collection<Unit> transportsToLoad) {
@@ -40,9 +37,8 @@ public class TransportUtils {
   }
 
   /**
-   * Returns a map of unit -> transport. Unit must already be loaded in the
-   * transport. If no units are loaded in the transports then an empty Map will
-   * be returned.
+   * Returns a map of unit -> transport. Unit must already be loaded in the transport. If no units are loaded in the
+   * transports then an empty Map will be returned.
    */
   private static Map<Unit, Unit> mapTransportsAlreadyLoaded(final Collection<Unit> units,
       final Collection<Unit> transports) {
@@ -67,8 +63,8 @@ public class TransportUtils {
   }
 
   /**
-   * Returns a map of unit -> transport. Tries to find transports to load all
-   * units. If it can't succeed returns an empty Map.
+   * Returns a map of unit -> transport. Tries to find transports to load all units. If it can't succeed returns an
+   * empty Map.
    */
   public static Map<Unit, Unit> mapTransportsToLoad(final Collection<Unit> units, final Collection<Unit> transports) {
     final List<Unit> canBeTransported = Match.getMatches(units, Matches.UnitCanBeTransported);

--- a/src/games/strategy/triplea/util/TransportUtils.java
+++ b/src/games/strategy/triplea/util/TransportUtils.java
@@ -194,4 +194,17 @@ public class TransportUtils {
     return totalLoad;
   }
 
+  public static int getTransportCost(final Collection<Unit> units) {
+    if (units == null) {
+      return 0;
+    }
+    int cost = 0;
+    final Iterator<Unit> iter = units.iterator();
+    while (iter.hasNext()) {
+      final Unit item = iter.next();
+      cost += UnitAttachment.get(item.getType()).getTransportCost();
+    }
+    return cost;
+  }
+
 }

--- a/src/games/strategy/triplea/util/TransportUtils.java
+++ b/src/games/strategy/triplea/util/TransportUtils.java
@@ -177,7 +177,7 @@ public class TransportUtils {
       @Override
       public int compare(final Unit o1, final Unit o2) {
         final int capacityLeft1 = TransportTracker.getAvailableCapacity(o1);
-        final int capacityLeft2 = TransportTracker.getAvailableCapacity(o1);
+        final int capacityLeft2 = TransportTracker.getAvailableCapacity(o2);
         return capacityLeft1 - capacityLeft2;
       }
     };

--- a/src/games/strategy/triplea/util/TransportUtils.java
+++ b/src/games/strategy/triplea/util/TransportUtils.java
@@ -110,26 +110,6 @@ public class TransportUtils {
     return mapping;
   }
 
-  private static Comparator<Unit> transportsThatPreviouslyUnloadedComeLast() {
-    return new Comparator<Unit>() {
-      @Override
-      public int compare(final Unit t1, final Unit t2) {
-        if (t1 == t2 || t1.equals(t2)) {
-          return 0;
-        }
-        final boolean t1previous = TransportTracker.hasTransportUnloadedInPreviousPhase(t1);
-        final boolean t2previous = TransportTracker.hasTransportUnloadedInPreviousPhase(t2);
-        if (t1previous == t2previous) {
-          return 0;
-        }
-        if (t1previous == false) {
-          return -1;
-        }
-        return 1;
-      }
-    };
-  }
-
   public static List<Unit> findUnitsToLoadOnAirTransports(final Collection<Unit> units,
       final Collection<Unit> transports) {
     final Collection<Unit> airTransports = Match.getMatches(transports, Matches.UnitIsAirTransport);

--- a/src/games/strategy/triplea/util/TransportUtils.java
+++ b/src/games/strategy/triplea/util/TransportUtils.java
@@ -21,8 +21,7 @@ import java.util.Map;
 public class TransportUtils {
 
   /**
-   * Returns a map of unit -> transport (null if no mapping can be done either because there is not sufficient transport
-   * capacity or because a unit is not with its transport)
+   * Returns a map of unit -> transport.
    */
   public static Map<Unit, Unit> mapTransports(final Route route, final Collection<Unit> units,
       final Collection<Unit> transportsToLoad) {
@@ -33,31 +32,6 @@ public class TransportUtils {
       return mapTransportsAlreadyLoaded(units, route.getStart().getUnits().getUnits());
     }
     return mapTransportsAlreadyLoaded(units, units);
-  }
-
-  /**
-   * Returns a map of unit -> transport. Unit must already be loaded in the transport.
-   */
-  private static Map<Unit, Unit> mapTransportsAlreadyLoaded(final Collection<Unit> units,
-      final Collection<Unit> transports) {
-    final Collection<Unit> canBeTransported = Match.getMatches(units, Matches.UnitCanBeTransported);
-    final Collection<Unit> canTransport = Match.getMatches(transports, Matches.UnitCanTransport);
-    final Map<Unit, Unit> mapping = new HashMap<Unit, Unit>();
-    final Iterator<Unit> land = canBeTransported.iterator();
-    while (land.hasNext()) {
-      final Unit currentTransported = land.next();
-      final Unit transport = TransportTracker.transportedBy(currentTransported);
-
-      // already being transported, make sure it is in transports
-      if (transport == null) {
-        continue;
-      }
-      if (!canTransport.contains(transport)) {
-        continue;
-      }
-      mapping.put(currentTransported, transport);
-    }
-    return mapping;
   }
 
   /**
@@ -171,6 +145,31 @@ public class TransportUtils {
       cost += UnitAttachment.get(item.getType()).getTransportCost();
     }
     return cost;
+  }
+
+  /**
+   * Returns a map of unit -> transport. Unit must already be loaded in the transport.
+   */
+  private static Map<Unit, Unit> mapTransportsAlreadyLoaded(final Collection<Unit> units,
+      final Collection<Unit> transports) {
+    final Collection<Unit> canBeTransported = Match.getMatches(units, Matches.UnitCanBeTransported);
+    final Collection<Unit> canTransport = Match.getMatches(transports, Matches.UnitCanTransport);
+    final Map<Unit, Unit> mapping = new HashMap<Unit, Unit>();
+    final Iterator<Unit> land = canBeTransported.iterator();
+    while (land.hasNext()) {
+      final Unit currentTransported = land.next();
+      final Unit transport = TransportTracker.transportedBy(currentTransported);
+
+      // already being transported, make sure it is in transports
+      if (transport == null) {
+        continue;
+      }
+      if (!canTransport.contains(transport)) {
+        continue;
+      }
+      mapping.put(currentTransported, transport);
+    }
+    return mapping;
   }
 
   private static List<Unit> sortByTransportCapacityAscending(final Collection<Unit> transports) {


### PR DESCRIPTION
This addressed point 1 from #553.

Essentially find the minimum number of transports needed for given land units instead of showing max number of transports. Did some significant refactoring with this as well.

Notes: 
- Planning to add some unit tests for at least the 2 transport loading methods to validate some basic scenarios.
- This is just the first of several transport improvements I'm planning to make.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/647)
<!-- Reviewable:end -->
