### PR TITLE
Settings validation result message improvement

### DIFF
--- a/src/games/strategy/triplea/settings/InputValidator.java
+++ b/src/games/strategy/triplea/settings/InputValidator.java
@@ -3,30 +3,46 @@ package games.strategy.triplea.settings;
 import java.io.File;
 import java.util.function.Function;
 
-public interface InputValidator extends Function<String, Boolean> {
+public class InputValidator implements Function<String, Boolean> {
 
-  InputValidator IS_DIRECTORY = ((string) -> (new File(string)).isDirectory());
+  public static final InputValidator IS_DIRECTORY = new InputValidator( ((string) -> (new File(string)).isDirectory()), "directory must exist");
 
-  InputValidator IS_INTEGER = ((string) -> {
+  private static final InputValidator IS_INTEGER = new InputValidator( ((string) -> {
     try {
       Integer.parseInt(string);
       return true;
     } catch (Exception e) {
       return false;
     }
-  });
+  }), "not a number");
 
   /**
    * Verifies a value is an integer and falls inside of a given range (inclusive)
    */
   static InputValidator inRange(int min, int max) {
-    return (value) -> {
+    return new InputValidator((value) -> {
       if(!IS_INTEGER.apply(value)) {
         return false;
       }
       int intValue = Integer.parseInt(value);
       return intValue  >= min && intValue <= max ;
-    };
+    }, "not in range: " + min + " - " + max);
   }
 
+  String getErrorMessage() {
+    return errorMessage;
+  }
+
+  private final String errorMessage;
+  private Function<String,Boolean> validator;
+
+  private InputValidator(Function<String, Boolean> validationFunction, String errorMessage) {
+    this.errorMessage = errorMessage;
+    this.validator = validationFunction;
+  }
+
+  @Override
+  public Boolean apply(String input) {
+    return validator.apply(input);
+  }
 }

--- a/src/games/strategy/triplea/settings/SettingInputComponent.java
+++ b/src/games/strategy/triplea/settings/SettingInputComponent.java
@@ -39,9 +39,8 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
    * Return true if a valid setting can be read from the input component and applied to the 'settings' data object.
    *
    * @param toUpdate The 'Settings' data object to be updated.
-   * @param inputComponent User input source
    */
-  boolean updateSettings(SettingsObjectType toUpdate, SettingsInput inputComponent);
+  boolean updateSettings(SettingsObjectType toUpdate);
 
   /**
    * Method to read the settings value from the SettingsObject that has the value saved.
@@ -180,8 +179,8 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
 
 
       @Override
-      public boolean updateSettings(Z toUpdate, SettingsInput inputComponent) {
-        String input = inputComponent.getText();
+      public boolean updateSettings(Z toUpdate) {
+        String input = getInputElement().getText();
 
         for (InputValidator validator : Arrays.asList(validators)) {
           boolean isValid = validator.apply(input);

--- a/src/games/strategy/triplea/settings/SettingInputComponent.java
+++ b/src/games/strategy/triplea/settings/SettingInputComponent.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.settings;
 import games.strategy.ui.SwingComponents;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -202,6 +203,18 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
       public void setValue(String valueToSet) {
         getInputElement().setText(valueToSet);
       }
+
+      @Override
+      public String getErrorMessage() {
+        String input = getInputElement().getText();
+
+        Optional<InputValidator>
+            failedValidator = Arrays.asList(validators).stream().filter(validator -> !validator.apply(input)).findFirst();
+        if(!failedValidator.isPresent()) {
+          return "";
+        }
+        return input + ", " + failedValidator.get().getErrorMessage();
+      }
     };
   }
 
@@ -210,4 +223,6 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
    * value
    */
   void setValue(String valueToSet);
+
+  String getErrorMessage();
 }

--- a/src/games/strategy/triplea/settings/SettingsTab.java
+++ b/src/games/strategy/triplea/settings/SettingsTab.java
@@ -19,7 +19,7 @@ public interface SettingsTab<T extends HasDefaults> {
       T settingsObject = getSettingsObject();
 
       String oldValue = input.getValue(settingsObject);
-      if (input.updateSettings(settingsObject, input.getInputElement())) {
+      if (input.updateSettings(settingsObject)) {
         String newValue = input.getValue(settingsObject);
         if(!newValue.equals(oldValue)) {
           msg.append("\n").append(input.getLabel()).append(": ").append(oldValue).append(" -> ").append(newValue);

--- a/src/games/strategy/triplea/settings/SettingsWindow.java
+++ b/src/games/strategy/triplea/settings/SettingsWindow.java
@@ -151,7 +151,7 @@ public class SettingsWindow extends SwingComponents.ModalJDialog {
               settingTab.getSettingsObject().setToDefault();
               SystemPreferences.flush();
               dispose();
-              SwingComponents.showDialog("Reverted the '" + settingTab.getTabTitle() + "' settings back to defaults");
+              SwingComponents.showDialog("Defaults Restored", "Reverted the '" + settingTab.getTabTitle() + "' settings back to defaults");
             })));
 
     buttonsPanel.add(Box.createHorizontalGlue());

--- a/src/games/strategy/ui/SwingComponents.java
+++ b/src/games/strategy/ui/SwingComponents.java
@@ -276,8 +276,8 @@ public class SwingComponents {
     SwingComponents.promptUser("Open external URL?", msg, () -> DesktopUtilityBrowserLauncher.openURL(url));
   }
 
-  public static void showDialog(String message) {
-    JOptionPane.showMessageDialog(null,message);
+  public static void showDialog(String title, String message) {
+    JOptionPane.showMessageDialog(null,message, title, JOptionPane.INFORMATION_MESSAGE);
   }
 
 


### PR DESCRIPTION
Will resolve #944 

Better SettingsWindow validation/result messages. The validation failure for folder paths was particularly weak. Below are screenshots of the save result message window over various use cases:
 
Only invalid settings:
![failed_to_save](https://cloud.githubusercontent.com/assets/12397753/16793505/62bba58a-4886-11e6-9387-7d95fda125b7.png)

Some valid, some invalid:
![mixed_folder_save](https://cloud.githubusercontent.com/assets/12397753/16793504/62bb4054-4886-11e6-9b66-cc9e65171d40.png)

Some valid, some invalid:
![mixed_update](https://cloud.githubusercontent.com/assets/12397753/16793506/62bcb560-4886-11e6-9ef1-4aa5d2f08099.png)

No settings changed:
![nothing_changed](https://cloud.githubusercontent.com/assets/12397753/16793503/62bacade-4886-11e6-907e-21eed56d6b31.png)

All valid:
![settings_saved](https://cloud.githubusercontent.com/assets/12397753/16793507/62bce396-4886-11e6-886b-2c8099627741.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/953)
<!-- Reviewable:end -->
