### PR TITLE
Fix bot loading of save games so it takes into account maps can have …

### DIFF
--- a/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -41,10 +41,6 @@ public class AvailableGames {
   public AvailableGames() {
     final Set<String> mapNamePropertyList = new HashSet<>();
     populateAvailableGames(m_availableGames, m_availableMapFolderOrZipNames, mapNamePropertyList);
-    // System.out.println(mapNamePropertyList);
-    // System.out.println(m_availableMapFolderOrZipNames);
-    m_availableMapFolderOrZipNames.retainAll(mapNamePropertyList);
-    // System.out.println(m_availableMapFolderOrZipNames);
   }
 
   public List<String> getGameNames() {
@@ -107,7 +103,7 @@ public class AvailableGames {
       return;
     }
     for (final File game : games.listFiles()) {
-      if (game.isFile() && game.getName().toLowerCase().endsWith("xml")) {
+      if (game.toURI() != null && game.isFile() && game.getName().toLowerCase().endsWith("xml")) {
         final boolean added = addToAvailableGames(game.toURI(), availableGames, mapNamePropertyList);
         if (added) {
           availableMapFolderOrZipNames.add(mapDir.getName());
@@ -145,6 +141,7 @@ public class AvailableGames {
       ClientLogger.logQuietly("Map: " + map, e);
     }
   }
+
 
   private static boolean addToAvailableGames(final URI uri, final Map<String, URI> availableGames,
       final Set<String> mapNamePropertyList) {

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -102,7 +102,8 @@ public class HeadlessGameServer {
         return;
       }
       final String mapNameProperty = data.getProperties().get(Constants.MAP_NAME, "");
-      if (!m_availableGames.getAvailableMapFolderOrZipNames().contains(mapNameProperty)) {
+      Set<String> availableMaps = m_availableGames.getAvailableMapFolderOrZipNames();
+      if (!availableMaps.contains(mapNameProperty) && !availableMaps.contains(mapNameProperty + "-master")) {
         System.out.println("Game mapName not in available games listing: " + mapNameProperty);
         return;
       }


### PR DESCRIPTION
…a '-master' suffix on them. To repro the original problem, join the 1.9 lobby, save a game, then try to load it from a bot. AFter selecting the map to load, an error happens on the bot server and nothing happens for the user. The problem is tha thte map name 'world_war_ii_global' is being compared to for example 'world_war_ii_global-master