### PR TITLE
Update map snapshot labels (#1423)

### DIFF
--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -1730,7 +1730,7 @@ public class TripleAFrame extends MainGameFrame {
         historyLog.setVisible(true);
       }
     });
-    popup.add(new AbstractAction("Save Screenshot") {
+    popup.add(new AbstractAction("Export Map Snapshot") {
       private static final long serialVersionUID = 1222760138263428443L;
 
       @Override

--- a/src/games/strategy/ui/SwingWorkerCompletionWaiter.java
+++ b/src/games/strategy/ui/SwingWorkerCompletionWaiter.java
@@ -33,6 +33,7 @@ import com.google.common.annotations.VisibleForTesting;
  * </pre>
  */
 public final class SwingWorkerCompletionWaiter implements PropertyChangeListener {
+  @VisibleForTesting
   static final String SWING_WORKER_STATE_PROPERTY_NAME = "state";
 
   private final ProgressWindow progressWindow;


### PR DESCRIPTION
This change updates all remaining user-facing text that uses "screenshot" to instead use "map snapshot", as described in #1423.

After PR #1419 was merged, I only found a single occurrence that needed to be replaced: the command label for exporting a map snapshot in the Game History panel context menu.  The shell command I ran from the repo root to search for possible occurrences follows:

```bash
$ find . -not \( -path ./.git -prune -o -path ./.gradle -prune -o -path ./bin -prune -o -path ./build -prune \) -type f | xargs grep -i screenshot
```

A [screenshot](https://cloud.githubusercontent.com/assets/4826349/21867402/04cdaac4-d81c-11e6-8ab4-2cb7dd0c7102.png) of the single UI change is attached.

Note that there is an additional commit in this PR for an annotation that should have been added as part of #1419.  Please advise if you'd like that moved to a separate PR or removed completely.
