### PR TITLE
Settings windows , show default value with settings descriptions

### DIFF
--- a/src/games/strategy/triplea/settings/IntegerValueRange.java
+++ b/src/games/strategy/triplea/settings/IntegerValueRange.java
@@ -1,0 +1,15 @@
+package games.strategy.triplea.settings;
+
+public class IntegerValueRange {
+
+  public final int lowerValue;
+  public final int upperValue;
+  public final int defaultValue;
+
+  public IntegerValueRange(int lowerValue, int upperValue, int defaultValue) {
+    this.lowerValue = lowerValue;
+    this.upperValue = upperValue;
+    this.defaultValue = defaultValue;
+  }
+
+}

--- a/src/games/strategy/triplea/settings/SettingInputComponent.java
+++ b/src/games/strategy/triplea/settings/SettingInputComponent.java
@@ -26,7 +26,7 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
 
   /**
    * @return Detailed (but concise) text description of what the setting represents. This is a message to the user
-   * describing a specific setting, what it does, and which values they should change it to.
+   *         describing a specific setting, what it does, and which values they should change it to.
    */
   String getDescription();
 
@@ -36,9 +36,9 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
   SettingsInput getInputElement();
 
   /**
-   * Return true if a valid setting can be read from  the input component and applied to the 'settings' data object.
+   * Return true if a valid setting can be read from the input component and applied to the 'settings' data object.
    *
-   * @param toUpdate       The 'Settings' data object to be updated.
+   * @param toUpdate The 'Settings' data object to be updated.
    * @param inputComponent User input source
    */
   boolean updateSettings(SettingsObjectType toUpdate, SettingsInput inputComponent);
@@ -52,12 +52,25 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
   String getValue(SettingsObjectType settingsType);
 
 
+
+  static <Z extends HasDefaults> SettingInputComponent<Z> build(IntegerValueRange valueRange,
+      final String label, final String description, JTextComponent component,
+      BiConsumer<Z, String> updater, Function<Z, String> extractor) {
+
+    String descriptionWithRange =
+        "(" + valueRange.lowerValue + " - " + valueRange + ", default: " + valueRange.defaultValue
+            + ") " + description;
+
+    return SettingInputComponent.build(label, descriptionWithRange, component, updater, extractor,
+        InputValidator.inRange(valueRange.lowerValue, valueRange.upperValue));
+  }
+
   /**
    * Factory method to create instances of this interface, backed by TextField component types
    */
   static <Z extends HasDefaults> SettingInputComponent<Z> build(final String label, final String description,
-      JTextComponent component,
-      BiConsumer<Z, String> updater, Function<Z, String> extractor, InputValidator... validators) {
+      JTextComponent component, BiConsumer<Z, String> updater,
+      Function<Z, String> extractor, InputValidator... validators) {
     SettingsInput inputComponent = new SettingsInput() {
       @Override
       public JComponent getSwingComponent() {
@@ -77,8 +90,9 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
     return build(label, description, inputComponent, updater, extractor, validators);
   }
 
-  static <Z extends HasDefaults> SettingInputComponent<Z> buildYesOrNoRadioButtons(final String label, final String description,
-      boolean initialValue, BiConsumer<Z, String> settingsObjectUpdater, Function<Z, String> settingsObjectExtractor) {
+  static <Z extends HasDefaults> SettingInputComponent<Z> buildYesOrNoRadioButtons(final String label,
+      final String description,boolean initialValue,  BiConsumer<Z, String> settingsObjectUpdater,
+      Function<Z, String> settingsObjectExtractor) {
 
     JRadioButton radioButtonYes = new JRadioButton("Yes");
     JRadioButton radioButtonNo = new JRadioButton("No");
@@ -109,8 +123,8 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
 
 
   /**
-     * Factory method to create instances of this interface backed by TextField component types
-     */
+   * Factory method to create instances of this interface backed by TextField component types
+   */
   static <Z extends HasDefaults> SettingInputComponent<Z> build(final String label, final String description,
       JPanel componentPanel, Supplier<String> componentReader,
       BiConsumer<Z, String> settingsObjectUpdater, Function<Z, String> settingsObjectExtractor,
@@ -194,7 +208,8 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
   }
 
   /**
-   * In cases where we try to update to an invalid value, set Value is called to restore the default/previous valid value
+   * In cases where we try to update to an invalid value, set Value is called to restore the default/previous valid
+   * value
    */
   void setValue(String valueToSet);
 }

--- a/src/games/strategy/triplea/settings/SettingInputComponent.java
+++ b/src/games/strategy/triplea/settings/SettingInputComponent.java
@@ -57,9 +57,8 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
       final String label, final String description, JTextComponent component,
       BiConsumer<Z, String> updater, Function<Z, String> extractor) {
 
-    String descriptionWithRange =
-        "(" + valueRange.lowerValue + " - " + valueRange + ", default: " + valueRange.defaultValue
-            + ") " + description;
+    String descriptionWithRange = "(" + valueRange.lowerValue + " - " + valueRange.upperValue
+        + ", default: " + valueRange.defaultValue + ")\n" + description;
 
     return SettingInputComponent.build(label, descriptionWithRange, component, updater, extractor,
         InputValidator.inRange(valueRange.lowerValue, valueRange.upperValue));
@@ -91,7 +90,7 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
   }
 
   static <Z extends HasDefaults> SettingInputComponent<Z> buildYesOrNoRadioButtons(final String label,
-      final String description,boolean initialValue,  BiConsumer<Z, String> settingsObjectUpdater,
+      final String description, boolean initialValue, BiConsumer<Z, String> settingsObjectUpdater,
       Function<Z, String> settingsObjectExtractor) {
 
     JRadioButton radioButtonYes = new JRadioButton("Yes");

--- a/src/games/strategy/triplea/settings/SettingsWindow.java
+++ b/src/games/strategy/triplea/settings/SettingsWindow.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.settings;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.Insets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -14,7 +13,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextArea;
-import javax.swing.UIManager;
 import javax.swing.border.BevelBorder;
 
 import games.strategy.engine.ClientContext;

--- a/src/games/strategy/triplea/settings/ai/AiSettings.java
+++ b/src/games/strategy/triplea/settings/ai/AiSettings.java
@@ -7,7 +7,7 @@ import games.strategy.triplea.settings.SystemPreferences;
 public class AiSettings implements HasDefaults {
 
 
-  private static final int DEFAULT_AI_PAUSE_DURACTION = 400;
+  static final int DEFAULT_AI_PAUSE_DURACTION = 400;
   private static final boolean DEFAULT_SHOW_BATTLE_BETWEEN_AI = true;
 
   @Override

--- a/src/games/strategy/triplea/settings/ai/AiTab.java
+++ b/src/games/strategy/triplea/settings/ai/AiTab.java
@@ -6,7 +6,7 @@ import java.util.List;
 import javax.swing.JTextField;
 
 import games.strategy.engine.ClientContext;
-import games.strategy.triplea.settings.InputValidator;
+import games.strategy.triplea.settings.IntegerValueRange;
 import games.strategy.triplea.settings.SettingInputComponent;
 import games.strategy.triplea.settings.SettingsTab;
 
@@ -16,12 +16,13 @@ public class AiTab implements SettingsTab<AiSettings> {
 
   public AiTab(AiSettings aiSettings) {
     inputs = Arrays.asList(
-        SettingInputComponent.build("(0-10000) AI Pause Duration",
+        SettingInputComponent.build(
+            new IntegerValueRange(0, 10000, AiSettings.DEFAULT_AI_PAUSE_DURACTION),
+            "AI Pause Duration",
             "Time delay (in milliseconds) between AI moves, allows for the AI moves to be watched",
             new JTextField(String.valueOf(aiSettings.getAiPauseDuration()), 5),
             ((settings, s) -> settings.setAiPauseDuration(s)),
-            (settings -> String.valueOf(aiSettings.getAiPauseDuration())),
-            InputValidator.inRange(0, 10000)),
+            (settings -> String.valueOf(aiSettings.getAiPauseDuration()))),
         SettingInputComponent.buildYesOrNoRadioButtons("Show Battles Between AIs",
             "When set to yes, combats between two AI players will be shown in a battle window.",
             aiSettings.showBattlesBetweenAi(),

--- a/src/games/strategy/triplea/settings/battle/calc/BattleCalcSettings.java
+++ b/src/games/strategy/triplea/settings/battle/calc/BattleCalcSettings.java
@@ -5,8 +5,8 @@ import games.strategy.triplea.settings.SystemPreferenceKey;
 import games.strategy.triplea.settings.SystemPreferences;
 
 public class BattleCalcSettings implements HasDefaults {
-  private static final int DEFAULT_SIMULATION_COUNT_DICE = 2000;
-  private static final int DEFAULT_SIMULATION_COUNT_LOW_LUCK = 500;
+  static final int DEFAULT_SIMULATION_COUNT_DICE = 2000;
+  static final int DEFAULT_SIMULATION_COUNT_LOW_LUCK = 500;
 
   @Override
   public void setToDefault() {

--- a/src/games/strategy/triplea/settings/battle/calc/BattleCalcTab.java
+++ b/src/games/strategy/triplea/settings/battle/calc/BattleCalcTab.java
@@ -6,7 +6,7 @@ import java.util.List;
 import javax.swing.JTextField;
 
 import games.strategy.engine.ClientContext;
-import games.strategy.triplea.settings.InputValidator;
+import games.strategy.triplea.settings.IntegerValueRange;
 import games.strategy.triplea.settings.SettingInputComponent;
 import games.strategy.triplea.settings.SettingsTab;
 
@@ -14,26 +14,26 @@ public class BattleCalcTab implements SettingsTab<BattleCalcSettings> {
 
   private final List<SettingInputComponent<BattleCalcSettings>> inputs;
 
-  private static String CALC_DESCRIPTION = "(1 - 10000) Default simulation count for the battle calculator";
+  private static String CALC_DESCRIPTION = "Default simulation count for the battle calculator";
 
   public BattleCalcTab(final BattleCalcSettings battleCalcSettings) {
 
     inputs = Arrays.asList(
-        SettingInputComponent.build("Default Dice Run Count",
+        SettingInputComponent.build(
+            new IntegerValueRange(1, 10000, BattleCalcSettings.DEFAULT_SIMULATION_COUNT_DICE),
+            "Default Dice Run Count",
             CALC_DESCRIPTION + " (dice games)",
             new JTextField(String.valueOf(battleCalcSettings.getSimulationCountDice()), 5),
             ((settings, s) -> settings.setSimulationCountDice(s)),
-            (settings -> String.valueOf(settings.getSimulationCountDice())),
-            InputValidator.inRange(1, 10000)
-        ),
+            (settings -> String.valueOf(settings.getSimulationCountDice()))),
 
-        SettingInputComponent.build("Default Low Luck Run Count",
+        SettingInputComponent.build(
+            new IntegerValueRange(1, 10000, BattleCalcSettings.DEFAULT_SIMULATION_COUNT_LOW_LUCK),
+            "Default Low Luck Run Count",
             CALC_DESCRIPTION + " (low luck games)",
             new JTextField(String.valueOf(battleCalcSettings.getSimulationCountLowLuck()), 5),
             ((settings, s) -> settings.setSimulationCountLowLuck(s)),
-            (settings -> String.valueOf(settings.getSimulationCountLowLuck())),
-            InputValidator.inRange(1, 10000)
-        )
+            (settings -> String.valueOf(settings.getSimulationCountLowLuck())))
     );
   }
 

--- a/src/games/strategy/triplea/settings/scrolling/ScrollSettings.java
+++ b/src/games/strategy/triplea/settings/scrolling/ScrollSettings.java
@@ -6,14 +6,14 @@ import games.strategy.triplea.settings.SystemPreferences;
 
 public class ScrollSettings implements HasDefaults {
 
-  private static final int DEFAULT_MAP_EDGE_SCROLL_SPEED = 30;
-  private static final int DEFAULT_MAP_EDGE_SCROLL_ZONE_SIZE = 30;
-  private static final int DEFAULT_MAP_EDGE_FASTER_SCROLL_MULTIPLIER = 2;
-  private static final int DEFAULT_MAP_EDGE_FASTER_SCROLL_ZONE_SIZE = 10;
+  static final int DEFAULT_MAP_EDGE_SCROLL_SPEED = 30;
+  static final int DEFAULT_MAP_EDGE_SCROLL_ZONE_SIZE = 30;
+  static final int DEFAULT_MAP_EDGE_FASTER_SCROLL_MULTIPLIER = 2;
+  static final int DEFAULT_MAP_EDGE_FASTER_SCROLL_ZONE_SIZE = 10;
 
-  private static final int DEFAULT_ARROW_KEY_SCROLL_SPEED = 70;
-  private static final int DEFAULT_FASTER_ARROW_KEY_SCROLL_MULTIPLIER = 3;
-  private static final int DEFAULT_WHEEL_SCROLL_AMOUNT = 60;
+  static final int DEFAULT_ARROW_KEY_SCROLL_SPEED = 70;
+  static final int DEFAULT_FASTER_ARROW_KEY_SCROLL_MULTIPLIER = 3;
+  static final int DEFAULT_WHEEL_SCROLL_AMOUNT = 60;
 
   @Override
   public void setToDefault() {

--- a/src/games/strategy/triplea/settings/scrolling/ScrollSettingsTab.java
+++ b/src/games/strategy/triplea/settings/scrolling/ScrollSettingsTab.java
@@ -6,7 +6,7 @@ import java.util.List;
 import javax.swing.JTextField;
 
 import games.strategy.engine.ClientContext;
-import games.strategy.triplea.settings.InputValidator;
+import games.strategy.triplea.settings.IntegerValueRange;
 import games.strategy.triplea.settings.SettingInputComponent;
 import games.strategy.triplea.settings.SettingsTab;
 
@@ -17,59 +17,60 @@ public class ScrollSettingsTab implements SettingsTab<ScrollSettings> {
   public ScrollSettingsTab(ScrollSettings settings) {
     inputs = Arrays.asList(
         SettingInputComponent.build(
-            "Arrow scroll speed", "(10-300) Arrow key scrolling speed",
+            new IntegerValueRange(2, 100, ScrollSettings.DEFAULT_ARROW_KEY_SCROLL_SPEED),
+            "Arrow scroll speed",
+            "Arrow key scrolling speed",
             new JTextField(String.valueOf(settings.getArrowKeyScrollSpeed()), 5),
             ((scrollSettings, s) -> scrollSettings.setArrowKeyScrollSpeed(s)),
-            scrollSettings -> String.valueOf(scrollSettings.getArrowKeyScrollSpeed()),
-            InputValidator.inRange(10, 300)),
+            scrollSettings -> String.valueOf(scrollSettings.getArrowKeyScrollSpeed())),
 
         SettingInputComponent.build(
+            new IntegerValueRange(2, 5, ScrollSettings.DEFAULT_FASTER_ARROW_KEY_SCROLL_MULTIPLIER),
             "Arrow scroll speed multiplier",
-            "(1-100) Arrow key scroll speed increase when control is held down",
+            "Arrow key scroll speed increase when control is held down",
             new JTextField(String.valueOf(settings.getFasterArrowKeyScrollMultiplier()), 5),
             ((scrollSettings, s) -> scrollSettings.setFasterArrowKeyScrollMultiplier(s)),
-            scrollSettings -> String.valueOf(scrollSettings.getFasterArrowKeyScrollMultiplier()),
-            InputValidator.inRange(2, 5)),
+            scrollSettings -> String.valueOf(scrollSettings.getFasterArrowKeyScrollMultiplier())),
 
         SettingInputComponent.build(
+            new IntegerValueRange(10, 250, ScrollSettings.DEFAULT_MAP_EDGE_SCROLL_SPEED),
             "Map Edge Scroll Speed",
-            "(10-300) How fast the map scrolls when the mouse cursor is placed close to the edge of the map",
+            "How fast the map scrolls when the mouse cursor is placed close to the edge of the map",
             new JTextField(String.valueOf(settings.getMapEdgeScrollSpeed()), 5),
             ((scrollSettings, s) -> scrollSettings.setMapEdgeScrollSpeed(s)),
-            scrollSettings -> String.valueOf(scrollSettings.getMapEdgeScrollSpeed()),
-            InputValidator.inRange(10, 300)),
+            scrollSettings -> String.valueOf(scrollSettings.getMapEdgeScrollSpeed())),
 
         SettingInputComponent.build(
+            new IntegerValueRange(0, 300, ScrollSettings.DEFAULT_MAP_EDGE_SCROLL_ZONE_SIZE),
             "Map Edge Scroll Zone Size",
-            "(0-400) How close the mouse cursor must be to the edge of the map for the map to scroll",
+            "How close the mouse cursor must be to the edge of the map for the map to scroll",
             new JTextField(String.valueOf(settings.getMapEdgeScrollZoneSize()), 5),
             ((scrollSettings, s) -> scrollSettings.setMapEdgeScrollZoneSize(s)),
-            scrollSettings -> String.valueOf(scrollSettings.getMapEdgeScrollZoneSize()),
-            InputValidator.inRange(0, 400)),
+            scrollSettings -> String.valueOf(scrollSettings.getMapEdgeScrollZoneSize())),
 
         SettingInputComponent.build(
+            new IntegerValueRange(0, 150, ScrollSettings.DEFAULT_MAP_EDGE_FASTER_SCROLL_ZONE_SIZE),
             "Map Edge Faster Scroll Zone Size",
-            "(0-200) How close the mouse curose must be to the edge of the map for the map to scroll faster",
+            "How close the mouse curose must be to the edge of the map for the map to scroll faster",
             new JTextField(String.valueOf(settings.getMapEdgeFasterScrollZoneSize()), 5),
             ((scrollSettings, s) -> scrollSettings.setMapEdgeFasterScrollZoneSize(s)),
-            scrollSettings -> String.valueOf(scrollSettings.getMapEdgeFasterScrollZoneSize()),
-            InputValidator.inRange(0, 200)),
+            scrollSettings -> String.valueOf(scrollSettings.getMapEdgeFasterScrollZoneSize())),
 
         SettingInputComponent.build(
+            new IntegerValueRange(2, 5, ScrollSettings.DEFAULT_MAP_EDGE_FASTER_SCROLL_MULTIPLIER),
             "Scroll Zone Multiplier",
-            "(2-5) How much faster the map scrolls when the mouse is closer to the edge",
+            "How much faster the map scrolls when the mouse is closer to the edge",
             new JTextField(String.valueOf(settings.getMapEdgeFasterScrollMultiplier()), 5),
             ((scrollSettings, s) -> scrollSettings.setMapEdgeFasterScrollMultiplier(s)),
-            scrollSettings -> String.valueOf(scrollSettings.getMapEdgeFasterScrollMultiplier()),
-            InputValidator.inRange(2, 5)),
+            scrollSettings -> String.valueOf(scrollSettings.getMapEdgeFasterScrollMultiplier())),
 
         SettingInputComponent.build(
+            new IntegerValueRange(10, 400, ScrollSettings.DEFAULT_WHEEL_SCROLL_AMOUNT),
             "Mouse Wheel Scroll Amount",
-            "(10-300) The distance the map is scrolled when the mouse wheel is used",
+            "The distance the map is scrolled when the mouse wheel is used",
             new JTextField(String.valueOf(settings.getWheelScrollAmount()), 5),
             ((scrollSettings, s) -> scrollSettings.setWheelScrollAmount(s)),
-            scrollSettings -> String.valueOf(scrollSettings.getWheelScrollAmount()),
-            InputValidator.inRange(10, 400)));
+            scrollSettings -> String.valueOf(scrollSettings.getWheelScrollAmount())));
   }
 
   @Override


### PR DESCRIPTION
Add the default value to the description for integer valued settings.
Tighten up the bounds on the scroll settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/921)
<!-- Reviewable:end -->
