### PR TITLE
Fix download map preview bug

### DIFF
--- a/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -245,14 +245,19 @@ public class DownloadMapsWindow extends JDialog {
       JList<String> gamesList, List<DownloadFileDescription> maps, MapAction action, JLabel mapSizeLabelToUpdate) {
     return e -> {
       final int index = gamesList.getSelectedIndex();
-      if( index > 0 ) {
-        DownloadFileDescription map = maps.get(index);
 
-        String text = createEditorPaneText(map);
-        descriptionPanel.setText(text);
-        descriptionPanel.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
+      boolean somethingIsSelected = index > 0;
+      if (somethingIsSelected) {
+        String mapName = gamesList.getModel().getElementAt(index);
 
-        updateMapUrlAndSizeLabel(map, action, mapSizeLabelToUpdate);
+        // find the map description by map name and update the map download detail panel
+        Optional<DownloadFileDescription> map = maps.stream().filter(mapDescription -> mapDescription.getMapName().equals(mapName)).findFirst();
+        if(map.isPresent()) {
+          String text = createEditorPaneText(map.get());
+          descriptionPanel.setText(text);
+          descriptionPanel.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
+          updateMapUrlAndSizeLabel(map.get(), action, mapSizeLabelToUpdate);
+        }
       }
     };
   }


### PR DESCRIPTION
Download map window bug fix #727 - find and show map details by map name, rather than relying on indexes which wind up getting out of sync


Problem is that we used one list that had all of the map names rendered in a list, and a second list that had all the download options. When you download, we removed from one list and not the other. Using indexes to match between the lists is buggy, since they get out of sync. So here will instead find maps by name in the map download list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/788)
<!-- Reviewable:end -->
