### PR TITLE
Prevent concurrent access to shared LockUtil fields

### DIFF
--- a/src/games/strategy/engine/data/GameData.java
+++ b/src/games/strategy/engine/data/GameData.java
@@ -61,7 +61,7 @@ public class GameData implements java.io.Serializable {
   private static final long serialVersionUID = -2612710634080125728L;
   public static final String GAME_UUID = "GAME_UUID";
   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-  private transient LockUtil lockUtil = LockUtil.getInstance();
+  private transient LockUtil lockUtil = LockUtil.INSTANCE;
   private volatile transient boolean forceInSwingEventThread = false;
   private String gameName;
   private Version gameVersion;
@@ -107,7 +107,7 @@ public class GameData implements java.io.Serializable {
 
   private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
-    lockUtil = LockUtil.getInstance();
+    lockUtil = LockUtil.INSTANCE;
   }
 
   /**

--- a/src/games/strategy/engine/data/GameData.java
+++ b/src/games/strategy/engine/data/GameData.java
@@ -61,7 +61,7 @@ public class GameData implements java.io.Serializable {
   private static final long serialVersionUID = -2612710634080125728L;
   public static final String GAME_UUID = "GAME_UUID";
   private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-  private transient LockUtil lockUtil = new LockUtil();
+  private transient LockUtil lockUtil = LockUtil.getInstance();
   private volatile transient boolean forceInSwingEventThread = false;
   private String gameName;
   private Version gameVersion;
@@ -107,7 +107,7 @@ public class GameData implements java.io.Serializable {
 
   private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
     in.defaultReadObject();
-    lockUtil = new LockUtil();
+    lockUtil = LockUtil.getInstance();
   }
 
   /**

--- a/src/games/strategy/thread/LockUtil.java
+++ b/src/games/strategy/thread/LockUtil.java
@@ -38,7 +38,8 @@ public final class LockUtil {
 
   // the locks the current thread has
   // because locks can be re-entrant, store this as a count
-  private final ThreadLocal<Map<Lock, Integer>> locksHeld = new ThreadLocal<>();
+  private final ThreadLocal<Map<Lock, Integer>> locksHeld = ThreadLocal.withInitial(() -> new HashMap<>());
+
   // a map of all the locks ever held when a lock was acquired
   // store weak references to everything so that locks don't linger here forever
   private final Map<Lock, Set<WeakLockRef>> locksHeldWhenAcquired = new WeakHashMap<>();
@@ -51,9 +52,6 @@ public final class LockUtil {
 
   public void acquireLock(final Lock aLock) {
     synchronized (mutex) {
-      if (locksHeld.get() == null) {
-        locksHeld.set(new HashMap<>());
-      }
       // we already have the lock, increaase the count
       if (locksHeld.get().containsKey(aLock)) {
         final int current = locksHeld.get().get(aLock);
@@ -104,9 +102,6 @@ public final class LockUtil {
   }
 
   public boolean isLockHeld(final Lock aLock) {
-    if (locksHeld.get() == null) {
-      return false;
-    }
     synchronized (mutex) {
       return locksHeld.get().containsKey(aLock);
     }

--- a/src/games/strategy/thread/LockUtil.java
+++ b/src/games/strategy/thread/LockUtil.java
@@ -139,7 +139,7 @@ public final class LockUtil {
     }
   }
 
-  protected static final class WeakLockRef extends WeakReference<Lock> {
+  private static final class WeakLockRef extends WeakReference<Lock> {
     // cache the hash code to make sure it doesn't change if our reference
     // has been cleared
     private final int hashCode;

--- a/src/games/strategy/thread/LockUtil.java
+++ b/src/games/strategy/thread/LockUtil.java
@@ -24,17 +24,8 @@ import com.google.common.annotations.VisibleForTesting;
  * you are considering your ambitious multi-threaded code a mistake, and you are trying to limit the damage.
  * <p>
  */
-public final class LockUtil {
-  private static final LockUtil instance = new LockUtil();
-
-  /**
-   * Gets the singleton {@code LockUtil} instance.
-   *
-   * @return The singleton {@code LockUtil} instance; never {@code null}.
-   */
-  public static LockUtil getInstance() {
-    return instance;
-  }
+public enum LockUtil {
+  INSTANCE;
 
   // the locks the current thread has
   // because locks can be re-entrant, store this as a count
@@ -46,10 +37,6 @@ public final class LockUtil {
   private final Object mutex = new Object();
 
   private final AtomicReference<ErrorReporter> errorReporterRef = new AtomicReference<>(new DefaultErrorReporter());
-
-  private LockUtil() {
-    // do nothing
-  }
 
   public void acquireLock(final Lock aLock) {
     // we already have the lock, increase the count

--- a/src/games/strategy/thread/LockUtil.java
+++ b/src/games/strategy/thread/LockUtil.java
@@ -21,17 +21,30 @@ import java.util.concurrent.locks.Lock;
  * you are considering your ambitious multi-threaded code a mistake, and you are trying to limit the damage.
  * <p>
  */
-public class LockUtil {
+public final class LockUtil {
+  private static final LockUtil instance = new LockUtil();
+
+  /**
+   * Gets the singleton {@code LockUtil} instance.
+   *
+   * @return The singleton {@code LockUtil} instance; never {@code null}.
+   */
+  public static LockUtil getInstance() {
+    return instance;
+  }
+
   // the locks the current thread has
   // because locks can be re-entrant, store this as a count
-  private final static ThreadLocal<Map<Lock, Integer>> m_locksHeld = new ThreadLocal<>();
+  private final ThreadLocal<Map<Lock, Integer>> m_locksHeld = new ThreadLocal<>();
   // a map of all the locks ever held when a lock was acquired
   // store weak references to everything so that locks don't linger here forever
-  private final static Map<Lock, Set<WeakLockRef>> m_locksHeldWhenAcquired = new WeakHashMap<>();
+  private final Map<Lock, Set<WeakLockRef>> m_locksHeldWhenAcquired = new WeakHashMap<>();
   private final Object m_mutex = new Object();
-  private static ErrorReporter m_errorReporter = new ErrorReporter();
+  private ErrorReporter m_errorReporter = new ErrorReporter();
 
-  public LockUtil() {}
+  private LockUtil() {
+    // do nothing
+  }
 
   public void acquireLock(final Lock aLock) {
     synchronized (m_mutex) {

--- a/src/games/strategy/triplea/ui/MapPanel.java
+++ b/src/games/strategy/triplea/ui/MapPanel.java
@@ -523,7 +523,7 @@ public class MapPanel extends ImageScrollerLargeView {
       final Rectangle2D.Double bounds = new Rectangle2D.Double(0, 0, getImageWidth(), getImageHeight());
       final Collection<Tile> tileList = tileManager.getTiles(bounds);
       for (final Tile tile : tileList) {
-        Tile.S_TILE_LOCKUTIL.acquireLock(tile.getLock());
+        tile.acquireLock();
         try {
           final Image img = tile.getImage(gameData, uiContext.getMapData());
           if (img != null) {
@@ -532,7 +532,7 @@ public class MapPanel extends ImageScrollerLargeView {
             g2d.drawImage(img, t, this);
           }
         } finally {
-          Tile.S_TILE_LOCKUTIL.releaseLock(tile.getLock());
+          tile.releaseLock();
         }
       }
     } finally {
@@ -690,7 +690,7 @@ public class MapPanel extends ImageScrollerLargeView {
     }
     for (final Tile tile : tileList) {
       Image img = null;
-      Tile.S_TILE_LOCKUTIL.acquireLock(tile.getLock());
+      tile.acquireLock();
       try {
         if (tile.isDirty()) {
           // take what we can get to avoid screen flicker
@@ -706,7 +706,7 @@ public class MapPanel extends ImageScrollerLargeView {
           g.drawImage(img, t, this);
         }
       } finally {
-        Tile.S_TILE_LOCKUTIL.releaseLock(tile.getLock());
+        tile.releaseLock();
       }
     }
   }

--- a/src/games/strategy/triplea/ui/screen/Tile.java
+++ b/src/games/strategy/triplea/ui/screen/Tile.java
@@ -29,7 +29,7 @@ import games.strategy.triplea.util.Stopwatch;
 import games.strategy.ui.Util;
 
 public class Tile {
-  public static final LockUtil S_TILE_LOCKUTIL = LockUtil.getInstance();
+  public static final LockUtil S_TILE_LOCKUTIL = LockUtil.INSTANCE;
   private static final boolean DRAW_DEBUG = false;
   private static final Logger s_logger = Logger.getLogger(Tile.class.getName());
   // allow the gc to implement memory management

--- a/src/games/strategy/triplea/ui/screen/Tile.java
+++ b/src/games/strategy/triplea/ui/screen/Tile.java
@@ -29,7 +29,7 @@ import games.strategy.triplea.util.Stopwatch;
 import games.strategy.ui.Util;
 
 public class Tile {
-  public static final LockUtil S_TILE_LOCKUTIL = new LockUtil();
+  public static final LockUtil S_TILE_LOCKUTIL = LockUtil.getInstance();
   private static final boolean DRAW_DEBUG = false;
   private static final Logger s_logger = Logger.getLogger(Tile.class.getName());
   // allow the gc to implement memory management

--- a/src/games/strategy/triplea/ui/screen/Tile.java
+++ b/src/games/strategy/triplea/ui/screen/Tile.java
@@ -51,16 +51,24 @@ public class Tile {
   }
 
   public boolean isDirty() {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       return m_isDirty || m_imageRef == null || m_imageRef.get() == null;
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
+  public void acquireLock() {
+    S_TILE_LOCKUTIL.acquireLock(m_lock);
+  }
+
+  public void releaseLock() {
+    S_TILE_LOCKUTIL.releaseLock(m_lock);
+  }
+
   public Image getImage(final GameData data, final MapData mapData) {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       if (m_imageRef == null) {
         m_imageRef = new SoftReference<>(createBlankImage());
@@ -82,7 +90,7 @@ public class Tile {
       }
       return image;
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
@@ -137,61 +145,61 @@ public class Tile {
   }
 
   public void addDrawables(final Collection<IDrawable> drawables) {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       m_contents.addAll(drawables);
       m_isDirty = true;
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
   public void addDrawable(final IDrawable d) {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       m_contents.add(d);
       m_isDirty = true;
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
   public void removeDrawable(final IDrawable d) {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       m_contents.remove(d);
       m_isDirty = true;
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
   public void removeDrawables(final Collection<IDrawable> c) {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       m_contents.removeAll(c);
       m_isDirty = true;
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
   public void clear() {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       m_contents.clear();
       m_isDirty = true;
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
   public List<IDrawable> getDrawables() {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       return new ArrayList<>(m_contents);
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
@@ -205,9 +213,5 @@ public class Tile {
 
   public int getY() {
     return m_y;
-  }
-
-  public Lock getLock() {
-    return m_lock;
   }
 }

--- a/src/games/strategy/triplea/ui/screen/TileManager.java
+++ b/src/games/strategy/triplea/ui/screen/TileManager.java
@@ -111,7 +111,7 @@ public class TileManager {
             (int) bounds.getWidth(), (int) bounds.getHeight());
       }
     }
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       final List<Tile> rVal = new ArrayList<>();
       for (final Tile tile : m_tiles) {
@@ -138,21 +138,29 @@ public class TileManager {
       }
       return rVal;
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
-  public Collection<UnitsDrawer> getUnitDrawables() {
+  private void acquireLock() {
     Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+  }
+
+  private void releaseLock() {
+    Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+  }
+
+  public Collection<UnitsDrawer> getUnitDrawables() {
+    acquireLock();
     try {
       return new ArrayList<>(m_allUnitDrawables);
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
   public void createTiles(final Rectangle bounds, final GameData data, final MapData mapData) {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       // create our tiles
       m_tiles = new ArrayList<>();
@@ -163,14 +171,14 @@ public class TileManager {
         }
       }
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
   public void resetTiles(final GameData data, final MapData mapData) {
     data.acquireReadLock();
     try {
-      Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+      acquireLock();
       try {
         final Iterator<Tile> allTiles = m_tiles.iterator();
         while (allTiles.hasNext()) {
@@ -199,7 +207,7 @@ public class TileManager {
           }
         }
       } finally {
-        Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+        releaseLock();
       }
     } finally {
       data.releaseReadLock();
@@ -209,7 +217,7 @@ public class TileManager {
   public void updateTerritories(final Collection<Territory> territories, final GameData data, final MapData mapData) {
     data.acquireReadLock();
     try {
-      Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+      acquireLock();
       try {
         if (territories == null) {
           return;
@@ -220,7 +228,7 @@ public class TileManager {
           updateTerritory(territory, data, mapData);
         }
       } finally {
-        Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+        releaseLock();
       }
     } finally {
       data.releaseReadLock();
@@ -230,13 +238,13 @@ public class TileManager {
   public void updateTerritory(final Territory territory, final GameData data, final MapData mapData) {
     data.acquireReadLock();
     try {
-      Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+      acquireLock();
       try {
         s_logger.log(Level.FINER, "Updating " + territory.getName());
         clearTerritory(territory);
         drawTerritory(territory, data, mapData);
       } finally {
-        Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+        releaseLock();
       }
     } finally {
       data.releaseReadLock();
@@ -376,7 +384,7 @@ public class TileManager {
 
   private Image createTerritoryImage(final Territory selected, final Territory focusOn, final GameData data,
       final MapData mapData, final boolean drawOutline) {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       // make a square
       final Rectangle bounds = mapData.getBoundingRect(focusOn);
@@ -454,7 +462,7 @@ public class TileManager {
       graphics.dispose();
       return rVal;
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
   }
 
@@ -516,7 +524,7 @@ public class TileManager {
     }
     data.acquireReadLock();
     try {
-      Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+      acquireLock();
       try {
         for (final UnitsDrawer drawer : m_allUnitDrawables) {
           final List<Unit> drawerUnits = drawer.getUnits(data).getSecond();
@@ -529,7 +537,7 @@ public class TileManager {
         }
         return null;
       } finally {
-        Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+        releaseLock();
       }
     } finally {
       data.releaseReadLock();
@@ -539,7 +547,7 @@ public class TileManager {
   public Tuple<Territory, List<Unit>> getUnitsAtPoint(final double x, final double y, final GameData gameData) {
     gameData.acquireReadLock();
     try {
-      Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+      acquireLock();
       try {
         for (final UnitsDrawer drawer : m_allUnitDrawables) {
           final Point placementPoint = drawer.getPlacementPoint();
@@ -551,7 +559,7 @@ public class TileManager {
         }
         return null;
       } finally {
-        Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+        releaseLock();
       }
     } finally {
       gameData.releaseReadLock();
@@ -560,34 +568,34 @@ public class TileManager {
 
   public void setTerritoryOverlay(final Territory territory, final Color color, final int alpha, final GameData data,
       final MapData mapData) {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       final IDrawable drawable = new TerritoryOverLayDrawable(color, territory.getName(), alpha, OP.DRAW);
       m_territoryOverlays.put(territory.getName(), drawable);
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
     updateTerritory(territory, data, mapData);
   }
 
   public void setTerritoryOverlayForBorder(final Territory territory, final Color color, final GameData data,
       final MapData mapData) {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       final IDrawable drawable = new TerritoryOverLayDrawable(color, territory.getName(), OP.DRAW);
       m_territoryOverlays.put(territory.getName(), drawable);
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
     updateTerritory(territory, data, mapData);
   }
 
   public void clearTerritoryOverlay(final Territory territory, final GameData data, final MapData mapData) {
-    Tile.S_TILE_LOCKUTIL.acquireLock(m_lock);
+    acquireLock();
     try {
       m_territoryOverlays.remove(territory.getName());
     } finally {
-      Tile.S_TILE_LOCKUTIL.releaseLock(m_lock);
+      releaseLock();
     }
     updateTerritory(territory, data, mapData);
   }

--- a/test/games/strategy/thread/LockUtilTest.java
+++ b/test/games/strategy/thread/LockUtilTest.java
@@ -21,7 +21,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class LockUtilTest {
-  private final LockUtil lockUtil = LockUtil.getInstance();
+  private final LockUtil lockUtil = LockUtil.INSTANCE;
 
   @Mock
   private LockUtil.ErrorReporter errorReporter;

--- a/test/games/strategy/thread/LockUtilTest.java
+++ b/test/games/strategy/thread/LockUtilTest.java
@@ -13,18 +13,18 @@ import org.junit.Test;
 
 import games.strategy.thread.LockUtil.ErrorReporter;
 
-public class LockUtilTest {
-  private static final LockUtil S_LOCKUTIL = new LockUtil();
+public final class LockUtilTest {
+  private final LockUtil lockUtil = LockUtil.getInstance();
   private final TestErrorReporter m_reporter = new TestErrorReporter();
 
   @Before
   public void setUp() {
-    S_LOCKUTIL.setErrorReporter(m_reporter);
+    lockUtil.setErrorReporter(m_reporter);
   }
 
   @Test
   public void testEmpty() {
-    assertFalse(S_LOCKUTIL.isLockHeld(new ReentrantLock()));
+    assertFalse(lockUtil.isLockHeld(new ReentrantLock()));
   }
 
   @Test
@@ -34,17 +34,17 @@ public class LockUtilTest {
       locks.add(new ReentrantLock());
     }
     for (final Lock l : locks) {
-      S_LOCKUTIL.acquireLock(l);
-      assertTrue(S_LOCKUTIL.isLockHeld(l));
+      lockUtil.acquireLock(l);
+      assertTrue(lockUtil.isLockHeld(l));
     }
     for (final Lock l : locks) {
-      S_LOCKUTIL.releaseLock(l);
-      assertFalse(S_LOCKUTIL.isLockHeld(l));
+      lockUtil.releaseLock(l);
+      assertFalse(lockUtil.isLockHeld(l));
     }
     assertFalse(m_reporter.errorOccured());
     // repeat the sequence, make sure no errors
     for (final Lock l : locks) {
-      S_LOCKUTIL.acquireLock(l);
+      lockUtil.acquireLock(l);
     }
     assertFalse(m_reporter.errorOccured());
   }
@@ -54,27 +54,27 @@ public class LockUtilTest {
     final Lock l1 = new ReentrantLock();
     final Lock l2 = new ReentrantLock();
     // acquire in the correct order
-    S_LOCKUTIL.acquireLock(l1);
-    S_LOCKUTIL.acquireLock(l2);
+    lockUtil.acquireLock(l1);
+    lockUtil.acquireLock(l2);
     // release
-    S_LOCKUTIL.releaseLock(l2);
-    S_LOCKUTIL.releaseLock(l1);
+    lockUtil.releaseLock(l2);
+    lockUtil.releaseLock(l1);
     assertFalse(m_reporter.errorOccured());
     // acquire locks in the wrong order
-    S_LOCKUTIL.acquireLock(l2);
-    S_LOCKUTIL.acquireLock(l1);
+    lockUtil.acquireLock(l2);
+    lockUtil.acquireLock(l1);
     assertTrue(m_reporter.errorOccured());
   }
 
   @Test
   public void testAcquireTwice() {
     final ReentrantLock l1 = new ReentrantLock();
-    S_LOCKUTIL.acquireLock(l1);
-    S_LOCKUTIL.acquireLock(l1);
-    S_LOCKUTIL.releaseLock(l1);
-    S_LOCKUTIL.releaseLock(l1);
+    lockUtil.acquireLock(l1);
+    lockUtil.acquireLock(l1);
+    lockUtil.releaseLock(l1);
+    lockUtil.releaseLock(l1);
     assertTrue(l1.getHoldCount() == 0);
-    assertFalse(S_LOCKUTIL.isLockHeld(l1));
+    assertFalse(lockUtil.isLockHeld(l1));
   }
 }
 


### PR DESCRIPTION
I came across this while debugging another [issue](https://github.com/triplea-game/triplea/pull/1477#issuecomment-273660108).  In summary, the `LockUtil` class uses a `static` field (`m_locksHeldWhenAcquired`) to track the order in which locks are acquired across all threads.  However, it uses an instance field to prevent concurrent access to `m_locksHeldWhenAcquired`.  There are multiple instances of `LockUtil` used in the application (e.g. `Tile.S_TILE_LOCKUTIL`, `GameData#lockUtil`, etc.).  Thus, different locks are being used by different `LockUtil` instances to synchronize, which may lead to concurrent access to `m_locksHeldWhenAcquired`.

In addition to the fix, I did a bit of refactoring around `LockUtil`.  Please advise if you'd like any of the refactorings backed out.

The highlights of this change are listed below:

* For all intents and purposes, the use of `static` fields in `LockUtil` effectively make it a singleton.  I went ahead and formalized this by fully implementing the singleton pattern in this class.
* I reduced the visibility of several `LockUtil` members (e.g. `ErrorReporter`), as they were only used for testing.
* Fields were renamed to conform to the project's [coding standard](http://www.triplea-game.org/dev_docs/dev/code_standards).
* Ensure access to the error reporter is atomic (it is unlikely this field will be accessed by multiple threads during testing, but just in case...); and ensure tests restore the original value of this field when complete.
* Remove unnecessary synchronization around `ThreadLocal` usage.
* Extract methods to acquire/release locks that hide the usage of `LockUtil` as much as possible (similar to what is done in `GameData`).

There are existing unit tests for `LockUtil`, which achieve nearly 100% coverage on the `LockUtil` methods.  However, this change seems somewhat risky given how much surface area `LockUtil` actually touches.  **I would appreciate any advice for additional tests (automated or manual) I could perform that would exercise a lot of concurrency around `GameData` and `Tile`s to ensure I didn't introduce any regressions.**