### PR TITLE
Issue 1335 - Support attackable multi hit infrastructure

### DIFF
--- a/src/games/strategy/triplea/delegate/Fire.java
+++ b/src/games/strategy/triplea/delegate/Fire.java
@@ -55,12 +55,13 @@ public class Fire implements IExecutable {
       final Territory battleSite, final Collection<TerritoryEffect> territoryEffects,
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie) {
     /*
-     * This is to remove any Factories, AAguns, and Infrastructure from possible targets for the firing.
-     * If, in the future, Infrastructure or other things could be taken casualty, then this will need to be changed back
-     * to:
+     * This is to remove any Factories, AAguns, and Infrastructure from possible targets for the firing (unless they
+     * have more than one hit point). If, in the future, Infrastructure or other things could be taken casualty, then
+     * this will need to be changed back to:
      * m_attackableUnits = attackableUnits;
      */
-    m_attackableUnits = Match.getMatches(attackableUnits, Matches.UnitIsNotInfrastructure);
+    m_attackableUnits = Match.getMatches(attackableUnits,
+    	new CompositeMatchOr<Unit>(Matches.UnitIsNotInfrastructure, Matches.UnitHasMoreThanOneHitPointTotal));
     m_canReturnFire = canReturnFire;
     m_firingUnits = firingUnits;
     m_stepName = stepName;

--- a/src/games/strategy/triplea/delegate/Matches.java
+++ b/src/games/strategy/triplea/delegate/Matches.java
@@ -561,6 +561,10 @@ public class Matches {
         if (!attack && ua.getDefense(player) > 0) {
           return true;
         }
+        // Or, if the unit has multiple hit points (to abosrb hits in combat even with 0 attack or defense)
+        if (ua.getHitPoints() > 1) {
+        	return true;
+        }
         // if unit can support other units, return true
         return !UnitSupportAttachment.get(ut).isEmpty();
       }
@@ -639,7 +643,8 @@ public class Matches {
       public boolean match(final Unit obj) {
         final Unit unit = obj;
         final UnitAttachment ua = UnitAttachment.get(unit.getType());
-        return !ua.getIsInfrastructure()
+        // Ensure unit is "attackable" when they have more than one hit point (even if it is infrastructure)
+        return (!ua.getIsInfrastructure() || ua.getHitPoints() > 1)
             && !UnitCanBeCapturedOnEnteringToInThisTerritory(player, terr, data).match(unit);
       }
     };


### PR DESCRIPTION
I'm in the middle of modding/overhauling Great War with my friend and we want to introduce trenches. At first, we took the Middle Earth approach of having cheap infrastructure with low defense, but then we found ourselves building single trenches here and there as a kind of "mine field" to slow down offensives which doesn't make sense- trenches need defenders to have any value. So instead, we thought trenches should be:

- Capturable - if no defenders are present, the other side can capture the trenches for their defense (happened a lot in WWI)
- Infrastructure - can't move once placed
- No defensive power - once again, useless by themselves, but good for absorbing hits to "protect" the units present that can fire back
- Two hit - they can be "repaired" if damaged but left alone for a turn - incentives attackers to hit heavily fortified territories hard to ensure capture or risk not making any progress, just like the "meat grinders" in WWI.

The engine almost supports this but needs a few changes. I don't believe this will affect any existing maps/games because it requires a very particular and unusual combination of unit attachments to have any affect. Basically it involves overriding some of the matching for infrastructure (that they aren't "attackable") if multi hit is also present.

I read about the needing a map to use/justify each code change, and we're not quite ready to deploy our Great War mod yet, but we plan to in the next couple months. I just wanted to start the discussion on this engine change so it could be in the next release.
