### PR TITLE
Inject special map prefix for github 'master' zip files

### DIFF
--- a/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -99,7 +99,7 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
       final Enumeration<? extends ZipEntry> zipEntryEnumeration = zipFile.entries();
       while (zipEntryEnumeration.hasMoreElements()) {
         final ZipEntry entry = zipEntryEnumeration.nextElement();
-        if (entry.getName().startsWith("games/") && entry.getName().toLowerCase().endsWith(".xml")) {
+        if (entry.getName().contains("games/") &&  entry.getName().toLowerCase().endsWith(".xml")) {
           final ZipProcessingResult result = processZipEntry(loader, entry, entries);
           if (result == ZipProcessingResult.ERROR) {
             badMapZip = true;

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,7 +24,7 @@ import games.strategy.util.UrlStreams;
  * Utility for managing where images and property files for maps and units should be loaded from.
  * Based on java Classloaders.
  */
-public class ResourceLoader {
+public class ResourceLoader implements Closeable {
   private final URLClassLoader m_loader;
   public static String RESOURCE_FOLDER = "assets";
 
@@ -159,6 +160,7 @@ public class ResourceLoader {
     m_loader = new URLClassLoader(urls);
   }
 
+  @Override
   public void close() {
     try {
       m_loader.close();

--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -27,6 +27,9 @@ public class ResourceLoader {
   private final URLClassLoader m_loader;
   public static String RESOURCE_FOLDER = "assets";
 
+  private final ResourceLocationTracker resourceLocationTracker;
+
+
   public static ResourceLoader getGameEngineAssetLoader() {
     return getMapResourceLoader("");
   }
@@ -55,7 +58,7 @@ public class ResourceLoader {
 
     dirs.add(resourceFolder.getAbsolutePath());
 
-    return new ResourceLoader(dirs.toArray(new String[dirs.size()]));
+    return new ResourceLoader(mapName, dirs.toArray(new String[dirs.size()]));
   }
 
   protected static String normalizeMapZipName(final String zipName) {
@@ -91,6 +94,9 @@ public class ResourceLoader {
     candidates.add(new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps", zipName));
 
     final String normalizedZipName = normalizeMapZipName(zipName);
+
+    // clicking github 'clone or download' and downloading the zip gives a zip that ends with "-master.zip"
+    candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), normalizeMapZipName(mapName) + "-master.zip"));
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), normalizedZipName));
 
     final Optional<File> match = candidates.stream().filter(file -> file.exists()).findFirst();
@@ -128,15 +134,8 @@ public class ResourceLoader {
     return rVal;
   }
 
-  public void close() {
-    try {
-      m_loader.close();
-    } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
-    }
-  }
 
-  private ResourceLoader(final String[] paths) {
+  private ResourceLoader(final String mapName, final String[] paths) {
     final URL[] urls = new URL[paths.length];
     for (int i = 0; i < paths.length; i++) {
       final File f = new File(paths[i]);
@@ -153,10 +152,19 @@ public class ResourceLoader {
         throw new IllegalStateException(e.getMessage());
       }
     }
+    resourceLocationTracker = new ResourceLocationTracker(mapName, urls);
     // Note: URLClassLoader does not always respect the ordering of the search URLs
     // To solve this we will get all matching paths and then filter by what matched
     // the assets folder.
     m_loader = new URLClassLoader(urls);
+  }
+
+  public void close() {
+    try {
+      m_loader.close();
+    } catch (final IOException e) {
+      ClientLogger.logQuietly(e);
+    }
   }
 
   public boolean hasPath(final String path) {
@@ -165,11 +173,12 @@ public class ResourceLoader {
   }
 
   /**
-   * @param path
+   * @param inputPath
    *        (The name of a resource is a '/'-separated path name that identifies the resource. Do not use '\' or
    *        File.separator)
    */
-  public URL getResource(final String path) {
+  public URL getResource(final String inputPath) {
+    String path = resourceLocationTracker.getMapPrefix() + inputPath;
     URL defaultUrl = null;
     // Return first any match that is not in the assets folder (we expect that to be the users maps folder (loading from
     // map.zip))

--- a/src/games/strategy/triplea/ResourceLocationTracker.java
+++ b/src/games/strategy/triplea/ResourceLocationTracker.java
@@ -1,0 +1,40 @@
+package games.strategy.triplea;
+
+import java.net.URL;
+import java.util.Arrays;
+
+/**
+ * Utility class containing the logic for whether or not to create a special resource loading path prefix.
+ */
+class ResourceLocationTracker {
+
+  /**
+   * master zip is the zipped folder format you get when downloading from a map repo via the 'clone or download' button
+   */
+  static final String MASTER_ZIP_MAGIC_PREFIX = "-master/map/";
+
+  static final String MASTER_ZIP_IDENTIFYING_SUFFIX = "-master.zip";
+
+  private final String mapPrefix;
+
+  /**
+   *
+   * @param mapName Used to construct any special resource loading path prefixes, used as needed depending upon which
+   *                resources are in the path
+   * @param resourcePaths The list of paths used for a map as resources. From this we can determine if the map is being
+   *                      loaded from a zip or a directory, and if zip, if it matches any particular naming.
+   */
+  ResourceLocationTracker(String mapName, URL[] resourcePaths) {
+    boolean isUsingMasterZip = Arrays.asList(resourcePaths)
+        .stream().filter(path -> path.toString().endsWith(MASTER_ZIP_IDENTIFYING_SUFFIX)).findAny().isPresent();
+    mapPrefix = isUsingMasterZip ? mapName + MASTER_ZIP_MAGIC_PREFIX : "";
+  }
+
+  /**
+   * Will return an empty string unless a special prefix is needed, in which case  that prefix is constructed
+   * basd on the map name.
+   */
+  String getMapPrefix() {
+    return mapPrefix;
+  }
+}

--- a/src/games/strategy/util/LocalizeHTML.java
+++ b/src/games/strategy/util/LocalizeHTML.java
@@ -95,7 +95,7 @@ public class LocalizeHTML {
           URL replacementURL = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + imageFileName);
 
           if (replacementURL == null || replacementURL.toString().length() == 0) {
-            System.out.println("Could not find: <map>/" + ASSET_IMAGE_FOLDER + imageFileName);
+            System.out.println("Could not find: " + mapNameDir + "/ " + ASSET_IMAGE_FOLDER + imageFileName);
             replacementURL = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + ASSET_IMAGE_NOT_FOUND);
           }
           if (replacementURL == null || replacementURL.toString().length() == 0) {

--- a/test/games/strategy/triplea/ResourceLocationTrackerTest.java
+++ b/test/games/strategy/triplea/ResourceLocationTrackerTest.java
@@ -1,0 +1,35 @@
+package games.strategy.triplea;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.net.URL;
+
+import org.junit.Test;
+
+
+public class ResourceLocationTrackerTest {
+  private ResourceLocationTracker testObj;
+
+  @Test
+  public void defaultEmptyMapPrefix() {
+    ResourceLocationTracker testObj = new ResourceLocationTracker("", new URL[0]);
+    assertThat(testObj.getMapPrefix(), is(""));
+  }
+
+  @Test
+  public void defaultEmptyMapPrefixWithMoreInterestingTestData() throws Exception {
+    ResourceLocationTracker testObj =
+        new ResourceLocationTracker("", new URL[] {new URL("file://localhost"), new URL("file://oldFormat.zip")});
+    assertThat(testObj.getMapPrefix(), is(""));
+  }
+
+  @Test
+  public void masterZipsGetSpecialPrefixBasedOnTheMapName() throws Exception {
+    final String fakeMapName = "fakeMapName";
+    ResourceLocationTracker testObj = new ResourceLocationTracker(fakeMapName,
+        new URL[] {new URL("file://pretend" + ResourceLocationTracker.MASTER_ZIP_IDENTIFYING_SUFFIX)});
+    assertThat(testObj.getMapPrefix(), is(fakeMapName + ResourceLocationTracker.MASTER_ZIP_MAGIC_PREFIX));
+  }
+
+}


### PR DESCRIPTION
Use a small ResourceLocationTracker location object  to contain the logic of if we need a special prefix or not when loading resources. The game previously assumed all map resources files to effectively be 'at the root'. A map downloaded from triplea-maps has a predictable format, it is named: {repoName}-master.zip, with folders "{repoName}/map".

The /map is an addition to better organize map files. We will be required to change the game code anyways to do the map rpefix, and allowing the '/map' means the current repo's do not need to be updated.

So, the Tracker finally will check the name of the zip file we are loading, if it ends with '-master.zip', then we'll assume a special path prefix, otheriwse the path prefix is empty, and things work as they did before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1164)
<!-- Reviewable:end -->
