### PR TITLE
Allow map clones as valid map folders

### DIFF
--- a/src/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -48,7 +48,7 @@ public class DownloadFile {
   protected DownloadFile(DownloadFileDescription download, Consumer<Integer> progressUpdateListener) {
     this.downloadDescription = download;
     this.progressUpdateListener = progressUpdateListener;
-    this.downloadCompletedListeners = Lists.newArrayList();
+    this.downloadCompletedListeners = new ArrayList<>();
   }
 
   public void startAsyncDownload() {

--- a/src/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -2,10 +2,10 @@ package games.strategy.engine.framework.map.download;
 
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 
 import games.strategy.debug.ClientLogger;

--- a/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -389,7 +389,7 @@ public class DownloadMapsWindow extends JFrame {
       DefaultListModel<String> listModel) {
     return (e) -> {
       List<String> selectedValues = gamesList.getSelectedValuesList();
-      List<DownloadFileDescription> downloadList = Lists.newArrayList();
+      List<DownloadFileDescription> downloadList = new ArrayList<>();
       for (DownloadFileDescription map : maps) {
         if (selectedValues.contains(map.getMapName())) {
           downloadList.add(map);

--- a/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -9,6 +9,7 @@ import java.awt.Frame;
 import java.awt.Rectangle;
 import java.awt.event.ActionListener;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/src/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/src/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -3,16 +3,15 @@ package games.strategy.engine.framework.map.download;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
 import javax.swing.DefaultListModel;
 
-import com.google.common.collect.Lists;
-
-import games.strategy.ui.SwingComponents;
 import games.strategy.debug.ClientLogger;
+import games.strategy.ui.SwingComponents;
 import games.strategy.util.Version;
 
 public class FileSystemAccessStrategy {

--- a/src/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/src/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -43,8 +43,8 @@ public class FileSystemAccessStrategy {
 
   private static Runnable createRemoveMapAction(List<DownloadFileDescription> maps, DefaultListModel<String> listModel) {
     return () -> {
-      List<DownloadFileDescription> fails = Lists.newArrayList();
-      List<DownloadFileDescription> deletes = Lists.newArrayList();
+      List<DownloadFileDescription> fails = new ArrayList<>();
+      List<DownloadFileDescription> deletes = new ArrayList<>();
 
       // delete the map files
       for (DownloadFileDescription map : maps) {

--- a/src/games/strategy/engine/framework/map/download/MapDownloadList.java
+++ b/src/games/strategy/engine/framework/map/download/MapDownloadList.java
@@ -1,9 +1,8 @@
 package games.strategy.engine.framework.map.download;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
-import com.google.common.collect.Lists;
 
 import games.strategy.util.Version;
 

--- a/src/games/strategy/engine/framework/map/download/MapDownloadList.java
+++ b/src/games/strategy/engine/framework/map/download/MapDownloadList.java
@@ -9,9 +9,9 @@ import games.strategy.util.Version;
 
 public class MapDownloadList {
 
-  private final List<DownloadFileDescription> available = Lists.newArrayList();
-  private final List<DownloadFileDescription> installed = Lists.newArrayList();
-  private final List<DownloadFileDescription> outOfDate = Lists.newArrayList();
+  private final List<DownloadFileDescription> available = new ArrayList<>();
+  private final List<DownloadFileDescription> installed = new ArrayList<>();
+  private final List<DownloadFileDescription> outOfDate = new ArrayList<>();
 
   public MapDownloadList(List<DownloadFileDescription> downloads, FileSystemAccessStrategy strategy) {
     for (DownloadFileDescription download : downloads) {

--- a/src/games/strategy/engine/framework/map/download/MapDownloadListSort.java
+++ b/src/games/strategy/engine/framework/map/download/MapDownloadListSort.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework.map.download;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.collect.Lists;

--- a/src/games/strategy/engine/framework/map/download/MapDownloadListSort.java
+++ b/src/games/strategy/engine/framework/map/download/MapDownloadListSort.java
@@ -20,17 +20,17 @@ public final class MapDownloadListSort {
   public static List<DownloadFileDescription> sortByMapName(List<DownloadFileDescription> downloads) {
     checkNotNull(downloads);
 
-    List<DownloadFileDescription> returnList = Lists.newArrayList();
+    List<DownloadFileDescription> returnList = new ArrayList<>();
 
     // Until we see a header, save each map to this List.
     // When we see a header, we'll sort this list, add it
     // to the return values, and then clear it.
-    List<DownloadFileDescription> maps = Lists.newArrayList();
+    List<DownloadFileDescription> maps = new ArrayList<>();
 
     for (DownloadFileDescription download : downloads) {
       if (download.isDummyUrl()) {
         returnList.addAll(sort(maps));
-        maps = Lists.newArrayList();
+        maps = new ArrayList<>();
 
         if (!returnList.isEmpty()) {
           // Add an empty row before any new headers (with exception to the first row)

--- a/src/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.framework.map.download;
 
 import java.awt.GridLayout;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -11,7 +12,6 @@ import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.SwingUtilities;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import games.strategy.ui.SwingComponents;

--- a/src/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -31,7 +31,7 @@ public final class MapDownloadProgressPanel extends JPanel {
   private JPanel labelGrid = SwingComponents.gridPanel(0, 1);
   private JPanel progressGrid = SwingComponents.gridPanel(0, 1);
 
-  private List<DownloadFileDescription> downloadList = Lists.newArrayList();
+  private List<DownloadFileDescription> downloadList = new ArrayList<>();
   private Map<DownloadFileDescription, JLabel> labels = Maps.newHashMap();
   private Map<DownloadFileDescription, JProgressBar> progressBars = Maps.newHashMap();
 
@@ -48,7 +48,7 @@ public final class MapDownloadProgressPanel extends JPanel {
 
 
   public void download(List<DownloadFileDescription> newDownloads) {
-    List<DownloadFileDescription> brandNewDownloads = Lists.newArrayList();
+    List<DownloadFileDescription> brandNewDownloads = new ArrayList<>();
     for (DownloadFileDescription download : newDownloads) {
       if (!downloadList.contains(download) && !download.isDummyUrl() && !download.getMapName().isEmpty()) {
         brandNewDownloads.add(download);

--- a/src/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -294,11 +294,11 @@ public class ClientSetupPanel extends SetupPanel {
   @Override
   public List<Action> getUserActions() {
     if (m_model == null) {
-      return Lists.newArrayList();
+      return new ArrayList<>();
     }
     final boolean isServerHeadless = m_model.getIsServerHeadlessCached();
     if (!isServerHeadless) {
-      return Lists.newArrayList();
+      return new ArrayList<>();
     }
     final List<Action> rVal = new ArrayList<>();
     rVal.add(m_model.getHostBotSetMapClientAction(this));

--- a/src/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -69,6 +69,6 @@ public abstract class SetupPanel extends JPanel implements ISetupPanel {
 
   @Override
   public List<Action> getUserActions() {
-    return Lists.newArrayList();
+    return new ArrayList<>();
   }
 }

--- a/src/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -1,13 +1,12 @@
 package games.strategy.engine.framework.startup.ui;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Observer;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.swing.Action;
 import javax.swing.JPanel;
-
-import com.google.common.collect.Lists;
 
 import games.strategy.engine.chat.IChatPanel;
 import games.strategy.engine.framework.startup.launcher.ILauncher;

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -39,7 +39,14 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
 
 
   public NewGameChooserModel() {
-    populate();
+    final Set<NewGameChooserEntry> parsedMapSet = parseMapFiles();
+
+    final List<NewGameChooserEntry> entries = Lists.newArrayList(parsedMapSet);
+    Collections.sort(entries, NewGameChooserEntry.getComparator());
+
+    for (final NewGameChooserEntry entry : entries) {
+      addElement(entry);
+    }
   }
 
   @Override
@@ -49,18 +56,6 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
 
   public static File getDefaultMapsDir() {
     return new File(ClientFileSystemHelper.getRootFolder(), "maps");
-  }
-
-
-  private void populate() {
-    final Set<NewGameChooserEntry> parsedMapSet = parseMapFiles();
-
-    final List<NewGameChooserEntry> entries = Lists.newArrayList(parsedMapSet);
-    Collections.sort(entries, NewGameChooserEntry.getComparator());
-
-    for (final NewGameChooserEntry entry : entries) {
-      addElement(entry);
-    }
   }
 
   private static List<File> allMapFiles() {

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -41,7 +41,7 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
   public NewGameChooserModel() {
     final Set<NewGameChooserEntry> parsedMapSet = parseMapFiles();
 
-    final List<NewGameChooserEntry> entries = Lists.newArrayList(parsedMapSet);
+    final List<NewGameChooserEntry> entries = new ArrayList<>(parsedMapSet);
     Collections.sort(entries, NewGameChooserEntry.getComparator());
 
     for (final NewGameChooserEntry entry : entries) {
@@ -90,7 +90,7 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
 
   private static List<NewGameChooserEntry> populateFromZip(final File map) {
     boolean badMapZip = false;
-    final List<NewGameChooserEntry> entries = Lists.newArrayList();
+    final List<NewGameChooserEntry> entries = new ArrayList<>();
 
     try (ZipFile zipFile = new ZipFile(map);
         final URLClassLoader loader = new URLClassLoader(new URL[] {map.toURI().toURL()})) {
@@ -202,7 +202,7 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
   }
 
   private static List<NewGameChooserEntry> populateFromDirectory(final File mapDir) {
-    final List<NewGameChooserEntry> entries = Lists.newArrayList();
+    final List<NewGameChooserEntry> entries = new ArrayList<>();
 
     // use contents under a "mapDir/map" folder if present, otherwise use the "mapDir/" contents directly
     final File mapFolder = new File(mapDir, "map");

--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -204,7 +204,12 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
   private static List<NewGameChooserEntry> populateFromDirectory(final File mapDir) {
     final List<NewGameChooserEntry> entries = Lists.newArrayList();
 
-    final File games = new File(mapDir, "games");
+    // use contents under a "mapDir/map" folder if present, otherwise use the "mapDir/" contents directly
+    final File mapFolder = new File(mapDir, "map");
+
+    final File parentFolder = mapFolder.exists() ? mapFolder : mapDir;
+    final File games = new File(parentFolder, "games");
+
     if (!games.exists()) {
       // no games in this map dir
       return entries;

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -83,6 +83,7 @@ public class ResourceLoader {
     final String zipName = dirName + ".zip";
     final List<File> candidates = new ArrayList<>();
     // prioritize user maps folder over root folder
+    candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), dirName + File.separator + "map"));
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), dirName));
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), zipName));
     candidates.add(new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps", dirName));
@@ -98,14 +99,16 @@ public class ResourceLoader {
         return f.exists();
       }
     });
-    if (existing.size() > 1) {
-      System.out.println("INFO: Found too many files for: " + mapName + "  found: " + existing);
-    }
+
+
     // At least one must exist
     if (existing.isEmpty()) {
       return Collections.emptyList();
     }
     final File match = existing.iterator().next();
+    if (existing.size() > 1) {
+      ClientLogger.logQuietly("INFO: Found multiple files for: " + mapName + " using: "+ match + ", candidates found: " + existing);
+    }
 
     final List<String> rVal = new ArrayList<>();
     rVal.add(match.getAbsolutePath());
@@ -181,7 +184,7 @@ public class ResourceLoader {
     // Return first any match that is not in the assets folder (we expect that to be the users maps folder (loading from
     // map.zip))
     // If we don't have any matches, then return any matches we had from the assets folder
-    for (URL element : getMatchingResources(path)) {// Collections.list(m_loader.getResources(path))) {
+    for (URL element : getMatchingResources(path)) {
       if (element.toString().contains(RESOURCE_FOLDER)) {
         defaultUrl = element;
       } else {

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -7,19 +7,16 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringTokenizer;
 
-import com.sun.deploy.util.SessionState;
-import games.strategy.ui.SwingComponents;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.startup.launcher.MapNotFoundException;
-import games.strategy.util.Match;
+import games.strategy.ui.SwingComponents;
 import games.strategy.util.UrlStreams;
 
 /**

--- a/src/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/games/strategy/triplea/delegate/DiceRoll.java
@@ -390,7 +390,7 @@ public class DiceRoll implements Externalizable {
   public static DiceRoll rollNDice(final IDelegateBridge bridge, final int rollCount, final int sides,
       final PlayerID playerRolling, final DiceType diceType, final String annotation) {
     if (rollCount == 0) {
-      return new DiceRoll(Lists.newArrayList(), 0);
+      return new DiceRoll(new ArrayList<>(), 0);
     }
     int[] random = bridge.getRandom(sides, rollCount, playerRolling, diceType, annotation);
     final List<Die> dice = new ArrayList<>();

--- a/src/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -193,7 +193,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
   }
 
   private static List<Integer> getSortedMoveIndexes(Set<UndoableMove> moves) {
-    List<Integer> moveIndexes = Lists.newArrayList();
+    List<Integer> moveIndexes = new ArrayList<>();
     for (UndoableMove move : moves) {
       moveIndexes.add(move.getIndex());
     }

--- a/src/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/games/strategy/triplea/ui/BattleDisplay.java
@@ -854,7 +854,7 @@ class BattleModel extends DefaultTableModel {
         unitPowerAndRollsMap = null;
       } else {
         unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(units,
-            Lists.newArrayList(m_enemyBattleModel.getUnits()), !m_attack, false, m_data, m_location,
+            new ArrayList<>(m_enemyBattleModel.getUnits()), !m_attack, false, m_data, m_location,
             m_territoryEffects, m_isAmphibious, m_amphibiousLandAttackers);
       }
     } finally {

--- a/src/games/strategy/triplea/ui/screen/TileManager.java
+++ b/src/games/strategy/triplea/ui/screen/TileManager.java
@@ -350,44 +350,6 @@ public class TileManager {
 
   public Image createTerritoryImage(final Territory t, final GameData data, final MapData mapData) {
     return createTerritoryImage(t, t, data, mapData, true);
-    // synchronized(m_mutex)
-    // {
-    // Rectangle bounds = mapData.getBoundingRect(t);
-    // Image rVal = Util.createImage( bounds.width, bounds.height, false);
-    // Graphics2D graphics = (Graphics2D) rVal.getGraphics();
-    // //start as a set to prevent duplicates
-    // Set<IDrawable> drawablesSet = new HashSet<IDrawable>();
-    // Iterator<Tile> tiles = getTiles(bounds).iterator();
-    // while(tiles.hasNext())
-    // {
-    // Tile tile = tiles.next();
-    // drawablesSet.addAll(tile.getDrawables());
-    // }
-    // List<IDrawable> orderedDrawables = new ArrayList<IDrawable>(drawablesSet);
-    // Collections.sort(orderedDrawables, new DrawableComparator());
-    // Iterator<IDrawable> drawers = orderedDrawables.iterator();
-    // while (drawers.hasNext())
-    // {
-    // IDrawable drawer = drawers.next();
-    // if(drawer.getLevel() >= IDrawable.UNITS_LEVEL)
-    // break;
-    // if(drawer.getLevel() == IDrawable.TERRITORY_TEXT_LEVEL)
-    // continue;
-    // drawer.draw(bounds, data, graphics, mapData);
-    // }
-    // Iterator iter = mapData.getPolygons(t).iterator();
-    // graphics.setStroke(new BasicStroke(5));
-    // graphics.setColor(Color.RED);
-    // while (iter.hasNext())
-    // {
-    // Polygon poly = (Polygon) iter.next();
-    // poly = new Polygon(poly.xpoints, poly.ypoints, poly.npoints);
-    // poly.translate(-bounds.x, -bounds.y);
-    // graphics.drawPolygon(poly);
-    // }
-    // graphics.dispose();
-    // return rVal;
-    // }
   }
 
   public Image createTerritoryImage(final Territory selected, final Territory focusOn, final GameData data,

--- a/test/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
+++ b/test/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
@@ -29,7 +29,7 @@ public class MapDownloadListSortTest {
 
   @Test
   public void testSortingSortedList() {
-    List<DownloadFileDescription> downloads = Lists.newArrayList(MAP_A, MAP_B, MAP_C);
+    List<DownloadFileDescription> downloads = new ArrayList<>(MAP_A, MAP_B, MAP_C);
 
     List<DownloadFileDescription> sorted = MapDownloadListSort.sortByMapName(downloads);
     assertSorted(sorted);
@@ -43,7 +43,7 @@ public class MapDownloadListSortTest {
 
   @Test
   public void testSortingUnSortedList() {
-    List<DownloadFileDescription> downloads = Lists.newArrayList(MAP_B, MAP_C, MAP_A);
+    List<DownloadFileDescription> downloads = new ArrayList<>(MAP_B, MAP_C, MAP_A);
     List<DownloadFileDescription> sorted = MapDownloadListSort.sortByMapName(downloads);
     assertSorted(sorted);
   }
@@ -51,7 +51,7 @@ public class MapDownloadListSortTest {
   @Test
   public void testInsertEmptyRowAboveHeaders() {
     List<DownloadFileDescription> downloads =
-        Lists.newArrayList(HEADER, HEADER);
+        new ArrayList<>(HEADER, HEADER);
     List<DownloadFileDescription> sorted = MapDownloadListSort.sortByMapName(downloads);
     assertThat(sorted.size(), is(downloads.size() + 1));
     assertThat(sorted.get(0).isDummyUrl(), is(true));
@@ -62,7 +62,7 @@ public class MapDownloadListSortTest {
   @Test
   public void testSortingUnSortedListWithHeaders() {
     List<DownloadFileDescription> downloads =
-        Lists.newArrayList(HEADER, MAP_B, MAP_A, HEADER, MAP_D, MAP_C, HEADER, HEADER);
+        new ArrayList<>(HEADER, MAP_B, MAP_A, HEADER, MAP_D, MAP_C, HEADER, HEADER);
     List<DownloadFileDescription> sorted = MapDownloadListSort.sortByMapName(downloads);
     assertThat(sorted.get(0).isDummyUrl(), is(true));
     assertThat(sorted.get(1).getMapName(), is(MAP_A.getMapName()));

--- a/test/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
+++ b/test/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
@@ -29,7 +29,7 @@ public class MapDownloadListSortTest {
 
   @Test
   public void testSortingSortedList() {
-    List<DownloadFileDescription> downloads = new ArrayList<>(MAP_A, MAP_B, MAP_C);
+    List<DownloadFileDescription> downloads = Lists.newArrayList(MAP_A, MAP_B, MAP_C);
 
     List<DownloadFileDescription> sorted = MapDownloadListSort.sortByMapName(downloads);
     assertSorted(sorted);
@@ -43,7 +43,7 @@ public class MapDownloadListSortTest {
 
   @Test
   public void testSortingUnSortedList() {
-    List<DownloadFileDescription> downloads = new ArrayList<>(MAP_B, MAP_C, MAP_A);
+    List<DownloadFileDescription> downloads = Lists.newArrayList(MAP_B, MAP_C, MAP_A);
     List<DownloadFileDescription> sorted = MapDownloadListSort.sortByMapName(downloads);
     assertSorted(sorted);
   }
@@ -51,7 +51,7 @@ public class MapDownloadListSortTest {
   @Test
   public void testInsertEmptyRowAboveHeaders() {
     List<DownloadFileDescription> downloads =
-        new ArrayList<>(HEADER, HEADER);
+        Lists.newArrayList(HEADER, HEADER);
     List<DownloadFileDescription> sorted = MapDownloadListSort.sortByMapName(downloads);
     assertThat(sorted.size(), is(downloads.size() + 1));
     assertThat(sorted.get(0).isDummyUrl(), is(true));
@@ -62,7 +62,7 @@ public class MapDownloadListSortTest {
   @Test
   public void testSortingUnSortedListWithHeaders() {
     List<DownloadFileDescription> downloads =
-        new ArrayList<>(HEADER, MAP_B, MAP_A, HEADER, MAP_D, MAP_C, HEADER, HEADER);
+    Lists.newArrayList(HEADER, MAP_B, MAP_A, HEADER, MAP_D, MAP_C, HEADER, HEADER);
     List<DownloadFileDescription> sorted = MapDownloadListSort.sortByMapName(downloads);
     assertThat(sorted.get(0).isDummyUrl(), is(true));
     assertThat(sorted.get(1).getMapName(), is(MAP_A.getMapName()));


### PR DESCRIPTION
Resolves #703 

Updates to pick up map contents from a "map" folder if present. This allows us to work on 'git clones' directly from the downloadedMaps folder

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/905)
<!-- Reviewable:end -->
