### PR TITLE
Remove option for scramble window always on top.

### DIFF
--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -1220,7 +1220,6 @@ public class TripleAFrame extends MainGameFrame {
         dialog.setContentPane(optionPane);
         dialog.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         dialog.setLocationRelativeTo(getParent());
-        dialog.setAlwaysOnTop(true);
         dialog.pack();
         dialog.setVisible(true);
         dialog.requestFocusInWindow();


### PR DESCRIPTION
 Hopefully will help problem with game window and scramble window competing to be always on top.