### PR TITLE
Fight Auto Kills plus single eligible combats

### DIFF
--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1487,7 +1487,7 @@ public class UnitAttachment extends DefaultAttachment {
     return Math.min(getData().getDiceSides(), Math.max(0, defenseValue));
   }
 
-  int getRawDefense() {
+  public int getRawDefense() {
     return m_defense;
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -100,7 +100,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       addBombardmentSources();
       m_needToAddBombardmentSources = false;
     }
+    fightCurrentBattle();
     m_battleTracker.fightAirRaidsAndStrategicBombing(m_bridge);
+    m_battleTracker.fightAutoKills(m_bridge);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -1162,8 +1162,9 @@ public class BattleTracker implements java.io.Serializable {
       }
     }
     if( count == 1 ) {
-      ((DependentBattle) lastAmphib).getAttackingFrom().stream().filter( t -> t != null )
+      ((DependentBattle) lastAmphib).getAttackingFrom().stream()
              .map( t -> getPendingBattle( t, false, BattleType.NORMAL ) )
+             .filter( battle -> battle != null )
              .forEach( battle -> battle.fight( aBridge ) );
       lastAmphib.fight( aBridge );
     }

--- a/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
@@ -1,0 +1,26 @@
+package games.strategy.triplea.delegate;
+
+import java.util.Collection;
+import java.util.Map;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+
+/**
+ * Battle with possible dependencies
+ * Includes MustFightBattle and NonFightingBattle
+ */
+abstract public class DependentBattle extends AbstractBattle {
+  private static final long serialVersionUID = 9119442509652443015L;
+
+  DependentBattle(final Territory battleSite, final PlayerID attacker, final BattleTracker battleTracker,
+      final boolean isBombingRun, final BattleType battleType, final GameData data) {
+    super(battleSite, attacker, battleTracker, isBombingRun, battleType, data);
+  }
+
+  abstract public Collection<Territory> getAttackingFrom();
+
+  abstract public Map<Territory, Collection<Unit>> getAttackingFromMap();
+}

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -129,6 +129,13 @@ public class Matches {
       return (ua.getTransportCapacity() != -1 && ua.getIsSea() && !ua.getIsCombatTransport());
     }
   };
+  public static final Match<Unit> UnitIsDefenselessTransport = new Match<Unit>() {
+    @Override
+    public boolean match(final Unit unit) {
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      return ua.getTransportCapacity() != -1 && ua.getIsSea() && ua.getRawDefense() == 0;
+    }
+  };
   public static final Match<Unit> UnitIsNotTransportButCouldBeCombatTransport = new Match<Unit>() {
     @Override
     public boolean match(final Unit unit) {

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -47,7 +47,7 @@ import games.strategy.util.Util;
 /**
  * Handles logic for battles in which fighting actually occurs.
  */
-public class MustFightBattle extends AbstractBattle implements BattleStepStrings {
+public class MustFightBattle extends DependentBattle implements BattleStepStrings {
   public static enum ReturnFire {
     ALL, SUBS, NONE
   }

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -31,7 +31,7 @@ import games.strategy.util.Util;
  * but the battle cannot be fought until a naval battle
  * occurs.
  */
-public class NonFightingBattle extends AbstractBattle {
+public class NonFightingBattle extends DependentBattle {
   private static final long serialVersionUID = -1699534010648145123L;
   private final Set<Territory> m_attackingFrom = new HashSet<>();
   private final Collection<Territory> m_amphibiousAttackFrom = new ArrayList<>();


### PR DESCRIPTION
Remove undefended transport combats, undefended amphibious assaults and auto fight if a single amphibious assault remains and/or a single combat remains after that.