### PR TITLE
Remove map mod flag in config so the variants maps now will be handled as normal maps

### DIFF
--- a/src/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -25,7 +25,7 @@ public class DownloadFileDescription {
 
 
   public enum DownloadType {
-    MAP, MAP_MOD, MAP_SKIN, MAP_TOOL
+    MAP, MAP_SKIN, MAP_TOOL
   }
 
 
@@ -94,10 +94,6 @@ public class DownloadFileDescription {
 
   public boolean isMap() {
     return downloadType == DownloadType.MAP;
-  }
-
-  public boolean isMapMod() {
-    return downloadType == DownloadType.MAP_MOD;
   }
 
   public boolean isMapSkin() {

--- a/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -129,8 +129,10 @@ public class DownloadMapsWindow extends JFrame {
 
       List<DownloadFileDescription> mapsByCategory =
           maps.stream().filter(map -> map.getMapCategory() == mapCategory).collect(Collectors.toList());
-      JTabbedPane subTab = createAvailableInstalledTabbedPanel(Optional.of(mapCategory.toString()), mapsByCategory);
-      mapTabs.add(mapCategory.toString(), subTab);
+      if(!mapsByCategory.isEmpty()) {
+        JTabbedPane subTab = createAvailableInstalledTabbedPanel(Optional.of(mapCategory.toString()), mapsByCategory);
+        mapTabs.add(mapCategory.toString(), subTab);
+      }
     }
     return mapTabs;
   }

--- a/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -109,9 +109,6 @@ public class DownloadMapsWindow extends JFrame {
     final List<DownloadFileDescription> maps = filterMaps(games, download -> download.isMap());
     outerTabs.add("Maps", createdTabbedPanelForMaps(maps));
 
-    final List<DownloadFileDescription> mods = filterMaps(games, download -> download.isMapMod());
-    outerTabs.add("Mods", createAvailableInstalledTabbedPanel(mapName, mods));
-
     final List<DownloadFileDescription> skins = filterMaps(games, download -> download.isMapSkin());
     outerTabs.add("Skins", createAvailableInstalledTabbedPanel(mapName, skins));
 

--- a/test/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
+++ b/test/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
@@ -20,13 +20,6 @@ public class DownloadFileDescriptionTest {
   }
 
   @Test
-  public void testIsMod() {
-    final DownloadFileDescription testObj = new DownloadFileDescription("", "", "", new Version(0, 0),
-        DownloadFileDescription.DownloadType.MAP_MOD, DownloadFileDescription.MapCategory.EXPERIMENTAL);
-    assertThat(testObj.isMapMod(), is(true));
-  }
-
-  @Test
   public void testIsSkin() {
     final DownloadFileDescription testObj = new DownloadFileDescription("", "", "", new Version(0, 0),
         DownloadFileDescription.DownloadType.MAP_SKIN, DownloadFileDescription.MapCategory.EXPERIMENTAL);

--- a/test/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
+++ b/test/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
@@ -17,7 +17,7 @@ public class DownloadFileParserTest {
 
   @Test
   public void testParseMap() {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestXml());
+    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestData());
     final List<DownloadFileDescription> games = DownloadFileParser.parse(inputStream);
     assertThat(games.size(), is(4));
     final DownloadFileDescription desc = games.get(0);
@@ -33,7 +33,7 @@ public class DownloadFileParserTest {
 
   @Test
   public void testParseModSkin() {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestXml());
+    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestData());
     final List<DownloadFileDescription> games = DownloadFileParser.parse(inputStream);
     assertThat(games.size(), is(4));
     final DownloadFileDescription desc = games.get(2);
@@ -44,7 +44,7 @@ public class DownloadFileParserTest {
 
   @Test
   public void testParseMapTool() {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestXml());
+    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestData());
     final List<DownloadFileDescription> games = DownloadFileParser.parse(inputStream);
     assertThat(games.size(), is(4));
     final DownloadFileDescription desc = games.get(3);
@@ -58,7 +58,7 @@ public class DownloadFileParserTest {
     return "  " + DownloadFileParser.Tags.mapType + ": " + type + "\n";
   }
 
-  private static byte[] buildTestXml() {
+  private static byte[] buildTestData() {
     String xml = "";
     xml += "- url: http://example.com/games/game.zip\n";
     xml += "  mapName: " + GAME_NAME + "\n";
@@ -67,8 +67,7 @@ public class DownloadFileParserTest {
     xml += "     <pre>Some notes about the game, simple html allowed.\n";
     xml += "     </pre>\n";
     xml += "- url: http://example.com/games/mod.zip\n";
-    xml += "  mapName: mapModName\n";
-    xml += createTypeTag(DownloadFileParser.ValueType.MAP_MOD);
+    // missing map type defaults to map
     xml += "  description: |\n";
     xml += "      map mod\n";
     xml += "- url: http://example.com/games/skin.zip\n";

--- a/test/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
+++ b/test/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
@@ -27,19 +27,6 @@ public class DownloadFileParserTest {
 
 
     assertThat(desc.isMap(), is(true));
-    assertThat(desc.isMapMod(), is(false));
-    assertThat(desc.isMapSkin(), is(false));
-    assertThat(desc.isMapTool(), is(false));
-  }
-
-  @Test
-  public void testParseMapMod() {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(buildTestXml());
-    final List<DownloadFileDescription> games = DownloadFileParser.parse(inputStream);
-    assertThat(games.size(), is(4));
-    final DownloadFileDescription desc = games.get(1);
-    assertThat(desc.isMap(), is(false));
-    assertThat(desc.isMapMod(), is(true));
     assertThat(desc.isMapSkin(), is(false));
     assertThat(desc.isMapTool(), is(false));
   }
@@ -51,7 +38,6 @@ public class DownloadFileParserTest {
     assertThat(games.size(), is(4));
     final DownloadFileDescription desc = games.get(2);
     assertThat(desc.isMap(), is(false));
-    assertThat(desc.isMapMod(), is(false));
     assertThat(desc.isMapSkin(), is(true));
     assertThat(desc.isMapTool(), is(false));
   }
@@ -63,7 +49,6 @@ public class DownloadFileParserTest {
     assertThat(games.size(), is(4));
     final DownloadFileDescription desc = games.get(3);
     assertThat(desc.isMap(), is(false));
-    assertThat(desc.isMapMod(), is(false));
     assertThat(desc.isMapSkin(), is(false));
     assertThat(desc.isMapTool(), is(true));
   }
@@ -110,7 +95,6 @@ public class DownloadFileParserTest {
     assertThat(download.isMap(), is(true));
     assertThat(download.isMapSkin(), is(false));
     assertThat(download.isMapTool(), is(false));
-    assertThat(download.isMapMod(), is(false));
   }
 
   private static byte[] createSimpleGameXmlWithNoTypeTag() {

--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -786,7 +786,6 @@
   version: 1
 
 - mapName: Big World Variations
-  mapType: MAP_MOD
   url: https://github.com/triplea-maps/big_world_variations/archive/master.zip
   img: http://tripleamaps.sourceforge.net/images/TripleA_big_world_mini.png
   description: |
@@ -801,7 +800,6 @@
     <br>
   version: 1
 - mapName: NWO Variants
-  mapType: MAP_MOD
   url: https://github.com/triplea-maps/nwo_variants/archive/master.zip
   img: http://tripleamaps.sourceforge.net/images/TripleA_new_world_order_mini.png
   description: |
@@ -822,7 +820,6 @@
     <br>You must have TripleA 1.5.x.x or later installed in order to use these game variants, as only triplea 1.5 or later come with "new_world_order" and the needed unit images.
   version: 1
 - mapName: Pact of Steel Variations
-  mapType: MAP_MOD
   url: https://github.com/triplea-maps/pact_of_steel_variations/archive/master.zip
   img: http://tripleamaps.sourceforge.net/images/TripleA_pact_of_steel_china_added_mini.png
   description: |
@@ -837,7 +834,6 @@
     <br>
   version: 1
 - mapName: World War II Revised Variations
-  mapType: MAP_MOD
   url: https://github.com/triplea-maps/world_war_ii_revised_variations/archive/master.zip
   description: |
     <br>6 army ffa
@@ -871,7 +867,6 @@
     <br>
   version: 1
 - mapName: Classic Variations
-  mapType: MAP_MOD
   url: https://github.com/triplea-maps/classic_variations/archive/master.zip
   img: http://tripleamaps.sourceforge.net/images/TripleA_ww2v1_classic_mini.png
   description: |


### PR DESCRIPTION
The maps have been updated with the base map files, so each one can stand on its own.

For the hide empty category update, here is a before and after:

before:
![before](https://cloud.githubusercontent.com/assets/12397753/18807277/b4c7a5f4-81f7-11e6-8e0a-3c18a707e001.png)

after:
![after](https://cloud.githubusercontent.com/assets/12397753/18807281/cd9c4c9c-81f7-11e6-9454-9a31e820af15.png)



Background: https://github.com/triplea-game/triplea/pull/1256