### PR TITLE
Odds Calc Test - Remove flaky tests

### DIFF
--- a/test/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorTest.java
+++ b/test/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorTest.java
@@ -1,10 +1,6 @@
 package games.strategy.triplea.oddsCalculator.ta;
 
-import static games.strategy.triplea.delegate.GameDataTestUtil.americans;
-import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
-import static games.strategy.triplea.delegate.GameDataTestUtil.submarine;
-import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
-import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
+import static games.strategy.triplea.delegate.GameDataTestUtil.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,25 +44,6 @@ public class OddsCalculatorTest extends TestCase {
     assertTrue(results.getDrawPercent() < 0.1);
   }
 
-  public void testBalancedFight() {
-    // 1 british tank in eastern canada, defending one german tank
-    // odds for win/loss/tie are all equal
-    final Territory eastCanada = m_data.getMap().getTerritory("Eastern Canada");
-    final List<Unit> defendingUnits = new ArrayList<>(eastCanada.getUnits().getUnits());
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    final List<Unit> attackingUnits = GameDataTestUtil.armour(m_data).create(1, germans, false);
-    final List<Unit> bombardingUnits = Collections.emptyList();
-    final IOddsCalculator calculator = new ConcurrentOddsCalculator("Test");
-    calculator.setGameData(m_data);
-    final AggregateResults results = calculator.setCalculateDataAndCalculate(germans, british, eastCanada,
-        attackingUnits, defendingUnits, bombardingUnits, TerritoryEffectHelper.getEffects(eastCanada), 500);
-    calculator.shutdown();
-    assertEquals(0.33, results.getAttackerWinPercent(), 0.09);
-    assertEquals(0.33, results.getDefenderWinPercent(), 0.09);
-    assertEquals(0.33, results.getDrawPercent(), 0.09);
-  }
-
   public void testKeepOneAttackingLand() {
     // 1 bomber and 1 infantry attacking
     // 1 fighter
@@ -84,45 +61,9 @@ public class OddsCalculatorTest extends TestCase {
     final AggregateResults results = calculator.setCalculateDataAndCalculate(germans, british, eastCanada,
         attackingUnits, defendingUnits, bombardingUnits, TerritoryEffectHelper.getEffects(eastCanada), 1000);
     calculator.shutdown();
-    assertEquals(0.8, results.getAttackerWinPercent(), 0.04);
-    assertEquals(0.16, results.getDefenderWinPercent(), 0.04);
+    assertEquals(0.8, results.getAttackerWinPercent(), 0.10);
+    assertEquals(0.16, results.getDefenderWinPercent(), 0.10);
   }
-
-  public void testNoUnitsInTerritory() {
-    // fight 1 tank against 1 tank,
-    // where none of the defending units are in the territry
-    // and we ignore some units that are in the territory
-    final Territory uk = m_data.getMap().getTerritory("United Kingdom");
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final List<Unit> attackingUnits = GameDataTestUtil.armour(m_data).create(1, germans);
-    final List<Unit> bombardingUnits = Collections.emptyList();
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    final List<Unit> defendingUnits = GameDataTestUtil.armour(m_data).create(1, british);
-    final OddsCalculator calculator = new OddsCalculator(m_data);
-    final AggregateResults results = calculator.setCalculateDataAndCalculate(germans, british, uk, attackingUnits,
-        defendingUnits, bombardingUnits, TerritoryEffectHelper.getEffects(uk), 1000);
-    calculator.shutdown();
-    assertEquals(0.33, results.getAttackerWinPercent(), 0.05);
-    assertEquals(0.33, results.getDefenderWinPercent(), 0.05);
-    assertEquals(0.33, results.getDrawPercent(), 0.05);
-  }
-
-  public void testSeaBattleWithTransport() {
-    // Attack a battleship with a battleship and a transport
-    final Territory sz2 = m_data.getMap().getTerritory("2 Sea Zone");
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final List<Unit> attackingUnits = GameDataTestUtil.battleship(m_data).create(1, germans);
-    attackingUnits.addAll(GameDataTestUtil.transport(m_data).create(1, germans));
-    final List<Unit> bombardingUnits = Collections.emptyList();
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    final List<Unit> defendingUnits = GameDataTestUtil.battleship(m_data).create(1, british);
-    final OddsCalculator calculator = new OddsCalculator(m_data);
-    final AggregateResults results = calculator.setCalculateDataAndCalculate(germans, british, sz2, attackingUnits,
-        defendingUnits, bombardingUnits, TerritoryEffectHelper.getEffects(sz2), 500);
-    calculator.shutdown();
-    assertTrue(results.getAttackerWinPercent() > 0.65);
-  }
-
 
   public void testAttackingTransports() {
     final Territory sz1 = territory("1 Sea Zone", m_data);


### PR DESCRIPTION
Delete flaky tests and increase tolerance of another flaky test case. Idea is to keep some of the test coverage while removing the more flaky and redundant tests

Addresses: https://github.com/triplea-game/triplea/issues/274

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/749)
<!-- Reviewable:end -->
