### PR TITLE
Better ThreadUtil.sleep, return boolean and interrupt current thread

### DIFF
--- a/src/games/strategy/debug/ThreadReader.java
+++ b/src/games/strategy/debug/ThreadReader.java
@@ -26,7 +26,9 @@ class ThreadReader implements Runnable {
       if (m_displayConsoleOnWrite && !parentConsole.isVisible()) {
         parentConsole.setVisible(true);
       }
-      ThreadUtil.sleep(CONSOLE_UPDATE_INTERVAL_MS);
+      if(!ThreadUtil.sleep(CONSOLE_UPDATE_INTERVAL_MS)) {
+        break;
+      }
     }
   }
 }

--- a/src/games/strategy/engine/framework/ClientGame.java
+++ b/src/games/strategy/engine/framework/ClientGame.java
@@ -129,7 +129,9 @@ public class ClientGame extends AbstractGame {
           } finally {
             m_data.releaseReadLock();
           }
-          ThreadUtil.sleep(100);
+          if(!ThreadUtil.sleep(100)) {
+            break;
+          }
           i++;
           if (i > 300 && !shownErrorMessage) {
             System.err.println("Waited more than 30 seconds for step to update. Something wrong.");

--- a/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -179,7 +179,6 @@ public class HeadlessGameServer {
     if (encryptedPassword.equals(hashedPassword)) {
       (new Thread(() -> {
         System.out.println("Remote Shutdown Initiated.");
-        ThreadUtil.sleep(1000);
         System.exit(0);
       })).start();
       return null;
@@ -561,7 +560,10 @@ public class HeadlessGameServer {
 
     final Runnable r = () -> {
       while (!m_shutDown) {
-        ThreadUtil.sleep(8000);
+        if(!ThreadUtil.sleep(8000)) {
+          m_shutDown = true;
+          break;
+        }
         if (m_setupPanelModel != null && m_setupPanelModel.getPanel() != null
             && m_setupPanelModel.getPanel().canGameStart()) {
           final boolean started = startHeadlessGame(m_setupPanelModel);

--- a/src/games/strategy/engine/framework/map/download/FileSizeWatcher.java
+++ b/src/games/strategy/engine/framework/map/download/FileSizeWatcher.java
@@ -30,7 +30,9 @@ public class FileSizeWatcher {
     return () -> {
       while (!stop) {
         progressListener.accept((int) fileToWatch.length());
-        ThreadUtil.sleep(50);
+        if(!ThreadUtil.sleep(50)) {
+          break;
+        }
       }
     };
   }

--- a/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/src/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -99,7 +99,8 @@ public class ClientLoginValidator implements ILoginValidator {
       if (!readPassword.equals(MD5Crypt.crypt(m_password, propertiesSentToClient.get(SALT_PROPERTY)))) {
         // sleep on average 2 seconds
         // try to prevent flooding to guess the password
-        ThreadUtil.sleep((int) (4000 * Math.random()));
+        // TODO: verify this prevention, does this protect against parallel connections?
+        ThreadUtil.sleep(4000 * Math.random()); // usage of sleep is okay.
         return "Invalid password";
       }
     }

--- a/src/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/games/strategy/engine/lobby/server/userDB/Database.java
@@ -182,7 +182,9 @@ public class Database {
     final Thread backupThread = new Thread(() -> {
       while (true) {
         // wait 7 days
-        ThreadUtil.sleep(7 * 24 * 60 * 60 * 1000);
+        if(!ThreadUtil.sleep(7 * 24 * 60 * 60 * 1000)) {
+          break;
+        }
         backup();
       }
     }, "TripleA Database Backup Thread");

--- a/src/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/src/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -145,7 +145,7 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
     final long endTime = NODE_IMPLEMENTATION_TIMEOUT + System.currentTimeMillis();
     while (System.currentTimeMillis() < endTime && !hasImplementors(endPointName)) {
       if(!ThreadUtil.sleep(50)) {
-        break;
+        return;
       }
     }
   }

--- a/src/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/src/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -144,7 +144,9 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
   public void waitForNodesToImplement(final String endPointName) {
     final long endTime = NODE_IMPLEMENTATION_TIMEOUT + System.currentTimeMillis();
     while (System.currentTimeMillis() < endTime && !hasImplementors(endPointName)) {
-      ThreadUtil.sleep(50);
+      if(!ThreadUtil.sleep(50)) {
+        break;
+      }
     }
   }
 

--- a/src/games/strategy/net/ClientMessenger.java
+++ b/src/games/strategy/net/ClientMessenger.java
@@ -84,7 +84,9 @@ public class ClientMessenger implements IClientMessenger, NIOSocketListener {
         if (m_socketChannel.finishConnect()) {
           break;
         }
-        ThreadUtil.sleep(50);
+        if(!ThreadUtil.sleep(50)) {
+          return;
+        }
         waitTimeMilliseconds += 50;
       }
     }

--- a/src/games/strategy/net/ClientMessenger.java
+++ b/src/games/strategy/net/ClientMessenger.java
@@ -85,6 +85,8 @@ public class ClientMessenger implements IClientMessenger, NIOSocketListener {
           break;
         }
         if(!ThreadUtil.sleep(50)) {
+          shutDown();
+          m_socket = null;
           return;
         }
         waitTimeMilliseconds += 50;
@@ -168,7 +170,9 @@ public class ClientMessenger implements IClientMessenger, NIOSocketListener {
   @Override
   public void shutDown() {
     m_shutDown = true;
-    m_socket.shutDown();
+    if(m_socket != null) {
+      m_socket.shutDown();
+    }
     try {
       m_socketChannel.close();
     } catch (final IOException e) {

--- a/src/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -97,7 +97,9 @@ public class RandomStartDelegate extends BaseTripleADelegate {
       if (m_currentPickingPlayer == null || !playersCanPick.contains(m_currentPickingPlayer)) {
         m_currentPickingPlayer = playersCanPick.get(0);
       }
-      ThreadUtil.sleep(250);
+      if(!ThreadUtil.sleep(250)) {
+        return;
+      }
       Territory picked;
       if (randomTerritories) {
         pos += hitRandom[i];

--- a/src/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
+++ b/src/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
@@ -177,7 +177,9 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
               + m_topicId + ".0;num_replies=" + numReplies);
           httpPost.addHeader("Accept", "*/*");
           // the site has spam prevention which means you can't post until 15 seconds after login
-          ThreadUtil.sleep(15 * 1000);
+          if(ThreadUtil.sleep(15 * 1000)) {
+            return false;
+          }
           httpPost.setConfig(RequestConfig.custom().setRedirectsEnabled(false).build());
           HttpProxy.addProxy(httpPost);
           try (CloseableHttpResponse response2 = client.execute(httpPost, httpContext)) {

--- a/src/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
+++ b/src/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
@@ -177,7 +177,7 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
               + m_topicId + ".0;num_replies=" + numReplies);
           httpPost.addHeader("Accept", "*/*");
           // the site has spam prevention which means you can't post until 15 seconds after login
-          if(ThreadUtil.sleep(15 * 1000)) {
+          if(!ThreadUtil.sleep(15 * 1000)) {
             return false;
           }
           httpPost.setConfig(RequestConfig.custom().setRedirectsEnabled(false).build());

--- a/src/games/strategy/triplea/ui/BattleStepsPanel.java
+++ b/src/games/strategy/triplea/ui/BattleStepsPanel.java
@@ -134,9 +134,7 @@ class BattleStepsPanel extends JPanel implements Active {
   }
 
   private void waitThenWalk() {
-    final Thread t = new Thread("Walk single step started at:" + new Date()) {
-      @Override
-      public void run() {
+    new Thread(() -> {
         synchronized (m_mutex) {
           if (m_hasWalkThread) {
             return;
@@ -144,16 +142,15 @@ class BattleStepsPanel extends JPanel implements Active {
           m_hasWalkThread = true;
         }
         try {
-          ThreadUtil.sleep(330);
-          SwingUtilities.invokeLater(() -> walkStep());
+          if(ThreadUtil.sleep(330)) {
+            SwingUtilities.invokeLater(this::walkStep);
+          }
         } finally {
           synchronized (m_mutex) {
             m_hasWalkThread = false;
           }
         }
-      }
-    };
-    t.start();
+    }).start();
   }
 
   /**

--- a/src/games/strategy/triplea/ui/MemoryLabel.java
+++ b/src/games/strategy/triplea/ui/MemoryLabel.java
@@ -71,7 +71,9 @@ class Updater implements Runnable {
   @Override
   public void run() {
     while (m_label.get() != null) {
-      sleep();
+      if(!ThreadUtil.sleep(2000)) {
+        return;
+      }
       update();
     }
   }
@@ -86,7 +88,4 @@ class Updater implements Runnable {
     });
   }
 
-  private static void sleep() {
-    ThreadUtil.sleep(2000);
-  }
 }

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -1474,24 +1474,25 @@ public class TripleAFrame extends MainGameFrame {
     if (player == null) {
       return;
     }
-    ThreadUtil.sleep(300);
-    SwingAction.invokeAndWait(() -> {
-      final Boolean play = requiredTurnSeries.get(player);
-      if (play != null && play) {
-        ClipPlayer.play(SoundPath.CLIP_REQUIRED_YOUR_TURN_SERIES, player);
-        requiredTurnSeries.put(player, false);
-      }
-      // center on capital of player, if it is a new player
-      if (!player.equals(lastStepPlayer)) {
-        lastStepPlayer = player;
-        data.acquireReadLock();
-        try {
-          mapPanel.centerOn(TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data));
-        } finally {
-          data.releaseReadLock();
+    if(ThreadUtil.sleep(300)) {
+      SwingAction.invokeAndWait(() -> {
+        final Boolean play = requiredTurnSeries.get(player);
+        if (play != null && play) {
+          ClipPlayer.play(SoundPath.CLIP_REQUIRED_YOUR_TURN_SERIES, player);
+          requiredTurnSeries.put(player, false);
         }
-      }
-    });
+        // center on capital of player, if it is a new player
+        if (!player.equals(lastStepPlayer)) {
+          lastStepPlayer = player;
+          data.acquireReadLock();
+          try {
+            mapPanel.centerOn(TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data));
+          } finally {
+            data.releaseReadLock();
+          }
+        }
+      });
+    }
   }
 
   GameDataChangeListener m_dataChangeListener = new GameDataChangeListener() {

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -1471,28 +1471,26 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   public void requiredTurnSeries(final PlayerID player) {
-    if (player == null) {
+    if (player == null || !ThreadUtil.sleep(300)) {
       return;
     }
-    if(ThreadUtil.sleep(300)) {
-      SwingAction.invokeAndWait(() -> {
-        final Boolean play = requiredTurnSeries.get(player);
-        if (play != null && play) {
-          ClipPlayer.play(SoundPath.CLIP_REQUIRED_YOUR_TURN_SERIES, player);
-          requiredTurnSeries.put(player, false);
+    SwingAction.invokeAndWait(() -> {
+      final Boolean play = requiredTurnSeries.get(player);
+      if (play != null && play) {
+        ClipPlayer.play(SoundPath.CLIP_REQUIRED_YOUR_TURN_SERIES, player);
+        requiredTurnSeries.put(player, false);
+      }
+      // center on capital of player, if it is a new player
+      if (!player.equals(lastStepPlayer)) {
+        lastStepPlayer = player;
+        data.acquireReadLock();
+        try {
+          mapPanel.centerOn(TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data));
+        } finally {
+          data.releaseReadLock();
         }
-        // center on capital of player, if it is a new player
-        if (!player.equals(lastStepPlayer)) {
-          lastStepPlayer = player;
-          data.acquireReadLock();
-          try {
-            mapPanel.centerOn(TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data));
-          } finally {
-            data.releaseReadLock();
-          }
-        }
-      });
-    }
+      }
+    });
   }
 
   GameDataChangeListener m_dataChangeListener = new GameDataChangeListener() {

--- a/src/games/strategy/util/ThreadUtil.java
+++ b/src/games/strategy/util/ThreadUtil.java
@@ -3,11 +3,27 @@ package games.strategy.util;
 /** Utility class for java Thread related operations */
 public class ThreadUtil {
 
-  public static void sleep(final int millis) {
+
+  public static boolean sleep(final double millis) {
+    return sleep((int) millis);
+  }
+
+  /**
+   * Sleeps the current thread, useful to handle interrupted exceptions.
+   * This method sets the interrupted flag on the current thread, per best practice:
+   *  - http://www.yegor256.com/2015/10/20/interrupted-exception.html
+   *  - http://stackoverflow.com/questions/3976344/handling-interruptedexception-in-java
+   *
+   * @param millis Number of milliseconds to sleep
+   * @return False on InterruptedException, true otherwise (implying that we have slept for the desired time duration)
+   */
+  public static boolean sleep(final int millis) {
     try {
       Thread.sleep(millis);
+      return true;
     } catch (final InterruptedException e) {
-      // ignore, general cause is the user sent an interrupt (killed the program)
+      Thread.currentThread().interrupt();
+      return false;
     }
   }
 }


### PR DESCRIPTION
Instead of swallowing the interrupted exception we will instead return false. This will allow clients to control the behavior as they would like. As per best practices, we also now interrupt the current thread. When catching an InterruptedException, the thing that read if the thread was interrupted, will have reset the interrupted flag. So to handle that it is best practice to set the interrupted flag again.

Further background and discussion:  https://github.com/triplea-game/triplea/issues/1448