### PR TITLE
Turn off Url connection caching

### DIFF
--- a/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -14,18 +14,21 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import com.sun.deploy.util.SessionState;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
 import games.strategy.engine.framework.ui.NewGameChooserModel;
 import games.strategy.triplea.Constants;
+import games.strategy.util.UrlStreams;
 
 /**
  * A list of all available games. We make sure we can parse them all, but we don't keep them in memory.
@@ -140,7 +143,7 @@ public class AvailableGames {
         entry = zis.getNextEntry();
       }
     } catch (final IOException e) {
-      ClientLogger.logQuietly("Map: "+ map, e);
+      ClientLogger.logQuietly("Map: " + map, e);
     }
   }
 
@@ -149,11 +152,11 @@ public class AvailableGames {
     if (uri == null) {
       return false;
     }
-    InputStream input = null;
     final AtomicReference<String> gameName = new AtomicReference<>();
-    try {
-      input = uri.toURL().openStream();
-      try {
+
+    Optional<InputStream> inputStream = UrlStreams.openStream(uri);
+    if (inputStream.isPresent()) {
+      try (InputStream input = inputStream.get()) {
         final GameData data = new GameParser().parse(input, gameName, s_delayedParsing);
         final String name = data.getGameName();
         final String mapName = data.getProperties().get(Constants.MAP_NAME, "");
@@ -164,18 +167,9 @@ public class AvailableGames {
           }
           return true;
         }
-      } catch (final Exception e2) {// ignore
-        System.err.println("Exception while parsing: " + uri.toString() + " : "
-            + (gameName.get() != null ? gameName.get() + " : " : "") + e2.getMessage());
-      }
-    } catch (final Exception e1) {// ignore
-      System.err.println("Exception while opening: " + uri.toString() + " : " + e1.getMessage());
-    } finally {
-      try {
-        if (input != null) {
-          input.close();
-        }
-      } catch (final IOException e3) {// ignore
+      } catch (final Exception e) {
+        ClientLogger.logError("Exception while parsing: " + uri.toString() + " : "
+            + (gameName.get() != null ? gameName.get() + " : " : ""), e);
       }
     }
     return false;
@@ -201,32 +195,16 @@ public class AvailableGames {
       return null;
     }
     final AtomicReference<String> gameName = new AtomicReference<>();
-    GameData data = null;
-    InputStream input = null;
-    boolean error = false;
-    try {
-      input = uri.toURL().openStream();
-      try {
-        data = new GameParser().parse(input, gameName, false);
-      } catch (final Exception e2) {
-        error = true;
-        System.err.println("Exception while parsing: " + uri.toString() + " : "
-            + (gameName.get() != null ? gameName.get() + " : " : "") + e2.getMessage());
-      }
-    } catch (final Exception e1) {
-      error = true;
-      System.err.println("Exception while opening: " + uri.toString() + " : " + e1.getMessage());
-    } finally {
-      try {
-        if (input != null) {
-          input.close();
-        }
-      } catch (final IOException e2) {// ignore
+
+    Optional<InputStream> inputStream = UrlStreams.openStream(uri);
+    if (inputStream.isPresent()) {
+      try (InputStream input = inputStream.get()) {
+        return new GameParser().parse(input, gameName, false);
+      } catch (final Exception e) {
+        ClientLogger.logError("Exception while parsing: " + uri.toString() + " : "
+            + (gameName.get() != null ? gameName.get() + " : " : ""), e);
       }
     }
-    if (error) {
-      return null;
-    }
-    return data;
+    return null;
   }
 }

--- a/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import com.sun.deploy.util.SessionState;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;

--- a/src/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
@@ -10,10 +10,12 @@ import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.Buffer;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Optional;
 
 import javax.imageio.ImageIO;
 import javax.swing.JButton;
@@ -26,6 +28,7 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentListener;
 
+import games.strategy.util.UrlStreams;
 import org.apache.commons.httpclient.methods.multipart.Part;
 
 import games.strategy.engine.framework.startup.ui.MainFrame;
@@ -145,12 +148,21 @@ public class MicroWebPosterEditor extends EditorPanel {
     final ArrayList<String> players = new ArrayList<>();
     try {
       final URL url = new URL(hostUrl + "getplayers.php");
-      final BufferedReader in = new BufferedReader(new InputStreamReader(url.openStream()));
-      String inputLine;
-      while ((inputLine = in.readLine()) != null) {
-        players.add(inputLine);
+      Optional<InputStream> inputStream = UrlStreams.openStream(url);
+      if (inputStream.isPresent()) {
+        try (InputStream stream = inputStream.get()) {
+          try (InputStreamReader reader = new InputStreamReader(stream)) {
+            try (BufferedReader bufferedReader = new BufferedReader(reader)) {
+              String inputLine;
+              while ((inputLine = bufferedReader.readLine()) != null) {
+                players.add(inputLine);
+              }
+            }
+          }
+
+        }
       }
-      in.close();
+
       for (int i = 0; i < players.size(); i++) {
         players.set(i, players.get(i).substring(0, players.get(i).indexOf("\t")));
       }

--- a/src/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
@@ -15,6 +15,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.Buffer;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import javax.imageio.ImageIO;
@@ -207,7 +208,7 @@ public class MicroWebPosterEditor extends EditorPanel {
         for (int i = 0; i < comboBoxes.size(); i++) {
           sb.append(m_parties[i]);
           sb.append(": ");
-          sb.append((String) comboBoxes.get(i).getSelectedItem());
+          sb.append(comboBoxes.get(i).getSelectedItem());
           sb.append("\n");
         }
         final java.util.List<Part> parts = new ArrayList<>();

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -79,13 +79,11 @@ public class NewGameChooserEntry {
       throw new GameParseException(e.getMessage());
     } catch (final SAXParseException e) {
       String msg = "Could not parse:" + m_url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber();
-      ClientLogger.logError(msg);
-      ClientLogger.logQuietly(e);
+      ClientLogger.logError(msg, e);
       throw new GameParseException(e.getMessage());
     } catch (final Exception e) {
       String msg = "Could not parse:" + m_url;
-      ClientLogger.logError(msg);
-      ClientLogger.logQuietly(e);
+      ClientLogger.logError(msg, e);
       throw new GameParseException(e.getMessage());
     }
   }

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import games.strategy.util.UrlStreams;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
@@ -42,7 +44,13 @@ public class NewGameChooserEntry {
       throws IOException, GameParseException, SAXException, EngineVersionException {
     m_url = uri;
     final AtomicReference<String> gameName = new AtomicReference<>();
-    try (InputStream input = uri.toURL().openStream()) {
+
+    Optional<InputStream> inputStream = UrlStreams.openStream(uri);
+    if(!inputStream.isPresent()) {
+      throw new IOException("Failed to open an input stream to: " + uri);
+    }
+
+    try (InputStream input = inputStream.get()) {
       final boolean delayParsing = GameRunner2.getDelayedParsing();
       m_data = new GameParser().parse(input, gameName, delayParsing);
       m_gameDataFullyLoaded = !delayParsing;
@@ -51,31 +59,34 @@ public class NewGameChooserEntry {
   }
 
   public void fullyParseGameData() throws GameParseException {
+    // TODO: We should be setting this in the the constructor. At this point, you have to call methods in the
+    // correct order for things to work, and that is bads.
     m_data = null;
 
-    String error = null;
     final AtomicReference<String> gameName = new AtomicReference<>();
 
-    try (InputStream input = m_url.toURL().openStream()) {
+    Optional<InputStream> inputStream = UrlStreams.openStream(m_url);
+    if(!inputStream.isPresent()) {
+      return;
+    }
+
+    try (InputStream input = inputStream.get()) {
       m_data = new GameParser().parse(input, gameName, false);
       m_gameDataFullyLoaded = true;
 
     } catch (final EngineVersionException e) {
       ClientLogger.logQuietly(e);
-      error = e.getMessage();
+      throw new GameParseException(e.getMessage());
     } catch (final SAXParseException e) {
       String msg = "Could not parse:" + m_url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber();
       ClientLogger.logError(msg);
       ClientLogger.logQuietly(e);
-      error = e.getMessage();
+      throw new GameParseException(e.getMessage());
     } catch (final Exception e) {
       String msg = "Could not parse:" + m_url;
       ClientLogger.logError(msg);
       ClientLogger.logQuietly(e);
-      error = e.getMessage();
-    }
-    if (error != null) {
-      throw new GameParseException(error);
+      throw new GameParseException(e.getMessage());
     }
   }
 
@@ -87,7 +98,11 @@ public class NewGameChooserEntry {
     m_data = null;
 
     final AtomicReference<String> gameName = new AtomicReference<>();
-    try (InputStream input = m_url.toURL().openStream()) {
+    Optional<InputStream> inputStream = UrlStreams.openStream(m_url);
+    if(!inputStream.isPresent()) {
+      return;
+    }
+    try (InputStream input = inputStream.get()) {
       m_data = new GameParser().parse(input, gameName, true);
       m_gameDataFullyLoaded = false;
     } catch (final EngineVersionException e) {

--- a/src/games/strategy/sound/ClipPlayer.java
+++ b/src/games/strategy/sound/ClipPlayer.java
@@ -23,16 +23,17 @@ import java.util.prefs.Preferences;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import games.strategy.util.UrlStreams;
+import javazoom.jl.player.AudioDevice;
+import javazoom.jl.player.FactoryRegistry;
+import javazoom.jl.player.advanced.AdvancedPlayer;
+
 import com.google.common.base.Throwables;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.triplea.ResourceLoader;
-import games.strategy.util.UrlStreams;
-import javazoom.jl.player.AudioDevice;
-import javazoom.jl.player.FactoryRegistry;
-import javazoom.jl.player.advanced.AdvancedPlayer;
 
 /**
  * Utility for loading and playing sound clips.
@@ -328,7 +329,6 @@ public class ClipPlayer {
    * phase_purchase_Germans=phase_purchase_Germans/game_start_Germans_01_anthem.mp3
    *
    * @param pathName
-   * @param subFolder
    */
   private List<URL> parseClipPaths(final String pathName) {
     // Check if there is a sound.properties path override for this resource

--- a/src/games/strategy/sound/ClipPlayer.java
+++ b/src/games/strategy/sound/ClipPlayer.java
@@ -275,8 +275,7 @@ public class ClipPlayer {
           Optional<InputStream> inputStream = UrlStreams.openStream(clip.toURL());
           if(inputStream.isPresent()) {
             final AudioDevice audioDevice = FactoryRegistry.systemRegistry().createAudioDevice();
-            final AdvancedPlayer audioPlayer = new AdvancedPlayer(inputStream.get(), audioDevice);
-            audioPlayer.play();
+            new AdvancedPlayer(inputStream.get(), audioDevice).play();
           }
         } catch (Exception e) {
           ClientLogger.logError("Failed to play: " + clip, e);

--- a/src/games/strategy/sound/ClipPlayer.java
+++ b/src/games/strategy/sound/ClipPlayer.java
@@ -1,6 +1,7 @@
 package games.strategy.sound;
 
 import java.io.File;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -15,6 +16,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
@@ -27,6 +29,8 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.triplea.ResourceLoader;
+import games.strategy.util.UrlStreams;
+import javazoom.jl.player.AudioDevice;
 import javazoom.jl.player.FactoryRegistry;
 import javazoom.jl.player.advanced.AdvancedPlayer;
 
@@ -268,10 +272,12 @@ public class ClipPlayer {
     if (clip != null) {
       (new Thread(() -> {
         try {
-          final AdvancedPlayer player = new AdvancedPlayer(
-              new java.net.URL(clip.toURL().toString()).openStream(),
-              FactoryRegistry.systemRegistry().createAudioDevice());
-          player.play();
+          Optional<InputStream> inputStream = UrlStreams.openStream(clip.toURL());
+          if(inputStream.isPresent()) {
+            final AudioDevice audioDevice = FactoryRegistry.systemRegistry().createAudioDevice();
+            final AdvancedPlayer audioPlayer = new AdvancedPlayer(inputStream.get(), audioDevice);
+            audioPlayer.play();
+          }
         } catch (Exception e) {
           ClientLogger.logError("Failed to play: " + clip, e);
         }

--- a/src/games/strategy/sound/SoundProperties.java
+++ b/src/games/strategy/sound/SoundProperties.java
@@ -27,23 +27,21 @@ public class SoundProperties {
 
   protected SoundProperties(final ResourceLoader loader) {
     final URL url = loader.getResource(PROPERTY_FILE);
-    if (url == null) {
-      // no property file found
-    } else {
-      try {
-        Optional<InputStream> inputStream = UrlStreams.openStream(url);
-        if(inputStream.isPresent()) {
+    if (url != null) {
+      Optional<InputStream> inputStream = UrlStreams.openStream(url);
+      if (inputStream.isPresent()) {
+        try {
           m_properties.load(inputStream.get());
+        } catch (final IOException e) {
+          System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
         }
-      } catch (final IOException e) {
-        System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
       }
     }
   }
 
   public static SoundProperties getInstance(final ResourceLoader loader) {
     if (s_op == null || Calendar.getInstance().getTimeInMillis() > timestamp + 1000) { // cache properties for 1
-                                                                                         // second
+                                                                                       // second
       s_op = new SoundProperties(loader);
       timestamp = Calendar.getInstance().getTimeInMillis();
     }

--- a/src/games/strategy/sound/SoundProperties.java
+++ b/src/games/strategy/sound/SoundProperties.java
@@ -1,11 +1,15 @@
 package games.strategy.sound;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.net.URLStreamHandler;
 import java.util.Calendar;
+import java.util.Optional;
 import java.util.Properties;
 
 import games.strategy.triplea.ResourceLoader;
+import games.strategy.util.UrlStreams;
 
 /**
  * sounds.properties file helper class
@@ -27,7 +31,10 @@ public class SoundProperties {
       // no property file found
     } else {
       try {
-        m_properties.load(url.openStream());
+        Optional<InputStream> inputStream = UrlStreams.openStream(url);
+        if(inputStream.isPresent()) {
+          m_properties.load(inputStream.get());
+        }
       } catch (final IOException e) {
         System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
       }

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -200,11 +200,8 @@ public class ResourceLoader {
   }
 
   /**
-   * @deprecated Avoid this method. It returns an InputStream, and you have to close it. It is easy not to do that.
-   * Instead prefer to create an object that wraps the thing you are parsing, and have
-   * your new object return exactly the data you want. In this case that object can handle closing the InputStream
+   * Ensure that you close the InputStream returned by this method when you are done using it.
    */
-  @Deprecated
   public InputStream getResourceAsStream(final String path) {
     URL url = getResource(path);
     if (url == null) {

--- a/src/games/strategy/triplea/ui/MapData.java
+++ b/src/games/strategy/triplea/ui/MapData.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -33,6 +34,7 @@ import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
+import games.strategy.util.UrlStreams;
 
 /**
  * contains data about the territories useful for drawing
@@ -157,6 +159,7 @@ public class MapData {
     m_resourceLoader = loader;
     try {
       final String prefix = "";
+      // TODO: each call to loader.getResourceAsStream opens an input stream, but we never close it, this is a resource leak.
       m_place = PointFileReaderWriter.readOneToMany(loader.getResourceAsStream(prefix + PLACEMENT_FILE));
       m_territoryEffects =
           PointFileReaderWriter.readOneToMany(loader.getResourceAsStream(prefix + TERRITORY_EFFECT_FILE));
@@ -178,7 +181,10 @@ public class MapData {
         if (url == null) {
           throw new IllegalStateException("No map.properties file defined");
         }
-        m_mapProperties.load(url.openStream());
+        Optional<InputStream> inputStream = UrlStreams.openStream(url);
+        if(inputStream.isPresent()) {
+          m_mapProperties.load(inputStream.get());
+        }
       } catch (final Exception e) {
         System.out.println("Error reading map.properties:" + e);
       }
@@ -216,8 +222,10 @@ public class MapData {
       return;
     }
     m_decorations = new HashMap<>();
-    try (InputStream stream = decorations.openStream()) {
-      final Map<String, List<Point>> points = PointFileReaderWriter.readOneToMany(stream);
+
+    Optional<InputStream> inputStream = UrlStreams.openStream(decorations);
+    if(inputStream.isPresent()) {
+      final Map<String, List<Point>> points = PointFileReaderWriter.readOneToMany(inputStream.get());
       for (final String name : points.keySet()) {
         final Image img = loadImage("misc/" + name);
         m_decorations.put(img, points.get(name));

--- a/src/games/strategy/triplea/ui/MapData.java
+++ b/src/games/strategy/triplea/ui/MapData.java
@@ -151,7 +151,7 @@ public class MapData {
    * Constructor TerritoryData(java.lang.String)
    * Sets the map directory for this instance of TerritoryData
    *
-   * @param java
+   * @param loader
    *        .lang.String
    *        mapNameDir the given map directory
    */
@@ -159,7 +159,6 @@ public class MapData {
     m_resourceLoader = loader;
     try {
       final String prefix = "";
-      // TODO: each call to loader.getResourceAsStream opens an input stream, but we never close it, this is a resource leak.
       m_place = PointFileReaderWriter.readOneToMany(loader.getResourceAsStream(prefix + PLACEMENT_FILE));
       m_territoryEffects =
           PointFileReaderWriter.readOneToMany(loader.getResourceAsStream(prefix + TERRITORY_EFFECT_FILE));

--- a/src/games/strategy/triplea/ui/NotificationMessages.java
+++ b/src/games/strategy/triplea/ui/NotificationMessages.java
@@ -1,11 +1,15 @@
 package games.strategy.triplea.ui;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Calendar;
+import java.util.Optional;
 import java.util.Properties;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.ResourceLoader;
+import games.strategy.util.UrlStreams;
 
 /** TODO: copy paste overlap with PoliticsText.java */
 public class NotificationMessages {
@@ -20,12 +24,14 @@ public class NotificationMessages {
     final ResourceLoader loader = AbstractUIContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
     if (url == null) {
-      // no propertyfile found
-    } else {
+      return;
+    }
+    Optional<InputStream> inputStream = UrlStreams.openStream(url);
+    if(inputStream.isPresent()) {
       try {
-        m_properties.load(url.openStream());
+        m_properties.load(inputStream.get());
       } catch (final IOException e) {
-        System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
+        ClientLogger.logError("Error reading " + PROPERTY_FILE, e);
       }
     }
   }

--- a/src/games/strategy/triplea/ui/NotificationMessages.java
+++ b/src/games/strategy/triplea/ui/NotificationMessages.java
@@ -23,15 +23,14 @@ public class NotificationMessages {
   protected NotificationMessages() {
     final ResourceLoader loader = AbstractUIContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
-    if (url == null) {
-      return;
-    }
-    Optional<InputStream> inputStream = UrlStreams.openStream(url);
-    if(inputStream.isPresent()) {
-      try {
-        m_properties.load(inputStream.get());
-      } catch (final IOException e) {
-        ClientLogger.logError("Error reading " + PROPERTY_FILE, e);
+    if (url != null) {
+      Optional<InputStream> inputStream = UrlStreams.openStream(url);
+      if (inputStream.isPresent()) {
+        try {
+          m_properties.load(inputStream.get());
+        } catch (final IOException e) {
+          ClientLogger.logError("Error reading " + PROPERTY_FILE, e);
+        }
       }
     }
   }

--- a/src/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/games/strategy/triplea/ui/ObjectivePanel.java
@@ -498,17 +498,15 @@ class ObjectiveProperties {
   protected ObjectiveProperties() {
     final ResourceLoader loader = AbstractUIContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
-    if (url == null) {
-      // no property file found
-    } else {
-      try {
+    if (url != null) {
         Optional<InputStream> inputStream = UrlStreams.openStream(url);
         if(inputStream.isPresent()) {
-          m_properties.load(inputStream.get());
+          try {
+            m_properties.load(inputStream.get());
+          } catch (final IOException e) {
+            System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
+          }
         }
-      } catch (final IOException e) {
-        System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
-      }
     }
   }
 

--- a/src/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/games/strategy/triplea/ui/ObjectivePanel.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.ui;
 import java.awt.Color;
 import java.awt.Component;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -78,6 +80,7 @@ import games.strategy.triplea.delegate.remote.ITechDelegate;
 import games.strategy.triplea.ui.display.DummyTripleADisplay;
 import games.strategy.util.IllegalCharacterRemover;
 import games.strategy.util.Tuple;
+import games.strategy.util.UrlStreams;
 
 /**
  * A panel that will show all objectives for all players, including if the objective is filled or not.
@@ -499,7 +502,10 @@ class ObjectiveProperties {
       // no property file found
     } else {
       try {
-        m_properties.load(url.openStream());
+        Optional<InputStream> inputStream = UrlStreams.openStream(url);
+        if(inputStream.isPresent()) {
+          m_properties.load(inputStream.get());
+        }
       } catch (final IOException e) {
         System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
       }

--- a/src/games/strategy/triplea/ui/PoliticsText.java
+++ b/src/games/strategy/triplea/ui/PoliticsText.java
@@ -1,11 +1,14 @@
 package games.strategy.triplea.ui;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Calendar;
+import java.util.Optional;
 import java.util.Properties;
 
 import games.strategy.triplea.ResourceLoader;
+import games.strategy.util.UrlStreams;
 
 /**
  * Returns a bunch of messages from politicstext.properties
@@ -28,13 +31,17 @@ public class PoliticsText {
   protected PoliticsText() {
     final ResourceLoader loader = AbstractUIContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
+
     if (url == null) {
       // no propertyfile found
     } else {
-      try {
-        m_properties.load(url.openStream());
-      } catch (final IOException e) {
-        System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
+      Optional<InputStream> inputStream = UrlStreams.openStream(url);
+      if(inputStream.isPresent()) {
+        try {
+          m_properties.load(inputStream.get());
+        } catch (final IOException e) {
+          System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
+        }
       }
     }
   }

--- a/src/games/strategy/triplea/ui/PoliticsText.java
+++ b/src/games/strategy/triplea/ui/PoliticsText.java
@@ -32,9 +32,7 @@ public class PoliticsText {
     final ResourceLoader loader = AbstractUIContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
 
-    if (url == null) {
-      // no propertyfile found
-    } else {
+    if (url != null) {
       Optional<InputStream> inputStream = UrlStreams.openStream(url);
       if(inputStream.isPresent()) {
         try {

--- a/src/games/strategy/triplea/ui/ProductionTabsProperties.java
+++ b/src/games/strategy/triplea/ui/ProductionTabsProperties.java
@@ -50,13 +50,13 @@ public class ProductionTabsProperties {
       propertyFile = PROPERTY_FILE + ".properties";
       url = loader.getResource(propertyFile);
       if (url != null) {
-        try {
-          Optional<InputStream> inputStream = UrlStreams.openStream(url);
-          if(inputStream.isPresent()) {
+        Optional<InputStream> inputStream = UrlStreams.openStream(url);
+        if (inputStream.isPresent()) {
+          try {
             m_properties.load(inputStream.get());
+          } catch (final IOException e) {
+            System.out.println("Error reading " + propertyFile + e);
           }
-        } catch (final IOException e) {
-          System.out.println("Error reading " + propertyFile + e);
         }
       }
     }

--- a/src/games/strategy/triplea/ui/ProductionTabsProperties.java
+++ b/src/games/strategy/triplea/ui/ProductionTabsProperties.java
@@ -1,16 +1,19 @@
 package games.strategy.triplea.ui;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 import games.strategy.engine.data.PlayerID;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.ui.ProductionPanel.Rule;
 import games.strategy.util.Tuple;
+import games.strategy.util.UrlStreams;
 
 public class ProductionTabsProperties {
   // Filename
@@ -46,10 +49,12 @@ public class ProductionTabsProperties {
       // no production_tabs.france.properties check for production_tabs.properties
       propertyFile = PROPERTY_FILE + ".properties";
       url = loader.getResource(propertyFile);
-      if (url == null) {
-      } else {
+      if (url != null) {
         try {
-          m_properties.load(url.openStream());
+          Optional<InputStream> inputStream = UrlStreams.openStream(url);
+          if(inputStream.isPresent()) {
+            m_properties.load(inputStream.get());
+          }
         } catch (final IOException e) {
           System.out.println("Error reading " + propertyFile + e);
         }

--- a/src/games/strategy/triplea/ui/TooltipProperties.java
+++ b/src/games/strategy/triplea/ui/TooltipProperties.java
@@ -25,16 +25,14 @@ public class TooltipProperties {
   protected TooltipProperties() {
     final ResourceLoader loader = AbstractUIContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
-    if (url == null) {
-      // no propertyfile found
-    } else {
-      try {
-        Optional<InputStream> inputStream = UrlStreams.openStream(url);
-        if(inputStream.isPresent()) {
+    if (url != null) {
+      Optional<InputStream> inputStream = UrlStreams.openStream(url);
+      if (inputStream.isPresent()) {
+        try {
           m_properties.load(inputStream.get());
+        } catch (final IOException e) {
+          System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
         }
-      } catch (final IOException e) {
-        System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
       }
     }
   }

--- a/src/games/strategy/triplea/ui/TooltipProperties.java
+++ b/src/games/strategy/triplea/ui/TooltipProperties.java
@@ -1,13 +1,16 @@
 package games.strategy.triplea.ui;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Calendar;
+import java.util.Optional;
 import java.util.Properties;
 
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.ResourceLoader;
+import games.strategy.util.UrlStreams;
 
 public class TooltipProperties {
   // Filename
@@ -26,7 +29,10 @@ public class TooltipProperties {
       // no propertyfile found
     } else {
       try {
-        m_properties.load(url.openStream());
+        Optional<InputStream> inputStream = UrlStreams.openStream(url);
+        if(inputStream.isPresent()) {
+          m_properties.load(inputStream.get());
+        }
       } catch (final IOException e) {
         System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
       }

--- a/src/games/strategy/triplea/ui/UserActionText.java
+++ b/src/games/strategy/triplea/ui/UserActionText.java
@@ -30,16 +30,14 @@ public class UserActionText {
   protected UserActionText() {
     final ResourceLoader loader = AbstractUIContext.getResourceLoader();
     final URL url = loader.getResource(PROPERTY_FILE);
-    if (url == null) {
-      // no property file found
-    } else {
-      try {
-        Optional<InputStream> inputStream = UrlStreams.openStream(url);
-        if(inputStream.isPresent()) {
+    if (url != null) {
+      Optional<InputStream> inputStream = UrlStreams.openStream(url);
+      if (inputStream.isPresent()) {
+        try {
           m_properties.load(inputStream.get());
+        } catch (final IOException e) {
+          System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
         }
-      } catch (final IOException e) {
-        System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
       }
     }
   }

--- a/src/games/strategy/triplea/ui/UserActionText.java
+++ b/src/games/strategy/triplea/ui/UserActionText.java
@@ -1,11 +1,14 @@
 package games.strategy.triplea.ui;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Calendar;
+import java.util.Optional;
 import java.util.Properties;
 
 import games.strategy.triplea.ResourceLoader;
+import games.strategy.util.UrlStreams;
 
 /**
  * Same as PoliticsText but for user actions.
@@ -31,7 +34,10 @@ public class UserActionText {
       // no property file found
     } else {
       try {
-        m_properties.load(url.openStream());
+        Optional<InputStream> inputStream = UrlStreams.openStream(url);
+        if(inputStream.isPresent()) {
+          m_properties.load(inputStream.get());
+        }
       } catch (final IOException e) {
         System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
       }

--- a/src/games/strategy/util/PointFileReaderWriter.java
+++ b/src/games/strategy/util/PointFileReaderWriter.java
@@ -45,6 +45,8 @@ public class PointFileReaderWriter {
         }
         current = reader.readLine();
       }
+    } finally {
+      stream.close();
     }
     return mapping;
   }
@@ -64,6 +66,8 @@ public class PointFileReaderWriter {
         }
         current = reader.readLine();
       }
+    } finally {
+      stream.close();
     }
     return mapping;
   }
@@ -171,6 +175,12 @@ public class PointFileReaderWriter {
     } catch (final IOException ioe) {
       ClientLogger.logError(ioe);
       System.exit(0);
+    } finally {
+      try {
+        stream.close();
+      } catch (IOException e) {
+        ClientLogger.logError(e);
+      }
     }
     return mapping;
   }
@@ -192,6 +202,12 @@ public class PointFileReaderWriter {
     } catch (final IOException e) {
       ClientLogger.logQuietly(e);
       System.exit(0);
+    } finally {
+      try {
+        stream.close();
+      } catch (IOException e) {
+        ClientLogger.logError(e);
+      }
     }
     return mapping;
   }

--- a/src/games/strategy/util/UrlStreams.java
+++ b/src/games/strategy/util/UrlStreams.java
@@ -1,0 +1,87 @@
+package games.strategy.util;
+
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.google.common.base.Throwables;
+
+import games.strategy.debug.ClientLogger;
+
+
+/**
+ * Utility class for opening input streams from URL and URI objects.
+ */
+public final class UrlStreams {
+
+  /**
+   * Opens an input stream to a given url. Returns Optional.empty() in case there is a failure.
+   * The failure message is logged to the user.
+   *
+   * @return Optional.empty() if there was a failure opening the strema, otherwise an optional
+   *         containing an input stream to the parameter uri.
+   */
+  public static Optional<InputStream> openStream(URL url) {
+    return new UrlStreams().newStream(url);
+  }
+
+
+  /**
+   * Opens an input stream to a given uri.
+   *
+   * @throws IllegalStateException if the given uri is malformed
+   *
+   * @return Optional.empty() if there was a failure opening the strema, otherwise an optional
+   *         containing an input stream to the parameter uri.
+   */
+  public static Optional<InputStream> openStream(URI uri) {
+    try {
+      return UrlStreams.openStream(uri.toURL());
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException("Bad uri specified: " + uri, e);
+    }
+  }
+
+  /** Used to obtain a connection from a given URL */
+  private final Function<URL, URLConnection> urlConnectionFactory;
+
+
+  protected UrlStreams() {
+    // By default just try open a connection, raise any exceptions encountered
+    this.urlConnectionFactory = (url) -> {
+      try {
+        return url.openConnection();
+      } catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+    };
+  }
+
+  /**
+   * For test, a constructor that allows mock object injection
+   */
+  protected UrlStreams(Function<URL, URLConnection> connectionFactory) {
+    this.urlConnectionFactory = connectionFactory;
+  }
+
+  protected Optional<InputStream> newStream(URL url) {
+    try {
+      URLConnection connection = urlConnectionFactory.apply(url);
+
+      // Turn off URL connection caching to avoid open file leaks. When caching is on, the InputStream
+      // returned is left open, even after you call 'InputStream.close()'
+      connection.setDefaultUseCaches(false); // TODO: verify - setDefaultUseCaches(false) may not be necessary
+      connection.setUseCaches(false);
+      return Optional.of(connection.getInputStream());
+    } catch (IOException e) {
+      ClientLogger.logError("Failed to open a connection to: " + url, e);
+      return Optional.empty();
+    }
+  }
+}

--- a/test/games/strategy/util/UrlStreamsTest.java
+++ b/test/games/strategy/util/UrlStreamsTest.java
@@ -1,0 +1,79 @@
+package games.strategy.util;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class UrlStreamsTest {
+
+  private UrlStreams testObj;
+
+  private URL fakeUrl;
+
+  @Mock
+  private URLConnection mockUrlConnection;
+  @Mock
+  private InputStream mockInputStream;
+
+
+  @Before
+  public void setup() throws Exception {
+    // set up the test object with a function that will return a mocked url connection
+    testObj = new UrlStreams(url -> mockUrlConnection);
+    fakeUrl = new URL("http://well-formed-url.com");
+  }
+
+  /**
+   * Check that we turned off caching on a mocked UrlConnection
+   */
+  @Test
+  public void cacheIsOff() throws Exception {
+    when(mockUrlConnection.getInputStream()).thenReturn(mockInputStream);
+
+    Optional<InputStream> connection = testObj.newStream(fakeUrl);
+
+    assertThat("expecting the same mocked http connection object back",
+        connection.get(), sameInstance(mockInputStream));
+    verify(mockUrlConnection).setUseCaches(false);
+    verify(mockUrlConnection).setDefaultUseCaches(false);
+  }
+
+
+  @Test
+  public void testErrorSuppressionWhenThereIsNoError()  throws Exception  {
+    when(mockUrlConnection.getInputStream()).thenReturn(mockInputStream);
+
+    Optional<InputStream> stream = testObj.newStream(fakeUrl);
+
+    assertThat("No issues connecting, we should have an inpuct stream back.",
+        stream.isPresent(), is(true));
+  }
+
+  @Test
+  public void testErrorSuppression()  throws Exception  {
+    when(mockUrlConnection.getInputStream()).thenThrow(new IOException("simulating an IOException being thrown"));
+
+    Optional<InputStream> stream = testObj.newStream(fakeUrl);
+
+    assertThat("No exceptions expected, but a failure to connect should return an empty object.",
+        stream.isPresent(), is(false));
+  }
+
+}


### PR DESCRIPTION
URL connection caching causes file leaks. 

In this PR, all of the places where we previously used URLs to create InputStreams have been replaced to use a connection that does not have caching enabled. (note: a code search was done for 'openStream', there may actually be more places where we use URLConnection to open files).

Objectives of this change:
- Fix PR: https://github.com/triplea-game/triplea/issues/508 "Available map list resource leak", this then allows for downloaded maps to be deleted  on windows (avoids a "file is open by another process and cannot be deleted error") 
- Fix many other readily identifiable cases where we have file connection leaks


How it was done:
- utility class `UrlStreams` was added, with a static method `UrlStreams.openStream(URL)`, that returns a stream that has caching turned off. 
- Then the code was updated to replace what was effectively: `new URL(..).openStream()`, with  `UrlStreams.openStream(URL)`,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/772)
<!-- Reviewable:end -->
