### PR TITLE
Rename test fixture classes

### DIFF
--- a/src/test/java/games/strategy/triplea/ui/RouteOptimizerTest.java
+++ b/src/test/java/games/strategy/triplea/ui/RouteOptimizerTest.java
@@ -19,7 +19,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 @RunWith(MockitoJUnitRunner.class)
-public class TestRouteOptimizer {
+public class RouteOptimizerTest {
 
   @Mock
   private MapPanel mapPanel;

--- a/src/test/java/games/strategy/triplea/ui/RouteTest.java
+++ b/src/test/java/games/strategy/triplea/ui/RouteTest.java
@@ -26,7 +26,7 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 
-public class TestRoute {
+public class RouteTest {
   private final Point[] dummyPoints = new Point[] {new Point(0, 0), new Point(100, 0), new Point(0, 100)};
   private final MapData dummyMapData = mock(MapData.class);
   private final MapRouteDrawer spyRouteDrawer = spy(new MapRouteDrawer(mock(MapPanel.class), dummyMapData));


### PR DESCRIPTION
I came across this while working my last PR.  I thought these classes were test utilities because they were prefixed with `Test`.  However, they are actually test fixtures, so the `Test` prefix is a bit confusing.  This PR simply renames them so `Test` is now the suffix, which seems to be the project convention.