### PR TITLE
Missing image fix and logging update

### DIFF
--- a/src/games/strategy/triplea/image/UnitImageFactory.java
+++ b/src/games/strategy/triplea/image/UnitImageFactory.java
@@ -146,9 +146,6 @@ public class UnitImageFactory {
     // URL uses '/' not '\'
     final String fileName = FILE_NAME_BASE + id.getName() + "/" + baseImageName + ".png";
     final URL url = resourceLoader.getResource(fileName);
-    if (url == null) {
-      ClientLogger.logError("MISSING IMAGE (this unit or image will be invisible): " + baseImageName + "  looking in: " + fileName);
-    }
     return Optional.ofNullable(url);
   }
 

--- a/src/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.prefs.Preferences;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
@@ -90,6 +91,11 @@ public class UnitsDrawer implements IDrawable {
     final Optional<Image> img =
         uiContext.getUnitImageFactory().getImage(type, owner, data, damaged > 0 || bombingUnitDamage > 0, disabled);
 
+    if (!img.isPresent()) {
+      ClientLogger
+          .logError("MISSING IMAGE (this unit or image will be invisible): " + type);
+    }
+
     if (img.isPresent() && enabledFlags) {
       int maxRange = new TripleAUnit(type, owner, data).getMaxMovementAllowed();
       switch (drawUnitNationMode) {
@@ -124,7 +130,9 @@ public class UnitsDrawer implements IDrawable {
           break;
       }
     } else{
-      drawUnit(graphics, img.get(), placementPoint, bounds);
+      if(img.isPresent()) {
+        drawUnit(graphics, img.get(), placementPoint, bounds);
+      }
     }
     // more then 1 unit of this category
     if (count != 1) {


### PR DESCRIPTION
Fix attempt to draw an image when it fails to load. Second, update missing image logging, only show an error message when trying to draw a missing image.

Addresses
 #831 "Edit Add Units Bug 1.9.0.0.2104"
 #830 "Unit help Image Bug 1.9.0.0.2024 "

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/847)
<!-- Reviewable:end -->
