### PR TITLE
Fix launch NPE in while loop, error.getMessage() can NPE. 

### DIFF
--- a/src/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -166,20 +166,11 @@ public class ServerLauncher extends AbstractLauncher {
       try {
         m_gameData.getGameLoader().startGame(m_serverGame, localPlayerSet, m_headless);
       } catch (final Exception e) {
+        ClientLogger.logError("Failed to launch", e);
         m_abortLaunch = true;
-        Throwable error = e;
-        while (error.getMessage() == null) {
-          error = error.getCause();
-        }
-        final String message = error.getMessage();
+
         if (m_gameLoadingWindow != null) {
           m_gameLoadingWindow.doneWait();
-        }
-        if (!m_headless) {
-          SwingUtilities.invokeLater(
-              () -> JOptionPane.showMessageDialog(null, message, "Warning", JOptionPane.WARNING_MESSAGE));
-        } else {
-          System.out.println(message);
         }
       }
       if (m_headless) {


### PR DESCRIPTION
Instead replace with ClientLogger, in a headless context we send the output message to System.out anyways when logging an error. Before we showed a pop-up, in the updated case we will show the error console in the foreground and unhide it if it was not visible (but no pop-up, however we do now have a stack trace in the error console)

NPE was happening here: `while (error.getMessage() == null) {`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1144)
<!-- Reviewable:end -->
