### PR TITLE
ClientLogger change No2

### DIFF
--- a/src/games/strategy/debug/ClientLogger.java
+++ b/src/games/strategy/debug/ClientLogger.java
@@ -12,7 +12,6 @@ public class ClientLogger {
   }
 
   private static void log(final PrintStream stream, final Throwable e) {
-    stream.println("Exception: " + e.getMessage());
     e.printStackTrace(stream);
   }
 

--- a/src/games/strategy/engine/framework/GameRunner.java
+++ b/src/games/strategy/engine/framework/GameRunner.java
@@ -1,7 +1,10 @@
 package games.strategy.engine.framework;
 
+import java.awt.AWTEvent;
+import java.awt.EventQueue;
 import java.awt.Image;
 import java.awt.MediaTracker;
+import java.awt.Toolkit;
 import java.awt.Window;
 import java.io.File;
 import java.io.FileInputStream;
@@ -139,6 +142,16 @@ public class GameRunner {
     ErrorConsole.getConsole();
     // do after we handle command line args
     checkForMemoryXMX();
+    Toolkit.getDefaultToolkit().getSystemEventQueue().push(new EventQueue() {
+      @Override
+      protected void dispatchEvent(AWTEvent newEvent) {
+        try {
+          super.dispatchEvent(newEvent);
+        } catch (Throwable t) {
+          ClientLogger.logError(t);
+        }
+      }
+    });
     SwingUtilities.invokeLater(() -> setupLookAndFeel());
     showMainFrame();
     new Thread(() -> setupLogging()).start();

--- a/src/games/strategy/engine/framework/GameRunner.java
+++ b/src/games/strategy/engine/framework/GameRunner.java
@@ -147,6 +147,7 @@ public class GameRunner {
       protected void dispatchEvent(AWTEvent newEvent) {
         try {
           super.dispatchEvent(newEvent);
+          // This ensures, that all exceptions/errors inside any swing framework (like substance) are logged correctly
         } catch (Throwable t) {
           ClientLogger.logError(t);
         }


### PR DESCRIPTION
See #1002 and #1008 for more information...
This recommits #1002 and ensures, that a proper stacktrace is printed from Swing UI exceptions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1014)
<!-- Reviewable:end -->
