### PR TITLE
Remove explicit driver loading

### DIFF
--- a/src/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/games/strategy/engine/lobby/server/userDB/Database.java
@@ -174,14 +174,6 @@ public class Database {
       }
       // setup the derby location
       System.getProperties().setProperty("derby.system.home", getCurrentDataBaseDir().getAbsolutePath());
-      // load the driver
-      try {
-        final String driver = "org.apache.derby.jdbc.EmbeddedDriver";
-        Class.forName(driver).newInstance();
-      } catch (final Exception e) {
-        s_logger.log(Level.SEVERE, e.getMessage(), e);
-        throw new Error("Could not load db driver");
-      }
       // shut the database down on finish
       Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
         @Override


### PR DESCRIPTION
This gets rid of the unecessary explicit loading of the derby driver (not required since java 5). My initial goal, was to  add a compile-time check for this library, since there is none.
Not achieved though, found this instead.
I could call a method on the library or call an constructor requiring no params, but since test are failing when this library is not present I did not...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/882)
<!-- Reviewable:end -->
