### PR TITLE
Defensive Roll Confirmation Hit Space Bar or timeout

### DIFF
--- a/src/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/games/strategy/triplea/ui/BattleDisplay.java
@@ -310,7 +310,8 @@ public class BattleDisplay extends JPanel {
     }
 
     final CountDownLatch continueLatch = new CountDownLatch(1);
-    SwingUtilities.invokeLater(() -> m_actionButton.setAction(SwingAction.of(message, e -> continueLatch.countDown())));
+    AbstractAction buttonAction = SwingAction.of(message, e -> continueLatch.countDown());
+    SwingUtilities.invokeLater(() -> m_actionButton.setAction(buttonAction));
     m_mapPanel.getUIContext().addShutdownLatch(continueLatch);
 
     // Set a auto-wait expiration if the option is set.


### PR DESCRIPTION
Should address: https://github.com/triplea-game/triplea/issues/537
First commit is a refactor/cleanup.
Second commit updates the logic to still allow for space confirmation before the timeout expires.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/680)
<!-- Reviewable:end -->