### PR TITLE
Fix #972 - game window freezing on shut down

### DIFF
--- a/src/games/strategy/util/EventThreadJOptionPane.java
+++ b/src/games/strategy/util/EventThreadJOptionPane.java
@@ -74,6 +74,10 @@ public class EventThreadJOptionPane {
 
   public static void showMessageDialog(final Component parentComponent, final Object message,
       final CountDownLatchHandler latchHandler) {
+    if (SwingUtilities.isEventDispatchThread()) {
+      JOptionPane.showMessageDialog(parentComponent, message);
+      return;
+    }
     final CountDownLatch latch = new CountDownLatch(1);
     SwingUtilities.invokeLater(() -> {
       JOptionPane.showMessageDialog(parentComponent, message);
@@ -88,6 +92,10 @@ public class EventThreadJOptionPane {
   public static int showOptionDialog(final Component parentComponent, final Object message, final String title,
       final int optionType, final int messageType, final Icon icon, final Object[] options, final Object initialValue,
       final CountDownLatchHandler latchHandler) {
+    if (SwingUtilities.isEventDispatchThread()) {
+      return JOptionPane.showOptionDialog(parentComponent, message, title, optionType, messageType, icon, options,
+          initialValue);
+    }
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicInteger rVal = new AtomicInteger();
     SwingUtilities.invokeLater(() -> {
@@ -104,6 +112,9 @@ public class EventThreadJOptionPane {
 
   public static int showConfirmDialog(final Component parentComponent, final Object message, final String title,
       final int optionType, final CountDownLatchHandler latchHandler) throws HeadlessException {
+    if (SwingUtilities.isEventDispatchThread()) {
+      return JOptionPane.showConfirmDialog(parentComponent, message, title, optionType);
+    }
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicInteger rVal = new AtomicInteger();
     SwingUtilities.invokeLater(() -> {


### PR DESCRIPTION
 Revert "Just use invokeLater to always run UI code, the extra check of the current thread is cheap, perhaps as cheap as us doing it ourselves"

This reverts commit 07d951cc419ae2f549b8b563277ea30951371b42.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/976)
<!-- Reviewable:end -->
