### PR TITLE
Remove unused StringUtil class

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/StringUtil.java
+++ b/src/main/java/games/strategy/triplea/ui/StringUtil.java
@@ -1,5 +1,0 @@
-package games.strategy.triplea.ui;
-
-public class StringUtil {
-  private StringUtil() {}
-}


### PR DESCRIPTION
Came across this while working PR #1541.  Looks like `StringUtil` died about a year and a half ago.