### PR TITLE
Include dice details in manual forum posts

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -71,7 +71,7 @@ public class FileMenu {
             : (step.getPlayerID() == null ? PlayerID.NULL_PLAYERID : step.getPlayerID()));
         final int round = gameData.getSequence().getRound();
         final HistoryLog historyLog = new HistoryLog();
-        historyLog.printFullTurn(gameData, false, GameStepPropertiesHelper.getTurnSummaryPlayers(gameData));
+        historyLog.printFullTurn(gameData, true, GameStepPropertiesHelper.getTurnSummaryPlayers(gameData));
         final PBEMMessagePoster poster = new PBEMMessagePoster(gameData, currentPlayer, round, title);
         PBEMMessagePoster.postTurn(title, historyLog, true, poster, null, frame, null);
       } finally {


### PR DESCRIPTION
Similar to #1526 but changes for Manual posts which do not allow the dice details to be turned on or off.

This is probably the more important case, in fact.

Can this be merged?