### PR TITLE
Added httpclient dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 	compile 'com.sun.mail:mailapi:1.5.5'
 	compile 'com.sun.mail:smtp:1.5.5'
 	compile 'commons-httpclient:commons-httpclient:3.1'
+	compile 'org.apache.httpcomponents:httpclient:4.5.2'
 	compile 'org.apache.commons:commons-math3:3.6.1'
 	compile 'org.mindrot:jbcrypt:0.3m'
 	compile 'org.yaml:snakeyaml:1.17'


### PR DESCRIPTION
Noticed this a couple days back... TripleA is using an outdated version of the apache httpclient.
The 4th version is hosted using a "new" name, and is kind of a rewrite.
Just adding the dependency in case we were to modify the http code anyways.
I tried migrating the old code, but since this code is getting "data objects" using the old API it would be very hard to not make any mistakes there. (In the Warclub forumposter code a List of HttpParts (what do they do?) is passed to a method which uses them to send a POST request)

Found [this cheatsheet](http://debuguide.blogspot.de/2013/01/quick-guide-for-migration-of-commons.html) to be useful, but not too useful.
Leaving it here though.