### PR TITLE
Show map name when reporting map parsing errors

### DIFF
--- a/src/games/strategy/engine/data/GameParseException.java
+++ b/src/games/strategy/engine/data/GameParseException.java
@@ -10,6 +10,6 @@ public class GameParseException extends Exception {
   }
 
   public GameParseException(final String mapName, final String error) {
-    super(Joiner.on(':').join(mapName, error).toString());
+    super(Joiner.on(':').join(mapName, error));
   }
 }

--- a/src/games/strategy/engine/data/GameParseException.java
+++ b/src/games/strategy/engine/data/GameParseException.java
@@ -1,9 +1,15 @@
 package games.strategy.engine.data;
 
+import com.google.common.base.Joiner;
+
 public class GameParseException extends Exception {
   private static final long serialVersionUID = 4015574053053781872L;
 
-  public GameParseException(final String error) {
-    super(error);
+  public GameParseException(final GameData gameData, final String error) {
+    this(gameData.getGameName(), error);
+  }
+
+  public GameParseException(final String mapName, final String error) {
+    super(Joiner.on(':').join(mapName, error).toString());
   }
 }

--- a/src/games/strategy/engine/data/GameParser.java
+++ b/src/games/strategy/engine/data/GameParser.java
@@ -52,6 +52,9 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.util.Tuple;
 import games.strategy.util.Version;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 public class GameParser {
   private static final Class<?>[] SETTER_ARGS = {String.class};
   private GameData data;
@@ -76,9 +79,8 @@ public class GameParser {
   public synchronized GameData parse(final InputStream stream, final AtomicReference<String> gameName,
       final boolean delayParsing)
       throws GameParseException, SAXException, EngineVersionException, IllegalArgumentException {
-    if (stream == null) {
-      throw new IllegalArgumentException("Stream must be non null");
-    }
+    checkNotNull(stream);
+
     Document doc = null;
     try {
       doc = getDocument(stream);
@@ -89,13 +91,13 @@ public class GameParser {
     data = new GameData();
     // mandatory fields
     // get the name of the map
-    parseInfo(getSingleChild("info", root));
+    parseInfo(getSingleChild(gameName.get(), "info", root));
     if (gameName != null) {
       gameName.set(data.getGameName());
     }
     // test minimum engine version FIRST
-    parseMinimumEngineVersionNumber(getSingleChild("triplea", root, true));
-    parseGameLoader(getSingleChild("loader", root));
+    parseMinimumEngineVersionNumber(getSingleChild(gameName.get(), "triplea", root, true));
+    parseGameLoader(gameName.get(), getSingleChild(gameName.get(), "loader", root));
     // if we manage to get this far, past the minimum engine version number test, AND we are still good, then check and
     // see if we have any
     // SAX errors we need to show
@@ -106,54 +108,54 @@ public class GameParser {
             + error.getLineNumber() + ", column: " + error.getColumnNumber() + ", error: " + error.getMessage());
       }
     }
-    parseDiceSides(getSingleChild("diceSides", root, true));
-    final Element playerListNode = getSingleChild("playerList", root);
+    parseDiceSides(getSingleChild(gameName.get(), "diceSides", root, true));
+    final Element playerListNode = getSingleChild(gameName.get(), "playerList", root);
     parsePlayerList(playerListNode);
-    parseAlliances(playerListNode);
-    final Node properties = getSingleChild("propertyList", root, true);
+    parseAlliances(gameName.get(), playerListNode);
+    final Node properties = getSingleChild(gameName.get(), "propertyList", root, true);
     if (properties != null) {
-      parseProperties(properties);
+      parseProperties(gameName.get(), properties);
     }
     // everything until here is needed to select a game, the rest can be parsed when a game is selected
     if (delayParsing) {
       return data;
     }
-    parseMap(getSingleChild("map", root));
-    final Element resourceList = getSingleChild("resourceList", root, true);
+    parseMap(gameName.get(), getSingleChild(gameName.get(), "map", root));
+    final Element resourceList = getSingleChild(gameName.get(), "resourceList", root, true);
     if (resourceList != null) {
       parseResources(resourceList);
     }
-    final Element unitList = getSingleChild("unitList", root, true);
+    final Element unitList = getSingleChild(gameName.get(), "unitList", root, true);
     if (unitList != null) {
       parseUnits(unitList);
     }
     // Parse all different relationshipTypes that are defined in the xml, for example: War, Allied, Neutral, NAP
-    final Element relationshipTypes = getSingleChild("relationshipTypes", root, true);
+    final Element relationshipTypes = getSingleChild(gameName.get(), "relationshipTypes", root, true);
     if (relationshipTypes != null) {
       parseRelationshipTypes(relationshipTypes);
     }
-    final Element territoryEffectList = getSingleChild("territoryEffectList", root, true);
+    final Element territoryEffectList = getSingleChild(gameName.get(), "territoryEffectList", root, true);
     if (territoryEffectList != null) {
       parseTerritoryEffects(territoryEffectList);
     }
-    parseGamePlay(getSingleChild("gamePlay", root));
-    final Element production = getSingleChild("production", root, true);
+    parseGamePlay(gameName.get(), getSingleChild(gameName.get(), "gamePlay", root));
+    final Element production = getSingleChild(gameName.get(), "production", root, true);
     if (production != null) {
-      parseProduction(production);
+      parseProduction(gameName.get(), production);
     }
-    final Element technology = getSingleChild("technology", root, true);
+    final Element technology = getSingleChild(gameName.get(), "technology", root, true);
     if (technology != null) {
-      parseTechnology(technology);
+      parseTechnology(gameName.get(), technology);
     } else {
       TechAdvance.createDefaultTechAdvances(data);
     }
-    final Element attachmentList = getSingleChild("attachmentList", root, true);
+    final Element attachmentList = getSingleChild(gameName.get(), "attachmentList", root, true);
     if (attachmentList != null) {
-      parseAttachments(attachmentList);
+      parseAttachments(gameName.get(), attachmentList);
     }
-    final Node initialization = getSingleChild("initialize", root, true);
+    final Node initialization = getSingleChild(gameName.get(), "initialize", root, true);
     if (initialization != null) {
-      parseInitialization(initialization);
+      parseInitialization(gameName.get(), initialization);
     }
     // set & override default relationships
     // sets the relationship between all players and the NullPlayer to NullRelation
@@ -168,10 +170,10 @@ public class GameParser {
       TechAbilityAttachment.setDefaultTechnologyAttachments(data);
     }
     try {
-      validate();
+      validate(gameName.get());
     } catch (final Exception e) {
       ClientLogger.logQuietly(e);
-      throw new GameParseException(e.getMessage());
+      throw new GameParseException(gameName.get(), e.getMessage());
     }
     return data;
   }
@@ -196,7 +198,7 @@ public class GameParser {
     }
   }
 
-  private void validate() throws GameParseException {
+  private void validate(String mapName) throws GameParseException {
     // validate unit attachments
     for (final UnitType u : data.getUnitTypeList()) {
       validateAttachments(u);
@@ -220,17 +222,17 @@ public class GameParser {
       validateAttachments(r);
     }
     // if relationships are used, every player should have a relationship with every other player
-    validateRelationships();
+    validateRelationships(mapName);
   }
 
-  private void validateRelationships() throws GameParseException {
+  private void validateRelationships(String mapName) throws GameParseException {
     // for every player
     for (final PlayerID player : data.getPlayerList()) {
       // in relation to every player
       for (final PlayerID player2 : data.getPlayerList()) {
         // See if there is a relationship between them
         if ((data.getRelationshipTracker().getRelationshipType(player, player2) == null)) {
-          throw new GameParseException("No relation set for: " + player.getName() + " and " + player2.getName());
+          throw new GameParseException(mapName, "No relation set for: " + player.getName() + " and " + player2.getName());
           // or else throw an exception!
         }
       }
@@ -277,12 +279,13 @@ public class GameParser {
   /**
    * If mustfind is true and cannot find the player an exception will be thrown.
    */
-  private PlayerID getPlayerID(final Element element, final String attribute, final boolean mustFind)
+  private PlayerID getPlayerID(final String mapName, final Element element, final String attribute,
+      final boolean mustFind)
       throws GameParseException {
     final String name = element.getAttribute(attribute);
     final PlayerID player = data.getPlayerList().getPlayerID(name);
     if (player == null && mustFind) {
-      throw new GameParseException("Could not find player. name:" + name);
+      throw new GameParseException(mapName, "Could not find player. name:" + name);
     }
     return player;
   }
@@ -295,22 +298,23 @@ public class GameParser {
    * @throws GameParseException
    *         when
    */
-  private RelationshipType getRelationshipType(final Element element, final String attribute, final boolean mustFind)
-      throws GameParseException {
+  private RelationshipType getRelationshipType(final String mapName, final Element element, final String attribute,
+      final boolean mustFind) throws GameParseException {
     final String name = element.getAttribute(attribute);
     final RelationshipType relation = data.getRelationshipTypeList().getRelationshipType(name);
     if (relation == null && mustFind) {
-      throw new GameParseException("Could not find relation name:" + name);
+      throw new GameParseException(mapName, "Could not find relation name:" + name);
     }
     return relation;
   }
 
-  private TerritoryEffect getTerritoryEffect(final Element element, final String attribute, final boolean mustFind)
+  private TerritoryEffect getTerritoryEffect(final String mapName, final Element element, final String attribute,
+      final boolean mustFind)
       throws GameParseException {
     final String name = element.getAttribute(attribute);
     final TerritoryEffect effect = data.getTerritoryEffectList().get(name);
     if (effect == null && mustFind) {
-      throw new GameParseException("Could not find territoryEffect name:" + name);
+      throw new GameParseException(mapName, "Could not find territoryEffect name:" + name);
     }
     return effect;
   }
@@ -318,12 +322,13 @@ public class GameParser {
   /**
    * If mustfind is true and cannot find the productionRule an exception will be thrown.
    */
-  private ProductionRule getProductionRule(final Element element, final String attribute, final boolean mustFind)
+  private ProductionRule getProductionRule(final String mapName, final Element element, final String attribute,
+      final boolean mustFind)
       throws GameParseException {
     final String name = element.getAttribute(attribute);
     final ProductionRule productionRule = data.getProductionRuleList().getProductionRule(name);
     if (productionRule == null && mustFind) {
-      throw new GameParseException("Could not find production rule. name:" + name);
+      throw new GameParseException(mapName, "Could not find production rule. name:" + name);
     }
     return productionRule;
   }
@@ -331,12 +336,12 @@ public class GameParser {
   /**
    * If mustfind is true and cannot find the productionRule an exception will be thrown.
    */
-  private RepairRule getRepairRule(final Element element, final String attribute, final boolean mustFind)
-      throws GameParseException {
+  private RepairRule getRepairRule(final String mapName, final Element element, final String attribute,
+      final boolean mustFind) throws GameParseException {
     final String name = element.getAttribute(attribute);
     final RepairRule repairRule = data.getRepairRuleList().getRepairRule(name);
     if (repairRule == null && mustFind) {
-      throw new GameParseException("Could not find production rule. name:" + name);
+      throw new GameParseException(mapName, "Could not find production rule. name:" + name);
     }
     return repairRule;
   }
@@ -344,12 +349,12 @@ public class GameParser {
   /**
    * If mustfind is true and cannot find the territory an exception will be thrown.
    */
-  private Territory getTerritory(final Element element, final String attribute, final boolean mustFind)
+  private Territory getTerritory(final String mapName, final Element element, final String attribute, final boolean mustFind)
       throws GameParseException {
     final String name = element.getAttribute(attribute);
     final Territory territory = data.getMap().getTerritory(name);
     if (territory == null && mustFind) {
-      throw new GameParseException("Could not find territory. name:" + name);
+      throw new GameParseException(mapName, "Could not find territory. name:" + name);
     }
     return territory;
   }
@@ -357,12 +362,12 @@ public class GameParser {
   /**
    * If mustfind is true and cannot find the unitType an exception will be thrown.
    */
-  private UnitType getUnitType(final Element element, final String attribute, final boolean mustFind)
+  private UnitType getUnitType(final String mapName, final Element element, final String attribute, final boolean mustFind)
       throws GameParseException {
     final String name = element.getAttribute(attribute);
     final UnitType type = data.getUnitTypeList().getUnitType(name);
     if (type == null && mustFind) {
-      throw new GameParseException("Could not find unitType. name:" + name);
+      throw new GameParseException(mapName, "Could not find unitType. name:" + name);
     }
     return type;
   }
@@ -370,7 +375,7 @@ public class GameParser {
   /**
    * If mustfind is true and cannot find the technology an exception will be thrown.
    */
-  private TechAdvance getTechnology(final Element element, final String attribute, final boolean mustFind)
+  private TechAdvance getTechnology(final String mapName, final Element element, final String attribute, final boolean mustFind)
       throws GameParseException {
     final String name = element.getAttribute(attribute);
     TechAdvance type = data.getTechnologyFrontier().getAdvanceByName(name);
@@ -378,7 +383,7 @@ public class GameParser {
       type = data.getTechnologyFrontier().getAdvanceByProperty(name);
     }
     if (type == null && mustFind) {
-      throw new GameParseException("Could not find technology. name:" + name);
+      throw new GameParseException(mapName, "Could not find technology. name:" + name);
     }
     return type;
   }
@@ -386,12 +391,12 @@ public class GameParser {
   /**
    * If mustfind is true and cannot find the Delegate an exception will be thrown.
    */
-  private IDelegate getDelegate(final Element element, final String attribute, final boolean mustFind)
+  private IDelegate getDelegate(final String mapName, final Element element, final String attribute, final boolean mustFind)
       throws GameParseException {
     final String name = element.getAttribute(attribute);
     final IDelegate delegate = data.getDelegateList().getDelegate(name);
     if (delegate == null && mustFind) {
-      throw new GameParseException("Could not find delegate. name:" + name);
+      throw new GameParseException(mapName, "Could not find delegate. name:" + name);
     }
     return delegate;
   }
@@ -399,12 +404,12 @@ public class GameParser {
   /**
    * If mustfind is true and cannot find the Resource an exception will be thrown.
    */
-  private Resource getResource(final Element element, final String attribute, final boolean mustFind)
+  private Resource getResource(final String mapName, final Element element, final String attribute, final boolean mustFind)
       throws GameParseException {
     final String name = element.getAttribute(attribute);
     final Resource resource = data.getResourceList().getResource(name);
     if (resource == null && mustFind) {
-      throw new GameParseException("Could not find resource. name:" + name);
+      throw new GameParseException(mapName, "Could not find resource. name:" + name);
     }
     return resource;
   }
@@ -412,12 +417,12 @@ public class GameParser {
   /**
    * If mustfind is true and cannot find the productionRule an exception will be thrown.
    */
-  private ProductionFrontier getProductionFrontier(final Element element, final String attribute,
+  private ProductionFrontier getProductionFrontier(final String mapName, final Element element, final String attribute,
       final boolean mustFind) throws GameParseException {
     final String name = element.getAttribute(attribute);
     final ProductionFrontier productionFrontier = data.getProductionFrontierList().getProductionFrontier(name);
     if (productionFrontier == null && mustFind) {
-      throw new GameParseException("Could not find production frontier. name:" + name);
+      throw new GameParseException(mapName, "Could not find production frontier. name:" + name);
     }
     return productionFrontier;
   }
@@ -425,12 +430,12 @@ public class GameParser {
   /**
    * If mustfind is true and cannot find the productionRule an exception will be thrown.
    */
-  private RepairFrontier getRepairFrontier(final Element element, final String attribute, final boolean mustFind)
+  private RepairFrontier getRepairFrontier(final String mapName, final Element element, final String attribute, final boolean mustFind)
       throws GameParseException {
     final String name = element.getAttribute(attribute);
     final RepairFrontier repairFrontier = data.getRepairFrontierList().getRepairFrontier(name);
     if (repairFrontier == null && mustFind) {
-      throw new GameParseException("Could not find production frontier. name:" + name);
+      throw new GameParseException(mapName, "Could not find production frontier. name:" + name);
     }
     return repairFrontier;
   }
@@ -439,7 +444,7 @@ public class GameParser {
    * Loads an instance of the given class.
    * Assumes a zero argument constructor.
    */
-  private Object getInstance(final String className) throws GameParseException {
+  private Object getInstance(final String mapName, final String className) throws GameParseException {
     Object instance = null;
     try {
       final Class<?> instanceClass = Class.forName(className);
@@ -447,11 +452,11 @@ public class GameParser {
     }
     // a lot can go wrong, the following list is just a subset of potential pitfalls
     catch (final ClassNotFoundException cnfe) {
-      throw new GameParseException("Class <" + className + "> could not be found.");
+      throw new GameParseException(mapName, "Class <" + className + "> could not be found.");
     } catch (final InstantiationException ie) {
-      throw new GameParseException("Class <" + className + "> could not be instantiated. ->" + ie.getMessage());
+      throw new GameParseException(mapName, "Class <" + className + "> could not be instantiated. ->" + ie.getMessage());
     } catch (final IllegalAccessException iae) {
-      throw new GameParseException("Constructor could not be accessed ->" + iae.getMessage());
+      throw new GameParseException(mapName, "Constructor could not be accessed ->" + iae.getMessage());
     }
     return instance;
   }
@@ -459,7 +464,7 @@ public class GameParser {
   /**
    * Loads a given class.
    */
-  private Class<?> getClassByName(final String className) throws GameParseException {
+  private Class<?> getClassByName(final String mapName, final String className) throws GameParseException {
     try {
       final Class<?> instanceClass = Class.forName(className);
       return instanceClass;
@@ -474,9 +479,9 @@ public class GameParser {
       }
       final String newClassName = newClassesForOldNames.get(className);
       if (newClassName != null) {
-        return getClassByName(newClassName);
+        return getClassByName(mapName, newClassName);
       }
-      throw new GameParseException("Class <" + className + "> could not be found.");
+      throw new GameParseException(mapName, "Class <" + className + "> could not be found.");
     }
   }
 
@@ -484,25 +489,26 @@ public class GameParser {
    * Get the given child.
    * If there is not exactly one child throw a SAXExcpetion
    */
-  private Element getSingleChild(final String name, final Element node) throws GameParseException {
-    return getSingleChild(name, node, false);
+  private Element getSingleChild(final String mapName, final String name, final Element node) throws GameParseException {
+    return getSingleChild(mapName, name, node, false);
   }
 
   /**
    * If optional is true, will not throw an exception if there are 0 children
    */
-  private Element getSingleChild(final String name, final Node node, final boolean optional) throws GameParseException {
+  private Element getSingleChild(final String mapName, final String name, final Node node, final boolean optional)
+      throws GameParseException {
     final List<Element> children = getChildren(name, node);
     // none found
     if (children.size() == 0) {
       if (optional) {
         return null;
       }
-      throw new GameParseException("No child called " + name);
+      throw new GameParseException(mapName, "No child called " + name);
     }
     // too many found
     if (children.size() > 1) {
-      throw new GameParseException("Too many children named " + name);
+      throw new GameParseException(mapName, "Too many children named " + name);
     }
     return children.get(0);
   }
@@ -549,23 +555,23 @@ public class GameParser {
     data.setGameVersion(new Version(version));
   }
 
-  private void parseGameLoader(final Node loader) throws GameParseException {
+  private void parseGameLoader(String mapName, final Node loader) throws GameParseException {
     final String className = ((Element) loader).getAttribute("javaClass");
-    final Object instance = getInstance(className);
+    final Object instance = getInstance(mapName, className);
     if (!(instance instanceof IGameLoader)) {
-      throw new GameParseException("Loader must implement IGameLoader.  Class Name:" + className);
+      throw new GameParseException(mapName, "Loader must implement IGameLoader.  Class Name:" + className);
     }
     data.setGameLoader((IGameLoader) instance);
   }
 
-  private void parseMap(final Node map) throws GameParseException {
+  private void parseMap(final String mapName, final Node map) throws GameParseException {
     final List<Element> grids = getChildren("grid", map);
     parseGrids(grids);
     // get the Territories
     final List<Element> territories = getChildren("territory", map);
     parseTerritories(territories);
     final List<Element> connections = getChildren("connection", map);
-    parseConnections(connections);
+    parseConnections(mapName, connections);
   }
 
   private void parseGrids(final List<Element> grids) throws GameParseException {
@@ -597,7 +603,7 @@ public class GameParser {
     } else if (horizontalConnections.equals("explicit")) {
       horizontalConnectionsImplict = false;
     } else {
-      throw new GameParseException("horizontal-connections attribute must be either \"explicit\" or \"implicit\"");
+      throw new GameParseException(data, "horizontal-connections attribute must be either \"explicit\" or \"implicit\"");
     }
     boolean verticalConnectionsImplict;
     if (verticalConnections.equals("implicit")) {
@@ -605,7 +611,7 @@ public class GameParser {
     } else if (verticalConnections.equals("explicit")) {
       verticalConnectionsImplict = false;
     } else {
-      throw new GameParseException("vertical-connections attribute must be either \"explicit\" or \"implicit\"");
+      throw new GameParseException(data, "vertical-connections attribute must be either \"explicit\" or \"implicit\"");
     }
     boolean diagonalConnectionsImplict;
     if (diagonalConnections.equals("implicit")) {
@@ -613,7 +619,7 @@ public class GameParser {
     } else if (diagonalConnections.equals("explicit")) {
       diagonalConnectionsImplict = false;
     } else {
-      throw new GameParseException("diagonal-connections attribute must be either \"explicit\" or \"implicit\"");
+      throw new GameParseException(data, "diagonal-connections attribute must be either \"explicit\" or \"implicit\"");
     }
     final int x_size = Integer.valueOf(xs);
     int y_size;
@@ -764,11 +770,11 @@ public class GameParser {
     }
   }
 
-  private void parseConnections(final List<Element> connections) throws GameParseException {
+  private void parseConnections(final String mapName, final List<Element> connections) throws GameParseException {
     final GameMap map = data.getMap();
     for (final Element current : connections) {
-      final Territory t1 = getTerritory(current, "t1", true);
-      final Territory t2 = getTerritory(current, "t2", true);
+      final Territory t1 = getTerritory(mapName, current, "t1", true);
+      final Territory t2 = getTerritory(mapName, current, "t2", true);
       map.addConnection(t1, t2);
     }
   }
@@ -820,16 +826,16 @@ public class GameParser {
     }
   }
 
-  private void parseAlliances(final Element root) throws GameParseException {
+  private void parseAlliances(final String mapName, final Element root) throws GameParseException {
     final AllianceTracker allianceTracker = data.getAllianceTracker();
     final Collection<PlayerID> players = data.getPlayerList().getPlayers();
     for (final Element current : getChildren("alliance", root)) {
-      final PlayerID p1 = getPlayerID(current, "player", true);
+      final PlayerID p1 = getPlayerID(mapName, current, "player", true);
       final String alliance = current.getAttribute("alliance");
       allianceTracker.addToAlliance(p1, alliance);
     }
     // if relationships aren't initialized based on relationshipInitialize we use the alliances to set the relationships
-    if (getSingleChild("relationshipInitialize", root, true) == null) {
+    if (getSingleChild(mapName, "relationshipInitialize", root, true) == null) {
       final RelationshipTracker relationshipTracker = data.getRelationshipTracker();
       final RelationshipTypeList relationshipTypeList = data.getRelationshipTypeList();
       // iterate through all players to get known allies and enemies
@@ -857,26 +863,26 @@ public class GameParser {
     }
   }
 
-  private void parseRelationInitialize(final List<Element> relations) throws GameParseException {
+  private void parseRelationInitialize(final String mapName, final List<Element> relations) throws GameParseException {
     if (relations.size() > 0) {
       final RelationshipTracker tracker = data.getRelationshipTracker();
       for (final Element current : relations) {
-        final PlayerID p1 = getPlayerID(current, "player1", true);
-        final PlayerID p2 = getPlayerID(current, "player2", true);
-        final RelationshipType r = getRelationshipType(current, "type", true);
+        final PlayerID p1 = getPlayerID(mapName, current, "player1", true);
+        final PlayerID p2 = getPlayerID(mapName, current, "player2", true);
+        final RelationshipType r = getRelationshipType(mapName, current, "type", true);
         final int roundValue = Integer.valueOf(current.getAttribute("roundValue"));
         tracker.setRelationship(p1, p2, r, roundValue);
       }
     }
   }
 
-  private void parseGamePlay(final Element root) throws GameParseException {
-    parseDelegates(getChildren("delegate", root));
-    parseSequence(getSingleChild("sequence", root));
-    parseOffset(getSingleChild("offset", root, true));
+  private void parseGamePlay(String mapName, final Element root) throws GameParseException {
+    parseDelegates(mapName, getChildren("delegate", root));
+    parseSequence(mapName, getSingleChild(mapName, "sequence", root));
+    parseOffset(getSingleChild(mapName, "offset", root, true));
   }
 
-  private void parseProperties(final Node root) throws GameParseException {
+  private void parseProperties(String mapName, final Node root) throws GameParseException {
     final Collection<String> runningList = new ArrayList<>();
     final GameProperties properties = data.getProperties();
     final Iterator<Element> children = getChildren("property", root).iterator();
@@ -896,7 +902,7 @@ public class GameParser {
         }
       }
       if (editable != null && editable.equalsIgnoreCase("true")) {
-        parseEditableProperty(current, property, value);
+        parseEditableProperty(mapName, current, property, value);
       } else {
         final List<Node> children2 = getNonTextNodesIgnoring(current, "value");
         if (children2.size() == 0) {
@@ -956,12 +962,12 @@ public class GameParser {
     }
   }
 
-  private void parseEditableProperty(final Element property, final String name, final String defaultValue)
+  private void parseEditableProperty(String mapName, final Element property, final String name, final String defaultValue)
       throws GameParseException {
     // what type
     final List<Node> children = getNonTextNodes(property);
     if (children.size() != 1) {
-      throw new GameParseException(
+      throw new GameParseException(mapName,
           "Editable properties must have exactly 1 child specifying the type. Number of children found:"
               + children.size() + " for node:" + property.getNodeName());
     }
@@ -991,7 +997,7 @@ public class GameParser {
     } else if (childName.equals("string")) {
       editableProperty = new StringProperty(name, null, defaultValue);
     } else {
-      throw new GameParseException("Unrecognized property type:" + childName);
+      throw new GameParseException(mapName, "Unrecognized property type:" + childName);
     }
     data.getProperties().addEditableProperty(editableProperty);
   }
@@ -1004,7 +1010,7 @@ public class GameParser {
     data.getSequence().setRoundOffset(roundOffset);
   }
 
-  private void parseDelegates(final List<Element> delegateList) throws GameParseException {
+  private void parseDelegates(String mapName, final List<Element> delegateList) throws GameParseException {
     final DelegateList delegates = data.getDelegateList();
     final Iterator<Element> iterator = delegateList.iterator();
     while (iterator.hasNext()) {
@@ -1013,9 +1019,9 @@ public class GameParser {
       final String className = current.getAttribute("javaClass");
       IDelegate delegate = null;
       try {
-        delegate = (IDelegate) getInstance(className);
+        delegate = (IDelegate) getInstance(mapName, className);
       } catch (final ClassCastException cce) {
-        throw new GameParseException("Class <" + className + "> is not a delegate.");
+        throw new GameParseException(mapName, "Class <" + className + "> is not a delegate.");
       }
       final String name = current.getAttribute("name");
       String displayName = current.getAttribute("display");
@@ -1027,16 +1033,16 @@ public class GameParser {
     }
   }
 
-  private void parseSequence(final Node sequence) throws GameParseException {
-    parseSteps(getChildren("step", sequence));
+  private void parseSequence(String mapName, final Node sequence) throws GameParseException {
+    parseSteps(mapName, getChildren("step", sequence));
   }
 
-  private void parseSteps(final List<Element> stepList) throws GameParseException {
+  private void parseSteps(String mapName, final List<Element> stepList) throws GameParseException {
     final Iterator<Element> iterator = stepList.iterator();
     while (iterator.hasNext()) {
       final Element current = iterator.next();
-      final IDelegate delegate = getDelegate(current, "delegate", true);
-      final PlayerID player = getPlayerID(current, "player", false);
+      final IDelegate delegate = getDelegate(mapName, current, "delegate", true);
+      final PlayerID player = getPlayerID(mapName, current, "player", false);
       final String name = current.getAttribute("name");
       String displayName = null;
       final List<Element> propertyElements = getChildren("stepProperty", current);
@@ -1048,7 +1054,7 @@ public class GameParser {
       if (current.hasAttribute("maxRunCount")) {
         final int runCount = Integer.parseInt(current.getAttribute("maxRunCount"));
         if (runCount <= 0) {
-          throw new GameParseException("maxRunCount must be positive");
+          throw new GameParseException(mapName, " maxRunCount must be positive");
         }
         step.setMaxRunCount(runCount);
       }
@@ -1066,106 +1072,109 @@ public class GameParser {
     return rVal;
   }
 
-  private void parseProduction(final Node root) throws GameParseException {
-    parseProductionRules(getChildren("productionRule", root));
-    parseProductionFrontiers(getChildren("productionFrontier", root));
-    parsePlayerProduction(getChildren("playerProduction", root));
-    parseRepairRules(getChildren("repairRule", root));
-    parseRepairFrontiers(getChildren("repairFrontier", root));
-    parsePlayerRepair(getChildren("playerRepair", root));
+  private void parseProduction(String mapName, final Node root) throws GameParseException {
+    parseProductionRules(mapName, getChildren("productionRule", root));
+    parseProductionFrontiers(mapName, getChildren("productionFrontier", root));
+    parsePlayerProduction(mapName, getChildren("playerProduction", root));
+    parseRepairRules(mapName, getChildren("repairRule", root));
+    parseRepairFrontiers(mapName, getChildren("repairFrontier", root));
+    parsePlayerRepair(mapName, getChildren("playerRepair", root));
   }
 
-  private void parseTechnology(final Node root) throws GameParseException {
-    parseTechnologies(getSingleChild("technologies", root, true));
-    parsePlayerTech(getChildren("playerTech", root));
+  private void parseTechnology(final String mapName, final Node root) throws GameParseException {
+    parseTechnologies(getSingleChild(mapName, "technologies", root, true));
+    parsePlayerTech(mapName, getChildren("playerTech", root));
   }
 
-  private void parseProductionRules(final List<Element> elements) throws GameParseException {
+  private void parseProductionRules(String mapName, final List<Element> elements) throws GameParseException {
     for (final Element current : elements) {
       final String name = current.getAttribute("name");
       final ProductionRule rule = new ProductionRule(name, data);
-      parseCosts(rule, getChildren("cost", current));
-      parseResults(rule, getChildren("result", current));
+
+      final List<Element> costElements = getChildren("cost", current);
+      if (costElements.isEmpty()) {
+        throw new GameParseException(mapName, "no costs  for rule:" + rule.getName());
+      }
+      parseCosts(mapName, rule, getChildren("cost", current));
+      parseResults(mapName, rule, getChildren("result", current));
       data.getProductionRuleList().addProductionRule(rule);
     }
   }
 
-  private void parseRepairRules(final List<Element> elements) throws GameParseException {
+  private void parseRepairRules(String mapName, final List<Element> elements) throws GameParseException {
     for (final Element current : elements) {
       final String name = current.getAttribute("name");
       final RepairRule rule = new RepairRule(name, data);
-      parseRepairCosts(rule, getChildren("cost", current));
-      parseRepairResults(rule, getChildren("result", current));
+      parseRepairCosts(mapName, rule, getChildren("cost", current));
+      parseRepairResults(mapName, rule, getChildren("result", current));
       data.getRepairRuleList().addRepairRule(rule);
     }
   }
 
-  private void parseCosts(final ProductionRule rule, final List<Element> elements) throws GameParseException {
-    if (elements.size() == 0) {
-      throw new GameParseException("no costs  for rule:" + rule.getName());
-    }
+  private void parseCosts(final String mapName, final ProductionRule rule, final List<Element> elements)
+      throws GameParseException {
     for (final Element current : elements) {
-      final Resource resource = getResource(current, "resource", true);
+      final Resource resource = getResource(mapName, current, "resource", true);
       final int quantity = Integer.parseInt(current.getAttribute("quantity"));
       rule.addCost(resource, quantity);
     }
   }
 
-  private void parseRepairCosts(final RepairRule rule, final List<Element> elements) throws GameParseException {
+  private void parseRepairCosts(String mapName, final RepairRule rule, final List<Element> elements) throws GameParseException {
     if (elements.size() == 0) {
-      throw new GameParseException("no costs  for rule:" + rule.getName());
+      throw new GameParseException(mapName, "no costs  for rule:" + rule.getName());
     }
     for (final Element current : elements) {
-      final Resource resource = getResource(current, "resource", true);
+      final Resource resource = getResource(mapName, current, "resource", true);
       final int quantity = Integer.parseInt(current.getAttribute("quantity"));
       rule.addCost(resource, quantity);
     }
   }
 
-  private void parseResults(final ProductionRule rule, final List<Element> elements) throws GameParseException {
+  private void parseResults(String mapName, final ProductionRule rule, final List<Element> elements) throws GameParseException {
     if (elements.size() == 0) {
-      throw new GameParseException("no results  for rule:" + rule.getName());
+      throw new GameParseException(mapName, "no results  for rule:" + rule.getName());
     }
     for (final Element current : elements) {
       // must find either a resource or a unit with the given name
       NamedAttachable result = null;
-      result = getResource(current, "resourceOrUnit", false);
+      result = getResource(mapName, current, "resourceOrUnit", false);
       if (result == null) {
-        result = getUnitType(current, "resourceOrUnit", false);
+        result = getUnitType(mapName, current, "resourceOrUnit", false);
       }
       if (result == null) {
-        throw new GameParseException("Could not find resource or unit" + current.getAttribute("resourceOrUnit"));
+        throw new GameParseException(mapName, "Could not find resource or unit" + current.getAttribute("resourceOrUnit"));
       }
       final int quantity = Integer.parseInt(current.getAttribute("quantity"));
       rule.addResult(result, quantity);
     }
   }
 
-  private void parseRepairResults(final RepairRule rule, final List<Element> elements) throws GameParseException {
+  private void parseRepairResults(String mapName, final RepairRule rule, final List<Element> elements) throws GameParseException {
     if (elements.size() == 0) {
-      throw new GameParseException("no results  for rule:" + rule.getName());
+      throw new GameParseException(mapName, "no results  for rule:" + rule.getName());
     }
     for (final Element current : elements) {
       // must find either a resource or a unit with the given name
       NamedAttachable result = null;
-      result = getResource(current, "resourceOrUnit", false);
+      result = getResource(mapName, current, "resourceOrUnit", false);
       if (result == null) {
-        result = getUnitType(current, "resourceOrUnit", false);
+        result = getUnitType(mapName, current, "resourceOrUnit", false);
       }
       if (result == null) {
-        throw new GameParseException("Could not find resource or unit" + current.getAttribute("resourceOrUnit"));
+        throw new GameParseException(mapName, "Could not find resource or unit" + current.getAttribute("resourceOrUnit"));
       }
       final int quantity = Integer.parseInt(current.getAttribute("quantity"));
       rule.addResult(result, quantity);
     }
   }
 
-  private void parseProductionFrontiers(final List<Element> elements) throws GameParseException {
+  private void parseProductionFrontiers(final String mapName, final List<Element> elements) throws GameParseException {
     final ProductionFrontierList frontiers = data.getProductionFrontierList();
     for (final Element current : elements) {
       final String name = current.getAttribute("name");
       final ProductionFrontier frontier = new ProductionFrontier(name, data);
-      parseFrontierRules(getChildren("frontierRules", current), frontier);
+      parseFrontierRules(mapName, getChildren("frontierRules", current), frontier);
       frontiers.addProductionFrontier(frontier);
     }
   }
@@ -1178,54 +1187,55 @@ public class GameParser {
     parseTechs(getChildren("techname", element), allTechs);
   }
 
-  private void parsePlayerTech(final List<Element> elements) throws GameParseException {
+  private void parsePlayerTech(String mapName, final List<Element> elements) throws GameParseException {
     for (final Element current : elements) {
-      final PlayerID player = getPlayerID(current, "player", true);
+      final PlayerID player = getPlayerID(mapName, current, "player", true);
       final TechnologyFrontierList categories = player.getTechnologyFrontierList();
-      parseCategories(getChildren("category", current), categories);
+      parseCategories(mapName, getChildren("category", current), categories);
     }
   }
 
-  private void parseCategories(final List<Element> elements, final TechnologyFrontierList categories)
+  private void parseCategories(final String mapName, final List<Element> elements,
+      final TechnologyFrontierList categories)
       throws GameParseException {
     for (final Element current : elements) {
       final TechnologyFrontier tf = new TechnologyFrontier(current.getAttribute("name"), data);
-      parseCategoryTechs(getChildren("tech", current), tf);
+      parseCategoryTechs(mapName, getChildren("tech", current), tf);
       categories.addTechnologyFrontier(tf);
     }
   }
 
-  private void parseRepairFrontiers(final List<Element> elements) throws GameParseException {
+  private void parseRepairFrontiers(final String mapName, final List<Element> elements) throws GameParseException {
     final RepairFrontierList frontiers = data.getRepairFrontierList();
     for (final Element current : elements) {
       final String name = current.getAttribute("name");
       final RepairFrontier frontier = new RepairFrontier(name, data);
-      parseRepairFrontierRules(getChildren("repairRules", current), frontier);
+      parseRepairFrontierRules(mapName, getChildren("repairRules", current), frontier);
       frontiers.addRepairFrontier(frontier);
     }
   }
 
-  private void parsePlayerProduction(final List<Element> elements) throws GameParseException {
+  private void parsePlayerProduction(final String mapName, final List<Element> elements) throws GameParseException {
     for (final Element current : elements) {
-      final PlayerID player = getPlayerID(current, "player", true);
-      final ProductionFrontier frontier = getProductionFrontier(current, "frontier", true);
+      final PlayerID player = getPlayerID(mapName, current, "player", true);
+      final ProductionFrontier frontier = getProductionFrontier(mapName, current, "frontier", true);
       player.setProductionFrontier(frontier);
     }
   }
 
-  private void parsePlayerRepair(final List<Element> elements) throws GameParseException {
+  private void parsePlayerRepair(final String mapName, final List<Element> elements) throws GameParseException {
     for (final Element current : elements) {
-      final PlayerID player = getPlayerID(current, "player", true);
-      final RepairFrontier repairFrontier = getRepairFrontier(current, "frontier", true);
+      final PlayerID player = getPlayerID(mapName, current, "player", true);
+      final RepairFrontier repairFrontier = getRepairFrontier(mapName, current, "frontier", true);
       player.setRepairFrontier(repairFrontier);
     }
   }
 
-  private void parseFrontierRules(final List<Element> elements, final ProductionFrontier frontier)
+  private void parseFrontierRules(final String mapName, final List<Element> elements, final ProductionFrontier frontier)
       throws GameParseException {
     final Iterator<Element> iter = elements.iterator();
     while (iter.hasNext()) {
-      final ProductionRule rule = getProductionRule(iter.next(), "name", true);
+      final ProductionRule rule = getProductionRule(mapName, iter.next(), "name", true);
       frontier.addRule(rule);
     }
   }
@@ -1248,7 +1258,7 @@ public class GameParser {
     }
   }
 
-  private void parseCategoryTechs(final List<Element> elements, final TechnologyFrontier frontier)
+  private void parseCategoryTechs(final String mapName, final List<Element> elements, final TechnologyFrontier frontier)
       throws GameParseException {
     for (final Element current : elements) {
       TechAdvance ta = data.getTechnologyFrontier().getAdvanceByProperty(current.getAttribute("name"));
@@ -1256,77 +1266,77 @@ public class GameParser {
         ta = data.getTechnologyFrontier().getAdvanceByName(current.getAttribute("name"));
       }
       if (ta == null) {
-        throw new GameParseException("Technology not found :" + current.getAttribute("name"));
+        throw new GameParseException(mapName, "Technology not found :" + current.getAttribute("name"));
       }
       frontier.addAdvance(ta);
     }
   }
 
-  private void parseRepairFrontierRules(final List<Element> elements, final RepairFrontier frontier)
+  private void parseRepairFrontierRules(final String mapName, final List<Element> elements, final RepairFrontier frontier)
       throws GameParseException {
     final Iterator<Element> iter = elements.iterator();
     while (iter.hasNext()) {
-      final RepairRule rule = getRepairRule(iter.next(), "name", true);
+      final RepairRule rule = getRepairRule(mapName, iter.next(), "name", true);
       frontier.addRule(rule);
     }
   }
 
-  private void parseAttachments(final Element root) throws GameParseException {
+  private void parseAttachments(String mapName, final Element root) throws GameParseException {
     final HashMap<String, Constructor<?>> constructors = new HashMap<>();
     for (final Element current : getChildren("attachment", root)) {
       // get class name and constructor
       final String className = current.getAttribute("javaClass");
       if (!constructors.containsKey(className)) {
         try {
-          final Class<?> objectClass = getClassByName(className);
+          final Class<?> objectClass = getClassByName(mapName, className);
           if (!IAttachment.class.isAssignableFrom(objectClass)) {
-            throw new GameParseException(className + " does not implement IAttachable");
+            throw new GameParseException(mapName, className + " does not implement IAttachable");
           }
           constructors.put(className, objectClass.getConstructor(IAttachment.attachmentConstructorParameter));
         } catch (final NoSuchMethodException | SecurityException exception) {
-          throw new GameParseException(
+          throw new GameParseException(mapName,
               "Constructor for class " + className + " could not be found: " + exception.getMessage());
         }
       }
       // find the attachable
       final String type = current.getAttribute("type");
-      final Attachable attachable = findAttachment(current, type);
+      final Attachable attachable = findAttachment(mapName, current, type);
       // create new attachment
       final String name = current.getAttribute("name");
       final List<Element> options = getChildren("option", current);
       try {
         final IAttachment attachment = (IAttachment) constructors.get(className).newInstance(name, attachable, data);
         attachable.addAttachment(name, attachment);
-        final ArrayList<Tuple<String, String>> attachmentOptionValues = setValues(attachment, options);
+        final ArrayList<Tuple<String, String>> attachmentOptionValues = setValues(mapName, attachment, options);
         // keep a list of attachment references in the order they were added
         data.addToAttachmentOrderAndValues(
             Tuple.of(attachment, attachmentOptionValues));
       } catch (final InstantiationException | InvocationTargetException | IllegalArgumentException | IllegalAccessException e) {
-        throw new GameParseException(
+        throw new GameParseException(mapName,
             "Attachment of type " + className + " could not be instanciated: " + e.getMessage());
       }
     }
   }
 
-  private Attachable findAttachment(final Element element, final String type) throws GameParseException {
+  private Attachable findAttachment(String mapName, final Element element, final String type) throws GameParseException {
     Attachable returnVal;
     final String name = "attachTo";
     if (type.equals("unitType")) {
-      returnVal = getUnitType(element, name, true);
+      returnVal = getUnitType(mapName, element, name, true);
     } else if (type.equals("territory")) {
-      returnVal = getTerritory(element, name, true);
+      returnVal = getTerritory(mapName, element, name, true);
     } else if (type.equals("resource")) {
-      returnVal = getResource(element, name, true);
+      returnVal = getResource(mapName, element, name, true);
     } else if (type.equals("territoryEffect")) {
-      returnVal = getTerritoryEffect(element, name, true);
+      returnVal = getTerritoryEffect(mapName, element, name, true);
     } else if (type.equals("player")) {
-      returnVal = getPlayerID(element, name, true);
+      returnVal = getPlayerID(mapName, element, name, true);
     } else if (type.equals("relationship")) {
-      returnVal = this.getRelationshipType(element, name, true);
+      returnVal = this.getRelationshipType(mapName, element, name, true);
     } else if (type.equals("technology")) {
-      returnVal = getTechnology(element, name, true);
+      returnVal = getTechnology(mapName, element, name, true);
     } else {
-      throw new GameParseException("Type not found to attach to:" + type);
+      throw new GameParseException(mapName, "Type not found to attach to:" + type);
     }
     return returnVal;
   }
@@ -1337,7 +1347,7 @@ public class GameParser {
     return first + aString.substring(1);
   }
 
-  private static ArrayList<Tuple<String, String>> setValues(final IAttachment attachment, final List<Element> values)
+  private static ArrayList<Tuple<String, String>> setValues(String mapName, final IAttachment attachment, final List<Element> values)
       throws GameParseException {
     final ArrayList<Tuple<String, String>> options = new ArrayList<>();
     for (final Element current : values) {
@@ -1347,11 +1357,11 @@ public class GameParser {
       try {
         name = current.getAttribute("name");
         if (name.length() == 0) {
-          throw new GameParseException("Option name with 0 length");
+          throw new GameParseException(mapName, "Option name with 0 length");
         }
         setter = attachment.getClass().getMethod("set" + capitalizeFirstLetter(name), SETTER_ARGS);
       } catch (final NoSuchMethodException nsme) {
-        throw new GameParseException("The following option name of " + attachment.getName() + " of class "
+        throw new GameParseException(mapName, "The following option name of " + attachment.getName() + " of class "
             + attachment.getClass().getName().substring(attachment.getClass().getName().lastIndexOf('.') + 1)
             + " are either misspelled or exist only in a future version of TripleA. Setter: " + name);
       }
@@ -1369,44 +1379,44 @@ public class GameParser {
         final Object[] args = {itemValues};
         setter.invoke(attachment, args);
       } catch (final IllegalAccessException iae) {
-        throw new GameParseException("Setter not public. Setter:" + name + " Class:" + attachment.getClass().getName());
+        throw new GameParseException(mapName, "Setter not public. Setter:" + name + " Class:" + attachment.getClass().getName());
       } catch (final InvocationTargetException ite) {
         ite.getCause().printStackTrace(System.out);
-        throw new GameParseException("Error setting property:" + name + " cause:" + ite.getCause().getMessage());
+        throw new GameParseException(mapName, "Error setting property:" + name + " cause:" + ite.getCause().getMessage());
       }
       options.add(Tuple.of(name, itemValues));
     }
     return options;
   }
 
-  private void parseInitialization(final Node root) throws GameParseException {
+  private void parseInitialization(final String mapName, final Node root) throws GameParseException {
     // parse territory owners
-    final Node owner = getSingleChild("ownerInitialize", root, true);
+    final Node owner = getSingleChild(mapName, "ownerInitialize", root, true);
     if (owner != null) {
-      parseOwner(getChildren("territoryOwner", owner));
+      parseOwner(mapName, getChildren("territoryOwner", owner));
     }
     // parse initial unit placement
-    final Node unit = getSingleChild("unitInitialize", root, true);
+    final Node unit = getSingleChild(mapName, "unitInitialize", root, true);
     if (unit != null) {
-      parseUnitPlacement(getChildren("unitPlacement", unit));
-      parseHeldUnits(getChildren("heldUnits", unit));
+      parseUnitPlacement(mapName, getChildren("unitPlacement", unit));
+      parseHeldUnits(mapName, getChildren("heldUnits", unit));
     }
     // parse resources given
-    final Node resource = getSingleChild("resourceInitialize", root, true);
+    final Node resource = getSingleChild(mapName, "resourceInitialize", root, true);
     if (resource != null) {
-      parseResourceInitialization(getChildren("resourceGiven", resource));
+      parseResourceInitialization(mapName, getChildren("resourceGiven", resource));
     }
     // parse relationships
-    final Node relationInitialize = getSingleChild("relationshipInitialize", root, true);
+    final Node relationInitialize = getSingleChild(mapName, "relationshipInitialize", root, true);
     if (relationInitialize != null) {
-      parseRelationInitialize(getChildren("relationship", relationInitialize));
+      parseRelationInitialize(mapName, getChildren("relationship", relationInitialize));
     }
   }
 
-  private void parseOwner(final List<Element> elements) throws GameParseException {
+  private void parseOwner(final String mapName, final List<Element> elements) throws GameParseException {
     for (final Element current : elements) {
-      final Territory territory = getTerritory(current, "territory", true);
-      final PlayerID owner = getPlayerID(current, "owner", true);
+      final Territory territory = getTerritory(mapName, current, "territory", true);
+      final PlayerID owner = getPlayerID(mapName, current, "owner", true);
       territory.setOwner(owner);
       // Set the original owner on startup.
       // TODO Look into this
@@ -1431,10 +1441,10 @@ public class GameParser {
     }
   }
 
-  private void parseUnitPlacement(final List<Element> elements) throws GameParseException {
+  private void parseUnitPlacement(final String mapName, final List<Element> elements) throws GameParseException {
     for (final Element current : elements) {
-      final Territory territory = getTerritory(current, "territory", true);
-      final UnitType type = getUnitType(current, "unitType", true);
+      final Territory territory = getTerritory(mapName, current, "territory", true);
+      final UnitType type = getUnitType(mapName, current, "unitType", true);
       final String ownerString = current.getAttribute("owner");
       final String hitsTakenString = current.getAttribute("hitsTaken");
       final String unitDamageString = current.getAttribute("unitDamage");
@@ -1442,13 +1452,13 @@ public class GameParser {
       if (ownerString == null || ownerString.trim().length() == 0) {
         owner = PlayerID.NULL_PLAYERID;
       } else {
-        owner = getPlayerID(current, "owner", false);
+        owner = getPlayerID(mapName, current, "owner", false);
       }
       final int hits;
       if (hitsTakenString != null && hitsTakenString.trim().length() > 0) {
         hits = Integer.parseInt(hitsTakenString);
         if (hits < 0 || hits > UnitAttachment.get(type).getHitPoints() - 1) {
-          throw new GameParseException(
+          throw new GameParseException(mapName,
               "hitsTaken cannot be less than zero or greater than one less than total hitpPoints");
         }
       } else {
@@ -1458,7 +1468,7 @@ public class GameParser {
       if (unitDamageString != null && unitDamageString.trim().length() > 0) {
         unitDamage = Integer.parseInt(unitDamageString);
         if (unitDamage < 0) {
-          throw new GameParseException("unitDamage cannot be less than zero");
+          throw new GameParseException(mapName, "unitDamage cannot be less than zero");
         }
       } else {
         unitDamage = 0;
@@ -1468,19 +1478,19 @@ public class GameParser {
     }
   }
 
-  private void parseHeldUnits(final List<Element> elements) throws GameParseException {
+  private void parseHeldUnits(final String mapName, final List<Element> elements) throws GameParseException {
     for (final Element current : elements) {
-      final PlayerID player = getPlayerID(current, "player", true);
-      final UnitType type = getUnitType(current, "unitType", true);
+      final PlayerID player = getPlayerID(mapName, current, "player", true);
+      final UnitType type = getUnitType(mapName, current, "unitType", true);
       final int quantity = Integer.parseInt(current.getAttribute("quantity"));
       player.getUnits().addAllUnits(type.create(quantity, player));
     }
   }
 
-  private void parseResourceInitialization(final List<Element> elements) throws GameParseException {
+  private void parseResourceInitialization(final String mapName, final List<Element> elements) throws GameParseException {
     for (final Element current : elements) {
-      final PlayerID player = getPlayerID(current, "player", true);
-      final Resource resource = getResource(current, "resource", true);
+      final PlayerID player = getPlayerID(mapName, current, "player", true);
+      final Resource resource = getResource(mapName, current, "resource", true);
       final int quantity = Integer.parseInt(current.getAttribute("quantity"));
       player.getResources().addResource(resource, quantity);
     }
@@ -1495,7 +1505,7 @@ public class GameParser {
       }
     }
     if (!errors.isEmpty()) {
-      throw new GameParseException(
+      throw new GameParseException(data,
           data.getGameName() + " does not have unit attachments for: " + MyFormatter.defaultNamedToTextList(errors));
     }
   }

--- a/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -33,7 +33,7 @@ public class GameSelectorModel extends Observable {
   /** Returns the folder where maps are held, example: "/maps" */
   public static final File DEFAULT_MAP_DIRECTORY = new File(ClientFileSystemHelper.getRootFolder(), "maps");
   private static final String DEFAULT_GAME_NAME_PREF = "DefaultGameName2";
-  private static final String DEFAULT_GAME_NAME = "Big World : 1942";
+  private static final String DEFAULT_GAME_NAME = "Tutorial";
   private static final String DEFAULT_GAME_URI_PREF = "DefaultGameURI";
   private static final String DEFAULT_GAME_URI = "";
   private GameData m_data = null;
@@ -326,7 +326,7 @@ public class GameSelectorModel extends Observable {
     final String userPreferredDefaultGameName =
         (forceFactoryDefault ? DEFAULT_GAME_NAME : prefs.get(DEFAULT_GAME_NAME_PREF, DEFAULT_GAME_NAME));
     final NewGameChooserModel model = NewGameChooser.getNewGameChooserModel();
-    selectedGame = model.findByName(userPreferredDefaultGameName);
+//    selectedGame = model.findByName(userPreferredDefaultGameName);
     if (selectedGame == null) {
       selectedGame = model.findByName(DEFAULT_GAME_NAME);
     }

--- a/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -326,7 +326,7 @@ public class GameSelectorModel extends Observable {
     final String userPreferredDefaultGameName =
         (forceFactoryDefault ? DEFAULT_GAME_NAME : prefs.get(DEFAULT_GAME_NAME_PREF, DEFAULT_GAME_NAME));
     final NewGameChooserModel model = NewGameChooser.getNewGameChooserModel();
-//    selectedGame = model.findByName(userPreferredDefaultGameName);
+    selectedGame = model.findByName(userPreferredDefaultGameName);
     if (selectedGame == null) {
       selectedGame = model.findByName(DEFAULT_GAME_NAME);
     }

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -76,15 +76,15 @@ public class NewGameChooserEntry {
 
     } catch (final EngineVersionException e) {
       ClientLogger.logQuietly(e);
-      throw new GameParseException(e.getMessage());
+      throw new GameParseException(m_url.toString(), e.getMessage());
     } catch (final SAXParseException e) {
       String msg = "Could not parse:" + m_url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber();
       ClientLogger.logError(msg, e);
-      throw new GameParseException(e.getMessage());
+      throw new GameParseException(m_url.toString(), e.getMessage());
     } catch (final Exception e) {
       String msg = "Could not parse:" + m_url;
       ClientLogger.logError(msg, e);
-      throw new GameParseException(e.getMessage());
+      throw new GameParseException(m_url.toString(), e.getMessage());
     }
   }
 

--- a/src/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/src/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -69,7 +69,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
         }
       }
       if (condition == null) {
-        throw new GameParseException("Could not find rule. name:" + subString + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find rule. name:" + subString + thisErrorMsg());
       }
       if (m_conditions == null) {
         m_conditions = new ArrayList<>();
@@ -133,19 +133,19 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
       final String[] nums = s.split("-");
       if (nums.length == 1) {
         if (Integer.parseInt(nums[0]) < 0) {
-          throw new GameParseException(
+          throw new GameParseException(getData(),
               "conditionType must be equal to 'AND' or 'OR' or 'XOR' or 'y' or 'y-z' where Y and Z are valid positive integers and Z is greater than Y"
                   + thisErrorMsg());
         }
       } else if (nums.length == 2) {
         if (Integer.parseInt(nums[0]) < 0 || Integer.parseInt(nums[1]) < 0
             || !(Integer.parseInt(nums[0]) < Integer.parseInt(nums[1]))) {
-          throw new GameParseException(
+          throw new GameParseException(getData(),
               "conditionType must be equal to 'AND' or 'OR' or 'XOR' or 'y' or 'y-z' where Y and Z are valid positive integers and Z is greater than Y"
                   + thisErrorMsg());
         }
       } else {
-        throw new GameParseException(
+        throw new GameParseException(getData(),
             "conditionType must be equal to 'AND' or 'OR' or 'XOR' or 'y' or 'y-z' where Y and Z are valid positive integers and Z is greater than Y"
                 + thisErrorMsg());
       }
@@ -313,12 +313,12 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
       final int i = getInt(s[0]);
       final int j = getInt(s[1]);
       if (i > j || i < 0 || j < 0 || i > 120 || j > 120) {
-        throw new GameParseException(
+        throw new GameParseException(getData(),
             "chance should have a format of \"x:y\" where x is <= y and both x and y are >=0 and <=120"
                 + thisErrorMsg());
       }
     } catch (final IllegalArgumentException iae) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "Invalid chance declaration: " + chance + " format: \"1:10\" for 10% chance" + thisErrorMsg());
     }
     m_chance = chance;

--- a/src/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/src/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -104,7 +104,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
       return;
     }
     if (!(value.equals("disallowed") || value.equals("allowed"))) {
-      throw new GameParseException("movementRestrictionType must be allowed or disallowed" + thisErrorMsg());
+      throw new GameParseException(getData(), "movementRestrictionType must be allowed or disallowed" + thisErrorMsg());
     }
     m_movementRestrictionType = value;
   }
@@ -127,7 +127,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   public void setProductionPerXTerritories(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "productionPerXTerritories cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitTypeToProduce;
@@ -139,11 +139,11 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeToProduce);
     if (ut == null) {
-      throw new GameParseException("No unit called: " + unitTypeToProduce + thisErrorMsg());
+      throw new GameParseException(getData(), "No unit called: " + unitTypeToProduce + thisErrorMsg());
     }
     final int n = getInt(s[0]);
     if (n <= 0) {
-      throw new GameParseException("productionPerXTerritories must be a positive integer" + thisErrorMsg());
+      throw new GameParseException(getData(), "productionPerXTerritories must be a positive integer" + thisErrorMsg());
     }
     m_productionPerXTerritories.put(ut, n);
   }

--- a/src/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -65,7 +65,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     for (final String p : names.split(":")) {
       final PlayerID player = pl.getPlayerID(p);
       if (player == null) {
-        throw new GameParseException("Could not find player. name:" + p + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find player. name:" + p + thisErrorMsg());
       }
       m_players.add(player);
     }
@@ -95,7 +95,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   @Override
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setChance(final String chance) throws GameParseException {
-    throw new GameParseException(
+    throw new GameParseException(getData(),
         "chance not allowed for use with RulesAttachments, instead use it with Triggers or PoliticalActions"
             + thisErrorMsg());
   }
@@ -225,7 +225,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     m_turns = new HashMap<>();
     final String[] s = turns.split(":");
     if (s.length < 1) {
-      throw new GameParseException("Empty turn list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty turn list" + thisErrorMsg());
     }
     for (final String subString : s) {
       int start, end;
@@ -235,7 +235,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
       } catch (final Exception e) {
         final String[] s2 = subString.split("-");
         if (s2.length != 2) {
-          throw new GameParseException("Invalid syntax for turn range, must be 'int-int'" + thisErrorMsg());
+          throw new GameParseException(getData(), "Invalid syntax for turn range, must be 'int-int'" + thisErrorMsg());
         }
         start = getInt(s2[0]);
         if (s2[1].equals("+")) {

--- a/src/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/src/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -147,10 +147,10 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   public void setWhen(final String when) throws GameParseException {
     final String[] s = when.split(":");
     if (s.length != 2) {
-      throw new GameParseException("when must exist in 2 parts: \"before/after:stepName\"." + thisErrorMsg());
+      throw new GameParseException(getData(), "when must exist in 2 parts: \"before/after:stepName\"." + thisErrorMsg());
     }
     if (!(s[0].equals(AFTER) || s[0].equals(BEFORE))) {
-      throw new GameParseException("when must start with: " + BEFORE + " or " + AFTER + thisErrorMsg());
+      throw new GameParseException(getData(), "when must start with: " + BEFORE + " or " + AFTER + thisErrorMsg());
     }
     m_when.add(Tuple.of(s[0], s[1]));
   }
@@ -324,7 +324,7 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   public void validate(final GameData data) throws GameParseException {
     super.validate(data);
     if (m_conditions == null) {
-      throw new GameParseException("must contain at least one condition: " + thisErrorMsg());
+      throw new GameParseException(getData(), "must contain at least one condition: " + thisErrorMsg());
     }
   }
 }

--- a/src/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/src/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -118,7 +118,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
       if (tempPlayer != null) {
         m_actionAccept.add(tempPlayer);
       } else {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
   }
@@ -214,7 +214,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   public void validate(final GameData data) throws GameParseException {
     super.validate(data);
     if (m_text.trim().length() <= 0) {
-      throw new GameParseException("value: text can't be empty" + thisErrorMsg());
+      throw new GameParseException(getData(), "value: text can't be empty" + thisErrorMsg());
     }
   }
 }

--- a/src/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/src/games/strategy/triplea/attachments/CanalAttachment.java
@@ -173,10 +173,11 @@ public class CanalAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameData data) throws GameParseException {
     if (m_canalName == null) {
-      throw new GameParseException("Canals must have a canalName set!" + thisErrorMsg());
+      throw new GameParseException(data, "Canals must have a canalName set!" + thisErrorMsg());
     }
     if (m_landTerritories == null || m_landTerritories.size() == 0) {
-      throw new GameParseException("Canal named " + m_canalName + " must have landTerritories set!" + thisErrorMsg());
+      throw new GameParseException(data,
+          "Canal named " + m_canalName + " must have landTerritories set!" + thisErrorMsg());
     }
   }
 }

--- a/src/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/src/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -89,14 +89,14 @@ public class PlayerAttachment extends DefaultAttachment {
   public void setPlacementLimit(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 3) {
-      throw new GameParseException("placementLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
+      throw new GameParseException(getData(), "placementLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
     }
     final int max = getInt(s[0]);
     if (max < 0) {
-      throw new GameParseException("placementLimit count must have a positive number" + thisErrorMsg());
+      throw new GameParseException(getData(), "placementLimit count must have a positive number" + thisErrorMsg());
     }
     if (!(s[1].equals("owned") || s[1].equals("allied") || s[1].equals("total"))) {
-      throw new GameParseException("placementLimit type must be: owned, allied, or total" + thisErrorMsg());
+      throw new GameParseException(getData(), "placementLimit type must be: owned, allied, or total" + thisErrorMsg());
     }
     final HashSet<UnitType> types = new HashSet<>();
     if (s[2].equalsIgnoreCase("all")) {
@@ -105,7 +105,7 @@ public class PlayerAttachment extends DefaultAttachment {
       for (int i = 2; i < s.length; i++) {
         final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
         if (ut == null) {
-          throw new GameParseException("No unit called: " + s[i] + thisErrorMsg());
+          throw new GameParseException(getData(), "No unit called: " + s[i] + thisErrorMsg());
         } else {
           types.add(ut);
         }
@@ -141,14 +141,14 @@ public class PlayerAttachment extends DefaultAttachment {
   public void setMovementLimit(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 3) {
-      throw new GameParseException("movementLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
+      throw new GameParseException(getData(), "movementLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
     }
     final int max = getInt(s[0]);
     if (max < 0) {
-      throw new GameParseException("movementLimit count must have a positive number" + thisErrorMsg());
+      throw new GameParseException(getData(), "movementLimit count must have a positive number" + thisErrorMsg());
     }
     if (!(s[1].equals("owned") || s[1].equals("allied") || s[1].equals("total"))) {
-      throw new GameParseException("movementLimit type must be: owned, allied, or total" + thisErrorMsg());
+      throw new GameParseException(getData(), "movementLimit type must be: owned, allied, or total" + thisErrorMsg());
     }
     final HashSet<UnitType> types = new HashSet<>();
     if (s[2].equalsIgnoreCase("all")) {
@@ -157,7 +157,7 @@ public class PlayerAttachment extends DefaultAttachment {
       for (int i = 2; i < s.length; i++) {
         final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
         if (ut == null) {
-          throw new GameParseException("No unit called: " + s[i] + thisErrorMsg());
+          throw new GameParseException(getData(), "No unit called: " + s[i] + thisErrorMsg());
         } else {
           types.add(ut);
         }
@@ -193,14 +193,14 @@ public class PlayerAttachment extends DefaultAttachment {
   public void setAttackingLimit(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 3) {
-      throw new GameParseException("attackingLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
+      throw new GameParseException(getData(), "attackingLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
     }
     final int max = getInt(s[0]);
     if (max < 0) {
-      throw new GameParseException("attackingLimit count must have a positive number" + thisErrorMsg());
+      throw new GameParseException(getData(), "attackingLimit count must have a positive number" + thisErrorMsg());
     }
     if (!(s[1].equals("owned") || s[1].equals("allied") || s[1].equals("total"))) {
-      throw new GameParseException("attackingLimit type must be: owned, allied, or total" + thisErrorMsg());
+      throw new GameParseException(getData(), "attackingLimit type must be: owned, allied, or total" + thisErrorMsg());
     }
     final HashSet<UnitType> types = new HashSet<>();
     if (s[2].equalsIgnoreCase("all")) {
@@ -209,7 +209,7 @@ public class PlayerAttachment extends DefaultAttachment {
       for (int i = 2; i < s.length; i++) {
         final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
         if (ut == null) {
-          throw new GameParseException("No unit called: " + s[i] + thisErrorMsg());
+          throw new GameParseException(getData(), "No unit called: " + s[i] + thisErrorMsg());
         } else {
           types.add(ut);
         }
@@ -301,7 +301,7 @@ public class PlayerAttachment extends DefaultAttachment {
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
-        throw new GameParseException("suicideAttackTargets: no such unit called " + u + thisErrorMsg());
+        throw new GameParseException(getData(), "suicideAttackTargets: no such unit called " + u + thisErrorMsg());
       }
       m_suicideAttackTargets.add(ut);
     }
@@ -334,15 +334,15 @@ public class PlayerAttachment extends DefaultAttachment {
   public void setSuicideAttackResources(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
-      throw new GameParseException("suicideAttackResources must have exactly 2 fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "suicideAttackResources must have exactly 2 fields" + thisErrorMsg());
     }
     final int attackValue = getInt(s[0]);
     if (attackValue < 0) {
-      throw new GameParseException("suicideAttackResources attack value must be positive" + thisErrorMsg());
+      throw new GameParseException(getData(), "suicideAttackResources attack value must be positive" + thisErrorMsg());
     }
     final Resource r = getData().getResourceList().getResource(s[1]);
     if (r == null) {
-      throw new GameParseException("no such resource: " + s[1] + thisErrorMsg());
+      throw new GameParseException(getData(), "no such resource: " + s[1] + thisErrorMsg());
     }
     m_suicideAttackResources.put(r, attackValue);
   }
@@ -452,7 +452,7 @@ public class PlayerAttachment extends DefaultAttachment {
       } else if (name.equalsIgnoreCase("true") || name.equalsIgnoreCase("false")) {
         m_giveUnitControl.clear();
       } else {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
   }
@@ -488,7 +488,7 @@ public class PlayerAttachment extends DefaultAttachment {
       if (tempPlayer != null) {
         m_captureUnitOnEnteringBy.add(tempPlayer);
       } else {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
   }
@@ -524,7 +524,7 @@ public class PlayerAttachment extends DefaultAttachment {
       if (tempPlayer != null) {
         m_shareTechnology.add(tempPlayer);
       } else {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
   }
@@ -560,7 +560,7 @@ public class PlayerAttachment extends DefaultAttachment {
       if (tempPlayer != null) {
         m_helpPayTechCost.add(tempPlayer);
       } else {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
   }

--- a/src/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/src/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -87,19 +87,19 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   public void setRelationshipChange(final String relChange) throws GameParseException {
     final String[] s = relChange.split(":");
     if (s.length != 3) {
-      throw new GameParseException("Invalid relationshipChange declaration: " + relChange
+      throw new GameParseException(getData(), "Invalid relationshipChange declaration: " + relChange
           + " \n Use: player1:player2:newRelation\n" + thisErrorMsg());
     }
     if (getData().getPlayerList().getPlayerID(s[0]) == null) {
-      throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n player: " + s[0]
+      throw new GameParseException(getData(), "Invalid relationshipChange declaration: " + relChange + " \n player: " + s[0]
           + " unknown in: " + getName() + thisErrorMsg());
     }
     if (getData().getPlayerList().getPlayerID(s[1]) == null) {
-      throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n player: " + s[1]
+      throw new GameParseException(getData(), "Invalid relationshipChange declaration: " + relChange + " \n player: " + s[1]
           + " unknown in: " + getName() + thisErrorMsg());
     }
     if (!Matches.isValidRelationshipName(getData()).match(s[2])) {
-      throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n relationshipType: "
+      throw new GameParseException(getData(), "Invalid relationshipChange declaration: " + relChange + " \n relationshipType: "
           + s[2] + " unknown in: " + getName() + thisErrorMsg());
     }
     m_relationshipChange.add(relChange);
@@ -155,7 +155,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   public void validate(final GameData data) throws GameParseException {
     super.validate(data);
     if (m_relationshipChange.isEmpty()) {
-      throw new GameParseException("value: relationshipChange can't be empty" + thisErrorMsg());
+      throw new GameParseException(getData(), "value: relationshipChange can't be empty" + thisErrorMsg());
     }
   }
 }

--- a/src/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/src/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -89,7 +89,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     } else if (archeType.toLowerCase().equals(ARCHETYPE_NEUTRAL)) {
       m_archeType = ARCHETYPE_NEUTRAL;
     } else {
-      throw new GameParseException("archeType must be " + ARCHETYPE_WAR + "," + ARCHETYPE_ALLIED + " or "
+      throw new GameParseException(getData(), "archeType must be " + ARCHETYPE_WAR + "," + ARCHETYPE_ALLIED + " or "
           + ARCHETYPE_NEUTRAL + " for " + thisErrorMsg());
     }
   }
@@ -195,17 +195,17 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     } else {
       final String[] s = integerCost.split(":");
       if (s.length < 1 || s.length > 2) {
-        throw new GameParseException("upkeepCost must have either 1 or 2 fields" + thisErrorMsg());
+        throw new GameParseException(getData(), "upkeepCost must have either 1 or 2 fields" + thisErrorMsg());
       }
       final int cost = getInt(s[0]);
       if (s.length == 2) {
         if (s[1].equals(UPKEEP_FLAT)) {
         } else if (s[1].equals(UPKEEP_PERCENTAGE)) {
           if (cost > 100) {
-            throw new GameParseException("upkeepCost may not have a percentage greater than 100" + thisErrorMsg());
+            throw new GameParseException(getData(), "upkeepCost may not have a percentage greater than 100" + thisErrorMsg());
           }
         } else {
-          throw new GameParseException(
+          throw new GameParseException(getData(),
               "upkeepCost must have either: " + UPKEEP_FLAT + " or " + UPKEEP_PERCENTAGE + thisErrorMsg());
         }
       }
@@ -227,7 +227,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setAlliancesCanChainTogether(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
-      throw new GameParseException("alliancesCanChainTogether must be either " + PROPERTY_DEFAULT + " or "
+      throw new GameParseException(getData(), "alliancesCanChainTogether must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
     m_alliancesCanChainTogether = value;
@@ -247,7 +247,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setIsDefaultWarPosition(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
-      throw new GameParseException("isDefaultWarPosition must be either " + PROPERTY_DEFAULT + " or " + PROPERTY_FALSE
+      throw new GameParseException(getData(), "isDefaultWarPosition must be either " + PROPERTY_DEFAULT + " or " + PROPERTY_FALSE
           + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
     m_isDefaultWarPosition = value;
@@ -267,7 +267,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setGivesBackOriginalTerritories(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
-      throw new GameParseException("givesBackOriginalTerritories must be either " + PROPERTY_DEFAULT + " or "
+      throw new GameParseException(getData(), "givesBackOriginalTerritories must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
     m_givesBackOriginalTerritories = value;
@@ -287,7 +287,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setCanMoveIntoDuringCombatMove(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
-      throw new GameParseException("canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
+      throw new GameParseException(getData(), "canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
     m_canMoveIntoDuringCombatMove = value;
@@ -308,7 +308,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setCanMoveThroughCanals(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
-      throw new GameParseException("canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
+      throw new GameParseException(getData(), "canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
     m_canMoveThroughCanals = value;
@@ -329,7 +329,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setRocketsCanFlyOver(final String value) throws GameParseException {
     if (!(value.equals(PROPERTY_DEFAULT) || value.equals(PROPERTY_FALSE) || value.equals(PROPERTY_TRUE))) {
-      throw new GameParseException("canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
+      throw new GameParseException(getData(), "canMoveIntoDuringCombatMove must be either " + PROPERTY_DEFAULT + " or "
           + PROPERTY_FALSE + " or " + PROPERTY_TRUE + thisErrorMsg());
     }
     m_rocketsCanFlyOver = value;

--- a/src/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/games/strategy/triplea/attachments/RulesAttachment.java
@@ -157,17 +157,17 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     }
     final String[] s = value.split(":");
     if (s.length != 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "destroyedTUV must have 2 fields, value=currentRound/allRounds, count= the amount of TUV that this player must destroy"
               + thisErrorMsg());
     }
     final int i = getInt(s[0]);
     if (i < -1) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "destroyedTUV count cannot be less than -1 [with -1 meaning the condition is not active]" + thisErrorMsg());
     }
     if (!(s[1].equals("currentRound") || s[1].equals("allRounds"))) {
-      throw new GameParseException("destroyedTUV value must be currentRound or allRounds" + thisErrorMsg());
+      throw new GameParseException(getData(), "destroyedTUV value must be currentRound or allRounds" + thisErrorMsg());
     }
     m_destroyedTUV = value;
   }
@@ -187,26 +187,27 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   public void setBattle(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 5) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "battle must have at least 5 fields, attacker:defender:resultType:round:territory1..." + thisErrorMsg());
     }
     final PlayerID attacker = getData().getPlayerList().getPlayerID(s[0]);
     if (attacker == null && !s[0].equalsIgnoreCase("any")) {
-      throw new GameParseException("no player named: " + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "no player named: " + s[0] + thisErrorMsg());
     }
     final PlayerID defender = getData().getPlayerList().getPlayerID(s[1]);
     if (defender == null && !s[1].equalsIgnoreCase("any")) {
-      throw new GameParseException("no player named: " + s[1] + thisErrorMsg());
+      throw new GameParseException(getData(), "no player named: " + s[1] + thisErrorMsg());
     }
     if (!s[2].equalsIgnoreCase("any")) {
-      throw new GameParseException("battle allows the following for resultType: any" + thisErrorMsg());
+      throw new GameParseException(getData(), "battle allows the following for resultType: any" + thisErrorMsg());
     }
     if (!s[3].equalsIgnoreCase("currentRound")) {
       try {
         getInt(s[3].split("-")[0]);
         getInt(s[3].split("-")[1]);
       } catch (final Exception e) {
-        throw new GameParseException("round must either be currentRound or two numbers like: 2-4" + thisErrorMsg());
+        throw new GameParseException(getData(),
+            "round must either be currentRound or two numbers like: 2-4" + thisErrorMsg());
       }
     }
     final ArrayList<Territory> terrs = new ArrayList<>();
@@ -215,7 +216,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     for (int i = 4; i < s.length; i++) {
       final Territory t = map.getTerritory(s[i]);
       if (t == null) {
-        throw new GameParseException("no such territory called: " + s[i] + thisErrorMsg());
+        throw new GameParseException(getData(), "no such territory called: " + s[i] + thisErrorMsg());
       }
       terrs.add(t);
     }
@@ -249,27 +250,27 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   public void setRelationship(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 3 || s.length > 4) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "relationship should have value=\"playername1:playername2:relationshiptype:numberOfRoundsExisting\""
               + thisErrorMsg());
     }
     if (getData().getPlayerList().getPlayerID(s[0]) == null) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "playername: " + s[0] + " isn't valid in condition with relationship: " + value + thisErrorMsg());
     }
     if (getData().getPlayerList().getPlayerID(s[1]) == null) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "playername: " + s[1] + " isn't valid in condition with relationship: " + value + thisErrorMsg());
     }
     if (!(s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_ALLIED)
         || s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_NEUTRAL)
         || s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_WAR)
         || Matches.isValidRelationshipName(getData()).match(s[2]))) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "relationship: " + s[2] + " isn't valid in condition with relationship: " + value + thisErrorMsg());
     }
     if (s.length == 4 && Integer.parseInt(s[3]) < -1) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "numberOfRoundsExisting should be a number between -1 and 100000.  -1 should be default value if you don't know what to put"
               + thisErrorMsg());
     }
@@ -513,20 +514,20 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   public void setUnitPresence(String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 1) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "unitPresence must have at least 2 fields. Format value=unit1 count=number, or value=unit1:unit2:unit3 count=number"
               + thisErrorMsg());
     }
     final int n = getInt(s[0]);
     if (n < 0) {
-      throw new GameParseException("unitPresence must be a positive integer" + thisErrorMsg());
+      throw new GameParseException(getData(), "unitPresence must be a positive integer" + thisErrorMsg());
     }
     for (int i = 1; i < s.length; i++) {
       final String unitTypeToProduce = s[i];
       // validate that this unit exists in the xml
       final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeToProduce);
       if (ut == null && !(unitTypeToProduce.equals("any") || unitTypeToProduce.equals("ANY"))) {
-        throw new GameParseException("No unit called: " + unitTypeToProduce + thisErrorMsg());
+        throw new GameParseException(getData(), "No unit called: " + unitTypeToProduce + thisErrorMsg());
       }
     }
     value = value.replaceFirst(s[0] + ":", "");
@@ -567,7 +568,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     final String[] s = players.split(":");
     int count = -1;
     if (s.length < 1) {
-      throw new GameParseException("Empty enemy list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty enemy list" + thisErrorMsg());
     }
     try {
       count = getInt(s[0]);
@@ -576,13 +577,13 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_atWarCount = 0;
     }
     if (s.length < 1 || s.length == 1 && count != -1) {
-      throw new GameParseException("Empty enemy list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty enemy list" + thisErrorMsg());
     }
     m_atWarPlayers = new HashSet<>();
     for (int i = count == -1 ? 0 : 1; i < s.length; i++) {
       final PlayerID player = getData().getPlayerList().getPlayerID(s[i]);
       if (player == null) {
-        throw new GameParseException("Could not find player. name:" + s[i] + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find player. name:" + s[i] + thisErrorMsg());
       }
       m_atWarPlayers.add(player);
     }
@@ -610,7 +611,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     final String[] s = newTechs.split(":");
     int count = -1;
     if (s.length < 1) {
-      throw new GameParseException("Empty tech list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty tech list" + thisErrorMsg());
     }
     try {
       count = getInt(s[0]);
@@ -619,7 +620,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       m_techCount = 0;
     }
     if (s.length < 1 || s.length == 1 && count != -1) {
-      throw new GameParseException("Empty tech list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty tech list" + thisErrorMsg());
     }
     m_techs = new ArrayList<>();
     for (int i = count == -1 ? 0 : 1; i < s.length; i++) {
@@ -628,7 +629,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         ta = getData().getTechnologyFrontier().getAdvanceByName(s[i]);
       }
       if (ta == null) {
-        throw new GameParseException("Technology not found :" + Arrays.toString(s) + thisErrorMsg());
+        throw new GameParseException(getData(), "Technology not found :" + Arrays.toString(s) + thisErrorMsg());
       }
       m_techs.add(ta);
     }

--- a/src/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -101,8 +101,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
   private IntegerMap<UnitType> m_defenseRollsBonus = new IntegerMap<>();
   private IntegerMap<UnitType> m_bombingBonus = new IntegerMap<>();
 
+  private final String mapName;
+
   public TechAbilityAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
+    mapName = gameData.getGameName();
   }
 
   // setters and getters
@@ -113,14 +116,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAttackBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("attackBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "attackBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -151,14 +154,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setDefenseBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("defenseBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "defenseBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -189,14 +192,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setMovementBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("movementBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "movementBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -227,14 +230,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setRadarBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("radarBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "radarBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -265,14 +268,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAirAttackBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("airAttackBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "airAttackBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -303,14 +306,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAirDefenseBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("airDefenseBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "airDefenseBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -338,17 +341,17 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setProductionBonus(final String value) throws GameParseException {
+  public void setProductionBonus(final String mapName, final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("productionBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "productionBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -373,10 +376,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMinimumTerritoryValueForProductionBonus(final String value) throws GameParseException {
+  public void setMinimumTerritoryValueForProductionBonus(final String mapName, final String value)
+      throws GameParseException {
     final int v = getInt(value);
     if ((v != -1) && (v < 0 || v > 10000)) {
-      throw new GameParseException(
+      throw new GameParseException(mapName,
           "minimumTerritoryValueForProductionBonus must be -1 (no effect), or be between 0 and 10000" + thisErrorMsg());
     }
     m_minimumTerritoryValueForProductionBonus = v;
@@ -396,10 +400,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setRepairDiscount(final String value) throws GameParseException {
+  public void setRepairDiscount(final String mapName, final String value) throws GameParseException {
     final int v = getInt(value);
     if ((v != -1) && (v < 0 || v > 100)) {
-      throw new GameParseException("m_repairDiscount must be -1 (no effect), or be between 0 and 100" + thisErrorMsg());
+      throw new GameParseException(mapName,
+          "m_repairDiscount must be -1 (no effect), or be between 0 and 100" + thisErrorMsg());
     }
     m_repairDiscount = v;
   }
@@ -421,7 +426,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setWarBondDiceSides(final String value) throws GameParseException {
     final int v = getInt(value);
     if ((v != -1) && (v < 0 || v > 200)) {
-      throw new GameParseException("warBondDiceSides must be -1 (no effect), or be between 0 and 200" + thisErrorMsg());
+      throw new GameParseException(mapName, "warBondDiceSides must be -1 (no effect), or be between 0 and 200" + thisErrorMsg());
     }
     m_warBondDiceSides = v;
   }
@@ -443,7 +448,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setWarBondDiceNumber(final String value) throws GameParseException {
     final int v = getInt(value);
     if (v < 0 || v > 100) {
-      throw new GameParseException("warBondDiceNumber must be between 0 and 100" + thisErrorMsg());
+      throw new GameParseException(mapName, "warBondDiceNumber must be between 0 and 100" + thisErrorMsg());
     }
     m_warBondDiceNumber = v;
   }
@@ -468,14 +473,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setRocketDiceNumber(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
-      throw new GameParseException("rocketDiceNumber must have two fields" + thisErrorMsg());
+      throw new GameParseException(mapName, "rocketDiceNumber must have two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -503,7 +508,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setRocketDistance(final String value) throws GameParseException {
     final int v = getInt(value);
     if (v < 0 || v > 100) {
-      throw new GameParseException("rocketDistance must be between 0 and 100" + thisErrorMsg());
+      throw new GameParseException(mapName, "rocketDistance must be between 0 and 100" + thisErrorMsg());
     }
     m_rocketDistance = v;
   }
@@ -525,7 +530,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setRocketNumberPerTerritory(final String value) throws GameParseException {
     final int v = getInt(value);
     if (v < 0 || v > 200) {
-      throw new GameParseException("rocketNumberPerTerritory must be between 0 and 200" + thisErrorMsg());
+      throw new GameParseException(mapName, "rocketNumberPerTerritory must be between 0 and 200" + thisErrorMsg());
     }
     m_rocketNumberPerTerritory = v;
   }
@@ -550,7 +555,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setUnitAbilitiesGained(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 2) {
-      throw new GameParseException(
+      throw new GameParseException(mapName,
           "unitAbilitiesGained must list the unit type, then all abilities gained" + thisErrorMsg());
     }
     String unitType;
@@ -558,7 +563,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
     }
     HashSet<String> abilities = m_unitAbilitiesGained.get(ut);
     if (abilities == null) {
@@ -568,7 +573,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     for (int i = 1; i < s.length; i++) {
       final String ability = s[i];
       if (!(ability.equals(ABILITY_CAN_BLITZ) || ability.equals(ABILITY_CAN_BOMBARD))) {
-        throw new GameParseException("unitAbilitiesGained so far only supports: " + ABILITY_CAN_BLITZ + " and "
+        throw new GameParseException(mapName, "unitAbilitiesGained so far only supports: " + ABILITY_CAN_BLITZ + " and "
             + ABILITY_CAN_BOMBARD + thisErrorMsg());
       }
       abilities.add(ability);
@@ -618,14 +623,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAirborneCapacity(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("airborneCapacity cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(mapName, "airborneCapacity cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -658,7 +663,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
-        throw new GameParseException("airborneTypes: no such unit type: " + u + thisErrorMsg());
+        throw new GameParseException(mapName, "airborneTypes: no such unit type: " + u + thisErrorMsg());
       }
       m_airborneTypes.add(ut);
     }
@@ -685,7 +690,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAirborneDistance(final String value) throws GameParseException {
     final int v = getInt(value);
     if (v < 0 || v > 100) {
-      throw new GameParseException("airborneDistance must be between 0 and 100" + thisErrorMsg());
+      throw new GameParseException(mapName, "airborneDistance must be between 0 and 100" + thisErrorMsg());
     }
     m_airborneDistance = v;
   }
@@ -712,7 +717,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
-        throw new GameParseException("airborneBases: no such unit type: " + u + thisErrorMsg());
+        throw new GameParseException(mapName, "airborneBases: no such unit type: " + u + thisErrorMsg());
       }
       m_airborneBases.add(ut);
     }
@@ -742,14 +747,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAirborneTargettedByAA(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 2) {
-      throw new GameParseException("airborneTargettedByAA must have at least two fields" + thisErrorMsg());
+      throw new GameParseException(mapName, "airborneTargettedByAA must have at least two fields" + thisErrorMsg());
     }
     final String aaType = s[0];
     final HashSet<UnitType> unitTypes = new HashSet<>();
     for (int i = 1; i < s.length; i++) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
       if (ut == null) {
-        throw new GameParseException("airborneTargettedByAA: no such unit type: " + s[i] + thisErrorMsg());
+        throw new GameParseException(mapName, "airborneTargettedByAA: no such unit type: " + s[i] + thisErrorMsg());
       }
       unitTypes.add(ut);
     }
@@ -780,14 +785,15 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAttackRollsBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("attackRollsBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(mapName,
+          "attackRollsBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -818,14 +824,15 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setDefenseRollsBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("defenseRollsBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(mapName,
+          "defenseRollsBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -856,14 +863,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setBombingBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("bombingBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(mapName, "bombingBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -1287,10 +1294,10 @@ public class TechAbilityAttachment extends DefaultAttachment {
           final List<UnitType> allFactories =
               Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeCanProduceUnits);
           for (final UnitType factory : allFactories) {
-            taa.setProductionBonus("2:" + factory.getName());
-            taa.setMinimumTerritoryValueForProductionBonus("3");
+            taa.setProductionBonus(data.getGameName(), "2:" + factory.getName());
+            taa.setMinimumTerritoryValueForProductionBonus(data.getGameName(), "3");
             // means a 50% discount, which is half price
-            taa.setRepairDiscount("50");
+            taa.setRepairDiscount(data.getGameName(), "50");
           }
         } else if (propertyString.equals(TechAdvance.TECH_PROPERTY_WAR_BONDS)) {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
@@ -1364,7 +1371,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     if (ta instanceof GenericTechAdvance) {
       final TechAdvance hardCodedAdvance = ((GenericTechAdvance) ta).getAdvance();
       if (hardCodedAdvance != null) {
-        throw new GameParseException(
+        throw new GameParseException(data,
             "A custom Generic Tech Advance naming a hardcoded tech, may not have a Tech Ability Attachment!"
                 + this.thisErrorMsg());
       }

--- a/src/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -101,11 +101,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
   private IntegerMap<UnitType> m_defenseRollsBonus = new IntegerMap<>();
   private IntegerMap<UnitType> m_bombingBonus = new IntegerMap<>();
 
-  private final String mapName;
-
   public TechAbilityAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
-    mapName = gameData.getGameName();
   }
 
   // setters and getters
@@ -426,7 +423,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setWarBondDiceSides(final String value) throws GameParseException {
     final int v = getInt(value);
     if ((v != -1) && (v < 0 || v > 200)) {
-      throw new GameParseException(mapName, "warBondDiceSides must be -1 (no effect), or be between 0 and 200" + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "warBondDiceSides must be -1 (no effect), or be between 0 and 200" + thisErrorMsg());
     }
     m_warBondDiceSides = v;
   }
@@ -448,7 +445,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setWarBondDiceNumber(final String value) throws GameParseException {
     final int v = getInt(value);
     if (v < 0 || v > 100) {
-      throw new GameParseException(mapName, "warBondDiceNumber must be between 0 and 100" + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "warBondDiceNumber must be between 0 and 100" + thisErrorMsg());
     }
     m_warBondDiceNumber = v;
   }
@@ -473,14 +470,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setRocketDiceNumber(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
-      throw new GameParseException(mapName, "rocketDiceNumber must have two fields" + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "rocketDiceNumber must have two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -508,7 +505,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setRocketDistance(final String value) throws GameParseException {
     final int v = getInt(value);
     if (v < 0 || v > 100) {
-      throw new GameParseException(mapName, "rocketDistance must be between 0 and 100" + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "rocketDistance must be between 0 and 100" + thisErrorMsg());
     }
     m_rocketDistance = v;
   }
@@ -530,7 +527,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setRocketNumberPerTerritory(final String value) throws GameParseException {
     final int v = getInt(value);
     if (v < 0 || v > 200) {
-      throw new GameParseException(mapName, "rocketNumberPerTerritory must be between 0 and 200" + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "rocketNumberPerTerritory must be between 0 and 200" + thisErrorMsg());
     }
     m_rocketNumberPerTerritory = v;
   }
@@ -555,7 +552,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setUnitAbilitiesGained(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 2) {
-      throw new GameParseException(mapName,
+      throw new GameParseException(getData().getGameName(),
           "unitAbilitiesGained must list the unit type, then all abilities gained" + thisErrorMsg());
     }
     String unitType;
@@ -563,7 +560,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "No unit called:" + unitType + thisErrorMsg());
     }
     HashSet<String> abilities = m_unitAbilitiesGained.get(ut);
     if (abilities == null) {
@@ -573,7 +570,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     for (int i = 1; i < s.length; i++) {
       final String ability = s[i];
       if (!(ability.equals(ABILITY_CAN_BLITZ) || ability.equals(ABILITY_CAN_BOMBARD))) {
-        throw new GameParseException(mapName, "unitAbilitiesGained so far only supports: " + ABILITY_CAN_BLITZ + " and "
+        throw new GameParseException(getData().getGameName(), "unitAbilitiesGained so far only supports: " + ABILITY_CAN_BLITZ + " and "
             + ABILITY_CAN_BOMBARD + thisErrorMsg());
       }
       abilities.add(ability);
@@ -623,14 +620,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAirborneCapacity(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException(mapName, "airborneCapacity cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "airborneCapacity cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -663,7 +660,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
-        throw new GameParseException(mapName, "airborneTypes: no such unit type: " + u + thisErrorMsg());
+        throw new GameParseException(getData().getGameName(), "airborneTypes: no such unit type: " + u + thisErrorMsg());
       }
       m_airborneTypes.add(ut);
     }
@@ -690,7 +687,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAirborneDistance(final String value) throws GameParseException {
     final int v = getInt(value);
     if (v < 0 || v > 100) {
-      throw new GameParseException(mapName, "airborneDistance must be between 0 and 100" + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "airborneDistance must be between 0 and 100" + thisErrorMsg());
     }
     m_airborneDistance = v;
   }
@@ -717,7 +714,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
-        throw new GameParseException(mapName, "airborneBases: no such unit type: " + u + thisErrorMsg());
+        throw new GameParseException(getData().getGameName(), "airborneBases: no such unit type: " + u + thisErrorMsg());
       }
       m_airborneBases.add(ut);
     }
@@ -747,14 +744,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAirborneTargettedByAA(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 2) {
-      throw new GameParseException(mapName, "airborneTargettedByAA must have at least two fields" + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "airborneTargettedByAA must have at least two fields" + thisErrorMsg());
     }
     final String aaType = s[0];
     final HashSet<UnitType> unitTypes = new HashSet<>();
     for (int i = 1; i < s.length; i++) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
       if (ut == null) {
-        throw new GameParseException(mapName, "airborneTargettedByAA: no such unit type: " + s[i] + thisErrorMsg());
+        throw new GameParseException(getData().getGameName(), "airborneTargettedByAA: no such unit type: " + s[i] + thisErrorMsg());
       }
       unitTypes.add(ut);
     }
@@ -785,7 +782,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setAttackRollsBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException(mapName,
+      throw new GameParseException(getData().getGameName(),
           "attackRollsBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
@@ -793,7 +790,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -824,7 +821,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setDefenseRollsBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException(mapName,
+      throw new GameParseException(getData().getGameName(),
           "defenseRollsBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
@@ -832,7 +829,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);
@@ -863,14 +860,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public void setBombingBonus(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException(mapName, "bombingBonus cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "bombingBonus cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitType;
     unitType = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitType);
     if (ut == null) {
-      throw new GameParseException(mapName, "No unit called:" + unitType + thisErrorMsg());
+      throw new GameParseException(getData().getGameName(), "No unit called:" + unitType + thisErrorMsg());
     }
     // we should allow positive and negative numbers
     final int n = getInt(s[0]);

--- a/src/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -222,11 +222,11 @@ public class TerritoryAttachment extends DefaultAttachment {
     final String[] s = value.split(":");
     final int amount = getInt(s[0]);
     if (s[1].equals(Constants.PUS)) {
-      throw new GameParseException("Please set PUs using production, not resource" + thisErrorMsg());
+      throw new GameParseException(getData(), "Please set PUs using production, not resource" + thisErrorMsg());
     }
     final Resource resource = getData().getResourceList().getResource(s[1]);
     if (resource == null) {
-      throw new GameParseException("No resource named: " + s[1] + thisErrorMsg());
+      throw new GameParseException(getData(), "No resource named: " + s[1] + thisErrorMsg());
     }
     m_resources.putResource(resource, amount);
   }
@@ -274,7 +274,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     }
     final PlayerID p = getData().getPlayerList().getPlayerID(value);
     if (p == null) {
-      throw new GameParseException("No Player named: " + value + thisErrorMsg());
+      throw new GameParseException(getData(), "No Player named: " + value + thisErrorMsg());
     }
     m_capital = value;
   }
@@ -432,7 +432,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     }
     final PlayerID tempPlayer = getData().getPlayerList().getPlayerID(player);
     if (tempPlayer == null) {
-      throw new GameParseException("No player named: " + player + thisErrorMsg());
+      throw new GameParseException(getData(), ", No player named: " + player + thisErrorMsg());
     }
     m_originalOwner = tempPlayer;
   }
@@ -479,7 +479,7 @@ public class TerritoryAttachment extends DefaultAttachment {
       } else if (name.equalsIgnoreCase("true") || name.equalsIgnoreCase("false")) {
         m_changeUnitOwners.clear();
       } else {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
   }
@@ -515,7 +515,7 @@ public class TerritoryAttachment extends DefaultAttachment {
       if (tempPlayer != null) {
         m_captureUnitOnEnteringBy.add(tempPlayer);
       } else {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
   }
@@ -547,13 +547,13 @@ public class TerritoryAttachment extends DefaultAttachment {
   public void setWhenCapturedByGoesTo(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "whenCapturedByGoesTo must have 2 player names separated by a colon" + thisErrorMsg());
     }
     for (final String name : s) {
       final PlayerID player = getData().getPlayerList().getPlayerID(name);
       if (player == null) {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
     m_whenCapturedByGoesTo.add(value);
@@ -589,7 +589,7 @@ public class TerritoryAttachment extends DefaultAttachment {
       if (effect != null) {
         m_territoryEffect.add(effect);
       } else {
-        throw new GameParseException("No TerritoryEffect named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No TerritoryEffect named: " + name + thisErrorMsg());
       }
     }
   }
@@ -625,7 +625,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     for (final String subString : value.split(":")) {
       final Territory territory = getData().getMap().getTerritory(subString);
       if (territory == null) {
-        throw new GameParseException("No territory called:" + subString + thisErrorMsg());
+        throw new GameParseException(getData(), "No territory called:" + subString + thisErrorMsg());
       }
       m_convoyAttached.add(territory);
     }

--- a/src/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/src/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -114,7 +114,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   private void setCombatEffect(final String combatEffect, final boolean defending) throws GameParseException {
     final String[] s = combatEffect.split(":");
     if (s.length < 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "combatDefenseEffect and combatOffenseEffect must have a count and at least one unitType" + thisErrorMsg());
     }
     final Iterator<String> iter = Arrays.asList(s).iterator();
@@ -123,7 +123,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
       final String unitTypeToProduce = iter.next();
       final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeToProduce);
       if (ut == null) {
-        throw new GameParseException("No unit called:" + unitTypeToProduce + thisErrorMsg());
+        throw new GameParseException(getData(), "No unit called:" + unitTypeToProduce + thisErrorMsg());
       }
       if (defending) {
         m_combatDefenseEffect.put(ut, effect);
@@ -151,12 +151,12 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   public void setNoBlitz(final String noBlitzUnitTypes) throws GameParseException {
     final String[] s = noBlitzUnitTypes.split(":");
     if (s.length < 1) {
-      throw new GameParseException("noBlitz must have at least one unitType" + thisErrorMsg());
+      throw new GameParseException(getData(), "noBlitz must have at least one unitType" + thisErrorMsg());
     }
     for (final String unitTypeName : Arrays.asList(s)) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeName);
       if (ut == null) {
-        throw new GameParseException("No unit called:" + unitTypeName + thisErrorMsg());
+        throw new GameParseException(getData(), "No unit called:" + unitTypeName + thisErrorMsg());
       }
       m_noBlitz.add(ut);
     }
@@ -189,12 +189,12 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   public void setUnitsNotAllowed(final String unitsNotAllowedUnitTypes) throws GameParseException {
     final String[] s = unitsNotAllowedUnitTypes.split(":");
     if (s.length < 1) {
-      throw new GameParseException("unitsNotAllowed must have at least one unitType" + thisErrorMsg());
+      throw new GameParseException(getData(), "unitsNotAllowed must have at least one unitType" + thisErrorMsg());
     }
     for (final String unitTypeName : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeName);
       if (ut == null) {
-        throw new GameParseException("No unit called:" + unitTypeName + thisErrorMsg());
+        throw new GameParseException(getData(), "No unit called:" + unitTypeName + thisErrorMsg());
       }
       m_unitsNotAllowed.add(ut);
     }

--- a/src/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -302,7 +302,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     // triggerName:numberOfTimes:useUses:testUses:testConditions:testChance
     final String[] s = value.split(":");
     if (s.length != 6) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "activateTrigger must have 6 parts: triggerName:numberOfTimes:useUses:testUses:testConditions:testChance"
               + thisErrorMsg());
     }
@@ -319,16 +319,16 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       }
     }
     if (trigger == null) {
-      throw new GameParseException("No TriggerAttachment named: " + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "No TriggerAttachment named: " + s[0] + thisErrorMsg());
     }
     if (trigger == this) {
-      throw new GameParseException("Cannot have a trigger activate itself!" + thisErrorMsg());
+      throw new GameParseException(getData(), "Cannot have a trigger activate itself!" + thisErrorMsg());
     }
     String options = value;
     options = options.replaceFirst((s[0] + ":"), "");
     final int numberOfTimes = getInt(s[1]);
     if (numberOfTimes < 0) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "activateTrigger must be positive for the number of times to fire: " + s[1] + thisErrorMsg());
     }
     getBool(s[2]);
@@ -363,7 +363,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     final ProductionFrontier front = getData().getProductionFrontierList().getProductionFrontier(s);
     if (front == null) {
-      throw new GameParseException("Could not find frontier. name:" + s + thisErrorMsg());
+      throw new GameParseException(getData(), "Could not find frontier. name:" + s + thisErrorMsg());
     }
     m_frontier = front;
   }
@@ -395,20 +395,20 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     final String[] s = prop.split(":");
     if (s.length != 2) {
-      throw new GameParseException("Invalid productionRule declaration: " + prop + thisErrorMsg());
+      throw new GameParseException(getData(), "Invalid productionRule declaration: " + prop + thisErrorMsg());
     }
     if (m_productionRule == null) {
       m_productionRule = new ArrayList<>();
     }
     if (getData().getProductionFrontierList().getProductionFrontier(s[0]) == null) {
-      throw new GameParseException("Could not find frontier. name:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "Could not find frontier. name:" + s[0] + thisErrorMsg());
     }
     String rule = s[1];
     if (rule.startsWith("-")) {
       rule = rule.replaceFirst("-", "");
     }
     if (getData().getProductionRuleList().getProductionRule(rule) == null) {
-      throw new GameParseException("Could not find production rule. name:" + rule + thisErrorMsg());
+      throw new GameParseException(getData(), "Could not find production rule. name:" + rule + thisErrorMsg());
     }
     m_productionRule.add(prop);
   }
@@ -479,7 +479,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         ta = getData().getTechnologyFrontier().getAdvanceByName(subString);
       }
       if (ta == null) {
-        throw new GameParseException("Technology not found :" + subString + thisErrorMsg());
+        throw new GameParseException(getData(), "Technology not found :" + subString + thisErrorMsg());
       }
       m_tech.add(ta);
     }
@@ -516,7 +516,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     final String[] s = techs.split(":");
     if (s.length < 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "Invalid tech availability: " + techs + " should be category:techs" + thisErrorMsg());
     }
     final String cat = s[0];
@@ -532,7 +532,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         ta = getData().getTechnologyFrontier().getAdvanceByName(s[i]);
       }
       if (ta == null) {
-        throw new GameParseException("Technology not found :" + s[i] + thisErrorMsg());
+        throw new GameParseException(getData(), "Technology not found :" + s[i] + thisErrorMsg());
       }
       tlist.put(ta, add);
     }
@@ -593,7 +593,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         }
       }
       if (!found) {
-        throw new GameParseException("Could not find unitSupportAttachment. name:" + s[i] + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find unitSupportAttachment. name:" + s[i] + thisErrorMsg());
       }
     }
   }
@@ -623,7 +623,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     final Resource r = getData().getResourceList().getResource(s);
     if (r == null) {
-      throw new GameParseException("Invalid resource: " + s + thisErrorMsg());
+      throw new GameParseException(getData(), "Invalid resource: " + s + thisErrorMsg());
     } else {
       m_resource = s;
     }
@@ -647,26 +647,26 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public void setRelationshipChange(final String relChange) throws GameParseException {
     final String[] s = relChange.split(":");
     if (s.length != 4) {
-      throw new GameParseException("Invalid relationshipChange declaration: " + relChange
+      throw new GameParseException(getData(), "Invalid relationshipChange declaration: " + relChange
           + " \n Use: player1:player2:oldRelation:newRelation\n" + thisErrorMsg());
     }
     if (getData().getPlayerList().getPlayerID(s[0]) == null) {
-      throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n player: " + s[0]
+      throw new GameParseException(getData(), "Invalid relationshipChange declaration: " + relChange + " \n player: " + s[0]
           + " unknown " + thisErrorMsg());
     }
     if (getData().getPlayerList().getPlayerID(s[1]) == null) {
-      throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n player: " + s[1]
+      throw new GameParseException(getData(), "Invalid relationshipChange declaration: " + relChange + " \n player: " + s[1]
           + " unknown " + thisErrorMsg());
     }
     if (!(s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_NEUTRAL) || s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY)
         || s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_ALLIED)
         || s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_WAR)
         || Matches.isValidRelationshipName(getData()).match(s[2]))) {
-      throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n relationshipType: "
+      throw new GameParseException(getData(), "Invalid relationshipChange declaration: " + relChange + " \n relationshipType: "
           + s[2] + " unknown " + thisErrorMsg());
     }
     if (Matches.isValidRelationshipName(getData()).invert().match(s[3])) {
-      throw new GameParseException("Invalid relationshipChange declaration: " + relChange + " \n relationshipType: "
+      throw new GameParseException(getData(), "Invalid relationshipChange declaration: " + relChange + " \n relationshipType: "
           + s[3] + " unknown " + thisErrorMsg());
     }
     m_relationshipChange.add(relChange);
@@ -701,7 +701,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     for (final String element : s) {
       final UnitType type = getData().getUnitTypeList().getUnitType(element);
       if (type == null) {
-        throw new GameParseException("Could not find unitType. name:" + element + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find unitType. name:" + element + thisErrorMsg());
       }
       m_unitType.add(type);
     }
@@ -732,24 +732,25 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     final String[] s = name.split(":");
     if (s.length != 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "unitAttachmentName must have 2 entries, the type of attachment and the name of the attachment."
               + thisErrorMsg());
     }
     // covers UnitAttachment, UnitSupportAttachment
     if (!(s[1].equals("UnitAttachment") || s[1].equals("UnitSupportAttachment"))) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "unitAttachmentName value must be UnitAttachment or UnitSupportAttachment" + thisErrorMsg());
     }
     // TODO validate attachment exists?
     if (s[0].length() < 1) {
-      throw new GameParseException("unitAttachmentName count must be a valid attachment name" + thisErrorMsg());
+      throw new GameParseException(getData(),
+          "unitAttachmentName count must be a valid attachment name" + thisErrorMsg());
     }
     if (s[1].equals("UnitAttachment") && !s[0].startsWith(Constants.UNIT_ATTACHMENT_NAME)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     if (s[1].equals("UnitSupportAttachment") && !s[0].startsWith(Constants.SUPPORT_ATTACHMENT_PREFIX)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     m_unitAttachmentName = Tuple.of(s[1], s[0]);
   }
@@ -821,7 +822,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     for (final String element : s) {
       final Territory terr = getData().getMap().getTerritory(element);
       if (terr == null) {
-        throw new GameParseException("Could not find territory. name:" + element + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find territory. name:" + element + thisErrorMsg());
       }
       m_territories.add(terr);
     }
@@ -852,24 +853,25 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     final String[] s = name.split(":");
     if (s.length != 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "territoryAttachmentName must have 2 entries, the type of attachment and the name of the attachment."
               + thisErrorMsg());
     }
     // covers TerritoryAttachment, CanalAttachment
     if (!(s[1].equals("TerritoryAttachment") || s[1].equals("CanalAttachment"))) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "territoryAttachmentName value must be TerritoryAttachment or CanalAttachment" + thisErrorMsg());
     }
     // TODO validate attachment exists?
     if (s[0].length() < 1) {
-      throw new GameParseException("territoryAttachmentName count must be a valid attachment name" + thisErrorMsg());
+      throw new GameParseException(getData(),
+          "territoryAttachmentName count must be a valid attachment name" + thisErrorMsg());
     }
     if (s[1].equals("TerritoryAttachment") && !s[0].startsWith(Constants.TERRITORY_ATTACHMENT_NAME)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     if (s[1].equals("CanalAttachment") && !s[0].startsWith(Constants.CANAL_ATTACHMENT_PREFIX)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     m_territoryAttachmentName = Tuple.of(s[1], s[0]);
   }
@@ -941,7 +943,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     for (final String element : s) {
       final PlayerID player = getData().getPlayerList().getPlayerID(element);
       if (player == null) {
-        throw new GameParseException("Could not find player. name:" + element + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find player. name:" + element + thisErrorMsg());
       }
       m_players.add(player);
     }
@@ -976,7 +978,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     final String[] s = name.split(":");
     if (s.length != 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "playerAttachmentName must have 2 entries, the type of attachment and the name of the attachment."
               + thisErrorMsg());
     }
@@ -984,32 +986,32 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (!(s[1].equals("PlayerAttachment") || s[1].equals("RulesAttachment") || s[1].equals("TriggerAttachment")
         || s[1].equals("TechAttachment") || s[1].equals("PoliticalActionAttachment")
         || s[1].equals("UserActionAttachment"))) {
-      throw new GameParseException(
-          "playerAttachmentName value must be PlayerAttachment or RulesAttachment or TriggerAttachment or TechAttachment or PoliticalActionAttachment or UserActionAttachment"
-              + thisErrorMsg());
+      throw new GameParseException(getData(), "playerAttachmentName value must be PlayerAttachment or "
+          + "RulesAttachment or TriggerAttachment or TechAttachment or PoliticalActionAttachment or UserActionAttachment"
+          + thisErrorMsg());
     }
     // TODO validate attachment exists?
     if (s[0].length() < 1) {
-      throw new GameParseException("playerAttachmentName count must be a valid attachment name" + thisErrorMsg());
+      throw new GameParseException(getData(), "playerAttachmentName count must be a valid attachment name" + thisErrorMsg());
     }
     if (s[1].equals("PlayerAttachment") && !s[0].startsWith(Constants.PLAYER_ATTACHMENT_NAME)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     if (s[1].equals("RulesAttachment") && !(s[0].startsWith(Constants.RULES_ATTACHMENT_NAME)
         || s[0].startsWith(Constants.RULES_OBJECTIVE_PREFIX) || s[0].startsWith(Constants.RULES_CONDITION_PREFIX))) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     if (s[1].equals("TriggerAttachment") && !s[0].startsWith(Constants.TRIGGER_ATTACHMENT_PREFIX)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     if (s[1].equals("TechAttachment") && !s[0].startsWith(Constants.TECH_ATTACHMENT_NAME)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     if (s[1].equals("PoliticalActionAttachment") && !s[0].startsWith(Constants.POLITICALACTION_ATTACHMENT_PREFIX)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     if (s[1].equals("UserActionAttachment") && !s[0].startsWith(Constants.USERACTION_ATTACHMENT_PREFIX)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     m_playerAttachmentName = Tuple.of(s[1], s[0]);
   }
@@ -1081,7 +1083,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     for (final String element : s) {
       final RelationshipType relation = getData().getRelationshipTypeList().getRelationshipType(element);
       if (relation == null) {
-        throw new GameParseException("Could not find relationshipType. name:" + element + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find relationshipType. name:" + element + thisErrorMsg());
       }
       m_relationshipTypes.add(relation);
     }
@@ -1112,22 +1114,22 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     final String[] s = name.split(":");
     if (s.length != 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "relationshipTypeAttachmentName must have 2 entries, the type of attachment and the name of the attachment."
               + thisErrorMsg());
     }
     // covers RelationshipTypeAttachment
     if (!(s[1].equals("RelationshipTypeAttachment"))) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "relationshipTypeAttachmentName value must be RelationshipTypeAttachment" + thisErrorMsg());
     }
     // TODO validate attachment exists?
     if (s[0].length() < 1) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "relationshipTypeAttachmentName count must be a valid attachment name" + thisErrorMsg());
     }
     if (s[1].equals("RelationshipTypeAttachment") && !s[0].startsWith(Constants.RELATIONSHIPTYPE_ATTACHMENT_NAME)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     m_relationshipTypeAttachmentName = Tuple.of(s[1], s[0]);
   }
@@ -1200,7 +1202,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     for (final String element : s) {
       final TerritoryEffect effect = getData().getTerritoryEffectList().get(element);
       if (effect == null) {
-        throw new GameParseException("Could not find territoryEffect. name:" + element + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find territoryEffect. name:" + element + thisErrorMsg());
       }
       m_territoryEffects.add(effect);
     }
@@ -1231,22 +1233,22 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     final String[] s = name.split(":");
     if (s.length != 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "territoryEffectAttachmentName must have 2 entries, the type of attachment and the name of the attachment."
               + thisErrorMsg());
     }
     // covers TerritoryEffectAttachment
     if (!(s[1].equals("TerritoryEffectAttachment"))) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "territoryEffectAttachmentName value must be TerritoryEffectAttachment" + thisErrorMsg());
     }
     // TODO validate attachment exists?
     if (s[0].length() < 1) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "territoryEffectAttachmentName count must be a valid attachment name" + thisErrorMsg());
     }
     if (s[1].equals("TerritoryEffectAttachment") && !s[0].startsWith(Constants.TERRITORYEFFECT_ATTACHMENT_NAME)) {
-      throw new GameParseException("attachment incorrectly named:" + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "attachment incorrectly named:" + s[0] + thisErrorMsg());
     }
     m_territoryEffectAttachmentName = Tuple.of(s[1], s[0]);
   }
@@ -1323,7 +1325,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     final String[] s = place.split(":");
     int count = -1, i = 0;
     if (s.length < 1) {
-      throw new GameParseException("Empty placement list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty placement list" + thisErrorMsg());
     }
     try {
       count = getInt(s[0]);
@@ -1332,18 +1334,18 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       count = 1;
     }
     if (s.length < 1 || s.length == 1 && count != -1) {
-      throw new GameParseException("Empty placement list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty placement list" + thisErrorMsg());
     }
     final Territory territory = getData().getMap().getTerritory(s[i]);
     if (territory == null) {
-      throw new GameParseException("Territory does not exist " + s[i] + thisErrorMsg());
+      throw new GameParseException(getData(), "Territory does not exist " + s[i] + thisErrorMsg());
     } else {
       i++;
       final IntegerMap<UnitType> map = new IntegerMap<>();
       for (; i < s.length; i++) {
         final UnitType type = getData().getUnitTypeList().getUnitType(s[i]);
         if (type == null) {
-          throw new GameParseException("UnitType does not exist " + s[i] + thisErrorMsg());
+          throw new GameParseException(getData(), "UnitType does not exist " + s[i] + thisErrorMsg());
         } else {
           map.add(type, count);
         }
@@ -1393,7 +1395,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     final String[] s = value.split(":");
     int count = -1, i = 0;
     if (s.length < 1) {
-      throw new GameParseException("Empty removeUnits list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty removeUnits list" + thisErrorMsg());
     }
     try {
       count = getInt(s[0]);
@@ -1402,7 +1404,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       count = 1;
     }
     if (s.length < 1 || s.length == 1 && count != -1) {
-      throw new GameParseException("Empty removeUnits list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty removeUnits list" + thisErrorMsg());
     }
     final Collection<Territory> territories = new ArrayList<>();
     final Territory terr = getData().getMap().getTerritory(s[i]);
@@ -1410,7 +1412,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       if (s[i].equalsIgnoreCase("all")) {
         territories.addAll(getData().getMap().getTerritories());
       } else {
-        throw new GameParseException("Territory does not exist " + s[i] + thisErrorMsg());
+        throw new GameParseException(getData(), "Territory does not exist " + s[i] + thisErrorMsg());
       }
     } else {
       territories.add(terr);
@@ -1424,7 +1426,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         if (s[i].equalsIgnoreCase("all")) {
           types.addAll(getData().getUnitTypeList().getAllUnitTypes());
         } else {
-          throw new GameParseException("UnitType does not exist " + s[i] + thisErrorMsg());
+          throw new GameParseException(getData(), "UnitType does not exist " + s[i] + thisErrorMsg());
         }
       } else {
         types.add(tp);
@@ -1473,7 +1475,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     final String[] s = place.split(":");
     int count = -1, i = 0;
     if (s.length < 1) {
-      throw new GameParseException("Empty purchase list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty purchase list" + thisErrorMsg());
     }
     try {
       count = getInt(s[0]);
@@ -1482,7 +1484,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       count = 1;
     }
     if (s.length < 1 || s.length == 1 && count != -1) {
-      throw new GameParseException("Empty purchase list" + thisErrorMsg());
+      throw new GameParseException(getData(), "Empty purchase list" + thisErrorMsg());
     } else {
       if (m_purchase == null) {
         m_purchase = new IntegerMap<>();
@@ -1490,7 +1492,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       for (; i < s.length; i++) {
         final UnitType type = getData().getUnitTypeList().getUnitType(s[i]);
         if (type == null) {
-          throw new GameParseException("UnitType does not exist " + s[i] + thisErrorMsg());
+          throw new GameParseException(getData(), "UnitType does not exist " + s[i] + thisErrorMsg());
         } else {
           m_purchase.add(type, count);
         }
@@ -1527,24 +1529,24 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     // can have "all" for territory and "any" for oldOwner
     final String[] s = value.split(":");
     if (s.length < 4) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "changeOwnership must have 4 fields: territory:oldOwner:newOwner:booleanConquered" + thisErrorMsg());
     }
     if (!s[0].equalsIgnoreCase("all")) {
       final Territory t = getData().getMap().getTerritory(s[0]);
       if (t == null) {
-        throw new GameParseException("No such territory: " + s[0] + thisErrorMsg());
+        throw new GameParseException(getData(), "No such territory: " + s[0] + thisErrorMsg());
       }
     }
     if (!s[1].equalsIgnoreCase("any")) {
       final PlayerID oldOwner = getData().getPlayerList().getPlayerID(s[1]);
       if (oldOwner == null) {
-        throw new GameParseException("No such player: " + s[1] + thisErrorMsg());
+        throw new GameParseException(getData(), "No such player: " + s[1] + thisErrorMsg());
       }
     }
     final PlayerID newOwner = getData().getPlayerList().getPlayerID(s[2]);
     if (newOwner == null) {
-      throw new GameParseException("No such player: " + s[2] + thisErrorMsg());
+      throw new GameParseException(getData(), "No such player: " + s[2] + thisErrorMsg());
     }
     getBool(s[3]);
     m_changeOwnership.add(value);

--- a/src/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/games/strategy/triplea/attachments/UnitAttachment.java
@@ -376,7 +376,7 @@ public class UnitAttachment extends DefaultAttachment {
       } else if (name.equalsIgnoreCase("true") || name.equalsIgnoreCase("false")) {
         m_canBeGivenByTerritoryTo.clear();
       } else {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
   }
@@ -412,7 +412,7 @@ public class UnitAttachment extends DefaultAttachment {
       if (tempPlayer != null) {
         m_canBeCapturedOnEnteringBy.add(tempPlayer);
       } else {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
   }
@@ -444,24 +444,24 @@ public class UnitAttachment extends DefaultAttachment {
   public void setWhenCapturedChangesInto(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 5 || (s.length - 1) % 2 != 0) {
-      throw new GameParseException("whenCapturedChangesInto must have 5 or more values, "
+      throw new GameParseException(getData(), "whenCapturedChangesInto must have 5 or more values, "
           + "playerFrom:playerTo:keepAttributes:unitType:howMany (you may have additional unitType:howMany:unitType:howMany, etc"
           + thisErrorMsg());
     }
     final PlayerID pfrom = getData().getPlayerList().getPlayerID(s[0]);
     if (pfrom == null && !s[0].equals("any")) {
-      throw new GameParseException("whenCapturedChangesInto: No player named: " + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "whenCapturedChangesInto: No player named: " + s[0] + thisErrorMsg());
     }
     final PlayerID pto = getData().getPlayerList().getPlayerID(s[1]);
     if (pto == null && !s[1].equals("any")) {
-      throw new GameParseException("whenCapturedChangesInto: No player named: " + s[1] + thisErrorMsg());
+      throw new GameParseException(getData(), "whenCapturedChangesInto: No player named: " + s[1] + thisErrorMsg());
     }
     getBool(s[2]);
     final IntegerMap<UnitType> unitsToMake = new IntegerMap<>();
     for (int i = 3; i < s.length; i++) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
       if (ut == null) {
-        throw new GameParseException("whenCapturedChangesInto: No unit named: " + s[3] + thisErrorMsg());
+        throw new GameParseException(getData(), "whenCapturedChangesInto: No unit named: " + s[3] + thisErrorMsg());
       }
       i++;
       final int howMany = getInt(s[i]);
@@ -512,7 +512,7 @@ public class UnitAttachment extends DefaultAttachment {
       if (tempPlayer != null) {
         m_destroyedWhenCapturedBy.add(Tuple.of(byOrFrom, tempPlayer));
       } else {
-        throw new GameParseException("No player named: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No player named: " + name + thisErrorMsg());
       }
     }
   }
@@ -810,7 +810,7 @@ public class UnitAttachment extends DefaultAttachment {
   public void setRepairsUnits(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0) {
-      throw new GameParseException("repairsUnits cannot be empty" + thisErrorMsg());
+      throw new GameParseException(getData(), "repairsUnits cannot be empty" + thisErrorMsg());
     }
     int amount = 1;
     int i = 0;
@@ -823,7 +823,7 @@ public class UnitAttachment extends DefaultAttachment {
     for (; i < s.length; i++) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
       if (ut == null) {
-        throw new GameParseException("No unit called:" + s[i] + thisErrorMsg());
+        throw new GameParseException(getData(), "No unit called:" + s[i] + thisErrorMsg());
       }
       m_repairsUnits.put(ut, amount);
     }
@@ -857,7 +857,7 @@ public class UnitAttachment extends DefaultAttachment {
     final String[] s = value.split(":");
     for (final String option : s) {
       if (!(option.equals("none") || option.equals("canOnlyPlaceInOriginalTerritories"))) {
-        throw new GameParseException("special does not allow: " + option + thisErrorMsg());
+        throw new GameParseException(getData(), "special does not allow: " + option + thisErrorMsg());
       }
       m_special.add(option);
     }
@@ -961,14 +961,14 @@ public class UnitAttachment extends DefaultAttachment {
   public void setWhenCombatDamaged(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (!(s.length == 3 || s.length == 4)) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "whenCombatDamaged must have 3 or 4 parts: value=effect:optionalNumber, count=integer:integer"
               + thisErrorMsg());
     }
     final int from = getInt(s[0]);
     final int to = getInt(s[1]);
     if (from < 0 || to < 0 || to < from) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "whenCombatDamaged damaged integers must be positive, and the second integer must be equal to or greater than the first"
               + thisErrorMsg());
     }
@@ -1758,14 +1758,14 @@ public class UnitAttachment extends DefaultAttachment {
   public void setGivesMovement(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("givesMovement cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "givesMovement cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitTypeToProduce;
     unitTypeToProduce = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeToProduce);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitTypeToProduce + thisErrorMsg());
+      throw new GameParseException(getData(), "No unit called:" + unitTypeToProduce + thisErrorMsg());
     }
     // we should allow positive and negative numbers, since you can give bonuses to units or take away a unit's movement
     final int n = getInt(s[0]);
@@ -1799,18 +1799,18 @@ public class UnitAttachment extends DefaultAttachment {
   public void setConsumesUnits(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
-      throw new GameParseException("consumesUnits must have two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "consumesUnits must have two fields" + thisErrorMsg());
     }
     String unitTypeToProduce;
     unitTypeToProduce = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeToProduce);
     if (ut == null) {
-      throw new GameParseException("No unit called:" + unitTypeToProduce + thisErrorMsg());
+      throw new GameParseException(getData(), "No unit called:" + unitTypeToProduce + thisErrorMsg());
     }
     final int n = getInt(s[0]);
     if (n < 1) {
-      throw new GameParseException("consumesUnits must have positive values" + thisErrorMsg());
+      throw new GameParseException(getData(), "consumesUnits must have positive values" + thisErrorMsg());
     }
     m_consumesUnits.put(ut, n);
   }
@@ -1842,18 +1842,18 @@ public class UnitAttachment extends DefaultAttachment {
   public void setCreatesUnitsList(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException("createsUnitsList cannot be empty or have more than two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "createsUnitsList cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String unitTypeToProduce;
     unitTypeToProduce = s[1];
     // validate that this unit exists in the xml
     final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeToProduce);
     if (ut == null) {
-      throw new GameParseException("createsUnitsList: No unit called:" + unitTypeToProduce + thisErrorMsg());
+      throw new GameParseException(getData(), "createsUnitsList: No unit called:" + unitTypeToProduce + thisErrorMsg());
     }
     final int n = getInt(s[0]);
     if (n < 1) {
-      throw new GameParseException("createsUnitsList must have positive values" + thisErrorMsg());
+      throw new GameParseException(getData(), "createsUnitsList must have positive values" + thisErrorMsg());
     }
     m_createsUnitsList.put(ut, n);
   }
@@ -1885,7 +1885,7 @@ public class UnitAttachment extends DefaultAttachment {
   public void setCreatesResourcesList(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length <= 0 || s.length > 2) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "createsResourcesList cannot be empty or have more than two fields" + thisErrorMsg());
     }
     String resourceToProduce;
@@ -1893,7 +1893,7 @@ public class UnitAttachment extends DefaultAttachment {
     // validate that this resource exists in the xml
     final Resource r = getData().getResourceList().getResource(resourceToProduce);
     if (r == null) {
-      throw new GameParseException("createsResourcesList: No resource called:" + resourceToProduce + thisErrorMsg());
+      throw new GameParseException(getData(), "createsResourcesList: No resource called:" + resourceToProduce + thisErrorMsg());
     }
     final int n = getInt(s[0]);
     m_createsResourcesList.put(r, n);
@@ -1926,18 +1926,18 @@ public class UnitAttachment extends DefaultAttachment {
   public void setFuelCost(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length != 2) {
-      throw new GameParseException("fuelCost must have two fields" + thisErrorMsg());
+      throw new GameParseException(getData(), "fuelCost must have two fields" + thisErrorMsg());
     }
     String resourceToProduce;
     resourceToProduce = s[1];
     // validate that this resource exists in the xml
     final Resource r = getData().getResourceList().getResource(resourceToProduce);
     if (r == null) {
-      throw new GameParseException("fuelCost: No resource called:" + resourceToProduce + thisErrorMsg());
+      throw new GameParseException(getData(), "fuelCost: No resource called:" + resourceToProduce + thisErrorMsg());
     }
     final int n = getInt(s[0]);
     if (n < 0) {
-      throw new GameParseException("fuelCost must have positive values" + thisErrorMsg());
+      throw new GameParseException(getData(), "fuelCost must have positive values" + thisErrorMsg());
     }
     m_fuelCost.put(r, n);
   }
@@ -2014,7 +2014,7 @@ public class UnitAttachment extends DefaultAttachment {
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
-        throw new GameParseException("bombingTargets: no such unit type: " + u + thisErrorMsg());
+        throw new GameParseException(getData(), "bombingTargets: no such unit type: " + u + thisErrorMsg());
       }
       m_bombingTargets.add(ut);
     }
@@ -2163,7 +2163,7 @@ public class UnitAttachment extends DefaultAttachment {
   public void setMaxAAattacks(final String s) throws GameParseException {
     final int attacks = getInt(s);
     if (attacks < -1) {
-      throw new GameParseException("maxAAattacks must be positive (or -1 for attacking all) " + thisErrorMsg());
+      throw new GameParseException(getData(), "maxAAattacks must be positive (or -1 for attacking all) " + thisErrorMsg());
     }
     m_maxAAattacks = getInt(s);
   }
@@ -2185,7 +2185,7 @@ public class UnitAttachment extends DefaultAttachment {
   public void setMaxRoundsAA(final String s) throws GameParseException {
     final int attacks = getInt(s);
     if (attacks < -1) {
-      throw new GameParseException("maxRoundsAA must be positive (or -1 for infinite) " + thisErrorMsg());
+      throw new GameParseException(getData(), "maxRoundsAA must be positive (or -1 for infinite) " + thisErrorMsg());
     }
     m_maxRoundsAA = getInt(s);
   }
@@ -2363,7 +2363,7 @@ public class UnitAttachment extends DefaultAttachment {
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
-        throw new GameParseException("AAtargets: no such unit type: " + u + thisErrorMsg());
+        throw new GameParseException(getData(), "AAtargets: no such unit type: " + u + thisErrorMsg());
       }
       m_targetsAA.add(ut);
     }
@@ -2409,7 +2409,7 @@ public class UnitAttachment extends DefaultAttachment {
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
-        throw new GameParseException("willNotFireIfPresent: no such unit type: " + u + thisErrorMsg());
+        throw new GameParseException(getData(), "willNotFireIfPresent: no such unit type: " + u + thisErrorMsg());
       }
       m_willNotFireIfPresent.add(ut);
     }
@@ -2477,18 +2477,18 @@ public class UnitAttachment extends DefaultAttachment {
     }
     final UnitType ut = (UnitType) this.getAttachedTo();
     if (ut == null) {
-      throw new GameParseException("getAttachedTo returned null" + thisErrorMsg());
+      throw new GameParseException(getData(), "getAttachedTo returned null" + thisErrorMsg());
     }
     final String[] s = value.split(":");
     if (s.length != 2) {
-      throw new GameParseException("movementLimit must have 2 fields, value and count" + thisErrorMsg());
+      throw new GameParseException(getData(), "movementLimit must have 2 fields, value and count" + thisErrorMsg());
     }
     final int max = getInt(s[0]);
     if (max < 0) {
-      throw new GameParseException("movementLimit count must have a positive number" + thisErrorMsg());
+      throw new GameParseException(getData(), "movementLimit count must have a positive number" + thisErrorMsg());
     }
     if (!(s[1].equals("owned") || s[1].equals("allied") || s[1].equals("total"))) {
-      throw new GameParseException("movementLimit value must owned, allied, or total" + thisErrorMsg());
+      throw new GameParseException(getData(), "movementLimit value must owned, allied, or total" + thisErrorMsg());
     }
     m_movementLimit = Tuple.of(max, s[1]);
   }
@@ -2514,18 +2514,18 @@ public class UnitAttachment extends DefaultAttachment {
     }
     final UnitType ut = (UnitType) this.getAttachedTo();
     if (ut == null) {
-      throw new GameParseException("getAttachedTo returned null" + thisErrorMsg());
+      throw new GameParseException(getData(), "getAttachedTo returned null" + thisErrorMsg());
     }
     final String[] s = value.split(":");
     if (s.length != 2) {
-      throw new GameParseException("attackingLimit must have 2 fields, value and count" + thisErrorMsg());
+      throw new GameParseException(getData(), "attackingLimit must have 2 fields, value and count" + thisErrorMsg());
     }
     final int max = getInt(s[0]);
     if (max < 0) {
-      throw new GameParseException("attackingLimit count must have a positive number" + thisErrorMsg());
+      throw new GameParseException(getData(), "attackingLimit count must have a positive number" + thisErrorMsg());
     }
     if (!(s[1].equals("owned") || s[1].equals("allied") || s[1].equals("total"))) {
-      throw new GameParseException("attackingLimit value must owned, allied, or total" + thisErrorMsg());
+      throw new GameParseException(getData(), "attackingLimit value must owned, allied, or total" + thisErrorMsg());
     }
     m_attackingLimit = Tuple.of(max, s[1]);
   }
@@ -2551,18 +2551,18 @@ public class UnitAttachment extends DefaultAttachment {
     }
     final UnitType ut = (UnitType) this.getAttachedTo();
     if (ut == null) {
-      throw new GameParseException("getAttachedTo returned null" + thisErrorMsg());
+      throw new GameParseException(getData(), "getAttachedTo returned null" + thisErrorMsg());
     }
     final String[] s = value.split(":");
     if (s.length != 2) {
-      throw new GameParseException("placementLimit must have 2 fields, value and count" + thisErrorMsg());
+      throw new GameParseException(getData(), "placementLimit must have 2 fields, value and count" + thisErrorMsg());
     }
     final int max = getInt(s[0]);
     if (max < 0) {
-      throw new GameParseException("placementLimit count must have a positive number" + thisErrorMsg());
+      throw new GameParseException(getData(), "placementLimit count must have a positive number" + thisErrorMsg());
     }
     if (!(s[1].equals("owned") || s[1].equals("allied") || s[1].equals("total"))) {
-      throw new GameParseException("placementLimit value must owned, allied, or total" + thisErrorMsg());
+      throw new GameParseException(getData(), "placementLimit value must owned, allied, or total" + thisErrorMsg());
     }
     m_placementLimit = Tuple.of(max, s[1]);
   }
@@ -2620,71 +2620,75 @@ public class UnitAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameData data) throws GameParseException {
     if (m_isAir) {
-      if (m_isSea /* || m_isFactory */ || m_isSub || m_transportCost != -1 || m_carrierCapacity != -1 || m_canBlitz
+      if (m_isSea || m_isSub || m_transportCost != -1 || m_carrierCapacity != -1 || m_canBlitz
           || m_canBombard || m_isMarine != 0 || m_isInfantry || m_isLandTransport || m_isAirTransportable
           || m_isCombatTransport) {
-        throw new GameParseException("air units cannot have certain properties, " + thisErrorMsg());
+        throw new GameParseException(getData(), "air units cannot have certain properties, " + thisErrorMsg());
       }
     } else if (m_isSea) {
-      if (m_canBlitz || m_isAir /* || m_isFactory */ || m_isStrategicBomber || m_carrierCost != -1
+      if (m_canBlitz || m_isAir || m_isStrategicBomber || m_carrierCost != -1
           || m_transportCost != -1 || m_isMarine != 0 || m_isInfantry || m_isLandTransport || m_isAirTransportable
           || m_isAirTransport || m_isKamikaze) {
-        throw new GameParseException("sea units cannot have certain properties, " + thisErrorMsg());
+        throw new GameParseException(getData(), "sea units cannot have certain properties, " + thisErrorMsg());
       }
     } else
     // if land
     {
       if (m_canBombard || m_isStrategicBomber || m_isSub || m_carrierCapacity != -1 || m_bombard != -1
           || m_transportCapacity != -1 || m_isAirTransport || m_isCombatTransport || m_isKamikaze) {
-        throw new GameParseException("land units cannot have certain properties, " + thisErrorMsg());
+        throw new GameParseException(getData(), "land units cannot have certain properties, " + thisErrorMsg());
       }
     }
     if (m_hitPoints < 1) {
-      throw new GameParseException("hitPoints cannot be zero or negative, " + thisErrorMsg());
+      throw new GameParseException(getData(), "hitPoints cannot be zero or negative, " + thisErrorMsg());
     }
     if (m_attackAA < 0 || m_attackAAmaxDieSides < -1 || m_attackAAmaxDieSides > 200 || m_offensiveAttackAA < 0
         || m_offensiveAttackAAmaxDieSides < -1 || m_offensiveAttackAAmaxDieSides > 200) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "attackAA or attackAAmaxDieSides or offensiveAttackAA or offensiveAttackAAmaxDieSides is wrong, "
               + thisErrorMsg());
     }
     if (m_carrierCapacity != -1 && m_carrierCost != -1) {
-      throw new GameParseException("carrierCost and carrierCapacity cannot be set at same time, " + thisErrorMsg());
+      throw new GameParseException(getData(),
+          "carrierCost and carrierCapacity cannot be set at same time, " + thisErrorMsg());
     }
     if (m_transportCost != -1 && m_transportCapacity != -1) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "transportCost and transportCapacity cannot be set at same time, " + thisErrorMsg());
     }
     if (((m_bombingBonus >= 0 || m_bombingMaxDieSides >= 0) && !(m_isStrategicBomber || m_isRocket))
         || (m_bombingBonus < -1 || m_bombingMaxDieSides < -1)
         || (m_bombingBonus > 10000 || m_bombingMaxDieSides > 200)) {
-      throw new GameParseException("something wrong with bombingBonus or bombingMaxDieSides, " + thisErrorMsg());
+      throw new GameParseException(getData(),
+          "something wrong with bombingBonus or bombingMaxDieSides, " + thisErrorMsg());
     }
     if (m_maxBuiltPerPlayer < -1) {
-      throw new GameParseException("maxBuiltPerPlayer cannot be negative, " + thisErrorMsg());
+      throw new GameParseException(getData(), "maxBuiltPerPlayer cannot be negative, " + thisErrorMsg());
     }
     if (m_isCombatTransport && m_transportCapacity < 1) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "cannot have isCombatTransport on unit without transportCapacity, " + thisErrorMsg());
     }
     if (m_isSea && m_transportCapacity != -1 && Properties.getTransportCasualtiesRestricted(data)
         && (m_attack > 0 || m_defense > 0) && !m_isCombatTransport) {
-      throw new GameParseException("Restricted transports cannot have attack or defense, " + thisErrorMsg());
+      throw new GameParseException(getData(),
+          "Restricted transports cannot have attack or defense, " + thisErrorMsg());
     }
     if (m_isConstruction
         && (m_constructionType == null || m_constructionType.equals("none") || m_constructionType.equals("")
             || m_constructionsPerTerrPerTypePerTurn < 0 || m_maxConstructionsPerTypePerTerr < 0)) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "Constructions must have constructionType and positive constructionsPerTerrPerType and maxConstructionsPerType, "
               + thisErrorMsg());
     }
     if (!m_isConstruction
         && (!(m_constructionType == null || m_constructionType.equals("none") || m_constructionType.equals(""))
             || m_constructionsPerTerrPerTypePerTurn >= 0 || m_maxConstructionsPerTypePerTerr >= 0)) {
-      throw new GameParseException("Constructions must have isConstruction true, " + thisErrorMsg());
+      throw new GameParseException(getData(),
+          "Constructions must have isConstruction true, " + thisErrorMsg());
     }
     if (m_constructionsPerTerrPerTypePerTurn > m_maxConstructionsPerTypePerTerr) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "Constructions must have constructionsPerTerrPerTypePerTurn Less than maxConstructionsPerTypePerTerr, "
               + thisErrorMsg());
     }
@@ -2698,7 +2702,7 @@ public class UnitAttachment extends DefaultAttachment {
     }
     if ((m_canBeDamaged && m_maxDamage < 1) || (m_canDieFromReachingMaxDamage && m_maxDamage < 1)
         || (!m_canBeDamaged && m_canDieFromReachingMaxDamage)) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "something wrong with canBeDamaged or maxDamage or canDieFromReachingMaxDamage or isFactory, "
               + thisErrorMsg());
     }
@@ -2707,10 +2711,10 @@ public class UnitAttachment extends DefaultAttachment {
       for (final String transport : m_canInvadeOnlyFrom) {
         final UnitType ut = getData().getUnitTypeList().getUnitType(transport);
         if (ut == null) {
-          throw new GameParseException("No unit called:" + transport + thisErrorMsg());
+          throw new GameParseException(getData(), "No unit called:" + transport + thisErrorMsg());
         }
         if (ut.getAttachments() == null || ut.getAttachments().isEmpty()) {
-          throw new GameParseException(transport + " has no attachments, please declare " + transport
+          throw new GameParseException(getData(), transport + " has no attachments, please declare " + transport
               + " in the xml before using it as a transport" + thisErrorMsg());
           // Units may be considered transported if they are on a carrier, or if they are paratroopers, or if they are
           // mech infantry. The
@@ -2723,14 +2727,17 @@ public class UnitAttachment extends DefaultAttachment {
         // first is ability, second is unit that we get it from
         final String[] s = value.split(":");
         if (s.length != 2) {
-          throw new GameParseException("receivesAbilityWhenWith must have 2 parts, 'ability:unit'" + thisErrorMsg());
+          throw new GameParseException(getData(),
+              "receivesAbilityWhenWith must have 2 parts, 'ability:unit'" + thisErrorMsg());
         }
         if (getData().getUnitTypeList().getUnitType(s[1]) == null) {
-          throw new GameParseException("receivesAbilityWhenWith, unit does not exist, name:" + s[1] + thisErrorMsg());
+          throw new GameParseException(getData(),
+              "receivesAbilityWhenWith, unit does not exist, name:" + s[1] + thisErrorMsg());
         }
         // currently only supports canBlitz (m_canBlitz)
         if (!s[0].equals("canBlitz")) {
-          throw new GameParseException("receivesAbilityWhenWith so far only supports: canBlitz" + thisErrorMsg());
+          throw new GameParseException(getData(),
+              "receivesAbilityWhenWith so far only supports: canBlitz" + thisErrorMsg());
         }
       }
     }
@@ -2743,7 +2750,8 @@ public class UnitAttachment extends DefaultAttachment {
         if (obj.equals(UNITSMAYNOTLEAVEALLIEDCARRIER)) {
           continue;
         }
-        throw new GameParseException("m_whenCombatDamaged so far only supports: " + UNITSMAYNOTLANDONCARRIER + ", "
+        throw new GameParseException(getData(),
+            "m_whenCombatDamaged so far only supports: " + UNITSMAYNOTLANDONCARRIER + ", "
             + UNITSMAYNOTLEAVEALLIEDCARRIER + thisErrorMsg());
       }
     }
@@ -2768,7 +2776,7 @@ public class UnitAttachment extends DefaultAttachment {
       // Validate all territories exist
       final Territory territory = getData().getMap().getTerritory(name);
       if (territory == null) {
-        throw new GameParseException("No territory called: " + name + thisErrorMsg());
+        throw new GameParseException(getData(), "No territory called: " + name + thisErrorMsg());
       }
       rVal.add(territory);
     }

--- a/src/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/src/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -101,7 +101,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     for (final String element : s) {
       final UnitType type = getData().getUnitTypeList().getUnitType(element);
       if (type == null) {
-        throw new GameParseException("Could not find unitType. name:" + element + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find unitType. name:" + element + thisErrorMsg());
       }
       m_unitType.add(type);
     }
@@ -131,7 +131,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
       } else if (element.equalsIgnoreCase("enemy")) {
         m_enemy = true;
       } else {
-        throw new GameParseException(faction + " faction must be allied, or enemy" + thisErrorMsg());
+        throw new GameParseException(getData(), faction + " faction must be allied, or enemy" + thisErrorMsg());
       }
     }
     m_faction = faction;
@@ -162,7 +162,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
       } else if (element.equalsIgnoreCase("offence")) {
         m_offence = true;
       } else {
-        throw new GameParseException(side + " side must be defence or offence" + thisErrorMsg());
+        throw new GameParseException(getData(), side + " side must be defence or offence" + thisErrorMsg());
       }
     }
     m_side = side;
@@ -193,7 +193,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
       } else if (element.equalsIgnoreCase("strength")) {
         m_strength = true;
       } else {
-        throw new GameParseException(dice + " dice must be roll or strength" + thisErrorMsg());
+        throw new GameParseException(getData(), dice + " dice must be roll or strength" + thisErrorMsg());
       }
     }
     m_dice = dice;
@@ -262,7 +262,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     for (final String element : s) {
       final PlayerID player = getData().getPlayerList().getPlayerID(element);
       if (player == null) {
-        throw new GameParseException("Could not find player. name:" + element + thisErrorMsg());
+        throw new GameParseException(getData(), "Could not find player. name:" + element + thisErrorMsg());
       } else {
         m_players.add(player);
       }

--- a/src/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/src/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -71,7 +71,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
     // triggerName:numberOfTimes:useUses:testUses:testConditions:testChance
     final String[] s = value.split(":");
     if (s.length != 6) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "activateTrigger must have 6 parts: triggerName:numberOfTimes:useUses:testUses:testConditions:testChance"
               + thisErrorMsg());
     }
@@ -88,13 +88,13 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
       }
     }
     if (trigger == null) {
-      throw new GameParseException("No TriggerAttachment named: " + s[0] + thisErrorMsg());
+      throw new GameParseException(getData(), "No TriggerAttachment named: " + s[0] + thisErrorMsg());
     }
     String options = value;
     options = options.replaceFirst((s[0] + ":"), "");
     final int numberOfTimes = getInt(s[1]);
     if (numberOfTimes < 0) {
-      throw new GameParseException(
+      throw new GameParseException(getData(),
           "activateTrigger must be positive for the number of times to fire: " + s[1] + thisErrorMsg());
     }
     getBool(s[2]);


### PR DESCRIPTION
…s are passed, we will know which erros correspond to which maps.

Note, this is a bit brute force of a fix. To refactor things for this to be a clean fix would be quite the undertaking, and would lead down a number of different refactor paths that would touch a lot of code. So for this PR, doing the necessary to wire through the additional map name data. 

Here is an example game parse error message after this update (note, before there was no map name in this error message, so it was mysterious which map had the problem):

```
Exception: Steampunk 1915:The following option name of techAbilityAttachment of class TechAbilityAttachment are either misspelled or exist only in a future version of TripleA. Setter: productionBonus
games.strategy.engine.data.GameParseException: Steampunk 1915:The following option name of techAbilityAttachment of class TechAbilityAttachment are either misspelled or exist only in a future version of TripleA. Setter: productionBonus
	at games.strategy.engine.data.GameParser.setValues(GameParser.java:1365)
	at games.strategy.engine.data.GameParser.parseAttachments(GameParser.java:1310)
	at games.strategy.engine.data.GameParser.parse(GameParser.java:154)
	at games.strategy.engine.framework.ui.NewGameChooserEntry.<init>(NewGameChooserEntry.java:55)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/970)
<!-- Reviewable:end -->
