### PR TITLE
Do not log errors when a map was deleted out from under the game.

### DIFF
--- a/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -75,7 +75,9 @@ public class GameSelectorModel extends Observable {
     m_fileName = entry.getLocation();
     setGameData(entry.getGameData());
     final Preferences prefs = Preferences.userNodeForPackage(this.getClass());
-    prefs.put(DEFAULT_GAME_NAME_PREF, entry.getGameData().getGameName());
+    if(entry.getGameData() != null ) {
+      prefs.put(DEFAULT_GAME_NAME_PREF, entry.getGameData().getGameName());
+    }
     prefs.put(DEFAULT_GAME_URI_PREF, entry.getURI().toString());
     try {
       prefs.flush();

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -47,7 +47,9 @@ public class NewGameChooserEntry {
 
     Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if(!inputStream.isPresent()) {
-      throw new IOException("Failed to open an input stream to: " + uri);
+      m_gameNameAndMapNameProperty = "";
+      // this means the map was deleted out from under us.
+      return;
     }
 
     try (InputStream input = inputStream.get()) {

--- a/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -21,10 +21,10 @@ import games.strategy.engine.framework.GameRunner;
 import games.strategy.triplea.Constants;
 
 public class NewGameChooserEntry {
-  private final URI m_url;
-  private GameData m_data;
-  private boolean m_gameDataFullyLoaded = false;
-  private final String m_gameNameAndMapNameProperty;
+  private final URI url;
+  private GameData gameData;
+  private boolean gameDataFullyLoaded = false;
+  private final String gameNameAndMapNameProperty;
 
 
   public static Comparator<NewGameChooserEntry> getComparator() {
@@ -42,49 +42,49 @@ public class NewGameChooserEntry {
 
   public NewGameChooserEntry(final URI uri)
       throws IOException, GameParseException, SAXException, EngineVersionException {
-    m_url = uri;
+    url = uri;
     final AtomicReference<String> gameName = new AtomicReference<>();
 
     Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if(!inputStream.isPresent()) {
-      m_gameNameAndMapNameProperty = "";
+      gameNameAndMapNameProperty = "";
       // this means the map was deleted out from under us.
       return;
     }
 
     try (InputStream input = inputStream.get()) {
       final boolean delayParsing = GameRunner.getDelayedParsing();
-      m_data = new GameParser(uri.toString()).parse(input, gameName, delayParsing);
-      m_gameDataFullyLoaded = !delayParsing;
-      m_gameNameAndMapNameProperty = getGameName() + ":" + getMapNameProperty();
+      gameData = new GameParser(uri.toString()).parse(input, gameName, delayParsing);
+      gameDataFullyLoaded = !delayParsing;
+      gameNameAndMapNameProperty = getGameName() + ":" + getMapNameProperty();
     }
   }
 
   public void fullyParseGameData() throws GameParseException {
     // TODO: We should be setting this in the the constructor. At this point, you have to call methods in the
     // correct order for things to work, and that is bads.
-    m_data = null;
+    gameData = null;
 
     final AtomicReference<String> gameName = new AtomicReference<>();
 
-    Optional<InputStream> inputStream = UrlStreams.openStream(m_url);
+    Optional<InputStream> inputStream = UrlStreams.openStream(url);
     if(!inputStream.isPresent()) {
       return;
     }
 
     try (InputStream input = inputStream.get()) {
-      m_data = new GameParser(m_url.toString()).parse(input, gameName, false);
-      m_gameDataFullyLoaded = true;
+      gameData = new GameParser(url.toString()).parse(input, gameName, false);
+      gameDataFullyLoaded = true;
 
     } catch (final EngineVersionException e) {
       ClientLogger.logQuietly(e);
       throw new GameParseException(e.getMessage());
     } catch (final SAXParseException e) {
-      String msg = "Could not parse:" + m_url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber();
+      String msg = "Could not parse:" + url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber();
       ClientLogger.logError(msg, e);
       throw new GameParseException(e.getMessage());
     } catch (final Exception e) {
-      String msg = "Could not parse:" + m_url;
+      String msg = "Could not parse:" + url;
       ClientLogger.logError(msg, e);
       throw new GameParseException(e.getMessage());
     }
@@ -95,48 +95,44 @@ public class NewGameChooserEntry {
    * If that fails, then do a short parse so the user doesn't get a null pointer error.
    */
   public void delayParseGameData() {
-    m_data = null;
+    gameData = null;
 
     final AtomicReference<String> gameName = new AtomicReference<>();
-    Optional<InputStream> inputStream = UrlStreams.openStream(m_url);
+    Optional<InputStream> inputStream = UrlStreams.openStream(url);
     if(!inputStream.isPresent()) {
       return;
     }
     try (InputStream input = inputStream.get()) {
-      m_data = new GameParser(m_url.toString()).parse(input, gameName, true);
-      m_gameDataFullyLoaded = false;
+      gameData = new GameParser(url.toString()).parse(input, gameName, true);
+      gameDataFullyLoaded = false;
     } catch (final EngineVersionException e) {
       System.out.println(e.getMessage());
     } catch (final SAXParseException e) {
       System.err.println(
-          "Could not parse:" + m_url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber());
+          "Could not parse:" + url + " error at line:" + e.getLineNumber() + " column:" + e.getColumnNumber());
       ClientLogger.logQuietly(e);
     } catch (final Exception e) {
-      System.err.println("Could not parse:" + m_url);
+      System.err.println("Could not parse:" + url);
       ClientLogger.logQuietly(e);
     }
   }
 
   public boolean isGameDataLoaded() {
-    return m_gameDataFullyLoaded;
+    return gameDataFullyLoaded;
   }
 
   public String getGameName() {
-    return m_data.getGameName();
+    return gameData.getGameName();
   }
 
   // the user may have selected a map skin instead of this map folder, so don't use this for anything except our
   // equals/hashcode below
   private String getMapNameProperty() {
-    final String mapName = (String) m_data.getProperties().get(Constants.MAP_NAME);
+    final String mapName = (String) gameData.getProperties().get(Constants.MAP_NAME);
     if (mapName == null || mapName.trim().length() == 0) {
       throw new IllegalStateException("Map name property not set on game");
     }
     return mapName;
-  }
-
-  public String getGameNameAndMapNameProperty() {
-    return m_gameNameAndMapNameProperty;
   }
 
   @Override
@@ -145,15 +141,15 @@ public class NewGameChooserEntry {
   }
 
   public GameData getGameData() {
-    return m_data;
+    return gameData;
   }
 
   public URI getURI() {
-    return m_url;
+    return url;
   }
 
   public String getLocation() {
-    final String raw = m_url.toString();
+    final String raw = url.toString();
     final String base = ClientFileSystemHelper.getRootFolder().toURI().toString() + "maps";
     if (raw.startsWith(base)) {
       return raw.substring(base.length());
@@ -166,7 +162,7 @@ public class NewGameChooserEntry {
 
   @Override
   public int hashCode() {
-    return getGameNameAndMapNameProperty().hashCode();
+    return gameNameAndMapNameProperty.hashCode();
   }
 
   @Override
@@ -181,15 +177,13 @@ public class NewGameChooserEntry {
       return false;
     }
     final NewGameChooserEntry other = (NewGameChooserEntry) obj;
-    if (m_data == null) {
-      if (other.m_data != null) {
-        return false;
-      }
+    if (gameData == null && other.gameData != null) {
+      return false;
     } else {
-      if (other.m_data == null) {
+      if (other.gameData == null) {
         return false;
       }
     }
-    return this.getGameNameAndMapNameProperty().equals(other.getGameNameAndMapNameProperty());
+    return this.gameNameAndMapNameProperty.equals(other.gameNameAndMapNameProperty);
   }
 }

--- a/src/games/strategy/util/UrlStreams.java
+++ b/src/games/strategy/util/UrlStreams.java
@@ -12,8 +12,6 @@ import java.util.function.Function;
 
 import com.google.common.base.Throwables;
 
-import games.strategy.debug.ClientLogger;
-
 
 /**
  * Utility class for opening input streams from URL and URI objects.
@@ -80,7 +78,6 @@ public final class UrlStreams {
       connection.setUseCaches(false);
       return Optional.of(connection.getInputStream());
     } catch (IOException e) {
-      ClientLogger.logError("Failed to open a connection to: " + url, e);
       return Optional.empty();
     }
   }


### PR DESCRIPTION
----
 
1st commit - Handles the regression part of #1045 

Repro:
- download a map
- launch it
- open download map dialog, delete it
- launch game > notice error

After fix, when you launch the game, there is no map parse error, and the map name is set to "-"

-----

2nd commit - minor cleanup, but notably variable name cleanup

----
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1052)
<!-- Reviewable:end -->
