### PR TITLE
No map load fixes

### DIFF
--- a/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -125,12 +125,19 @@ public class DownloadMapsWindow extends JFrame {
 
   private static Optional<DownloadFileDescription> findMap(final String mapName,
       final List<DownloadFileDescription> games) {
+
+    final String normalizedName = normalizeName(mapName);
     for (DownloadFileDescription download : games) {
-      if (download.getMapName().equalsIgnoreCase(mapName)) {
+      if (download.getMapName().equalsIgnoreCase(mapName)
+          || normalizedName.equals(normalizeName(download.getMapName()))) {
         return Optional.of(download);
       }
     }
     return Optional.empty();
+  }
+
+  private static String normalizeName(String mapName) {
+    return mapName.replace(' ', '_').toLowerCase();
   }
 
 

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -28,9 +28,12 @@ public class ResourceLoader {
   public static String RESOURCE_FOLDER = "assets";
 
   public static ResourceLoader getGameEngineAssetLoader() {
-    return getMapResourceLoader(null);
+    return getMapResourceLoader("");
   }
 
+  /**
+   * Returns a resource loader that will find assets in a map directory.
+   */
   public static ResourceLoader getMapResourceLoader(final String mapName) {
     File atFolder = ClientFileSystemHelper.getRootFolder();
     File resourceFolder = new File(atFolder, RESOURCE_FOLDER);
@@ -92,7 +95,8 @@ public class ResourceLoader {
 
     Optional<File> match = candidates.stream().filter(file -> file.exists()).findFirst();
     if(!match.isPresent()) {
-      ClientLogger.logError("Could not find map: " +mapName + " in any of the following locations: " + candidates);
+      // if we get no results, we will eventually prompt the user to download the map
+      return new ArrayList<>();
     }
     ClientLogger.logQuietly("Loading map: " + mapName + ", from: " + match.get().getAbsolutePath());
 

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -45,7 +45,7 @@ public class ResourceLoader {
 
     final List<String> dirs = getPaths(mapName);
     if (mapName != null && dirs.isEmpty()) {
-      SwingComponents.promptUser("Download map?",
+      SwingComponents.promptUser("Download Map?",
           "Map missing: " + mapName + ", could not join game.\nWould you like to download the map now?"
               + "\nOnce the download completes, you may reconnect to this game.",
           () -> DownloadMapsWindow.showDownloadMapsWindow(mapName));

--- a/src/games/strategy/triplea/TripleAPlayer.java
+++ b/src/games/strategy/triplea/TripleAPlayer.java
@@ -86,7 +86,9 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
 
   @Override
   public void reportMessage(final String message, final String title) {
-    ui.notifyMessage(message, title);
+    if(ui != null ) {
+      ui.notifyMessage(message, title);
+    }
   }
 
   @Override
@@ -97,8 +99,8 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       return;
     }
     if (ui == null) {
-      System.out.println("Game frame is null, but entered player step: " + name + " for player: " + this.toString());
-      // headless games shouldn't get here, but lets try returning anyway
+      // We will get here if we are loading a save game of a map that we do not have. Caller code should be doing
+      // the error handling, so just return..
       return;
     }
     // TODO: parsing which UI thing we should run based on the string name of a possibly extended delegate


### PR DESCRIPTION
Series of fixes for when loading a save game of a map which you do not have downloaded

1. Abort processing if an Optional map load comes back empty. Before we were logging a warning, then continued to  dereference the empty optional (resulting in an error).

2. When searching for a map to download by name, check a normalized name in addition to a case insensitive match. I was seeing "new_world_order" be compared to "New World Order".

3. Small avoid NPE fix, and remove unnecessary logging when we will prompt to download a missing map anwayys

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1035)
<!-- Reviewable:end -->
