### PR TITLE
ChatFloodControl test made deterministic

### DIFF
--- a/src/games/strategy/engine/chat/ChatFloodControl.java
+++ b/src/games/strategy/engine/chat/ChatFloodControl.java
@@ -4,7 +4,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Simple flood control, only allow so many events per window of time
+ * Simple flood control, only allow so many events per window of time. During each rolling time window, anyone that
+ * sends more than "N" messages will be filtered until the next time window begins.
+ *
  */
 public class ChatFloodControl {
   private static final int ONE_MINUTE = 60 * 1000;
@@ -30,9 +32,10 @@ public class ChatFloodControl {
         clearTime = now + WINDOW;
       }
       if (!messageCount.containsKey(from)) {
-        messageCount.put(from, 0);
+        messageCount.put(from, 1);
+      } else {
+        messageCount.put(from, messageCount.get(from) + 1);
       }
-      messageCount.put(from, messageCount.get(from) + 1);
       return messageCount.get(from) <= EVENTS_PER_WINDOW;
     }
   }

--- a/src/games/strategy/engine/chat/ChatFloodControl.java
+++ b/src/games/strategy/engine/chat/ChatFloodControl.java
@@ -11,8 +11,16 @@ public class ChatFloodControl {
   static final int EVENTS_PER_WINDOW = 20;
   static final int WINDOW = ONE_MINUTE;
   private final Object lock = new Object();
-  private long clearTime = System.currentTimeMillis();
   private final Map<String, Integer> messageCount = new HashMap<>();
+  private long clearTime;
+
+  public ChatFloodControl() {
+    this(System.currentTimeMillis());
+  }
+
+  ChatFloodControl(long initialClearTime) {
+    clearTime = initialClearTime;
+  }
 
   public boolean allow(final String from, final long now) {
     synchronized (lock) {

--- a/test/games/strategy/engine/chat/ChatFloodControlTest.java
+++ b/test/games/strategy/engine/chat/ChatFloodControlTest.java
@@ -6,7 +6,8 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class ChatFloodControlTest {
-  private final ChatFloodControl testObj = new ChatFloodControl();
+  private final static long INITIAL_CLEAR_TIME = 100;
+  private final ChatFloodControl testObj = new ChatFloodControl(INITIAL_CLEAR_TIME);
 
   @Test
   public void testSimple() {
@@ -15,17 +16,19 @@ public class ChatFloodControlTest {
 
   @Test
   public void testDeny() {
+    long now = 123;
     for (int i = 0; i < ChatFloodControl.EVENTS_PER_WINDOW; i++) {
-      testObj.allow("", System.currentTimeMillis());
+      assertTrue(testObj.allow("",now));
     }
-    assertFalse(testObj.allow("", System.currentTimeMillis()));
+    assertFalse(testObj.allow("", now));
   }
 
   @Test
-  public void testReney() {
+  public void throttlingReleasedAfterTimePeriod() {
+    long now = 100;
     for (int i = 0; i < 100; i++) {
-      testObj.allow("", System.currentTimeMillis());
+      testObj.allow("", now);
     }
-    assertTrue(testObj.allow("", System.currentTimeMillis() + 1000 * 60 * 60));
+    assertTrue(testObj.allow("", INITIAL_CLEAR_TIME + ChatFloodControl.WINDOW + 1));
   }
 }

--- a/test/games/strategy/engine/chat/ChatFloodControlTest.java
+++ b/test/games/strategy/engine/chat/ChatFloodControlTest.java
@@ -6,26 +6,26 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class ChatFloodControlTest {
-  private final ChatFloodControl fc = new ChatFloodControl();
+  private final ChatFloodControl testObj = new ChatFloodControl();
 
   @Test
   public void testSimple() {
-    assertTrue(fc.allow("", System.currentTimeMillis()));
+    assertTrue(testObj.allow("", System.currentTimeMillis()));
   }
 
   @Test
   public void testDeny() {
     for (int i = 0; i < ChatFloodControl.EVENTS_PER_WINDOW; i++) {
-      fc.allow("", System.currentTimeMillis());
+      testObj.allow("", System.currentTimeMillis());
     }
-    assertFalse(fc.allow("", System.currentTimeMillis()));
+    assertFalse(testObj.allow("", System.currentTimeMillis()));
   }
 
   @Test
   public void testReney() {
     for (int i = 0; i < 100; i++) {
-      fc.allow("", System.currentTimeMillis());
+      testObj.allow("", System.currentTimeMillis());
     }
-    assertTrue(fc.allow("", System.currentTimeMillis() + 1000 * 60 * 60));
+    assertTrue(testObj.allow("", System.currentTimeMillis() + 1000 * 60 * 60));
   }
 }


### PR DESCRIPTION
Should address #887

Makes ChatFloodControlTest.java deterministic, it should no longer be flaky (1a9064f)

Recommend a commit-by-commit review for this one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1012)
<!-- Reviewable:end -->
