### PR TITLE
Fix NPE, 'getInGameLobbyWatcher' is null during single player games, …

### DIFF
--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -2172,8 +2172,9 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   public Optional<InGameLobbyWatcherWrapper> getInGameLobbyWatcher() {
-    if( ServerGame.class.isAssignableFrom(getGame().getClass())) {
-      return Optional.of(((ServerGame) getGame()).getInGameLobbyWatcher());
+    if(ServerGame.class.isAssignableFrom(getGame().getClass())) {
+      ServerGame serverGame = (ServerGame) getGame();
+      return Optional.ofNullable(serverGame.getInGameLobbyWatcher());
     } else {
       return Optional.empty();
     }


### PR DESCRIPTION
…but we still do have a 'ServerGame'. There was a mistake that assumed a 'ServerGame' was only for lobby games.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/971)
<!-- Reviewable:end -->
