### PR TITLE
ClientLogger change

### DIFF
--- a/src/games/strategy/debug/ClientLogger.java
+++ b/src/games/strategy/debug/ClientLogger.java
@@ -12,7 +12,6 @@ public class ClientLogger {
   }
 
   private static void log(final PrintStream stream, final Throwable e) {
-    stream.println("Exception: " + e.getMessage());
     e.printStackTrace(stream);
   }
 


### PR DESCRIPTION
Previously every time an exception is logged, we do `stream.println("Exception:" + e.getMessage());` and `e.printStackTrace(stream);` afterwards.
I removed the "custom" error logging, because IMO it's not really useful and leads to confusion, since most of the time the message is null.
Example:
```
Exception: https://raw.githubusercontent.com/triplea-game/triplea/master/latest_version.properties
java.io.FileNotFoundException: https://raw.githubusercontent.com/triplea-game/triplea/master/latest_version.properties
...
```

1. The Message does tell us nothing about the real exception, just helps us getting to know the context.
2. It's not telling us anything new... The message is already printed in the StackTrace
3. `"Exception:"` it's obvious that this is an exception - no need for that message


Another Example:
```
Exception: null
java.lang.Exception
	at games.strategy.engine.framework.GameRunner.main(GameRunner.java:148)
```
It's very likely to think, that the exception is a NullPointer, but it is not...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1002)
<!-- Reviewable:end -->
