### PR TITLE
Put settings window descriptions in a scroll pane

### DIFF
--- a/src/games/strategy/triplea/settings/SettingsWindow.java
+++ b/src/games/strategy/triplea/settings/SettingsWindow.java
@@ -102,7 +102,7 @@ public class SettingsWindow extends SwingComponents.ModalJDialog {
     // the vertical struct gives the row height
     contentRow.add(Box.createVerticalStrut(ROW_HEIGHT));
 
-    contentRow.add(descriptionComponent);
+    contentRow.add(SwingComponents.newJScrollPane(descriptionComponent));
     contentRow.setBorder(new BevelBorder(BevelBorder.LOWERED));
     return contentRow;
   }


### PR DESCRIPTION
Quick attempt to fix this screenshot:
https://cloud.githubusercontent.com/assets/19562310/17273383/57492e8a-56b3-11e6-9ac1-fbbd73161227.png

I was not able to repro that same UI view - but this PR should somewhat address that problem (#1028)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1039)
<!-- Reviewable:end -->
