### PR TITLE
Give a better error message when failing to download from the triplea…

### DIFF
--- a/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -78,7 +78,7 @@ public class DownloadMapsWindow extends JFrame {
     final String popupWindowTitle = "Downloading list of availabe maps....";
     BackgroundTaskRunner.runInBackground(null, popupWindowTitle, download);
     final List<DownloadFileDescription> games = download.getDownloads();
-    checkNotNull(games);
+    checkNotNull(games, "Failed to download map listing from: " + ClientContext.mapListingSource().getMapListDownloadSite());
 
     final Frame parentFrame = JOptionPane.getFrameForComponent(parent);
     final DownloadMapsWindow dia = new DownloadMapsWindow(mapName, games);


### PR DESCRIPTION
…_maps.yaml file, can be triggered by misconfiguring game_engine.properties

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1053)
<!-- Reviewable:end -->
