### PR TITLE
Remover 'faster' scroll zone on map edge (includes bug fix)

### DIFF
--- a/src/games/strategy/triplea/settings/scrolling/ScrollSettings.java
+++ b/src/games/strategy/triplea/settings/scrolling/ScrollSettings.java
@@ -8,8 +8,6 @@ public class ScrollSettings implements HasDefaults {
 
   static final int DEFAULT_MAP_EDGE_SCROLL_SPEED = 30;
   static final int DEFAULT_MAP_EDGE_SCROLL_ZONE_SIZE = 30;
-  static final int DEFAULT_MAP_EDGE_FASTER_SCROLL_MULTIPLIER = 2;
-  static final int DEFAULT_MAP_EDGE_FASTER_SCROLL_ZONE_SIZE = 5;
 
   static final int DEFAULT_ARROW_KEY_SCROLL_SPEED = 70;
   static final int DEFAULT_FASTER_ARROW_KEY_SCROLL_MULTIPLIER = 3;
@@ -19,8 +17,6 @@ public class ScrollSettings implements HasDefaults {
   public void setToDefault() {
     setMapEdgeScrollSpeed(String.valueOf(DEFAULT_MAP_EDGE_SCROLL_SPEED));
     setMapEdgeScrollZoneSize(String.valueOf(DEFAULT_MAP_EDGE_SCROLL_ZONE_SIZE));
-    setMapEdgeFasterScrollMultiplier(String.valueOf(DEFAULT_MAP_EDGE_FASTER_SCROLL_MULTIPLIER));
-    setMapEdgeFasterScrollZoneSize(String.valueOf(DEFAULT_MAP_EDGE_FASTER_SCROLL_ZONE_SIZE));
 
     setArrowKeyScrollSpeed(String.valueOf(DEFAULT_ARROW_KEY_SCROLL_SPEED));
     setFasterArrowKeyScrollMultiplier(String.valueOf(DEFAULT_FASTER_ARROW_KEY_SCROLL_MULTIPLIER));
@@ -31,23 +27,6 @@ public class ScrollSettings implements HasDefaults {
   private int getProp(final SystemPreferenceKey key, final int defaultValue) {
     return SystemPreferences.get(key, defaultValue);
   }
-
-  public int getMapEdgeFasterScrollZoneSize() {
-    return getProp(SystemPreferenceKey.MAP_EDGE_FASTER_SCROLL_ZONE_SIZE, DEFAULT_MAP_EDGE_FASTER_SCROLL_ZONE_SIZE);
-  }
-
-  public void setMapEdgeFasterScrollMultiplier(final String value) {
-    SystemPreferences.put(SystemPreferenceKey.MAP_EDGE_FASTER_SCROLL_MULTIPLER, value);
-  }
-
-  public int getMapEdgeFasterScrollMultiplier() {
-    return getProp(SystemPreferenceKey.MAP_EDGE_FASTER_SCROLL_MULTIPLER, DEFAULT_MAP_EDGE_FASTER_SCROLL_MULTIPLIER);
-  }
-
-  public void setMapEdgeFasterScrollZoneSize(final String value) {
-    SystemPreferences.put(SystemPreferenceKey.MAP_EDGE_FASTER_SCROLL_ZONE_SIZE, value);
-  }
-
 
   public int getMapEdgeScrollZoneSize() {
     return getProp(SystemPreferenceKey.MAP_EDGE_SCROLL_ZONE_SIZE, DEFAULT_MAP_EDGE_SCROLL_ZONE_SIZE);

--- a/src/games/strategy/triplea/settings/scrolling/ScrollSettingsTab.java
+++ b/src/games/strategy/triplea/settings/scrolling/ScrollSettingsTab.java
@@ -46,24 +46,8 @@ public class ScrollSettingsTab implements SettingsTab<ScrollSettings> {
             "Map Edge Scroll Zone Size",
             "How close the mouse cursor must be to the edge of the map for the map to scroll",
             new JTextField(String.valueOf(settings.getMapEdgeScrollZoneSize()), 5),
-            ScrollSettings::setMapEdgeFasterScrollZoneSize,
+            ScrollSettings::setMapEdgeScrollZoneSize,
             scrollSettings -> String.valueOf(scrollSettings.getMapEdgeScrollZoneSize())),
-
-        SettingInputComponentFactory.buildIntegerText(
-            new IntegerValueRange(0, 100, ScrollSettings.DEFAULT_MAP_EDGE_FASTER_SCROLL_ZONE_SIZE),
-            "Map Edge Faster Scroll Zone Size",
-            "How close the mouse cursor must be to the edge of the map for the map to scroll faster",
-            new JTextField(String.valueOf(settings.getMapEdgeFasterScrollZoneSize()), 5),
-            ScrollSettings::setMapEdgeFasterScrollZoneSize,
-            scrollSettings -> String.valueOf(scrollSettings.getMapEdgeFasterScrollZoneSize())),
-
-        SettingInputComponentFactory.buildIntegerText(
-            new IntegerValueRange(2, 5, ScrollSettings.DEFAULT_MAP_EDGE_FASTER_SCROLL_MULTIPLIER),
-            "Scroll Zone Multiplier",
-            "Multiplier for how much faster the map scrolls when the mouse is closest to the edge",
-            new JTextField(String.valueOf(settings.getMapEdgeFasterScrollMultiplier()), 5),
-            ScrollSettings::setMapEdgeFasterScrollMultiplier,
-            scrollSettings -> String.valueOf(scrollSettings.getMapEdgeFasterScrollMultiplier())),
 
         SettingInputComponentFactory.buildIntegerText(
             new IntegerValueRange(10, 400, ScrollSettings.DEFAULT_WHEEL_SCROLL_AMOUNT),

--- a/src/games/strategy/ui/ImageScrollerLargeView.java
+++ b/src/games/strategy/ui/ImageScrollerLargeView.java
@@ -66,7 +66,6 @@ public class ImageScrollerLargeView extends JComponent {
   // scrolling
   private final javax.swing.Timer m_timer = new javax.swing.Timer(50, m_timerAction);
   private boolean m_inside = false;
-  private boolean m_insideFasterPosition;
   private int m_insideCount = 0;
   private int m_edge = NONE;
   private final List<ScrollListener> m_scrollListeners = new ArrayList<>();
@@ -286,10 +285,6 @@ public class ImageScrollerLargeView extends JComponent {
     } else if ((m_edge & RIGHT) != 0) {
       dx = scrollSettings.getMapEdgeScrollSpeed();
     }
-    if (this.m_insideFasterPosition) {
-      dx *= scrollSettings.getMapEdgeFasterScrollMultiplier();
-      dy *= scrollSettings.getMapEdgeFasterScrollMultiplier();
-    }
 
     dx = (int) (dx / m_scale);
     dy = (int) (dy / m_scale);
@@ -304,28 +299,15 @@ public class ImageScrollerLargeView extends JComponent {
 
   private int getNewEdge(final int x, final int y, final int width, final int height) {
     int newEdge = NONE;
-    this.m_insideFasterPosition = false;
     if (x < scrollSettings.getMapEdgeScrollZoneSize()) {
       newEdge += LEFT;
-      if (x < scrollSettings.getMapEdgeFasterScrollZoneSize()) {
-        this.m_insideFasterPosition = true;
-      }
     } else if (width - x < scrollSettings.getMapEdgeScrollZoneSize()) {
       newEdge += RIGHT;
-      if ((width - x) < scrollSettings.getMapEdgeFasterScrollZoneSize()) {
-        this.m_insideFasterPosition = true;
-      }
     }
     if (y < scrollSettings.getMapEdgeScrollZoneSize()) {
       newEdge += TOP;
-      if (y < scrollSettings.getMapEdgeFasterScrollZoneSize()) {
-        this.m_insideFasterPosition = true;
-      }
     } else if (height - y < scrollSettings.getMapEdgeScrollZoneSize()) {
       newEdge += BOTTOM;
-      if ((height - y) < scrollSettings.getMapEdgeFasterScrollZoneSize()) {
-        this.m_insideFasterPosition = true;
-      }
     }
     return newEdge;
   }


### PR DESCRIPTION
The faster scroll zone divided the map edge scroll zones into two. The first one, further away from the edge, would scroll at a fixed rate, and then when closer in the faster scroll the scrolling would  speed up. The feature never caught on very well, and was a substitute for the lack of controls over the scroll zone size and scroll speed. With those as features, simplifying this not popular feature seems prudent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1202)
<!-- Reviewable:end -->
