### PR TITLE
AI refactor territory value utils to improve performance

### DIFF
--- a/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -217,12 +217,10 @@ public class ProCombatMoveAI {
       if (isFFA == 1 && TUVSwing > 0) {
         TUVSwing *= 0.5;
       }
-      final double territoryValue =
-          (1 + isLand + isCanHold * (1 + 2 * isFFA)) * (1 + isEmptyLand) * (1 + isFactory) * (1 - 0.5 * isAmphib)
-              * production;
-      double attackValue =
-          (TUVSwing + territoryValue) * (1 + 4 * isEnemyCapital) * (1 + 2 * isNotNeutralAdjacentToMyCapital)
-              * (1 - 0.9 * isNeutral);
+      final double territoryValue = (1 + isLand + isCanHold * (1 + 2 * isFFA)) * (1 + isEmptyLand) * (1 + isFactory)
+          * (1 - 0.5 * isAmphib) * production;
+      double attackValue = (TUVSwing + territoryValue) * (1 + 4 * isEnemyCapital)
+          * (1 + 2 * isNotNeutralAdjacentToMyCapital) * (1 - 0.9 * isNeutral);
 
       // Check if a negative value neutral territory should be attacked
       if (attackValue <= 0 && !patd.isNeedAmphibUnits() && !t.isWater() && t.getOwner().isNull()) {
@@ -239,9 +237,8 @@ public class ProCombatMoveAI {
         for (final Territory nearbyEnemyTerritory : nearbyEnemyTerritories) {
           boolean allAlliedNeighborsHaveRoute = true;
           for (final Territory nearbyAlliedTerritory : nearbyTerritoriesWithOwnedUnits) {
-            final int distance =
-                data.getMap().getDistance_IgnoreEndForCondition(nearbyAlliedTerritory, nearbyEnemyTerritory,
-                    ProMatches.territoryIsEnemyNotNeutralOrAllied(player, data));
+            final int distance = data.getMap().getDistance_IgnoreEndForCondition(nearbyAlliedTerritory,
+                nearbyEnemyTerritory, ProMatches.territoryIsEnemyNotNeutralOrAllied(player, data));
             if (distance < 0 || distance > 2) {
               allAlliedNeighborsHaveRoute = false;
               break;
@@ -255,8 +252,8 @@ public class ProCombatMoveAI {
             cantReachEnemyTerritories.add(nearbyEnemyTerritory);
           }
         }
-        ProLogger.debug(t.getName() + " calculated nearby enemy value=" + nearbyEnemyValue + " from "
-            + cantReachEnemyTerritories);
+        ProLogger.debug(
+            t.getName() + " calculated nearby enemy value=" + nearbyEnemyValue + " from " + cantReachEnemyTerritories);
         if (nearbyEnemyValue > 0) {
           ProLogger.trace(t.getName() + " updating negative neutral attack value=" + attackValue);
           attackValue = nearbyEnemyValue * .001 / (1 - attackValue);
@@ -277,8 +274,8 @@ public class ProCombatMoveAI {
       patd.setValue(attackValue);
       if (attackValue <= 0
           || (isDefensive && attackValue <= 8 && data.getMap().getDistance(ProData.myCapital, t) <= 3)) {
-        ProLogger.debug("Removing territory that has a negative attack value: " + t.getName() + ", AttackValue="
-            + patd.getValue());
+        ProLogger.debug(
+            "Removing territory that has a negative attack value: " + t.getName() + ", AttackValue=" + patd.getValue());
         it.remove();
       }
     }
@@ -335,9 +332,8 @@ public class ProCombatMoveAI {
       if (areSuccessful) {
         for (final ProTerritory patd : territoriesToTryToAttack) {
           patd.setCanAttack(true);
-          final double estimate =
-              ProBattleUtils.estimateStrengthDifference(patd.getTerritory(), patd.getUnits(),
-                  patd.getMaxEnemyDefenders(player, data));
+          final double estimate = ProBattleUtils.estimateStrengthDifference(patd.getTerritory(), patd.getUnits(),
+              patd.getMaxEnemyDefenders(player, data));
           if (estimate < patd.getStrengthEstimate()) {
             patd.setStrengthEstimate(estimate);
           }
@@ -418,8 +414,8 @@ public class ProCombatMoveAI {
       final double territoryValue = territoryValueMap.get(t) * (1 + 4 * isFactory);
       if (!t.isWater() && territoryValue < averageValue) {
         attackMap.get(t).setCanHold(false);
-        ProLogger.debug(t + ", CanHold=false, value=" + territoryValueMap.get(t) + ", averageAttackFromValue="
-            + averageValue);
+        ProLogger.debug(
+            t + ", CanHold=false, value=" + territoryValueMap.get(t) + ", averageAttackFromValue=" + averageValue);
         continue;
       }
       if (enemyAttackOptions.getMax(t) != null) {
@@ -427,27 +423,23 @@ public class ProCombatMoveAI {
         // Find max remaining defenders
         final Set<Unit> attackingUnits = new HashSet<>(patd.getMaxUnits());
         attackingUnits.addAll(patd.getMaxAmphibUnits());
-        final ProBattleResult result =
-            calc.estimateAttackBattleResults(player, t, new ArrayList<>(attackingUnits),
-                patd.getMaxEnemyDefenders(player, data), patd.getMaxBombardUnits());
+        final ProBattleResult result = calc.estimateAttackBattleResults(player, t, new ArrayList<>(attackingUnits),
+            patd.getMaxEnemyDefenders(player, data), patd.getMaxBombardUnits());
         final List<Unit> remainingUnitsToDefendWith =
             Match.getMatches(result.getAverageAttackersRemaining(), Matches.UnitIsAir.invert());
         ProLogger.debug(t + ", value=" + territoryValueMap.get(t) + ", averageAttackFromValue=" + averageValue
             + ", MyAttackers=" + attackingUnits.size() + ", RemainingUnits=" + remainingUnitsToDefendWith.size());
 
         // Determine counter attack results to see if I can hold it
-        final ProBattleResult result2 =
-            calc.calculateBattleResults(player, t, patd.getMaxEnemyUnits(), remainingUnitsToDefendWith,
-                enemyAttackOptions.getMax(t).getMaxBombardUnits(), false);
-        final boolean canHold =
-            (!result2.isHasLandUnitRemaining() && !t.isWater()) || (result2.getTUVSwing() < 0)
-                || (result2.getWinPercentage() < ProData.minWinPercentage);
+        final ProBattleResult result2 = calc.calculateBattleResults(player, t, patd.getMaxEnemyUnits(),
+            remainingUnitsToDefendWith, enemyAttackOptions.getMax(t).getMaxBombardUnits(), false);
+        final boolean canHold = (!result2.isHasLandUnitRemaining() && !t.isWater()) || (result2.getTUVSwing() < 0)
+            || (result2.getWinPercentage() < ProData.minWinPercentage);
         patd.setCanHold(canHold);
-        ProLogger
-            .debug(t + ", CanHold=" + canHold + ", MyDefenders=" + remainingUnitsToDefendWith.size()
-                + ", EnemyAttackers=" + patd.getMaxEnemyUnits().size() + ", win%=" + result2.getWinPercentage()
-                + ", EnemyTUVSwing=" + result2.getTUVSwing() + ", hasLandUnitRemaining="
-                + result2.isHasLandUnitRemaining());
+        ProLogger.debug(
+            t + ", CanHold=" + canHold + ", MyDefenders=" + remainingUnitsToDefendWith.size() + ", EnemyAttackers="
+                + patd.getMaxEnemyUnits().size() + ", win%=" + result2.getWinPercentage() + ", EnemyTUVSwing="
+                + result2.getTUVSwing() + ", hasLandUnitRemaining=" + result2.isHasLandUnitRemaining());
       } else {
         attackMap.get(t).setCanHold(true);
         ProLogger.debug(t + ", CanHold=true since no enemy counter attackers, value=" + territoryValueMap.get(t)
@@ -465,8 +457,8 @@ public class ProCombatMoveAI {
     for (final Iterator<ProTerritory> it = prioritizedTerritories.iterator(); it.hasNext();) {
       final ProTerritory patd = it.next();
       final Territory t = patd.getTerritory();
-      ProLogger.debug("Checking territory=" + patd.getTerritory().getName() + " with isAmphib="
-          + patd.isNeedAmphibUnits());
+      ProLogger
+          .debug("Checking territory=" + patd.getTerritory().getName() + " with isAmphib=" + patd.isNeedAmphibUnits());
 
       // Remove empty convoy zones that can't be held
       if (!patd.isCanHold() && enemyAttackOptions.getMax(t) != null && t.isWater()
@@ -493,8 +485,8 @@ public class ProCombatMoveAI {
         } else if (patd.isNeedAmphibUnits() && patd.getValue() < 2) {
 
           // Remove amphib territories that aren't worth attacking
-          ProLogger.debug("Removing low value amphib territory that can't be held: " + t.getName()
-              + ", enemyAttackers=" + enemyAttackOptions.getMax(t).getMaxUnits() + ", enemyAmphibAttackers="
+          ProLogger.debug("Removing low value amphib territory that can't be held: " + t.getName() + ", enemyAttackers="
+              + enemyAttackOptions.getMax(t).getMaxUnits() + ", enemyAmphibAttackers="
               + enemyAttackOptions.getMax(t).getMaxAmphibUnits());
           it.remove();
           continue;
@@ -552,12 +544,10 @@ public class ProCombatMoveAI {
     // Find land territories with no can't move units and adjacent to enemy land units
     final List<Unit> alreadyMovedUnits = new ArrayList<>();
     for (final Territory t : ProData.myUnitTerritories) {
-      final boolean hasAlliedLandUnits =
-          Match.someMatch(t.getUnits().getUnits(),
-              ProMatches.unitCantBeMovedAndIsAlliedDefenderAndNotInfra(player, data, t));
-      final Set<Territory> enemyNeighbors =
-          data.getMap().getNeighbors(t,
-              Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player, Matches.UnitIsLand));
+      final boolean hasAlliedLandUnits = Match.someMatch(t.getUnits().getUnits(),
+          ProMatches.unitCantBeMovedAndIsAlliedDefenderAndNotInfra(player, data, t));
+      final Set<Territory> enemyNeighbors = data.getMap().getNeighbors(t,
+          Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player, Matches.UnitIsLand));
       enemyNeighbors.removeAll(territoriesToAttack);
       if (!t.isWater() && !hasAlliedLandUnits && !enemyNeighbors.isEmpty()) {
         int minCost = Integer.MAX_VALUE;
@@ -648,12 +638,12 @@ public class ProCombatMoveAI {
             if (defendMap.get(unloadTerritory) != null) {
               defenders.addAll(defendMap.get(unloadTerritory).getMaxUnits());
             }
-            final ProBattleResult result =
-                calc.calculateBattleResults(player, unloadTerritory, enemyAttackOptions.getMax(unloadTerritory)
-                    .getMaxUnits(), new ArrayList<>(defenders), new HashSet<>(), false);
-            final ProBattleResult minResult =
-                calc.calculateBattleResults(player, unloadTerritory, enemyAttackOptions.getMax(unloadTerritory)
-                    .getMaxUnits(), territoryTransportAndBombardMap.get(unloadTerritory), new HashSet<>(), false);
+            final ProBattleResult result = calc.calculateBattleResults(player, unloadTerritory,
+                enemyAttackOptions.getMax(unloadTerritory).getMaxUnits(), new ArrayList<>(defenders), new HashSet<>(),
+                false);
+            final ProBattleResult minResult = calc.calculateBattleResults(player, unloadTerritory,
+                enemyAttackOptions.getMax(unloadTerritory).getMaxUnits(),
+                territoryTransportAndBombardMap.get(unloadTerritory), new HashSet<>(), false);
             final double minTUVSwing = Math.min(result.getTUVSwing(), minResult.getTUVSwing());
             if (minTUVSwing > 0) {
               totalEnemyTUVSwing += minTUVSwing;
@@ -668,9 +658,8 @@ public class ProCombatMoveAI {
         }
 
         // Determine whether its worth attacking
-        final ProBattleResult result =
-            calc.calculateBattleResults(player, t, patd.getUnits(), patd.getMaxEnemyDefenders(player, data), patd
-                .getBombardTerritoryMap().keySet(), true);
+        final ProBattleResult result = calc.calculateBattleResults(player, t, patd.getUnits(),
+            patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet(), true);
         int production = 0;
         int isEnemyCapital = 0;
         final TerritoryAttachment ta = TerritoryAttachment.get(t);
@@ -756,9 +745,8 @@ public class ProCombatMoveAI {
       }
 
       // Re-sort attack options
-      sortedUnitAttackOptions =
-          ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions, attackMap,
-              ProData.unitTerritoryMap, calc);
+      sortedUnitAttackOptions = ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions,
+          attackMap, ProData.unitTerritoryMap, calc);
 
       // Set air units in any territory with no AA (don't move planes to empty territories)
       for (final Iterator<Unit> it = sortedUnitAttackOptions.keySet().iterator(); it.hasNext();) {
@@ -803,9 +791,8 @@ public class ProCombatMoveAI {
       }
 
       // Re-sort attack options
-      sortedUnitAttackOptions =
-          ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions, attackMap,
-              ProData.unitTerritoryMap, calc);
+      sortedUnitAttackOptions = ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions,
+          attackMap, ProData.unitTerritoryMap, calc);
 
       // Find territory that we can try to hold that needs unit
       for (final Iterator<Unit> it = sortedUnitAttackOptions.keySet().iterator(); it.hasNext();) {
@@ -839,9 +826,8 @@ public class ProCombatMoveAI {
       }
 
       // Re-sort attack options
-      sortedUnitAttackOptions =
-          ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions, attackMap,
-              ProData.unitTerritoryMap, calc);
+      sortedUnitAttackOptions = ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions,
+          attackMap, ProData.unitTerritoryMap, calc);
 
       // Add sea units to any territory that significantly increases TUV gain
       for (final Iterator<Unit> it = sortedUnitAttackOptions.keySet().iterator(); it.hasNext();) {
@@ -853,16 +839,14 @@ public class ProCombatMoveAI {
         for (final Territory t : sortedUnitAttackOptions.get(unit)) {
           final ProTerritory patd = attackMap.get(t);
           if (attackMap.get(t).getBattleResult() == null) {
-            attackMap.get(t).setBattleResult(
-                calc.estimateAttackBattleResults(player, t, patd.getUnits(), patd.getMaxEnemyDefenders(player, data),
-                    patd.getBombardTerritoryMap().keySet()));
+            attackMap.get(t).setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+                patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
           }
           final ProBattleResult result = attackMap.get(t).getBattleResult();
           final List<Unit> attackers = new ArrayList<>(patd.getUnits());
           attackers.add(unit);
-          final ProBattleResult result2 =
-              calc.estimateAttackBattleResults(player, t, attackers, patd.getMaxEnemyDefenders(player, data), patd
-                  .getBombardTerritoryMap().keySet());
+          final ProBattleResult result2 = calc.estimateAttackBattleResults(player, t, attackers,
+              patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet());
           final double unitValue = ProData.unitValueMap.getInt(unit.getType());
           if ((result2.getTUVSwing() - unitValue / 3) > result.getTUVSwing()) {
             attackMap.get(t).addUnit(unit);
@@ -896,25 +880,22 @@ public class ProCombatMoveAI {
             && !ProMatches.territoryIsWaterAndAdjacentToOwnedFactory(player, data).match(t)) {
           List<Unit> remainingUnitsToDefendWith =
               Match.getMatches(result.getAverageAttackersRemaining(), Matches.UnitIsAir.invert());
-          ProBattleResult result2 =
-              calc.calculateBattleResults(player, t, patd.getMaxEnemyUnits(), remainingUnitsToDefendWith,
-                  patd.getMaxBombardUnits(), false);
+          ProBattleResult result2 = calc.calculateBattleResults(player, t, patd.getMaxEnemyUnits(),
+              remainingUnitsToDefendWith, patd.getMaxBombardUnits(), false);
           if (patd.isCanHold() && result2.getTUVSwing() > 0) {
             final List<Unit> unusedUnits = new ArrayList<>(patd.getMaxUnits());
             unusedUnits.addAll(patd.getMaxAmphibUnits());
             unusedUnits.removeAll(usedUnits);
             unusedUnits.addAll(remainingUnitsToDefendWith);
-            final ProBattleResult result3 =
-                calc.calculateBattleResults(player, t, patd.getMaxEnemyUnits(), unusedUnits, patd.getMaxBombardUnits(),
-                    false);
+            final ProBattleResult result3 = calc.calculateBattleResults(player, t, patd.getMaxEnemyUnits(), unusedUnits,
+                patd.getMaxBombardUnits(), false);
             if (result3.getTUVSwing() < result2.getTUVSwing()) {
               result2 = result3;
               remainingUnitsToDefendWith = unusedUnits;
             }
           }
-          canHold =
-              (!result2.isHasLandUnitRemaining() && !t.isWater()) || (result2.getTUVSwing() < 0)
-                  || (result2.getWinPercentage() < ProData.minWinPercentage);
+          canHold = (!result2.isHasLandUnitRemaining() && !t.isWater()) || (result2.getTUVSwing() < 0)
+              || (result2.getWinPercentage() < ProData.minWinPercentage);
           if (result2.getTUVSwing() > 0) {
             enemyCounterTUVSwing = result2.getTUVSwing();
           }
@@ -965,11 +946,9 @@ public class ProCombatMoveAI {
         }
 
         // Determine whether to remove attack
-        if (!patd.isStrafing()
-            && (result.getWinPercentage() < ProData.minWinPercentage || !result.isHasLandUnitRemaining()
-                || (isNeutral && !canHold)
-                || (attackValue < 0 && (!isNeutral || allUnitsCanAttackOtherTerritory || result
-                    .getBattleRounds() >= 4)))) {
+        if (!patd.isStrafing() && (result.getWinPercentage() < ProData.minWinPercentage
+            || !result.isHasLandUnitRemaining() || (isNeutral && !canHold)
+            || (attackValue < 0 && (!isNeutral || allUnitsCanAttackOtherTerritory || result.getBattleRounds() >= 4)))) {
           territoryToRemove = patd;
         }
         ProLogger.debug(patd.getResultString() + ", attackValue=" + attackValue + ", territoryValue=" + territoryValue
@@ -1076,9 +1055,8 @@ public class ProCombatMoveAI {
     }
 
     // Re-sort attack options
-    sortedUnitAttackOptions =
-        ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions, attackMap,
-            ProData.unitTerritoryMap, calc);
+    sortedUnitAttackOptions = ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions,
+        attackMap, ProData.unitTerritoryMap, calc);
 
     // Set non-air units in territories that can be held
     for (final Iterator<Unit> it = sortedUnitAttackOptions.keySet().iterator(); it.hasNext();) {
@@ -1093,9 +1071,8 @@ public class ProCombatMoveAI {
         final ProTerritory patd = attackMap.get(t);
         if (!attackMap.get(t).isCurrentlyWins() && attackMap.get(t).isCanHold()) {
           if (attackMap.get(t).getBattleResult() == null) {
-            attackMap.get(t).setBattleResult(
-                calc.estimateAttackBattleResults(player, t, patd.getUnits(), patd.getMaxEnemyDefenders(player, data),
-                    patd.getBombardTerritoryMap().keySet()));
+            attackMap.get(t).setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+                patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
           }
           final ProBattleResult result = attackMap.get(t).getBattleResult();
           if (result.getWinPercentage() < minWinPercentage
@@ -1113,9 +1090,8 @@ public class ProCombatMoveAI {
     }
 
     // Re-sort attack options
-    sortedUnitAttackOptions =
-        ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions, attackMap,
-            ProData.unitTerritoryMap, calc);
+    sortedUnitAttackOptions = ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions,
+        attackMap, ProData.unitTerritoryMap, calc);
 
     // Set air units in territories that can't be held (don't move planes to empty territories)
     for (final Iterator<Unit> it = sortedUnitAttackOptions.keySet().iterator(); it.hasNext();) {
@@ -1132,13 +1108,11 @@ public class ProCombatMoveAI {
 
           // Check if air unit should avoid this territory due to no guaranteed safe landing location
           final boolean isEnemyCapital = ProUtils.getLiveEnemyCapitals(data, player).contains(t);
-          final boolean isAdjacentToAlliedCapital =
-              Matches.territoryHasNeighborMatching(data,
-                  Matches.territoryIsInList(ProUtils.getLiveAlliedCapitals(data, player))).match(t);
+          final boolean isAdjacentToAlliedCapital = Matches.territoryHasNeighborMatching(data,
+              Matches.territoryIsInList(ProUtils.getLiveAlliedCapitals(data, player))).match(t);
           final int range = TripleAUnit.get(unit).getMovementLeft();
-          final int distance =
-              data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
-                  ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
+          final int distance = data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
+              ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
           final boolean usesMoreThanHalfOfRange = distance > range / 2;
           if (isAirUnit && !isEnemyCapital && !isAdjacentToAlliedCapital && usesMoreThanHalfOfRange) {
             continue;
@@ -1176,9 +1150,8 @@ public class ProCombatMoveAI {
     }
 
     // Re-sort attack options
-    sortedUnitAttackOptions =
-        ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions, attackMap,
-            ProData.unitTerritoryMap, calc);
+    sortedUnitAttackOptions = ProSortMoveOptionsUtils.sortUnitNeededOptionsThenAttack(player, sortedUnitAttackOptions,
+        attackMap, ProData.unitTerritoryMap, calc);
 
     // Set remaining units in any territory that needs it (don't move planes to empty territories)
     for (final Iterator<Unit> it = sortedUnitAttackOptions.keySet().iterator(); it.hasNext();) {
@@ -1191,13 +1164,12 @@ public class ProCombatMoveAI {
         if (!patd.isCurrentlyWins()) {
 
           // Check if air unit should avoid this territory due to no guaranteed safe landing location
-          final boolean isAdjacentToAlliedFactory =
-              Matches.territoryHasNeighborMatching(data,
-                  ProMatches.territoryHasInfraFactoryAndIsAlliedLand(player, data)).match(t);
+          final boolean isAdjacentToAlliedFactory = Matches
+              .territoryHasNeighborMatching(data, ProMatches.territoryHasInfraFactoryAndIsAlliedLand(player, data))
+              .match(t);
           final int range = TripleAUnit.get(unit).getMovementLeft();
-          final int distance =
-              data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
-                  ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
+          final int distance = data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
+              ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
           final boolean usesMoreThanHalfOfRange = distance > range / 2;
           final boolean territoryValueIsLessThanUnitValue =
               patd.getValue() < ProData.unitValueMap.getInt(unit.getType());
@@ -1218,9 +1190,8 @@ public class ProCombatMoveAI {
             final boolean isOverwhelmingWin =
                 ProBattleUtils.checkForOverwhelmingWin(player, t, patd.getUnits(), defendingUnits);
             final boolean hasAA = Match.someMatch(defendingUnits, Matches.UnitIsAAforAnything);
-            if (!isAirUnit
-                || (!hasNoDefenders && !isOverwhelmingWin
-                    && (!hasAA || result.getWinPercentage() < minWinPercentage))) {
+            if (!isAirUnit || (!hasNoDefenders && !isOverwhelmingWin
+                && (!hasAA || result.getWinPercentage() < minWinPercentage))) {
               minWinPercentage = result.getWinPercentage();
               minWinTerritory = t;
             }
@@ -1335,9 +1306,8 @@ public class ProCombatMoveAI {
 
                 // Find units to load
                 final Set<Territory> territoriesCanLoadFrom = proTransportData.getTransportMap().get(t);
-                final List<Unit> amphibUnitsToAdd =
-                    ProTransportUtils.getUnitsToTransportFromTerritories(player, transport, territoriesCanLoadFrom,
-                        alreadyAttackedWithUnits);
+                final List<Unit> amphibUnitsToAdd = ProTransportUtils.getUnitsToTransportFromTerritories(player,
+                    transport, territoriesCanLoadFrom, alreadyAttackedWithUnits);
                 if (amphibUnitsToAdd.isEmpty()) {
                   continue;
                 }
@@ -1352,9 +1322,8 @@ public class ProCombatMoveAI {
                   loadFromTerritories.add(ProData.unitTerritoryMap.get(u));
                 }
                 for (final Territory territoryToMoveTransport : territoriesToMoveTransport) {
-                  if (proTransportData.getSeaTransportMap().containsKey(territoryToMoveTransport)
-                      && proTransportData.getSeaTransportMap().get(territoryToMoveTransport)
-                          .containsAll(loadFromTerritories)) {
+                  if (proTransportData.getSeaTransportMap().containsKey(territoryToMoveTransport) && proTransportData
+                      .getSeaTransportMap().get(territoryToMoveTransport).containsAll(loadFromTerritories)) {
                     List<Unit> attackers = new ArrayList<>();
                     if (enemyAttackOptions.getMax(territoryToMoveTransport) != null) {
                       attackers = enemyAttackOptions.getMax(territoryToMoveTransport).getMaxUnits();
@@ -1460,8 +1429,8 @@ public class ProCombatMoveAI {
         attackMap.get(minWinTerritory).getBombardTerritoryMap().put(u, minBombardFromTerritory);
         attackMap.get(minWinTerritory).setBattleResult(null);
         sortedUnitAttackOptions.remove(u);
-        ProLogger.trace("Adding bombard to " + minWinTerritory + ", units=" + u + ", bombardFrom="
-            + minBombardFromTerritory);
+        ProLogger.trace(
+            "Adding bombard to " + minWinTerritory + ", units=" + u + ", bombardFrom=" + minBombardFromTerritory);
       }
     }
     return sortedUnitAttackOptions;
@@ -1518,9 +1487,8 @@ public class ProCombatMoveAI {
       // Determine counter attack results to see if I can hold it
       final Set<Unit> enemyAttackingUnits = new HashSet<>(enemyAttackOptions.getMax(myCapital).getMaxUnits());
       enemyAttackingUnits.addAll(enemyAttackOptions.getMax(myCapital).getMaxAmphibUnits());
-      final ProBattleResult result =
-          calc.estimateDefendBattleResults(player, myCapital, new ArrayList<>(enemyAttackingUnits), defenders,
-              enemyAttackOptions.getMax(myCapital).getMaxBombardUnits());
+      final ProBattleResult result = calc.estimateDefendBattleResults(player, myCapital,
+          new ArrayList<>(enemyAttackingUnits), defenders, enemyAttackOptions.getMax(myCapital).getMaxBombardUnits());
       ProLogger.trace("Current capital result hasLandUnitRemaining=" + result.isHasLandUnitRemaining() + ", TUVSwing="
           + result.getTUVSwing() + ", defenders=" + defenders.size() + ", attackers=" + enemyAttackingUnits.size());
 
@@ -1686,13 +1654,11 @@ public class ProCombatMoveAI {
   }
 
   private boolean canAirSafelyLandAfterAttack(final Unit unit, final Territory t) {
-    final boolean isAdjacentToAlliedFactory =
-        Matches.territoryHasNeighborMatching(data,
-            ProMatches.territoryHasInfraFactoryAndIsAlliedLand(player, data)).match(t);
+    final boolean isAdjacentToAlliedFactory = Matches
+        .territoryHasNeighborMatching(data, ProMatches.territoryHasInfraFactoryAndIsAlliedLand(player, data)).match(t);
     final int range = TripleAUnit.get(unit).getMovementLeft();
-    final int distance =
-        data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
-            ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
+    final int distance = data.getMap().getDistance_IgnoreEndForCondition(ProData.unitTerritoryMap.get(unit), t,
+        ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
     final boolean usesMoreThanHalfOfRange = distance > range / 2;
     return isAdjacentToAlliedFactory || !usesMoreThanHalfOfRange;
   }

--- a/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -88,8 +88,10 @@ public class ProCombatMoveAI {
       clearedTerritories.add(patd.getTerritory());
     }
     territoryManager.populateEnemyAttackOptions(clearedTerritories, new ArrayList<>());
+    Set<Territory> territoriesToCheck = new HashSet<>(clearedTerritories);
+    territoriesToCheck.addAll(ProData.myUnitTerritories);
     Map<Territory, Double> territoryValueMap =
-        ProTerritoryValueUtils.findTerritoryValues(player, new ArrayList<>(), clearedTerritories);
+        ProTerritoryValueUtils.findTerritoryValues(player, new ArrayList<>(), clearedTerritories, territoriesToCheck);
     determineTerritoriesThatCanBeHeld(attackOptions, territoryValueMap);
     prioritizeAttackOptions(player, attackOptions);
     removeTerritoriesThatArentWorthAttacking(attackOptions);
@@ -107,7 +109,10 @@ public class ProCombatMoveAI {
       }
     }
     territoryManager.populateEnemyAttackOptions(clearedTerritories, new ArrayList<>(possibleTransportTerritories));
-    territoryValueMap = ProTerritoryValueUtils.findTerritoryValues(player, new ArrayList<>(), clearedTerritories);
+    territoriesToCheck = new HashSet<>(clearedTerritories);
+    territoriesToCheck.addAll(ProData.myUnitTerritories);
+    territoryValueMap =
+        ProTerritoryValueUtils.findTerritoryValues(player, new ArrayList<>(), clearedTerritories, territoriesToCheck);
     determineTerritoriesThatCanBeHeld(attackOptions, territoryValueMap);
     removeTerritoriesThatArentWorthAttacking(attackOptions);
 

--- a/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -25,7 +25,6 @@ public class ProTerritoryValueUtils {
 
   public static double findTerritoryAttackValue(final PlayerID player, final Territory t) {
     final GameData data = ProData.getData();
-
     final int isEnemyFactory = ProMatches.territoryHasInfraFactoryAndIsEnemyLand(player, data).match(t) ? 1 : 0;
     double value = 3 * TerritoryAttachment.getProduction(t) * (isEnemyFactory + 1);
     if (!t.isWater() && t.getOwner().isNull()) {
@@ -36,11 +35,13 @@ public class ProTerritoryValueUtils {
       final double TUVSwing = -(strength / 8) * ProData.minCostPerHitPoint;
       value += TUVSwing;
     }
+
     return value;
   }
 
   public static Map<Territory, Double> findTerritoryValues(final PlayerID player,
       final List<Territory> territoriesThatCantBeHeld, final List<Territory> territoriesToAttack) {
+
     return findTerritoryValues(player, territoriesThatCantBeHeld, territoriesToAttack,
         new HashSet<>(ProData.getData().getMap().getTerritories()));
   }
@@ -70,17 +71,17 @@ public class ProTerritoryValueUtils {
         territoryValueMap.put(t, value);
       }
     }
+
     return territoryValueMap;
   }
 
   public static Map<Territory, Double> findSeaTerritoryValues(final PlayerID player,
       final List<Territory> territoriesThatCantBeHeld) {
-    final GameData data = ProData.getData();
-    final List<Territory> allTerritories = data.getMap().getTerritories();
 
     // Determine value for water territories
     final Map<Territory, Double> territoryValueMap = new HashMap<>();
-    for (final Territory t : allTerritories) {
+    final GameData data = ProData.getData();
+    for (final Territory t : data.getMap().getTerritories()) {
       if (!territoriesThatCantBeHeld.contains(t) && t.isWater()
           && !data.getMap().getNeighbors(t, Matches.TerritoryIsWater).isEmpty()) {
 
@@ -128,14 +129,14 @@ public class ProTerritoryValueUtils {
         territoryValueMap.put(t, 0.0);
       }
     }
+
     return territoryValueMap;
   }
 
   private static int findMaxLandMassSize(final PlayerID player) {
-    final GameData data = ProData.getData();
-    final List<Territory> allTerritories = data.getMap().getTerritories();
     int maxLandMassSize = 1;
-    for (final Territory t : allTerritories) {
+    final GameData data = ProData.getData();
+    for (final Territory t : data.getMap().getTerritories()) {
       if (!t.isWater()) {
         final int landMassSize = 1 + data.getMap()
             .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true)).size();
@@ -144,6 +145,7 @@ public class ProTerritoryValueUtils {
         }
       }
     }
+
     return maxLandMassSize;
   }
 
@@ -152,9 +154,9 @@ public class ProTerritoryValueUtils {
       final List<Territory> territoriesToAttack) {
 
     // Get all enemy factories and capitals (check if most territories have factories and if so remove them)
+    final Set<Territory> enemyCapitalsAndFactories = new HashSet<>();
     final GameData data = ProData.getData();
     final List<Territory> allTerritories = data.getMap().getTerritories();
-    final Set<Territory> enemyCapitalsAndFactories = new HashSet<>();
     enemyCapitalsAndFactories.addAll(
         Match.getMatches(allTerritories, ProMatches.territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(player,
             data, ProUtils.getPotentialEnemyPlayers(player), territoriesThatCantBeHeld)));
@@ -166,6 +168,7 @@ public class ProTerritoryValueUtils {
     enemyCapitalsAndFactories.addAll(ProUtils.getLiveEnemyCapitals(data, player));
     enemyCapitalsAndFactories.removeAll(territoriesToAttack);
 
+    // Find value for each enemy capital and factory
     final Map<Territory, Double> enemyCapitalsAndFactoriesMap = new HashMap<>();
     for (final Territory t : enemyCapitalsAndFactories) {
 
@@ -190,6 +193,7 @@ public class ProTerritoryValueUtils {
           * landMassSize / maxLandMassSize;
       enemyCapitalsAndFactoriesMap.put(t, value);
     }
+
     return enemyCapitalsAndFactoriesMap;
   }
 
@@ -247,6 +251,7 @@ public class ProTerritoryValueUtils {
     if (ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t)) {
       value *= 1.1; // prefer territories with factories
     }
+
     return value;
   }
 
@@ -311,11 +316,13 @@ public class ProTerritoryValueUtils {
       }
     }
     final double value = capitalOrFactoryValue / 100 + nearbyLandValue / 10;
+
     return value;
   }
 
   private static Set<Territory> findNearbyEnemyCapitalsAndFactories(final Territory t,
       final Map<Territory, Double> enemyCapitalsAndFactoriesMap) {
+
     Set<Territory> nearbyEnemyCapitalsAndFactories = new HashSet<>();
     for (int i = 9; i <= 30; i++) {
       nearbyEnemyCapitalsAndFactories = ProData.getData().getMap().getNeighbors(t, i);
@@ -324,6 +331,7 @@ public class ProTerritoryValueUtils {
         break;
       }
     }
+
     return nearbyEnemyCapitalsAndFactories;
   }
 

--- a/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -201,20 +201,12 @@ public class ProTerritoryValueUtils {
       return 0.0;
     }
 
-    // Find nearby capitals and factories
-    final GameData data = ProData.getData();
-    Set<Territory> neighborTerritories = new HashSet<>();
-    for (int i = 9; i <= 30; i++) {
-      neighborTerritories = data.getMap().getNeighbors(t, i);
-      neighborTerritories.retainAll(enemyCapitalsAndFactoriesMap.keySet());
-      if (!neighborTerritories.isEmpty()) {
-        break;
-      }
-    }
-
     // Determine value based on enemy factory land distance
     final List<Double> values = new ArrayList<>();
-    for (final Territory enemyCapitalOrFactory : neighborTerritories) {
+    final GameData data = ProData.getData();
+    final Set<Territory> nearbyEnemyCapitalsAndFactories =
+        findNearbyEnemyCapitalsAndFactories(t, enemyCapitalsAndFactoriesMap);
+    for (final Territory enemyCapitalOrFactory : nearbyEnemyCapitalsAndFactories) {
       final int distance = data.getMap().getDistance(t, enemyCapitalOrFactory,
           ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
       if (distance > 0) {
@@ -267,19 +259,11 @@ public class ProTerritoryValueUtils {
       return 0.0;
     }
 
-    // Find nearby capitals and factories
-    Set<Territory> neighborTerritories = new HashSet<>();
-    for (int i = 9; i <= 30; i++) {
-      neighborTerritories = data.getMap().getNeighbors(t, i);
-      neighborTerritories.retainAll(enemyCapitalsAndFactoriesMap.keySet());
-      if (!neighborTerritories.isEmpty()) {
-        break;
-      }
-    }
-
     // Determine value based on enemy factory distance
     final List<Double> values = new ArrayList<>();
-    for (final Territory enemyCapitalOrFactory : neighborTerritories) {
+    final Set<Territory> nearbyEnemyCapitalsAndFactories =
+        findNearbyEnemyCapitalsAndFactories(t, enemyCapitalsAndFactoriesMap);
+    for (final Territory enemyCapitalOrFactory : nearbyEnemyCapitalsAndFactories) {
       final Route route = data.getMap().getRoute_IgnoreEnd(t, enemyCapitalOrFactory,
           ProMatches.territoryCanMoveSeaUnits(player, data, true));
       if (route == null || MoveValidator.validateCanal(route, null, player, data) != null) {
@@ -328,6 +312,19 @@ public class ProTerritoryValueUtils {
     }
     final double value = capitalOrFactoryValue / 100 + nearbyLandValue / 10;
     return value;
+  }
+
+  private static Set<Territory> findNearbyEnemyCapitalsAndFactories(final Territory t,
+      final Map<Territory, Double> enemyCapitalsAndFactoriesMap) {
+    Set<Territory> nearbyEnemyCapitalsAndFactories = new HashSet<>();
+    for (int i = 9; i <= 30; i++) {
+      nearbyEnemyCapitalsAndFactories = ProData.getData().getMap().getNeighbors(t, i);
+      nearbyEnemyCapitalsAndFactories.retainAll(enemyCapitalsAndFactoriesMap.keySet());
+      if (!nearbyEnemyCapitalsAndFactories.isEmpty()) {
+        break;
+      }
+    }
+    return nearbyEnemyCapitalsAndFactories;
   }
 
 }

--- a/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -41,6 +41,13 @@ public class ProTerritoryValueUtils {
 
   public static Map<Territory, Double> findTerritoryValues(final PlayerID player,
       final List<Territory> territoriesThatCantBeHeld, final List<Territory> territoriesToAttack) {
+    return findTerritoryValues(player, territoriesThatCantBeHeld, territoriesToAttack,
+        new HashSet<>(ProData.getData().getMap().getTerritories()));
+  }
+
+  public static Map<Territory, Double> findTerritoryValues(final PlayerID player,
+      final List<Territory> territoriesThatCantBeHeld, final List<Territory> territoriesToAttack,
+      final Set<Territory> territoriesToCheck) {
     final GameData data = ProData.getData();
     final List<Territory> allTerritories = data.getMap().getTerritories();
 
@@ -99,7 +106,7 @@ public class ProTerritoryValueUtils {
 
     // Determine value for land territories
     final Map<Territory, Double> territoryValueMap = new HashMap<>();
-    for (final Territory t : allTerritories) {
+    for (final Territory t : territoriesToCheck) {
       if (!t.isWater() && !territoriesThatCantBeHeld.contains(t)) {
 
         // Determine value based on enemy factory land distance
@@ -153,7 +160,7 @@ public class ProTerritoryValueUtils {
     }
 
     // Determine value for water territories
-    for (final Territory t : allTerritories) {
+    for (final Territory t : territoriesToCheck) {
       if (!territoriesThatCantBeHeld.contains(t) && t.isWater()
           && !data.getMap().getNeighbors(t, Matches.TerritoryIsWater).isEmpty()) {
 

--- a/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -1,5 +1,13 @@
 package games.strategy.triplea.ai.proAI.util;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Route;
@@ -9,14 +17,6 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.MoveValidator;
 import games.strategy.util.Match;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Pro AI battle utilities.
@@ -46,10 +46,9 @@ public class ProTerritoryValueUtils {
 
     // Get all enemy factories and capitals (check if most territories have factories and if so remove them)
     final Set<Territory> enemyCapitalsAndFactories = new HashSet<>();
-    enemyCapitalsAndFactories.addAll(Match.getMatches(
-        allTerritories,
-        ProMatches.territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(player, data,
-            ProUtils.getPotentialEnemyPlayers(player), territoriesThatCantBeHeld)));
+    enemyCapitalsAndFactories.addAll(
+        Match.getMatches(allTerritories, ProMatches.territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(player,
+            data, ProUtils.getPotentialEnemyPlayers(player), territoriesThatCantBeHeld)));
     final int numPotentialEnemyTerritories =
         Match.countMatches(allTerritories, Matches.isTerritoryOwnedBy(ProUtils.getPotentialEnemyPlayers(player)));
     if (enemyCapitalsAndFactories.size() * 2 >= numPotentialEnemyTerritories) {
@@ -62,9 +61,8 @@ public class ProTerritoryValueUtils {
     int maxLandMassSize = 1;
     for (final Territory t : allTerritories) {
       if (!t.isWater()) {
-        final int landMassSize =
-            1 + data.getMap().getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true))
-                .size();
+        final int landMassSize = 1 + data.getMap()
+            .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true)).size();
         if (landMassSize > maxLandMassSize) {
           maxLandMassSize = landMassSize;
         }
@@ -92,12 +90,10 @@ public class ProTerritoryValueUtils {
       final int isNeutral = t.getOwner().isNull() ? 1 : 0;
 
       // Calculate value
-      final int landMassSize =
-          1 + data.getMap().getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true))
-              .size();
-      final double value =
-          Math.sqrt(factoryProduction + Math.sqrt(playerProduction)) * 32 / (1 + 3 * isNeutral) * landMassSize
-              / maxLandMassSize;
+      final int landMassSize = 1 + data.getMap()
+          .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true)).size();
+      final double value = Math.sqrt(factoryProduction + Math.sqrt(playerProduction)) * 32 / (1 + 3 * isNeutral)
+          * landMassSize / maxLandMassSize;
       enemyCapitalsAndFactoriesMap.put(t, value);
     }
 
@@ -109,9 +105,8 @@ public class ProTerritoryValueUtils {
         // Determine value based on enemy factory land distance
         final List<Double> values = new ArrayList<>();
         for (final Territory enemyCapitalOrFactory : enemyCapitalsAndFactoriesMap.keySet()) {
-          final int distance =
-              data.getMap().getDistance(t, enemyCapitalOrFactory,
-                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
+          final int distance = data.getMap().getDistance(t, enemyCapitalOrFactory,
+              ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
           if (distance > 0) {
             values.add(enemyCapitalsAndFactoriesMap.get(enemyCapitalOrFactory) / Math.pow(2, distance));
           }
@@ -126,19 +121,18 @@ public class ProTerritoryValueUtils {
         double nearbyEnemyValue = 0;
         final Set<Territory> nearbyTerritories =
             data.getMap().getNeighbors(t, 2, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
-        final List<Territory> nearbyEnemyTerritories =
-            Match.getMatches(nearbyTerritories,
-                ProMatches.territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
+        final List<Territory> nearbyEnemyTerritories = Match.getMatches(nearbyTerritories,
+            ProMatches.territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
         nearbyEnemyTerritories.removeAll(territoriesToAttack);
         for (final Territory nearbyEnemyTerritory : nearbyEnemyTerritories) {
-          final int distance =
-              data.getMap().getDistance(t, nearbyEnemyTerritory,
-                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
+          final int distance = data.getMap().getDistance(t, nearbyEnemyTerritory,
+              ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
           if (distance > 0) {
             double value = TerritoryAttachment.getProduction(nearbyEnemyTerritory);
             if (nearbyEnemyTerritory.getOwner().isNull()) {
               value = findTerritoryAttackValue(player, nearbyEnemyTerritory) / 3; // find neutral value
-            } else if (ProMatches.territoryIsAlliedLandAndHasNoEnemyNeighbors(player, data).match(nearbyEnemyTerritory)) {
+            } else if (ProMatches.territoryIsAlliedLandAndHasNoEnemyNeighbors(player, data)
+                .match(nearbyEnemyTerritory)) {
               value *= 0.1; // reduce value for can't hold amphib allied territories
             }
             if (value > 0) {
@@ -146,9 +140,8 @@ public class ProTerritoryValueUtils {
             }
           }
         }
-        final int landMassSize =
-            1 + data.getMap().getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true))
-                .size();
+        final int landMassSize = 1 + data.getMap()
+            .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true)).size();
         double value = nearbyEnemyValue * landMassSize / maxLandMassSize + capitalOrFactoryValue;
         if (ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t)) {
           value *= 1.1; // prefer territories with factories
@@ -167,9 +160,8 @@ public class ProTerritoryValueUtils {
         // Determine value based on enemy factory distance
         final List<Double> values = new ArrayList<>();
         for (final Territory enemyCapitalOrFactory : enemyCapitalsAndFactoriesMap.keySet()) {
-          final Route route =
-              data.getMap().getRoute_IgnoreEnd(t, enemyCapitalOrFactory,
-                  ProMatches.territoryCanMoveSeaUnits(player, data, true));
+          final Route route = data.getMap().getRoute_IgnoreEnd(t, enemyCapitalOrFactory,
+              ProMatches.territoryCanMoveSeaUnits(player, data, true));
           if (route == null || MoveValidator.validateCanal(route, null, player, data) != null) {
             continue;
           }
@@ -191,16 +183,15 @@ public class ProTerritoryValueUtils {
             Match.getMatches(nearbyTerritories, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, false));
         nearbyLandTerritories.removeAll(territoriesToAttack);
         for (final Territory nearbyLandTerritory : nearbyLandTerritories) {
-          final Route route =
-              data.getMap().getRoute_IgnoreEnd(t, nearbyLandTerritory,
-                  ProMatches.territoryCanMoveSeaUnits(player, data, true));
+          final Route route = data.getMap().getRoute_IgnoreEnd(t, nearbyLandTerritory,
+              ProMatches.territoryCanMoveSeaUnits(player, data, true));
           if (route == null || MoveValidator.validateCanal(route, null, player, data) != null) {
             continue;
           }
           final int distance = route.numberOfSteps();
           if (distance > 0 && distance <= 3) {
-            if (ProMatches.territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld).match(
-                nearbyLandTerritory)) {
+            if (ProMatches.territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld)
+                .match(nearbyLandTerritory)) {
               double value = TerritoryAttachment.getProduction(nearbyLandTerritory);
               if (nearbyLandTerritory.getOwner().isNull()) {
                 value = findTerritoryAttackValue(player, nearbyLandTerritory);
@@ -234,13 +225,11 @@ public class ProTerritoryValueUtils {
         double nearbySeaProductionValue = 0;
         final Set<Territory> nearbySeaTerritories =
             data.getMap().getNeighbors(t, 4, ProMatches.territoryCanMoveSeaUnits(player, data, true));
-        final List<Territory> nearbyEnemySeaTerritories =
-            Match.getMatches(nearbySeaTerritories,
-                ProMatches.territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
+        final List<Territory> nearbyEnemySeaTerritories = Match.getMatches(nearbySeaTerritories,
+            ProMatches.territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
         for (final Territory nearbyEnemySeaTerritory : nearbyEnemySeaTerritories) {
-          final Route route =
-              data.getMap().getRoute_IgnoreEnd(t, nearbyEnemySeaTerritory,
-                  ProMatches.territoryCanMoveSeaUnits(player, data, true));
+          final Route route = data.getMap().getRoute_IgnoreEnd(t, nearbyEnemySeaTerritory,
+              ProMatches.territoryCanMoveSeaUnits(player, data, true));
           if (route == null || MoveValidator.validateCanal(route, null, player, data) != null) {
             continue;
           }
@@ -256,9 +245,8 @@ public class ProTerritoryValueUtils {
         final List<Territory> nearbyEnemySeaUnitTerritories =
             Match.getMatches(nearbySeaTerritories, Matches.territoryHasEnemyUnits(player, data));
         for (final Territory nearbyEnemySeaTerritory : nearbyEnemySeaUnitTerritories) {
-          final Route route =
-              data.getMap().getRoute_IgnoreEnd(t, nearbyEnemySeaTerritory,
-                  ProMatches.territoryCanMoveSeaUnits(player, data, true));
+          final Route route = data.getMap().getRoute_IgnoreEnd(t, nearbyEnemySeaTerritory,
+              ProMatches.territoryCanMoveSeaUnits(player, data, true));
           if (route == null || MoveValidator.validateCanal(route, null, player, data) != null) {
             continue;
           }

--- a/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -119,9 +119,19 @@ public class ProTerritoryValueUtils {
       if (!territoriesThatCantBeHeld.contains(t) && t.isWater()
           && !data.getMap().getNeighbors(t, Matches.TerritoryIsWater).isEmpty()) {
 
+        // Find nearby capitals and factories
+        Set<Territory> neighborTerritories = new HashSet<>();
+        for (int i = 9; i <= 30; i++) {
+          neighborTerritories = data.getMap().getNeighbors(t, i);
+          neighborTerritories.retainAll(enemyCapitalsAndFactoriesMap.keySet());
+          if (!neighborTerritories.isEmpty()) {
+            break;
+          }
+        }
+
         // Determine value based on enemy factory distance
         final List<Double> values = new ArrayList<>();
-        for (final Territory enemyCapitalOrFactory : enemyCapitalsAndFactoriesMap.keySet()) {
+        for (final Territory enemyCapitalOrFactory : neighborTerritories) {
           final Route route = data.getMap().getRoute_IgnoreEnd(t, enemyCapitalOrFactory,
               ProMatches.territoryCanMoveSeaUnits(player, data, true));
           if (route == null || MoveValidator.validateCanal(route, null, player, data) != null) {
@@ -160,6 +170,11 @@ public class ProTerritoryValueUtils {
               }
               nearbyLandValue += value;
             }
+            if (!territoryValueMap.containsKey(nearbyLandTerritory)) {
+              final double value = findLandValue(nearbyLandTerritory, player, maxLandMassSize,
+                  enemyCapitalsAndFactoriesMap, territoriesThatCantBeHeld, territoriesToAttack);
+              territoryValueMap.put(nearbyLandTerritory, value);
+            }
             nearbyLandValue += territoryValueMap.get(nearbyLandTerritory);
           }
         }
@@ -169,6 +184,7 @@ public class ProTerritoryValueUtils {
         territoryValueMap.put(t, 0.0);
       }
     }
+
     return territoryValueMap;
   }
 

--- a/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -23,6 +23,9 @@ import games.strategy.util.Match;
  */
 public class ProTerritoryValueUtils {
 
+  private static int MIN_FACTORY_CHECK_DISTANCE = 9;
+  private static int MAX_FACTORY_CHECK_DISTANCE = 30;
+
   public static double findTerritoryAttackValue(final PlayerID player, final Territory t) {
     final GameData data = ProData.getData();
     final int isEnemyFactory = ProMatches.territoryHasInfraFactoryAndIsEnemyLand(player, data).match(t) ? 1 : 0;
@@ -324,7 +327,7 @@ public class ProTerritoryValueUtils {
       final Map<Territory, Double> enemyCapitalsAndFactoriesMap) {
 
     Set<Territory> nearbyEnemyCapitalsAndFactories = new HashSet<>();
-    for (int i = 9; i <= 30; i++) {
+    for (int i = MIN_FACTORY_CHECK_DISTANCE; i <= MAX_FACTORY_CHECK_DISTANCE; i++) {
       nearbyEnemyCapitalsAndFactories = ProData.getData().getMap().getNeighbors(t, i);
       nearbyEnemyCapitalsAndFactories.retainAll(enemyCapitalsAndFactoriesMap.keySet());
       if (!nearbyEnemyCapitalsAndFactories.isEmpty()) {


### PR DESCRIPTION
High level goal is to improve performance of Fast AI on large maps (this PR addresses CombatMove in particular).

Currently the AI always find 'territory value' for all territories on a map. This tends to be rather slow for larger maps such as WaW as it involves doing distance calculations for all territories even though each nation only really cares about territories that it can move to or is already on.

This PR improves performance mainly by allowing a list of territories to be passed in rather than having to find value for all territories. It also adds a check to find only the closest factories to avoid calculating distances for factories that are really far away from territories so add very little value. Lots of refactoring changes made as well to improve code readability and maintainability. Its probably not perfect but a step in the right direction.

Overall, performance for combat move phase on WaW German turn 1 went from around 14-15s before to 7-8s after the change when using Fast AI. This should make even a more dramatic improvement for smaller AI nations as they have few that need calculated but would previously calculate value for the entire map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/908)
<!-- Reviewable:end -->
