### PR TITLE
Update unload transport default to use min number of transports

### DIFF
--- a/src/games/strategy/engine/data/Unit.java
+++ b/src/games/strategy/engine/data/Unit.java
@@ -95,6 +95,13 @@ public class Unit extends GameDataComponent implements Serializable {
     return this.m_uid.equals(other.m_uid);
   }
 
+  public boolean hasSamePropertiesAndState(final Unit unit) {
+    if (m_type == null || m_owner == null) {
+      return false;
+    }
+    return m_type.equals(unit.getType()) && m_owner.equals(unit.getOwner()) && m_hits == unit.getHits();
+  }
+
   @Override
   public int hashCode() {
     if (m_type == null || m_owner == null || m_uid == null || this.getData() == null) {

--- a/src/games/strategy/engine/data/Unit.java
+++ b/src/games/strategy/engine/data/Unit.java
@@ -95,7 +95,7 @@ public class Unit extends GameDataComponent implements Serializable {
     return this.m_uid.equals(other.m_uid);
   }
 
-  public boolean hasSamePropertiesAndState(final Unit unit) {
+  public boolean isEquivalent(final Unit unit) {
     if (m_type == null || m_owner == null) {
       return false;
     }

--- a/src/games/strategy/triplea/ui/MovePanel.java
+++ b/src/games/strategy/triplea/ui/MovePanel.java
@@ -207,9 +207,7 @@ public class MovePanel extends AbstractMovePanel {
     sortTransportsToUnload(candidateTransports, route);
 
     // unitsToUnload are actually dependents, but need to select transports
-    final Map<Unit, Unit> unitsToTransports =
-        TransportUtils.mapTransportsAlreadyLoaded(unitsToUnload, candidateTransports);
-    final Set<Unit> defaultSelections = new HashSet<>(unitsToTransports.values());
+    final Set<Unit> defaultSelections = TransportUtils.findMinTransportsToUnload(unitsToUnload, candidateTransports);
 
     // Match criteria to ensure that chosen transports will match selected units
     final Match<Collection<Unit>> transportsToUnloadMatch = new Match<Collection<Unit>>() {

--- a/src/games/strategy/triplea/util/TransportUtils.java
+++ b/src/games/strategy/triplea/util/TransportUtils.java
@@ -136,7 +136,7 @@ public class TransportUtils {
       unitToPotentialTransports = sortByTransportOptionsAscending(unitToPotentialTransports);
       final Unit currentUnit = unitToPotentialTransports.keySet().iterator().next();
       final Unit selectedTransport = findOptimalTransportToUnloadFrom(currentUnit, unitToPotentialTransports);
-      removeTransportAndLoadedUnits(selectedTransport, unitToPotentialTransports);
+      unitToPotentialTransports = removeTransportAndLoadedUnits(selectedTransport, unitToPotentialTransports);
       result.add(selectedTransport);
     }
     return result;
@@ -294,7 +294,7 @@ public class TransportUtils {
     return selectedTransport;
   }
 
-  private static void removeTransportAndLoadedUnits(final Unit transport,
+  private static Map<Unit, List<Unit>> removeTransportAndLoadedUnits(final Unit transport,
       final Map<Unit, List<Unit>> unitToPotentialTransports) {
     for (final Unit loadedUnit : TransportTracker.transporting(transport)) {
       if (containsEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet())) {
@@ -303,6 +303,7 @@ public class TransportUtils {
       }
     }
     unitToPotentialTransports.values().stream().forEach(t -> t.remove(transport));
+    return unitToPotentialTransports;
   }
 
   private static boolean containsEquivalentUnit(final Unit unit, final Collection<Unit> units) {

--- a/src/games/strategy/triplea/util/TransportUtils.java
+++ b/src/games/strategy/triplea/util/TransportUtils.java
@@ -249,7 +249,7 @@ public class TransportUtils {
     final List<Unit> canTransport = Match.getMatches(transports, Matches.UnitCanTransport);
     final Map<Unit, List<Unit>> result = new LinkedHashMap<>();
     for (final Unit unit : canBeTransported) {
-      final List<Unit> transportOptions = new ArrayList<Unit>();
+      final List<Unit> transportOptions = new ArrayList<>();
       for (final Unit transport : canTransport) {
         if (containsEquivalentUnit(unit, TransportTracker.transporting(transport))) {
           transportOptions.add(transport);

--- a/src/games/strategy/triplea/util/TransportUtils.java
+++ b/src/games/strategy/triplea/util/TransportUtils.java
@@ -306,11 +306,11 @@ public class TransportUtils {
   }
 
   private static boolean containsEquivalentUnit(final Unit unit, final Collection<Unit> units) {
-    return units.stream().anyMatch(u -> u.hasSamePropertiesAndState(unit));
+    return units.stream().anyMatch(u -> u.isEquivalent(unit));
   }
 
   private static Unit getEquivalentUnit(final Unit unit, final Collection<Unit> units) {
-    return units.stream().filter(u -> u.hasSamePropertiesAndState(unit)).findFirst().get();
+    return units.stream().filter(u -> u.isEquivalent(unit)).findFirst().get();
   }
 
 }

--- a/src/games/strategy/triplea/util/TransportUtils.java
+++ b/src/games/strategy/triplea/util/TransportUtils.java
@@ -5,10 +5,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Unit;
@@ -122,6 +125,23 @@ public class TransportUtils {
     return mapping;
   }
 
+  /**
+   * Returns list of transports. Transports must contain all units. Can swap units with equivalent state in order to
+   * minimize transports used to unload.
+   */
+  public static Set<Unit> findMinTransportsToUnload(final Collection<Unit> units, final Collection<Unit> transports) {
+    final Set<Unit> result = new HashSet<>();
+    Map<Unit, List<Unit>> unitToPotentialTransports = findTransportsThatUnitsCouldUnloadFrom(units, transports);
+    while (!unitToPotentialTransports.isEmpty()) {
+      unitToPotentialTransports = sortByTransportOptionsAscending(unitToPotentialTransports);
+      final Unit currentUnit = unitToPotentialTransports.keySet().iterator().next();
+      final Unit selectedTransport = findOptimalTransportToUnloadFrom(currentUnit, unitToPotentialTransports);
+      removeTransportAndLoadedUnits(selectedTransport, unitToPotentialTransports);
+      result.add(selectedTransport);
+    }
+    return result;
+  }
+
   public static List<Unit> findUnitsToLoadOnAirTransports(final Collection<Unit> units,
       final Collection<Unit> transports) {
 
@@ -221,6 +241,76 @@ public class TransportUtils {
         it.remove();
       }
     }
+  }
+
+  private static Map<Unit, List<Unit>> findTransportsThatUnitsCouldUnloadFrom(final Collection<Unit> units,
+      final Collection<Unit> transports) {
+    final List<Unit> canBeTransported = Match.getMatches(units, Matches.UnitCanBeTransported);
+    final List<Unit> canTransport = Match.getMatches(transports, Matches.UnitCanTransport);
+    final Map<Unit, List<Unit>> result = new LinkedHashMap<>();
+    for (final Unit unit : canBeTransported) {
+      final List<Unit> transportOptions = new ArrayList<Unit>();
+      for (final Unit transport : canTransport) {
+        if (containsEquivalentUnit(unit, TransportTracker.transporting(transport))) {
+          transportOptions.add(transport);
+        }
+      }
+      result.put(unit, transportOptions);
+    }
+    return result;
+  }
+
+  private static Map<Unit, List<Unit>> sortByTransportOptionsAscending(
+      final Map<Unit, List<Unit>> unitToPotentialTransports) {
+    final Map<Unit, List<Unit>> result = new LinkedHashMap<>();
+    unitToPotentialTransports.entrySet().stream()
+        .sorted((o1, o2) -> o1.getValue().size() - o2.getValue().size())
+        .forEachOrdered(e -> result.put(e.getKey(), e.getValue()));
+    return result;
+  }
+
+  private static Unit findOptimalTransportToUnloadFrom(final Unit unit,
+      final Map<Unit, List<Unit>> unitToPotentialTransports) {
+    double minAverageTransportOptions = Integer.MAX_VALUE;
+    Unit selectedTransport = unitToPotentialTransports.get(unit).get(0);
+    for (final Unit transport : unitToPotentialTransports.get(unit)) {
+      int transportOptions = 0;
+      for (final Unit loadedUnit : TransportTracker.transporting(transport)) {
+        if (containsEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet())) {
+          final Unit equivalentUnit = getEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet());
+          transportOptions += unitToPotentialTransports.get(equivalentUnit).size();
+        } else {
+          transportOptions = Integer.MAX_VALUE;
+          break;
+        }
+      }
+      final double averageTransportOptions =
+          (double) transportOptions / TransportTracker.transporting(transport).size();
+      if (averageTransportOptions < minAverageTransportOptions) {
+        minAverageTransportOptions = averageTransportOptions;
+        selectedTransport = transport;
+      }
+    }
+    return selectedTransport;
+  }
+
+  private static void removeTransportAndLoadedUnits(final Unit transport,
+      final Map<Unit, List<Unit>> unitToPotentialTransports) {
+    for (final Unit loadedUnit : TransportTracker.transporting(transport)) {
+      if (containsEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet())) {
+        final Unit unit = getEquivalentUnit(loadedUnit, unitToPotentialTransports.keySet());
+        unitToPotentialTransports.remove(unit);
+      }
+    }
+    unitToPotentialTransports.values().stream().forEach(t -> t.remove(transport));
+  }
+
+  private static boolean containsEquivalentUnit(final Unit unit, final Collection<Unit> units) {
+    return units.stream().anyMatch(u -> u.hasSamePropertiesAndState(unit));
+  }
+
+  private static Unit getEquivalentUnit(final Unit unit, final Collection<Unit> units) {
+    return units.stream().filter(u -> u.hasSamePropertiesAndState(unit)).findFirst().get();
   }
 
 }


### PR DESCRIPTION
Address point 3 on #553 

Now tries to find the min number of transports to unload for the selected units. Previously it just randomly selected transports which usually led to poor defaults.

There is a considerable amount of difficult logic for this change as finding the min number of transports isn't easy. This also is an exact solution but rather an approximation as checking every possible combination could be extremely slow.

The algorithm is based on finding the number of transports each 'unit' could be unloaded from and sorting them by ascending options. This allows the units with the least options to choose their transport first (think I select 1 tank and 1 infantry on a group of transports that only has 1 tank loaded but lots of infantry, I want to pick the transport with the tank to unload first). It then has a kind of scoring to find the best transport to select for the given unit (the one that has the most units that are selected but also has units with the least options). It essentially keeps doing this again and again til all units have selected a transport and returns a list of all the transports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/762)
<!-- Reviewable:end -->
