### PR TITLE
Remove ellipses from menu items, consistent help menu title

### DIFF
--- a/src/games/strategy/engine/framework/networkMaintenance/BanPlayerAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/BanPlayerAction.java
@@ -18,7 +18,7 @@ public class BanPlayerAction extends AbstractAction {
   private final IServerMessenger m_messenger;
 
   public BanPlayerAction(final Component parent, final IServerMessenger messenger) {
-    super("Ban Player From Game...");
+    super("Ban Player From Game");
     m_parent = JOptionPane.getFrameForComponent(parent);
     m_messenger = messenger;
   }

--- a/src/games/strategy/engine/framework/networkMaintenance/BootPlayerAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/BootPlayerAction.java
@@ -18,7 +18,7 @@ public class BootPlayerAction extends AbstractAction {
   private final IServerMessenger m_messenger;
 
   public BootPlayerAction(final Component parent, final IServerMessenger messenger) {
-    super("Remove Player...");
+    super("Remove Player");
     m_parent = JOptionPane.getFrameForComponent(parent);
     m_messenger = messenger;
   }

--- a/src/games/strategy/engine/framework/networkMaintenance/ChangeGameOptionsClientAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/ChangeGameOptionsClientAction.java
@@ -23,7 +23,7 @@ public class ChangeGameOptionsClientAction extends AbstractAction {
   private final IServerStartupRemote m_serverRemote;
 
   public ChangeGameOptionsClientAction(final Component parent, final IServerStartupRemote serverRemote) {
-    super("Edit Game Options...");
+    super("Edit Game Options");
     m_parent = JOptionPane.getFrameForComponent(parent);
     m_serverRemote = serverRemote;
   }

--- a/src/games/strategy/engine/framework/networkMaintenance/ChangeGameToSaveGameClientAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/ChangeGameToSaveGameClientAction.java
@@ -16,7 +16,7 @@ public class ChangeGameToSaveGameClientAction extends AbstractAction {
   private final IClientMessenger m_clientMessenger;
 
   public ChangeGameToSaveGameClientAction(final Component parent, final IClientMessenger clientMessenger) {
-    super("Change To Gamesave (Load Game)...");
+    super("Change To Gamesave (Load Game)");
     m_parent = JOptionPane.getFrameForComponent(parent);
     m_clientMessenger = clientMessenger;
   }

--- a/src/games/strategy/engine/framework/networkMaintenance/ChangeToAutosaveClientAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/ChangeToAutosaveClientAction.java
@@ -18,7 +18,7 @@ public class ChangeToAutosaveClientAction extends AbstractAction {
 
   public ChangeToAutosaveClientAction(final Component parent, final IClientMessenger clientMessenger,
       final SaveGameFileChooser.AUTOSAVE_TYPE typeOfAutosave) {
-    super("Change To " + typeOfAutosave.toString().toLowerCase() + "...");
+    super("Change To " + typeOfAutosave.toString().toLowerCase());
     m_parent = JOptionPane.getFrameForComponent(parent);
     m_clientMessenger = clientMessenger;
     m_typeOfAutosave = typeOfAutosave;

--- a/src/games/strategy/engine/framework/networkMaintenance/GetGameSaveClientAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/GetGameSaveClientAction.java
@@ -19,7 +19,7 @@ public class GetGameSaveClientAction extends AbstractAction {
   private final IServerStartupRemote m_serverRemote;
 
   public GetGameSaveClientAction(final Component parent, final IServerStartupRemote serverRemote) {
-    super("Download Gamesave (Save Game)...");
+    super("Download Gamesave (Save Game)");
     m_parent = JOptionPane.getFrameForComponent(parent);
     m_serverRemote = serverRemote;
   }

--- a/src/games/strategy/engine/framework/networkMaintenance/MutePlayerAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/MutePlayerAction.java
@@ -18,7 +18,7 @@ public class MutePlayerAction extends AbstractAction {
   private final IServerMessenger m_messenger;
 
   public MutePlayerAction(final Component parent, final IServerMessenger messenger) {
-    super("Mute Player's Chatting...");
+    super("Mute Player's Chatting");
     m_parent = JOptionPane.getFrameForComponent(parent);
     m_messenger = messenger;
   }

--- a/src/games/strategy/engine/framework/networkMaintenance/SetMapClientAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/SetMapClientAction.java
@@ -21,7 +21,7 @@ public class SetMapClientAction extends AbstractAction {
 
   public SetMapClientAction(final Component parent, final IClientMessenger clientMessenger,
       final List<String> availableGames) {
-    super("Change Game To...");
+    super("Change Game To");
     m_parent = JOptionPane.getFrameForComponent(parent);
     m_clientMessenger = clientMessenger;
     m_availableGames = availableGames;

--- a/src/games/strategy/engine/framework/networkMaintenance/SetPasswordAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/SetPasswordAction.java
@@ -21,7 +21,7 @@ public class SetPasswordAction extends AbstractAction {
 
   public SetPasswordAction(final Component parent, final InGameLobbyWatcherWrapper watcher,
       final ClientLoginValidator validator) {
-    super("Set Game Password...");
+    super("Set Game Password");
     m_validator = validator;
     m_parent = parent;
     m_lobbyWatcher = watcher;

--- a/src/games/strategy/sound/SoundOptions.java
+++ b/src/games/strategy/sound/SoundOptions.java
@@ -25,10 +25,10 @@ public final class SoundOptions {
 
   /**
    * @param parentMenu
-   *        menu where to add the menu item "Sound Options..."
+   *        menu where to add the menu item "Sound Options"
    */
   public static void addToMenu(final JMenu parentMenu) {
-    final JMenuItem soundOptions = new JMenuItem("Sound Options...");
+    final JMenuItem soundOptions = new JMenuItem("Sound Options");
     soundOptions.setMnemonic(KeyEvent.VK_S);
     soundOptions.addActionListener(new ActionListener() {
       @Override
@@ -40,7 +40,7 @@ public final class SoundOptions {
   }
 
   public static void addToPanel(final JPanel parentPanel) {
-    final JButton soundOptions = new JButton("Sound Options...");
+    final JButton soundOptions = new JButton("Sound Options");
     soundOptions.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent e) {

--- a/src/games/strategy/triplea/ui/menubar/DebugMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/DebugMenu.java
@@ -29,7 +29,7 @@ public class DebugMenu {
     }
 
     debugMenu.add(new EnablePerformanceLoggingCheckBox());
-    debugMenu.add(SwingAction.of("Show Console...", e -> {
+    debugMenu.add(SwingAction.of("Show Console", e -> {
       ErrorConsole.getConsole().setVisible(true);
       ErrorConsole.getConsole().append(DebugUtils.getMemory());
     })).setMnemonic(KeyEvent.VK_C);

--- a/src/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -89,7 +89,7 @@ public class ExportMenu {
 
   // TODO: create a second menu option for parsing current attachments
   private void addExportXML(final JMenu parentMenu) {
-    final Action exportXML = SwingAction.of("Export game.xml file (Beta)...", e -> exportXMLFile());
+    final Action exportXML = SwingAction.of("Export game.xml file (Beta)", e -> exportXMLFile());
     parentMenu.add(exportXML).setMnemonic(KeyEvent.VK_X);
   }
 
@@ -132,7 +132,7 @@ public class ExportMenu {
 
 
   private void addSaveScreenshot(final JMenu parentMenu) {
-    AbstractAction abstractAction = SwingAction.of("Export Screenshot...", e-> {
+    AbstractAction abstractAction = SwingAction.of("Export Screenshot", e-> {
 
       HistoryPanel historyPanel = frame.getHistoryPanel();
       final HistoryNode curNode;
@@ -367,12 +367,12 @@ public class ExportMenu {
   }
 
   private void addExportStatsFull(final JMenu parentMenu) {
-    final Action showDiceStats = SwingAction.of("Export Full Game Stats...", e -> createAndSaveStats(true));
+    final Action showDiceStats = SwingAction.of("Export Full Game Stats", e -> createAndSaveStats(true));
     parentMenu.add(showDiceStats).setMnemonic(KeyEvent.VK_F);
   }
 
   private void addExportStats(final JMenu parentMenu) {
-    final Action showDiceStats = SwingAction.of("Export Short Game Stats...", e -> createAndSaveStats(false));
+    final Action showDiceStats = SwingAction.of("Export Short Game Stats", e -> createAndSaveStats(false));
     parentMenu.add(showDiceStats).setMnemonic(KeyEvent.VK_S);
   }
 
@@ -629,7 +629,7 @@ public class ExportMenu {
   }
 
   private void addExportUnitStats(final JMenu parentMenu) {
-    final JMenuItem menuFileExport = new JMenuItem(SwingAction.of("Export Unit Charts...", e -> {
+    final JMenuItem menuFileExport = new JMenuItem(SwingAction.of("Export Unit Charts", e -> {
       final JFileChooser chooser = new JFileChooser();
       chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
       final File rootDir = new File(System.getProperties().getProperty("user.dir"));
@@ -655,7 +655,7 @@ public class ExportMenu {
 
 
   private void addExportSetupCharts(final JMenu parentMenu) {
-    final JMenuItem menuFileExport = new JMenuItem(SwingAction.of("Export Setup Charts...", e -> {
+    final JMenuItem menuFileExport = new JMenuItem(SwingAction.of("Export Setup Charts", e -> {
       final JFrame frame = new JFrame("Export Setup Files");
       frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
       GameData clonedGameData;

--- a/src/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -45,7 +45,7 @@ public class FileMenu {
   }
 
   private JMenuItem createSaveMenu() {
-    final JMenuItem menuFileSave = new JMenuItem(SwingAction.of("Save...", e -> {
+    final JMenuItem menuFileSave = new JMenuItem(SwingAction.of("Save", e -> {
       final File f = TripleAMenuBar.getSaveGameLocationDialog(frame);
       if (f != null) {
         game.saveGame(f);
@@ -59,7 +59,7 @@ public class FileMenu {
   }
 
   protected JMenuItem addPostPBEM() {
-    final JMenuItem menuPBEM = new JMenuItem(SwingAction.of("Post PBEM/PBF Gamesave...", e -> {
+    final JMenuItem menuPBEM = new JMenuItem(SwingAction.of("Post PBEM/PBF Gamesave", e -> {
       if (gameData == null || !PBEMMessagePoster.GameDataHasPlayByEmailOrForumMessengers(gameData)) {
         return;
       }

--- a/src/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -94,7 +94,7 @@ public class GameMenu {
 
 
   private void addShowVerifiedDice(final JMenu parentMenu) {
-    final Action showVerifiedDice = SwingAction.of("Show Verified Dice..",
+    final Action showVerifiedDice = SwingAction.of("Show Verified Dice",
         e -> new VerifiedRandomNumbersDialog(frame.getRootPane()).setVisible(true));
     if (game instanceof ClientGame) {
       parentMenu.add(showVerifiedDice).setMnemonic(KeyEvent.VK_V);
@@ -103,7 +103,7 @@ public class GameMenu {
 
   protected void addGameOptionsMenu(final JMenu menuGame) {
     if (!gameData.getProperties().getEditableProperties().isEmpty()) {
-      final AbstractAction optionsAction = SwingAction.of("Game Options...", e -> {
+      final AbstractAction optionsAction = SwingAction.of("Game Options", e -> {
         final PropertiesUI ui = new PropertiesUI(gameData.getProperties().getEditableProperties(), false);
         JOptionPane.showMessageDialog(frame, ui, "Game options", JOptionPane.PLAIN_MESSAGE);
       });
@@ -141,7 +141,7 @@ public class GameMenu {
   private void addNotificationSettings(final JMenu parentMenu) {
     final JMenu notificationMenu = new JMenu();
     notificationMenu.setMnemonic(KeyEvent.VK_U);
-    notificationMenu.setText("User Notifications...");
+    notificationMenu.setText("User Notifications");
     final JCheckBoxMenuItem showEndOfTurnReport = new JCheckBoxMenuItem("Show End of Turn Report");
     showEndOfTurnReport.setMnemonic(KeyEvent.VK_R);
     final JCheckBoxMenuItem showTriggeredNotifications = new JCheckBoxMenuItem("Show Triggered Notifications");
@@ -199,7 +199,7 @@ public class GameMenu {
   }
 
   private void addShowDiceStats(final JMenu parentMenu) {
-    final Action showDiceStats = SwingAction.of("Show Dice Stats...", e -> {
+    final Action showDiceStats = SwingAction.of("Show Dice Stats", e -> {
       final IRandomStats randomStats =
           (IRandomStats) game.getRemoteMessenger().getRemote(IRandomStats.RANDOM_STATS_REMOTE_NAME);
       final RandomStatsDetails stats = randomStats.getRandomStats(gameData.getDiceSides());
@@ -210,7 +210,7 @@ public class GameMenu {
   }
 
   private void addRollDice(final JMenu parentMenu) {
-    final JMenuItem RollDiceBox = new JMenuItem("Roll Dice...");
+    final JMenuItem RollDiceBox = new JMenuItem("Roll Dice");
     RollDiceBox.setMnemonic(KeyEvent.VK_R);
     RollDiceBox.addActionListener(new ActionListener() {
       @Override
@@ -259,7 +259,7 @@ public class GameMenu {
   }
 
   private void addBattleCalculatorMenu(final JMenu menuGame) {
-    final Action showBattleMenu = SwingAction.of("Battle Calculator...", e -> OddsCalculatorDialog.show(frame, null));
+    final Action showBattleMenu = SwingAction.of("Battle Calculator", e -> OddsCalculatorDialog.show(frame, null));
     final JMenuItem showBattleMenuItem = menuGame.add(showBattleMenu);
     showBattleMenuItem.setMnemonic(KeyEvent.VK_B);
     showBattleMenuItem.setAccelerator(

--- a/src/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -66,7 +66,7 @@ public class HelpMenu {
 
 
   private void addMoveHelpMenu(final JMenu parentMenu) {
-    parentMenu.add(SwingAction.of("Movement/Selection help...", e -> {
+    parentMenu.add(SwingAction.of("Movement/Selection help", e -> {
       // html formatted string
       final String hints = "<b> Selecting Units</b><br>" + "Left click on a unit stack to select 1 unit.<br>"
           + "ALT-Left click on a unit stack to select 10 units of that type in the stack.<br>"
@@ -161,7 +161,7 @@ public class HelpMenu {
 
 
   private void addUnitHelpMenu(final JMenu parentMenu) {
-    parentMenu.add(SwingAction.of("Unit help...", e -> {
+    parentMenu.add(SwingAction.of("Unit help", e -> {
       final JEditorPane editorPane = new JEditorPane();
       editorPane.setEditable(false);
       editorPane.setContentType("text/html");
@@ -224,7 +224,7 @@ public class HelpMenu {
       gameNotesPane.setEditable(false);
       gameNotesPane.setContentType("text/html");
       gameNotesPane.setText(notes);
-      parentMenu.add(SwingAction.of("Game Notes...", e ->
+      parentMenu.add(SwingAction.of("Game Notes", e ->
           SwingUtilities.invokeLater(() -> {
             final JEditorPane pane = gameNotesPane;
             final JScrollPane scroll = new JScrollPane(pane);
@@ -285,7 +285,7 @@ public class HelpMenu {
     scroll.setBorder(null);
     if (System.getProperty("mrj.version") == null) {
       parentMenu.addSeparator();
-      parentMenu.add(SwingAction.of("About...", e -> {
+      parentMenu.add(SwingAction.of("About", e -> {
         JOptionPane.showMessageDialog(null, editorPane, "About " + gameData.getGameName(),
             JOptionPane.PLAIN_MESSAGE);
       })).setMnemonic(KeyEvent.VK_A);

--- a/src/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -66,7 +66,8 @@ public class HelpMenu {
 
 
   private void addMoveHelpMenu(final JMenu parentMenu) {
-    parentMenu.add(SwingAction.of("Movement/Selection help", e -> {
+    String moveSelectionHelpTitle = "Movement/Selection Help";
+    parentMenu.add(SwingAction.of(moveSelectionHelpTitle, e -> {
       // html formatted string
       final String hints = "<b> Selecting Units</b><br>" + "Left click on a unit stack to select 1 unit.<br>"
           + "ALT-Left click on a unit stack to select 10 units of that type in the stack.<br>"
@@ -104,7 +105,7 @@ public class HelpMenu {
       editorPane.setContentType("text/html");
       editorPane.setText(hints);
       final JScrollPane scroll = new JScrollPane(editorPane);
-      JOptionPane.showMessageDialog(null, scroll, "Movement Help", JOptionPane.PLAIN_MESSAGE);
+      JOptionPane.showMessageDialog(null, scroll, moveSelectionHelpTitle, JOptionPane.PLAIN_MESSAGE);
     })).setMnemonic(KeyEvent.VK_M);
   }
 

--- a/src/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -410,31 +410,31 @@ public class LobbyMenu extends JMenuBar {
    * @param parentMenu
    */
   private static void addHelpMenu(final JMenu parentMenu) {
-    final JMenuItem hostingLink = new JMenuItem("How to Host...");
+    final JMenuItem hostingLink = new JMenuItem("How to Host");
     hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_HOSTING_MAPS));
     parentMenu.add(hostingLink);
 
-    final JMenuItem bugReport = new JMenuItem("Bug Report...");
+    final JMenuItem bugReport = new JMenuItem("Bug Report");
     bugReport.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES));
     parentMenu.add(bugReport);
 
-    final JMenuItem lobbyRules = new JMenuItem("Lobby Rules...");
+    final JMenuItem lobbyRules = new JMenuItem("Lobby Rules");
     lobbyRules.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB_LOBBY_RULES ));
     parentMenu.add(lobbyRules);
 
-    final JMenuItem warClub = new JMenuItem("War Club & Ladder...");
+    final JMenuItem warClub = new JMenuItem("War Club & Ladder");
     warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB));
     parentMenu.add(warClub);
 
-    final JMenuItem donateLink = new JMenuItem("Donate...");
+    final JMenuItem donateLink = new JMenuItem("Donate");
     donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));
     parentMenu.add(donateLink);
 
-    final JMenuItem helpLink = new JMenuItem("Help...");
+    final JMenuItem helpLink = new JMenuItem("Help");
     helpLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.WEBSITE_HELP));
     parentMenu.add(helpLink);
 
-    final JMenuItem ruleBookLink = new JMenuItem("Rule Book...");
+    final JMenuItem ruleBookLink = new JMenuItem("Rule Book");
     ruleBookLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK));
     parentMenu.add(ruleBookLink);
   }

--- a/src/games/strategy/triplea/ui/menubar/NetworkMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/NetworkMenu.java
@@ -74,7 +74,7 @@ public class NetworkMenu {
   private void addShowPlayers(final JMenu menuGame) {
     if (!game.getData().getProperties().getEditableProperties().isEmpty()) {
       final AbstractAction optionsAction =
-          SwingAction.of("Show Who is Who...", e -> PlayersPanel.showPlayers(game, frame));
+          SwingAction.of("Show Who is Who", e -> PlayersPanel.showPlayers(game, frame));
       menuGame.add(optionsAction);
     }
   }

--- a/src/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -115,7 +115,7 @@ public class ViewMenu {
   }
 
   private void addShowGameUuid(final JMenu menuView) {
-    menuView.add(SwingAction.of("Game UUID...", e -> {
+    menuView.add(SwingAction.of("Game UUID", e -> {
       final String id = (String) gameData.getProperties().get(GameData.GAME_UUID);
       final JTextField text = new JTextField();
       text.setText(id);
@@ -131,7 +131,7 @@ public class ViewMenu {
   }
 
   private void addSetLookAndFeel(final JMenu menuView) {
-    menuView.add(SwingAction.of("Set Look and Feel...", e -> {
+    menuView.add(SwingAction.of("Set Look and Feel", e -> {
       final Triple<JList<String>, Map<String, String>, String> lookAndFeel = TripleAMenuBar.getLookAndFeelList();
       final JList<String> list = lookAndFeel.getFirst();
       final String currentKey = lookAndFeel.getThird();
@@ -154,7 +154,7 @@ public class ViewMenu {
 
 
   private void addZoomMenu(final JMenu menuGame) {
-    final Action mapZoom = SwingAction.of("Map Zoom...", e -> {
+    final Action mapZoom = SwingAction.of("Map Zoom", e -> {
       final SpinnerNumberModel model = new SpinnerNumberModel();
       model.setMaximum(100);
       model.setMinimum(15);
@@ -430,7 +430,7 @@ public class ViewMenu {
   }
 
   private void addMapFontAndColorEditorMenu(final JMenu parentMenu) {
-    final Action mapFontOptions = SwingAction.of("Edit Map Font and Color...", e -> {
+    final Action mapFontOptions = SwingAction.of("Edit Map Font and Color", e -> {
       final List<IEditableProperty> properties = new ArrayList<>();
       final NumberProperty fontsize =
           new NumberProperty("Font Size", null, 60, 0, MapImage.getPropertyMapFont().getSize());

--- a/src/games/strategy/triplea/ui/menubar/WebHelpMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/WebHelpMenu.java
@@ -17,37 +17,37 @@ public class WebHelpMenu {
   }
 
   private static void addWebMenu(final JMenu parentMenu) {
-    final JMenuItem hostingLink = new JMenuItem("How to Host...");
+    final JMenuItem hostingLink = new JMenuItem("How to Host");
     hostingLink.setMnemonic(KeyEvent.VK_H);
     hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.SF_HOSTING_MAPS));
     parentMenu.add(hostingLink);
 
-    final JMenuItem bugReport = new JMenuItem("Bug Report...");
+    final JMenuItem bugReport = new JMenuItem("Bug Report");
     bugReport.setMnemonic(KeyEvent.VK_B);
     bugReport.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES));
     parentMenu.add(bugReport);
 
-    final JMenuItem lobbyRules = new JMenuItem("Lobby Rules...");
+    final JMenuItem lobbyRules = new JMenuItem("Lobby Rules");
     lobbyRules.setMnemonic(KeyEvent.VK_L);
     lobbyRules.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB_LOBBY_RULES ));
     parentMenu.add(lobbyRules);
 
-    final JMenuItem warClub = new JMenuItem("War Club & Ladder...");
+    final JMenuItem warClub = new JMenuItem("War Club & Ladder");
     warClub.setMnemonic(KeyEvent.VK_W);
     warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_WAR_CLUB));
     parentMenu.add(warClub);
     
-    final JMenuItem donateLink = new JMenuItem("Donate...");
+    final JMenuItem donateLink = new JMenuItem("Donate");
     donateLink.setMnemonic(KeyEvent.VK_O);
     donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));
     parentMenu.add(donateLink);
 
-    final JMenuItem helpLink = new JMenuItem("Help...");
+    final JMenuItem helpLink = new JMenuItem("Help");
     helpLink.setMnemonic(KeyEvent.VK_G);
     helpLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.WEBSITE_HELP));
     parentMenu.add(helpLink);
 
-    final JMenuItem ruleBookLink = new JMenuItem("Rule Book...");
+    final JMenuItem ruleBookLink = new JMenuItem("Rule Book");
     ruleBookLink.setMnemonic(KeyEvent.VK_K);
     ruleBookLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK));
     parentMenu.add(ruleBookLink);


### PR DESCRIPTION
Addresses point L and K in #958

The usage of "..." at the end of menu names is not consistent, this PR removes it from all of the menu drop downs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/962)
<!-- Reviewable:end -->
