### PR TITLE
Background wait dialog can now be closed

### DIFF
--- a/src/games/strategy/engine/framework/ui/background/WaitDialog.java
+++ b/src/games/strategy/engine/framework/ui/background/WaitDialog.java
@@ -17,8 +17,6 @@ public class WaitDialog extends JDialog {
 
   public WaitDialog(final Component parent, final String waitMessage, final Action cancelAction) {
     super(JOptionPane.getFrameForComponent(parent), "Please Wait", true);
-    setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
-    setUndecorated(true);
     final WaitPanel panel = new WaitPanel(waitMessage);
     getContentPane().setLayout(new BorderLayout());
     getContentPane().add(panel, BorderLayout.CENTER);


### PR DESCRIPTION
Fixes :  #1032
Dialog is shown when updating maps or getting the map download list

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1044)
<!-- Reviewable:end -->
