### PR TITLE
Added Primitive Casting

### DIFF
--- a/src/games/strategy/engine/data/ChangeFactory.java
+++ b/src/games/strategy/engine/data/ChangeFactory.java
@@ -1029,9 +1029,9 @@ class ObjectPropertyChange extends Change {
    */
   private Object resolve(final Object value) {
     if (value instanceof Boolean) {
-      return (Boolean) value;
+      return (boolean) value;
     } else if (value instanceof Integer) {
-      return (Integer) value;
+      return (int) value;
     }
     return value;
   }


### PR DESCRIPTION
Not sure about this: @DanVanAtta removed the unnecessary unboxing in #799...
Now the compiler complains about an unnecessary casting from Object to Boolean to Object...
The initial reason for this method was to save memory space...
I don't know if this is working like intended, because an Object is returned either way...
TL,DR;
2 Options:

- Merge this PR or
- Remove the resolve Method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/870)
<!-- Reviewable:end -->
