### PR TITLE
Acquire GameData read lock during screenshot export (#1445)

### DIFF
--- a/src/games/strategy/triplea/ui/MapPanel.java
+++ b/src/games/strategy/triplea/ui/MapPanel.java
@@ -476,20 +476,25 @@ public class MapPanel extends ImageScrollerLargeView {
     final Graphics2D g2d = (Graphics2D) checkNotNull(g);
     // make sure we use the same data for the entire print
     final GameData gameData = m_data;
-    final Rectangle2D.Double bounds = new Rectangle2D.Double(0, 0, getImageWidth(), getImageHeight());
-    final Collection<Tile> tileList = tileManager.getTiles(bounds);
-    for (final Tile tile : tileList) {
-      Tile.S_TILE_LOCKUTIL.acquireLock(tile.getLock());
-      try {
-        final Image img = tile.getImage(gameData, uiContext.getMapData());
-        if (img != null) {
-          final AffineTransform t = new AffineTransform();
-          t.translate((tile.getBounds().x - bounds.getX()) * m_scale, (tile.getBounds().y - bounds.getY()) * m_scale);
-          g2d.drawImage(img, t, this);
+    gameData.acquireReadLock();
+    try {
+      final Rectangle2D.Double bounds = new Rectangle2D.Double(0, 0, getImageWidth(), getImageHeight());
+      final Collection<Tile> tileList = tileManager.getTiles(bounds);
+      for (final Tile tile : tileList) {
+        Tile.S_TILE_LOCKUTIL.acquireLock(tile.getLock());
+        try {
+          final Image img = tile.getImage(gameData, uiContext.getMapData());
+          if (img != null) {
+            final AffineTransform t = new AffineTransform();
+            t.translate((tile.getBounds().x - bounds.getX()) * m_scale, (tile.getBounds().y - bounds.getY()) * m_scale);
+            g2d.drawImage(img, t, this);
+          }
+        } finally {
+          Tile.S_TILE_LOCKUTIL.releaseLock(tile.getLock());
         }
-      } finally {
-        Tile.S_TILE_LOCKUTIL.releaseLock(tile.getLock());
       }
+    } finally {
+      gameData.releaseReadLock();
     }
   }
 


### PR DESCRIPTION
This is an attempt to fix issue #1445.  The change is much smaller than it appears; please view the changes while [ignoring whitespace differences](https://github.com/blog/967-github-secrets#whitespace).

Manual testing confirmed that the "Lock not held" errors no longer appear in the console when exporting a screenshot from the Game History panel.

I introduced the synchronization block as far down the call stack as possible to minimize the time in which the `GameData` read lock is held, while at the same time ensuring the `GameData` was consistent for all `Tiles`s redrawn by `MapPanel#drawMapImage()`.

However, I originally attempted to acquire the lock even further down the stack because it appears the `GameData` is only accessed when a `Tile` has to be redrawn.  Therefore, I thought I could acquire the lock specifically around the following line in `Tile#getImage()`:

```
draw(g, data, mapData);
```

(I wasn't **entirely** convinced this was the right thing to do because I wasn't sure if allowing the `GameData` to potentially be modified in-between `Tile` draws made sense [i.e. the `GameData` state may not be consistent relative to the entire `MapPanel#drawMapImage()` operation].  In reality, it didn't matter; see below.)

Unfortunately, this resulted in several exceptions raised by the `LockUtil` class regarding locks being taken out of order.  Apparently, at some time in the past of the program's execution, the `GameData` lock was acquired before a `Tile` lock, and `LockUtil` enforces this ordering for all future attempts to lock (or at least until a GC happens that may wipe out the weak references?).  So, in the end, I went back to the change you see in this PR, which acquires the locks in the previously-defined order.