### PR TITLE
Load map selection in background, faster main UI window load.

### DIFF
--- a/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -264,7 +264,7 @@ public class GameSelectorModel extends Observable {
     // clear out ai cached properties (this ended up being the best place to put it, as we have definitely left a game
     // at this point)
     ProAI.gameOverClearCache();
-    loadDefaultGame(ui, false);
+    new Thread(() -> loadDefaultGame(ui, false)).start();
   }
 
   /**


### PR DESCRIPTION
Previously the game would parse the 'currently selected map' to know what to show for the 'map name' on teh main UI. This blcoking event generally is not noticeable, until map parsing is at its worst case (30 seconds+). This update pushes the map parsing to a background thread, which then unblocks the main UI from loading. When the map is done parsing, the map name label will populate. Otherwise the user is free to select a different map or to click any other main window button.

Resolves: https://github.com/triplea-game/triplea/issues/985


----
While loading:
![map_still_loading](https://cloud.githubusercontent.com/assets/12397753/22053389/1a17fd10-dd05-11e6-9f48-c126c2bf096a.png)


----
After loading:
![map_loaded](https://cloud.githubusercontent.com/assets/12397753/22053390/1a295ef2-dd05-11e6-9ab1-58393b2595c5.png)


