### PR TITLE
XML Map Creator: Output notes in CDATA section

### DIFF
--- a/src/tools/map/xml/creator/MapXmlHelper.java
+++ b/src/tools/map/xml/creator/MapXmlHelper.java
@@ -299,6 +299,10 @@ public class MapXmlHelper {
     MapXmlHelper.mapXmlData.setMapXMLFile(mapXMLFile);
   }
 
+  static void setMapXmlData(final MapXmlData mapXmlData) {
+    MapXmlHelper.mapXmlData = mapXmlData;
+  }
+
   private static MapXmlData mapXmlData = new MapXmlData();
 
   static void putXmlStrings(final String key, final String value) {
@@ -966,7 +970,7 @@ public class MapXmlHelper {
       final Element property = doc.createElement(XML_NODE_NAME_PROPERTY);
       property.setAttribute(XML_ATTR_PROPERTY_NAME_NAME, XML_ATTR_VALUE_PROPERTY_NAME_NOTES);
       final Element propertyValue = doc.createElement(XML_NODE_NAME_VALUE);
-      propertyValue.setTextContent(getNotes());
+      propertyValue.appendChild(doc.createCDATASection(getNotes()));
       property.appendChild(propertyValue);
       propertyList.appendChild(property);
     }

--- a/test/tools/map/xml/creator/MapXmlHelperTest.java
+++ b/test/tools/map/xml/creator/MapXmlHelperTest.java
@@ -1,0 +1,40 @@
+package tools.map.xml.creator;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.junit.Test;
+import org.w3c.dom.CDATASection;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+public final class MapXmlHelperTest {
+  @Test
+  public void testNotesShouldBePlacedWithinCdataSection() throws Exception {
+    final String notes = "lorum<br/>ipsum";
+    initMapXmlData().setNotes(notes);
+
+    final Document document = MapXmlHelper.getXMLDocument();
+
+    final NodeList nodes = selectNodes(document, "//property[@name=\"notes\"]/value/child::node()");
+    assertThat(nodes.getLength(), is(1));
+    assertThat(nodes.item(0), is(instanceOf(CDATASection.class)));
+    assertThat(nodes.item(0).getTextContent(), is(notes));
+  }
+
+  private static MapXmlData initMapXmlData() {
+    final MapXmlData mapXmlData = new MapXmlData();
+    MapXmlHelper.setMapXmlData(mapXmlData);
+    return mapXmlData;
+  }
+
+  private static NodeList selectNodes(final Document document, final String expression) throws Exception {
+    final XPath xpath = XPathFactory.newInstance().newXPath();
+    return (NodeList) xpath.evaluate(expression, document, XPathConstants.NODESET);
+  }
+}


### PR DESCRIPTION
This change partially addresses the concern raised in issue #467 regarding the presence of character entity references in the game XML, which makes it difficult to edit by hand.  Specifically, it ensures the XML Map Creator always outputs notes within a CDATA section.

The unit test is probably a bit of overkill here.  As this was my first time writing TripleA code, I was simply trying to get comfortable.  Please advise if you'd like the test (and supporting code) reverted -- that would leave a single line change in _MapXmlHelper.java_.