### PR TITLE
Prevent UI deadlock after version update (#1493)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ addons:
 jdk:
 - oraclejdk8
 install: true
+before_script:
+- "export DISPLAY=:99.0"
+- "sh -e /etc/init.d/xvfb start"
 script:
 ## validate yamls before we do anything else
 - ruby -e "require 'yaml';puts YAML.load_file('./triplea_maps.yaml')" > /dev/null || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ addons:
 jdk:
 - oraclejdk8
 install: true
-before_script:
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
 script:
 ## validate yamls before we do anything else
 - ruby -e "require 'yaml';puts YAML.load_file('./triplea_maps.yaml')" > /dev/null || exit 1

--- a/src/main/java/games/strategy/util/EventThreadJOptionPane.java
+++ b/src/main/java/games/strategy/util/EventThreadJOptionPane.java
@@ -114,7 +114,8 @@ public final class EventThreadJOptionPane {
             initialValue));
   }
 
-  private static int invokeAndWait(final CountDownLatchHandler latchHandler, final IntSupplier supplier) {
+  @VisibleForTesting
+  static int invokeAndWait(final CountDownLatchHandler latchHandler, final IntSupplier supplier) {
     return invokeAndWait(latchHandler, () -> Optional.of(supplier.getAsInt())).get();
   }
 

--- a/src/main/java/games/strategy/util/EventThreadJOptionPane.java
+++ b/src/main/java/games/strategy/util/EventThreadJOptionPane.java
@@ -26,6 +26,11 @@ public class EventThreadJOptionPane {
 
   public static void showMessageDialog(final Component parentComponent, final Object message, final String title,
       final int messageType, final boolean useJLabel, final CountDownLatchHandler latchHandler) {
+    if (SwingUtilities.isEventDispatchThread()) {
+      JOptionPane.showMessageDialog(parentComponent, useJLabel ? createJLabelInScrollPane((String) message) : message,
+          title, messageType);
+      return;
+    }
     final CountDownLatch latch = new CountDownLatch(1);
     SwingUtilities.invokeLater(() -> {
       JOptionPane.showMessageDialog(parentComponent, useJLabel ? createJLabelInScrollPane((String) message) : message,

--- a/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
+++ b/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
@@ -29,7 +29,7 @@ public final class EventThreadJOptionPaneTest {
   private final CountDownLatchHandler latchHandler = new CountDownLatchHandler(true);
 
   @Test
-  public void testInvokeAndWait_ShouldRunSupplierOnEDTWhenNotCalledFromEDT() throws Exception {
+  public void testInvokeAndWaitWithSupplier_ShouldRunSupplierOnEDTWhenNotCalledFromEDT() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicBoolean runOnEDT = new AtomicBoolean(false);
 
@@ -46,7 +46,7 @@ public final class EventThreadJOptionPaneTest {
   }
 
   @Test
-  public void testInvokeAndWait_ShouldNotDeadlockWhenCalledFromEDT() throws Exception {
+  public void testInvokeAndWaitWithSupplier_ShouldNotDeadlockWhenCalledFromEDT() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicBoolean run = new AtomicBoolean(false);
 
@@ -63,16 +63,17 @@ public final class EventThreadJOptionPaneTest {
   }
 
   @Test
-  public void testInvokeAndWait_ShouldReturnSupplierResult() {
-    final int expectedResult = 42;
+  public void testInvokeAndWaitWithSupplier_ShouldReturnSupplierResult() {
+    final Object expectedResult = new Object();
 
-    final int actualResult = EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.of(expectedResult)).get();
+    final Object actualResult =
+        EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.of(expectedResult)).get();
 
     assertThat(actualResult, is(expectedResult));
   }
 
   @Test
-  public void testInvokeAndWait_ShouldRegisterAndUnregisterLatchWithLatchHandler() {
+  public void testInvokeAndWaitWithSupplier_ShouldRegisterAndUnregisterLatchWithLatchHandler() {
     EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.empty());
 
     verify(latchHandler, times(1)).addShutdownLatch(any(CountDownLatch.class));
@@ -80,10 +81,19 @@ public final class EventThreadJOptionPaneTest {
   }
 
   @Test
-  public void testInvokeAndWait_ShouldRunSuccessfullyWhenLatchHandlerIsNull() {
+  public void testInvokeAndWaitWithSupplier_ShouldRunSuccessfullyWhenLatchHandlerIsNull() {
+    final Object expectedResult = new Object();
+
+    final Object actualResult = EventThreadJOptionPane.invokeAndWait(null, () -> Optional.of(expectedResult)).get();
+
+    assertThat(actualResult, is(expectedResult));
+  }
+
+  @Test
+  public void testInvokeAndWaitWithIntSupplier_ShouldReturnIntSupplierResult() {
     final int expectedResult = 42;
 
-    final int actualResult = EventThreadJOptionPane.invokeAndWait(null, () -> Optional.of(expectedResult)).get();
+    final int actualResult = EventThreadJOptionPane.invokeAndWait(latchHandler, () -> expectedResult);
 
     assertThat(actualResult, is(expectedResult));
   }

--- a/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
+++ b/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -35,7 +36,7 @@ public final class EventThreadJOptionPaneTest {
     new Thread(() -> {
       EventThreadJOptionPane.invokeAndWait(latchHandler, () -> {
         runOnEDT.set(SwingUtilities.isEventDispatchThread());
-        return 0;
+        return Optional.empty();
       });
       latch.countDown();
     }).start();
@@ -52,7 +53,7 @@ public final class EventThreadJOptionPaneTest {
     SwingUtilities.invokeLater(() -> {
       EventThreadJOptionPane.invokeAndWait(latchHandler, () -> {
         run.set(true);
-        return 0;
+        return Optional.empty();
       });
       latch.countDown();
     });
@@ -65,14 +66,14 @@ public final class EventThreadJOptionPaneTest {
   public void testInvokeAndWait_ShouldReturnSupplierResult() {
     final int expectedResult = 42;
 
-    final int actualResult = EventThreadJOptionPane.invokeAndWait(latchHandler, () -> expectedResult);
+    final int actualResult = EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.of(expectedResult)).get();
 
     assertThat(actualResult, is(expectedResult));
   }
 
   @Test
   public void testInvokeAndWait_ShouldRegisterAndUnregisterLatchWithLatchHandler() {
-    EventThreadJOptionPane.invokeAndWait(latchHandler, () -> 0);
+    EventThreadJOptionPane.invokeAndWait(latchHandler, () -> Optional.empty());
 
     verify(latchHandler, times(1)).addShutdownLatch(any(CountDownLatch.class));
     verify(latchHandler, times(1)).removeShutdownLatch(any(CountDownLatch.class));
@@ -82,7 +83,7 @@ public final class EventThreadJOptionPaneTest {
   public void testInvokeAndWait_ShouldRunSuccessfullyWhenLatchHandlerIsNull() {
     final int expectedResult = 42;
 
-    final int actualResult = EventThreadJOptionPane.invokeAndWait(null, () -> expectedResult);
+    final int actualResult = EventThreadJOptionPane.invokeAndWait(null, () -> Optional.of(expectedResult)).get();
 
     assertThat(actualResult, is(expectedResult));
   }

--- a/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
+++ b/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
@@ -1,0 +1,89 @@
+package games.strategy.util;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.swing.SwingUtilities;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class EventThreadJOptionPaneTest {
+  @Rule
+  public final Timeout globalTimeout = new Timeout(5, TimeUnit.SECONDS);
+
+  @Spy
+  private final CountDownLatchHandler latchHandler = new CountDownLatchHandler(true);
+
+  @Test
+  public void testInvokeAndWait_ShouldRunSupplierOnEDTWhenNotCalledFromEDT() throws Exception {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicBoolean runOnEDT = new AtomicBoolean(false);
+
+    new Thread(() -> {
+      EventThreadJOptionPane.invokeAndWait(latchHandler, () -> {
+        runOnEDT.set(SwingUtilities.isEventDispatchThread());
+        return 0;
+      });
+      latch.countDown();
+    }).start();
+    latch.await();
+
+    assertThat(runOnEDT.get(), is(true));
+  }
+
+  @Test
+  public void testInvokeAndWait_ShouldNotDeadlockWhenCalledFromEDT() throws Exception {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicBoolean run = new AtomicBoolean(false);
+
+    SwingUtilities.invokeLater(() -> {
+      EventThreadJOptionPane.invokeAndWait(latchHandler, () -> {
+        run.set(true);
+        return 0;
+      });
+      latch.countDown();
+    });
+    latch.await();
+
+    assertThat(run.get(), is(true));
+  }
+
+  @Test
+  public void testInvokeAndWait_ShouldReturnSupplierResult() {
+    final int expectedResult = 42;
+
+    final int actualResult = EventThreadJOptionPane.invokeAndWait(latchHandler, () -> expectedResult);
+
+    assertThat(actualResult, is(expectedResult));
+  }
+
+  @Test
+  public void testInvokeAndWait_ShouldRegisterAndUnregisterLatchWithLatchHandler() {
+    EventThreadJOptionPane.invokeAndWait(latchHandler, () -> 0);
+
+    verify(latchHandler, times(1)).addShutdownLatch(any(CountDownLatch.class));
+    verify(latchHandler, times(1)).removeShutdownLatch(any(CountDownLatch.class));
+  }
+
+  @Test
+  public void testInvokeAndWait_ShouldRunSuccessfullyWhenLatchHandlerIsNull() {
+    final int expectedResult = 42;
+
+    final int actualResult = EventThreadJOptionPane.invokeAndWait(null, () -> expectedResult);
+
+    assertThat(actualResult, is(expectedResult));
+  }
+}


### PR DESCRIPTION
This PR addresses issue #1493.

The root cause of the problem was in the `EventThreadJOptionPane#showMessageDialog(Component, Object, String, int, boolean, CountDownLatchHandler)` method.  This method would wait for a latch to be signaled from the EDT.  However, the implementation took no precaution if it itself was invoked on the EDT (which was the case when it was called from `GameRunner#checkForLatestEngineVersionOut()`), in which case it would deadlock because the code that called `CountDownLatch#countDown()` would never be run.

(H/t to @simon33-2 for doing the heavy lifting to [track down](https://github.com/triplea-game/triplea/issues/1493#issuecomment-280837662) the location of the deadlock.)

#### Functional changes
Modified the `EventThreadJOptionPane#showMessageDialog()` overload in question to immediately show the message dialog, without waiting for any latch, if it is invoked on the EDT (see 59eb730).

#### Functional issues for review
None.

#### Refactoring changes
There was a lot of duplicated boilerplate between the various `EventThreadJOptionPane#showXXXDialog()` methods.  (I suspect the failure to display the dialog immediately in `showMessageDialog()` when invoked on the EDT was simply a copy-paste error.)  I extracted the new `invokeAndWait()` method (and a few convenience overloads) to remove the duplication (see b57c4ed, d991445, and aee1d1b).

#### Refactoring issues for review
I'd appreciate some careful scrutiny on the Extract Method refactoring to ensure I correctly preserved the various `JOptionPane` calls in each `showXXXDialog()` method.

#### Testing
In order to test the issue reported in #1493, I faked a version update detection with the following change:

```patch
diff --git a/src/main/java/games/strategy/engine/framework/GameRunner.java b/src/main/java/games/strategy/engine/framework/GameRunner.java
index f663ac3..f065ad5 100644
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -494,7 +494,7 @@ public class GameRunner {
       if (latestEngineOut == null) {
         return false;
       }
-      if (ClientContext.engineVersion().getVersion().isLessThan(latestEngineOut.getLatestVersionOut())) {
+      if (!ClientContext.engineVersion().getVersion().isLessThan(latestEngineOut.getLatestVersionOut())) {
         SwingUtilities
             .invokeLater(() -> EventThreadJOptionPane.showMessageDialog(null, latestEngineOut.getOutOfDateComponent(),
                 "Please Update TripleA", JOptionPane.INFORMATION_MESSAGE, false, new CountDownLatchHandler(true)));
```

I verified that the "Please Update TripleA" dialog is displayed without any deadlock, and no errors appear in the console.

I introduced new unit tests to cover the extracted method.  However, applying the (non-IDE-automated) Extract Method refactoring to the methods of `EventThreadJOptionPane` could affect more than 50 call sites.  I did not manually test all these regression possibilities.  In fact, the only other code path I found that I could easily get down allowed me to test `showConfirmDialog()`.  Therefore, of the five `showXXXDialog()` methods, `showMessageDialog(Component, Object, CountDownLatchHandler)` and `showOptionDialog()` were not manually tested.

If the lack of manual testing for those two methods is a concern, I have no problem backing out the entire refactoring.  I think my difficulty with finding a code path to manually test those other methods is simply due to my lack of experience with TripleA.  So, if someone can provide me with repro steps to reach them, I'd be happy to verify there are no regressions.