### PR TITLE
Correct battle order in certain cases. Also a UI improvement

### DIFF
--- a/src/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/games/strategy/triplea/delegate/BattleDelegate.java
@@ -101,43 +101,49 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       m_needToAddBombardmentSources = false;
     }
     
-    final Iterator<Territory> battleTerritories = m_battleTracker.getPendingBattleSites(true).iterator(); // get bombing/air raids
-    if( battleTerritories.size() > 1 ) return;      // If more than one, don't fight any battles here
-    final Territory t = battleTerritories.next();
-    final IBattle battle = m_battleTracker.getPendingBattle(t, true, BattleType.AIR_RAID);
-    if( battle == null ) battle = m_battleTracker.getPendingBattle(t, true, BattleType.BOMBING_RAID);
-    battle.fight();
-    
+    Territory lastAmphib = null, lastNonAmphib = null, t;
+    IBattle battle;
+    Iterator<Territory> battleTerritories = m_battleTracker.getPendingBattleSites(true).iterator(); // get bombing/air raids
+    if( battleTerritories.hasNext() ) {
+      t = battleTerritories.next();
+      if( battleTerritories.hasNext() ) return; // If more than one air/boming raid do nothing here
+      battle = m_battleTracker.getPendingBattle(t, true, null);
+      if( battle == null ) {
+        System.out.println("Air/Bombing Raid gone missing in BattleDelegate");
+      }
+      battle.fight(m_bridge);
+      battle = m_battleTracker.getPendingBattle(t, true, BattleType.BOMBING_RAID );  // check to see if there's still a bombing raid for the territory - i.e. previous battle was an air raid
+      if( battle != null ) battle.fight(m_bridge);
+    }
+
     battleTerritories = m_battleTracker.getPendingBattleSites(false).iterator();      // Get normal combats
-    int battleCount = 0, amphibCount = 0;
-    final IBattle battle;
-    final Territory lastAmphib = null, lastNonAmphib = null;
+    int landBattleCount = 0, amphibCount = 0;
     while (battleTerritories.hasNext()) {
-      final Territory t = battleTerritories.next();
+      t = battleTerritories.next();
       battle = m_battleTracker.getPendingBattle(t, false, BattleType.NORMAL);
       // we only care about battles where we must fight
       // this check is really to avoid implementing getAttackingFrom() in other battle subclasses
-      if (!(battle instanceof MustFightBattle)) {
+      if (!(battle instanceof MustFightBattle) || t.isWater() ) {
         continue;
       }
-      battleCount++;
-      if( !t.isWater() ) {
-        final Map<Territory, Collection<Unit>> attackingFromMap = ((MustFightBattle) battle).getAttackingFromMap();
-        final Iterator<Territory> bombardingTerritories = ((MustFightBattle) battle).getAttackingFrom().iterator();
-        while (bombardingTerritories.hasNext()) {
-          final Territory neighbor = bombardingTerritories.next();
-          if (!neighbor.isWater() || Match.allMatch(attackingFromMap.get(neighbor), Matches.UnitIsAir) continue;
-          amphibCount++;
-          lastAmphib = t;
-        }
+      landBattleCount++;
+      final Map<Territory, Collection<Unit>> attackingFromMap = ((MustFightBattle) battle).getAttackingFromMap();
+      final Iterator<Territory> bombardingTerritories = ((MustFightBattle) battle).getAttackingFrom().iterator();
+      while (bombardingTerritories.hasNext()) {
+        final Territory neighbor = bombardingTerritories.next();
+        if (!neighbor.isWater() || Match.allMatch(attackingFromMap.get(neighbor), Matches.UnitIsAir) ) continue;
+        amphibCount++;
+        lastAmphib = t;
       }
-      if( lastAmphib != t ) lastNonAmphib = t;
+      if( lastAmphib != t ) lastNonAmphib = t;  // If we didn't find amphibious then it was the last non-amphib, obviously. Did this need a comment?
     }
 
+    if( amphibCount > 1 ) return;
+
     // Fight amphibious assault if there is one. Fight naval battles in random order if prerequisites first.
-    while( amphibCount == 1
+    while( amphibCount > 0
         && (battle = m_battleTracker.getPendingBattle( lastAmphib, false, BattleType.NORMAL )) != null
-        && battle instanceof mustFightBattle) {
+        && battle instanceof MustFightBattle ) {
       if( m_currentBattle != null && m_currentBattle != battle ) {
         m_currentBattle.fight(m_bridge);
         continue;
@@ -146,14 +152,21 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // are there battles that must occur first
       final Collection<IBattle> allMustPrecede = m_battleTracker.getDependentOn(battle);
       if (!allMustPrecede.isEmpty()) {
-        battle = allMustPrecede.iterator().next();
+        final Iterator<IBattle> seaBattles = allMustPrecede.iterator();
+        do {
+          battle = seaBattles.next();
+        } while( ! (battle instanceof MustFightBattle ) && seaBattles.hasNext() );
       }
-      if( battle instanceof mustFightBattle ) battle.fight(m_bridge);
+      if( battle != null ) {
+        battle.fight(m_bridge);
+        if( battle.getTerritory() == lastAmphib ) landBattleCount--;            // Reduce count of battles only if we've found the actual amphibious assault, not a dependent sea battle
+      }
     }
-    
-    if( ( battleCount == 2 && amphibCount == 1 )
-     || ( battleCount == 1 && amphibCount == 0 ) {
-      m_battleTracker.getPendingBattle( lastNonAmphib, false, BattleType.NORMAL ).fight(m_bridge);
+
+    if( landBattleCount == 1 ) {  // If there is only one remaining normal combat, fight it here rather than requiring the user to click it.
+      battle = m_battleTracker.getPendingBattle( lastNonAmphib, false, BattleType.NORMAL );
+      if( battle != null ) battle.fight(m_bridge);
+      else System.out.format( "Non amphib battle in territory %s not found\n", lastNonAmphib.toString() );
     }
 
   }


### PR DESCRIPTION
Battle order is supposed to be:
Strategic Bombing (including air raids)
Amphibious Assaults
Others.

What this change does is automatically spawn the combats in this order:
- if there is only air raid or strategic bombing raid (but not if there is one of each), then triggers the following bombing raid for the single air raid (if any), 
- triggers an Amphibious Assault if there is only one, including any dependent sea combats which are done first (if there are multiple the order is not defined)
- triggers a remaining combat if only one is left

If there are multiple SBRs, this PR results in no change from the present. If there are multiple amphibious assaults - the change only affects SBRs.

Known issues:
- In theory you can amphibiously assault a single territory from two SZs with sea combat in both SZs. In this case you should be able to decide which one to do first but you can't.
- If the sea combat fails, the amphibious assault probably isn't required to be selected next but it is.

So it fixes the combat order for 90-99% of SBRs and about 50% of amphibious assaults. Also reduces some annoying UI features like being told to do the sea combat first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1062)
<!-- Reviewable:end -->
