### PR TITLE
Apply Swing Look and Feel immediately to mitigate poison pill look and feels

### DIFF
--- a/src/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/src/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -1,11 +1,14 @@
 package games.strategy.engine.framework.lookandfeel;
 
+import java.util.Arrays;
 import java.util.List;
 
 import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 
 import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.settings.SystemPreferenceKey;
 import games.strategy.triplea.settings.SystemPreferences;
@@ -56,6 +59,16 @@ public class LookAndFeel {
   }
 
   public static void setDefaultLookAndFeel(final String lookAndFeelClassName) {
+    try {
+      UIManager.setLookAndFeel(lookAndFeelClassName);
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+        | UnsupportedLookAndFeelException e) {
+      ClientLogger.logError("Unable to load look and feel: " + lookAndFeelClassName
+          + ", retaining the old look and feel. Please do not select this look and feel, it does not work."
+          + " Please do report this to the developers so the look and feel can be addressed. When doing so, please"
+          + " include this list of installed look and feel debug data: " + Arrays.asList(UIManager.getInstalledLookAndFeels()) , e);
+      return;
+    }
     SystemPreferences.put(SystemPreferenceKey.LOOK_AND_FEEL_PREF, lookAndFeelClassName);
   }
 }

--- a/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -163,7 +163,8 @@ public class EnginePreferences extends JDialog {
         }
         LookAndFeel.setDefaultLookAndFeel(lookAndFeels.get(selectedValue));
         EventThreadJOptionPane.showMessageDialog(m_parentFrame,
-            "The look and feel will update when you restart TripleA", new CountDownLatchHandler(true));
+            "The look and feel has been applied. Please restart TripleA for it to take full effect",
+            new CountDownLatchHandler(true));
       }
     }));
     m_gameParser.addActionListener(SwingAction.of("Enable/Disable Delayed Parsing of Game XML's", e -> {
@@ -172,7 +173,8 @@ public class EnginePreferences extends JDialog {
       final Object[] options = {"Parse Selected", "Parse All", "Cancel"};
       final int answer = JOptionPane.showOptionDialog(m_parentFrame,
           new JLabel("<html>Delay Parsing of Game Data from XML until game is selected?" + "<br><br>'" + options[1]
-              + "' means each map is fully parsed as TripleA starts (useful for testing to make sure all your maps are valid)."
+              + "' means each map is fully parsed as TripleA starts (useful for testing to make sure all your maps are valid,"
+              + "but can slow down the game significantly)."
               + "<br><br>Your current setting is: '" + (current ? options[0].toString() : options[1].toString())
               + "'</html>"),
           "Select Parsing Method", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options,


### PR DESCRIPTION
When look and feel is selected, it is saved to preferences and then loaded next on startup. It was reported in: https://github.com/triplea-game/triplea/issues/1208 a case where startup froze while applying the look and feel. This then required the user to find the system preference file on their system and to update it by hand to avoid the error on every startup (poison pill).

To mitigate this, we can apply the look and feel setting immediately, before we set the system property. This way if we never get past the look and feel, we will leave the system property unaltered. At least in this case if TripleA is force killed, the system property will remain a valid default.

On one hand it is very nice the look and feel is applied right away. On the other rendering is very weird. So, a simple messaging update is included to let a user know that the setting has taken partial effect, and recommends a restart.

(while in that code the setting option delayed map parsing was tweaked  as well to explicitly indicate it can hurt game performance)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/triplea-game/triplea/1211)
<!-- Reviewable:end -->
