### PR TITLE
Remove unused NullForumPoster methods

### DIFF
--- a/src/main/java/games/strategy/engine/pbem/NullForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/NullForumPoster.java
@@ -2,8 +2,6 @@ package games.strategy.engine.pbem;
 
 import java.io.File;
 
-import games.strategy.engine.data.Change;
-import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 import games.strategy.engine.framework.startup.ui.editors.IBean;
 
@@ -64,11 +62,6 @@ public class NullForumPoster implements IForumPoster {
   public String getHelpText() {
     return "Will never be called";
   }
-
-  public void gameStepChanged(final String stepName, final String delegateName, final PlayerID player, final int round,
-      final String displayName) {}
-
-  public void gameDataChanged(final Change change) {}
 
   @Override
   public boolean postTurnSummary(final String summary, final String subject) {


### PR DESCRIPTION
The removed methods have been present on `NullForumPoster` since it was introduced in [`082eb93`](https://github.com/triplea-game/triplea/commit/082eb9382ef96e12ce61fb03d574f75ed445e09c#diff-356c5321ca25c9987440bc962c4ea6ad).  `NullForumPoster` evolved from the old `NullPBEMMessenger` class, which, I'm assuming at some point, must have implemented the `GameStepListener` and `GameDataChangeListener` interfaces (I didn't go back further than 082eb93 in the history to see if this was true).  I'm assuming the original author simply overlooked removing these unused methods during the redesign of the PBEM system.