### PR TITLE
Add a missing game shutdown call. Without this, when we fail to start…

### DIFF
--- a/src/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -337,6 +337,7 @@ public class ClientModel implements IMessengerErrorListener {
               data.testLocksOnRead();
             } catch (final Exception e) {
               ClientLogger.logQuietly(e);
+              m_game.shutDown();
               m_messenger.shutDown();
               m_gameLoadingWindow.doneWait();
               // an ugly hack, we need a better

--- a/src/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -282,20 +282,30 @@ public class ClientModel implements IMessengerErrorListener {
 
   private void startGame(final byte[] gameData, final Map<String, INode> players, final CountDownLatch onDone,
       final boolean gameRunning) {
-    SwingUtilities.invokeLater(() -> {
-      m_gameLoadingWindow.setVisible(true);
-      m_gameLoadingWindow.setLocationRelativeTo(JOptionPane.getFrameForComponent(m_ui));
-      m_gameLoadingWindow.showWait();
+    SwingUtilities.invokeLater(new Runnable() {
+      @Override
+      public void run() {
+        m_gameLoadingWindow.setVisible(true);
+        m_gameLoadingWindow.setLocationRelativeTo(JOptionPane.getFrameForComponent(m_ui));
+        m_gameLoadingWindow.showWait();
+      }
     });
-    final Runnable r = () -> {
-      try {
-        startGameInNewThread(gameData, players, gameRunning);
-      } catch (final RuntimeException e) {
-        m_gameLoadingWindow.doneWait();
-        throw e;
-      } finally {
-        if (onDone != null) {
-          onDone.countDown();
+
+    // DO NOT REPLACE THIS WITH A LAMBDA! We are very dependendant upon an exception being thrown in the code below
+    // and killing this thread. Without that a zombie player will connect to the bot and the game will then proceed
+    // with no-op moves until the player kills the java process.
+    final Runnable r = new Runnable() {
+      @Override
+      public void run() {
+        try {
+          startGameInNewThread(gameData, players, gameRunning);
+        } catch (final RuntimeException e) {
+          m_gameLoadingWindow.doneWait();
+          throw e;
+        } finally {
+          if (onDone != null) {
+            onDone.countDown();
+          }
         }
       }
     };


### PR DESCRIPTION
… a game due to MapNotFoundException for example, we were not sending a terminate signal to the host. The heartbeat check between host and client does not seem to work very well, in which case a zombie player advances turns continuously until the java process is terminated. With the missing shutdown call in place, we get the 1.8 behavior where the game exits back to the staging screen.