### PR TITLE
AllianceTracker Serialization proxy pattern

### DIFF
--- a/src/games/strategy/engine/data/AllianceTracker.java
+++ b/src/games/strategy/engine/data/AllianceTracker.java
@@ -1,16 +1,15 @@
 package games.strategy.engine.data;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.MultimapBuilder;
-
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Set;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 
 /**
  * Tracks alliances between players.
@@ -20,14 +19,37 @@ import java.util.Set;
  * victory conditions.
  * Not used for determining in-game alliances (instead, see the Relationship tracker for that).
  */
-public class AllianceTracker extends GameDataComponent {
+public class AllianceTracker implements Serializable {
   private static final long serialVersionUID = 2815023984535209353L;
   // maps PlayerID to Collection of alliances names
-  private Multimap<PlayerID, String> alliances = HashMultimap.create();
+  private final Multimap<PlayerID, String> alliances;
 
-  public AllianceTracker(final GameData data) {
-    super(data);
+  public AllianceTracker() {
+    alliances = HashMultimap.create();
   }
+
+  public AllianceTracker(Multimap<PlayerID, String> alliances) {
+    this.alliances = alliances;
+  }
+
+  @WriteReplaceMagicMethod
+  public Object writeReplace() {
+    return new SerializationProxy(this);
+  }
+
+  private static class SerializationProxy implements Serializable {
+    private static final long serialVersionUID = -4193924040595347947L;
+    private final Multimap<PlayerID, String> alliances;
+
+    public SerializationProxy(AllianceTracker allianceTracker) {
+      alliances = ImmutableMultimap.copyOf(allianceTracker.alliances);
+    }
+
+    private Object readResolve() {
+      return new AllianceTracker(alliances);
+    }
+  }
+
 
   /**
    * Adds PlayerID player to the alliance specified by allianceName.

--- a/src/games/strategy/engine/data/GameData.java
+++ b/src/games/strategy/engine/data/GameData.java
@@ -70,7 +70,7 @@ public class GameData implements java.io.Serializable {
   private transient ListenerList<GameDataChangeListener> dataChangeListeners =
       new ListenerList<>();
   private transient ListenerList<GameMapListener> gameMapListeners = new ListenerList<>();
-  private final AllianceTracker alliances = new AllianceTracker(this);
+  private final AllianceTracker alliances = new AllianceTracker();
   // Tracks current relationships between players, this is empty if relationships aren't used
   private final RelationshipTracker relationships = new RelationshipTracker(this);
   private final DelegateList delegateList;

--- a/src/games/strategy/engine/data/WriteReplaceMagicMethod.java
+++ b/src/games/strategy/engine/data/WriteReplaceMagicMethod.java
@@ -1,0 +1,19 @@
+package games.strategy.engine.data;
+
+
+/**
+ * Annotation to mark magic 'writeReplace' methods that are used to support the serialization proxy pattern:
+ * - http://blog.codefx.org/design/patterns/serialization-proxy-pattern/
+ * - https://dzone.com/articles/serialization-proxy-pattern
+ * - http://vard-lokkur.blogspot.com/2014/06/serialization-proxy-pattern-example.html
+ *
+ * A typical usage of this annotation will look like this:
+ * <code>
+ *    @WriteReplaceMagicMethod
+ *    public Object writeReplace() {
+ *      return new SerializationProxy(this);
+ *    }
+ * </code>
+ */
+public @interface WriteReplaceMagicMethod {
+}


### PR DESCRIPTION
2 new commits based on top of: https://github.com/triplea-game/triplea/pull/914

Allows for us to have a no-arg constructor when creating AllianceTracker, and makes it a bit safer to avoid save game version compatibility issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/938)
<!-- Reviewable:end -->
