### PR TITLE
Deploy only from official repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ deploy:
   prerelease: true
   on:
     tags: false
+    repo: triplea-game/triplea
     branches:
       only:
         - master


### PR DESCRIPTION
This change ensures that the `deploy` stage on Travis is only executed for the official TripleA repo.

I came across this while working a PR and trying to keep my fork's `master` branch in sync with the upstream repo.  I don't know if other TripleA devs configure their own Travis builds for their forks, but I did (to ensure my branches build successfully on Travis before creating the actual PR), and it fails whenever I push the `master` branch to my fork (e.g. see [here](https://travis-ci.org/ssoloff/triplea/builds/191080791)).  My non-`master` branches build fine because the deployment phase is limited to only the `master` branch in `.travis.yml`.

The deployment failure in my Travis build is due to not having a proper Install4J license installed in the environment.  However, even if I were to have the environment set up correctly, it would probably fail later on when an attempt is made to deploy the build as a GitHub release under the official TripleA repo.  That lead me to believe that the deployment phase should only be executed when run from the official TripleA repo.

I was unable to locate any user-specific mechanism on Travis to, for example, configure it to not build the `master` branch on my fork.  Everything I read in the Travis docs seems to indicate that all build configuration is done via `.travis.yml`.  Please let me know if I missed something and there is a way to not build `master` (or to exclude the deployment phase) using something other than `.travis.yml`.

I tested the change on a completely new [fork](https://github.com/ssoloff/triplea-travis-test) to which I pushed the change to `master` and verified Travis [no longer runs](https://travis-ci.org/ssoloff/triplea-travis-test/builds/186589785) the deployment phase.  Obviously, I'm unable to verify that Travis *still* runs the deployment phase on the official repo with this change. :smiley:

Otherwise, this isn't that big of a deal to me -- it's mostly annoying getting notifications from Travis about a build failure any time I push to `master`.  Feel free to reject this PR if it's not something the TripleA team experiences.