### PR TITLE
Added "proxy" method to create checked class arrays

### DIFF
--- a/test/games/strategy/engine/message/RemoteInterfaceHelperTest.java
+++ b/test/games/strategy/engine/message/RemoteInterfaceHelperTest.java
@@ -7,13 +7,15 @@ import java.util.Comparator;
 
 import org.junit.Test;
 
+import games.strategy.test.TestUtil;
+
 public class RemoteInterfaceHelperTest {
 
   @Test
   public void testSimple() {
     assertEquals("compare", RemoteInterfaceHelper.getMethodInfo(0, Comparator.class).getFirst());
     assertEquals("add", RemoteInterfaceHelper.getMethodInfo(0, Collection.class).getFirst());
-    assertEquals(0, RemoteInterfaceHelper.getNumber("add", new Class[] {Object.class}, Collection.class));
-    assertEquals(2, RemoteInterfaceHelper.getNumber("clear", new Class[] {}, Collection.class));
+    assertEquals(0, RemoteInterfaceHelper.getNumber("add", TestUtil.getClassArrayFrom(Object.class), Collection.class));
+    assertEquals(2, RemoteInterfaceHelper.getNumber("clear", TestUtil.getClassArrayFrom(), Collection.class));
   }
 }

--- a/test/games/strategy/engine/message/unifiedmessenger/EndPointTest.java
+++ b/test/games/strategy/engine/message/unifiedmessenger/EndPointTest.java
@@ -10,6 +10,8 @@ import games.strategy.engine.message.RemoteMethodCallResults;
 import games.strategy.engine.message.unifiedmessenger.EndPoint;
 import org.junit.Test;
 
+import games.strategy.test.TestUtil;
+
 public class EndPointTest {
 
   @Test
@@ -17,7 +19,7 @@ public class EndPointTest {
     final EndPoint endPoint = new EndPoint("", Comparator.class, false);
     endPoint.addImplementor((Comparator<Object>) (o1, o2) -> 2);
     final RemoteMethodCall call = new RemoteMethodCall("", "compare", new Object[] {"", ""},
-        new Class[] {Object.class, Object.class}, Comparator.class);
+        TestUtil.getClassArrayFrom(Object.class, Object.class), Comparator.class);
     final List<RemoteMethodCallResults> results = endPoint.invokeLocal(call, endPoint.takeANumber(), null);
     assertEquals(results.size(), 1);
     assertEquals(2, (results.iterator().next()).getRVal());

--- a/test/games/strategy/test/TestUtil.java
+++ b/test/games/strategy/test/TestUtil.java
@@ -57,4 +57,8 @@ public class TestUtil {
     SwingAction.invokeAndWait(() -> {
     });
   }
+  
+  public static Class<?>[] getClassArrayFrom(Class<?>... classes){
+    return classes;
+  }
 }

--- a/test/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/test/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -20,6 +20,7 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.random.ScriptedRandomSource;
+import games.strategy.test.TestUtil;
 import games.strategy.triplea.delegate.IBattle.BattleType;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.xml.LoadGameUtil;
@@ -329,6 +330,6 @@ public class AirThatCantLandUtilTest {
       }
     };
     return (ITripleAPlayer) Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(),
-        new Class[] {ITripleAPlayer.class}, handler);
+        TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
   }
 }

--- a/test/games/strategy/triplea/delegate/LHTRTest.java
+++ b/test/games/strategy/triplea/delegate/LHTRTest.java
@@ -26,6 +26,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.random.IRandomSource;
 import games.strategy.engine.random.ScriptedRandomSource;
+import games.strategy.test.TestUtil;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -116,7 +117,8 @@ public class LHTRTest {
       }
     };
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
-        .newProxyInstance(Thread.currentThread().getContextClassLoader(), new Class[] {ITripleAPlayer.class}, handler);
+        .newProxyInstance(Thread.currentThread().getContextClassLoader(),
+            TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
     bridge.setRemote(player);
     // move 1 fighter over the aa gun in caucus
     final Route route = new Route();
@@ -173,7 +175,8 @@ public class LHTRTest {
       }
     };
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
-        .newProxyInstance(Thread.currentThread().getContextClassLoader(), new Class[] {ITripleAPlayer.class}, handler);
+        .newProxyInstance(Thread.currentThread().getContextClassLoader(),
+            TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
     bridge.setRemote(player);
     final int PUsBeforeRaid = germans.getResources().getQuantity(m_data.getResourceList().getResource(Constants.PUS));
     battle.fight(bridge);
@@ -213,7 +216,8 @@ public class LHTRTest {
       }
     };
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
-        .newProxyInstance(Thread.currentThread().getContextClassLoader(), new Class[] {ITripleAPlayer.class}, handler);
+        .newProxyInstance(Thread.currentThread().getContextClassLoader(),
+            TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
     bridge.setRemote(player);
     final int PUsBeforeRaid = germans.getResources().getQuantity(m_data.getResourceList().getResource(Constants.PUS));
     battle.fight(bridge);

--- a/test/games/strategy/triplea/delegate/RevisedTest.java
+++ b/test/games/strategy/triplea/delegate/RevisedTest.java
@@ -73,6 +73,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.random.ScriptedRandomSource;
+import games.strategy.test.TestUtil;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TechAttachment;
@@ -987,7 +988,8 @@ public class RevisedTest {
       }
     };
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
-        .newProxyInstance(Thread.currentThread().getContextClassLoader(), new Class[] {ITripleAPlayer.class}, handler);
+        .newProxyInstance(Thread.currentThread().getContextClassLoader(),
+            TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
     bridge.setRemote(player);
     // int PUsBeforeRaid = germans.getResources().getQuantity(m_data.getResourceList().getResource(Constants.PUS));
     final int pusBeforeRaid = germans.getResources().getQuantity(m_data.getResourceList().getResource(Constants.PUS));

--- a/test/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/test/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -84,6 +84,7 @@ import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.random.ScriptedRandomSource;
+import games.strategy.test.TestUtil;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TechAttachment;
@@ -1134,7 +1135,8 @@ public class WW2V3_41_Test {
       }
     };
     final ITripleAPlayer player = (ITripleAPlayer) Proxy
-        .newProxyInstance(Thread.currentThread().getContextClassLoader(), new Class[] {ITripleAPlayer.class}, handler);
+        .newProxyInstance(Thread.currentThread().getContextClassLoader(),
+            TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
     bridge.setRemote(player);
     // Perform the combat movement
     move.setDelegateBridgeAndPlayer(bridge);

--- a/test/games/strategy/triplea/util/WrappedInvocationHandlerTest.java
+++ b/test/games/strategy/triplea/util/WrappedInvocationHandlerTest.java
@@ -6,17 +6,19 @@ import java.lang.reflect.Proxy;
 
 import org.junit.Test;
 
+import games.strategy.test.TestUtil;
+
 public class WrappedInvocationHandlerTest {
 
   @Test
   public void testEquals() {
     final String s1 = "test";
     final WrappedInvocationHandler handler = new WrappedInvocationHandler(s1);
-    final Object o1 = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] {}, handler);
+    final Object o1 = Proxy.newProxyInstance(getClass().getClassLoader(), TestUtil.getClassArrayFrom(), handler);
     assertEquals(o1.hashCode(), s1.hashCode());
     final String s2 = "test";
     final WrappedInvocationHandler handler2 = new WrappedInvocationHandler(s2);
-    final Object o2 = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] {}, handler2);
+    final Object o2 = Proxy.newProxyInstance(getClass().getClassLoader(), TestUtil.getClassArrayFrom(), handler2);
     assertEquals(o1, o2);
   }
 }


### PR DESCRIPTION
This adds a method (and uses it) which allows to create a class array which is not treated as rawtype.
This removes all the rawtype warnings inside the test folder

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/990)
<!-- Reviewable:end -->
