### PR TITLE
Remove double map parsing

### DIFF
--- a/src/games/strategy/engine/framework/ui/NewGameChooser.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooser.java
@@ -45,7 +45,6 @@ public class NewGameChooser extends JDialog {
     setupListeners();
     setWidgetActivation();
     updateInfoPanel();
-    refreshGameList();
   }
 
   private void createComponents() {
@@ -197,24 +196,6 @@ public class NewGameChooser extends JDialog {
   /** Populates the NewGameChooserModel cache if empty, then returns the cached instance */
   public synchronized static NewGameChooserModel getNewGameChooserModel() {
       return new NewGameChooserModel();
-  }
-
-
-  /**
-   * Refreshes the game list (from disk) then caches the new list
-   */
-  private void refreshGameList() {
-    gameList.setEnabled(false);
-    final NewGameChooserEntry selected = getSelected();
-        try {
-          gameListModel = getNewGameChooserModel();
-          gameList.setModel(gameListModel);
-          if(selected != null){
-            selectGame(selected.getGameData().getGameName());
-          }
-        } finally {
-          gameList.setEnabled(true);
-        }
   }
 
   private void selectAndReturn() {


### PR DESCRIPTION
Remove the call to 'refreshGameList' on creation of the NewGameChooserEntry. Before this call would have likely hit the map cache, which would have been primed in a back ground thread. But now we reload the map list whenever anyone clicks 'open game', and so this round of map parsing is wasted. Worst yet, when maps have errors, the map parsing is slow, so this behavior causes the game to load very slowly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/980)
<!-- Reviewable:end -->
