### PR TITLE
Use standard junit 4 runner. Plays much better with intellij. Junit j…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,8 @@ dependencies {
 
 	testCompile 'org.apache.derby:derby:10.10.1.1'
 	testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
-	testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.0-M1'
-	testCompile 'org.junit.platform:junit-platform-runner:1.0.0-M1'
-	testCompile 'org.junit.vintage:junit-vintage-engine:4.12.0-M1'//JUnit Backwards compatibility
 	testCompile 'org.mockito:mockito-core:2.0.82-beta'
+	testCompile 'junit:junit:4.12'
 }
 
 test {


### PR DESCRIPTION
…upiter runner had a nicer output, but not worth the cost of a lot of extra difficulty running tests from IDE.