### PR TITLE
Web/Lobby help menu clean+updates

### DIFF
--- a/src/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -20,6 +20,7 @@ import javax.swing.JSplitPane;
 import javax.swing.JTextPane;
 import javax.swing.SpinnerNumberModel;
 
+import games.strategy.triplea.ui.menubar.LobbyMenu;
 import games.strategy.ui.SwingAction;
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.ChatMessagePanel;
@@ -352,13 +353,13 @@ public class LobbyFrame extends JFrame {
     return m_client;
   }
 
-  void setShowChatTime(final boolean showTime) {
+  public void setShowChatTime(final boolean showTime) {
     if (m_chatMessagePanel != null) {
       m_chatMessagePanel.setShowTime(showTime);
     }
   }
 
-  void shutdown() {
+  public void shutdown() {
     System.exit(0);
   }
 

--- a/src/games/strategy/engine/lobby/client/ui/LobbyMenu.java
+++ b/src/games/strategy/engine/lobby/client/ui/LobbyMenu.java
@@ -409,32 +409,39 @@ public class LobbyMenu extends JMenuBar {
    */
   private static void addHelpMenu(final JMenu parentMenu) {
     final JMenuItem hostingLink = new JMenuItem("How to Host...");
-    final JMenuItem mapLink = new JMenuItem("Install Maps...");
-    final JMenuItem bugReport = new JMenuItem("Bug Report...");
-    final JMenuItem lobbyRules = new JMenuItem("Lobby Rules...");
-    final JMenuItem warClub = new JMenuItem("War Club & Ladder...");
-    final JMenuItem devForum = new JMenuItem("Developer Forum...");
-    final JMenuItem donateLink = new JMenuItem("Donate...");
-    final JMenuItem helpLink = new JMenuItem("Help...");
-    final JMenuItem ruleBookLink = new JMenuItem("Rule Book...");
-
     hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_HOSTING_MAPS));
-    mapLink.addActionListener(e  -> SwingComponents.newOpenUrlConfirmationDialog( UrlConstants.SF_HOSTING_MAPS));
-    bugReport.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_TICKET_LIST));
-    lobbyRules.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB_LOBBY_RULES ));
-    warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB));
-    devForum.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_FORUM));
-    donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));
-    helpLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.WEBSITE_HELP));
-    ruleBookLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK));
     parentMenu.add(hostingLink);
+
+    final JMenuItem mapLink = new JMenuItem("Install Maps...");
+    mapLink.addActionListener(e  -> SwingComponents.newOpenUrlConfirmationDialog( UrlConstants.SF_HOSTING_MAPS));
     parentMenu.add(mapLink);
+
+    final JMenuItem bugReport = new JMenuItem("Bug Report...");
+    bugReport.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_TICKET_LIST));
     parentMenu.add(bugReport);
+
+    final JMenuItem lobbyRules = new JMenuItem("Lobby Rules...");
+    lobbyRules.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB_LOBBY_RULES ));
     parentMenu.add(lobbyRules);
+
+    final JMenuItem warClub = new JMenuItem("War Club & Ladder...");
+    warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB));
     parentMenu.add(warClub);
+
+    final JMenuItem devForum = new JMenuItem("Developer Forum...");
+    devForum.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_FORUM));
     parentMenu.add(devForum);
+
+    final JMenuItem donateLink = new JMenuItem("Donate...");
+    donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));
     parentMenu.add(donateLink);
+
+    final JMenuItem helpLink = new JMenuItem("Help...");
+    helpLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.WEBSITE_HELP));
     parentMenu.add(helpLink);
+
+    final JMenuItem ruleBookLink = new JMenuItem("Rule Book...");
+    ruleBookLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK));
     parentMenu.add(ruleBookLink);
   }
 

--- a/src/games/strategy/engine/lobby/client/ui/LobbyMenu.java
+++ b/src/games/strategy/engine/lobby/client/ui/LobbyMenu.java
@@ -412,10 +412,6 @@ public class LobbyMenu extends JMenuBar {
     hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_HOSTING_MAPS));
     parentMenu.add(hostingLink);
 
-    final JMenuItem mapLink = new JMenuItem("Install Maps...");
-    mapLink.addActionListener(e  -> SwingComponents.newOpenUrlConfirmationDialog( UrlConstants.SF_HOSTING_MAPS));
-    parentMenu.add(mapLink);
-
     final JMenuItem bugReport = new JMenuItem("Bug Report...");
     bugReport.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_TICKET_LIST));
     parentMenu.add(bugReport);

--- a/src/games/strategy/triplea/UrlConstants.java
+++ b/src/games/strategy/triplea/UrlConstants.java
@@ -1,8 +1,5 @@
 package games.strategy.triplea;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-
 public enum UrlConstants {
   GITHUB_ISSUES("http://github.com/triplea-game/triplea/issues/new"),
   WEBSITE_HELP("http://triplea-game.github.io/docs/"),
@@ -19,9 +16,8 @@ public enum UrlConstants {
 
 
   private final String urlString;
-  private String description;
 
-  private UrlConstants(final String value) {
+  UrlConstants(final String value) {
     this.urlString = value;
   }
 
@@ -30,15 +26,4 @@ public enum UrlConstants {
     return urlString;
   }
 
-  public String getDescription() {
-    return description;
-  }
-
-  public URL toURL() {
-    try {
-      return new URL(urlString);
-    } catch (MalformedURLException e) {
-      throw new IllegalStateException("Invalid URL: "+ urlString, e);
-    }
-  }
 }

--- a/src/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -415,7 +415,7 @@ public class LobbyMenu extends JMenuBar {
     parentMenu.add(hostingLink);
 
     final JMenuItem bugReport = new JMenuItem("Bug Report...");
-    bugReport.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_TICKET_LIST));
+    bugReport.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES));
     parentMenu.add(bugReport);
 
     final JMenuItem lobbyRules = new JMenuItem("Lobby Rules...");
@@ -425,10 +425,6 @@ public class LobbyMenu extends JMenuBar {
     final JMenuItem warClub = new JMenuItem("War Club & Ladder...");
     warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB));
     parentMenu.add(warClub);
-
-    final JMenuItem devForum = new JMenuItem("Developer Forum...");
-    devForum.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_FORUM));
-    parentMenu.add(devForum);
 
     final JMenuItem donateLink = new JMenuItem("Donate...");
     donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));

--- a/src/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.lobby.client.ui;
+package games.strategy.triplea.ui.menubar;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -22,6 +22,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 
+import games.strategy.engine.lobby.client.ui.LobbyFrame;
+import games.strategy.engine.lobby.client.ui.MacLobbyWrapper;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
 import games.strategy.engine.framework.GameRunner;

--- a/src/games/strategy/triplea/ui/menubar/WebHelpMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/WebHelpMenu.java
@@ -19,41 +19,41 @@ public class WebHelpMenu {
   private static void addWebMenu(final JMenu parentMenu) {
     final JMenuItem hostingLink = new JMenuItem("How to Host...");
     hostingLink.setMnemonic(KeyEvent.VK_H);
-    final JMenuItem mapLink = new JMenuItem("Install Maps...");
-    mapLink.setMnemonic(KeyEvent.VK_I);
+    hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_HOSTING_MAPS));
+    parentMenu.add(hostingLink);
+
     final JMenuItem bugReport = new JMenuItem("Bug Report...");
-    bugReport.setMnemonic(KeyEvent.VK_B);
+    bugReport.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES));
+    parentMenu.add(bugReport);
+
     final JMenuItem lobbyRules = new JMenuItem("Lobby Rules...");
     lobbyRules.setMnemonic(KeyEvent.VK_L);
+    lobbyRules.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB_LOBBY_RULES ));
+    parentMenu.add(lobbyRules);
+
     final JMenuItem warClub = new JMenuItem("War Club & Ladder...");
     warClub.setMnemonic(KeyEvent.VK_W);
+    warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB));
+    parentMenu.add(warClub);
+
     final JMenuItem devForum = new JMenuItem("Developer Forum...");
     devForum.setMnemonic(KeyEvent.VK_E);
+    devForum.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_FORUM));
+    parentMenu.add(devForum);
+
     final JMenuItem donateLink = new JMenuItem("Donate...");
     donateLink.setMnemonic(KeyEvent.VK_O);
+    donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));
+    parentMenu.add(donateLink);
+
     final JMenuItem helpLink = new JMenuItem("Help...");
     helpLink.setMnemonic(KeyEvent.VK_G);
+    helpLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.WEBSITE_HELP));
+    parentMenu.add(helpLink);
+
     final JMenuItem ruleBookLink = new JMenuItem("Rule Book...");
     ruleBookLink.setMnemonic(KeyEvent.VK_K);
-
-    hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_HOSTING_MAPS));
-    mapLink.addActionListener(e  -> SwingComponents.newOpenUrlConfirmationDialog( UrlConstants.SF_HOSTING_MAPS));
-    bugReport.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_TICKET_LIST));
-    lobbyRules.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB_LOBBY_RULES ));
-    warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB));
-    devForum.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_FORUM));
-    donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));
-    helpLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.WEBSITE_HELP));
     ruleBookLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK));
-
-    parentMenu.add(hostingLink);
-    parentMenu.add(mapLink);
-    parentMenu.add(bugReport);
-    parentMenu.add(lobbyRules);
-    parentMenu.add(warClub);
-    parentMenu.add(devForum);
-    parentMenu.add(donateLink);
-    parentMenu.add(helpLink);
     parentMenu.add(ruleBookLink);
   }
 

--- a/src/games/strategy/triplea/ui/menubar/WebHelpMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/WebHelpMenu.java
@@ -35,12 +35,7 @@ public class WebHelpMenu {
     warClub.setMnemonic(KeyEvent.VK_W);
     warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB));
     parentMenu.add(warClub);
-
-    final JMenuItem devForum = new JMenuItem("Developer Forum...");
-    devForum.setMnemonic(KeyEvent.VK_E);
-    devForum.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_FORUM));
-    parentMenu.add(devForum);
-
+    
     final JMenuItem donateLink = new JMenuItem("Donate...");
     donateLink.setMnemonic(KeyEvent.VK_O);
     donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));

--- a/src/games/strategy/triplea/ui/menubar/WebHelpMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/WebHelpMenu.java
@@ -23,6 +23,7 @@ public class WebHelpMenu {
     parentMenu.add(hostingLink);
 
     final JMenuItem bugReport = new JMenuItem("Bug Report...");
+    bugReport.setMnemonic(KeyEvent.VK_B);
     bugReport.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES));
     parentMenu.add(bugReport);
 


### PR DESCRIPTION
This PR fixes a number of out of date source forge links. (#769)

Change summary:
- fix variable declaration/usage grouping
- cleanup in url constants
- move LobbyMenu to be grouped with other classes
- remove 'how to download' maps menu
- remove 'developer forum' menu
- Update submit bug report web and lobby menu item to open a github page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/885)
<!-- Reviewable:end -->
