### PR TITLE
Remove scramble 'wait' option

### DIFF
--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -1103,16 +1103,14 @@ public class TripleAFrame extends MainGameFrame {
         unitPanels.add(unitPanel);
         final String optionAttack = "Attack";
         final String optionNone = "None";
-        final String optionWait = "Wait";
-        final Object[] options = {optionAttack, optionNone, optionWait};
+        final Object[] options = {optionAttack, optionNone};
         final JOptionPane optionPane = new JOptionPane(unitPanel, JOptionPane.PLAIN_MESSAGE,
-            JOptionPane.YES_NO_CANCEL_OPTION, null, options, options[2]);
+            JOptionPane.YES_NO_CANCEL_OPTION, null, options, options[1]);
         final JDialog dialog =
             new JDialog((Frame) getParent(), "Select units to Suicide Attack using " + attackResourceToken.getName());
         dialog.setContentPane(optionPane);
         dialog.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         dialog.setLocationRelativeTo(getParent());
-        dialog.setAlwaysOnTop(true);
         dialog.pack();
         dialog.setVisible(true);
         dialog.requestFocusInWindow();
@@ -1141,16 +1139,9 @@ public class TripleAFrame extends MainGameFrame {
             dialog.removeAll();
             dialog.dispose();
             continueLatch.countDown();
-          } else {
-            unitPanels.clear();
-            selection.clear();
-            dialog.setVisible(false);
-            dialog.removeAll();
-            dialog.dispose();
-            ThreadUtil.sleep(500);
-            run();
           }
         });
+
       }
     });
     mapPanel.getUIContext().addShutdownLatch(continueLatch);
@@ -1212,10 +1203,9 @@ public class TripleAFrame extends MainGameFrame {
         panel.add(panel2, BorderLayout.CENTER);
         final String optionScramble = "Scramble";
         final String optionNone = "None";
-        final String optionWait = "Wait";
-        final Object[] options = {optionScramble, optionNone, optionWait};
+        final Object[] options = {optionScramble, optionNone};
         final JOptionPane optionPane = new JOptionPane(panel, JOptionPane.PLAIN_MESSAGE,
-            JOptionPane.YES_NO_CANCEL_OPTION, null, options, options[2]);
+            JOptionPane.YES_NO_CANCEL_OPTION, null, options, options[1]);
         final JDialog dialog = new JDialog((Frame) getParent(), "Select units to scramble to " + scrambleTo.getName());
         dialog.setContentPane(optionPane);
         dialog.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
@@ -1243,14 +1233,6 @@ public class TripleAFrame extends MainGameFrame {
             dialog.removeAll();
             dialog.dispose();
             continueLatch.countDown();
-          } else {
-            choosers.clear();
-            selection.clear();
-            dialog.setVisible(false);
-            dialog.removeAll();
-            dialog.dispose();
-            ThreadUtil.sleep(500);
-            run();
           }
         });
       }
@@ -1304,15 +1286,13 @@ public class TripleAFrame extends MainGameFrame {
         panel.add(chooserScrollPane, BorderLayout.CENTER);
         final String optionSelect = "Select";
         final String optionNone = "None";
-        final String optionWait = "Wait";
-        final Object[] options = {optionSelect, optionNone, optionWait};
+        final Object[] options = {optionSelect, optionNone};
         final JOptionPane optionPane = new JOptionPane(panel, JOptionPane.PLAIN_MESSAGE,
-            JOptionPane.YES_NO_CANCEL_OPTION, null, options, options[2]);
+            JOptionPane.YES_NO_CANCEL_OPTION, null, options, options[1]);
         final JDialog dialog = new JDialog((Frame) getParent(), message);
         dialog.setContentPane(optionPane);
         dialog.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         dialog.setLocationRelativeTo(getParent());
-        dialog.setAlwaysOnTop(true);
         dialog.pack();
         dialog.setVisible(true);
         dialog.requestFocusInWindow();
@@ -1333,13 +1313,6 @@ public class TripleAFrame extends MainGameFrame {
             dialog.removeAll();
             dialog.dispose();
             continueLatch.countDown();
-          } else {
-            selection.clear();
-            dialog.setVisible(false);
-            dialog.removeAll();
-            dialog.dispose();
-            ThreadUtil.sleep(500);
-            run();
           }
         });
       }

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -1111,6 +1111,7 @@ public class TripleAFrame extends MainGameFrame {
         dialog.setContentPane(optionPane);
         dialog.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         dialog.setLocationRelativeTo(getParent());
+        dialog.setAlwaysOnTop(true);
         dialog.pack();
         dialog.setVisible(true);
         dialog.requestFocusInWindow();
@@ -1210,6 +1211,7 @@ public class TripleAFrame extends MainGameFrame {
         dialog.setContentPane(optionPane);
         dialog.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         dialog.setLocationRelativeTo(getParent());
+        dialog.setAlwaysOnTop(true);
         dialog.pack();
         dialog.setVisible(true);
         dialog.requestFocusInWindow();
@@ -1293,6 +1295,7 @@ public class TripleAFrame extends MainGameFrame {
         dialog.setContentPane(optionPane);
         dialog.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         dialog.setLocationRelativeTo(getParent());
+        dialog.setAlwaysOnTop(true);
         dialog.pack();
         dialog.setVisible(true);
         dialog.requestFocusInWindow();


### PR DESCRIPTION
It appears that on Mac OS there is a property change event that is fired frequently on the dialog without user interaction. This then triggers the 'else' branch intended for when you click wait, which then clears the dialog and re-displays it after 500ms. We have reports of the scramble dialog 'flashing' on the screen. If it is the case that we are getting a property change event frequently, then the else branch would be causing that. Meanwhile, there is not much value in the 'wait' button. The window not always on top, and not modal allows interaction with the map. We almost may as well not have the option, and it could prevent this severe bug that is rendering some maps unplayable on Mac.