### PR TITLE
Disable user actions that exceed available resources (#1361)

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -191,6 +191,7 @@ public class UserActionPanel extends ActionPanel {
     int row = 0;
     final Insets insets = new Insets(1, 1, 1, 1);
     for (final UserActionAttachment uaa : m_validUserActions) {
+      final boolean canPlayerAffordUserAction = canPlayerAffordUserAction(getCurrentPlayer(), uaa);
       userActionButtonPanel.add(getOtherPlayerFlags(uaa), new GridBagConstraints(0, row, 1, 1, 1.0, 1.0,
           GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, insets, 0, 0));
       final JButton button = new JButton(getActionButtonText(uaa));
@@ -202,13 +203,21 @@ public class UserActionPanel extends ActionPanel {
         parent.setVisible(false);
         release();
       });
+      button.setEnabled(canPlayerAffordUserAction);
       userActionButtonPanel.add(button, new GridBagConstraints(1, row, 1, 1, 1.0, 1.0, GridBagConstraints.WEST,
           GridBagConstraints.HORIZONTAL, insets, 0, 0));
-      userActionButtonPanel.add(getActionDescriptionLabel(uaa), new GridBagConstraints(2, row, 1, 1, 5.0, 1.0,
+      final JLabel descriptionLabel = getActionDescriptionLabel(uaa);
+      descriptionLabel.setEnabled(canPlayerAffordUserAction);
+      userActionButtonPanel.add(descriptionLabel, new GridBagConstraints(2, row, 1, 1, 5.0, 1.0,
           GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, insets, 0, 0));
       row++;
     }
     return userActionButtonPanel;
+  }
+
+  @VisibleForTesting
+  static boolean canPlayerAffordUserAction(final PlayerID player, final UserActionAttachment userAction) {
+    return userAction.getCostPU() <= player.getResources().getQuantity(Constants.PUS);
   }
 
   /**


### PR DESCRIPTION
This PR is a follow-up to #1541.  It addresses the secondary issue discussed in the comments between @Cernelius and @ron-murhammer regarding how to display user actions that are too expensive.  This PR implements the compromise solution whereby such user actions are disabled but still visible.

#### Functional changes
* For user actions whose cost exceeds the player's available resources, the corresponding button and description label are disabled.

#### Functional issues for review
* None

#### Refactoring
* I refactored `UserActionPanelTest` in order to avoid some duplication that appeared after I added new tests as part of this PR.

#### Testing
I followed the same procedure that I used in #1541 in order to manually test the UI.  (However, I added a fourth user action in order to demonstrate the change a bit better; an updated [patch](https://github.com/triplea-game/triplea/files/795464/the_pact_of_steel-issue-1361-part-2.patch.txt) is attached.)

Below are screenshots that demonstrate the change after a purchase.  First, the initial offer of four user actions:

![issue-1361-screenshot-initial](https://cloud.githubusercontent.com/assets/4826349/23243584/d880a072-f94d-11e6-9a22-36f6c27c07de.png)

All actions are enabled as their individual costs are less than the player's available resources (37 PUs).

After purchasing "[20 PU] Send Aid":

![issue-1361-screenshot-after-send-aid-20-pu](https://cloud.githubusercontent.com/assets/4826349/23243601/ea166218-f94d-11e6-9f25-94d28df1be32.png)

"[30 PU] Send Aid" is now disabled because its cost exceeds the player's available resources (17 PUs).  "[10 PU] Send Aid" and "Send Greetings" remain enabled.