### PR TITLE
Rockets fire after scramble/kamikaze/SBR

### DIFF
--- a/src/games/strategy/triplea/Properties.java
+++ b/src/games/strategy/triplea/Properties.java
@@ -677,5 +677,9 @@ public class Properties implements Constants {
     return data.getProperties().get(CONTROL_ALL_CANALS_BETWEEN_TERRITORIES_TO_PASS, false);
   }
 
+  public static boolean getRollRocketsAfterSBR(final GameData data) {
+    return data.getProperties().get("Roll rocket damage after processing SBR", false);
+  }
+
   private Properties() {}
 }

--- a/src/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/games/strategy/triplea/delegate/BattleDelegate.java
@@ -114,6 +114,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       m_needToAddBombardmentSources = false;
     }
     fightCurrentBattle();
+    if (rocketHelper != null && !games.strategy.triplea.Properties.getRollRocketsAfterSBR(getData())) {
+      rocketHelper.fireRockets(m_bridge, m_bridge.getPlayerID());
+      rocketHelper = null;
+    }
     m_battleTracker.fightAirRaidsAndStrategicBombing(m_bridge);
     if (rocketHelper != null) {
       rocketHelper.fireRockets(m_bridge, m_bridge.getPlayerID());

--- a/src/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/src/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -132,15 +132,15 @@ public class GameStepPropertiesHelper {
    * Fire rockets after phase is over. Normally would occur after combat move for WW2v2 and WW2v3, and after noncombat
    * move for WW2v1.
    */
-  static boolean isFireRockets(final GameData data) {
+  static boolean isFireRockets(final GameData data, final boolean moveDelegate) {
     final boolean isFireRockets;
     data.acquireReadLock();
     try {
       final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_fireRockets);
-      if (prop != null) {
+      if (prop != null && moveDelegate) {
         isFireRockets = Boolean.parseBoolean(prop);
       } else if (games.strategy.triplea.Properties.getWW2V2(data) || games.strategy.triplea.Properties.getWW2V3(data)) {
-        isFireRockets = isCombatDelegate(data);
+        isFireRockets = !moveDelegate;         //ww2v2/3 we don't fire in combat move
       } else {
         isFireRockets = isNonCombatDelegate(data);
       }

--- a/src/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/games/strategy/triplea/delegate/MoveDelegate.java
@@ -189,11 +189,12 @@ public class MoveDelegate extends AbstractMoveDelegate {
       removeAirThatCantLand();
     }
 
-    // WW2V2/WW2V3, fires at end of combat move
+    // WW2V2/WW2V3, fires at end of combat move - now moved to the start of the BattleDelegate
     // WW2V1, fires at end of non combat move
-    if (GameStepPropertiesHelper.isFireRockets(data)) {
+    if (GameStepPropertiesHelper.isFireRockets(data,true)) {
       if (m_needToDoRockets && TechTracker.hasRocket(m_bridge.getPlayerID())) {
         final RocketsFireHelper helper = new RocketsFireHelper();
+        helper.findRocketTargets(m_bridge, m_bridge.getPlayerID());
         helper.fireRockets(m_bridge, m_bridge.getPlayerID());
         m_needToDoRockets = false;
       }

--- a/src/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -113,14 +113,15 @@ public class RocketsFireHelper {
         continue;
       }
       // Ask the user where each rocket launcher should target.
-      final Territory target = getTarget(targets, player, bridge, territory);
-      if (target != null) {
+      while (true) {
+        final Territory target = getTarget(targets, player, bridge, territory);
+        if (target == null) {
+          break;
+        }
         final Collection<Unit> enemyUnits = target.getUnits().getMatches(
             new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
         final Collection<Unit> enemyTargetsTotal =
             Match.getMatches(enemyUnits, Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(target).invert());
-        attackingFromTerritories.add(territory);
-        attackedTerritories.put(territory, target);
         if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
           final HashSet<UnitType> legalTargetsForTheseRockets = new HashSet<>();
           final Collection<Unit> rockets = new ArrayList<>(
@@ -143,16 +144,17 @@ public class RocketsFireHelper {
           if (enemyTargets.size() == 1) {
             unitTarget = enemyTargets.iterator().next();
           } else {
-            while (unitTarget == null) {
-              final ITripleAPlayer iplayer = (ITripleAPlayer) bridge.getRemotePlayer(player);
-              unitTarget = iplayer.whatShouldBomberBomb(target, enemyTargets, rockets);
-            }
+            final ITripleAPlayer iplayer = (ITripleAPlayer) bridge.getRemotePlayer(player);
+            unitTarget = iplayer.whatShouldBomberBomb(target, enemyTargets, rockets);
           }
           if (unitTarget == null) {
-            throw new IllegalStateException("No Targets in " + target.getName());
+            continue;
           }
           attackedUnits.put(territory,unitTarget);
         }
+        attackingFromTerritories.add(territory);
+        attackedTerritories.put(territory, target);
+        break;
       }
     }
   }

--- a/src/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -38,7 +38,7 @@ import games.strategy.util.Match;
  * Logic to fire rockets.
  */
 public class RocketsFireHelper {
-  private Set<Territory> attackingTerritories = new HashSet<>();
+  private Set<Territory> attackingFromTerritories = new HashSet<>();
   private Map<Territory,Territory> attackedTerritories = new LinkedHashMap<>();
   private Map<Territory,Unit> attackedUnits = new LinkedHashMap<>();
 
@@ -94,7 +94,7 @@ public class RocketsFireHelper {
 
   public void fireRockets(final IDelegateBridge bridge, final PlayerID player) {
     final boolean DamageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(bridge.getData());
-    for( final Territory attacker : attackingTerritories ) {
+    for( final Territory attacker : attackingFromTerritories ) {
       // Roll dice for the rocket attack damage and apply it
       fireRocket(player, attackedTerritories.get(attacker), bridge, attacker,
         DamageFromBombingDoneToUnits ? attackedUnits.get(attacker) : null);
@@ -119,7 +119,7 @@ public class RocketsFireHelper {
             new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
         final Collection<Unit> enemyTargetsTotal =
             Match.getMatches(enemyUnits, Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(target).invert());
-        attackingTerritories.add(territory);
+        attackingFromTerritories.add(territory);
         attackedTerritories.put(territory, target);
         if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
           final HashSet<UnitType> legalTargetsForTheseRockets = new HashSet<>();
@@ -171,7 +171,7 @@ public class RocketsFireHelper {
     final Territory attacked = getTarget(targets, player, bridge, null);
 
     if (attacked != null) {
-      attackingTerritories.add(null);
+      attackingFromTerritories.add(null);
       attackedTerritories.put(null,attacked);
     }
   }

--- a/src/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/games/strategy/triplea/ui/TripleAFrame.java
@@ -949,8 +949,8 @@ public class TripleAFrame extends MainGameFrame {
     });
     final JPanel panel = comps.getFirst();
     final JList<?> list = comps.getSecond();
-    final String[] options = {"OK"};
-    final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_OPTION,
+    final String[] options = {"OK","Cancel"};
+    final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_CANCEL_OPTION,
         JOptionPane.PLAIN_MESSAGE, null, options, null, getUIContext().getCountDownLatchHandler());
     if (selection == 0) {
       selected.set((Unit) list.getSelectedValue());


### PR DESCRIPTION
This resolves a couple of minor remaining issues with Rockets.

1) Rocket fire can disable an airbase before scrambling occurs. This is incorrect
2) Rocket fire combined with SBR allows attackers to vary their attacks based on the results of the rocket attack.

Classic rockets still fire at the end of the NCM.