### PR TITLE
Add a missing 'implements Serializable' to a SerializationProxy

### DIFF
--- a/src/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
+++ b/src/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
@@ -38,7 +38,8 @@ public class BattleRecords implements Serializable {
   }
 
   @SerializationProxySupport
-  private static class SerializationProxy {
+  private static class SerializationProxy implements Serializable {
+    private static final long serialVersionUID = 3837818110273155404L;
     private final HashMap<PlayerID, HashMap<GUID, BattleRecord>> records;
     public SerializationProxy(BattleRecords battleRecords) {
       this.records= battleRecords.m_records;


### PR DESCRIPTION
Fixes #1064

We were getting an error message similar to:
  java.io.NotSerializableException: games.strategy.triplea.delegate.dataObjects.BattleRecords$SerializationProxy
    at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
    at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
This is due to a missing 'implements Serializable', it is a bit hard to track down since the stack trace is usually not directly to the non-serializable object. Mostly had to look at recent SerializationProxies that might have been added and remember that they need to implement Serializable. After all  it is the proxy that is actually being serialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1075)
<!-- Reviewable:end -->
