### PR TITLE
Automatic air raids

### DIFF
--- a/src/games/strategy/engine/data/PlayerID.java
+++ b/src/games/strategy/engine/data/PlayerID.java
@@ -21,6 +21,11 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
   private final TechnologyFrontierList m_technologyFrontiers;
   private String m_whoAmI = "null:no_one";
 
+
+  public PlayerID(final String name, final GameData data) {
+    this(name, false, false, data);
+  }
+
   /** Creates new Player */
   public PlayerID(final String name, final boolean optional, final boolean canBeDisabled, final GameData data) {
     super(name, data);

--- a/src/games/strategy/engine/data/Route.java
+++ b/src/games/strategy/engine/data/Route.java
@@ -355,8 +355,8 @@ public class Route implements Serializable, Iterable<Territory> {
    *         the route consists of only a starting territory
    */
   public Territory getEnd() {
-    if (m_steps.size() == 0) {
-      return null;
+    if (m_steps.isEmpty()) {
+      return m_start;
     }
     return m_steps.get(m_steps.size() - 1);
   }

--- a/src/games/strategy/engine/data/Route.java
+++ b/src/games/strategy/engine/data/Route.java
@@ -303,8 +303,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return last territory in the route, this is the destination or null if
-   *         the route consists of only a starting territory
+   * @return last territory in the route
    */
   public Territory getEnd() {
     if (m_steps.isEmpty()) {

--- a/src/games/strategy/engine/data/Territory.java
+++ b/src/games/strategy/engine/data/Territory.java
@@ -8,6 +8,10 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   // In a grid-based game, stores the coordinate of the Territory
   private final int[] m_coordinate;
 
+  public Territory(final String name, final GameData data) {
+    this(name, false, data);
+  }
+
   /** Creates new Territory */
   public Territory(final String name, final boolean water, final GameData data) {
     super(name, data);

--- a/src/games/strategy/engine/data/Unit.java
+++ b/src/games/strategy/engine/data/Unit.java
@@ -16,7 +16,7 @@ public class Unit extends GameDataComponent {
   /**
    * Creates new Unit. Should use a call to UnitType.create(). Owner can be null
    */
-  protected Unit(final UnitType type, final PlayerID owner, final GameData data) {
+  public Unit(final UnitType type, final PlayerID owner, final GameData data) {
     super(data);
     m_type = Preconditions.checkNotNull(type);
     m_uid = new GUID();

--- a/src/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
+++ b/src/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
@@ -7,7 +7,7 @@ import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.util.PropertyUtil;
 
-class ObjectPropertyChange extends Change {
+public class ObjectPropertyChange extends Change {
   private static final long serialVersionUID = 4218093376094170940L;
   private final Object m_object;
   private String m_property;

--- a/src/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -138,15 +138,7 @@ public class TerritoryAttachment extends DefaultAttachment {
    * Convenience method. Can return null.
    */
   public static TerritoryAttachment get(final Territory t) {
-    return get(t, false);
-  }
-
-  public static TerritoryAttachment get(final Territory t, final boolean allowNull) {
-    final TerritoryAttachment rVal = (TerritoryAttachment) t.getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
-    if (!allowNull && rVal == null && !t.isWater()) {
-      throw new IllegalStateException("No territory attachment for:" + t.getName());
-    }
-    return rVal;
+    return (TerritoryAttachment) t.getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
   }
 
   public static TerritoryAttachment get(final Territory t, final String nameOfAttachment) {

--- a/src/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -292,7 +292,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     final Collection<Tuple<Territory, Collection<Unit>>> changeList =
         new ArrayList<>();
     for (final Territory currTerritory : territories) {
-      final TerritoryAttachment ta = TerritoryAttachment.get(currTerritory, true);
+      final TerritoryAttachment ta = TerritoryAttachment.get(currTerritory);
       // if ownership should change in this territory
       if (ta != null && ta.getChangeUnitOwners() != null && !ta.getChangeUnitOwners().isEmpty()) {
         final Collection<PlayerID> terrNewOwners = ta.getChangeUnitOwners();

--- a/src/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/games/strategy/triplea/delegate/BattleDelegate.java
@@ -100,6 +100,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       addBombardmentSources();
       m_needToAddBombardmentSources = false;
     }
+    m_battleTracker.raids(m_bridge);
   }
 
   /**

--- a/src/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/games/strategy/triplea/delegate/BattleDelegate.java
@@ -100,7 +100,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       addBombardmentSources();
       m_needToAddBombardmentSources = false;
     }
-    m_battleTracker.fightAirRaids(m_bridge);
+    m_battleTracker.fightAirCombats(m_bridge);
   }
 
   /**

--- a/src/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/games/strategy/triplea/delegate/BattleDelegate.java
@@ -100,7 +100,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       addBombardmentSources();
       m_needToAddBombardmentSources = false;
     }
-    m_battleTracker.fightAirCombats(m_bridge);
+    m_battleTracker.fightBombingRaids(m_bridge);
   }
 
   /**

--- a/src/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/games/strategy/triplea/delegate/BattleDelegate.java
@@ -100,7 +100,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       addBombardmentSources();
       m_needToAddBombardmentSources = false;
     }
-    m_battleTracker.raids(m_bridge);
+    m_battleTracker.fightStrategicBombingRuns(m_bridge);
   }
 
   /**

--- a/src/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/games/strategy/triplea/delegate/BattleDelegate.java
@@ -100,7 +100,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       addBombardmentSources();
       m_needToAddBombardmentSources = false;
     }
-    m_battleTracker.fightStrategicBombingRuns(m_bridge);
+    m_battleTracker.fightAirRaids(m_bridge);
   }
 
   /**

--- a/src/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/games/strategy/triplea/delegate/BattleTracker.java
@@ -1106,14 +1106,14 @@ public class BattleTracker implements java.io.Serializable {
    * Auto fight means we automatically begin the fight without user action. This is to avoid clicks during the
    * air battle and SBR phase, and to enforce game rules that these phases are fought first before any other combat.
    */
-  void fightStrategicBombingRuns(final IDelegateBridge delegateBridge) {
+  void fightAirRaids(final IDelegateBridge delegateBridge) {
     boolean bombing = true;
-    fightStrategicBombingRuns(delegateBridge, () -> getPendingBattleSites(bombing),
+    fightAirRaids(delegateBridge, () -> getPendingBattleSites(bombing),
             (territory, battleType) -> getPendingBattle(territory, bombing, battleType));
   }
 
   @VisibleForTesting
-  void fightStrategicBombingRuns(final IDelegateBridge delegateBridge, Supplier<Collection<Territory>> pendingBattleSiteSupplier,
+  void fightAirRaids(final IDelegateBridge delegateBridge, Supplier<Collection<Territory>> pendingBattleSiteSupplier,
              BiFunction<Territory, BattleType, IBattle> pendingBattleFunction) {
 
 

--- a/src/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/games/strategy/triplea/delegate/BattleTracker.java
@@ -1102,18 +1102,18 @@ public class BattleTracker implements java.io.Serializable {
 
 
   /**
-   * 'Auto-fight' all of the air battles. First doing the air-raids (air battles), then the strategic boming runs.
+   * 'Auto-fight' all of the air battles and strategic bombing runs.
    * Auto fight means we automatically begin the fight without user action. This is to avoid clicks during the
    * air battle and SBR phase, and to enforce game rules that these phases are fought first before any other combat.
    */
-  void fightAirRaids(final IDelegateBridge delegateBridge) {
+  void fightAirCombats(final IDelegateBridge delegateBridge) {
     boolean bombing = true;
-    fightAirRaids(delegateBridge, () -> getPendingBattleSites(bombing),
+    fightAirCombats(delegateBridge, () -> getPendingBattleSites(bombing),
             (territory, battleType) -> getPendingBattle(territory, bombing, battleType));
   }
 
   @VisibleForTesting
-  void fightAirRaids(final IDelegateBridge delegateBridge, Supplier<Collection<Territory>> pendingBattleSiteSupplier,
+  void fightAirCombats(final IDelegateBridge delegateBridge, Supplier<Collection<Territory>> pendingBattleSiteSupplier,
              BiFunction<Territory, BattleType, IBattle> pendingBattleFunction) {
 
 

--- a/src/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/games/strategy/triplea/delegate/BattleTracker.java
@@ -1106,14 +1106,14 @@ public class BattleTracker implements java.io.Serializable {
    * Auto fight means we automatically begin the fight without user action. This is to avoid clicks during the
    * air battle and SBR phase, and to enforce game rules that these phases are fought first before any other combat.
    */
-  void fightAirCombats(final IDelegateBridge delegateBridge) {
+  void fightBombingRaids(final IDelegateBridge delegateBridge) {
     boolean bombing = true;
-    fightAirCombats(delegateBridge, () -> getPendingBattleSites(bombing),
+    fightBombingRaids(delegateBridge, () -> getPendingBattleSites(bombing),
             (territory, battleType) -> getPendingBattle(territory, bombing, battleType));
   }
 
   @VisibleForTesting
-  void fightAirCombats(final IDelegateBridge delegateBridge, Supplier<Collection<Territory>> pendingBattleSiteSupplier,
+  void fightBombingRaids(final IDelegateBridge delegateBridge, Supplier<Collection<Territory>> pendingBattleSiteSupplier,
              BiFunction<Territory, BattleType, IBattle> pendingBattleFunction) {
 
 

--- a/src/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/games/strategy/triplea/delegate/BattleTracker.java
@@ -1084,6 +1084,16 @@ public class BattleTracker implements java.io.Serializable {
     }
   }
 
+  public void raids(final IDelegateBridge m_bridge) {
+    // Remove air raids - this finds  all the raids in the battle tracker
+    for( final Territory t : getPendingBattleSites(true) ) {
+      final IBattle airRaid = getPendingBattle(t, true, BattleType.AIR_RAID);   // Get air raid for current territory (if any)
+      if( airRaid != null ) {
+        airRaid.fight(m_bridge);
+      }
+    }
+  }
+
   @Override
   public String toString() {
     return "BattleTracker:" + "\n" + "Conquered:" + m_conquered + "\n" + "Blitzed:" + m_blitzed + "\n" + "Fought:"

--- a/src/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -319,7 +319,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     m_battleTracker.getBattleRecords().addResultToBattle(m_attacker, m_battleID, m_defender, m_attackerLostTUV,
         m_defenderLostTUV, m_battleResultDescription, new BattleResults(this, m_data));
     m_isOver = true;
-    m_battleTracker.removeBattle(StrategicBombingRaidBattle.this);
+    m_battleTracker.removeBattle(this);
   }
 
   private void showBattle(final IDelegateBridge bridge) {

--- a/src/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/src/games/strategy/triplea/ui/history/HistoryLog.java
@@ -435,7 +435,7 @@ public class HistoryLog extends JFrame {
     for (final Territory t : territories) {
       final List<Unit> ownedUnits = t.getUnits().getMatches(Matches.unitIsOwnedByOfAnyOfThesePlayers(players));
       // see if there's a flag
-      final TerritoryAttachment ta = TerritoryAttachment.get(t, true);
+      final TerritoryAttachment ta = TerritoryAttachment.get(t);
       boolean hasFlag = false;
       if (ta == null) {
         hasFlag = false;

--- a/test/games/strategy/triplea/delegate/BattleTrackerTest.java
+++ b/test/games/strategy/triplea/delegate/BattleTrackerTest.java
@@ -52,7 +52,7 @@ public class BattleTrackerTest {
 
 	@Test
 	public void verifyRaidsWithNoBattles() {
-		testObj.fightStrategicBombingRuns(mockDelegateBridge);
+		testObj.fightAirRaids(mockDelegateBridge);
 	}
 
 	@Test
@@ -75,7 +75,7 @@ public class BattleTrackerTest {
 		// set up the testObj to have the bombing battle
 		testObj.addBombingBattle(route, attackers, playerId, mockDelegateBridge, null, null);
 
-		testObj.fightStrategicBombingRuns(mockDelegateBridge, () -> Collections.singleton(territory), mockGetBattleFunction);
+		testObj.fightAirRaids(mockDelegateBridge, () -> Collections.singleton(territory), mockGetBattleFunction);
 
 		verify(mockBattle, times(1)).fight(mockDelegateBridge);
 	}

--- a/test/games/strategy/triplea/delegate/BattleTrackerTest.java
+++ b/test/games/strategy/triplea/delegate/BattleTrackerTest.java
@@ -52,7 +52,7 @@ public class BattleTrackerTest {
 
 	@Test
 	public void verifyRaidsWithNoBattles() {
-		testObj.fightAirCombats(mockDelegateBridge);
+		testObj.fightBombingRaids(mockDelegateBridge);
 	}
 
 	@Test
@@ -75,7 +75,7 @@ public class BattleTrackerTest {
 		// set up the testObj to have the bombing battle
 		testObj.addBombingBattle(route, attackers, playerId, mockDelegateBridge, null, null);
 
-		testObj.fightAirCombats(mockDelegateBridge, () -> Collections.singleton(territory), mockGetBattleFunction);
+		testObj.fightBombingRaids(mockDelegateBridge, () -> Collections.singleton(territory), mockGetBattleFunction);
 
 		verify(mockBattle, times(1)).fight(mockDelegateBridge);
 	}

--- a/test/games/strategy/triplea/delegate/BattleTrackerTest.java
+++ b/test/games/strategy/triplea/delegate/BattleTrackerTest.java
@@ -1,0 +1,82 @@
+package games.strategy.triplea.delegate;
+
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.RelationshipTracker;
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.properties.GameProperties;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.Constants;
+import games.strategy.triplea.TripleAUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BattleTrackerTest {
+
+
+	@Mock
+	private IDelegateBridge mockDelegateBridge;
+	@Mock
+	private GameData mockGameData;
+	@Mock
+	private GameProperties mockGameProperties;
+	@Mock
+	private RelationshipTracker mockRelationshipTracker;
+	@Mock
+	private BiFunction<Territory, IBattle.BattleType, IBattle> mockGetBattleFunction;
+	@Mock
+	private IBattle mockBattle;
+
+	private BattleTracker testObj;
+
+	@Before
+	public void setup() {
+		testObj = new BattleTracker();
+	}
+
+	@Test
+	public void verifyRaidsWithNoBattles() {
+		testObj.fightStrategicBombingRuns(mockDelegateBridge);
+	}
+
+	@Test
+	public void verifyRaids() {
+		Territory territory = new Territory("terrName", mockGameData);
+		Route route = new Route(territory);
+		PlayerID playerId = new PlayerID("name", mockGameData);
+
+		// need at least one attacker for there to be considered a battle.
+		Unit unit = new TripleAUnit(new UnitType("unit", mockGameData), playerId, mockGameData);
+		List<Unit> attackers = Collections.singletonList(unit);
+
+		when(mockDelegateBridge.getData()).thenReturn(mockGameData);
+		when(mockGameData.getProperties()).thenReturn(mockGameProperties);
+		when(mockGameData.getRelationshipTracker()).thenReturn(mockRelationshipTracker);
+		when(mockGameProperties.get(Constants.RAIDS_MAY_BE_PRECEEDED_BY_AIR_BATTLES, false))
+			.thenReturn(true);
+		when(mockGetBattleFunction.apply(territory, IBattle.BattleType.BOMBING_RAID)).thenReturn(mockBattle);
+
+		// set up the testObj to have the bombing battle
+		testObj.addBombingBattle(route, attackers, playerId, mockDelegateBridge, null, null);
+
+		testObj.fightStrategicBombingRuns(mockDelegateBridge, () -> Collections.singleton(territory), mockGetBattleFunction);
+
+		verify(mockBattle, times(1)).fight(mockDelegateBridge);
+	}
+}

--- a/test/games/strategy/triplea/delegate/BattleTrackerTest.java
+++ b/test/games/strategy/triplea/delegate/BattleTrackerTest.java
@@ -52,7 +52,7 @@ public class BattleTrackerTest {
 
 	@Test
 	public void verifyRaidsWithNoBattles() {
-		testObj.fightAirRaids(mockDelegateBridge);
+		testObj.fightAirCombats(mockDelegateBridge);
 	}
 
 	@Test
@@ -75,7 +75,7 @@ public class BattleTrackerTest {
 		// set up the testObj to have the bombing battle
 		testObj.addBombingBattle(route, attackers, playerId, mockDelegateBridge, null, null);
 
-		testObj.fightAirRaids(mockDelegateBridge, () -> Collections.singleton(territory), mockGetBattleFunction);
+		testObj.fightAirCombats(mockDelegateBridge, () -> Collections.singleton(territory), mockGetBattleFunction);
 
 		verify(mockBattle, times(1)).fight(mockDelegateBridge);
 	}

--- a/test/games/strategy/triplea/delegate/RevisedTest.java
+++ b/test/games/strategy/triplea/delegate/RevisedTest.java
@@ -57,6 +57,8 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import games.strategy.engine.random.IRandomSource;
+import games.strategy.engine.random.PlainRandomSource;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -320,35 +322,6 @@ public class RevisedTest {
     assertNull(placeable.getErrorMessage());
     final String error = bidPlaceDelegate(m_data).placeUnits(units, uk);
     assertNull(error);
-  }
-
-  @Test
-  public void testBombingRaid() {
-    final MoveDelegate moveDelegate = (MoveDelegate) m_data.getDelegateList().getDelegate("move");
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
-    bridge.setStepName("CombatMove");
-    moveDelegate.setDelegateBridgeAndPlayer(bridge);
-    moveDelegate.start();
-    when(dummyPlayer.shouldBomberBomb(any())).thenReturn(true);
-    bridge.setRemote(dummyPlayer);
-    final Territory uk = territory("United Kingdom", m_data);
-    final Territory germany = territory("Germany", m_data);
-    final Route route = new Route(uk, territory("6 Sea Zone", m_data), territory("5 Sea Zone", m_data), germany);
-    final String error = moveDelegate.move(uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), route);
-    assertNull(error);
-    final BattleTracker tracker = AbstractMoveDelegate.getBattleTracker(m_data);
-    // there should be a bombing battle
-    assertTrue(tracker.hasPendingBattle(germany, true));
-    // there should not be a normal battle
-    assertFalse(tracker.hasPendingBattle(germany, false));
-    // start the battle phase, this should not add a new battle
-    moveDelegate.end();
-    battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    battleDelegate(m_data).start();
-    // there should be a bombing battle
-    assertTrue(tracker.hasPendingBattle(germany, true));
-    // there should not be a normal battle
-    assertFalse(tracker.hasPendingBattle(germany, false));
   }
 
   @Test

--- a/test/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/test/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -1115,51 +1115,6 @@ public class WW2V3_41_Test {
     assertEquals(2, mfb.getBombardingUnits().size());
   }
 
-  // TODO this test needs work kev
-  @Test
-  public void testAAFireWithRadar() {
-    final PlayerID russians = russians(m_data);
-    final PlayerID germans = germans(m_data);
-    TechAttachment.get(russians).setAARadar("true");
-    final MoveDelegate move = moveDelegate(m_data);
-    final ITestDelegateBridge bridge = getDelegateBridge(germans);
-    bridge.setStepName("CombatMove");
-    final Territory poland = territory("Poland", m_data);
-    final Territory russia = territory("Russia", m_data);
-    // Add bomber to Poland and attack
-    addTo(poland, bomber(m_data).create(1, germans));
-    // The game will ask us if we want to move bomb, say yes.
-    final InvocationHandler handler = new InvocationHandler() {
-      @Override
-      public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
-        return true;
-      }
-    };
-    final ITripleAPlayer player = (ITripleAPlayer) Proxy
-        .newProxyInstance(Thread.currentThread().getContextClassLoader(),
-            TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
-    bridge.setRemote(player);
-    // Perform the combat movement
-    move.setDelegateBridgeAndPlayer(bridge);
-    move.start();
-    move(poland.getUnits().getMatches(Matches.UnitIsStrategicBomber), m_data.getMap().getRoute(poland, russia));
-    move.end();
-    // start the battle phase
-    battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    battleDelegate(m_data).start();
-    // aa guns rolls 1, hits
-    bridge.setRandomSource(new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR}));
-    final StrategicBombingRaidBattle battle =
-        (StrategicBombingRaidBattle) battleDelegate(m_data).getBattleTracker().getPendingBattle(russia, true, null);
-    // aa guns rolls 1, hits
-    // bridge.setRandomSource(new ScriptedRandomSource( new int[] {0, 6} ));
-    final int PUsBeforeRaid = russians.getResources().getQuantity(m_data.getResourceList().getResource(Constants.PUS));
-    battle.fight(bridge);
-    final int PUsAfterRaid = russians.getResources().getQuantity(m_data.getResourceList().getResource(Constants.PUS));
-    // Changed to match StrategicBombingRaidBattle changes
-    assertEquals(PUsBeforeRaid, PUsAfterRaid);
-  }
-
   @Test
   public void testCarrierWithAlliedPlanes() {
     final Territory sz8 = territory("8 Sea Zone", m_data);


### PR DESCRIPTION
Builds on top of: https://github.com/triplea-game/triplea/pull/1426

Included:
- Bombing and air raids are "auto-selected"
  - This reduces clicks in the game flow, these battles have to be fought
  - Game rules would have these battles fought first, then amphib. We are for now forcing that these battles be fought first. See #1426 for more discussion on purpose

Test notes:
@simon33-2  - quite right to point out that possible to test is not the same as easy to test. There are a number of scaffolding changes included just to make testing easier to write. 

Enhancements on #1426 
- added checks for SBR in addition to Air raids, and will fight those first as well
- added unit test + scaffolding

Now that we auto-fight SBR's, a few integration tests broke. I removed rather than fixing them since they can no longer test anything. They were dependent on battles still existing after calling BattleDelegate.start(), which is now no longer the case. With the unit test in place we have test coverage, so we can remove the integration tests.