### PR TITLE
Removed Cross-Version-Code, renamed capital Getters

### DIFF
--- a/src/games/strategy/engine/chat/Chat.java
+++ b/src/games/strategy/engine/chat/Chat.java
@@ -240,11 +240,11 @@ public class Chat {
 
   private final List<INode> m_playersThatLeft_Last10 = new ArrayList<>();
 
-  public List<INode> GetPlayersThatLeft_Last10() {
+  public List<INode> getPlayersThatLeft_Last10() {
     return new ArrayList<>(m_playersThatLeft_Last10);
   }
 
-  public List<INode> GetOnlinePlayers() {
+  public List<INode> getOnlinePlayers() {
     return new ArrayList<>(m_nodes);
   }
 

--- a/src/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/src/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -114,7 +114,7 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
    * set minimum size based on players (number and max name length) and distribution to playerIDs
    */
   private void setDynamicPreferredSize() {
-    final List<INode> onlinePlayers = m_chat.GetOnlinePlayers();
+    final List<INode> onlinePlayers = m_chat.getOnlinePlayers();
     int maxNameLength = 0;
     final FontMetrics fontMetrics = this.getFontMetrics(UIManager.getFont("TextField.font"));
     for (final INode iNode : onlinePlayers) {

--- a/src/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/src/games/strategy/engine/data/CompositeRouteFinder.java
@@ -112,7 +112,7 @@ public class CompositeRouteFinder {
   private HashMap<Territory, Integer> CreateScoreMap(final Collection<Territory> ters, final Territory startTer) {
     final HashMap<Territory, Integer> result = new HashMap<>();
     for (final Territory ter : m_map.getTerritories()) {
-      result.put(ter, GetTerScore(ter));
+      result.put(ter, getTerScore(ter));
     }
     return result;
   }
@@ -120,7 +120,7 @@ public class CompositeRouteFinder {
   /*
    * Returns the score of the best match that matches this territory
    */
-  private Integer GetTerScore(final Territory ter) {
+  private Integer getTerScore(final Territory ter) {
     int bestMatchingScore = Integer.MAX_VALUE;
     for (final Match<Territory> match : m_matches.keySet()) {
       final int score = m_matches.get(match);

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
@@ -195,7 +195,7 @@ public class HeadlessConsoleController {
       for (final INode node : nodes) {
         final String realName = node.getName().split(" ")[0];
         final String ip = node.getAddress().getHostAddress();
-        final String mac = messenger.GetPlayerMac(node.getName());
+        final String mac = messenger.getPlayerMac(node.getName());
         if (realName.equals(name)) {
           messenger.NotifyUsernameMutingOfPlayer(realName, new Date(expire));
           messenger.NotifyIPMutingOfPlayer(ip, new Date(expire));
@@ -285,7 +285,7 @@ public class HeadlessConsoleController {
       for (final INode node : nodes) {
         final String realName = node.getName().split(" ")[0];
         final String ip = node.getAddress().getHostAddress();
-        final String mac = messenger.GetPlayerMac(node.getName());
+        final String mac = messenger.getPlayerMac(node.getName());
         if (realName.equals(name)) {
           try {
             messenger.NotifyUsernameMiniBanningOfPlayer(realName, new Date(expire));

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -325,7 +325,7 @@ public class HeadlessGameServer {
             for (final INode node : nodes) {
               final String realName = node.getName().split(" ")[0];
               final String ip = node.getAddress().getHostAddress();
-              final String mac = messenger.GetPlayerMac(node.getName());
+              final String mac = messenger.getPlayerMac(node.getName());
               if (realName.equals(playerName)) {
                 System.out.println("Remote Mute of Player: " + playerName);
                 messenger.NotifyUsernameMutingOfPlayer(realName, new Date(expire));
@@ -415,7 +415,7 @@ public class HeadlessGameServer {
             for (final INode node : nodes) {
               final String realName = node.getName().split(" ")[0];
               final String ip = node.getAddress().getHostAddress();
-              final String mac = messenger.GetPlayerMac(node.getName());
+              final String mac = messenger.getPlayerMac(node.getName());
               if (realName.equals(playerName)) {
                 System.out.println("Remote Ban of Player: " + playerName);
                 try {

--- a/src/games/strategy/engine/framework/networkMaintenance/BanPlayerAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/BanPlayerAction.java
@@ -47,7 +47,7 @@ public class BanPlayerAction extends AbstractAction {
       if (node.getName().equals(name)) {
         final String realName = node.getName().split(" ")[0];
         final String ip = node.getAddress().getHostAddress();
-        final String mac = m_messenger.GetPlayerMac(node.getName());
+        final String mac = m_messenger.getPlayerMac(node.getName());
         m_messenger.NotifyUsernameMiniBanningOfPlayer(realName, null);
         m_messenger.NotifyIPMiniBanningOfPlayer(ip, null);
         m_messenger.NotifyMacMiniBanningOfPlayer(mac, null);

--- a/src/games/strategy/engine/framework/networkMaintenance/MutePlayerAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/MutePlayerAction.java
@@ -47,7 +47,7 @@ public class MutePlayerAction extends AbstractAction {
       if (node.getName().equals(name)) {
         final String realName = node.getName().split(" ")[0];
         final String ip = node.getAddress().getHostAddress();
-        final String mac = m_messenger.GetPlayerMac(node.getName());
+        final String mac = m_messenger.getPlayerMac(node.getName());
         m_messenger.NotifyUsernameMutingOfPlayer(realName, null);
         m_messenger.NotifyIPMutingOfPlayer(ip, null);
         m_messenger.NotifyMacMutingOfPlayer(mac, null);

--- a/src/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
+++ b/src/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
@@ -13,7 +13,6 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.nio.Buffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -29,7 +28,6 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentListener;
 
-import games.strategy.util.UrlStreams;
 import org.apache.commons.httpclient.methods.multipart.Part;
 
 import games.strategy.engine.framework.startup.ui.MainFrame;
@@ -37,6 +35,7 @@ import games.strategy.engine.framework.startup.ui.editors.validators.IValidator;
 import games.strategy.engine.pbem.IWebPoster;
 import games.strategy.engine.pbem.TripleAWebPoster;
 import games.strategy.ui.ProgressWindow;
+import games.strategy.util.UrlStreams;
 
 /**
  * A class for displaying settings for the micro web site poster

--- a/src/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -93,7 +93,7 @@ public class LobbyFrame extends JFrame {
     });
   }
 
-  public ChatMessagePanel GetChatMessagePanel() {
+  public ChatMessagePanel getChatMessagePanel() {
     return m_chatMessagePanel;
   }
 

--- a/src/games/strategy/engine/lobby/client/ui/LobbyMenu.java
+++ b/src/games/strategy/engine/lobby/client/ui/LobbyMenu.java
@@ -102,11 +102,11 @@ public class LobbyMenu extends JMenuBar {
                 .getRemoteMessenger().getRemote(ModeratorController.getModeratorControllerName());
             final StringBuilder builder = new StringBuilder();
             builder.append("Online Players:\r\n\r\n");
-            for (final INode player : m_frame.GetChatMessagePanel().getChat().GetOnlinePlayers()) {
+            for (final INode player : m_frame.getChatMessagePanel().getChat().getOnlinePlayers()) {
               builder.append(controller.getInformationOn(player)).append("\r\n\r\n");
             }
             builder.append("Players That Have Left (Last 10):\r\n\r\n");
-            for (final INode player : m_frame.GetChatMessagePanel().getChat().GetPlayersThatLeft_Last10()) {
+            for (final INode player : m_frame.getChatMessagePanel().getChat().getPlayersThatLeft_Last10()) {
               builder.append(controller.getInformationOn(player)).append("\r\n\r\n");
             }
             final Runnable componentCreation = new Runnable() {

--- a/src/games/strategy/engine/lobby/server/AbstractModeratorController.java
+++ b/src/games/strategy/engine/lobby/server/AbstractModeratorController.java
@@ -27,7 +27,7 @@ public abstract class AbstractModeratorController implements IModeratorControlle
   }
 
   protected String getNodeMacAddress(final INode node) {
-    return m_serverMessenger.GetPlayerMac(node.getName());
+    return m_serverMessenger.getPlayerMac(node.getName());
   }
 
   protected String getRealName(final INode node) {

--- a/src/games/strategy/engine/message/DummyMessenger.java
+++ b/src/games/strategy/engine/message/DummyMessenger.java
@@ -175,7 +175,7 @@ public class DummyMessenger implements IServerMessenger {
   public void NotifyUsernameMiniBanningOfPlayer(final String username, final Date expires) {}
 
   @Override
-  public String GetPlayerMac(final String name) {
+  public String getPlayerMac(final String name) {
     return "DummyMacAddress";
   }
 

--- a/src/games/strategy/net/IServerMessenger.java
+++ b/src/games/strategy/net/IServerMessenger.java
@@ -41,7 +41,7 @@ public interface IServerMessenger extends IMessenger {
 
   void NotifyUsernameMiniBanningOfPlayer(String username, Date expires);
 
-  String GetPlayerMac(String name);
+  String getPlayerMac(String name);
 
   void NotifyUsernameMutingOfPlayer(String username, Date muteExpires);
 

--- a/src/games/strategy/net/ServerMessenger.java
+++ b/src/games/strategy/net/ServerMessenger.java
@@ -183,7 +183,7 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
   private final HashMap<String, String> m_cachedMacAddresses = new HashMap<>();
 
   @Override
-  public String GetPlayerMac(final String name) {
+  public String getPlayerMac(final String name) {
     synchronized (m_cachedListLock) {
       String mac = m_cachedMacAddresses.get(name);
       if (mac == null) {
@@ -258,17 +258,17 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
 
   private void ScheduleUsernameUnmuteAt(final String username, final long checkTime) {
     final Timer unmuteUsernameTimer = new Timer("Username unmute timer");
-    unmuteUsernameTimer.schedule(GetUsernameUnmuteTask(username), new Date(checkTime));
+    unmuteUsernameTimer.schedule(getUsernameUnmuteTask(username), new Date(checkTime));
   }
 
   private void ScheduleIpUnmuteAt(final String ip, final long checkTime) {
     final Timer unmuteIpTimer = new Timer("IP unmute timer");
-    unmuteIpTimer.schedule(GetIpUnmuteTask(ip), new Date(checkTime));
+    unmuteIpTimer.schedule(getIpUnmuteTask(ip), new Date(checkTime));
   }
 
   private void ScheduleMacUnmuteAt(final String mac, final long checkTime) {
     final Timer unmuteMacTimer = new Timer("Mac unmute timer");
-    unmuteMacTimer.schedule(GetMacUnmuteTask(mac), new Date(checkTime));
+    unmuteMacTimer.schedule(getMacUnmuteTask(mac), new Date(checkTime));
   }
 
   public void NotifyPlayerLogin(final String uniquePlayerName, final String ip, final String mac) {
@@ -306,7 +306,7 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
 
   private final HashMap<String, String> m_playersThatLeftMacs_Last10 = new HashMap<>();
 
-  public HashMap<String, String> GetPlayersThatLeftMacs_Last10() {
+  public HashMap<String, String> getPlayersThatLeftMacs_Last10() {
     return m_playersThatLeftMacs_Last10;
   }
 
@@ -343,7 +343,7 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
         } else if (IsIpMuted(msg.getFrom().getAddress().getHostAddress())) {
           bareBonesSendChatMessage(YOU_HAVE_BEEN_MUTED_LOBBY, msg.getFrom());
           return;
-        } else if (IsMacMuted(GetPlayerMac(msg.getFrom().getName()))) {
+        } else if (IsMacMuted(getPlayerMac(msg.getFrom().getName()))) {
           bareBonesSendChatMessage(YOU_HAVE_BEEN_MUTED_LOBBY, msg.getFrom());
           return;
         }
@@ -357,7 +357,7 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
           bareBonesSendChatMessage(YOU_HAVE_BEEN_MUTED_GAME, msg.getFrom());
           return;
         }
-        if (IsMacMuted(GetPlayerMac(msg.getFrom().getName()))) {
+        if (IsMacMuted(getPlayerMac(msg.getFrom().getName()))) {
           bareBonesSendChatMessage(YOU_HAVE_BEEN_MUTED_GAME, msg.getFrom());
           return;
         }
@@ -662,7 +662,7 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
     }
   }
 
-  private TimerTask GetUsernameUnmuteTask(final String username) {
+  private TimerTask getUsernameUnmuteTask(final String username) {
     return createUnmuteTimerTask(
         () -> (isLobby() && new MutedUsernameController().getUsernameUnmuteTime(username) == -1) || (isGame()),
         () -> m_liveMutedUsernames.remove(username)
@@ -682,14 +682,14 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
     };
   }
 
-  private TimerTask GetIpUnmuteTask(final String ip) {
+  private TimerTask getIpUnmuteTask(final String ip) {
     return createUnmuteTimerTask(
         () -> (isLobby() && new MutedIpController().getIpUnmuteTime(ip) == -1) || (isGame()),
         () -> m_liveMutedIpAddresses.remove(ip)
     );
   }
 
-  private TimerTask GetMacUnmuteTask(final String mac) {
+  private TimerTask getMacUnmuteTask(final String mac) {
     return createUnmuteTimerTask(
         () -> (isLobby() && new MutedMacController().getMacUnmuteTime(mac) == -1) || (isGame()),
         () -> m_liveMutedMacAddresses.remove(mac)

--- a/src/games/strategy/sound/SoundProperties.java
+++ b/src/games/strategy/sound/SoundProperties.java
@@ -3,7 +3,6 @@ package games.strategy.sound;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.net.URLStreamHandler;
 import java.util.Calendar;
 import java.util.Optional;
 import java.util.Properties;

--- a/src/games/strategy/triplea/ai/fastAI/AggregateEstimate.java
+++ b/src/games/strategy/triplea/ai/fastAI/AggregateEstimate.java
@@ -31,12 +31,12 @@ public class AggregateEstimate extends AggregateResults {
   }
 
   @Override
-  public List<Unit> GetAverageAttackingUnitsRemaining() {
+  public List<Unit> getAverageAttackingUnitsRemaining() {
     return remainingAttackingUnits;
   }
 
   @Override
-  public List<Unit> GetAverageDefendingUnitsRemaining() {
+  public List<Unit> getAverageDefendingUnitsRemaining() {
     return remainingDefendingUnits;
   }
 

--- a/src/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -136,8 +136,8 @@ public class ProOddsCalculator {
 
     // Find battle result statistics
     final double winPercentage = results.getAttackerWinPercent() * 100;
-    final List<Unit> averageAttackersRemaining = results.GetAverageAttackingUnitsRemaining();
-    final List<Unit> averageDefendersRemaining = results.GetAverageDefendingUnitsRemaining();
+    final List<Unit> averageAttackersRemaining = results.getAverageAttackingUnitsRemaining();
+    final List<Unit> averageDefendersRemaining = results.getAverageDefendingUnitsRemaining();
     final List<Unit> mainCombatAttackers =
         Match.getMatches(attackingUnits, Matches.UnitCanBeInBattle(true, !t.isWater(), data, 1, false, true, true));
     final List<Unit> mainCombatDefenders =

--- a/src/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
+++ b/src/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
@@ -38,7 +38,7 @@ public class AggregateResults implements Serializable {
   /**
    * This could be null if we have zero results!
    */
-  public BattleResults GetBattleResultsClosestToAverage() {
+  public BattleResults getBattleResultsClosestToAverage() {
     double closestBattleDif = Integer.MAX_VALUE;
     BattleResults closestBattle = null;
     for (final BattleResults results : m_results) {
@@ -53,15 +53,15 @@ public class AggregateResults implements Serializable {
     return closestBattle;
   }
 
-  public List<Unit> GetAverageAttackingUnitsRemaining() {
+  public List<Unit> getAverageAttackingUnitsRemaining() {
     // can be null!
-    final BattleResults results = GetBattleResultsClosestToAverage();
+    final BattleResults results = getBattleResultsClosestToAverage();
     return results == null ? new ArrayList<>() : results.getRemainingAttackingUnits();
   }
 
-  public List<Unit> GetAverageDefendingUnitsRemaining() {
+  public List<Unit> getAverageDefendingUnitsRemaining() {
     // can be null!
-    final BattleResults results = GetBattleResultsClosestToAverage();
+    final BattleResults results = getBattleResultsClosestToAverage();
     return results == null ? new ArrayList<>() : results.getRemainingDefendingUnits();
   }
 

--- a/src/games/strategy/triplea/ui/TechPanel.java
+++ b/src/games/strategy/triplea/ui/TechPanel.java
@@ -60,10 +60,10 @@ public class TechPanel extends ActionPanel {
         m_actionLabel.setText(id.getName() + " Tech Roll");
         add(m_actionLabel);
         if (isWW2V3TechModel()) {
-          add(new JButton(GetTechTokenAction));
+          add(new JButton(getTechTokenAction));
           add(new JButton(JustRollTech));
         } else {
-          add(new JButton(GetTechRollsAction));
+          add(new JButton(getTechRollsAction));
           add(new JButton(DontBother));
         }
       }
@@ -103,7 +103,7 @@ public class TechPanel extends ActionPanel {
     return Util.difference(allAdvances, currentAdvances);
   }
 
-  private final Action GetTechRollsAction = SwingAction.of("Roll Tech...", e -> {
+  private final Action getTechRollsAction = SwingAction.of("Roll Tech...", e -> {
     TechAdvance advance = null;
     if (isWW2V2() || (isSelectableTechRoll() && !isWW2V3TechModel())) {
       final List<TechAdvance> available = getAvailableTechs();
@@ -151,7 +151,7 @@ public class TechPanel extends ActionPanel {
     m_techRoll = null;
     release();
   });
-  private final Action GetTechTokenAction = SwingAction.of("Buy Tech Tokens...", e -> {
+  private final Action getTechTokenAction = SwingAction.of("Buy Tech Tokens...", e -> {
     final PlayerID currentPlayer = getCurrentPlayer();
     m_currTokens = currentPlayer.getResources().getQuantity(Constants.TECH_TOKENS);
     // Notify user if there are no more techs to acheive


### PR DESCRIPTION
You could say that this is a partial revert of a partial revert of #828 
But this doesn't change the getMacCode in a such a dramatic way...
If you look at the getMacCode, you'll see that previously, when tripleA was still using java 5, a Method object was created to be run on the localIp. Now, we are requiring java 8 and so this part can be removed...
Also I refactore the catch blocks to catch Exceptions on not throwables (when an Error (not an Exception) is thrown, it's probably a failure of the JVM not of tripleA)

Also I renamed all getter methods starting with a capital G
([Interesting](https://en.wikipedia.org/wiki/Letter_case) as a non-native english speaker I just asked myself what the difference between uppercase and capital is ^^ there are just too many words for the same thing...)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/862)
<!-- Reviewable:end -->
