### PR TITLE
On the staging screens, replace usage of the word 'game' when a 'map' is intended.

### DIFF
--- a/src/games/strategy/engine/framework/networkMaintenance/ChangeGameOptionsClientAction.java
+++ b/src/games/strategy/engine/framework/networkMaintenance/ChangeGameOptionsClientAction.java
@@ -44,7 +44,7 @@ public class ChangeGameOptionsClientAction extends AbstractAction {
       final String ok = "OK";
       final String cancel = "Cancel";
       pane.setOptions(new Object[] {ok, cancel});
-      final JDialog window = pane.createDialog(JOptionPane.getFrameForComponent(m_parent), "Game Options");
+      final JDialog window = pane.createDialog(JOptionPane.getFrameForComponent(m_parent), "Map Options");
       window.setVisible(true);
       final Object buttonPressed = pane.getValue();
       if (buttonPressed == null || buttonPressed.equals(cancel)) {

--- a/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -141,12 +141,12 @@ public class GameSelectorPanel extends JPanel implements Observer {
     m_versionText = new JLabel();
     m_roundText = new JLabel();
     m_fileNameText = new JLabel();
-    m_loadNewGame = new JButton("Select Game");
+    m_loadNewGame = new JButton("Select Map");
     m_loadNewGame.setToolTipText(
         "<html>Select a game from all the maps/games that come with TripleA, <br>and the ones you have downloaded.</html>");
     m_loadSavedGame = new JButton("Open Saved Game");
     m_loadSavedGame.setToolTipText("Open a previously saved game, or an autosave.");
-    m_gameOptions = new JButton("Game Options");
+    m_gameOptions = new JButton("Map Options");
     m_gameOptions.setToolTipText(
         "<html>Set options for the currently selected game, <br>such as enabling/disabling Low Luck, or Technology, etc.</html>");
   }
@@ -280,7 +280,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
     final String makeDefault = "Make Default";
     final String reset = "Reset";
     pane.setOptions(new Object[] {ok, makeDefault, reset, cancel});
-    final JDialog window = pane.createDialog(JOptionPane.getFrameForComponent(this), "Game Options");
+    final JDialog window = pane.createDialog(JOptionPane.getFrameForComponent(this), "Map Options");
     window.setVisible(true);
     final Object buttonPressed = pane.getValue();
     if (buttonPressed == null || buttonPressed.equals(cancel)) {

--- a/src/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/src/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -98,9 +98,9 @@ public class GameMenu {
 
   protected void addGameOptionsMenu(final JMenu menuGame) {
     if (!gameData.getProperties().getEditableProperties().isEmpty()) {
-      final AbstractAction optionsAction = SwingAction.of("Game Options", e -> {
+      final AbstractAction optionsAction = SwingAction.of("Map Options", e -> {
         final PropertiesUI ui = new PropertiesUI(gameData.getProperties().getEditableProperties(), false);
-        JOptionPane.showMessageDialog(frame, ui, "Game options", JOptionPane.PLAIN_MESSAGE);
+        JOptionPane.showMessageDialog(frame, ui, "Map Options", JOptionPane.PLAIN_MESSAGE);
       });
       menuGame.add(optionsAction).setMnemonic(KeyEvent.VK_O);
     }


### PR DESCRIPTION
The code refers to a set of rules + XML file as a game. The code and more generally a game is also the same thing as a map, plus a series of user actions advancing the game, ie: a game-in-progress. What has wound up happening is the word "game" is used mostly everywhere, a bit confusingly when actually just a "map" is being referred to.  This change updates teh staging screens to use the words "game" and "map" more consistently.

Before:
![before](https://cloud.githubusercontent.com/assets/12397753/17917989/eaefbaee-6975-11e6-9cd4-ef06fa829b54.png)

After:
![after](https://cloud.githubusercontent.com/assets/12397753/17917990/eaf14f58-6975-11e6-8933-a4aad33c5136.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1117)
<!-- Reviewable:end -->
