### PR TITLE
Use a cache when querying download length, do not start download progress bars until download starts.

### DIFF
--- a/src/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -20,7 +20,7 @@ import games.strategy.engine.ClientFileSystemHelper;
  */
 public class DownloadFile {
 
-  public static enum DownloadState {
+  public enum DownloadState {
     NOT_STARTED, DOWNLOADING, CANCELLED, DONE
   }
 

--- a/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -27,12 +27,12 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
+import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionListener;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner;
-import games.strategy.engine.framework.startup.ui.MainFrame;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import games.strategy.ui.SwingComponents;
 import games.strategy.util.Version;

--- a/src/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -106,16 +106,8 @@ public final class MapDownloadProgressPanel extends JPanel {
       final Runnable completionListener =
           () -> SwingUtilities.invokeLater(() -> progressBar.setValue(progressBar.getMaximum()));
 
-      (new Thread(() -> {
-        final Optional<Integer> length = DownloadUtils.getDownloadLength(download.newURL());
-        if (length.isPresent()) {
-          SwingUtilities.invokeLater(() -> {
-            progressBar.setMinimum(0);
-            progressBar.setMaximum(length.get());
-          });
-        }
-        downloadCoordinator.accept(download, progressListener, completionListener);
-      })).start();
+
+      downloadCoordinator.accept(download, progressListener, completionListener, progressBar);
     }
   }
 }


### PR DESCRIPTION
Should fix download progress bars that display "[ ]". The problem there is that we would request
the length of each download file all at the same time while setting the upper length of each progress
bar. To fix, we move the set of the upper end length to the time when download starts. We download 3 maps at the same time, which means we'll fire off a batch of 3 requests.

To further avoid request throttling, we can add a cache to avoid unnecessary requests for the content length of URLs which we have already requested once before.

-----

If we still see problems with failure to get download length (IE: progress bar shows `[ ]`, which is -1 content length -  we could turn parallel download down to 2.

The updates included should keep us to below 10 requests per second. Before we would 1 request immediately for each map, easily could be 40 requests if all maps are downloaded at once (even though only 3 download at a time, the problem iswith the progress bar initialization code, that needs an upper bound to be set before progress can be rendered correctly)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1210)
<!-- Reviewable:end -->
