### PR TITLE
Simplify get view to model code in table sorter

### DIFF
--- a/src/games/strategy/engine/lobby/client/ui/TableSorter.java
+++ b/src/games/strategy/engine/lobby/client/ui/TableSorter.java
@@ -204,17 +204,15 @@ class TableSorter extends AbstractTableModel {
   }
 
   private Row[] getViewToModel() {
-    if (viewToModel == null) {
       final int tableModelRowCount = tableModel.getRowCount();
-      viewToModel = new Row[tableModelRowCount];
+      Row[] viewToModelRows = new Row[tableModelRowCount];
       for (int row = 0; row < tableModelRowCount; row++) {
-        viewToModel[row] = new Row(row);
+        viewToModelRows[row] = new Row(row);
       }
       if (isSorting()) {
-        Arrays.sort(viewToModel);
+        Arrays.sort(viewToModelRows);
       }
-    }
-    return viewToModel;
+      return viewToModelRows;
   }
 
   int modelIndex(final int viewIndex) {
@@ -222,14 +220,13 @@ class TableSorter extends AbstractTableModel {
   }
 
   private int[] getModelToView() {
-    if (modelToView == null) {
-      final int n = getViewToModel().length;
-      modelToView = new int[n];
-      for (int i = 0; i < n; i++) {
-        modelToView[modelIndex(i)] = i;
-      }
+    Row[] viewToModel = getViewToModel();
+
+    int[] modelToViewRows = new int[viewToModel.length];
+    for (int i = 0; i < viewToModel.length; i++) {
+      modelToViewRows[viewToModel[i].modelIndex] = i;
     }
-    return modelToView;
+    return modelToViewRows;
   }
 
   // TableModel interface methods


### PR DESCRIPTION
Try to avoid stack trace reported in: https://github.com/triplea-game/triplea/issues/1356
```
java.lang.ArrayIndexOutOfBoundsException: 13
at games.strategy.engine.lobby.client.ui.TableSorter.modelIndex(TableSorter.java:231)
at games.strategy.engine.lobby.client.ui.TableSorter.getValueAt(TableSorter.java:277)
```