### PR TITLE
Show Map Name on Game Parse Failures

### DIFF
--- a/src/games/strategy/engine/data/GameParseException.java
+++ b/src/games/strategy/engine/data/GameParseException.java
@@ -6,4 +6,9 @@ public class GameParseException extends Exception {
   public GameParseException(final String error) {
     super(error);
   }
+
+  public GameParseException(final String mapName, final String error) {
+    super("MapName: " + mapName + ", " + error);
+  }
+
 }

--- a/src/games/strategy/engine/data/GameParser.java
+++ b/src/games/strategy/engine/data/GameParser.java
@@ -58,8 +58,11 @@ public class GameParser {
   private final Collection<SAXParseException> errorsSAX = new ArrayList<>();
   public static final String DTD_FILE_NAME = "game.dtd";
   private static HashMap<String, String> newClassesForOldNames;
+  private final String mapName;
 
-  public GameParser() {}
+  public GameParser(String mapName) {
+    this.mapName = mapName;
+  }
 
   /**
    * Parses a file into a GameData object.

--- a/src/games/strategy/engine/data/GameParser.java
+++ b/src/games/strategy/engine/data/GameParser.java
@@ -86,7 +86,7 @@ public class GameParser {
     try {
       doc = getDocument(stream);
     } catch (final IOException | ParserConfigurationException e) {
-      throw new IllegalStateException(e);
+      throw new IllegalStateException("Error parsing: " + mapName, e);
     }
     final Element root = doc.getDocumentElement();
     data = new GameData();
@@ -173,8 +173,8 @@ public class GameParser {
     try {
       validate();
     } catch (final Exception e) {
-      ClientLogger.logQuietly(e);
-      throw new GameParseException(e.getMessage());
+      ClientLogger.logQuietly("Error parsing: " + mapName, e);
+      throw new GameParseException(mapName, e.getMessage());
     }
     return data;
   }
@@ -233,7 +233,7 @@ public class GameParser {
       for (final PlayerID player2 : data.getPlayerList()) {
         // See if there is a relationship between them
         if ((data.getRelationshipTracker().getRelationshipType(player, player2) == null)) {
-          throw new GameParseException("No relation set for: " + player.getName() + " and " + player2.getName());
+          throw new GameParseException(mapName, "No relation set for: " + player.getName() + " and " + player2.getName());
           // or else throw an exception!
         }
       }
@@ -253,7 +253,7 @@ public class GameParser {
     final String dtdFile = "/games/strategy/engine/xml/" + DTD_FILE_NAME;
     final URL url = GameParser.class.getResource(dtdFile);
     if (url == null) {
-      throw new RuntimeException(String.format("Could not find in classpath %s", dtdFile));
+      throw new RuntimeException("Map: "+ mapName + ", " + String.format("Could not find in classpath %s", dtdFile));
     }
     final String dtdSystem = url.toExternalForm();
     final String system = dtdSystem.substring(0, dtdSystem.length() - 8);
@@ -285,7 +285,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final PlayerID player = data.getPlayerList().getPlayerID(name);
     if (player == null && mustFind) {
-      throw new GameParseException("Could not find player. name:" + name);
+      throw new GameParseException(mapName, "Could not find player. name:" + name);
     }
     return player;
   }
@@ -303,7 +303,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final RelationshipType relation = data.getRelationshipTypeList().getRelationshipType(name);
     if (relation == null && mustFind) {
-      throw new GameParseException("Could not find relation name:" + name);
+      throw new GameParseException(mapName, "Could not find relation name:" + name);
     }
     return relation;
   }
@@ -313,7 +313,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final TerritoryEffect effect = data.getTerritoryEffectList().get(name);
     if (effect == null && mustFind) {
-      throw new GameParseException("Could not find territoryEffect name:" + name);
+      throw new GameParseException(mapName, "Could not find territoryEffect name:" + name);
     }
     return effect;
   }
@@ -326,7 +326,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final ProductionRule productionRule = data.getProductionRuleList().getProductionRule(name);
     if (productionRule == null && mustFind) {
-      throw new GameParseException("Could not find production rule. name:" + name);
+      throw new GameParseException(mapName, "Could not find production rule. name:" + name);
     }
     return productionRule;
   }
@@ -339,7 +339,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final RepairRule repairRule = data.getRepairRuleList().getRepairRule(name);
     if (repairRule == null && mustFind) {
-      throw new GameParseException("Could not find production rule. name:" + name);
+      throw new GameParseException(mapName, "Could not find production rule. name:" + name);
     }
     return repairRule;
   }
@@ -352,7 +352,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final Territory territory = data.getMap().getTerritory(name);
     if (territory == null && mustFind) {
-      throw new GameParseException("Could not find territory. name:" + name);
+      throw new GameParseException(mapName, "Could not find territory. name:" + name);
     }
     return territory;
   }
@@ -365,7 +365,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final UnitType type = data.getUnitTypeList().getUnitType(name);
     if (type == null && mustFind) {
-      throw new GameParseException("Could not find unitType. name:" + name);
+      throw new GameParseException(mapName, "Could not find unitType. name:" + name);
     }
     return type;
   }
@@ -381,7 +381,7 @@ public class GameParser {
       type = data.getTechnologyFrontier().getAdvanceByProperty(name);
     }
     if (type == null && mustFind) {
-      throw new GameParseException("Could not find technology. name:" + name);
+      throw new GameParseException(mapName, "Could not find technology. name:" + name);
     }
     return type;
   }
@@ -394,7 +394,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final IDelegate delegate = data.getDelegateList().getDelegate(name);
     if (delegate == null && mustFind) {
-      throw new GameParseException("Could not find delegate. name:" + name);
+      throw new GameParseException(mapName, "Could not find delegate. name:" + name);
     }
     return delegate;
   }
@@ -407,7 +407,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final Resource resource = data.getResourceList().getResource(name);
     if (resource == null && mustFind) {
-      throw new GameParseException("Could not find resource. name:" + name);
+      throw new GameParseException(mapName, "Could not find resource. name:" + name);
     }
     return resource;
   }
@@ -420,7 +420,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final ProductionFrontier productionFrontier = data.getProductionFrontierList().getProductionFrontier(name);
     if (productionFrontier == null && mustFind) {
-      throw new GameParseException("Could not find production frontier. name:" + name);
+      throw new GameParseException(mapName, "Could not find production frontier. name:" + name);
     }
     return productionFrontier;
   }
@@ -433,7 +433,7 @@ public class GameParser {
     final String name = element.getAttribute(attribute);
     final RepairFrontier repairFrontier = data.getRepairFrontierList().getRepairFrontier(name);
     if (repairFrontier == null && mustFind) {
-      throw new GameParseException("Could not find production frontier. name:" + name);
+      throw new GameParseException(mapName, "Could not find production frontier. name:" + name);
     }
     return repairFrontier;
   }
@@ -450,11 +450,11 @@ public class GameParser {
     }
     // a lot can go wrong, the following list is just a subset of potential pitfalls
     catch (final ClassNotFoundException cnfe) {
-      throw new GameParseException("Class <" + className + "> could not be found.");
+      throw new GameParseException(mapName, "Class <" + className + "> could not be found.");
     } catch (final InstantiationException ie) {
-      throw new GameParseException("Class <" + className + "> could not be instantiated. ->" + ie.getMessage());
+      throw new GameParseException(mapName, "Class <" + className + "> could not be instantiated. ->" + ie.getMessage());
     } catch (final IllegalAccessException iae) {
-      throw new GameParseException("Constructor could not be accessed ->" + iae.getMessage());
+      throw new GameParseException(mapName, "Constructor could not be accessed ->" + iae.getMessage());
     }
     return instance;
   }
@@ -479,7 +479,7 @@ public class GameParser {
       if (newClassName != null) {
         return getClassByName(newClassName);
       }
-      throw new GameParseException("Class <" + className + "> could not be found.");
+      throw new GameParseException(mapName, "Class <" + className + "> could not be found.");
     }
   }
 
@@ -501,11 +501,11 @@ public class GameParser {
       if (optional) {
         return null;
       }
-      throw new GameParseException("No child called " + name);
+      throw new GameParseException(mapName, "No child called " + name);
     }
     // too many found
     if (children.size() > 1) {
-      throw new GameParseException("Too many children named " + name);
+      throw new GameParseException(mapName, "Too many children named " + name);
     }
     return children.get(0);
   }
@@ -556,7 +556,7 @@ public class GameParser {
     final String className = ((Element) loader).getAttribute("javaClass");
     final Object instance = getInstance(className);
     if (!(instance instanceof IGameLoader)) {
-      throw new GameParseException("Loader must implement IGameLoader.  Class Name:" + className);
+      throw new GameParseException(mapName, "Loader must implement IGameLoader.  Class Name:" + className);
     }
     data.setGameLoader((IGameLoader) instance);
   }
@@ -590,7 +590,7 @@ public class GameParser {
   /**
    * Creates and adds new territories and their connections to their map, based on a grid.
    */
-  public static void setGrids(final GameData data, final String gridType, final String name, final String xs,
+  private void setGrids(final GameData data, final String gridType, final String name, final String xs,
       final String ys, final Set<String> water, final String horizontalConnections, final String verticalConnections,
       final String diagonalConnections, final boolean addingOntoExistingMap) throws GameParseException {
     final GameMap map = data.getMap();
@@ -600,7 +600,7 @@ public class GameParser {
     } else if (horizontalConnections.equals("explicit")) {
       horizontalConnectionsImplict = false;
     } else {
-      throw new GameParseException("horizontal-connections attribute must be either \"explicit\" or \"implicit\"");
+      throw new GameParseException(mapName, "horizontal-connections attribute must be either \"explicit\" or \"implicit\"");
     }
     boolean verticalConnectionsImplict;
     if (verticalConnections.equals("implicit")) {
@@ -608,7 +608,7 @@ public class GameParser {
     } else if (verticalConnections.equals("explicit")) {
       verticalConnectionsImplict = false;
     } else {
-      throw new GameParseException("vertical-connections attribute must be either \"explicit\" or \"implicit\"");
+      throw new GameParseException(mapName, "vertical-connections attribute must be either \"explicit\" or \"implicit\"");
     }
     boolean diagonalConnectionsImplict;
     if (diagonalConnections.equals("implicit")) {
@@ -616,7 +616,7 @@ public class GameParser {
     } else if (diagonalConnections.equals("explicit")) {
       diagonalConnectionsImplict = false;
     } else {
-      throw new GameParseException("diagonal-connections attribute must be either \"explicit\" or \"implicit\"");
+      throw new GameParseException(mapName, "diagonal-connections attribute must be either \"explicit\" or \"implicit\"");
     }
     final int x_size = Integer.valueOf(xs);
     int y_size;
@@ -964,7 +964,7 @@ public class GameParser {
     // what type
     final List<Node> children = getNonTextNodes(property);
     if (children.size() != 1) {
-      throw new GameParseException(
+      throw new GameParseException(mapName,
           "Editable properties must have exactly 1 child specifying the type. Number of children found:"
               + children.size() + " for node:" + property.getNodeName());
     }
@@ -994,7 +994,7 @@ public class GameParser {
     } else if (childName.equals("string")) {
       editableProperty = new StringProperty(name, null, defaultValue);
     } else {
-      throw new GameParseException("Unrecognized property type:" + childName);
+      throw new GameParseException(mapName, "Unrecognized property type:" + childName);
     }
     data.getProperties().addEditableProperty(editableProperty);
   }
@@ -1018,7 +1018,7 @@ public class GameParser {
       try {
         delegate = (IDelegate) getInstance(className);
       } catch (final ClassCastException cce) {
-        throw new GameParseException("Class <" + className + "> is not a delegate.");
+        throw new GameParseException(mapName, "Class <" + className + "> is not a delegate.");
       }
       final String name = current.getAttribute("name");
       String displayName = current.getAttribute("display");
@@ -1051,7 +1051,7 @@ public class GameParser {
       if (current.hasAttribute("maxRunCount")) {
         final int runCount = Integer.parseInt(current.getAttribute("maxRunCount"));
         if (runCount <= 0) {
-          throw new GameParseException("maxRunCount must be positive");
+          throw new GameParseException(mapName, "maxRunCount must be positive");
         }
         step.setMaxRunCount(runCount);
       }
@@ -1105,7 +1105,7 @@ public class GameParser {
 
   private void parseCosts(final ProductionRule rule, final List<Element> elements) throws GameParseException {
     if (elements.size() == 0) {
-      throw new GameParseException("no costs  for rule:" + rule.getName());
+      throw new GameParseException(mapName, "no costs  for rule:" + rule.getName());
     }
     for (final Element current : elements) {
       final Resource resource = getResource(current, "resource", true);
@@ -1116,7 +1116,7 @@ public class GameParser {
 
   private void parseRepairCosts(final RepairRule rule, final List<Element> elements) throws GameParseException {
     if (elements.size() == 0) {
-      throw new GameParseException("no costs  for rule:" + rule.getName());
+      throw new GameParseException(mapName, "no costs  for rule:" + rule.getName());
     }
     for (final Element current : elements) {
       final Resource resource = getResource(current, "resource", true);
@@ -1127,7 +1127,7 @@ public class GameParser {
 
   private void parseResults(final ProductionRule rule, final List<Element> elements) throws GameParseException {
     if (elements.size() == 0) {
-      throw new GameParseException("no results  for rule:" + rule.getName());
+      throw new GameParseException(mapName, "no results  for rule:" + rule.getName());
     }
     for (final Element current : elements) {
       // must find either a resource or a unit with the given name
@@ -1137,7 +1137,7 @@ public class GameParser {
         result = getUnitType(current, "resourceOrUnit", false);
       }
       if (result == null) {
-        throw new GameParseException("Could not find resource or unit" + current.getAttribute("resourceOrUnit"));
+        throw new GameParseException("mapName, Could not find resource or unit" + current.getAttribute("resourceOrUnit"));
       }
       final int quantity = Integer.parseInt(current.getAttribute("quantity"));
       rule.addResult(result, quantity);
@@ -1146,7 +1146,7 @@ public class GameParser {
 
   private void parseRepairResults(final RepairRule rule, final List<Element> elements) throws GameParseException {
     if (elements.size() == 0) {
-      throw new GameParseException("no results  for rule:" + rule.getName());
+      throw new GameParseException(mapName, "no results  for rule:" + rule.getName());
     }
     for (final Element current : elements) {
       // must find either a resource or a unit with the given name
@@ -1156,7 +1156,7 @@ public class GameParser {
         result = getUnitType(current, "resourceOrUnit", false);
       }
       if (result == null) {
-        throw new GameParseException("Could not find resource or unit" + current.getAttribute("resourceOrUnit"));
+        throw new GameParseException(mapName, "Could not find resource or unit" + current.getAttribute("resourceOrUnit"));
       }
       final int quantity = Integer.parseInt(current.getAttribute("quantity"));
       rule.addResult(result, quantity);
@@ -1259,7 +1259,7 @@ public class GameParser {
         ta = data.getTechnologyFrontier().getAdvanceByName(current.getAttribute("name"));
       }
       if (ta == null) {
-        throw new GameParseException("Technology not found :" + current.getAttribute("name"));
+        throw new GameParseException(mapName, "Technology not found :" + current.getAttribute("name"));
       }
       frontier.addAdvance(ta);
     }
@@ -1283,11 +1283,11 @@ public class GameParser {
         try {
           final Class<?> objectClass = getClassByName(className);
           if (!IAttachment.class.isAssignableFrom(objectClass)) {
-            throw new GameParseException(className + " does not implement IAttachable");
+            throw new GameParseException(mapName, className + " does not implement IAttachable");
           }
           constructors.put(className, objectClass.getConstructor(IAttachment.attachmentConstructorParameter));
         } catch (final NoSuchMethodException | SecurityException exception) {
-          throw new GameParseException(
+          throw new GameParseException(mapName,
               "Constructor for class " + className + " could not be found: " + exception.getMessage());
         }
       }
@@ -1305,7 +1305,7 @@ public class GameParser {
         data.addToAttachmentOrderAndValues(
             Tuple.of(attachment, attachmentOptionValues));
       } catch (final InstantiationException | InvocationTargetException | IllegalArgumentException | IllegalAccessException e) {
-        throw new GameParseException(
+        throw new GameParseException(mapName,
             "Attachment of type " + className + " could not be instanciated: " + e.getMessage());
       }
     }
@@ -1329,7 +1329,7 @@ public class GameParser {
     } else if (type.equals("technology")) {
       returnVal = getTechnology(element, name, true);
     } else {
-      throw new GameParseException("Type not found to attach to:" + type);
+      throw new GameParseException(mapName, "Type not found to attach to:" + type);
     }
     return returnVal;
   }
@@ -1340,7 +1340,7 @@ public class GameParser {
     return first + aString.substring(1);
   }
 
-  private static ArrayList<Tuple<String, String>> setValues(final IAttachment attachment, final List<Element> values)
+  private ArrayList<Tuple<String, String>> setValues(final IAttachment attachment, final List<Element> values)
       throws GameParseException {
     final ArrayList<Tuple<String, String>> options = new ArrayList<>();
     for (final Element current : values) {
@@ -1350,11 +1350,11 @@ public class GameParser {
       try {
         name = current.getAttribute("name");
         if (name.length() == 0) {
-          throw new GameParseException("Option name with 0 length");
+          throw new GameParseException(mapName, "Option name with 0 length");
         }
         setter = attachment.getClass().getMethod("set" + capitalizeFirstLetter(name), SETTER_ARGS);
       } catch (final NoSuchMethodException nsme) {
-        throw new GameParseException("The following option name of " + attachment.getName() + " of class "
+        throw new GameParseException(mapName, "The following option name of " + attachment.getName() + " of class "
             + attachment.getClass().getName().substring(attachment.getClass().getName().lastIndexOf('.') + 1)
             + " are either misspelled or exist only in a future version of TripleA. Setter: " + name);
       }
@@ -1372,10 +1372,10 @@ public class GameParser {
         final Object[] args = {itemValues};
         setter.invoke(attachment, args);
       } catch (final IllegalAccessException iae) {
-        throw new GameParseException("Setter not public. Setter:" + name + " Class:" + attachment.getClass().getName());
+        throw new GameParseException(mapName, "Setter not public. Setter:" + name + " Class:" + attachment.getClass().getName());
       } catch (final InvocationTargetException ite) {
         ite.getCause().printStackTrace(System.out);
-        throw new GameParseException("Error setting property:" + name + " cause:" + ite.getCause().getMessage());
+        throw new GameParseException(mapName, "Error setting property:" + name + " cause:" + ite.getCause().getMessage());
       }
       options.add(Tuple.of(name, itemValues));
     }
@@ -1451,7 +1451,7 @@ public class GameParser {
       if (hitsTakenString != null && hitsTakenString.trim().length() > 0) {
         hits = Integer.parseInt(hitsTakenString);
         if (hits < 0 || hits > UnitAttachment.get(type).getHitPoints() - 1) {
-          throw new GameParseException(
+          throw new GameParseException(mapName,
               "hitsTaken cannot be less than zero or greater than one less than total hitpPoints");
         }
       } else {
@@ -1461,7 +1461,7 @@ public class GameParser {
       if (unitDamageString != null && unitDamageString.trim().length() > 0) {
         unitDamage = Integer.parseInt(unitDamageString);
         if (unitDamage < 0) {
-          throw new GameParseException("unitDamage cannot be less than zero");
+          throw new GameParseException(mapName, "unitDamage cannot be less than zero");
         }
       } else {
         unitDamage = 0;
@@ -1498,7 +1498,7 @@ public class GameParser {
       }
     }
     if (!errors.isEmpty()) {
-      throw new GameParseException(
+      throw new GameParseException(mapName,
           data.getGameName() + " does not have unit attachments for: " + MyFormatter.defaultNamedToTextList(errors));
     }
   }

--- a/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -156,7 +156,7 @@ public class AvailableGames {
     Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if (inputStream.isPresent()) {
       try (InputStream input = inputStream.get()) {
-        final GameData data = new GameParser().parse(input, gameName, s_delayedParsing);
+        final GameData data = new GameParser(uri.toString()).parse(input, gameName, s_delayedParsing);
         final String name = data.getGameName();
         final String mapName = data.getProperties().get(Constants.MAP_NAME, "");
         if (!availableGames.containsKey(name)) {
@@ -198,7 +198,7 @@ public class AvailableGames {
     Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if (inputStream.isPresent()) {
       try (InputStream input = inputStream.get()) {
-        return new GameParser().parse(input, gameName, false);
+        return new GameParser(uri.toString()).parse(input, gameName, false);
       } catch (final Exception e) {
         ClientLogger.logError("Exception while parsing: " + uri.toString() + " : "
             + (gameName.get() != null ? gameName.get() + " : " : ""), e);

--- a/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -121,7 +121,7 @@ public class GameSelectorModel extends Observable {
       // if the file name is xml, load it as a new game
       if (file.getName().toLowerCase().endsWith("xml")) {
         try (FileInputStream fis = new FileInputStream(file)) {
-          newData = (new GameParser()).parse(fis, gameName, false);
+          newData = (new GameParser(file.getAbsolutePath())).parse(fis, gameName, false);
         }
       }
       // the extension should be tsvg, but

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -52,7 +52,7 @@ public class NewGameChooserEntry {
 
     try (InputStream input = inputStream.get()) {
       final boolean delayParsing = GameRunner.getDelayedParsing();
-      m_data = new GameParser().parse(input, gameName, delayParsing);
+      m_data = new GameParser(uri.toString()).parse(input, gameName, delayParsing);
       m_gameDataFullyLoaded = !delayParsing;
       m_gameNameAndMapNameProperty = getGameName() + ":" + getMapNameProperty();
     }
@@ -71,7 +71,7 @@ public class NewGameChooserEntry {
     }
 
     try (InputStream input = inputStream.get()) {
-      m_data = new GameParser().parse(input, gameName, false);
+      m_data = new GameParser(m_url.toString()).parse(input, gameName, false);
       m_gameDataFullyLoaded = true;
 
     } catch (final EngineVersionException e) {
@@ -101,7 +101,7 @@ public class NewGameChooserEntry {
       return;
     }
     try (InputStream input = inputStream.get()) {
-      m_data = new GameParser().parse(input, gameName, true);
+      m_data = new GameParser(m_url.toString()).parse(input, gameName, true);
       m_gameDataFullyLoaded = false;
     } catch (final EngineVersionException e) {
       System.out.println(e.getMessage());

--- a/src/tools/map/xml/creator/MapXmlCreator.java
+++ b/src/tools/map/xml/creator/MapXmlCreator.java
@@ -1114,7 +1114,7 @@ public class MapXmlCreator extends JFrame {
     final FileInputStream in = new FileInputStream(gameXMLPath);
 
     // parse using builder to get DOM representation of the XML file
-    final org.w3c.dom.Document dom = new GameParser().getDocument(in);
+    final org.w3c.dom.Document dom = new GameParser(gameXMLPath).getDocument(in);
 
     GAME_STEP goToStep = MapXmlHelper.parseValuesFromXML(dom);
 

--- a/test/games/strategy/engine/data/AllianceTrackerTest.java
+++ b/test/games/strategy/engine/data/AllianceTrackerTest.java
@@ -20,7 +20,7 @@ public class AllianceTrackerTest {
     // get the xml file
     final URL url = this.getClass().getResource("Test.xml");
     final InputStream input = url.openStream();
-    m_data = (new GameParser()).parse(input, new AtomicReference<>(), false);
+    m_data = (new GameParser(url.toString())).parse(input, new AtomicReference<>(), false);
   }
 
   @Test

--- a/test/games/strategy/engine/data/ChangeTest.java
+++ b/test/games/strategy/engine/data/ChangeTest.java
@@ -30,7 +30,7 @@ public class ChangeTest {
     final URL url = this.getClass().getResource("Test.xml");
     // System.out.println(url);
     final InputStream input = url.openStream();
-    m_data = (new GameParser()).parse(input, new AtomicReference<>(), false);
+    m_data = (new GameParser(url.toString())).parse(input, new AtomicReference<>(), false);
   }
 
   private Change serialize(final Change aChange) throws Exception {

--- a/test/games/strategy/engine/data/SerializationTest.java
+++ b/test/games/strategy/engine/data/SerializationTest.java
@@ -26,10 +26,10 @@ public class SerializationTest {
     final URL url = this.getClass().getResource("Test.xml");
     // get the source data
     InputStream input = url.openStream();
-    m_dataSource = (new GameParser()).parse(input, new AtomicReference<>(), false);
+    m_dataSource = (new GameParser(url.toString())).parse(input, new AtomicReference<>(), false);
     // get the sink data
     input = url.openStream();
-    m_dataSink = (new GameParser()).parse(input, new AtomicReference<>(), false);
+    m_dataSink = (new GameParser(url.toString())).parse(input, new AtomicReference<>(), false);
   }
 
   private Object serialize(final Object anObject) throws Exception {

--- a/test/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/test/games/strategy/engine/framework/GameDataManagerTest.java
@@ -24,7 +24,7 @@ public class GameDataManagerTest {
     final URL url = SerializationTest.class.getResource("Test.xml");
     // get the source data
     final InputStream input = url.openStream();
-    (new GameParser()).parse(input, new AtomicReference<>(), false);
+    (new GameParser(url.toString())).parse(input, new AtomicReference<>(), false);
   }
 
   @Test

--- a/test/games/strategy/engine/xml/ParserTest.java
+++ b/test/games/strategy/engine/xml/ParserTest.java
@@ -34,7 +34,7 @@ public class ParserTest {
     final URL url = this.getClass().getResource("GameExample.xml");
     // System.out.println(url);
     final InputStream input = url.openStream();
-    gameData = (new GameParser()).parse(input, new AtomicReference<>(), false);
+    gameData = (new GameParser(url.toString())).parse(input, new AtomicReference<>(), false);
   }
 
   @Test

--- a/test/games/strategy/triplea/delegate/DelegateTest.java
+++ b/test/games/strategy/triplea/delegate/DelegateTest.java
@@ -87,7 +87,7 @@ public class DelegateTest {
     // get the xml file
     final URL url = this.getClass().getResource("DelegateTest.xml");
     final InputStream input = url.openStream();
-    m_data = (new GameParser()).parse(input, new AtomicReference<>(), false);
+    m_data = (new GameParser(url.toString())).parse(input, new AtomicReference<>(), false);
     input.close();
     british = GameDataTestUtil.british(m_data);
     british.addAttachment(Constants.TECH_ATTACHMENT_NAME, new TechAttachment());

--- a/test/games/strategy/triplea/xml/LoadGameUtil.java
+++ b/test/games/strategy/triplea/xml/LoadGameUtil.java
@@ -28,7 +28,7 @@ public class LoadGameUtil {
       if (is == null) {
         throw new IllegalStateException(game + " does not exist");
       }
-      return (new GameParser()).parse(is, new AtomicReference<>(), false);
+      return (new GameParser(game)).parse(is, new AtomicReference<>(), false);
     } catch (final Exception e) {
       throw new IllegalStateException(e);
     }


### PR DESCRIPTION
Try number 2 to get map names in error messages. This time instead we constructor inject the mapname rather than passing it to every method. This is a much cleaner approach, and does not muck with APIs used to bind XML values.

Related to #1018

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1019)
<!-- Reviewable:end -->
