### PR TITLE
Fix for  getRootFolder() when running in intelliJ

### DIFF
--- a/src/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/games/strategy/engine/ClientFileSystemHelper.java
@@ -1,6 +1,7 @@
 package games.strategy.engine;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.config.GameEnginePropertyFileReader;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.GameRunner2;
 import games.strategy.util.Version;
@@ -10,6 +11,9 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Pure utility class, final and private constructor to enforce this
@@ -76,16 +80,28 @@ public final class ClientFileSystemHelper {
   private static File getRootRelativeToClassFile(final String fileName) {
     File f = new File(fileName);
 
-    // move up 1 directory for each package
+    // move up one directory for each package
     final int moveUpCount = GameRunner2.class.getName().split("\\.").length + 1;
     for (int i = 0; i < moveUpCount; i++) {
       f = f.getParentFile();
     }
+
+    // keep moving up one directory until we find the game_engine properties file that we expect to be at the root
+    while(!folderContainsGamePropsFile(f)) {
+      f = f.getParentFile();
+    }
+
     if (!f.exists()) {
       System.err.println("Could not find root folder, does  not exist:" + f);
       return new File(System.getProperties().getProperty("user.dir"));
     }
     return f;
+  }
+
+  private static boolean folderContainsGamePropsFile(File folder) {
+    File[] files = folder.listFiles();
+    List<String> fileNames = Arrays.asList(files).stream().map(file->file.getName()).collect(Collectors.toList());
+    return fileNames.contains(GameEnginePropertyFileReader.GAME_ENGINE_PROPERTY_FILE);
   }
 
   public static boolean areWeOldExtraJar() {

--- a/src/games/strategy/engine/config/GameEnginePropertyFileReader.java
+++ b/src/games/strategy/engine/config/GameEnginePropertyFileReader.java
@@ -16,7 +16,7 @@ import games.strategy.engine.ClientFileSystemHelper;
  */
 public class GameEnginePropertyFileReader implements PropertyReader {
 
-  private static final String GAME_ENGINE_PROPERTY_FILE =  "game_engine.properties";
+  public static final String GAME_ENGINE_PROPERTY_FILE = "game_engine.properties";
   private final File propertyFile;
 
   public GameEnginePropertyFileReader() {


### PR DESCRIPTION
 instead of resolving to the 'build/classes' folder, go up further to the project root until we find the game engine properties file. Should not alter the behavior for eclipse or when loading from jar.

Relatively important fix, without this the PBEM button fails because it cannot find the dice_servers folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/922)
<!-- Reviewable:end -->
