### PR TITLE
Rocket fix

### DIFF
--- a/src/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1487,7 +1487,7 @@ public class UnitAttachment extends DefaultAttachment {
     return Math.min(getData().getDiceSides(), Math.max(0, defenseValue));
   }
 
-  int getRawDefense() {
+  public int getRawDefense() {
     return m_defense;
   }
 

--- a/src/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/games/strategy/triplea/delegate/BattleDelegate.java
@@ -101,6 +101,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       m_needToAddBombardmentSources = false;
     }
     m_battleTracker.fightBombingRaids(m_bridge);
+    m_battleTracker.fightAutoKills(m_bridge);
   }
 
   /**

--- a/src/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/games/strategy/triplea/delegate/BattleTracker.java
@@ -1139,6 +1139,19 @@ public class BattleTracker implements java.io.Serializable {
     }
   }
 
+  public void fightAutoKills(final IDelegateBridge delegateBridge) {
+    // Kill undefended transports. Done here to remove potentially dependent sea battles below
+    for( final Territory t : getPendingBattleSites(false) ) {  // Loop through normal combats i.e. not bombing or air raid
+      final IBattle battle = getPendingBattle(t, false, BattleType.NORMAL);
+      if(getDependentOn(battle).isEmpty())  {
+        if(Match.allMatch( battle.getDefendingUnits(), Matches.UnitIsTransportButNotCombatTransport)
+          || battle instanceof NonFightingBattle) {
+          battle.fight( delegateBridge );           // Must be fought here to remove dependencies
+        }
+      }
+    }
+  }
+
   @Override
   public String toString() {
     return "BattleTracker:" + "\n" + "Conquered:" + m_conquered + "\n" + "Blitzed:" + m_blitzed + "\n" + "Fought:"

--- a/src/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/games/strategy/triplea/delegate/BattleTracker.java
@@ -1144,7 +1144,7 @@ public class BattleTracker implements java.io.Serializable {
     for( final Territory t : getPendingBattleSites(false) ) {  // Loop through normal combats i.e. not bombing or air raid
       final IBattle battle = getPendingBattle(t, false, BattleType.NORMAL);
       if(getDependentOn(battle).isEmpty())  {
-        if(Match.allMatch( battle.getDefendingUnits(), Matches.UnitIsTransportButNotCombatTransport)
+        if(Match.allMatch( battle.getDefendingUnits(), Matches.UnitIsDefenselessTransport)
           || battle instanceof NonFightingBattle) {
           battle.fight( delegateBridge );           // Must be fought here to remove dependencies
         }

--- a/src/games/strategy/triplea/delegate/Matches.java
+++ b/src/games/strategy/triplea/delegate/Matches.java
@@ -121,6 +121,13 @@ public class Matches {
       return (ua.getIsCombatTransport() && ua.getIsSea());
     }
   };
+  public static final Match<Unit> UnitIsDefenselessTransport = new Match<Unit>() {
+    @Override
+    public boolean match(final Unit unit) {
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      return (ua.getTransportCapacity() != -1 && ua.getIsSea() && ua.getRawDefense() == 0);
+    }
+  };
   public static final Match<Unit> UnitIsNotCombatTransport = new InverseMatch<>(UnitIsCombatTransport);
   public static final Match<Unit> UnitIsTransportButNotCombatTransport = new Match<Unit>() {
     @Override

--- a/src/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -88,6 +89,7 @@ public class RocketsFireHelper {
   private void fireWW2V2(final IDelegateBridge bridge, final PlayerID player, final Set<Territory> rocketTerritories) {
     final GameData data = bridge.getData();
     final Set<Territory> attackedTerritories = new HashSet<>();
+    final Set<Territory> attackingTerritories = new HashSet<>();
     final boolean oneAttackPerTerritory = !isRocketAttacksPerFactoryInfinite(data);
     for (final Territory territory : rocketTerritories) {
       final Set<Territory> targets = getTargetsWithinRange(territory, data, player);
@@ -99,11 +101,13 @@ public class RocketsFireHelper {
       }
       final Territory target = getTarget(targets, player, bridge, territory);
       if (target != null) {
-        if (oneAttackPerTerritory) {
-          attackedTerritories.add(target);
-        }
-        fireRocket(player, target, bridge, territory);
+        attackedTerritories.add(target);
+        attackingTerritories.add(territory);
       }
+    }
+    Iterator<Territory> attackers = attackingTerritories.iterator();
+    for( final Territory defender : attackedTerritories ) {
+			fireRocket(player, defender, bridge, attackers.next());
     }
   }
 


### PR DESCRIPTION
This PR resolves the issue where Rockets can be targeted after the first rocket's damage has been rolled. On maps with multiple rocket attacks possible, you should be required to nominate all your rocket attacks before rolling any of them. This bug fix stipulates this. On maps such as classic with only one rocket attack possible, no change is made.