### PR TITLE
Replace route translation, fix horizontal line drawing problem

### DIFF
--- a/src/games/strategy/triplea/ui/MapRouteDrawer.java
+++ b/src/games/strategy/triplea/ui/MapRouteDrawer.java
@@ -60,13 +60,16 @@ public class MapRouteDrawer {
     final int numTerritories = route.getAllTerritories().size();
     final int xOffset = mapPanel.getXOffset();
     final int yOffset = mapPanel.getYOffset();
-    final Point[] points = routeOptimizer.getTranslatedRoute(getRoutePoints(routeDescription, mapData));
+
+    Point[] routePoints = getRoutePoints(routeDescription, mapData);
+    Point[] points = routeOptimizer.normalizeForHorizontalWrapping(routePoints).toArray(new Point[routePoints.length]);
+
     final boolean tooFewTerritories = numTerritories <= 1;
     final boolean tooFewPoints = points.length <= 2;
     final double scale = mapPanel.getScale();
     if (tooFewTerritories || tooFewPoints) {
       if (routeDescription.getEnd() != null) {// AI has no End Point
-        drawDirectPath(graphics, routeDescription.getStart(), routeDescription.getEnd(), xOffset, yOffset, scale);
+        drawDirectPath(graphics, points[0], points[points.length-1], xOffset, yOffset, scale);
       } else {
         drawDirectPath(graphics, points[0], points[points.length - 1], xOffset, yOffset, scale);
       }
@@ -117,7 +120,7 @@ public class MapRouteDrawer {
       final int yOffset, final double scale) {
     final BufferedImage cursorImage = (BufferedImage) routeDescription.getCursorImage();
     if (cursorImage != null) {
-      for (Point[] endPoint : routeOptimizer.getAllPoints(routeOptimizer.getLastEndPoint())) {
+      for (Point[] endPoint : routeOptimizer.getAllPoints(routeDescription.getEnd())) {
         graphics.drawImage(cursorImage,
             (int) (((endPoint[0].x - xOffset) - (cursorImage.getWidth() / 2)) * scale),
             (int) (((endPoint[0].y - yOffset) - (cursorImage.getHeight() / 2)) * scale), null);
@@ -140,8 +143,7 @@ public class MapRouteDrawer {
    */
   private void drawDirectPath(final Graphics2D graphics, final Point start, final Point end, final int xOffset,
       final int yOffset, final double scale) {
-    final Point[] points = routeOptimizer.getTranslatedRoute(start, end);
-    for (Point[] newPoints : routeOptimizer.getAllPoints(points)) {
+    for (Point[] newPoints : routeOptimizer.getAllPoints(start, end)) {
       drawLineWithTranslate(graphics, new Line2D.Float(newPoints[0], newPoints[1]), xOffset,
           yOffset, scale);
       if (newPoints[0].distance(newPoints[1]) > arrowLength) {

--- a/test/games/strategy/triplea/ui/TestRoute.java
+++ b/test/games/strategy/triplea/ui/TestRoute.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Shape;
@@ -40,6 +41,7 @@ public class TestRoute {
                                           // territory
     dummyRoute.add(mock(Territory.class));
     when(dummyMapData.getCenter(any(Territory.class))).thenReturn(dummyPoints[1]);
+    when(dummyMapData.getMapDimensions()).thenReturn(new Dimension(1000,1000));
   }
 
   @Test


### PR DESCRIPTION
Fixes horizontal line problem reported in: https://github.com/triplea-game/triplea/issues/1056

The problem related to map "seams", where we would go from a high map coordinate, to a low one. For example, a coordinate of 900 to a coordinate of 50 with a map width of 1000. The existing code would translate and get at least the mouse cursor point to be effectively 1050. The next point though could be something like 70. It seems in that case two far offscreen coordinates were used to draw the route "the wrong way" around the globe. This effectively comes out to be a flat line.

For the fix, it was observed that routes wtih negative coordinates worked well. In this case we use the map width to detect if we have crossed a map seam. If two points are further apart than the map width, then we must have crossed it. For any points that are greater than a mapWidth apart, we subtract the full map width to get a negative number. This way for example a point that was once at postion 900 on a 1000 width map is now at -100. So for example when previously we may have had x positions 900 and 50, that would translate to -100 and 50.

Note, this does not fix the vertical direction, it might be broken there with weird vertical lines.


Before:
![before](https://cloud.githubusercontent.com/assets/12397753/18258673/17cc7034-738f-11e6-9384-03d1aa39dfab.png)


After:
![after](https://cloud.githubusercontent.com/assets/12397753/18258675/1b7e086e-738f-11e6-95d6-ddd6eacd3c6a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1199)
<!-- Reviewable:end -->
