### PR TITLE
Keep the game open if the host connection drops. 

### DIFF
--- a/src/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -409,19 +409,14 @@ public class ClientModel implements IMessengerErrorListener {
     return getServerStartup();
   }
 
-  private void connectionLost() {
-    EventThreadJOptionPane.showMessageDialog(m_ui, " Connection To Server Lost", "Connection Lost",
-        JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler(true));
-    if (m_game != null) {
-      m_game.shutDown();
-      m_game = null;
-    }
-    MainFrame.getInstance().clientLeftGame();
-  }
 
   @Override
   public void messengerInvalid(final IMessenger messenger, final Exception reason) {
-    connectionLost();
+    // The self chat disconnect notification is simply so we have an on-screen notification of the disconnect.
+    // In case for example there are many game windows open, it may not be clear which game disconnected.
+    MainFrame.getInstance().getChat().sendMessage("*** Was Disconnected ***", false);
+    EventThreadJOptionPane.showMessageDialog(m_ui, "Connection to game host lost.\nPlease save and restart.", "Connection Lost!",
+        JOptionPane.ERROR_MESSAGE, new CountDownLatchHandler(true));
   }
 
   public IChatPanel getChatPanel() {


### PR DESCRIPTION
This allows players  to get a clean save of a game before closing after a host crash. In addition to staying open, we'll send a chat message to the (local) disconnected game to make sure there is something that ties the disconnected game window with the disconnect pop-up. This addresses #1362