### PR TITLE
AI add strategic bombing

### DIFF
--- a/src/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProAI.java
@@ -139,7 +139,8 @@ public class ProAI extends AbstractAI {
   }
 
   @Override
-  protected void move(final boolean nonCombat, final IMoveDelegate moveDel, final GameData data, final PlayerID player) {
+  protected void move(final boolean nonCombat, final IMoveDelegate moveDel, final GameData data,
+      final PlayerID player) {
     final long start = System.currentTimeMillis();
     BattleCalculator.clearOOLCache();
     ProLogUI.notifyStartOfRound(data.getSequence().getRound(), player.getName());
@@ -311,7 +312,7 @@ public class ProAI extends AbstractAI {
 
   @Override
   public boolean shouldBomberBomb(final Territory territory) {
-    return false;
+    return combatMoveAI.isBombing();
   }
 
   @Override

--- a/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -150,7 +150,7 @@ public class ProCombatMoveAI {
     final List<Collection<Unit>> moveUnits = new ArrayList<>();
     final List<Route> moveRoutes = new ArrayList<>();
     ProMoveUtils.calculateMoveRoutes(player, moveUnits, moveRoutes, attackMap, true);
-    ProMoveUtils.doMove(moveUnits, moveRoutes, null, moveDel);
+    ProMoveUtils.doMove(moveUnits, moveRoutes, moveDel);
 
     moveUnits.clear();
     moveRoutes.clear();
@@ -161,13 +161,13 @@ public class ProCombatMoveAI {
     moveUnits.clear();
     moveRoutes.clear();
     ProMoveUtils.calculateBombardMoveRoutes(player, moveUnits, moveRoutes, attackMap);
-    ProMoveUtils.doMove(moveUnits, moveRoutes, null, moveDel);
+    ProMoveUtils.doMove(moveUnits, moveRoutes, moveDel);
 
     moveUnits.clear();
     moveRoutes.clear();
     isBombing = true;
     ProMoveUtils.calculateBombingRoutes(player, moveUnits, moveRoutes, attackMap);
-    ProMoveUtils.doMove(moveUnits, moveRoutes, null, moveDel);
+    ProMoveUtils.doMove(moveUnits, moveRoutes, moveDel);
     isBombing = false;
   }
 

--- a/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -48,6 +48,8 @@ import games.strategy.util.Match;
  */
 public class ProCombatMoveAI {
 
+  private static final int MIN_BOMBING_SCORE = 4; // Avoid bombing low production factories with AA
+
   private final ProAI ai;
   private final ProOddsCalculator calc;
   private GameData data;
@@ -726,7 +728,7 @@ public class ProCombatMoveAI {
           continue;
         }
         Optional<Territory> maxBombingTerritory = Optional.empty();
-        int maxBombingScore = 3;
+        int maxBombingScore = MIN_BOMBING_SCORE;
         for (final Territory t : bomberMoveMap.get(unit)) {
           final boolean territoryCanBeBombed = t.getUnits().someMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
           if (territoryCanBeBombed && canAirSafelyLandAfterAttack(unit, t)) {
@@ -739,7 +741,7 @@ public class ProCombatMoveAI {
             final int numExistingBombers = attackMap.get(t).getBombers().size();
             final int remainingDamagePotential = maxDamage - 3 * numExistingBombers;
             final int bombingScore = (1 + 9 * noAABombingDefense) * remainingDamagePotential;
-            if (bombingScore > maxBombingScore) {
+            if (bombingScore >= maxBombingScore) {
               maxBombingScore = bombingScore;
               maxBombingTerritory = Optional.of(t);
             }

--- a/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -147,26 +147,22 @@ public class ProCombatMoveAI {
     this.data = data;
     this.player = player;
 
-    // Calculate attack routes and perform moves
     final List<Collection<Unit>> moveUnits = new ArrayList<>();
     final List<Route> moveRoutes = new ArrayList<>();
     ProMoveUtils.calculateMoveRoutes(player, moveUnits, moveRoutes, attackMap, true);
     ProMoveUtils.doMove(moveUnits, moveRoutes, null, moveDel);
 
-    // Calculate amphib attack routes and perform moves
     moveUnits.clear();
     moveRoutes.clear();
     final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
     ProMoveUtils.calculateAmphibRoutes(player, moveUnits, moveRoutes, transportsToLoad, attackMap, true);
     ProMoveUtils.doMove(moveUnits, moveRoutes, transportsToLoad, moveDel);
 
-    // Calculate bombard routes and perform moves
     moveUnits.clear();
     moveRoutes.clear();
     ProMoveUtils.calculateBombardMoveRoutes(player, moveUnits, moveRoutes, attackMap);
     ProMoveUtils.doMove(moveUnits, moveRoutes, null, moveDel);
 
-    // Calculate bombing routes and perform moves
     moveUnits.clear();
     moveRoutes.clear();
     isBombing = true;

--- a/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -1,5 +1,17 @@
 package games.strategy.triplea.ai.proAI;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Route;
@@ -29,18 +41,6 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import games.strategy.util.Match;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
 
 /**
  * Pro combat move AI.
@@ -262,7 +262,8 @@ public class ProCombatMoveAI {
 
       // Remove negative value territories
       patd.setValue(attackValue);
-      if (attackValue <= 0 || (isDefensive && attackValue <= 8 && data.getMap().getDistance(ProData.myCapital, t) <= 3)) {
+      if (attackValue <= 0
+          || (isDefensive && attackValue <= 8 && data.getMap().getDistance(ProData.myCapital, t) <= 3)) {
         ProLogger.debug("Removing territory that has a negative attack value: " + t.getName() + ", AttackValue="
             + patd.getValue());
         it.remove();
@@ -695,6 +696,27 @@ public class ProCombatMoveAI {
       Map<Unit, Set<Territory>> sortedUnitAttackOptions =
           tryToAttackTerritories(prioritizedTerritories, alreadyMovedUnits);
 
+
+      // Get all units that have already moved
+      final Set<Unit> alreadyAttackedWithUnits = new HashSet<>();
+      for (final Territory t : attackMap.keySet()) {
+        alreadyAttackedWithUnits.addAll(attackMap.get(t).getUnits());
+        alreadyAttackedWithUnits.addAll(attackMap.get(t).getAmphibAttackMap().keySet());
+      }
+
+      // Check to see if any infrastructure can be bombed
+      for (final Unit unit : unitAttackMap.keySet()) {
+        if (!Matches.UnitIsStrategicBomber.match(unit) || alreadyAttackedWithUnits.contains(unit)) {
+          continue;
+        }
+        for (final Territory t : unitAttackMap.get(unit)) {
+          final boolean territoryCanBeBombed = t.getUnits().someMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
+          if (territoryCanBeBombed && canAirSafelyLandAfterAttack(unit, t)) {
+            System.out.println(unit + " can bomb: " + t);
+          }
+        }
+      }
+
       // Re-sort attack options
       sortedUnitAttackOptions =
           ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions, attackMap,
@@ -714,15 +736,7 @@ public class ProCombatMoveAI {
 
           // Check if air unit should avoid this territory due to no guaranteed safe landing location
           final boolean isEnemyFactory = ProMatches.territoryHasInfraFactoryAndIsEnemyLand(player, data).match(t);
-          final boolean isAdjacentToAlliedFactory =
-              Matches.territoryHasNeighborMatching(data,
-                  ProMatches.territoryHasInfraFactoryAndIsAlliedLand(player, data)).match(t);
-          final int range = TripleAUnit.get(unit).getMovementLeft();
-          final int distance =
-              data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
-                  ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
-          final boolean usesMoreThanHalfOfRange = distance > range / 2;
-          if (!isEnemyFactory && !isAdjacentToAlliedFactory && usesMoreThanHalfOfRange) {
+          if (!isEnemyFactory && !canAirSafelyLandAfterAttack(unit, t)) {
             continue;
           }
           if (patd.getBattleResult() == null) {
@@ -915,8 +929,9 @@ public class ProCombatMoveAI {
         // Determine whether to remove attack
         if (!patd.isStrafing()
             && (result.getWinPercentage() < ProData.minWinPercentage || !result.isHasLandUnitRemaining()
-                || (isNeutral && !canHold) || (attackValue < 0 && (!isNeutral || allUnitsCanAttackOtherTerritory || result
-                .getBattleRounds() >= 4)))) {
+                || (isNeutral && !canHold)
+                || (attackValue < 0 && (!isNeutral || allUnitsCanAttackOtherTerritory || result
+                    .getBattleRounds() >= 4)))) {
           territoryToRemove = patd;
         }
         ProLogger.debug(patd.getResultString() + ", attackValue=" + attackValue + ", territoryValue=" + territoryValue
@@ -1166,7 +1181,8 @@ public class ProCombatMoveAI {
                 ProBattleUtils.checkForOverwhelmingWin(player, t, patd.getUnits(), defendingUnits);
             final boolean hasAA = Match.someMatch(defendingUnits, Matches.UnitIsAAforAnything);
             if (!isAirUnit
-                || (!hasNoDefenders && !isOverwhelmingWin && (!hasAA || result.getWinPercentage() < minWinPercentage))) {
+                || (!hasNoDefenders && !isOverwhelmingWin
+                    && (!hasAA || result.getWinPercentage() < minWinPercentage))) {
               minWinPercentage = result.getWinPercentage();
               minWinTerritory = t;
             }
@@ -1630,4 +1646,17 @@ public class ProCombatMoveAI {
       }
     }
   }
+
+  private boolean canAirSafelyLandAfterAttack(final Unit unit, final Territory t) {
+    final boolean isAdjacentToAlliedFactory =
+        Matches.territoryHasNeighborMatching(data,
+            ProMatches.territoryHasInfraFactoryAndIsAlliedLand(player, data)).match(t);
+    final int range = TripleAUnit.get(unit).getMovementLeft();
+    final int distance =
+        data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
+            ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
+    final boolean usesMoreThanHalfOfRange = distance > range / 2;
+    return isAdjacentToAlliedFactory || !usesMoreThanHalfOfRange;
+  }
+
 }

--- a/src/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -1,5 +1,18 @@
 package games.strategy.triplea.ai.proAI;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Route;
@@ -36,19 +49,6 @@ import games.strategy.triplea.delegate.dataObjects.MoveValidationResult;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
 
 /**
  * Pro non-combat move AI.
@@ -181,7 +181,7 @@ public class ProNonCombatMoveAI {
     final List<Collection<Unit>> moveUnits = new ArrayList<>();
     final List<Route> moveRoutes = new ArrayList<>();
     ProMoveUtils.calculateMoveRoutes(player, moveUnits, moveRoutes, moveMap, false);
-    ProMoveUtils.doMove(moveUnits, moveRoutes, null, moveDel);
+    ProMoveUtils.doMove(moveUnits, moveRoutes, moveDel);
 
     // Calculate amphib move routes and perform moves
     moveUnits.clear();
@@ -671,7 +671,7 @@ public class ProNonCombatMoveAI {
           if (result.getWinPercentage() > maxWinPercentage
               && ((t.equals(ProData.myCapital) && result.getWinPercentage() > (100 - ProData.winPercentage))
                   || (hasFactory && result.getWinPercentage() > (100 - ProData.minWinPercentage)) || result
-                  .getTUVSwing() >= 0)) {
+                      .getTUVSwing() >= 0)) {
             maxWinTerritory = t;
             maxWinPercentage = result.getWinPercentage();
           }
@@ -725,7 +725,7 @@ public class ProNonCombatMoveAI {
           if (result.getWinPercentage() > maxWinPercentage
               && ((t.equals(ProData.myCapital) && result.getWinPercentage() > (100 - ProData.winPercentage))
                   || (hasFactory && result.getWinPercentage() > (100 - ProData.minWinPercentage)) || result
-                  .getTUVSwing() >= 0)) {
+                      .getTUVSwing() >= 0)) {
             maxWinTerritory = t;
             maxWinPercentage = result.getWinPercentage();
           }
@@ -851,7 +851,8 @@ public class ProNonCombatMoveAI {
                 for (final Territory territoryToMoveTransport : territoriesToMoveTransport) {
                   if (proTransportData.getSeaTransportMap().containsKey(territoryToMoveTransport)
                       && proTransportData.getSeaTransportMap().get(territoryToMoveTransport)
-                          .containsAll(loadFromTerritories) && moveMap.get(territoryToMoveTransport) != null
+                          .containsAll(loadFromTerritories)
+                      && moveMap.get(territoryToMoveTransport) != null
                       && (moveMap.get(territoryToMoveTransport).isCanHold() || hasFactory)) {
                     final List<Unit> attackers = moveMap.get(territoryToMoveTransport).getMaxEnemyUnits();
                     final List<Unit> defenders = moveMap.get(territoryToMoveTransport).getAllDefenders();
@@ -1108,7 +1109,8 @@ public class ProNonCombatMoveAI {
                   && amphibData.getSeaTransportMap().get(territoryToMoveTransport).containsAll(loadFromTerritories)
                   && moveMap.get(territoryToMoveTransport) != null
                   && moveMap.get(territoryToMoveTransport).isCanHold()
-                  && (moveMap.get(t).getValue() > maxValue || moveMap.get(territoryToMoveTransport).getValue() > maxSeaValue)) {
+                  && (moveMap.get(t).getValue() > maxValue
+                      || moveMap.get(territoryToMoveTransport).getValue() > maxSeaValue)) {
                 maxValueTerritory = t;
                 maxAmphibUnitsToAdd = amphibUnitsToAdd;
                 maxValue = moveMap.get(t).getValue();
@@ -1836,7 +1838,8 @@ public class ProNonCombatMoveAI {
         final int hasOwnedCarrier =
             Match.someMatch(moveMap.get(t).getAllDefenders(), ProMatches.UnitIsOwnedCarrier(player)) ? 1 : 0;
         final double airValue =
-            (200.0 * numSeaAttackTerritories + 100 * numLandAttackTerritories + 10 * numEnemyAttackTerritories + numNearbyEnemyTerritories)
+            (200.0 * numSeaAttackTerritories + 100 * numLandAttackTerritories + 10 * numEnemyAttackTerritories
+                + numNearbyEnemyTerritories)
                 / (1 + cantHoldWithoutAllies) / (1 + cantHoldWithoutAllies * isntFactory) * (1 + hasOwnedCarrier);
         if (airValue > maxAirValue) {
           maxAirValue = airValue;

--- a/src/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -103,8 +103,9 @@ public final class ProTechAI {
     }
     final Set<Territory> waterTerr = data.getMap().getNeighbors(location, Matches.TerritoryIsWater);
     while (playerIter.hasNext()) {
-      float seaStrength = 0.0F, firstStrength = 0.0F, secondStrength = 0.0F, blitzStrength = 0.0F, strength = 0.0F, airStrength =
-          0.0F;
+      float seaStrength = 0.0F, firstStrength = 0.0F, secondStrength = 0.0F, blitzStrength = 0.0F, strength = 0.0F,
+          airStrength =
+              0.0F;
       ePlayer = playerIter.next();
       final CompositeMatch<Unit> enemyPlane =
           new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.unitIsOwnedBy(ePlayer), Matches.UnitCanMove);
@@ -457,6 +458,9 @@ public final class ProTechAI {
    */
   private static List<Unit> findPlaneAttackersThatCanLand(final Territory start, final int maxDistance,
       final PlayerID player, final GameData data, final List<Territory> ignore, final List<Territory> checked) {
+    if (checked.isEmpty()) {
+      return new ArrayList<>();
+    }
     final IntegerMap<Territory> distance = new IntegerMap<>();
     final IntegerMap<Unit> unitDistance = new IntegerMap<>();
     final List<Unit> units = new ArrayList<>();

--- a/src/games/strategy/triplea/ai/proAI/data/ProMyMoveOptions.java
+++ b/src/games/strategy/triplea/ai/proAI/data/ProMyMoveOptions.java
@@ -1,13 +1,13 @@
 package games.strategy.triplea.ai.proAI.data;
 
-import games.strategy.engine.data.Territory;
-import games.strategy.engine.data.Unit;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
 
 public class ProMyMoveOptions {
 
@@ -16,6 +16,7 @@ public class ProMyMoveOptions {
   private final Map<Unit, Set<Territory>> transportMoveMap;
   private final Map<Unit, Set<Territory>> bombardMap;
   private final List<ProTransport> transportList;
+  private final Map<Unit, Set<Territory>> bomberMoveMap;
 
   public ProMyMoveOptions() {
     territoryMap = new HashMap<>();
@@ -23,6 +24,7 @@ public class ProMyMoveOptions {
     transportMoveMap = new HashMap<>();
     bombardMap = new HashMap<>();
     transportList = new ArrayList<>();
+    bomberMoveMap = new HashMap<>();
   }
 
   public ProMyMoveOptions(final ProMyMoveOptions myMoveOptions) {
@@ -34,6 +36,7 @@ public class ProMyMoveOptions {
     transportMoveMap.putAll(myMoveOptions.transportMoveMap);
     bombardMap.putAll(myMoveOptions.bombardMap);
     transportList.addAll(myMoveOptions.transportList);
+    bomberMoveMap.putAll(myMoveOptions.bomberMoveMap);
   }
 
   public Map<Territory, ProTerritory> getTerritoryMap() {
@@ -54,6 +57,10 @@ public class ProMyMoveOptions {
 
   public List<ProTransport> getTransportList() {
     return transportList;
+  }
+
+  public Map<Unit, Set<Territory>> getBomberMoveMap() {
+    return bomberMoveMap;
   }
 
 }

--- a/src/games/strategy/triplea/ai/proAI/data/ProTerritory.java
+++ b/src/games/strategy/triplea/ai/proAI/data/ProTerritory.java
@@ -1,5 +1,12 @@
 package games.strategy.triplea.ai.proAI.data;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
@@ -11,18 +18,12 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.util.Match;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 public class ProTerritory {
 
   private Territory territory;
   private List<Unit> maxUnits;
   private List<Unit> units;
+  private List<Unit> bombers;
   private ProBattleResult maxBattleResult;
   private double value;
   private double seaValue;
@@ -61,6 +62,7 @@ public class ProTerritory {
     this.territory = territory;
     maxUnits = new ArrayList<>();
     units = new ArrayList<>();
+    bombers = new ArrayList<>();
     cantMoveUnits = new ArrayList<>();
     maxEnemyUnits = new ArrayList<>();
     maxEnemyBombardUnits = new HashSet<>();
@@ -92,6 +94,7 @@ public class ProTerritory {
     this.territory = patd.getTerritory();
     maxUnits = new ArrayList<>(patd.getMaxUnits());
     units = new ArrayList<>(patd.getUnits());
+    bombers = new ArrayList<>(patd.getBombers());
     cantMoveUnits = new ArrayList<>(patd.getCantMoveUnits());
     maxEnemyUnits = new ArrayList<>(patd.getMaxEnemyUnits());
     maxEnemyBombardUnits = new HashSet<>(patd.getMaxEnemyBombardUnits());
@@ -431,5 +434,13 @@ public class ProTerritory {
 
   public List<Unit> getMaxScrambleUnits() {
     return maxScrambleUnits;
+  }
+
+  public List<Unit> getBombers() {
+    return bombers;
+  }
+
+  public void setBombers(final List<Unit> bombers) {
+    this.bombers = bombers;
   }
 }

--- a/src/games/strategy/triplea/ai/proAI/simulate/ProSimulateTurnUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/simulate/ProSimulateTurnUtils.java
@@ -1,5 +1,14 @@
 package games.strategy.triplea.ai.proAI.simulate;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.ChangeFactory;
 import games.strategy.engine.data.GameData;
@@ -24,15 +33,6 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.OriginalOwnerTracker;
 import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.util.Match;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * Pro AI simulate turn utilities.
@@ -139,6 +139,11 @@ public class ProSimulateTurnUtils {
           patd.addUnit(toUnit);
           ProLogger.trace("---Transferring unit " + u + " to " + toUnit);
         }
+      }
+      for (final Unit u : moveMap.get(fromTerritory).getBombers()) {
+        final Unit toUnit = transferUnit(u, unitTerritoryMap, usedUnits, toData, player);
+        patd.getBombers().add(toUnit);
+        ProLogger.trace("---Transferring bomber " + u + " to " + toUnit);
       }
       for (final Unit u : bombardMap.keySet()) {
         final Unit toUnit = transferUnit(u, unitTerritoryMap, usedUnits, toData, player);

--- a/src/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
@@ -306,6 +306,11 @@ public class ProMoveUtils {
   }
 
   public static void doMove(final List<Collection<Unit>> moveUnits, final List<Route> moveRoutes,
+      final IMoveDelegate moveDel) {
+    doMove(moveUnits, moveRoutes, null, moveDel);
+  }
+
+  public static void doMove(final List<Collection<Unit>> moveUnits, final List<Route> moveRoutes,
       final List<Collection<Unit>> transportsToLoad, final IMoveDelegate moveDel) {
 
     final GameData data = ProData.getData();

--- a/src/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
@@ -1,5 +1,13 @@
 package games.strategy.triplea.ai.proAI.util;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Route;
@@ -14,14 +22,6 @@ import games.strategy.triplea.delegate.MoveValidator;
 import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import games.strategy.util.Match;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Pro AI move utilities.
@@ -194,7 +194,8 @@ public class ProMoveUtils {
                   && maxUnitDistance <= minUnitDistance
                   && distanceFromUnloadTerritory < movesLeft
                   && (maxUnitDistance < minUnitDistance
-                      || (maxUnitDistance > 1 && neighborDistanceFromEnd > maxDistanceFromEnd) || (maxUnitDistance <= 1 && neighborDistanceFromEnd < maxDistanceFromEnd))) {
+                      || (maxUnitDistance > 1 && neighborDistanceFromEnd > maxDistanceFromEnd)
+                      || (maxUnitDistance <= 1 && neighborDistanceFromEnd < maxDistanceFromEnd))) {
                 territoryToMoveTo = neighbor;
                 minUnitDistance = maxUnitDistance;
                 if (neighborDistanceFromEnd > maxDistanceFromEnd) {
@@ -265,6 +266,39 @@ public class ProMoveUtils {
           route =
               data.getMap().getRoute_IgnoreEnd(startTerritory, bombardFromTerritory,
                   ProMatches.territoryCanMoveSeaUnitsThrough(player, data, true));
+        }
+        moveRoutes.add(route);
+      }
+    }
+  }
+
+  public static void calculateBombingRoutes(final PlayerID player, final List<Collection<Unit>> moveUnits,
+      final List<Route> moveRoutes, final Map<Territory, ProTerritory> attackMap) {
+
+    final GameData data = ProData.getData();
+
+    // Loop through all territories to attack
+    for (final Territory t : attackMap.keySet()) {
+
+      // Loop through each unit that is attacking the current territory
+      for (final Unit u : attackMap.get(t).getBombers()) {
+
+        // Skip if unit is already in move to territory
+        final Territory startTerritory = ProData.unitTerritoryMap.get(u);
+        if (startTerritory == null || startTerritory.equals(t)) {
+          continue;
+        }
+
+        // Add unit to move list
+        final List<Unit> unitList = new ArrayList<>();
+        unitList.add(u);
+        moveUnits.add(unitList);
+
+        // Determine route and add to move list
+        Route route = null;
+        if (Match.allMatch(unitList, Matches.UnitIsAir)) {
+          route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,
+              ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
         }
         moveRoutes.add(route);
       }


### PR DESCRIPTION
Add strategic bombing ability to AI. It mostly only uses it if it has bombers left over after attacking. Pretty basic calculations at this point and focused on revised rules currently. Future iterations will expand to properly cover v3 rules, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/860)
<!-- Reviewable:end -->
