### PR TITLE
Remove redundant casts

### DIFF
--- a/src/games/strategy/common/ui/BasicGameMenuBar.java
+++ b/src/games/strategy/common/ui/BasicGameMenuBar.java
@@ -621,7 +621,7 @@ public abstract class BasicGameMenuBar<CustomGameFrame extends MainGameFrame> ex
       final String currentKey = lookAndFeel.getThird();
       final Map<String, String> lookAndFeels = lookAndFeel.getSecond();
       if (JOptionPane.showConfirmDialog(frame, list) == JOptionPane.OK_OPTION) {
-        final String selectedValue = (String) list.getSelectedValue();
+        final String selectedValue = list.getSelectedValue();
         if (selectedValue == null) {
           return;
         }

--- a/src/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/src/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -219,7 +219,7 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
     if (index == -1) {
       return;
     }
-    final INode player = (INode) m_listModel.get(index);
+    final INode player = m_listModel.get(index);
     final JPopupMenu menu = new JPopupMenu();
     boolean hasActions = false;
     for (final IPlayerActionFactory factory : m_actionFactories) {

--- a/src/games/strategy/engine/data/GameMap.java
+++ b/src/games/strategy/engine/data/GameMap.java
@@ -88,7 +88,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
       // m_gridDimensions[i];
       listIndex += coordinate[i] * multiplier;
     }
-    return ((ArrayList<Territory>) m_territories).get(listIndex);
+    return m_territories.get(listIndex);
   }
 
   protected void reorderTerritoryList() {

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
@@ -388,7 +388,7 @@ public class HeadlessConsoleController {
         if (server.getSetupPanelModel() != null) {
           final ISetupPanel setup = server.getSetupPanelModel().getPanel();
           if (setup != null && setup instanceof ServerSetupPanel) {
-            ((ServerSetupPanel) setup).shutDown();// this is causing a deadlock when in a shutdown hook, due to swing/awt. so we will shut
+            setup.shutDown();// this is causing a deadlock when in a shutdown hook, due to swing/awt. so we will shut
                                                   // it down here instead.
           }
         }

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameSelectorPanel.java
@@ -295,7 +295,7 @@ public class HeadlessGameSelectorPanel extends JPanel implements Observer {
       final int option = JOptionPane.showConfirmDialog(null, listScroll, "Choose Game", JOptionPane.OK_CANCEL_OPTION,
           JOptionPane.PLAIN_MESSAGE);
       if (option == JOptionPane.OK_OPTION) {
-        final String gameSelected = (String) list.getSelectedValue();
+        final String gameSelected = list.getSelectedValue();
         m_model.load(m_availableGames.getGameData(gameSelected), m_availableGames.getGameFilePath(gameSelected));
       }
     }

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -622,7 +622,7 @@ public class HeadlessGameServer {
           // this is causing a deadlock when in a shutdown hook, due to swing/awt
           // ((ServerSetupPanel) setup).shutDown();
         } else if (setup != null && setup instanceof HeadlessServerSetup) {
-          ((HeadlessServerSetup) setup).shutDown();
+          setup.shutDown();
         }
       }
     } catch (final Exception e) {

--- a/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -152,7 +152,7 @@ public class EnginePreferences extends JDialog {
         final String currentKey = lookAndFeel.getThird();
         final Map<String, String> lookAndFeels = lookAndFeel.getSecond();
         if (JOptionPane.showConfirmDialog(m_parentFrame, list) == JOptionPane.OK_OPTION) {
-          final String selectedValue = (String) list.getSelectedValue();
+          final String selectedValue = list.getSelectedValue();
           if (selectedValue == null) {
             return;
           }

--- a/src/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
@@ -139,7 +139,7 @@ public class MicroWebPosterEditor extends EditorPanel {
     if (!((String) m_hosts.getSelectedItem()).endsWith("/")) {
       hostUrl = (String) m_hosts.getSelectedItem();
     } else {
-      hostUrl = (String) m_hosts.getSelectedItem() + "/";
+      hostUrl = m_hosts.getSelectedItem() + "/";
     }
     final ArrayList<String> players = new ArrayList<>();
     try {

--- a/src/games/strategy/engine/framework/startup/ui/editors/SelectAndViewEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/SelectAndViewEditor.java
@@ -198,7 +198,7 @@ public class SelectAndViewEditor extends EditorPanel {
     boolean found = false;
     int i;
     for (i = 0; i < model.getSize(); i++) {
-      final IBean candidate = (IBean) model.getElementAt(i);
+      final IBean candidate = model.getElementAt(i);
       if (candidate.sameType(bean)) {
         found = true;
         newModel.addElement(bean);

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -44,7 +44,7 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
 
   @Override
   public NewGameChooserEntry get(final int i) {
-    return (NewGameChooserEntry) super.get(i);
+    return super.get(i);
   }
 
   public static File getDefaultMapsDir() {

--- a/src/games/strategy/net/IPFinder.java
+++ b/src/games/strategy/net/IPFinder.java
@@ -50,10 +50,10 @@ public class IPFinder {
     }
     final List<InetAddress> allButLoopback = new ArrayList<>();
     while (enum1.hasMoreElements()) {
-      final NetworkInterface netface = (NetworkInterface) enum1.nextElement();
+      final NetworkInterface netface = enum1.nextElement();
       final Enumeration<InetAddress> enum2 = netface.getInetAddresses();
       while (enum2.hasMoreElements()) {
-        final InetAddress ip2 = (InetAddress) enum2.nextElement();
+        final InetAddress ip2 = enum2.nextElement();
         if (!ip2.isLoopbackAddress()) {
           allButLoopback.add(ip2);
         }
@@ -111,11 +111,11 @@ public class IPFinder {
   public static void main(final String[] args) throws SocketException, UnknownHostException {
     final Enumeration<NetworkInterface> enum1 = NetworkInterface.getNetworkInterfaces();
     while (enum1.hasMoreElements()) {
-      final NetworkInterface netface = (NetworkInterface) enum1.nextElement();
+      final NetworkInterface netface = enum1.nextElement();
       System.out.println("interface:" + netface);
       final Enumeration<InetAddress> enum2 = netface.getInetAddresses();
       while (enum2.hasMoreElements()) {
-        final InetAddress ip2 = (InetAddress) enum2.nextElement();
+        final InetAddress ip2 = enum2.nextElement();
         System.out.println(" address:" + ip2 + " is private:" + isPrivateNetworkAddress(ip2) + " is loopback:"
             + ip2.isLoopbackAddress());
       }

--- a/src/games/strategy/triplea/TripleAPlayer.java
+++ b/src/games/strategy/triplea/TripleAPlayer.java
@@ -762,7 +762,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
   public Tuple<Territory, Set<Unit>> pickTerritoryAndUnits(final List<Territory> territoryChoices,
       final List<Unit> unitChoices, final int unitsPerPick) {
     if (territoryChoices == null || territoryChoices.isEmpty() || unitsPerPick < 1) {
-      return Tuple.of((Territory) null, (Set<Unit>) new HashSet<Unit>());
+      return Tuple.of(null, new HashSet<Unit>());
     }
     return ui.pickTerritoryAndUnits(this.getPlayerID(), territoryChoices, unitChoices, unitsPerPick);
   }

--- a/src/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/games/strategy/triplea/ui/BattleDisplay.java
@@ -447,7 +447,7 @@ public class BattleDisplay extends JPanel {
       // retreat
       final RetreatComponent comp = new RetreatComponent(possible);
       final int option = JOptionPane.showConfirmDialog(BattleDisplay.this, comp, message,
-          JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, (Icon) null);
+          JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null);
       if (option == JOptionPane.OK_OPTION) {
         if (comp.getSelection() != null) {
           retreatTo[0] = comp.getSelection();
@@ -520,7 +520,7 @@ public class BattleDisplay extends JPanel {
     private void updateImage() {
       final int width = 250;
       final int height = 250;
-      final Image img = m_mapPanel.getTerritoryImage((Territory) m_list.getSelectedValue(), m_location);
+      final Image img = m_mapPanel.getTerritoryImage(m_list.getSelectedValue(), m_location);
       final Image finalImage = Util.createImage(width, height, true);
       final Graphics g = finalImage.getGraphics();
       g.drawImage(img, 0, 0, width, height, this);
@@ -529,7 +529,7 @@ public class BattleDisplay extends JPanel {
     }
 
     public Territory getSelection() {
-      return (Territory) m_list.getSelectedValue();
+      return m_list.getSelectedValue();
     }
   }
 

--- a/src/games/strategy/triplea/ui/MapPanel.java
+++ b/src/games/strategy/triplea/ui/MapPanel.java
@@ -338,7 +338,7 @@ public class MapPanel extends ImageScrollerLargeView {
       if (!unitSelectionListeners.isEmpty()) {
         Tuple<Territory, List<Unit>> tuple = tileManager.getUnitsAtPoint(x, y, m_data);
         if (tuple == null) {
-          tuple = Tuple.of(getTerritory(x, y), (List<Unit>) new ArrayList<Unit>(0));
+          tuple = Tuple.of(getTerritory(x, y), new ArrayList<Unit>(0));
         }
         notifyUnitSelected(tuple.getSecond(), tuple.getFirst(), md);
       }

--- a/src/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/games/strategy/triplea/ui/ObjectivePanel.java
@@ -834,7 +834,7 @@ class EditorPaneTableCellRenderer extends JEditorPane implements TableCellRender
     if (rows == null) {
       cellSizes.put(table, rows = new HashMap<>());
     }
-    Map<Integer, Integer> rowheights = (Map<Integer, Integer>) rows.get(new Integer(row));
+    Map<Integer, Integer> rowheights = rows.get(new Integer(row));
     if (rowheights == null) {
       rows.put(new Integer(row), rowheights = new HashMap<>());
     }
@@ -866,7 +866,7 @@ class EditorPaneTableCellRenderer extends JEditorPane implements TableCellRender
     if (rows == null) {
       return 0;
     }
-    final Map<?,?> rowheights = (Map<?,?>) rows.get(new Integer(row));
+    final Map<?,?> rowheights = rows.get(new Integer(row));
     if (rowheights == null) {
       return 0;
     }

--- a/src/games/strategy/triplea/ui/PlayerChooser.java
+++ b/src/games/strategy/triplea/ui/PlayerChooser.java
@@ -72,7 +72,7 @@ public class PlayerChooser extends JOptionPane {
    */
   public PlayerID getSelected() {
     if (getValue() != null && getValue().equals(JOptionPane.OK_OPTION)) {
-      return (PlayerID) m_list.getSelectedValue();
+      return m_list.getSelectedValue();
     }
     return null;
   }
@@ -91,7 +91,7 @@ class PlayerChooserRenderer extends DefaultListCellRenderer {
   public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
       final boolean isSelected, final boolean cellHasFocus) {
     super.getListCellRendererComponent(list, ((PlayerID) value).getName(), index, isSelected, cellHasFocus);
-    if (m_uiContext == null || (PlayerID) value == PlayerID.NULL_PLAYERID) {
+    if (m_uiContext == null || value == PlayerID.NULL_PLAYERID) {
       setIcon(new ImageIcon(Util.createImage(32, 32, true)));
     } else {
       setIcon(new ImageIcon(m_uiContext.getFlagImageFactory().getFlag((PlayerID) value)));

--- a/src/games/strategy/triplea/ui/TechPanel.java
+++ b/src/games/strategy/triplea/ui/TechPanel.java
@@ -122,7 +122,7 @@ public class TechPanel extends ActionPanel {
       if (choice != JOptionPane.OK_OPTION) {
         return;
       }
-      advance = (TechAdvance) list.getSelectedValue();
+      advance = list.getSelectedValue();
     }
     final int PUs = getCurrentPlayer().getResources().getQuantity(Constants.PUS);
     final String message = "Roll Tech";

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -985,7 +985,7 @@ public class TripleAFrame extends MainGameFrame {
       final List<Territory> territoryChoices, final List<Unit> unitChoices, final int unitsPerPick) {
     if (messageAndDialogThreadPool == null) {
       return Tuple.of(territoryChoices.iterator().next(),
-          (Set<Unit>) new HashSet<>(Match.getNMatches(unitChoices, unitsPerPick, Match.getAlwaysMatch())));
+          new HashSet<>(Match.getNMatches(unitChoices, unitsPerPick, Match.getAlwaysMatch())));
     }
     // total hacks
     messageAndDialogThreadPool.waitForAll();
@@ -1176,7 +1176,7 @@ public class TripleAFrame extends MainGameFrame {
           final int maxAllowed =
               Math.min(BattleDelegate.getMaxScrambleCount(possibleScramblers.get(from).getFirst()), possible.size());
           final UnitChooser chooser =
-              new UnitChooser(possible, Collections.emptyMap(), data, false, uiContext);
+              new UnitChooser(possible, Collections.<Unit, Collection<Unit>>emptyMap(), data, false, uiContext);
           chooser.setMaxAndShowMaxButton(maxAllowed);
           choosers.add(Tuple.of(from, chooser));
           panelChooser.add(chooser);
@@ -1276,7 +1276,7 @@ public class TripleAFrame extends MainGameFrame {
         panelChooser.add(new JLabel(" "));
         final int maxAllowed = possible.size();
         final UnitChooser chooser =
-            new UnitChooser(possible, Collections.emptyMap(), data, false, uiContext);
+            new UnitChooser(possible, Collections.<Unit, Collection<Unit>>emptyMap(), data, false, uiContext);
         chooser.setMaxAndShowMaxButton(maxAllowed);
         panelChooser.add(chooser);
         chooserScrollPane = new JScrollPane(panelChooser);

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -1176,7 +1176,7 @@ public class TripleAFrame extends MainGameFrame {
           final int maxAllowed =
               Math.min(BattleDelegate.getMaxScrambleCount(possibleScramblers.get(from).getFirst()), possible.size());
           final UnitChooser chooser =
-              new UnitChooser(possible, Collections.<Unit, Collection<Unit>>emptyMap(), data, false, uiContext);
+              new UnitChooser(possible, Collections.emptyMap(), data, false, uiContext);
           chooser.setMaxAndShowMaxButton(maxAllowed);
           choosers.add(Tuple.of(from, chooser));
           panelChooser.add(chooser);
@@ -1276,7 +1276,7 @@ public class TripleAFrame extends MainGameFrame {
         panelChooser.add(new JLabel(" "));
         final int maxAllowed = possible.size();
         final UnitChooser chooser =
-            new UnitChooser(possible, Collections.<Unit, Collection<Unit>>emptyMap(), data, false, uiContext);
+            new UnitChooser(possible, Collections.emptyMap(), data, false, uiContext);
         chooser.setMaxAndShowMaxButton(maxAllowed);
         panelChooser.add(chooser);
         chooserScrollPane = new JScrollPane(panelChooser);

--- a/src/games/strategy/triplea/ui/display/TripleADisplay.java
+++ b/src/games/strategy/triplea/ui/display/TripleADisplay.java
@@ -125,7 +125,7 @@ public class TripleADisplay implements ITripleADisplay {
           // if we have any local players, we are not an observer
           isObserver = false;
           if (player instanceof TripleAPlayer) {
-            if (IGameLoader.CLIENT_PLAYER_TYPE.equals(((TripleAPlayer) player).getType())) {
+            if (IGameLoader.CLIENT_PLAYER_TYPE.equals(player.getType())) {
               isClient = true;
             } else {
               isHost = true;

--- a/src/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/src/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -437,7 +437,7 @@ class HistoryTreeCellRenderer extends DefaultTreeCellRenderer {
           icon.setImage(m_uiContext.getFlagImageFactory().getSmallFlag(player));
           setIcon(icon);
         } else {
-          final String text = ((Step) value).toString() + " (" + player.getName() + ")";
+          final String text = value.toString() + " (" + player.getName() + ")";
           super.getTreeCellRendererComponent(tree, text, sel, expanded, leaf, row, haveFocus);
         }
       } else {

--- a/src/util/image/ImageShrinker.java
+++ b/src/util/image/ImageShrinker.java
@@ -59,7 +59,7 @@ public class ImageShrinker {
     param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
     param.setCompressionQuality((float) 1.0);
     encoder.setOutput(out);
-    encoder.write((IIOMetadata) null, new IIOImage(thumbImage, null, null), param);
+    encoder.write(null, new IIOImage(thumbImage, null, null), param);
     out.close();
     System.out.println("Image successfully written to " + file.getPath());
     System.exit(0);

--- a/src/util/triplea/mapXmlCreator/UnitAttatchmentsRow.java
+++ b/src/util/triplea/mapXmlCreator/UnitAttatchmentsRow.java
@@ -33,7 +33,7 @@ class UnitAttachmentsRow extends DynamicRow {
 
       @Override
       public void focusLost(FocusEvent e) {
-        String newAttachmentName = (String) textFieldAttachmentName.getText().trim();
+        String newAttachmentName = textFieldAttachmentName.getText().trim();
         if (!currentValue.equals(newAttachmentName)) {
           final String newUnitAttachmentKey = newAttachmentName + "_" + unitName;
           if (MapXmlHelper.getUnitAttachmentsMap().containsKey(newUnitAttachmentKey)) {


### PR DESCRIPTION
Some more cleanup via static analysis tools - remove unnecessary casts

I checked rebasing on https://github.com/triplea-game/triplea/pull/743 for merge conflicts and things were reasonable. That makes sense since this PR removes casts we do not need outright, while #743 takes more effort to eliminate casts that were necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/757)
<!-- Reviewable:end -->
