### PR TITLE
Make 'Export Setup Charts' menu and window have same name

### DIFF
--- a/src/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -656,7 +656,7 @@ public class ExportMenu {
 
   private void addExportSetupCharts(final JMenu parentMenu) {
     final JMenuItem menuFileExport = new JMenuItem(SwingAction.of("Export Setup Charts", e -> {
-      final JFrame frame = new JFrame("Export Setup Files");
+      final JFrame frame = new JFrame("Export Setup Charts");
       frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
       GameData clonedGameData;
       gameData.acquireReadLock();


### PR DESCRIPTION
Addresses point I in https://github.com/triplea-game/triplea/issues/958

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/961)
<!-- Reviewable:end -->
