### PR TITLE
Remove unused private method parameters

### DIFF
--- a/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/src/main/java/games/strategy/engine/chat/Chat.java
@@ -364,14 +364,14 @@ public class Chat {
       }
       synchronized (mutexNodes) {
         if (to.equals(messengers.getChannelMessenger().getLocalNode().getName())) {
-          handleSlap("You were slapped by " + from.getName(), to, from);
+          handleSlap("You were slapped by " + from.getName(), from);
         } else if (from.equals(messengers.getChannelMessenger().getLocalNode())) {
-          handleSlap("You just slapped " + to, to, from);
+          handleSlap("You just slapped " + to, from);
         }
       }
     }
 
-    private void handleSlap(String message, String to, INode from) {
+    private void handleSlap(String message, INode from) {
       for (final IChatListener listener : listeners) {
         chatHistory.add(new ChatMessage(message, from.getName(), false));
         listener.addMessageWithSound(message, from.getName(), false, SoundPath.CLIP_CHAT_SLAP);

--- a/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -49,7 +49,7 @@ public class CompositeRouteFinder {
   public Route findRoute(final Territory start, final Territory end) {
     final HashSet<Territory> allMatchingTers =
         ToHashSet(Match.getMatches(m_map.getTerritories(), new CompositeMatchOr<>(m_matches.keySet())));
-    final HashMap<Territory, Integer> terScoreMap = CreateScoreMap(allMatchingTers, start);
+    final HashMap<Territory, Integer> terScoreMap = CreateScoreMap();
     final HashMap<Territory, Integer> routeScoreMap = new HashMap<>();
     int bestRouteToEndScore = Integer.MAX_VALUE;
     final HashMap<Territory, Territory> previous = new HashMap<>();
@@ -109,7 +109,7 @@ public class CompositeRouteFinder {
     return new Route(routeTers);
   }
 
-  private HashMap<Territory, Integer> CreateScoreMap(final Collection<Territory> ters, final Territory startTer) {
+  private HashMap<Territory, Integer> CreateScoreMap() {
     final HashMap<Territory, Integer> result = new HashMap<>();
     for (final Territory ter : m_map.getTerritories()) {
       result.put(ter, getTerScore(ter));

--- a/src/main/java/games/strategy/engine/data/DelegateList.java
+++ b/src/main/java/games/strategy/engine/data/DelegateList.java
@@ -33,11 +33,11 @@ public class DelegateList extends GameDataComponent implements Iterable<IDelegat
     return m_delegates.get(name);
   }
 
-  private void writeObject(final ObjectOutputStream out) {
+  private void writeObject(@SuppressWarnings("unused") final ObjectOutputStream out) {
     // dont write since delegates should be handled seperatly.
   }
 
-  private void readObject(final ObjectInputStream in) {
+  private void readObject(@SuppressWarnings("unused") final ObjectInputStream in) {
     m_delegates = new HashMap<>();
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -57,7 +57,7 @@ public class InGameLobbyWatcher {
   private final Observer m_gameSelectorModelObserver = (o, arg) -> gameSelectorModelUpdated();
   private IGame m_game;
   private final GameStepListener m_gameStepListener =
-      (stepName, delegateName, player, round, displayName) -> InGameLobbyWatcher.this.gameStepChanged(stepName, round);
+      (stepName, delegateName, player, round, displayName) -> InGameLobbyWatcher.this.gameStepChanged(round);
   // we create this messenger, and use it to connect to the
   // game lobby
   private final IMessenger m_messenger;
@@ -135,11 +135,12 @@ public class InGameLobbyWatcher {
     m_game = game;
     if (game != null) {
       game.addGameStepListener(m_gameStepListener);
-      gameStepChanged(game.getData().getSequence().getStep().getName(), game.getData().getSequence().getRound());
+      final String stepName = game.getData().getSequence().getStep().getName();
+      gameStepChanged(game.getData().getSequence().getRound());
     }
   }
 
-  private void gameStepChanged(final String stepName, final int round) {
+  private void gameStepChanged(final int round) {
     synchronized (m_mutex) {
       if (!m_gameDescription.getRound().equals(Integer.toString(round))) {
         m_gameDescription.setRound(round + "");

--- a/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -53,7 +53,7 @@ public class LobbyLoginValidator implements ILoginValidator {
   public String verifyConnection(final Map<String, String> propertiesSentToClient,
       final Map<String, String> propertiesReadFromClient, final String clientName, final String clientMac,
       final SocketAddress remoteAddress) {
-    final String error = verifyConnectionInternal(propertiesReadFromClient, clientName, clientMac, remoteAddress);
+    final String error = verifyConnectionInternal(propertiesReadFromClient, clientName, clientMac);
     if (error != null) {
       s_logger.info("Bad login attemp from " + remoteAddress + " for user " + clientName + " error:" + error);
       AccessLog.failedLogin(clientName, ((InetSocketAddress) remoteAddress).getAddress(), error);
@@ -65,7 +65,7 @@ public class LobbyLoginValidator implements ILoginValidator {
   }
 
   private String verifyConnectionInternal(final Map<String, String> propertiesReadFromClient, final String clientName,
-      final String hashedMac, final SocketAddress remoteAddress) {
+      final String hashedMac) {
     if (propertiesReadFromClient == null) {
       return "No Client Properties";
     }

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -40,7 +40,7 @@ public class AIUtils {
    */
   static int getCost(final UnitType unitType, final PlayerID player, final GameData data) {
     final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-    final ProductionRule rule = getProductionRule(unitType, player, data);
+    final ProductionRule rule = getProductionRule(unitType, player);
     if (rule == null) {
       return Integer.MAX_VALUE;
     } else {
@@ -53,7 +53,7 @@ public class AIUtils {
    * <p>
    * If no such rule can be found, then return null.
    */
-  private static ProductionRule getProductionRule(final UnitType unitType, final PlayerID player, final GameData data) {
+  private static ProductionRule getProductionRule(final UnitType unitType, final PlayerID player) {
     final ProductionFrontier frontier = player.getProductionFrontier();
     if (frontier == null) {
       return null;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
@@ -396,7 +396,7 @@ public class ProBidAI {
     // Matches.TerritoryIsLand);
     final Territory capitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
     final List<Territory> factoryTerritories =
-        Match.getMatches(findUnitTerr(data, player, ourFactory), Matches.isTerritoryOwnedBy(player));
+        Match.getMatches(findUnitTerr(data, ourFactory), Matches.isTerritoryOwnedBy(player));
     factoryTerritories.removeAll(impassableTerrs);
     /**
      * Bid place with following criteria:
@@ -434,8 +434,8 @@ public class ProBidAI {
       // Matches.territoryHasEnemyUnits(player, data));
       final CompositeMatch<Territory> waterFactoryWaterTerr = new CompositeMatchAnd<>(Matches.TerritoryIsWater,
           Matches.territoryHasOwnedNeighborWithOwnedUnitMatching(data, player, Matches.UnitCanProduceUnits));
-      final List<Territory> enemySeaTerr = findUnitTerr(data, player, enemyAttackUnit);
-      final List<Territory> isWaterTerr = onlyWaterTerr(data, enemySeaTerr);
+      final List<Territory> enemySeaTerr = findUnitTerr(data, enemyAttackUnit);
+      final List<Territory> isWaterTerr = onlyWaterTerr(enemySeaTerr);
       enemySeaTerr.retainAll(isWaterTerr);
       Territory maxEnemySeaTerr = null;
       int maxUnits = 0;
@@ -484,7 +484,7 @@ public class ProBidAI {
           ourSemiRankedBidTerrs.remove(noRouteTerr);
         }
       }
-      final List<Territory> isWaterTerr = onlyWaterTerr(data, ourSemiRankedBidTerrs);
+      final List<Territory> isWaterTerr = onlyWaterTerr(ourSemiRankedBidTerrs);
       ourSemiRankedBidTerrs.removeAll(isWaterTerr);
       ourSemiRankedBidTerrs.removeAll(impassableTerrs);
       // This will bid a max of 5 units to ALL territories except for the capitol. The capitol gets units last, and gets
@@ -1106,8 +1106,7 @@ public class ProBidAI {
    * Return Territories containing any unit depending on unitCondition
    * Differs from findCertainShips because it doesn't require the units be owned
    */
-  private static List<Territory> findUnitTerr(final GameData data, final PlayerID player,
-      final Match<Unit> unitCondition) {
+  private static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units
     final CompositeMatch<Unit> limitShips = new CompositeMatchAnd<>(unitCondition);
     final List<Territory> shipTerr = new ArrayList<>();
@@ -1416,7 +1415,7 @@ public class ProBidAI {
           Matches.UnitCanBeTransported, Matches.UnitIsNotAA, Matches.UnitCanMove);
       final CompositeMatch<Unit> aTransport =
           new CompositeMatchAnd<>(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
-      final List<Territory> eFTerrs = findUnitTerr(data, ePlayer, enemyPlane);
+      final List<Territory> eFTerrs = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0, maxBomberDistance = 0;
       // should change this to read production frontier and tech
       // reality is 99% of time units considered will have full move.
@@ -1435,7 +1434,7 @@ public class ProBidAI {
       if (maxBomberDistance < 0) {
         maxBomberDistance = 0;
       }
-      final List<Territory> eTTerrs = findUnitTerr(data, ePlayer, aTransport);
+      final List<Territory> eTTerrs = findUnitTerr(data, aTransport);
       int maxTransportDistance = 0;
       for (final Territory eTTerr : eTTerrs) {
         final List<Unit> eTUnits = eTTerr.getUnits().getMatches(aTransport);
@@ -1807,7 +1806,7 @@ public class ProBidAI {
       if (distance.getInt(current) == maxDistance) {
         break;
       }
-      for (final Territory neighbor : data.getMap().getNeighbors(current, TerritoryIsNotImpassableToAirUnits(data))) {
+      for (final Territory neighbor : data.getMap().getNeighbors(current, TerritoryIsNotImpassableToAirUnits())) {
         if (!distance.keySet().contains(neighbor)) {
           q.add(neighbor);
           distance.put(neighbor, distance.getInt(current) + 1);
@@ -1999,7 +1998,7 @@ public class ProBidAI {
    * returns all territories that are water territories. used to remove convoy zones from places the ai will put a
    * factory
    */
-  private static List<Territory> onlyWaterTerr(final GameData data, final List<Territory> allTerr) {
+  private static List<Territory> onlyWaterTerr(final List<Territory> allTerr) {
     final List<Territory> water = new ArrayList<>(allTerr);
     final Iterator<Territory> wFIter = water.iterator();
     while (wFIter.hasNext()) {
@@ -2216,14 +2215,14 @@ public class ProBidAI {
     return sorted;
   }
 
-  private static Match<Territory> TerritoryIsNotImpassableToAirUnits(final GameData data) {
-    return new InverseMatch<>(TerritoryIsImpassableToAirUnits(data));
+  private static Match<Territory> TerritoryIsNotImpassableToAirUnits() {
+    return new InverseMatch<>(TerritoryIsImpassableToAirUnits());
   }
 
   /**
    * Assumes that water is passable to air units always
    */
-  private static Match<Territory> TerritoryIsImpassableToAirUnits(final GameData data) {
+  private static Match<Territory> TerritoryIsImpassableToAirUnits() {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -2242,7 +2241,7 @@ public class ProBidAI {
   private static List<Territory> getNeighboringLandTerritories(final GameData data, final PlayerID player,
       final Territory check) {
     final ArrayList<Territory> rVal = new ArrayList<>();
-    final List<Territory> checkList = getExactNeighbors(check, 1, player, data, false);
+    final List<Territory> checkList = getExactNeighbors(check, 1, data, false);
     for (final Territory t : checkList) {
       if (Matches.isTerritoryAllied(player, data).match(t)
           && Matches.TerritoryIsNotImpassableToLandUnits(player, data).match(t)) {
@@ -2257,8 +2256,8 @@ public class ProBidAI {
    * Removes the inner circle neighbors
    * neutral - whether to include neutral countries
    */
-  private static List<Territory> getExactNeighbors(final Territory territory, final int distance, final PlayerID player,
-      final GameData data, final boolean neutral) {
+  private static List<Territory> getExactNeighbors(final Territory territory, final int distance, final GameData data,
+      final boolean neutral) {
     // old functionality retained, i.e. no route condition is imposed.
     // feel free to change, if you are confortable all calls to this function conform.
     final CompositeMatch<Territory> endCond = new CompositeMatchAnd<>(Matches.TerritoryIsImpassable.invert());

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
@@ -66,7 +66,7 @@ public class ProData {
     unitTerritoryMap = ProUtils.createUnitTerritoryMap();
     unitValueMap = BattleCalculator.getCostsForTUV(player, data);
     purchaseOptions = new ProPurchaseOptionMap(player, data);
-    minCostPerHitPoint = getMinCostPerHitPoint(player, purchaseOptions.getLandOptions());
+    minCostPerHitPoint = getMinCostPerHitPoint(purchaseOptions.getLandOptions());
   }
 
   public static ProAI getProAI() {
@@ -81,8 +81,7 @@ public class ProData {
     return player;
   }
 
-  private static double getMinCostPerHitPoint(final PlayerID player,
-      final List<ProPurchaseOption> landPurchaseOptions) {
+  private static double getMinCostPerHitPoint(final List<ProPurchaseOption> landPurchaseOptions) {
     double minCostPerHitPoint = Double.MAX_VALUE;
     for (final ProPurchaseOption ppo : landPurchaseOptions) {
       if (ppo.getCostPerHitPoint() < minCostPerHitPoint) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -304,10 +304,10 @@ public class ProPurchaseAI {
       }
     }
     // Place regular land units
-    placeLandUnits(placeNonConstructionTerritories, prioritizedLandTerritories, placeDelegate, false);
+    placeLandUnits(prioritizedLandTerritories, placeDelegate, false);
 
     // Place isConstruction land units (needs separated since placeDelegate.getPlaceableUnits doesn't handle combined)
-    placeLandUnits(placeNonConstructionTerritories, prioritizedLandTerritories, placeDelegate, true);
+    placeLandUnits(prioritizedLandTerritories, placeDelegate, true);
   }
 
   private void findDefendersInPlaceTerritories(final Map<Territory, ProPurchaseTerritory> purchaseTerritories) {
@@ -1772,9 +1772,8 @@ public class ProPurchaseAI {
     }
   }
 
-  private void placeLandUnits(final Map<Territory, ProPurchaseTerritory> placeNonConstructionTerritories,
-      final List<ProPlaceTerritory> prioritizedLandTerritories, final IAbstractPlaceDelegate placeDelegate,
-      final boolean isConstruction) {
+  private void placeLandUnits(final List<ProPlaceTerritory> prioritizedLandTerritories,
+      final IAbstractPlaceDelegate placeDelegate, final boolean isConstruction) {
 
     ProLogger.info("Place land with isConstruction=" + isConstruction + ", units=" + player.getUnits().getUnits());
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -116,7 +116,7 @@ public final class ProTechAI {
           Matches.UnitCanBeTransported, Matches.UnitIsNotAA, Matches.UnitCanMove);
       final CompositeMatch<Unit> aTransport =
           new CompositeMatchAnd<>(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
-      final List<Territory> eFTerrs = findUnitTerr(data, ePlayer, enemyPlane);
+      final List<Territory> eFTerrs = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0, maxBomberDistance = 0;
       // should change this to read production frontier and tech
       // reality is 99% of time units considered will have full move.
@@ -135,7 +135,7 @@ public final class ProTechAI {
       if (maxBomberDistance < 0) {
         maxBomberDistance = 0;
       }
-      final List<Territory> eTTerrs = findUnitTerr(data, ePlayer, aTransport);
+      final List<Territory> eTTerrs = findUnitTerr(data, aTransport);
       int maxTransportDistance = 0;
       for (final Territory eTTerr : eTTerrs) {
         final List<Unit> eTUnits = eTTerr.getUnits().getMatches(aTransport);
@@ -473,7 +473,7 @@ public final class ProTechAI {
       if (distance.getInt(current) == maxDistance) {
         break;
       }
-      for (final Territory neighbor : data.getMap().getNeighbors(current, TerritoryIsNotImpassableToAirUnits(data))) {
+      for (final Territory neighbor : data.getMap().getNeighbors(current, TerritoryIsNotImpassableToAirUnits())) {
         if (!distance.keySet().contains(neighbor)) {
           q.add(neighbor);
           distance.put(neighbor, distance.getInt(current) + 1);
@@ -589,7 +589,7 @@ public final class ProTechAI {
   private static List<Territory> getNeighboringLandTerritories(final GameData data, final PlayerID player,
       final Territory check) {
     final ArrayList<Territory> rVal = new ArrayList<>();
-    final List<Territory> checkList = getExactNeighbors(check, 1, player, data, false);
+    final List<Territory> checkList = getExactNeighbors(check, 1, data, false);
     for (final Territory t : checkList) {
       if (Matches.isTerritoryAllied(player, data).match(t)
           && Matches.TerritoryIsNotImpassableToLandUnits(player, data).match(t)) {
@@ -604,8 +604,8 @@ public final class ProTechAI {
    * Removes the inner circle neighbors
    * neutral - whether to include neutral countries
    */
-  private static List<Territory> getExactNeighbors(final Territory territory, final int distance, final PlayerID player,
-      final GameData data, final boolean neutral) {
+  private static List<Territory> getExactNeighbors(final Territory territory, final int distance, final GameData data,
+      final boolean neutral) {
     // old functionality retained, i.e. no route condition is imposed.
     // feel free to change, if you are confortable all calls to this function conform.
     final CompositeMatch<Territory> endCond = new CompositeMatchAnd<>(Matches.TerritoryIsImpassable.invert());
@@ -665,8 +665,7 @@ public final class ProTechAI {
    * Return Territories containing any unit depending on unitCondition
    * Differs from findCertainShips because it doesn't require the units be owned
    */
-  private static List<Territory> findUnitTerr(final GameData data, final PlayerID player,
-      final Match<Unit> unitCondition) {
+  private static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units
     final CompositeMatch<Unit> limitShips = new CompositeMatchAnd<>(unitCondition);
     final List<Territory> shipTerr = new ArrayList<>();
@@ -734,14 +733,14 @@ public final class ProTechAI {
     return sorted;
   }
 
-  private static Match<Territory> TerritoryIsNotImpassableToAirUnits(final GameData data) {
-    return new InverseMatch<>(TerritoryIsImpassableToAirUnits(data));
+  private static Match<Territory> TerritoryIsNotImpassableToAirUnits() {
+    return new InverseMatch<>(TerritoryIsImpassableToAirUnits());
   }
 
   /**
    * Assumes that water is passable to air units always
    */
-  private static Match<Territory> TerritoryIsImpassableToAirUnits(final GameData data) {
+  private static Match<Territory> TerritoryIsImpassableToAirUnits() {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -283,7 +283,7 @@ public class ProTerritoryManager {
         ProMatches.territoryHasEnemyUnitsOrCantBeHeld(player, data, territoriesThatCantBeHeld), enemyTerritories,
         alliedTerritories, true, isCheckingEnemyAttacks, isIgnoringRelationships);
     findAmphibMoveOptions(player, myUnitTerritories, moveMap, transportMapList, landRoutesMap,
-        ProMatches.territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld), enemyTerritories, true,
+        ProMatches.territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld), true,
         isCheckingEnemyAttacks, isIgnoringRelationships);
     findBombardOptions(player, myUnitTerritories, moveMap, bombardMap, transportMapList, isCheckingEnemyAttacks);
   }
@@ -366,7 +366,7 @@ public class ProTerritoryManager {
         ProMatches.territoryHasPotentialEnemyUnits(player, data, otherPlayers), new ArrayList<>(), new ArrayList<>(),
         true, false, true);
     findAmphibMoveOptions(player, myUnitTerritories, moveMap, transportMapList, landRoutesMap,
-        ProMatches.territoryIsPotentialEnemy(player, data, otherPlayers), new ArrayList<>(), true, false, true);
+        ProMatches.territoryIsPotentialEnemy(player, data, otherPlayers), true, false, true);
     findBombardOptions(player, myUnitTerritories, moveMap, bombardMap, transportMapList, false);
   }
 
@@ -387,7 +387,7 @@ public class ProTerritoryManager {
         ProMatches.territoryIsNotConqueredAlliedLand(player, data), new ArrayList<>(), new ArrayList<>(), false,
         isCheckingEnemyAttacks, false);
     findAmphibMoveOptions(player, myUnitTerritories, moveMap, transportMapList, landRoutesMap,
-        Matches.isTerritoryAllied(player, data), new ArrayList<>(), false, isCheckingEnemyAttacks, false);
+        Matches.isTerritoryAllied(player, data), false, isCheckingEnemyAttacks, false);
   }
 
   private ProOtherMoveOptions findEnemyDefendOptions(final PlayerID player) {
@@ -730,8 +730,7 @@ public class ProTerritoryManager {
   private void findAmphibMoveOptions(final PlayerID player, final List<Territory> myUnitTerritories,
       final Map<Territory, ProTerritory> moveMap, final List<ProTransport> transportMapList,
       final Map<Territory, Set<Territory>> landRoutesMap, final Match<Territory> moveAmphibToTerritoryMatch,
-      final List<Territory> enemyTerritories, final boolean isCombatMove, final boolean isCheckingEnemyAttacks,
-      final boolean isIgnoringRelationships) {
+      final boolean isCombatMove, final boolean isCheckingEnemyAttacks, final boolean isIgnoringRelationships) {
     final GameData data = ProData.getData();
 
     for (final Territory myUnitTerritory : myUnitTerritories) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
@@ -62,12 +62,12 @@ public class ProLogWindow extends javax.swing.JDialog {
     addWindowListener(new java.awt.event.WindowAdapter() {
       @Override
       public void windowClosing(final java.awt.event.WindowEvent evt) {
-        formWindowClosing(evt);
+        formWindowClosing();
       }
 
       @Override
       public void windowOpened(final java.awt.event.WindowEvent evt) {
-        formWindowOpened(evt);
+        formWindowOpened();
       }
     });
     getContentPane().setLayout(new java.awt.GridBagLayout());
@@ -78,7 +78,7 @@ public class ProLogWindow extends javax.swing.JDialog {
     v_restoreDefaultsButton.setMinimumSize(new java.awt.Dimension(118, 23));
     v_restoreDefaultsButton.setName("v_restoreDefaultsButton");
     v_restoreDefaultsButton.setPreferredSize(new java.awt.Dimension(118, 23));
-    v_restoreDefaultsButton.addActionListener(evt -> v_restoreDefaultsButtonActionPerformed(evt));
+    v_restoreDefaultsButton.addActionListener(evt -> v_restoreDefaultsButtonActionPerformed());
     gridBagConstraints = new java.awt.GridBagConstraints();
     gridBagConstraints.gridx = 0;
     gridBagConstraints.gridy = 0;
@@ -89,7 +89,7 @@ public class ProLogWindow extends javax.swing.JDialog {
     v_settingsDetailsButton.setMinimumSize(new java.awt.Dimension(115, 23));
     v_settingsDetailsButton.setName("v_settingsDetailsButton");
     v_settingsDetailsButton.setPreferredSize(new java.awt.Dimension(115, 23));
-    v_settingsDetailsButton.addActionListener(evt -> v_settingsDetailsButtonActionPerformed(evt));
+    v_settingsDetailsButton.addActionListener(evt -> v_settingsDetailsButtonActionPerformed());
     gridBagConstraints = new java.awt.GridBagConstraints();
     gridBagConstraints.gridx = 2;
     gridBagConstraints.gridy = 0;
@@ -102,7 +102,7 @@ public class ProLogWindow extends javax.swing.JDialog {
     jPanel13.setLayout(new java.awt.GridBagLayout());
     v_cancelButton.setText("Cancel");
     v_cancelButton.setName("v_cancelButton");
-    v_cancelButton.addActionListener(evt -> v_cancelButtonActionPerformed(evt));
+    v_cancelButton.addActionListener(evt -> v_cancelButtonActionPerformed());
     gridBagConstraints = new java.awt.GridBagConstraints();
     gridBagConstraints.gridx = 1;
     gridBagConstraints.gridy = 0;
@@ -110,7 +110,7 @@ public class ProLogWindow extends javax.swing.JDialog {
     jPanel13.add(v_cancelButton, gridBagConstraints);
     v_okButton.setText("OK");
     v_okButton.setName("v_okButton");
-    v_okButton.addActionListener(evt -> v_okButtonActionPerformed(evt));
+    v_okButton.addActionListener(evt -> v_okButtonActionPerformed());
     gridBagConstraints = new java.awt.GridBagConstraints();
     gridBagConstraints.gridx = 0;
     gridBagConstraints.gridy = 0;
@@ -166,7 +166,7 @@ public class ProLogWindow extends javax.swing.JDialog {
     v_enableAILogging.setSelected(true);
     v_enableAILogging.setText("Enable AI Logging");
     v_enableAILogging.setName("v_enableAILogging");
-    v_enableAILogging.addChangeListener(evt -> v_enableAILoggingStateChanged(evt));
+    v_enableAILogging.addChangeListener(evt -> v_enableAILoggingStateChanged());
     gridBagConstraints = new java.awt.GridBagConstraints();
     gridBagConstraints.gridx = 0;
     gridBagConstraints.gridy = 0;
@@ -200,7 +200,7 @@ public class ProLogWindow extends javax.swing.JDialog {
     v_limitLogHistoryCB.setSelected(true);
     v_limitLogHistoryCB.setText("Limit Log History To:");
     v_limitLogHistoryCB.setName("v_limitLogHistoryCB");
-    v_limitLogHistoryCB.addChangeListener(evt -> v_limitLogHistoryCBStateChanged(evt));
+    v_limitLogHistoryCB.addChangeListener(evt -> v_limitLogHistoryCBStateChanged());
     gridBagConstraints = new java.awt.GridBagConstraints();
     gridBagConstraints.gridx = 4;
     gridBagConstraints.gridy = 0;
@@ -231,7 +231,7 @@ public class ProLogWindow extends javax.swing.JDialog {
     setBounds((screenSize.width - 800), 25, 775, 401);
   }
 
-  private void formWindowOpened(final java.awt.event.WindowEvent evt) {
+  private void formWindowOpened() {
     loadSettings(ProLogSettings.loadSettings());
     this.pack();
   }
@@ -269,7 +269,7 @@ public class ProLogWindow extends javax.swing.JDialog {
     return settings;
   }
 
-  private void v_restoreDefaultsButtonActionPerformed(final java.awt.event.ActionEvent evt) {
+  private void v_restoreDefaultsButtonActionPerformed() {
     final int result = JOptionPane.showConfirmDialog(rootPane, "Are you sure you want to reset all AI settings?",
         "Reset Default Settings", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
     if (result == JOptionPane.OK_OPTION) {
@@ -282,32 +282,32 @@ public class ProLogWindow extends javax.swing.JDialog {
     }
   }
 
-  private void v_enableAILoggingStateChanged(final javax.swing.event.ChangeEvent evt) {
+  private void v_enableAILoggingStateChanged() {
     v_logDepth.setEnabled(v_enableAILogging.isSelected());
     v_limitLogHistoryCB.setEnabled(v_enableAILogging.isSelected());
   }
 
-  private void v_limitLogHistoryCBStateChanged(final javax.swing.event.ChangeEvent evt) {
+  private void v_limitLogHistoryCBStateChanged() {
     v_limitLogHistoryToSpinner.setEnabled(v_limitLogHistoryCB.isSelected() && v_enableAILogging.isSelected());
   }
 
-  private void formWindowClosing(final java.awt.event.WindowEvent evt) {
-    v_cancelButtonActionPerformed(null);
+  private void formWindowClosing() {
+    v_cancelButtonActionPerformed();
   }
 
-  private void v_okButtonActionPerformed(final java.awt.event.ActionEvent evt) {
+  private void v_okButtonActionPerformed() {
     final ProLogSettings settings = createSettings();
     ProLogSettings.saveSettings(settings);
     this.setVisible(false);
   }
 
-  private void v_cancelButtonActionPerformed(final java.awt.event.ActionEvent evt) {
+  private void v_cancelButtonActionPerformed() {
     final ProLogSettings settings = ProLogSettings.loadSettings();
     loadSettings(settings);
     this.setVisible(false);
   }
 
-  private void v_settingsDetailsButtonActionPerformed(final java.awt.event.ActionEvent evt) {
+  private void v_settingsDetailsButtonActionPerformed() {
     final JDialog dialog = new JDialog(this, "Pro AI - Settings Details");
     String message = "";
     if (v_tabPaneMain.getSelectedIndex() == 0) // Debugging

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -115,7 +115,7 @@ public class WeakAI extends AbstractAI {
     final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
     // load the transports first
     // they may be able to move farther
-    populateTransportLoad(false, data, moveUnits, moveRoutes, transportsToLoad, player);
+    populateTransportLoad(data, moveUnits, moveRoutes, transportsToLoad, player);
     doMove(moveUnits, moveRoutes, transportsToLoad, moveDel);
     moveRoutes.clear();
     moveUnits.clear();
@@ -129,7 +129,7 @@ public class WeakAI extends AbstractAI {
     transportsToLoad.clear();
     // load the transports again if we can
     // they may be able to move farther
-    populateTransportLoad(false, data, moveUnits, moveRoutes, transportsToLoad, player);
+    populateTransportLoad(data, moveUnits, moveRoutes, transportsToLoad, player);
     doMove(moveUnits, moveRoutes, transportsToLoad, moveDel);
     moveRoutes.clear();
     moveUnits.clear();
@@ -145,7 +145,7 @@ public class WeakAI extends AbstractAI {
     final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
     // load the transports first
     // they may be able to take part in a battle
-    populateTransportLoad(true, data, moveUnits, moveRoutes, transportsToLoad, player);
+    populateTransportLoad(data, moveUnits, moveRoutes, transportsToLoad, player);
     doMove(moveUnits, moveRoutes, transportsToLoad, moveDel);
     moveRoutes.clear();
     moveUnits.clear();
@@ -166,9 +166,8 @@ public class WeakAI extends AbstractAI {
     doMove(moveUnits, moveRoutes, null, moveDel);
   }
 
-  private void populateTransportLoad(final boolean nonCombat, final GameData data,
-      final List<Collection<Unit>> moveUnits, final List<Route> moveRoutes,
-      final List<Collection<Unit>> transportsToLoad, final PlayerID player) {
+  private void populateTransportLoad(final GameData data, final List<Collection<Unit>> moveUnits,
+      final List<Route> moveRoutes, final List<Collection<Unit>> transportsToLoad, final PlayerID player) {
     if (!isAmphibAttack(player, data)) {
       return;
     }
@@ -234,8 +233,7 @@ public class WeakAI extends AbstractAI {
     }
   }
 
-  private List<Unit> load2Transports(final boolean reload, final GameData data, final List<Unit> transportsToLoad,
-      final Territory loadFrom, final PlayerID player) {
+  private List<Unit> load2Transports(final List<Unit> transportsToLoad) {
     final List<Unit> units = new ArrayList<>();
     for (final Unit transport : transportsToLoad) {
       final Collection<Unit> landunits = TransportTracker.transporting(transport);
@@ -289,7 +287,7 @@ public class WeakAI extends AbstractAI {
     } else {
       unitsToMove.addAll(transports.subList(0, maxTrans));
     }
-    final List<Unit> landUnits = load2Transports(true, data, unitsToMove, firstSeaZoneOnAmphib, player);
+    final List<Unit> landUnits = load2Transports(unitsToMove);
     final Route r = getMaxSeaRoute(data, firstSeaZoneOnAmphib, lastSeaZoneOnAmphib, player);
     moveRoutes.add(r);
     unitsToMove.addAll(landUnits);

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1593,7 +1593,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private static void placeUnits(final TriggerAttachment t, final Territory terr, final IntegerMap<UnitType> uMap,
-      final PlayerID player, final GameData data, final IDelegateBridge aBridge) {
+      final PlayerID player, final IDelegateBridge aBridge) {
     // createUnits
     final List<Unit> units = new ArrayList<>();
     for (final UnitType u : uMap.keySet()) {
@@ -2464,7 +2464,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       for (final PlayerID aPlayer : t.getPlayers()) {
         for (final Territory ter : t.getPlacement().keySet()) {
           for (int i = 0; i < eachMultiple; ++i) {
-            placeUnits(t, ter, t.getPlacement().get(ter), aPlayer, data, aBridge);
+            placeUnits(t, ter, t.getPlacement().get(ter), aPlayer, aBridge);
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -54,7 +54,7 @@ public class AirMovementValidator {
     }
     // Find which aircraft cannot find friendly land to land on
     final Collection<Unit> ownedAirThatMustLandOnCarriers =
-        getAirThatMustLandOnCarriers(data, getAirUnitsToValidate(units, route, player), route, result, player);
+        getAirThatMustLandOnCarriers(data, getAirUnitsToValidate(units, route, player), route, result);
     if (ownedAirThatMustLandOnCarriers.isEmpty()) {
       // we are done, everything can find a place to land
       return result;
@@ -645,7 +645,7 @@ public class AirMovementValidator {
   }
 
   private static Collection<Unit> getAirThatMustLandOnCarriers(final GameData data, final Collection<Unit> ownedAir,
-      final Route route, final MoveValidationResult result, final PlayerID player) {
+      final Route route, final MoveValidationResult result) {
     final Collection<Unit> airThatMustLandOnCarriers = new ArrayList<>();
     final Match<Unit> canLandOnCarriers = Matches.UnitCanLandOnCarrier;
     for (final Unit unit : ownedAir) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -644,9 +644,9 @@ public class BattleCalculator {
       final boolean allowMultipleHitsPerUnit, final boolean bonus) {
     final CasualtyList defaultCasualtySelection = new CasualtyList();
     // Sort units by power and cost in ascending order
-    final List<Unit> sorted = sortUnitsForCasualtiesWithSupport(targetsToPickFrom, hits, defending, player,
+    final List<Unit> sorted = sortUnitsForCasualtiesWithSupport(targetsToPickFrom, defending, player,
         enemyUnits, amphibious, amphibiousLandAttackers, battlesite, costs,
-        territoryEffects, data, allowMultipleHitsPerUnit, bonus);
+        territoryEffects, data, bonus);
     // Remove two hit bb's selecting them first for default casualties
     int numSelectedCasualties = 0;
     if (allowMultipleHitsPerUnit) {
@@ -688,11 +688,10 @@ public class BattleCalculator {
    * provided.
    * (Veqryn)
    */
-  private static List<Unit> sortUnitsForCasualtiesWithSupport(final Collection<Unit> targetsToPickFrom, final int hits,
+  private static List<Unit> sortUnitsForCasualtiesWithSupport(final Collection<Unit> targetsToPickFrom,
       final boolean defending, final PlayerID player, final Collection<Unit> enemyUnits, final boolean amphibious,
       final Collection<Unit> amphibiousLandAttackers, final Territory battlesite, final IntegerMap<UnitType> costs,
-      final Collection<TerritoryEffect> territoryEffects, final GameData data, final boolean allowMultipleHitsPerUnit,
-      final boolean bonus) {
+      final Collection<TerritoryEffect> territoryEffects, final GameData data, final boolean bonus) {
 
     // Convert unit lists to unit type lists
     final List<UnitType> targetTypes = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -382,7 +382,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     return null;
   }
 
-  private static void landParatroopers(final PlayerID player, final Territory battleSite, final GameData data,
+  private static void landParatroopers(final PlayerID player, final Territory battleSite,
       final IDelegateBridge bridge) {
     if (TechTracker.hasParatroopers(player)) {
       final Collection<Unit> airTransports =
@@ -463,7 +463,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         // separately, after aa
         // fires)
         if (enemyUnits.isEmpty() || Match.allMatch(enemyUnits, Matches.UnitIsInfrastructure)) {
-          landParatroopers(player, territory, data, aBridge);
+          landParatroopers(player, territory, aBridge);
         }
         aBridge.getHistoryWriter().startEvent(player.getName() + " creates battle in territory " + territory.getName());
         battleTracker.addBattle(new RouteScripted(territory), attackingUnits, player, aBridge, null, null);
@@ -1130,7 +1130,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             territory = canLandHere.iterator().next();
           }
           if (territory.isWater()) {
-            landPlanesOnCarriers(m_bridge, alliedDefendingAir, defendingAir, canLandHere, alliedCarrier, alliedPlane,
+            landPlanesOnCarriers(m_bridge, alliedDefendingAir, defendingAir, alliedCarrier, alliedPlane,
                 territory, battleSite);
           } else {
             moveAirAndLand(m_bridge, defendingAir, defendingAir, territory, battleSite);
@@ -1143,7 +1143,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         if (canLandHere.size() > 0 && defendingAir.size() > 0) {
           territory = canLandHere.iterator().next();
           if (territory.isWater()) {
-            landPlanesOnCarriers(m_bridge, alliedDefendingAir, defendingAir, canLandHere, alliedCarrier, alliedPlane,
+            landPlanesOnCarriers(m_bridge, alliedDefendingAir, defendingAir, alliedCarrier, alliedPlane,
                 territory, battleSite);
           } else {
             moveAirAndLand(m_bridge, defendingAir, defendingAir, territory, battleSite);
@@ -1172,9 +1172,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   }
 
   private static void landPlanesOnCarriers(final IDelegateBridge bridge, final CompositeMatch<Unit> alliedDefendingAir,
-      final Collection<Unit> defendingAir, final Collection<Territory> canLandHere,
-      final CompositeMatch<Unit> alliedCarrier, final CompositeMatch<Unit> alliedPlane, final Territory newTerritory,
-      final Territory battleSite) {
+      final Collection<Unit> defendingAir, final CompositeMatch<Unit> alliedCarrier,
+      final CompositeMatch<Unit> alliedPlane, final Territory newTerritory, final Territory battleSite) {
     // Get the capacity of the carriers in the selected zone
     final Collection<Unit> alliedCarriersSelected = newTerritory.getUnits().getMatches(alliedCarrier);
     final Collection<Unit> alliedPlanesSelected = newTerritory.getUnits().getMatches(alliedPlane);

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -25,10 +25,6 @@ import games.strategy.util.Triple;
  */
 public class EditValidator {
   private static String validateTerritoryBasic(final GameData data, final Territory territory) {
-    return validateTerritoryBasic(data, territory, null);
-  }
-
-  private static String validateTerritoryBasic(final GameData data, final Territory territory, final PlayerID player) {
     final String result = null;
     /*
      * // territory cannot contain enemy units
@@ -60,7 +56,7 @@ public class EditValidator {
         && TerritoryAttachment.get(territory) == null) {
       return "Territory is water and has no attachment";
     }
-    if ((result = validateTerritoryBasic(data, territory, player)) != null) {
+    if ((result = validateTerritoryBasic(data, territory)) != null) {
       return result;
     }
     return result;
@@ -126,7 +122,7 @@ public class EditValidator {
         return "Can't add sea units to land";
       }
     }
-    if ((result = validateTerritoryBasic(data, territory, player)) != null) {
+    if ((result = validateTerritoryBasic(data, territory)) != null) {
       return result;
     }
     return result;
@@ -144,7 +140,7 @@ public class EditValidator {
      * if (!Match.allMatch(units, Matches.unitIsOwnedBy(player)))
      * return "Not all units have the same owner";
      */
-    if ((result = validateTerritoryBasic(data, territory, player)) != null) {
+    if ((result = validateTerritoryBasic(data, territory)) != null) {
       return result;
     }
     // if transport selected, all transported units must be deleted too

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -210,15 +210,6 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
   @Override
   public Serializable saveState() {
-    return saveState(true);
-  }
-
-  /**
-   * Returns the state of the Delegate. We don't want to save the undoState if
-   * we are saving the state for an undo move (we don't need it, it will just
-   * take up extra space).
-   */
-  private Serializable saveState(final boolean saveUndo) {
     final MoveExtendedDelegateState state = new MoveExtendedDelegateState();
     state.superState = super.saveState();
     state.m_needToInitialize = m_needToInitialize;

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -321,8 +321,8 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     if (m_stack.isExecuting()) {
       final ITripleADisplay display = getDisplay(bridge);
       display.showBattle(m_battleID, m_battleSite, getBattleTitle(),
-          removeNonCombatants(m_attackingUnits, true, m_attacker, false, false, false),
-          removeNonCombatants(m_defendingUnits, false, m_defender, false, false, false), m_killed,
+          removeNonCombatants(m_attackingUnits, true, false, false, false),
+          removeNonCombatants(m_defendingUnits, false, false, false, false), m_killed,
           m_attackingWaitingToDie, m_defendingWaitingToDie, m_dependentUnits, m_attacker, m_defender, isAmphibious(),
           getBattleType(), m_amphibiousLandAttackers);
       display.listBattleSteps(m_battleID, m_stepStrings);
@@ -357,8 +357,8 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     m_stepStrings = determineStepStrings(true, bridge);
     final ITripleADisplay display = getDisplay(bridge);
     display.showBattle(m_battleID, m_battleSite, getBattleTitle(),
-        removeNonCombatants(m_attackingUnits, true, m_attacker, false, false, false),
-        removeNonCombatants(m_defendingUnits, false, m_defender, false, false, false), m_killed,
+        removeNonCombatants(m_attackingUnits, true, false, false, false),
+        removeNonCombatants(m_defendingUnits, false, false, false, false), m_killed,
         m_attackingWaitingToDie, m_defendingWaitingToDie, m_dependentUnits, m_attacker, m_defender, isAmphibious(),
         getBattleType(), m_amphibiousLandAttackers);
     display.listBattleSteps(m_battleID, m_stepStrings);
@@ -388,7 +388,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
       }
     }
     // push on stack in opposite order of execution
-    pushFightLoopOnStack(true, bridge);
+    pushFightLoopOnStack(true);
     m_stack.execute(bridge);
   }
 
@@ -683,7 +683,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          fireOffensiveAAGuns(bridge);
+          fireOffensiveAAGuns();
         }
       });
     }
@@ -693,7 +693,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          fireDefensiveAAGuns(bridge);
+          fireDefensiveAAGuns();
         }
       });
     }
@@ -731,7 +731,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          fireSuicideUnitsAttack(bridge);
+          fireSuicideUnitsAttack();
         }
       });
       steps.add(new IExecutable() {
@@ -739,7 +739,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          fireSuicideUnitsDefend(bridge);
+          fireSuicideUnitsDefend();
         }
       });
       steps.add(new IExecutable() {
@@ -769,7 +769,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     }
   }
 
-  private void pushFightLoopOnStack(final boolean firstRun, final IDelegateBridge bridge) {
+  private void pushFightLoopOnStack(final boolean firstRun) {
     if (m_isOver) {
       return;
     }
@@ -954,7 +954,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        pushFightLoopOnStack(false, bridge);
+        pushFightLoopOnStack(false);
       }
     };
     steps.add(new IExecutable() {
@@ -1054,7 +1054,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          defendSubs(bridge, returnFireAgainstDefendingSubs);
+          defendSubs(returnFireAgainstDefendingSubs);
         }
       });
     }
@@ -1063,7 +1063,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        attackSubs(bridge, returnFireAgainstAttackingSubs);
+        attackSubs(returnFireAgainstAttackingSubs);
       }
     });
     final boolean defendingSubsFireWithAllDefenders = !defenderSubsFireFirst()
@@ -1075,7 +1075,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          defendSubs(bridge, returnFireAgainstDefendingSubs);
+          defendSubs(returnFireAgainstDefendingSubs);
         }
       });
     }
@@ -1087,7 +1087,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          attackAirOnNonSubs(bridge);
+          attackAirOnNonSubs();
         }
       });
     }
@@ -1098,7 +1098,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        attackNonSubs(bridge);
+        attackNonSubs();
       }
     });
     if (!defenderSubsFireFirst() && (!defendingSubsSneakAttack3() || defendingSubsFireWithAllDefenders)) {
@@ -1107,7 +1107,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          defendSubs(bridge, returnFireAgainstDefendingSubs);
+          defendSubs(returnFireAgainstDefendingSubs);
         }
       });
     }
@@ -1119,7 +1119,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          defendAirOnNonSubs(bridge);
+          defendAirOnNonSubs();
         }
       });
     }
@@ -1129,7 +1129,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        defendNonSubs(bridge);
+        defendNonSubs();
       }
     });
   }
@@ -1520,8 +1520,8 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     return remaining;
   }
 
-  private Change retreatFromDependents(final Collection<Unit> units, final IDelegateBridge bridge,
-      final Territory retreatTo, final Collection<IBattle> dependentBattles) {
+  private Change retreatFromDependents(final Collection<Unit> units, final Territory retreatTo,
+      final Collection<IBattle> dependentBattles) {
     final CompositeChange change = new CompositeChange();
     for (final IBattle dependent : dependentBattles) {
       final Route route = new Route();
@@ -1536,7 +1536,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
   }
 
   // Retreat landed units from allied territory when their transport retreats
-  private Change retreatFromNonCombat(Collection<Unit> units, final IDelegateBridge bridge, final Territory retreatTo) {
+  private Change retreatFromNonCombat(Collection<Unit> units, final Territory retreatTo) {
     final CompositeChange change = new CompositeChange();
     units = Match.getMatches(units, Matches.UnitIsTransport);
     final Collection<Unit> retreated = getTransportDependents(units, m_data);
@@ -1625,10 +1625,10 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
       final Collection<IBattle> dependentBattles = m_battleTracker.getBlocked(this);
       // If there are no dependent battles, check landings in allied territories
       if (dependentBattles.isEmpty()) {
-        change.add(retreatFromNonCombat(retreating, bridge, to));
+        change.add(retreatFromNonCombat(retreating, to));
         // Else retreat the units from combat when their transport retreats
       } else {
-        change.add(retreatFromDependents(retreating, bridge, to, dependentBattles));
+        change.add(retreatFromDependents(retreating, to, dependentBattles));
       }
     }
     bridge.addChange(change);
@@ -1669,10 +1669,10 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
       final Collection<IBattle> dependentBattles = m_battleTracker.getBlocked(this);
       // If there are no dependent battles, check landings in allied territories
       if (dependentBattles.isEmpty()) {
-        change.add(retreatFromNonCombat(nonAirRetreating, bridge, to));
+        change.add(retreatFromNonCombat(nonAirRetreating, to));
         // Else retreat the units from combat when their transport retreats
       } else {
-        change.add(retreatFromDependents(nonAirRetreating, bridge, to, dependentBattles));
+        change.add(retreatFromDependents(nonAirRetreating, to, dependentBattles));
       }
     }
     bridge.addChange(change);
@@ -1692,7 +1692,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
   private void fire(final String stepName, final Collection<Unit> firingUnits, final Collection<Unit> attackableUnits,
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie, final boolean defender, final ReturnFire returnFire,
-      final IDelegateBridge bridge, final String text) {
+      final String text) {
     final PlayerID firing = defender ? m_defender : m_attacker;
     final PlayerID defending = !defender ? m_defender : m_attacker;
     if (firingUnits.isEmpty()) {
@@ -1713,14 +1713,14 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     if (isDefendingSuicideAndMunitionUnitsDoNotFire()) {
       final List<Unit> deadUnits = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);
       getDisplay(bridge).deadUnitNotification(m_battleID, m_attacker, deadUnits, m_dependentUnits);
-      remove(deadUnits, bridge, m_battleSite, false, false);
+      remove(deadUnits, bridge, m_battleSite, false);
     } else {
       final List<Unit> deadUnits = new ArrayList<>();
       deadUnits.addAll(Match.getMatches(m_defendingUnits, Matches.UnitIsSuicide));
       deadUnits.addAll(Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide));
       getDisplay(bridge).deadUnitNotification(m_battleID, m_attacker, deadUnits, m_dependentUnits);
       getDisplay(bridge).deadUnitNotification(m_battleID, m_defender, deadUnits, m_dependentUnits);
-      remove(deadUnits, bridge, m_battleSite, false, null);
+      remove(deadUnits, bridge, m_battleSite, null);
     }
   }
 
@@ -1768,7 +1768,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
         final Change change = ChangeFactory.markNoMovementChange(Match.getMatches(enemyUnits, Matches.UnitIsSea));
         bridge.addChange(change);
         final boolean defender = player.equals(m_defender);
-        remove(alliedTransports, bridge, m_battleSite, false, defender);
+        remove(alliedTransports, bridge, m_battleSite, defender);
       }
     }
   }
@@ -1811,7 +1811,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
           new CompositeMatchAnd<>(notSubmergedAndType, Matches.UnitIsSupporterOrHasCombatAbility(enemy, m_data)));
     }
     if (!hasUnitsThatCanRollLeft && enemyHasUnitsThatCanRollLeft) {
-      remove(unitsToKill, bridge, m_battleSite, false, !attacker);
+      remove(unitsToKill, bridge, m_battleSite, !attacker);
     }
   }
 
@@ -1839,7 +1839,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     }
   }
 
-  private void defendNonSubs(final IDelegateBridge bridge) {
+  private void defendNonSubs() {
     if (m_attackingUnits.size() == 0) {
       return;
     }
@@ -1858,11 +1858,11 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_attackingUnits);
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_attackingWaitingToDie);
     fire(m_attacker.getName() + SELECT_CASUALTIES, units, m_attackingUnits, allEnemyUnitsAliveOrWaitingToDie, true,
-        ReturnFire.ALL, bridge, "Defenders fire, ");
+        ReturnFire.ALL, "Defenders fire, ");
   }
 
   // If there are no attacking DDs but defending SUBs, fire AIR at non-SUB forces ONLY
-  private void attackAirOnNonSubs(final IDelegateBridge bridge) {
+  private void attackAirOnNonSubs() {
     if (m_defendingUnits.size() == 0) {
       return;
     }
@@ -1880,7 +1880,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
       allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingUnits);
       allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingWaitingToDie);
       fire(m_defender.getName() + SELECT_CASUALTIES, units, enemyUnitsNotSubs, allEnemyUnitsAliveOrWaitingToDie, false,
-          ReturnFire.ALL, bridge, "Attacker's aircraft fire,");
+          ReturnFire.ALL, "Attacker's aircraft fire,");
     }
   }
 
@@ -1889,7 +1889,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
         && Match.noneMatch(firing, Matches.UnitIsDestroyer));
   }
 
-  private void defendAirOnNonSubs(final IDelegateBridge bridge) {
+  private void defendAirOnNonSubs() {
     if (m_attackingUnits.size() == 0) {
       return;
     }
@@ -1907,13 +1907,13 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
       allEnemyUnitsAliveOrWaitingToDie.addAll(m_attackingUnits);
       allEnemyUnitsAliveOrWaitingToDie.addAll(m_attackingWaitingToDie);
       fire(m_attacker.getName() + SELECT_CASUALTIES, units, enemyUnitsNotSubs, allEnemyUnitsAliveOrWaitingToDie, true,
-          ReturnFire.ALL, bridge, "Defender's aircraft fire,");
+          ReturnFire.ALL, "Defender's aircraft fire,");
     }
   }
 
   // If there are no attacking DDs, but defending SUBs, remove attacking AIR as they've already fired- otherwise fire
   // all attackers.
-  private void attackNonSubs(final IDelegateBridge bridge) {
+  private void attackNonSubs() {
     if (m_defendingUnits.size() == 0) {
       return;
     }
@@ -1934,10 +1934,10 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingUnits);
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingWaitingToDie);
     fire(m_defender.getName() + SELECT_CASUALTIES, units, m_defendingUnits, allEnemyUnitsAliveOrWaitingToDie, false,
-        ReturnFire.ALL, bridge, "Attackers fire,");
+        ReturnFire.ALL, "Attackers fire,");
   }
 
-  private void attackSubs(final IDelegateBridge bridge, final ReturnFire returnFire) {
+  private void attackSubs(final ReturnFire returnFire) {
     final Collection<Unit> firing = Match.getMatches(m_attackingUnits, Matches.UnitIsSub);
     if (firing.isEmpty()) {
       return;
@@ -1948,10 +1948,10 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingUnits);
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingWaitingToDie);
     fire(m_defender.getName() + SELECT_SUB_CASUALTIES, firing, attacked, allEnemyUnitsAliveOrWaitingToDie, false,
-        returnFire, bridge, "Subs fire,");
+        returnFire, "Subs fire,");
   }
 
-  private void defendSubs(final IDelegateBridge bridge, final ReturnFire returnFire) {
+  private void defendSubs(final ReturnFire returnFire) {
     if (m_attackingUnits.size() == 0) {
       return;
     }
@@ -1970,7 +1970,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_attackingUnits);
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_attackingWaitingToDie);
     fire(m_attacker.getName() + SELECT_SUB_CASUALTIES, firing, attacked, allEnemyUnitsAliveOrWaitingToDie, true,
-        returnFire, bridge, "Subs defend, ");
+        returnFire, "Subs defend, ");
   }
 
   void removeCasualties(final Collection<Unit> killed, final ReturnFire returnFire, final boolean defender,
@@ -1992,9 +1992,9 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
       } else {
         m_attackingWaitingToDie.addAll(Match.getMatches(killed, Matches.UnitIsSub));
       }
-      remove(Match.getMatches(killed, Matches.UnitIsNotSub), bridge, m_battleSite, isAA, defender);
+      remove(Match.getMatches(killed, Matches.UnitIsNotSub), bridge, m_battleSite, defender);
     } else if (returnFire == ReturnFire.NONE) {
-      remove(killed, bridge, m_battleSite, isAA, defender);
+      remove(killed, bridge, m_battleSite, defender);
     }
     // remove from the active fighting
     if (defender) {
@@ -2029,11 +2029,11 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
       allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingUnits);
       allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingWaitingToDie);
       fire(SELECT_NAVAL_BOMBARDMENT_CASUALTIES, bombard, attacked, allEnemyUnitsAliveOrWaitingToDie, false,
-          canReturnFire ? ReturnFire.ALL : ReturnFire.NONE, bridge, "Bombard");
+          canReturnFire ? ReturnFire.ALL : ReturnFire.NONE, "Bombard");
     }
   }
 
-  private void fireSuicideUnitsAttack(final IDelegateBridge bridge) {
+  private void fireSuicideUnitsAttack() {
     // TODO: add a global toggle for returning fire (Veqryn)
     final CompositeMatch<Unit> attackableUnits = new CompositeMatchAnd<>(
         Matches.UnitIsNotInfrastructureAndNotCapturedOnEntering(m_attacker, m_battleSite, m_data),
@@ -2058,11 +2058,11 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingUnits);
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingWaitingToDie);
     fire(m_defender.getName() + SELECT_CASUALTIES_SUICIDE, suicideAttackers, attackedDefenders,
-        allEnemyUnitsAliveOrWaitingToDie, false, canReturnFire ? ReturnFire.ALL : ReturnFire.NONE, bridge,
+        allEnemyUnitsAliveOrWaitingToDie, false, canReturnFire ? ReturnFire.ALL : ReturnFire.NONE,
         SUICIDE_ATTACK);
   }
 
-  private void fireSuicideUnitsDefend(final IDelegateBridge bridge) {
+  private void fireSuicideUnitsDefend() {
     if (isDefendingSuicideAndMunitionUnitsDoNotFire()) {
       return;
     }
@@ -2089,7 +2089,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_attackingUnits);
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_attackingWaitingToDie);
     fire(m_attacker.getName() + SELECT_CASUALTIES_SUICIDE, suicideDefenders, attackedAttackers,
-        allEnemyUnitsAliveOrWaitingToDie, true, canReturnFire ? ReturnFire.ALL : ReturnFire.NONE, bridge,
+        allEnemyUnitsAliveOrWaitingToDie, true, canReturnFire ? ReturnFire.ALL : ReturnFire.NONE,
         SUICIDE_DEFEND);
   }
 
@@ -2148,11 +2148,11 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     return m_amphibiousAttackFrom;
   }
 
-  private void fireOffensiveAAGuns(final IDelegateBridge bridge) {
+  private void fireOffensiveAAGuns() {
     m_stack.push(new FireAA(false));
   }
 
-  private void fireDefensiveAAGuns(final IDelegateBridge bridge) {
+  private void fireDefensiveAAGuns() {
     m_stack.push(new FireAA(true));
   }
 
@@ -2318,7 +2318,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
    *         combatants include such things as factories, aaguns, land units
    *         in a water battle.
    */
-  private List<Unit> removeNonCombatants(final Collection<Unit> units, final boolean attacking, final PlayerID player,
+  private List<Unit> removeNonCombatants(final Collection<Unit> units, final boolean attacking,
       final boolean doNotIncludeAA, final boolean doNotIncludeSeaBombardmentUnits, final boolean removeForNextRound) {
     final List<Unit> unitList = new ArrayList<>(units);
     if (m_battleSite.isWater()) {
@@ -2345,9 +2345,9 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
 
   private void removeNonCombatants(final IDelegateBridge bridge, final boolean doNotIncludeAA,
       final boolean doNotIncludeSeaBombardmentUnits, final boolean removeForNextRound) {
-    final List<Unit> notRemovedDefending = removeNonCombatants(m_defendingUnits, false, m_defender, doNotIncludeAA,
+    final List<Unit> notRemovedDefending = removeNonCombatants(m_defendingUnits, false, doNotIncludeAA,
         doNotIncludeSeaBombardmentUnits, removeForNextRound);
-    final List<Unit> notRemovedAttacking = removeNonCombatants(m_attackingUnits, true, m_attacker, doNotIncludeAA,
+    final List<Unit> notRemovedAttacking = removeNonCombatants(m_attackingUnits, true, doNotIncludeAA,
         doNotIncludeSeaBombardmentUnits, removeForNextRound);
     final Collection<Unit> toRemoveDefending = Util.difference(m_defendingUnits, notRemovedDefending);
     final Collection<Unit> toRemoveAttacking = Util.difference(m_attackingUnits, notRemovedAttacking);
@@ -2415,7 +2415,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
   }
 
   private void remove(final Collection<Unit> killed, final IDelegateBridge bridge, final Territory battleSite,
-      final boolean isAA, final Boolean defenderDying) {
+      final Boolean defenderDying) {
     if (killed.size() == 0) {
       return;
     }
@@ -2461,7 +2461,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
       if (landedTerritory == null) {
         throw new IllegalStateException("not unloaded?:" + units);
       }
-      remove(lost, bridge, landedTerritory, false, false);
+      remove(lost, bridge, landedTerritory, false);
     }
   }
 
@@ -2469,7 +2469,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     final Collection<Unit> units = new ArrayList<>();
     units.addAll(m_attackingWaitingToDie);
     units.addAll(m_defendingWaitingToDie);
-    remove(units, bridge, m_battleSite, false, null);
+    remove(units, bridge, m_battleSite, null);
     m_defendingWaitingToDie.clear();
     m_attackingWaitingToDie.clear();
   }
@@ -2504,7 +2504,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
       m_battleTracker.getBattleRecords().addResultToBattle(m_attacker, m_battleID, m_defender, m_attackerLostTUV,
           m_defenderLostTUV, m_battleResultDescription, new BattleResults(this, m_data));
     }
-    checkDefendingPlanesCanLand(bridge, m_defender);
+    checkDefendingPlanesCanLand();
     BattleTracker.captureOrDestroyUnits(m_battleSite, m_defender, m_defender, bridge, null);
     if (!m_headless) {
       bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_FAILURE, m_attacker);
@@ -2523,7 +2523,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
           m_defenderLostTUV, m_battleResultDescription, new BattleResults(this, m_data));
       bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_STALEMATE, m_attacker);
     }
-    checkDefendingPlanesCanLand(bridge, m_defender);
+    checkDefendingPlanesCanLand();
   }
 
   private void attackerWins(final IDelegateBridge bridge) {
@@ -2589,7 +2589,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
    * The defender has won, but there may be defending fighters that cant stay
    * in the sea zone due to insufficient carriers.
    */
-  private void checkDefendingPlanesCanLand(final IDelegateBridge bridge, final PlayerID defender) {
+  private void checkDefendingPlanesCanLand() {
     if (m_headless) {
       return;
     }
@@ -2765,7 +2765,7 @@ public class MustFightBattle extends AbstractBattle implements BattleStepStrings
     // previous battle's remove method
     lost = Match.getMatches(lost, Matches.unitIsInTerritory(m_battleSite));
     if (!withdrawn) {
-      remove(lost, bridge, m_battleSite, false, false);
+      remove(lost, bridge, m_battleSite, false);
     }
     if (m_attackingUnits.isEmpty()) {
       final IntegerMap<UnitType> costs = BattleCalculator.getCostsForTUV(m_attacker, m_data);

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -310,7 +310,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
         m_bridge.getPlayerID().getName() + " fails on action: " + MyFormatter.attachmentNameToText(paa.getName());
     m_bridge.getHistoryWriter().addChildToEvent(transcriptText);
     sendNotification(PoliticsText.getInstance().getNotificationFailure(paa.getText()));
-    notifyOtherPlayers(paa, PoliticsText.getInstance().getNotificationFailureOthers(paa.getText()));
+    notifyOtherPlayers(PoliticsText.getInstance().getNotificationFailureOthers(paa.getText()));
   }
 
   /**
@@ -321,14 +321,14 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   private void notifySuccess(final PoliticalActionAttachment paa) {
     getSoundChannel().playSoundForAll(SoundPath.CLIP_POLITICAL_ACTION_SUCCESSFUL, m_player);
     sendNotification(PoliticsText.getInstance().getNotificationSucccess(paa.getText()));
-    notifyOtherPlayers(paa, PoliticsText.getInstance().getNotificationSuccessOthers(paa.getText()));
+    notifyOtherPlayers(PoliticsText.getInstance().getNotificationSuccessOthers(paa.getText()));
   }
 
   /**
    * Send a notification to the other players involved in this action (all
    * players except the player starting the action)
    */
-  private void notifyOtherPlayers(final PoliticalActionAttachment paa, final String notification) {
+  private void notifyOtherPlayers(final String notification) {
     if (!"NONE".equals(notification)) {
       // we can send it to just paa.getOtherPlayers(), or we can send it to all players. both are good options.
       final Collection<PlayerID> currentPlayer = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -158,7 +158,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
    */
   @Override
   public String purchase(final IntegerMap<ProductionRule> productionRules) {
-    final IntegerMap<Resource> costs = getCosts(productionRules, m_player);
+    final IntegerMap<Resource> costs = getCosts(productionRules);
     final IntegerMap<NamedAttachable> results = getResults(productionRules);
     if (!(canAfford(costs, m_player))) {
       return NOT_ENOUGH_RESOURCES;
@@ -323,7 +323,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
     }
   };
 
-  private IntegerMap<Resource> getCosts(final IntegerMap<ProductionRule> productionRules, final PlayerID player) {
+  private IntegerMap<Resource> getCosts(final IntegerMap<ProductionRule> productionRules) {
     final IntegerMap<Resource> costs = new IntegerMap<>();
     final Iterator<ProductionRule> rules = productionRules.keySet().iterator();
     while (rules.hasNext()) {

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -101,7 +101,7 @@ public class RocketsFireHelper {
         continue;
       }
       // Ask the user where each rocket launcher should target.
-      final Territory target = getTarget(targets, player, bridge, territory);
+      final Territory target = getTarget(targets, bridge, territory);
       if (target != null) {
         attackedTerritories.add(target);
         attackingFromTerritories.put(target,territory);
@@ -124,7 +124,7 @@ public class RocketsFireHelper {
       bridge.getHistoryWriter().startEvent(player.getName() + " has no targets to attack with rockets");
       return;
     }
-    final Territory attacked = getTarget(targets, player, bridge, null);
+    final Territory attacked = getTarget(targets, bridge, null);
 
     if (attacked != null) {
       fireRocket(player, attacked, bridge, null);
@@ -174,7 +174,7 @@ public class RocketsFireHelper {
     return hasFactory;
   }
 
-  private Territory getTarget(final Collection<Territory> targets, final PlayerID player, final IDelegateBridge bridge,
+  private Territory getTarget(final Collection<Territory> targets, final IDelegateBridge bridge,
       final Territory from) {
     // ask even if there is only once choice, that will allow the user to not attack if he doesn't want to
     return ((ITripleAPlayer) bridge.getRemotePlayer()).whereShouldRocketsAttack(targets, from);

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -204,7 +204,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
       return result.setErrorReturnResult("Destination Is Out Of Range");
     }
     final Collection<PlayerID> alliesForBases = data.getRelationshipTracker().getAllies(player, true);
-    final Match<Unit> airborneBaseMatch = getAirborneMatch(player, airborneBases, alliesForBases);
+    final Match<Unit> airborneBaseMatch = getAirborneMatch(airborneBases, alliesForBases);
     final Territory start = route.getStart();
     final Territory end = route.getEnd();
     final Collection<Unit> basesAtStart = start.getUnits().getMatches(airborneBaseMatch);
@@ -287,12 +287,11 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   }
 
   private static Match<Unit> getAirborneBaseMatch(final PlayerID player, final GameData data) {
-    return getAirborneMatch(player, TechAbilityAttachment.getAirborneBases(player, data),
+    return getAirborneMatch(TechAbilityAttachment.getAirborneBases(player, data),
         data.getRelationshipTracker().getAllies(player, true));
   }
 
-  private static Match<Unit> getAirborneMatch(final PlayerID player, final Set<UnitType> types,
-      final Collection<PlayerID> unitOwners) {
+  private static Match<Unit> getAirborneMatch(final Set<UnitType> types, final Collection<PlayerID> unitOwners) {
     return new CompositeMatchAnd<>(Matches.unitIsOwnedByOfAnyOfThesePlayers(unitOwners),
         Matches.unitIsOfTypes(types), Matches.UnitIsNotDisabled, Matches.unitHasNotMoved,
         Matches.UnitIsAirborne.invert());
@@ -334,7 +333,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     final GameMap map = data.getMap();
     final Collection<PlayerID> alliesForBases = data.getRelationshipTracker().getAllies(player, true);
     final Collection<Territory> territoriesWeCanLaunchFrom = Match.getMatches(map.getTerritories(),
-        Matches.territoryHasUnitsThatMatch(getAirborneMatch(player, airborneBases, alliesForBases)));
+        Matches.territoryHasUnitsThatMatch(getAirborneMatch(airborneBases, alliesForBases)));
 
     return !territoriesWeCanLaunchFrom.isEmpty();
   }

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -418,7 +418,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              removeAAHits(bridge, m_dice, m_casualties, currentTypeAA);
+              removeAAHits(bridge, m_casualties, currentTypeAA);
             }
           }
         };
@@ -519,7 +519,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     }
   }
 
-  private void removeAAHits(final IDelegateBridge bridge, final DiceRoll dice, final CasualtyDetails casualties,
+  private void removeAAHits(final IDelegateBridge bridge, final CasualtyDetails casualties,
       final String currentTypeAA) {
     final List<Unit> killed = casualties.getKilled();
     if (!killed.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -232,14 +232,13 @@ public final class TileImageFactory {
   private Image loadImage(final URL imageLocation, final String fileName, final boolean transparent,
       final boolean cache, final boolean scale) {
     if (s_showMapBlends && s_showReliefImages && transparent) {
-      return loadBlendedImage(imageLocation, fileName, transparent, cache, scale);
+      return loadBlendedImage(fileName, cache, scale);
     } else {
       return loadUnblendedImage(imageLocation, fileName, transparent, cache, scale);
     }
   }
 
-  private Image loadBlendedImage(final URL imageLocation, final String fileName, final boolean transparent,
-      final boolean cache, final boolean scale) {
+  private Image loadBlendedImage(final String fileName, final boolean cache, final boolean scale) {
     BufferedImage reliefFile = null;
     BufferedImage baseFile = null;
     // The relief tile

--- a/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -111,7 +111,7 @@ public class UnitImageFactory {
   public Optional<Image> getImage(final UnitType type, final PlayerID player, final GameData data,
       final boolean damaged,
       final boolean disabled) {
-    final String baseName = getBaseImageName(type, player, data, damaged, disabled);
+    final String baseName = getBaseImageName(type, player, damaged, disabled);
     final String fullName = baseName + player.getName();
     if (m_images.containsKey(fullName)) {
       return Optional.of(m_images.get(fullName));
@@ -187,7 +187,7 @@ public class UnitImageFactory {
   public Optional<ImageIcon> getIcon(final UnitType type, final PlayerID player, final GameData data,
       final boolean damaged,
       final boolean disabled) {
-    final String baseName = getBaseImageName(type, player, data, damaged, disabled);
+    final String baseName = getBaseImageName(type, player, damaged, disabled);
     final String fullName = baseName + player.getName();
     if (m_icons.containsKey(fullName)) {
       return Optional.of(m_icons.get(fullName));
@@ -202,8 +202,8 @@ public class UnitImageFactory {
     return Optional.of(icon);
   }
 
-  private static String getBaseImageName(final UnitType type, final PlayerID id, final GameData data,
-      final boolean damaged, final boolean disabled) {
+  private static String getBaseImageName(final UnitType type, final PlayerID id, final boolean damaged,
+      final boolean disabled) {
     StringBuilder name = new StringBuilder(32);
     name.append(type.getName());
     if (!type.getName().endsWith("_hit") && !type.getName().endsWith("_disabled")) {

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -120,7 +120,7 @@ public class EditPanel extends ActionPanel {
         m_currentAction = this;
         setWidgetActivation();
         final List<Unit> allUnits = new ArrayList<>(m_selectedTerritory.getUnits().getUnits());
-        sortUnitsToRemove(allUnits, m_selectedTerritory);
+        sortUnitsToRemove(allUnits);
         final MustMoveWithDetails mustMoveWithDetails;
         try {
           getData().acquireReadLock();
@@ -368,7 +368,7 @@ public class EditPanel extends ActionPanel {
           CANCEL_EDIT_ACTION.actionPerformed(null);
           return;
         }
-        sortUnitsToRemove(units, m_selectedTerritory);
+        sortUnitsToRemove(units);
         Collections.sort(units, new UnitBattleComparator(false,
             BattleCalculator.getCostsForTuvForAllPlayersMergedAndAveraged(getData()), null, getData(), true, false));
         Collections.reverse(units);
@@ -414,7 +414,7 @@ public class EditPanel extends ActionPanel {
           CANCEL_EDIT_ACTION.actionPerformed(null);
           return;
         }
-        sortUnitsToRemove(units, m_selectedTerritory);
+        sortUnitsToRemove(units);
         Collections.sort(units, new UnitBattleComparator(false,
             BattleCalculator.getCostsForTuvForAllPlayersMergedAndAveraged(getData()), null, getData(), true, false));
         Collections.reverse(units);
@@ -530,8 +530,7 @@ public class EditPanel extends ActionPanel {
     setWidgetActivation();
   }
 
-  private void sortUnitsToRemove(final List<Unit> units,
-      /* final MustMoveWithDetails mustMoveWith, */final Territory territory) {
+  private void sortUnitsToRemove(final List<Unit> units) {
     if (units.isEmpty()) {
       return;
     }

--- a/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -274,7 +274,7 @@ public class TileManager {
       drawing.add(m_territoryOverlays.get(territory.getName()));
     }
     if (m_uiContext.getShowTerritoryEffects()) {
-      drawTerritoryEffects(territory, data, mapData, drawnOn, drawing);
+      drawTerritoryEffects(territory, mapData, drawing);
     }
     if (m_uiContext.getShowUnits()) {
       drawUnits(territory, mapData, drawnOn, drawing);
@@ -327,8 +327,7 @@ public class TileManager {
     m_territoryTiles.put(territory.getName(), drawnOn);
   }
 
-  private void drawTerritoryEffects(final Territory territory, final GameData data, final MapData mapData,
-      final Set<Tile> drawnOn, final Set<IDrawable> drawing) {
+  private void drawTerritoryEffects(final Territory territory, final MapData mapData, final Set<IDrawable> drawing) {
     final Iterator<Point> effectPoints = mapData.getTerritoryEffectPoints(territory).iterator();
     Point drawingPoint = effectPoints.next();
     for (final TerritoryEffect te : TerritoryEffectHelper.getEffects(territory)) {

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -111,10 +111,10 @@ public class UnitsDrawer implements IDrawable {
             graphics.drawImage(flag, (placementPoint.x - bounds.x) + xoffset, (placementPoint.y - bounds.y) + yoffset,
                 null);
           }
-          drawUnit(graphics, img.get(), placementPoint, bounds);
+          drawUnit(graphics, img.get(), bounds);
           break;
         case NEXT_TO:
-          drawUnit(graphics, img.get(), placementPoint, bounds);
+          drawUnit(graphics, img.get(), bounds);
           // If unit is not in the "excluded list" it will get drawn
           if (maxRange != 0) {
             final Image flag = uiContext.getFlagImageFactory().getSmallFlag(owner);
@@ -133,7 +133,7 @@ public class UnitsDrawer implements IDrawable {
       }
     } else {
       if (img.isPresent()) {
-        drawUnit(graphics, img.get(), placementPoint, bounds);
+        drawUnit(graphics, img.get(), bounds);
       }
     }
     // more then 1 unit of this category
@@ -190,8 +190,7 @@ public class UnitsDrawer implements IDrawable {
   /**
    * This draws the given image onto the given graphics object
    */
-  private void drawUnit(final Graphics2D graphics, final Image image, final Point placementPoint2,
-      final Rectangle bounds) {
+  private void drawUnit(final Graphics2D graphics, final Image image, final Rectangle bounds) {
     graphics.drawImage(image, placementPoint.x - bounds.x, placementPoint.y - bounds.y, null);
   }
 

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -265,7 +265,8 @@ public class DecorationPlacer extends JFrame {
     imagePanel.addMouseListener(new MouseAdapter() {
       @Override
       public void mouseClicked(final MouseEvent e) {
-        mouseEvent(e.getPoint(), e.isControlDown() || e.isShiftDown(), SwingUtilities.isRightMouseButton(e));
+        final Point point = e.getPoint();
+        mouseEvent(e.isControlDown() || e.isShiftDown(), SwingUtilities.isRightMouseButton(e));
       }
     });
     // set up the image panel size dimensions ...etc
@@ -677,16 +678,14 @@ public class DecorationPlacer extends JFrame {
   }
 
   /**
-   * mouseEvent(java.awt.Point, java.lang.boolean, java.lang.boolean)
+   * mouseEvent(java.lang.boolean, java.lang.boolean)
    *
-   * @param java
-   *        .awt.Point point a point clicked by mouse
    * @param java
    *        .lang.boolean ctrlDown true if ctrl key was hit
    * @param java
    *        .lang.boolean rightMouse true if the right mouse button was hit
    */
-  private void mouseEvent(final Point point, final boolean ctrlDown, final boolean rightMouse) {
+  private void mouseEvent(final boolean ctrlDown, final boolean rightMouse) {
     if (s_cheapMutex) {
       return;
     }


### PR DESCRIPTION
This PR removes unused parameters from private methods.

I've been wading into some of the core domain logic to try to better understand game mechanics.  My motivation for these changes was to remove some of the noise that was making it difficult for me to concentrate on the relevant bits.  After removing some unused parameters in the code I was focusing on, it seemed like a good idea to just plow ahead and extend the refactoring to all private methods.

#### Functional changes
None.

#### Refactoring changes
* Removed unused parameters from the vast majority of private methods (see below for exceptions) and updated all affected call sites.
* Some methods are called via reflection (e.g. serialization hooks such as `readObject(ObjectInputStream)`) and the unused parameters must not be removed to ensure the method signature remains as expected by the runtime.  In those cases, the unused parameters were annotated with `@SuppressWarnings("unused")`.

#### Refactoring issues for review
* This looks like a large PR due to the number of files modified.  However, because only private methods were refactored, each file can be reviewed independently.  That should hopefully keep the cognitive load down for the reviewers.  If anyone feels the PR is still too large, I'm open to breaking it up into multiple, smaller PRs (or to reject some changes outright if it's felt they are too risky or just not productive).
* To ensure these refactorings were safe, all possible side effects were preserved.  This resulted in the introduction of four unused local variables at some call sites.  I believe each of those locals can actually be removed, as I could not identify any side effects in the corresponding calls.  However, to keep this PR straightforward, I chose to leave them in for now; a future PR can focus on removing them.
* I think I captured all the arguments that had possible side effects (as documented in the previous bullet), but I may have missed some.  **Reviewers should flag any call arguments that were removed that are not just simple variable references.**
* **Reviewers should flag any methods that may be invoked via reflection that I didn't realize were done so.**