### PR TITLE
Remove misleading space in path from log message

### DIFF
--- a/src/main/java/games/strategy/util/LocalizeHTML.java
+++ b/src/main/java/games/strategy/util/LocalizeHTML.java
@@ -95,7 +95,7 @@ public class LocalizeHTML {
           URL replacementURL = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + imageFileName);
 
           if (replacementURL == null || replacementURL.toString().length() == 0) {
-            System.out.println("Could not find: " + mapNameDir + "/ " + ASSET_IMAGE_FOLDER + imageFileName);
+            System.out.println("Could not find: " + mapNameDir + "/" + ASSET_IMAGE_FOLDER + imageFileName);
             replacementURL = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + ASSET_IMAGE_NOT_FOUND);
           }
           if (replacementURL == null || replacementURL.toString().length() == 0) {


### PR DESCRIPTION
This PR removes a misleading space present in an image path that is logged when the image cannot be found.  The presence of the space apparently caused some [confusion](https://github.com/triplea-game/triplea/issues/1560#issue-211568230) when a user was trying to diagnose a problem:

> I think the problem is the space in "Invasion_USA/ doc/images/invasionusa.png" but I don't where the bad code is.

The space was introduced in [372f336](https://github.com/triplea-game/triplea/commit/372f336e26a092277a11dc0d6e5f3d001e0abea6#diff-e90a431e4162fa7d1fa8e15d58d79119).  I'm assuming it was a mistake, but @DanVanAtta can confirm if it was actually intentional.