### PR TITLE
Fix territory image name loading: #899 

### DIFF
--- a/src/games/strategy/triplea/ui/MapData.java
+++ b/src/games/strategy/triplea/ui/MapData.java
@@ -204,11 +204,23 @@ public class MapData {
     }
     for (final String name : m_centers.keySet()) {
       try {
-        final Image img = loadImage("territoryNames/" + name + ".png");
+        String normalizedName = name.replace(' ', '_');
+        String path = "territoryNames/" + normalizedName + ".png";
+        Image img = loadImage(path);
+
+        if(img == null ) {
+          path = "territoryNames/" + normalizedName + ".png";
+          img = loadImage(path);
+        }
+
         if (img != null) {
           m_territoryNameImages.put(name, img);
+        } else {
+          ClientLogger.logQuietly("Failed to find image: " + path);
         }
+
       } catch (final Exception e) {
+        ClientLogger.logQuietly("Territory image name loading failed: "+  name , e);
         // skip that territory then
       }
     }


### PR DESCRIPTION
Quick and dirty fix for #899.
File names were normalized to have spaces replaced with underscores

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/900)
<!-- Reviewable:end -->
