### PR TITLE
ProcessorRunnerUtil.java - Use class.getName() instead of using hardcoded String value

### DIFF
--- a/src/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/src/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -122,7 +122,8 @@ public class ProcessRunnerUtil {
     System.out.println("Max Memory:" + runtime.maxMemory() / mb);
     final List<String> commands = new ArrayList<>();
     ProcessRunnerUtil.populateBasicJavaArgs(commands);
-    final String javaClass = "util.image.MapCreator";
+
+    final String javaClass = MapCreator.class.getName();
     commands.add(javaClass);
     System.out.println("Testing ProcessRunnerUtil");
     System.out.println(commands);


### PR DESCRIPTION
I tested that the map creator still launches after this update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/758)
<!-- Reviewable:end -->
