### PR TITLE
Allow bid units to be placed on any owned territory.

### DIFF
--- a/src/games/strategy/triplea/TripleAPlayer.java
+++ b/src/games/strategy/triplea/TripleAPlayer.java
@@ -130,7 +130,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     } else if (name.endsWith("Battle")) {
       battle();
     } else if (name.endsWith("Place")) {
-      place(GameStepPropertiesHelper.isBid(getGameData()));
+      place();
     } else if (name.endsWith("Politics")) {
       politics(true);
     } else if (name.endsWith("UserActions")) {
@@ -489,7 +489,8 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     }
   }
 
-  private void place(final boolean bid) {
+  private void place() {
+    boolean bid = GameStepPropertiesHelper.isBid(getGameData());
     if (getPlayerBridge().isGameOver()) {
       return;
     }
@@ -520,7 +521,8 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
           continue;
         }
       }
-      final String error = placeDel.placeUnits(placeData.getUnits(), placeData.getAt());
+      final String error = placeDel.placeUnits(placeData.getUnits(), placeData.getAt(),
+          bid ? IAbstractPlaceDelegate.BidMode.BID : IAbstractPlaceDelegate.BidMode.NOT_BID);
       if (error != null) {
         ui.notifyError(error);
       }

--- a/src/games/strategy/triplea/ai/proAI/ProBidAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProBidAI.java
@@ -615,7 +615,7 @@ public class ProBidAI {
     for (final Unit unit : toPlace) {
       final List<Unit> unitList = new ArrayList<>();
       unitList.add(unit);
-      final String message = del.placeUnits(unitList, t);
+      final String message = del.placeUnits(unitList, t, IAbstractPlaceDelegate.BidMode.BID);
       if (message != null) {
         ProLogger.warn(message);
         ProLogger.warn("Attempt was at: " + t + " with: " + unit);

--- a/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -1864,7 +1864,7 @@ public class ProPurchaseAI {
     for (final Unit unit : toPlace) {
       final List<Unit> unitList = new ArrayList<>();
       unitList.add(unit);
-      final String message = del.placeUnits(unitList, t);
+      final String message = del.placeUnits(unitList, t, IAbstractPlaceDelegate.BidMode.NOT_BID);
       if (message != null) {
         ProLogger.warn(message);
         ProLogger.warn("Attempt was at: " + t + " with: " + unit);

--- a/src/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -1091,7 +1091,7 @@ public class WeakAI extends AbstractAI {
   }
 
   private void doPlace(final Territory where, final Collection<Unit> toPlace, final IAbstractPlaceDelegate del) {
-    final String message = del.placeUnits(new ArrayList<>(toPlace), where);
+    final String message = del.placeUnits(new ArrayList<>(toPlace), where, IAbstractPlaceDelegate.BidMode.NOT_BID);
     if (message != null) {
       s_logger.fine(message);
       s_logger.fine("Attempt was at:" + where + " with:" + toPlace);

--- a/src/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/src/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -16,6 +16,11 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate {
    */
   String placeUnits(Collection<Unit> units, Territory at, BidMode bidMode);
 
+  default String placeUnits(Collection<Unit> units, Territory at) {
+    return placeUnits(units, at, BidMode.NOT_BID);
+  }
+
+
   public enum BidMode {
     BID, NOT_BID
   }

--- a/src/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/src/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -20,8 +20,7 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate {
     return placeUnits(units, at, BidMode.NOT_BID);
   }
 
-
-  public enum BidMode {
+  enum BidMode {
     BID, NOT_BID
   }
   /**

--- a/src/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/src/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -14,8 +14,11 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate {
    *        territory to place
    * @return an error code if the placement was not successful
    */
-  String placeUnits(Collection<Unit> units, Territory at);
+  String placeUnits(Collection<Unit> units, Territory at, BidMode bidMode);
 
+  public enum BidMode {
+    BID, NOT_BID
+  }
   /**
    * Query what units can be produced in a given territory.
    * ProductionResponse may indicate an error string that there

--- a/src/games/strategy/ui/SwingComponents.java
+++ b/src/games/strategy/ui/SwingComponents.java
@@ -250,7 +250,8 @@ public class SwingComponents {
   }
 
   public static void showDialog(final String title, final String message) {
-    JOptionPane.showMessageDialog(null, message, title, JOptionPane.INFORMATION_MESSAGE);
+    SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(null, message, title,
+        JOptionPane.INFORMATION_MESSAGE));
   }
 
 

--- a/test/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/test/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,13 +55,13 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testValid() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = m_delegate.placeUnits(getUnits(map, british), uk);
+    final String response = m_delegate.placeUnits(getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
   }
 
   @Test
   public void testNotCorrectUnitsValid() {
-    final String response = m_delegate.placeUnits(infantry.create(3, british), uk);
+    final String response = m_delegate.placeUnits(infantry.create(3, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertError(response);
   }
 
@@ -84,7 +85,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testLandCanGoInLandZone() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = m_delegate.placeUnits(getUnits(map, british), uk);
+    final String response = m_delegate.placeUnits(getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
   }
 

--- a/test/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/test/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -512,7 +512,7 @@ public class WW2V3_41_Test {
     placeDelegate.setDelegateBridgeAndPlayer(getDelegateBridge(germans(m_data)));
     placeDelegate.start();
     addTo(germans(m_data), aaGun(m_data).create(1, germans(m_data)), m_data);
-    errorResults = placeDelegate.placeUnits(getUnits(map, germans), germany);
+    errorResults = placeDelegate.placeUnits(getUnits(map, germans), germany, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(errorResults);
     assertEquals(germany.getUnits().getUnitCount(), preCount + 3);
   }

--- a/test/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/test/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -64,6 +64,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 
+import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -276,7 +277,7 @@ public class WW2V3_41_Test {
     del.setDelegateBridgeAndPlayer(getDelegateBridge(british(m_data)));
     del.start();
     addTo(british(m_data), transport(m_data).create(1, british(m_data)), m_data);
-    final String error = del.placeUnits(Collections.<Unit>emptyList(), territory("United Kingdom", m_data));
+    final String error = del.placeUnits(Collections.<Unit>emptyList(), territory("United Kingdom", m_data), IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertNull(error);
   }
 
@@ -676,7 +677,7 @@ public class WW2V3_41_Test {
     // Get the number of units before placing
     int preCount = kiangsu.getUnits().getUnitCount();
     // Place the infantry
-    String response = placeDelegate.placeUnits(getUnits(map, chinese), kiangsu);
+    String response = placeDelegate.placeUnits(getUnits(map, chinese), kiangsu, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
     assertEquals(preCount + 1, kiangsu.getUnits().getUnitCount());
     /*
@@ -689,7 +690,7 @@ public class WW2V3_41_Test {
     // Get the number of units before placing
     preCount = yunnan.getUnits().getUnitCount();
     // Place the infantry
-    response = placeDelegate.placeUnits(getUnits(map, chinese), yunnan);
+    response = placeDelegate.placeUnits(getUnits(map, chinese), yunnan, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
     final int midCount = yunnan.getUnits().getUnitCount();
     // Make sure they were all placed
@@ -700,7 +701,7 @@ public class WW2V3_41_Test {
     map = new IntegerMap<>();
     map.add(infantryType, 1);
     addTo(chinese(m_data), infantry(m_data).create(1, chinese(m_data)), m_data);
-    response = placeDelegate.placeUnits(getUnits(map, chinese), yunnan);
+    response = placeDelegate.placeUnits(getUnits(map, chinese), yunnan, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertError(response);
     // Make sure none were placed
     final int postCount = yunnan.getUnits().getUnitCount();


### PR DESCRIPTION
Disables the 'requires another unit' condition for bid placement. This allows for bids to be placed on more territories in for example 270BC.  Though, we are trading in a for a new problem where the bid is unrestricted in quantity. This latter problem is more or less easily player enforced, while before hand the game engine completely disallowed any bid placement at all on what should be valid territories for placement.
