### PR TITLE
RouteDrawer MapBounds fix (partial #863)

### DIFF
--- a/src/games/strategy/triplea/ui/MapRouteDrawer.java
+++ b/src/games/strategy/triplea/ui/MapRouteDrawer.java
@@ -66,7 +66,7 @@ public class MapRouteDrawer {
     final boolean tooFewPoints = points.length <= 2;
     final double scale = mapPanel.getScale();
     if (tooFewTerritories || tooFewPoints) {
-      if (routeDescription.getEnd() != null) {
+      if (routeDescription.getEnd() != null) {//AI has no End Point
         drawDirectPath(graphics, getPointOnMap(routeDescription.getStart(), xOffset, yOffset, imageWidth, imageHeight),
             getPointOnMap(routeDescription.getEnd(), xOffset, yOffset, imageWidth, imageHeight), xOffset, yOffset,
             scale);
@@ -226,20 +226,21 @@ public class MapRouteDrawer {
    * @return The "real" Point
    */
   private static Point getPointOnMap(Point point, int xOffset, int yOffset, int width, int height) {
-    int x = (int) point.getX();
-    int y = (int) point.getY();
+    Point newPoint = point;
+    int x = (int) newPoint.getX();
+    int y = (int) newPoint.getY();
     if (x - width > xOffset) {
-      point = new Point(x - width, y);
+      newPoint = new Point(x - width, y);
     } else if (x - width > 0) {
-      point = new Point(x + width, y);
+      newPoint = new Point(x + width, y);
     }
-    x = (int) point.getX();// If the value changed
+    x = (int) newPoint.getX();// If the value changed
     if (y - height > yOffset) {
-      point = new Point(x, y - height);
+      newPoint = new Point(x, y - height);
     } else if (y - height > 0) {
-      point = new Point(x, y + height);
+      newPoint = new Point(x, y + height);
     }
-    return point;
+    return newPoint;
   }
 
   /**

--- a/src/games/strategy/triplea/ui/MapRouteDrawer.java
+++ b/src/games/strategy/triplea/ui/MapRouteDrawer.java
@@ -229,17 +229,18 @@ public class MapRouteDrawer {
    * @return The "real" Point
    */
   private static Point getPointOnMap(Point point, int xOffset, int yOffset, int width, int height) {
-    double x = point.getX();
-    double y = point.getY();
+    int x = (int) point.getX();
+    int y = (int) point.getY();
     if (x - width > xOffset) {
-      point.setLocation(x - width, y);
+      point = new Point(x - width, y);
     } else if (x - width > 0) {
-      point.setLocation(x + width, y);
+      point = new Point(x + width, y);
     }
+    x = (int) point.getX();// If the value changed
     if (y - height > yOffset) {
-      point.setLocation(x, y - height);
+      point = new Point(x, y - height);
     } else if (y - height > 0) {
-      point.setLocation(x, y + height);
+      point = new Point(x, y + height);
     }
     return point;
   }

--- a/src/games/strategy/triplea/ui/MapRouteDrawer.java
+++ b/src/games/strategy/triplea/ui/MapRouteDrawer.java
@@ -67,11 +67,13 @@ public class MapRouteDrawer {
     final double scale = mapPanel.getScale();
     if (tooFewTerritories || tooFewPoints) {
       if (routeDescription.getEnd() != null) {
-        drawDirectPath(graphics, routeDescription.getStart(), routeDescription.getEnd(), xOffset, yOffset, scale,
-            imageWidth, imageHeight);
+        drawDirectPath(graphics, getPointOnMap(routeDescription.getStart(), xOffset, yOffset, imageWidth, imageHeight),
+            getPointOnMap(routeDescription.getEnd(), xOffset, yOffset, imageWidth, imageHeight), xOffset, yOffset,
+            scale);
       } else {
-        drawDirectPath(graphics, points[0], points[points.length - 1], xOffset, yOffset, scale, imageWidth,
-            imageHeight);
+        drawDirectPath(graphics, getPointOnMap(points[0], xOffset, yOffset, imageWidth, imageHeight),
+            getPointOnMap(points[points.length - 1], xOffset, yOffset, imageWidth, imageHeight), xOffset, yOffset,
+            scale);
       }
       if (tooFewPoints && !tooFewTerritories) {
         drawMoveLength(graphics, points, xOffset, yOffset, scale, numTerritories, maxMovement);
@@ -134,14 +136,9 @@ public class MapRouteDrawer {
    * @param xOffset The horizontal pixel-difference between the frame and the Map
    * @param yOffset The vertical pixel-difference between the frame and the Map
    * @param jointsize The diameter of the Points being drawn
-   * @param width The width of the Map
-   * @param height The height of the Map
    * @param scale The scale-factor of the Map
    */
-  private void drawDirectPath(Graphics2D graphics, Point start, Point end, int xOffset, int yOffset, double scale,
-      int width, int height) {
-    start = getPointOnMap(start, xOffset, yOffset, width, height);
-    end = getPointOnMap(end, xOffset, yOffset, width, height);
+  private void drawDirectPath(Graphics2D graphics, Point start, Point end, int xOffset, int yOffset, double scale) {
     drawLineWithTranslate(graphics, new Line2D.Float(start, end), xOffset,
         yOffset, scale);
     if (start.distance(end) > arrowLength) {

--- a/test/games/strategy/triplea/ui/TestRoute.java
+++ b/test/games/strategy/triplea/ui/TestRoute.java
@@ -31,12 +31,15 @@ public class TestRoute {
   private Route dummyRoute = spy(new Route());
   private MapData dummyMapData = mock(MapData.class);
   private RouteDescription dummyRouteDescription = spy(new RouteDescription(dummyRoute, dummyPoints[0], dummyPoints[2], null));
+  private MapPanel dummyMapPanel = mock(MapPanel.class);
   
   @Before
   public void setUp(){
     dummyRoute.add(mock(Territory.class));//This will be overridden with the startPoint, since it's the origin territory
     dummyRoute.add(mock(Territory.class));
     when(dummyMapData.getCenter(any(Territory.class))).thenReturn(dummyPoints[1]);
+    when(dummyMapPanel.getXOffset()).thenReturn(0);
+    when(dummyMapPanel.getYOffset()).thenReturn(0);
   }
   
   @Test
@@ -71,7 +74,7 @@ public class TestRoute {
   
   @Test
   public void testPointAcquisition(){
-    assertArrayEquals(dummyPoints, spyRouteDrawer.getRoutePoints(dummyRouteDescription, dummyMapData));
+    assertArrayEquals(dummyPoints, spyRouteDrawer.getRoutePoints(dummyRouteDescription, dummyMapData, 0, 0, 0, 0));
   }
   
   @Test

--- a/test/games/strategy/triplea/ui/TestRoute.java
+++ b/test/games/strategy/triplea/ui/TestRoute.java
@@ -31,15 +31,12 @@ public class TestRoute {
   private Route dummyRoute = spy(new Route());
   private MapData dummyMapData = mock(MapData.class);
   private RouteDescription dummyRouteDescription = spy(new RouteDescription(dummyRoute, dummyPoints[0], dummyPoints[2], null));
-  private MapPanel dummyMapPanel = mock(MapPanel.class);
   
   @Before
   public void setUp(){
     dummyRoute.add(mock(Territory.class));//This will be overridden with the startPoint, since it's the origin territory
     dummyRoute.add(mock(Territory.class));
     when(dummyMapData.getCenter(any(Territory.class))).thenReturn(dummyPoints[1]);
-    when(dummyMapPanel.getXOffset()).thenReturn(0);
-    when(dummyMapPanel.getYOffset()).thenReturn(0);
   }
   
   @Test

--- a/test/games/strategy/triplea/ui/TestRoute.java
+++ b/test/games/strategy/triplea/ui/TestRoute.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 
+import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Shape;
@@ -26,57 +27,83 @@ import games.strategy.engine.data.Territory;
 
 public class TestRoute {
   private MapRouteDrawer spyRouteDrawer = spy(new MapRouteDrawer());
-  private Point[] dummyPoints = new Point[]{new Point(0,0), new Point(100,0), new Point(0,100)};
+  private Point[] dummyPoints = new Point[] {new Point(0, 0), new Point(100, 0), new Point(0, 100)};
   private double[] dummyIndex = spyRouteDrawer.createParameterizedIndex(dummyPoints);
   private Route dummyRoute = spy(new Route());
   private MapData dummyMapData = mock(MapData.class);
-  private RouteDescription dummyRouteDescription = spy(new RouteDescription(dummyRoute, dummyPoints[0], dummyPoints[2], null));
-  
+  private RouteDescription dummyRouteDescription =
+      spy(new RouteDescription(dummyRoute, dummyPoints[0], dummyPoints[2], null));
+
   @Before
-  public void setUp(){
-    dummyRoute.add(mock(Territory.class));//This will be overridden with the startPoint, since it's the origin territory
+  public void setUp() {
+    dummyRoute.add(mock(Territory.class));// This will be overridden with the startPoint, since it's the origin
+                                          // territory
     dummyRoute.add(mock(Territory.class));
     when(dummyMapData.getCenter(any(Territory.class))).thenReturn(dummyPoints[1]);
   }
-  
+
   @Test
-  public void testIndex(){
-    assertArrayEquals(spyRouteDrawer.createParameterizedIndex(new Point[]{}), new double[]{}, 0);
+  public void testIndex() {
+    assertArrayEquals(spyRouteDrawer.createParameterizedIndex(new Point[] {}), new double[] {}, 0);
     assertEquals(dummyIndex.length, dummyPoints.length);
-    //Not sure whether it makes sense to include a Test for specific values
-    //The way the index is being calculated may change to a better System
-    //Check the link for more information
-    //http://stackoverflow.com/a/37370620/5769952
+    // Not sure whether it makes sense to include a Test for specific values
+    // The way the index is being calculated may change to a better System
+    // Check the link for more information
+    // http://stackoverflow.com/a/37370620/5769952
   }
-  
+
   @Test
-  public void testCurve(){
-    final double[] testYValues = new double[]{20, 40, 90};
+  public void testCurve() {
+    final double[] testYValues = new double[] {20, 40, 90};
     final PolynomialSplineFunction testFunction = new SplineInterpolator().interpolate(dummyIndex, testYValues);
     final double[] coords = spyRouteDrawer.getCoords(testFunction, dummyIndex);
     final double stepSize = testFunction.getKnots()[testFunction.getKnots().length - 1] / coords.length;
-    assertEquals(testYValues[0] * stepSize, coords[(int)Math.round(dummyIndex[0])], 1);
-    assertEquals(testYValues[1] * stepSize, coords[(int)Math.round(dummyIndex[1])], 1);
-    assertEquals(testYValues[2] * stepSize, coords[(int)Math.round(dummyIndex[2])], 1);
-    //TODO change the calculation so that delta = 0;
+    assertEquals(testYValues[0] * stepSize, coords[(int) Math.round(dummyIndex[0])], 1);
+    assertEquals(testYValues[1] * stepSize, coords[(int) Math.round(dummyIndex[1])], 1);
+    assertEquals(testYValues[2] * stepSize, coords[(int) Math.round(dummyIndex[2])], 1);
+    // TODO change the calculation so that delta = 0;
   }
-  
+
   @Test
-  public void testPointSplitting(){
-    double[] xCoords = new double[]{0, 100, 0};
-    double[] yCoords = new double[]{0, 0, 100};
+  public void testPointSplitting() {
+    double[] xCoords = new double[] {0, 100, 0};
+    double[] yCoords = new double[] {0, 0, 100};
     assertArrayEquals(xCoords, spyRouteDrawer.getValues(dummyPoints, point -> point.getX()), 0);
     assertArrayEquals(yCoords, spyRouteDrawer.getValues(dummyPoints, point -> point.getY()), 0);
   }
-  
+
   @Test
-  public void testPointAcquisition(){
-    assertArrayEquals(dummyPoints, spyRouteDrawer.getRoutePoints(dummyRouteDescription, dummyMapData, 0, 0, 0, 0));
+  public void testPointAcquisition() {
+    assertArrayEquals(dummyPoints,
+        spyRouteDrawer.getRoutePoints(dummyRouteDescription, dummyMapData, 0, 0, new Dimension(0, 0)));
+    for (int i = 0; i < 10; i++) {
+      assertArrayEquals(dummyPoints, spyRouteDrawer.getRoutePoints(dummyRouteDescription, dummyMapData, randomInt(),
+          randomInt(), new Dimension(0, 0)));
+      assertArrayEquals(dummyPoints, spyRouteDrawer.getRoutePoints(dummyRouteDescription, dummyMapData, 0, 0,
+          new Dimension(randomInt(1000, 100), randomInt(1000, 100))));
+      int randX = randomInt(1000, 0);
+      int randY = randomInt(1000, 0);
+      assertEquals(new Point(randX, randY),
+          MapRouteDrawer.getPointOnMap(new Point(), randX, randY, new Dimension(randX, randY)));
+    }
   }
-  
+
+  private static int randomInt(int max, int min) {
+    if (max - min < 0) {
+      int oldMax = max;
+      max = min;
+      min = oldMax;
+    }
+    return (int) ((Math.random() * (max - min)) + min);
+  }
+
+  private static int randomInt() {
+    return randomInt(1000, -1000);
+  }
+
   @Test
-  public void testCorrectParameterHandling(){
-    //Should not throw any exception - should do nothing
+  public void testCorrectParameterHandling() {
+    // Should not throw any exception - should do nothing
     spyRouteDrawer.drawRoute(null, null, null, null, null);
     MapPanel mockedMapPanel = mock(MapPanel.class);
     when(mockedMapPanel.getXOffset()).thenReturn(0);
@@ -88,10 +115,10 @@ public class TestRoute {
     when(mockGraphics.getClip()).thenReturn(mockShape);
     spyRouteDrawer.drawRoute(mockGraphics, dummyRouteDescription, mockedMapPanel, dummyMapData, "2");
     verify(mockGraphics, atLeastOnce()).draw(any(Line2D.class));
-    verify(mockedMapPanel).getXOffset();//Those methods are needed
+    verify(mockedMapPanel).getXOffset();// Those methods are needed
     verify(mockedMapPanel).getYOffset();
     verify(mockedMapPanel).getScale();
-    
+
     verify(dummyRouteDescription, times(2)).getRoute();
     verify(dummyRouteDescription.getRoute(), atLeastOnce()).getAllTerritories();
   }


### PR DESCRIPTION
This adresses the critical part of #863.
Playing as america works now...
What still isn't working, is the route when scrolling once around the world (When moving units normally the user shouldn't notice...)
For example it comes from east and goes back to the east (the start point is the west in the east)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/898)
<!-- Reviewable:end -->
