### PR TITLE
Show dice details by default

### DIFF
--- a/src/games/strategy/engine/pbem/ForumPosterComponent.java
+++ b/src/games/strategy/engine/pbem/ForumPosterComponent.java
@@ -113,6 +113,7 @@ public class ForumPosterComponent extends JPanel {
       add(m_includeProductionCheckbox);
     }
     if (allowDiceBattleDetails) {
+      m_showDetailsCheckbox.setSelected(true);
       add(m_showDetailsCheckbox);
     }
     if (allowDiceStatistics) {


### PR DESCRIPTION
Any chance of this one line change being merged?

I find I'm always going back through the history to find this.