### PR TITLE
Removed the use of the SoftJEditorPane

### DIFF
--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -94,13 +94,12 @@ import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.IllegalCharacterRemover;
 import games.strategy.util.LocalizeHTML;
-import games.strategy.util.SoftJEditorPane;
 import games.strategy.util.Triple;
 
 public abstract class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> extends JMenuBar {
   private static final long serialVersionUID = -1447295944297939539L;
   protected final CustomGameFrame frame;
-  protected SoftJEditorPane gameNotesPane;
+  protected JEditorPane gameNotesPane;
 
   public BasicGameMenuBar(final CustomGameFrame frame) {
     this.frame = frame;
@@ -155,11 +154,11 @@ public abstract class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> ex
 
   public void dispose() {
     if (gameNotesPane != null) {
-      gameNotesPane.dispose();
+      gameNotesPane.setVisible(false);
     }
   }
 
-  public SoftJEditorPane getGameNotesJEditorPane() {
+  public JEditorPane getGameNotesJEditorPane() {
     return gameNotesPane;
   }
 
@@ -169,10 +168,11 @@ public abstract class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> ex
     final String notesProperty = getData().getProperties().get("notes", "");
     if (notesProperty != null && notesProperty.trim().length() != 0) {
       final String notes = LocalizeHTML.localizeImgLinksInHTML(notesProperty.trim());
-      gameNotesPane = new SoftJEditorPane(notes);
+      gameNotesPane = new JEditorPane();
+      gameNotesPane.setText(notes);
       parentMenu.add(SwingAction.of("Game Notes...", e ->
           SwingUtilities.invokeLater(() -> {
-            final JEditorPane pane = gameNotesPane.getComponent();
+            final JEditorPane pane = gameNotesPane;
             final JScrollPane scroll = new JScrollPane(pane);
             scroll.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
             final JDialog dialog = new JDialog(frame);

--- a/src/games/strategy/triplea/ui/NotesPanel.java
+++ b/src/games/strategy/triplea/ui/NotesPanel.java
@@ -13,11 +13,10 @@ import javax.swing.SwingUtilities;
 
 import games.strategy.common.swing.SwingAction;
 import games.strategy.engine.data.GameData;
-import games.strategy.util.SoftJEditorPane;
 
 public class NotesPanel extends JPanel {
   private static final long serialVersionUID = 2746643868463714526L;
-  protected final SoftJEditorPane m_gameNotesPane;
+  protected final JEditorPane m_gameNotesPane;
   protected final GameData m_data;
   final JButton m_refresh = new JButton("Refresh Notes");
 
@@ -27,7 +26,7 @@ public class NotesPanel extends JPanel {
   // so instead we keep the main copy in the BasicGameMenuBar, and then give it to the notes tab. this prevents out of
   // memory errors for
   // maps with large images in their games notes.
-  public NotesPanel(final GameData data, final SoftJEditorPane gameNotesPane) {
+  public NotesPanel(final GameData data, final JEditorPane gameNotesPane) {
     m_data = data;
     m_gameNotesPane = gameNotesPane;
     initLayout();
@@ -64,8 +63,7 @@ public class NotesPanel extends JPanel {
     NotesPanel.this.add(new JLabel(" "));
     NotesPanel.this.add(m_refresh);
     NotesPanel.this.add(new JLabel(" "));
-    final JEditorPane pane = m_gameNotesPane.getComponent();
-    final JScrollPane scroll = new JScrollPane(pane);
+    final JScrollPane scroll = new JScrollPane(m_gameNotesPane);
     scroll.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
     NotesPanel.this.add(scroll);
     // NotesPanel.this.invalidate();


### PR DESCRIPTION
The SoftJEditorPane object was marked as deprecated and described as very buggy...
It was supposed to cache images etc. since they are downloaded on the fly...
Those images (at least the ones in the Game Chooser menu) have very small file sizes - IMO caching is not neccessary.
I have a (relatively) slow Internet connection (16k) and the images are loading instantly.(I did an extreme test with 1Mbps and I got the same Result)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/671)
<!-- Reviewable:end -->
