### PR TITLE
Log the resource loading paths to the console window. These are the p…

### DIFF
--- a/src/games/strategy/triplea/ResourceLoader.java
+++ b/src/games/strategy/triplea/ResourceLoader.java
@@ -59,6 +59,7 @@ public class ResourceLoader implements Closeable {
 
     dirs.add(resourceFolder.getAbsolutePath());
 
+    ClientLogger.logQuietly("Loading resources from the following paths: " + dirs);
     return new ResourceLoader(mapName, dirs.toArray(new String[dirs.size()]));
   }
 


### PR DESCRIPTION
…aths where map resources are found. For example, if you search for maps/polygons.txt, then for each path listed, we will search for that base path plus 'maps/polygons.txt'