### PR TITLE
Fix console being created on a non-AWT thread

### DIFF
--- a/src/games/strategy/debug/ErrorConsole.java
+++ b/src/games/strategy/debug/ErrorConsole.java
@@ -1,15 +1,24 @@
 package games.strategy.debug;
 
+import games.strategy.common.swing.SwingAction;
+import games.strategy.triplea.ui.ErrorHandler;
+
+import javax.swing.SwingUtilities;
+
 public class ErrorConsole extends GenericConsole {
   private static final long serialVersionUID = -3489030525309243438L;
-  private static ErrorConsole s_console;
-
+  private static ErrorConsole console;
 
   public static ErrorConsole getConsole() {
-    if (s_console == null) {
-      s_console = new ErrorConsole();
+    if (console == null) {
+      SwingAction.invokeAndWait(() -> {
+        console = new ErrorConsole();
+        console.displayStandardOutput();
+        console.displayStandardError();
+        ErrorHandler.registerExceptionHandler();
+      });
     }
-    return s_console;
+    return console;
   }
 
   @Override

--- a/src/games/strategy/engine/framework/GameRunner2.java
+++ b/src/games/strategy/engine/framework/GameRunner2.java
@@ -143,11 +143,6 @@ public class GameRunner2 {
       showMainFrame();
     }
     (new Thread(() -> setupLogging())).start();
-    (new Thread(() -> {
-      ErrorConsole.getConsole().displayStandardError();
-      ErrorConsole.getConsole().displayStandardOutput();
-      ErrorHandler.registerExceptionHandler();
-    })).start();
 
     setupProxies();
     (new Thread(() -> checkForUpdates())).start();


### PR DESCRIPTION
We're getting an error message on startup due to the console creating TextFields on the wrong thread. Fix this by creating the console instance in the AWT thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/732)
<!-- Reviewable:end -->
