### PR TITLE
Rocket bug fix

### DIFF
--- a/src/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -107,7 +107,7 @@ public class RocketsFireHelper {
       }
     }
     for( final Territory target : attackedTerritories ) {
-			fireRocket(player, target, bridge, attackingTerritories.get(target));
+      fireRocket(player, target, bridge, attackingTerritories.get(target));
     }
   }
 

--- a/src/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -90,7 +91,7 @@ public class RocketsFireHelper {
   private void fireWW2V2(final IDelegateBridge bridge, final PlayerID player, final Set<Territory> rocketTerritories) {
     final GameData data = bridge.getData();
     final Set<Territory> attackedTerritories = new HashSet<>();
-    final LinkedHashMap<Territory,Territory> attackingTerritories = new LinkedHashMap<>();
+    final Map<Territory,Territory> attackingTerritories = new LinkedHashMap<>();
     final boolean oneAttackPerTerritory = !isRocketAttacksPerFactoryInfinite(data);
     for (final Territory territory : rocketTerritories) {
       final Set<Territory> targets = getTargetsWithinRange(territory, data, player);

--- a/src/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -101,6 +101,7 @@ public class RocketsFireHelper {
       if (targets.isEmpty()) {
         continue;
       }
+      // Ask the user where the rocket launch should target.
       final Territory target = getTarget(targets, player, bridge, territory);
       if (target != null) {
         attackedTerritories.add(target);
@@ -108,6 +109,7 @@ public class RocketsFireHelper {
       }
     }
     for( final Territory target : attackedTerritories ) {
+      // Roll dice for the rocket attack damage and apply it here.
       fireRocket(player, target, bridge, attackingTerritories.get(target));
     }
   }

--- a/src/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -89,7 +90,7 @@ public class RocketsFireHelper {
   private void fireWW2V2(final IDelegateBridge bridge, final PlayerID player, final Set<Territory> rocketTerritories) {
     final GameData data = bridge.getData();
     final Set<Territory> attackedTerritories = new HashSet<>();
-    final Set<Territory> attackingTerritories = new HashSet<>();
+    final LinkedHashMap<Territory,Territory> attackingTerritories = new LinkedHashMap<>();
     final boolean oneAttackPerTerritory = !isRocketAttacksPerFactoryInfinite(data);
     for (final Territory territory : rocketTerritories) {
       final Set<Territory> targets = getTargetsWithinRange(territory, data, player);
@@ -102,12 +103,11 @@ public class RocketsFireHelper {
       final Territory target = getTarget(targets, player, bridge, territory);
       if (target != null) {
         attackedTerritories.add(target);
-        attackingTerritories.add(territory);
+        attackingTerritories.put(target,territory);
       }
     }
-    Iterator<Territory> attackers = attackingTerritories.iterator();
-    for( final Territory defender : attackedTerritories ) {
-			fireRocket(player, defender, bridge, attackers.next());
+    for( final Territory target : attackedTerritories ) {
+			fireRocket(player, target, bridge, attackingTerritories.get(target));
     }
   }
 

--- a/src/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -88,6 +89,7 @@ public class RocketsFireHelper {
   private void fireWW2V2(final IDelegateBridge bridge, final PlayerID player, final Set<Territory> rocketTerritories) {
     final GameData data = bridge.getData();
     final Set<Territory> attackedTerritories = new HashSet<>();
+    final Set<Territory> attackingTerritories = new HashSet<>();
     final boolean oneAttackPerTerritory = !isRocketAttacksPerFactoryInfinite(data);
     for (final Territory territory : rocketTerritories) {
       final Set<Territory> targets = getTargetsWithinRange(territory, data, player);
@@ -99,11 +101,13 @@ public class RocketsFireHelper {
       }
       final Territory target = getTarget(targets, player, bridge, territory);
       if (target != null) {
-        if (oneAttackPerTerritory) {
-          attackedTerritories.add(target);
-        }
-        fireRocket(player, target, bridge, territory);
+        attackedTerritories.add(target);
+        attackingTerritories.add(territory);
       }
+    }
+    Iterator<Territory> attackers = attackingTerritories.iterator();
+    for( final Territory defender : attackedTerritories ) {
+			fireRocket(player, defender, bridge, attackers.next());
     }
   }
 


### PR DESCRIPTION
Fix bug which allows attacker to see result of first rocket attack before deciding subsequent rocket attacks' targets. This should not be possible. All targets should be decided before any results are resolved.

Required some two attempts to avoid picking up my other open PR