### PR TITLE
Fix gamenotes HTML broken

### DIFF
--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -99,7 +99,7 @@ import games.strategy.util.Triple;
 public abstract class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> extends JMenuBar {
   private static final long serialVersionUID = -1447295944297939539L;
   protected final CustomGameFrame frame;
-  protected JEditorPane gameNotesPane;
+  protected JLabel gameNotesPane;
 
   public BasicGameMenuBar(final CustomGameFrame frame) {
     this.frame = frame;
@@ -158,7 +158,7 @@ public abstract class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> ex
     }
   }
 
-  public JEditorPane getGameNotesJEditorPane() {
+  public JLabel getGameNotesJEditorPane() {
     return gameNotesPane;
   }
 
@@ -168,11 +168,11 @@ public abstract class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> ex
     final String notesProperty = getData().getProperties().get("notes", "");
     if (notesProperty != null && notesProperty.trim().length() != 0) {
       final String notes = LocalizeHTML.localizeImgLinksInHTML(notesProperty.trim());
-      gameNotesPane = new JEditorPane();
-      gameNotesPane.setText(notes);
-      parentMenu.add(SwingAction.of("Game Notes...", e ->
+      gameNotesPane = new JLabel();
+      gameNotesPane.setText("<html>" + notes + "</html>");
+      parentMenu.add(SwingAction.of("<html>Game Notes...</html>", e ->
           SwingUtilities.invokeLater(() -> {
-            final JEditorPane pane = gameNotesPane;
+            final JLabel pane = gameNotesPane;
             final JScrollPane scroll = new JScrollPane(pane);
             scroll.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
             final JDialog dialog = new JDialog(frame);

--- a/src/games/strategy/triplea/ui/NotesPanel.java
+++ b/src/games/strategy/triplea/ui/NotesPanel.java
@@ -16,7 +16,7 @@ import games.strategy.engine.data.GameData;
 
 public class NotesPanel extends JPanel {
   private static final long serialVersionUID = 2746643868463714526L;
-  protected final JEditorPane m_gameNotesPane;
+  protected final JLabel m_gameNotesPane;
   protected final GameData m_data;
   final JButton m_refresh = new JButton("Refresh Notes");
 
@@ -26,7 +26,7 @@ public class NotesPanel extends JPanel {
   // so instead we keep the main copy in the BasicGameMenuBar, and then give it to the notes tab. this prevents out of
   // memory errors for
   // maps with large images in their games notes.
-  public NotesPanel(final GameData data, final JEditorPane gameNotesPane) {
+  public NotesPanel(final GameData data, final JLabel gameNotesPane) {
     m_data = data;
     m_gameNotesPane = gameNotesPane;
     initLayout();
@@ -43,7 +43,6 @@ public class NotesPanel extends JPanel {
         }
       });
     }));
-    // layoutNotes();
     removeNotes();
   }
 
@@ -52,7 +51,6 @@ public class NotesPanel extends JPanel {
     NotesPanel.this.add(new JLabel(" "));
     NotesPanel.this.add(m_refresh);
     NotesPanel.this.add(new JLabel(" "));
-    // NotesPanel.this.invalidate();
   }
 
   void layoutNotes() {
@@ -66,7 +64,6 @@ public class NotesPanel extends JPanel {
     final JScrollPane scroll = new JScrollPane(m_gameNotesPane);
     scroll.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
     NotesPanel.this.add(scroll);
-    // NotesPanel.this.invalidate();
   }
 
   public boolean isEmpty() {


### PR DESCRIPTION
Switch from a JEditorPane to JLabel, and insert explicity html tags. A JEditorPane with explicit HTML tags renders the content literally, hence why we are switching to a JLabel as well.

Addresses #728

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/738)
<!-- Reviewable:end -->
