### PR TITLE
Remove 'cancel' option from rocket attack select unit dialog

### DIFF
--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -956,13 +956,12 @@ public class TripleAFrame extends MainGameFrame {
     });
     final JPanel panel = comps.getFirst();
     final JList<?> list = comps.getSecond();
-    final String[] options = {"OK", "Cancel"};
-    final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_CANCEL_OPTION,
+    final String[] options = {"OK"};
+    final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_OPTION,
         JOptionPane.PLAIN_MESSAGE, null, options, null, getUIContext().getCountDownLatchHandler());
     if (selection == 0) {
       selected.set((Unit) list.getSelectedValue());
     }
-    // Unit selected = (Unit) list.getSelectedValue();
     return selected.get();
   }
 


### PR DESCRIPTION
The cancel button stays on the same screen when selecting rocket damage targets, in effect it does nothing. This is a quick change to remove the button. A good next step/enhancement to the game would be to add the cancel back in, and have it so when cancel is clicked a player can pick a new territory to rocket attack. This looks to be a difficult change at the moment since the territory to attack is pretty baked into the unit target selection. Thus for now we remove the button that does nothing.

Addresses: https://github.com/triplea-game/triplea/issues/1209