### PR TITLE
HotFix Deployment [IMORTANT]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_deploy:
 - mkdir -p maps
 - (cd maps; wget https://github.com/triplea-maps/tutorial/releases/download/0.66/tutorial.zip)
 ## Create the installers
-- gradle release
+- ./gradlew release
 ## Push a tag to github, will trigger the releases process 
 - chmod +x ./.travis/push_tag && ./.travis/push_tag
 ## rest is commented out, work in progress.. does not work and needs some debugging.


### PR DESCRIPTION
The current master is erroring (not failing) because it's not using gradle version 2.5 or higher.
That's why we need to use the wrapper instead.


@DanVanAtta @ron-murhammer please merge as quickly as possible... As long as this PR is not merged, no further artifacts are deployed...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/988)
<!-- Reviewable:end -->
