### PR TITLE
Checkstyle: Convert tabs to spaces

### DIFF
--- a/src/main/java/games/strategy/engine/data/Unit.java
+++ b/src/main/java/games/strategy/engine/data/Unit.java
@@ -38,9 +38,9 @@ public class Unit extends GameDataComponent {
   public PlayerID getOwner() {
     return m_owner;
   }
-  
+
   public UnitAttachment getUnitAttachment() {
-  	return (UnitAttachment) m_type.getAttachment("unitAttachment");
+    return (UnitAttachment) m_type.getAttachment("unitAttachment");
   }
 
   /**

--- a/src/main/java/games/strategy/util/LocalizeHTML.java
+++ b/src/main/java/games/strategy/util/LocalizeHTML.java
@@ -39,11 +39,11 @@ public class LocalizeHTML {
    * href # follow by "href" word
    * \s*=\s* # allows spaces on either side of the equal sign,
    * ( # start of group #1
-   * "([^"]*")						#						allow string with double quotes enclosed - "string"
+   * "([^"]*") # allow string with double quotes enclosed - "string"
    * | # ..or
    * '[^']*' # allow string with single quotes enclosed - 'string'
    * | # ..or
-   * ([^'">]+)		#						can't contains one single quotes, double quotes ">"
+   * ([^'">]+) # can't contains one single quotes, double quotes ">"
    * ) # end of group #1
    */
   public static final String PATTERN_HTML_A_HREF_TAG = "\\s*(?i)href\\s*=\\s*(\"([^\"]*\")|'[^']*'|([^'\">\\s]+))";

--- a/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
@@ -30,53 +30,53 @@ import static org.mockito.Mockito.when;
 public class BattleTrackerTest {
 
 
-	@Mock
-	private IDelegateBridge mockDelegateBridge;
-	@Mock
-	private GameData mockGameData;
-	@Mock
-	private GameProperties mockGameProperties;
-	@Mock
-	private RelationshipTracker mockRelationshipTracker;
-	@Mock
-	private BiFunction<Territory, IBattle.BattleType, IBattle> mockGetBattleFunction;
-	@Mock
-	private IBattle mockBattle;
+  @Mock
+  private IDelegateBridge mockDelegateBridge;
+  @Mock
+  private GameData mockGameData;
+  @Mock
+  private GameProperties mockGameProperties;
+  @Mock
+  private RelationshipTracker mockRelationshipTracker;
+  @Mock
+  private BiFunction<Territory, IBattle.BattleType, IBattle> mockGetBattleFunction;
+  @Mock
+  private IBattle mockBattle;
 
-	private BattleTracker testObj;
+  private BattleTracker testObj;
 
-	@Before
-	public void setup() {
-		testObj = new BattleTracker();
-	}
+  @Before
+  public void setup() {
+    testObj = new BattleTracker();
+  }
 
-	@Test
-	public void verifyRaidsWithNoBattles() {
-		testObj.fightAirRaidsAndStrategicBombing(mockDelegateBridge);
-	}
+  @Test
+  public void verifyRaidsWithNoBattles() {
+    testObj.fightAirRaidsAndStrategicBombing(mockDelegateBridge);
+  }
 
-	@Test
-	public void verifyRaids() {
-		Territory territory = new Territory("terrName", mockGameData);
-		Route route = new Route(territory);
-		PlayerID playerId = new PlayerID("name", mockGameData);
+  @Test
+  public void verifyRaids() {
+    Territory territory = new Territory("terrName", mockGameData);
+    Route route = new Route(territory);
+    PlayerID playerId = new PlayerID("name", mockGameData);
 
-		// need at least one attacker for there to be considered a battle.
-		Unit unit = new TripleAUnit(new UnitType("unit", mockGameData), playerId, mockGameData);
-		List<Unit> attackers = Collections.singletonList(unit);
+    // need at least one attacker for there to be considered a battle.
+    Unit unit = new TripleAUnit(new UnitType("unit", mockGameData), playerId, mockGameData);
+    List<Unit> attackers = Collections.singletonList(unit);
 
-		when(mockDelegateBridge.getData()).thenReturn(mockGameData);
-		when(mockGameData.getProperties()).thenReturn(mockGameProperties);
-		when(mockGameData.getRelationshipTracker()).thenReturn(mockRelationshipTracker);
-		when(mockGameProperties.get(Constants.RAIDS_MAY_BE_PRECEEDED_BY_AIR_BATTLES, false))
-			.thenReturn(true);
-		when(mockGetBattleFunction.apply(territory, IBattle.BattleType.BOMBING_RAID)).thenReturn(mockBattle);
+    when(mockDelegateBridge.getData()).thenReturn(mockGameData);
+    when(mockGameData.getProperties()).thenReturn(mockGameProperties);
+    when(mockGameData.getRelationshipTracker()).thenReturn(mockRelationshipTracker);
+    when(mockGameProperties.get(Constants.RAIDS_MAY_BE_PRECEEDED_BY_AIR_BATTLES, false))
+        .thenReturn(true);
+    when(mockGetBattleFunction.apply(territory, IBattle.BattleType.BOMBING_RAID)).thenReturn(mockBattle);
 
-		// set up the testObj to have the bombing battle
-		testObj.addBombingBattle(route, attackers, playerId, mockDelegateBridge, null, null);
+    // set up the testObj to have the bombing battle
+    testObj.addBombingBattle(route, attackers, playerId, mockDelegateBridge, null, null);
 
-		testObj.fightAirRaidsAndStrategicBombing(mockDelegateBridge, () -> Collections.singleton(territory), mockGetBattleFunction);
+    testObj.fightAirRaidsAndStrategicBombing(mockDelegateBridge, () -> Collections.singleton(territory), mockGetBattleFunction);
 
-		verify(mockBattle, times(1)).fight(mockDelegateBridge);
-	}
+    verify(mockBattle, times(1)).fight(mockDelegateBridge);
+  }
 }

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -82,23 +82,23 @@ public class GameDataTestUtil {
 
   // Some units hard coded here rather than placed in Constants at the request of community members Ref: Pull Request 1074
   public static UnitType tacBomber(final GameData data) {
-    return unitType("tactical_bomber", data);			
+    return unitType("tactical_bomber", data);
   }
 
   public static UnitType airbase(final GameData data) {
-    return unitType("airbase", data);			
+    return unitType("airbase", data);
   }
 
   public static UnitType harbour(final GameData data) {
-    return unitType("harbour", data);			
+    return unitType("harbour", data);
   }
 
   public static UnitType factoryMajor(final GameData data) {
-    return unitType("factory_major", data);			
+    return unitType("factory_major", data);
   }
 
   public static UnitType factoryMinor(final GameData data) {
-    return unitType("factory_minor", data);			
+    return unitType("factory_minor", data);
   }
 
   public static UnitType fighter(final GameData data) {

--- a/src/test/resources/DelegateTest.xml
+++ b/src/test/resources/DelegateTest.xml
@@ -3,1381 +3,1381 @@
 
 <game>
 
-	<info name="delegateTest" version="1" />
-	
+    <info name="delegateTest" version="1" />
+
     <loader javaClass="games.strategy.triplea.TripleA"/>
 
-	
-	<map>
-	    <territory name="Afghanistan"/>
-	    <territory name="Alaska"/>
-	    <territory name="Algeria"/>
-	    <territory name="Anglo Sudan Egypt"/>
-	    <territory name="Angola"/>
-	    <territory name="Argentina-Chile"/>
-	    <territory name="Australia"/>
-	    <territory name="Borneo Celebes"/>
-	    <territory name="Brazil"/>
-	    <territory name="Caroline Islands"/>
-	    <territory name="Caucasus"/>
-	    <territory name="China"/>
-	    <territory name="Columbia"/>
-	    <territory name="Congo"/>
-	    <territory name="Cuba"/>
-	    <territory name="East Indies"/>
-	    <territory name="East Canada"/>
-	    <territory name="East Europe"/>
-	    <territory name="East US"/>
-	    <territory name="Eire"/>
-	    <territory name="Evenki National Okrug"/>
-	    <territory name="Finland Norway"/>
-	    <territory name="French Equatorial Africa"/>
-	    <territory name="French Indo China"/>
-	    <territory name="French West Africa"/>
-	    <territory name="Germany"/>
-	    <territory name="Gibraltar"/>
-	    <territory name="Hawaiian Islands"/>
-	    <territory name="India"/>
-	    <territory name="Italian East Africa"/>
-	    <territory name="Japan"/>
-	    <territory name="Karelia S.S.R."/>
-	    <territory name="Kazakh S.S.R."/>
-	    <territory name="Kenya-Rhodesia"/>
-	    <territory name="Kwangtung"/>
-	    <territory name="Libya"/>
-	    <territory name="Madagascar"/>
-	    <territory name="Manchuria"/>
-	    <territory name="Mexico"/>
-	    <territory name="Midway"/>
-	    <territory name="Mongolia"/>
-	    <territory name="Mozambique"/>
-	    <territory name="New Guinea"/>
-	    <territory name="New Zealand"/>
-	    <territory name="Novosibirsk"/>
-	    <territory name="Okinawa"/>
-	    <territory name="Panama"/>
-	    <territory name="Persia"/>
-	    <territory name="Peru"/>
-	    <territory name="Philippines"/>
-	    <territory name="Rio del Oro"/>
-	    <territory name="Russia"/>
-	    <territory name="Saudi Arabia"/>
-	    <territory name="Sinkiang"/>
-	    <territory name="Solomon Islands"/>
-	    <territory name="South Africa"/>
-	    <territory name="South Europe"/>
-	    <territory name="Soviet Far East"/>
-	    <territory name="Spain"/>
-	    <territory name="Sweden"/>
-	    <territory name="Switzerland"/>
-	    <territory name="Syria Jordan"/>
-	    <territory name="Turkey"/>
-	    <territory name="Ukraine S.S.R."/>
-	    <territory name="United Kingdom"/>
-	    <territory name="Wake Island"/>
-	    <territory name="West Canada"/>
-	    <territory name="West Europe"/>
-	    <territory name="West US"/>
-	    <territory name="Yakut S.S.R."/>
-	    <territory name="Yunnan"/>
-	    <territory name="Alaska Sea Zone" water="true" />
-	    <territory name="Angola Sea Zone" water="true" />
-	    <territory name="Antartic Sea Zone" water="true" />
-	    <territory name="Baltic Sea Zone" water="true" />
-	    <territory name="Black Sea Zone" water="true" />
-	    <territory name="Borneo Sea Zone" water="true" />
-	    <territory name="Carribean Sea Zone" water="true" />
-	    <territory name="Caroline Islands Sea Zone" water="true" />
-	    <territory name="Caspian Sea Zone" water="true" />
-	    <territory name="Central Mediteranean Sea Zone" water="true" />
-	    <territory name="Congo Sea Zone" water="true" />
-	    <territory name="East Argentina Sea Zone" water="true" />
-	    <territory name="East Compass Sea Zone" water="true" />
-	    <territory name="East Indies Sea Zone" water="true" />
-	    <territory name="East Canada Sea Zone" water="true" />
-	    <territory name="East Mediteranean Sea Zone" water="true" />
-	    <territory name="East Pacific Sea Zone" water="true" />
-	    <territory name="East US Sea Zone" water="true" />
-	    <territory name="French Indo China Sea Zone" water="true" />
-	    <territory name="Hawaii Sea Zone" water="true" />
-	    <territory name="Indian Ocean Sea Zone" water="true" />
-	    <territory name="Japan Sea Zone" water="true" />
-	    <territory name="Karelia Sea Zone" water="true" />
-	    <territory name="Kwangtung Sea Zone" water="true" />
-	    <territory name="Mexico Sea Zone" water="true" />
-	    <territory name="Midway Sea Zone" water="true" />
-	    <territory name="Mozambique Sea Zone" water="true" />
-	    <territory name="New Guinea Sea Zone" water="true" />
-	    <territory name="New Zealand Sea Zone" water="true" />
-	    <territory name="North Australia Sea Zone" water="true" />
-	    <territory name="North Brazil Sea Zone" water="true" />
-	    <territory name="North Sea Zone" water="true" />
-	    <territory name="North Atlantic Sea Zone" water="true" />
-	    <territory name="North Pacific Sea Zone" water="true" />
-	    <territory name="Okinawa Sea Zone" water="true" />
-	    <territory name="Peru Sea Zone" water="true" />
-	    <territory name="Philippines Sea Zone" water="true" />
-	    <territory name="Red Sea Zone" water="true" />
-	    <territory name="Solomon Islands Sea Zone" water="true" />
-	    <territory name="South Africa Sea Zone" water="true" />
-	    <territory name="South Argentina Sea Zone" water="true" />
-	    <territory name="South Australia Sea Zone" water="true" />
-	    <territory name="South Brazil Sea Zone" water="true" />
-	    <territory name="South Compass Sea Zone" water="true" />
-	    <territory name="South East Madagascar Sea Zone" water="true" />
-	    <territory name="South Pacific Sea Zone" water="true"/>
-	    <territory name="South Atlantic Sea Zone" water="true" />
-	    <territory name="Soviet Far East Sea Zone" water="true" />
-	    <territory name="Wake Island Sea Zone" water="true" />
-	    <territory name="West Africa Sea Zone" water="true" />
-	    <territory name="West Compass Sea Zone" water="true" />
-	    <territory name="West Australia Sea Zone" water="true" />
-	    <territory name="West Canada Sea Zone" water="true" />
-	    <territory name="West Mediteranean Sea Zone" water="true" />
-	    <territory name="West Panama Sea Zone" water="true" />
-	    <territory name="West Spain Sea Zone" water="true" />
-	    <territory name="West US Sea Zone" water="true" />
-	    <connection t1="East Canada Sea Zone" t2="East Canada" />
-	    <connection t1="East Canada Sea Zone" t2="North Sea Zone" />
-	    <connection t1="West Spain Sea Zone" t2="East Canada Sea Zone" />
-	    <connection t1="North Atlantic Sea Zone" t2="East Canada Sea Zone" />
-	    <connection t1="East Canada Sea Zone" t2="East US Sea Zone" />
-	    <connection t1="East Canada Sea Zone" t2="West Canada" />
-	    <connection t1="East Canada" t2="East US" />
-	    <connection t1="East US" t2="East US Sea Zone" />
-	    <connection t1="Carribean Sea Zone" t2="East US Sea Zone" />
-	    <connection t1="Carribean Sea Zone" t2="North Atlantic Sea Zone" />
-	    <connection t1="Carribean Sea Zone" t2="North Brazil Sea Zone" />
-	    <connection t1="Carribean Sea Zone" t2="Columbia" />
-	    <connection t1="Carribean Sea Zone" t2="Panama" />
-	    <connection t1="Carribean Sea Zone" t2="Cuba" />
-	    <connection t1="Columbia" t2="Panama" />
-	    <connection t1="Columbia" t2="West Panama Sea Zone" />
-	    <connection t1="Panama" t2="West Panama Sea Zone" />
-	    <connection t1="Peru" t2="Peru Sea Zone" />
-	    <connection t1="Peru" t2="Brazil" />
-	    <connection t1="Peru" t2="Columbia" />
-	    <connection t1="Columbia" t2="Brazil" />
-	    <connection t1="West Panama Sea Zone" t2="Peru Sea Zone" />
-	    <connection t1="West Panama Sea Zone" t2="Carribean Sea Zone" />
-	    <connection t1="Peru" t2="Argentina-Chile" />
-	    <connection t1="Peru Sea Zone" t2="Argentina-Chile" />
-	    <connection t1="Peru Sea Zone" t2="South Argentina Sea Zone" />
-	    <connection t1="Argentina-Chile" t2="Brazil" />
-	    <connection t1="Argentina-Chile" t2="East Argentina Sea Zone" />
-	    <connection t1="Argentina-Chile" t2="South Argentina Sea Zone" />
-	    <connection t1="South Argentina Sea Zone" t2="East Argentina Sea Zone" />
-	    <connection t1="South Argentina Sea Zone" t2="South Atlantic Sea Zone" />
-	    <connection t1="East Argentina Sea Zone" t2="South Atlantic Sea Zone" />
-	    <connection t1="South Argentina Sea Zone" t2="Antartic Sea Zone" />
-	    <connection t1="East Argentina Sea Zone" t2="South Brazil Sea Zone" />
-	    <connection t1="South Brazil Sea Zone" t2="Brazil" />
-	    <connection t1="Brazil" t2="North Brazil Sea Zone" />
-	    <connection t1="South Brazil Sea Zone" t2="South Atlantic Sea Zone" />
-	    <connection t1="South Brazil Sea Zone" t2="West Africa Sea Zone" />
-	    <connection t1="South Brazil Sea Zone" t2="Congo Sea Zone" />
-	    <connection t1="South Brazil Sea Zone" t2="North Brazil Sea Zone" />
-	    <connection t1="North Brazil Sea Zone" t2="North Atlantic Sea Zone" />
-	    <connection t1="North Brazil Sea Zone" t2="West Africa Sea Zone" />
-	    <connection t1="North Atlantic Sea Zone" t2="West Africa Sea Zone" />
-	    <connection t1="North Atlantic Sea Zone" t2="West Spain Sea Zone" />
-	    <connection t1="North Atlantic Sea Zone" t2="East US Sea Zone" />
-	    <connection t1="Eire" t2="North Sea Zone" />
-	    <connection t1="United Kingdom" t2="North Sea Zone" />
-	    <connection t1="North Sea Zone" t2="West Spain Sea Zone" />
-	    <connection t1="North Sea Zone" t2="Karelia Sea Zone" />
-	    <connection t1="North Sea Zone" t2="West Europe" />
-	    <connection t1="North Sea Zone" t2="Finland Norway" />
-	    <connection t1="North Sea Zone" t2="Baltic Sea Zone" />
-	    <connection t1="West Spain Sea Zone" t2="West Mediteranean Sea Zone" />
-	    <connection t1="West Spain Sea Zone" t2="Spain" />
-	    <connection t1="West Spain Sea Zone" t2="West Europe" />
-	    <connection t1="West Spain Sea Zone" t2="Algeria" />
-	    <connection t1="West Spain Sea Zone" t2="West Africa Sea Zone" />
-	    <connection t1="West Africa Sea Zone" t2="Rio del Oro" />
-	    <connection t1="West Africa Sea Zone" t2="French West Africa" />
-	    <connection t1="West Africa Sea Zone" t2="Congo Sea Zone" />
-	    <connection t1="Congo Sea Zone" t2="South Atlantic Sea Zone" />
-	    <connection t1="Congo Sea Zone" t2="South Brazil Sea Zone" />
-	    <connection t1="Congo Sea Zone" t2="French Equatorial Africa" />
-	    <connection t1="Congo Sea Zone" t2="Congo" />
-	    <connection t1="Congo Sea Zone" t2="Angola Sea Zone" />
-	    <connection t1="South Atlantic Sea Zone" t2="Antartic Sea Zone" />
-	    <connection t1="South Atlantic Sea Zone" t2="Angola Sea Zone" />
-	    <connection t1="Angola Sea Zone" t2="South Africa" />
-	    <connection t1="Angola Sea Zone" t2="South Africa Sea Zone" />
-	    <connection t1="Angola Sea Zone" t2="Angola" />
-	    <connection t1="Angola Sea Zone" t2="Antartic Sea Zone" />
-	    <connection t1="Rio del Oro" t2="French West Africa" />
-	    <connection t1="French West Africa" t2="Algeria" />
-	    <connection t1="French West Africa" t2="French Equatorial Africa" />
-	    <connection t1="Algeria" t2="West Mediteranean Sea Zone" />
-	    <connection t1="Algeria" t2="Libya" />
-	    <connection t1="Algeria" t2="French Equatorial Africa" />
-	    <connection t1="Libya" t2="Central Mediteranean Sea Zone" />
-	    <connection t1="Libya" t2="French Equatorial Africa" />
-	    <connection t1="Libya" t2="Anglo Sudan Egypt" />
-	    <connection t1="Anglo Sudan Egypt" t2="East Mediteranean Sea Zone" />
-	    <connection t1="Anglo Sudan Egypt" t2="Red Sea Zone" />
-	    <connection t1="Anglo Sudan Egypt" t2="Italian East Africa" />
-	    <connection t1="Anglo Sudan Egypt" t2="French Equatorial Africa" />
-	    <connection t1="Anglo Sudan Egypt" t2="Congo" />
-	    <connection t1="Anglo Sudan Egypt" t2="Kenya-Rhodesia" />
-	    <connection t1="Italian East Africa" t2="Kenya-Rhodesia" />
-	    <connection t1="Italian East Africa" t2="Red Sea Zone" />
-	    <connection t1="French Equatorial Africa" t2="Congo" />
-	    <connection t1="Congo" t2="Angola" />
-	    <connection t1="Congo" t2="Kenya-Rhodesia" />
-	    <connection t1="Angola" t2="Kenya-Rhodesia" />
-	    <connection t1="Kenya-Rhodesia" t2="South Africa" />
-	    <connection t1="Angola" t2="South Africa" />
-	    <connection t1="South Africa" t2="Mozambique" />
-	    <connection t1="Mozambique" t2="Kenya-Rhodesia" />
-	    <connection t1="South Africa Sea Zone" t2="South East Madagascar Sea Zone" />
-	    <connection t1="South Africa" t2="South Africa Sea Zone" />
-	    <connection t1="South Africa" t2="Mozambique Sea Zone" />
-	    <connection t1="Mozambique" t2="Mozambique Sea Zone" />
-	    <connection t1="Kenya-Rhodesia" t2="Mozambique Sea Zone" />
-	    <connection t1="South Africa Sea Zone" t2="Madagascar" />
-	    <connection t1="South East Madagascar Sea Zone" t2="Madagascar" />
-	    <connection t1="Madagascar" t2="West Compass Sea Zone" />
-	    <connection t1="Madagascar" t2="Mozambique Sea Zone" />
-	    <connection t1="Gibraltar" t2="West Mediteranean Sea Zone" />
-	    <connection t1="Spain" t2="West Europe" />
-	    <connection t1="Spain" t2="West Mediteranean Sea Zone" />
-	    <connection t1="West Europe" t2="West Mediteranean Sea Zone" />
-	    <connection t1="West Europe" t2="Switzerland" />
-	    <connection t1="Switzerland" t2="Germany" />
-	    <connection t1="Switzerland" t2="South Europe" />
-	    <connection t1="Germany" t2="West Europe" />
-	    <connection t1="Karelia S.S.R." t2="Baltic Sea Zone" />
-	    <connection t1="Germany" t2="Baltic Sea Zone" />
-	    <connection t1="Germany" t2="South Europe" />
-	    <connection t1="Germany" t2="East Europe" />
-	    <connection t1="Finland Norway" t2="Sweden" />
-	    <connection t1="Finland Norway" t2="Karelia S.S.R." />
-	    <connection t1="Karelia S.S.R." t2="Karelia Sea Zone" />
-	    <connection t1="Baltic Sea Zone" t2="Sweden" />
-	    <connection t1="Baltic Sea Zone" t2="East Europe" />
-	    <connection t1="Baltic Sea Zone" t2="Finland Norway" />
-	    <connection t1="West Europe" t2="Baltic Sea Zone" />
-	    <connection t1="South Europe" t2="Central Mediteranean Sea Zone" />
-	    <connection t1="South Europe" t2="East Europe" />
-	    <connection t1="West Europe" t2="South Europe" />
-	    <connection t1="West Mediteranean Sea Zone" t2="Central Mediteranean Sea Zone" />
-	    <connection t1="Central Mediteranean Sea Zone" t2="East Mediteranean Sea Zone" />
-	    <connection t1="Central Mediteranean Sea Zone" t2="Black Sea Zone" />
-	    <connection t1="East Mediteranean Sea Zone" t2="Syria Jordan" />
-	    <connection t1="East Mediteranean Sea Zone" t2="Turkey" />
-	    <connection t1="Black Sea Zone" t2="Turkey" />
-	    <connection t1="Black Sea Zone" t2="Caucasus" />
-	    <connection t1="Black Sea Zone" t2="East Europe" />
-	    <connection t1="Black Sea Zone" t2="Ukraine S.S.R." />
-	    <connection t1="Black Sea Zone" t2="East Mediteranean Sea Zone" />
-	    <connection t1="Caspian Sea Zone" t2="Caucasus" />
-	    <connection t1="Caspian Sea Zone" t2="Kazakh S.S.R." />
-	    <connection t1="Caspian Sea Zone" t2="Persia" />
-	    <connection t1="Caspian Sea Zone" t2="Russia" />
-	    <connection t1="East Europe" t2="Ukraine S.S.R." />
-	    <connection t1="East Europe" t2="Karelia S.S.R." />
-	    <connection t1="Ukraine S.S.R." t2="Karelia S.S.R." />
-	    <connection t1="Ukraine S.S.R." t2="Caucasus" />
-	    <connection t1="Caucasus" t2="Karelia S.S.R." />
-	    <connection t1="Caucasus" t2="Russia" />
-	    <connection t1="Russia" t2="Kazakh S.S.R." />
-	    <connection t1="Russia" t2="Novosibirsk" />
-	    <connection t1="Russia" t2="Evenki National Okrug" />
-	    <connection t1="Karelia S.S.R." t2="Russia" />
-	    <connection t1="Gibraltar" t2="Spain" />
-	    <connection t1="Anglo Sudan Egypt" t2="Syria Jordan" />
-	    <connection t1="East Mediteranean Sea Zone" t2="Red Sea Zone" />
-	    <connection t1="Syria Jordan" t2="Red Sea Zone" />
-	    <connection t1="Saudi Arabia" t2="Red Sea Zone" />
-	    <connection t1="Saudi Arabia" t2="Syria Jordan" />
-	    <connection t1="Saudi Arabia" t2="Persia" />
-	    <connection t1="Syria Jordan" t2="Persia" />
-	    <connection t1="Syria Jordan" t2="Turkey" />
-	    <connection t1="Turkey" t2="Persia" />
-	    <connection t1="Caucasus" t2="Persia" />
-	    <connection t1="Turkey" t2="Caucasus" />
-	    <connection t1="Evenki National Okrug" t2="Yakut S.S.R." />
-	    <connection t1="Evenki National Okrug" t2="Novosibirsk" />
-	    <connection t1="Yakut S.S.R." t2="Soviet Far East" />
-	    <connection t1="Yakut S.S.R." t2="Manchuria" />
-	    <connection t1="Yakut S.S.R." t2="Mongolia" />
-	    <connection t1="Kazakh S.S.R." t2="Novosibirsk" />
-	    <connection t1="Kazakh S.S.R." t2="Persia" />
-	    <connection t1="Kazakh S.S.R." t2="Afghanistan" />
-	    <connection t1="Kazakh S.S.R." t2="Sinkiang" />
-	    <connection t1="Novosibirsk" t2="Mongolia" />
-	    <connection t1="Novosibirsk" t2="Sinkiang" />
-	    <connection t1="Novosibirsk" t2="Yakut S.S.R." />
-	    <connection t1="Soviet Far East" t2="Soviet Far East Sea Zone" />
-	    <connection t1="Soviet Far East" t2="Manchuria" />
-	    <connection t1="Mongolia" t2="Sinkiang" />
-	    <connection t1="Mongolia" t2="China" />
-	    <connection t1="Mongolia" t2="Manchuria" />
-	    <connection t1="Persia" t2="Afghanistan" />
-	    <connection t1="Afghanistan" t2="India" />
-	    <connection t1="Afghanistan" t2="Sinkiang" />
-	    <connection t1="Sinkiang" t2="India" />
-	    <connection t1="Sinkiang" t2="China" />
-	    <connection t1="Sinkiang" t2="French Indo China" />
-	    <connection t1="China" t2="French Indo China" />
-	    <connection t1="India" t2="Indian Ocean Sea Zone" />
-	    <connection t1="India" t2="French Indo China" />
-	    <connection t1="Manchuria" t2="Japan Sea Zone" />
-	    <connection t1="China" t2="Manchuria" />
-	    <connection t1="Manchuria" t2="Kwangtung" />
-	    <connection t1="China" t2="Kwangtung" />
-	    <connection t1="Kwangtung" t2="French Indo China" />
-	    <connection t1="Kwangtung" t2="Kwangtung Sea Zone" />
-	    <connection t1="French Indo China Sea Zone" t2="French Indo China" />
-	    <connection t1="Persia" t2="India" />
-	    <connection t1="Red Sea Zone" t2="Indian Ocean Sea Zone" />
-	    <connection t1="Red Sea Zone" t2="West Compass Sea Zone" />
-	    <connection t1="Mozambique Sea Zone" t2="Red Sea Zone" />
-	    <connection t1="Red Sea Zone" t2="Persia" />
-	    <connection t1="South Africa Sea Zone" t2="Mozambique Sea Zone" />
-	    <connection t1="South East Madagascar Sea Zone" t2="West Compass Sea Zone" />
-	    <connection t1="South East Madagascar Sea Zone" t2="South Compass Sea Zone" />
-	    <connection t1="West Compass Sea Zone" t2="Mozambique Sea Zone" />
-	    <connection t1="West Compass Sea Zone" t2="East Compass Sea Zone" />
-	    <connection t1="West Compass Sea Zone" t2="South Compass Sea Zone" />
-	    <connection t1="West Compass Sea Zone" t2="Indian Ocean Sea Zone" />
-	    <connection t1="East Compass Sea Zone" t2="Indian Ocean Sea Zone" />
-	    <connection t1="East Compass Sea Zone" t2="South Compass Sea Zone" />
-	    <connection t1="East Compass Sea Zone" t2="South Australia Sea Zone" />
-	    <connection t1="East Compass Sea Zone" t2="West Australia Sea Zone" />
-	    <connection t1="East Compass Sea Zone" t2="East Indies Sea Zone" />
-	    <connection t1="Indian Ocean Sea Zone" t2="French Indo China Sea Zone" />
-	    <connection t1="Indian Ocean Sea Zone" t2="East Indies Sea Zone" />
-	    <connection t1="South Australia Sea Zone" t2="West Australia Sea Zone" />
-	    <connection t1="South Australia Sea Zone" t2="South Compass Sea Zone" />
-	    <connection t1="South Australia Sea Zone" t2="New Zealand Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="South Australia Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="New Zealand Sea Zone" />
-	    <connection t1="West Australia Sea Zone" t2="North Australia Sea Zone" />
-	    <connection t1="West Australia Sea Zone" t2="East Indies Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="Solomon Islands Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="New Guinea Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="Borneo Sea Zone" />
-	    <connection t1="West Australia Sea Zone" t2="Australia" />
-	    <connection t1="Australia" t2="South Australia Sea Zone" />
-	    <connection t1="Australia" t2="North Australia Sea Zone" />
-	    <connection t1="New Zealand Sea Zone" t2="New Zealand" />
-	    <connection t1="Solomon Islands Sea Zone" t2="New Zealand Sea Zone" />
-	    <connection t1="New Zealand Sea Zone" t2="South Pacific Sea Zone" />
-	    <connection t1="New Zealand Sea Zone" t2="East Pacific Sea Zone" />
-	    <connection t1="South Pacific Sea Zone" t2="East Pacific Sea Zone" />
-	    <connection t1="South Pacific Sea Zone" t2="Solomon Islands Sea Zone" />
-	    <connection t1="South Pacific Sea Zone" t2="Hawaii Sea Zone" />
-	    <connection t1="South Pacific Sea Zone" t2="Mexico Sea Zone" />
-	    <connection t1="East Pacific Sea Zone" t2="Mexico Sea Zone" />
-	    <connection t1="Soviet Far East Sea Zone" t2="Alaska Sea Zone" />
-	    <connection t1="Alaska Sea Zone" t2="Alaska" />
-	    <connection t1="Alaska Sea Zone" t2="West Canada Sea Zone" />
-	    <connection t1="West Canada Sea Zone" t2="Alaska" />
-	    <connection t1="West Canada Sea Zone" t2="West Canada" />
-	    <connection t1="Alaska Sea Zone" t2="North Pacific Sea Zone" />
-	    <connection t1="Alaska Sea Zone" t2="Midway Sea Zone" />
-	    <connection t1="Midway" t2="Midway Sea Zone" />
-	    <connection t1="Wake Island" t2="Wake Island Sea Zone" />
-	    <connection t1="Okinawa" t2="Okinawa Sea Zone" />
-	    <connection t1="Philippines" t2="Philippines Sea Zone" />
-	    <connection t1="New Guinea" t2="New Guinea Sea Zone" />
-	    <connection t1="Solomon Islands" t2="Solomon Islands Sea Zone" />
-	    <connection t1="East Indies" t2="East Indies Sea Zone" />
-	    <connection t1="Borneo Celebes" t2="Borneo Sea Zone" />
-	    <connection t1="Japan" t2="Japan Sea Zone" />
-	    <connection t1="Hawaiian Islands" t2="Hawaii Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="Soviet Far East Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="North Pacific Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="Okinawa Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="Philippines Sea Zone" />
-	    <connection t1="Okinawa Sea Zone" t2="Philippines Sea Zone" />
-	    <connection t1="Okinawa Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="Borneo Sea Zone" t2="Philippines Sea Zone" />
-	    <connection t1="French Indo China Sea Zone" t2="Philippines Sea Zone" />
-	    <connection t1="French Indo China Sea Zone" t2="Borneo Sea Zone" />
-	    <connection t1="French Indo China Sea Zone" t2="Kwangtung Sea Zone" />
-	    <connection t1="Philippines Sea Zone" t2="Kwangtung Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="North Pacific Sea Zone" t2="Midway Sea Zone" />
-	    <connection t1="North Pacific Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="Midway Sea Zone" t2="Hawaii Sea Zone" />
-	    <connection t1="Midway Sea Zone" t2="West US Sea Zone" />
-	    <connection t1="Midway Sea Zone" t2="West Canada Sea Zone" />
-	    <connection t1="West US Sea Zone" t2="Hawaii Sea Zone" />
-	    <connection t1="Hawaii Sea Zone" t2="Mexico Sea Zone" />
-	    <connection t1="Mexico Sea Zone" t2="Mexico" />
-	    <connection t1="Mexico" t2="West US" />
-	    <connection t1="West US" t2="West Canada" />
-	    <connection t1="West US Sea Zone" t2="West US" />
-	    <connection t1="Hawaii Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="Hawaii Sea Zone" t2="Solomon Islands Sea Zone" />
-	    <connection t1="West Canada" t2="East Canada" />
-	    <connection t1="West US" t2="East US" />
-	    <connection t1="Mexico" t2="Panama" />
-	    <connection t1="Mexico Sea Zone" t2="West Panama Sea Zone" />
-	    <connection t1="East Pacific Sea Zone" t2="Peru Sea Zone" />
-	    <connection t1="New Zealand Sea Zone" t2="South Argentina Sea Zone" />
-	    <connection t1="Alaska" t2="West Canada" />
-	    <connection t1="Peru Sea Zone" t2="New Zealand Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="East Indies Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Solomon Islands Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="Solomon Islands Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Okinawa Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Philippines Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Borneo Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="New Guinea Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Caroline Islands" />
-	</map>
-	<resourceList>
-		<resource name="PUs"/>
-	</resourceList>
-	<playerList>
-		<player name="Japanese" optional="false"/>
-		<player name="Germans" optional="false"/>
-		<player name="British" optional="false"/>
-		<player name="Chinese" optional="false"/>
-		<player name="Americans" optional="false"/>
-		<player name="Russians" optional="false"></player>
-		<alliance player="Americans" alliance="imperial"/>
-		<alliance player="British" alliance="imperial"/>
-		<alliance player="Chinese" alliance="imperial"/>
-		<alliance player="Russians" alliance="imperial"/>
-		
-		<alliance player="Germans" alliance="Axis"/>
-		<alliance player="Japanese" alliance="Axis"/>
-	</playerList>
-	<unitList>
-		<unit name="infantry"/>
-		<unit name="armour"/>
-		<unit name="fighter"/>
-		<unit name="bomber"/>
-		<unit name="transport"/>
-		<unit name="battleship"/>
-		<unit name="carrier"/>
-		<unit name="submarine"/>
-		<unit name="factory"/>
-		<unit name="aaGun"/>
-	</unitList>
+
+    <map>
+        <territory name="Afghanistan"/>
+        <territory name="Alaska"/>
+        <territory name="Algeria"/>
+        <territory name="Anglo Sudan Egypt"/>
+        <territory name="Angola"/>
+        <territory name="Argentina-Chile"/>
+        <territory name="Australia"/>
+        <territory name="Borneo Celebes"/>
+        <territory name="Brazil"/>
+        <territory name="Caroline Islands"/>
+        <territory name="Caucasus"/>
+        <territory name="China"/>
+        <territory name="Columbia"/>
+        <territory name="Congo"/>
+        <territory name="Cuba"/>
+        <territory name="East Indies"/>
+        <territory name="East Canada"/>
+        <territory name="East Europe"/>
+        <territory name="East US"/>
+        <territory name="Eire"/>
+        <territory name="Evenki National Okrug"/>
+        <territory name="Finland Norway"/>
+        <territory name="French Equatorial Africa"/>
+        <territory name="French Indo China"/>
+        <territory name="French West Africa"/>
+        <territory name="Germany"/>
+        <territory name="Gibraltar"/>
+        <territory name="Hawaiian Islands"/>
+        <territory name="India"/>
+        <territory name="Italian East Africa"/>
+        <territory name="Japan"/>
+        <territory name="Karelia S.S.R."/>
+        <territory name="Kazakh S.S.R."/>
+        <territory name="Kenya-Rhodesia"/>
+        <territory name="Kwangtung"/>
+        <territory name="Libya"/>
+        <territory name="Madagascar"/>
+        <territory name="Manchuria"/>
+        <territory name="Mexico"/>
+        <territory name="Midway"/>
+        <territory name="Mongolia"/>
+        <territory name="Mozambique"/>
+        <territory name="New Guinea"/>
+        <territory name="New Zealand"/>
+        <territory name="Novosibirsk"/>
+        <territory name="Okinawa"/>
+        <territory name="Panama"/>
+        <territory name="Persia"/>
+        <territory name="Peru"/>
+        <territory name="Philippines"/>
+        <territory name="Rio del Oro"/>
+        <territory name="Russia"/>
+        <territory name="Saudi Arabia"/>
+        <territory name="Sinkiang"/>
+        <territory name="Solomon Islands"/>
+        <territory name="South Africa"/>
+        <territory name="South Europe"/>
+        <territory name="Soviet Far East"/>
+        <territory name="Spain"/>
+        <territory name="Sweden"/>
+        <territory name="Switzerland"/>
+        <territory name="Syria Jordan"/>
+        <territory name="Turkey"/>
+        <territory name="Ukraine S.S.R."/>
+        <territory name="United Kingdom"/>
+        <territory name="Wake Island"/>
+        <territory name="West Canada"/>
+        <territory name="West Europe"/>
+        <territory name="West US"/>
+        <territory name="Yakut S.S.R."/>
+        <territory name="Yunnan"/>
+        <territory name="Alaska Sea Zone" water="true" />
+        <territory name="Angola Sea Zone" water="true" />
+        <territory name="Antartic Sea Zone" water="true" />
+        <territory name="Baltic Sea Zone" water="true" />
+        <territory name="Black Sea Zone" water="true" />
+        <territory name="Borneo Sea Zone" water="true" />
+        <territory name="Carribean Sea Zone" water="true" />
+        <territory name="Caroline Islands Sea Zone" water="true" />
+        <territory name="Caspian Sea Zone" water="true" />
+        <territory name="Central Mediteranean Sea Zone" water="true" />
+        <territory name="Congo Sea Zone" water="true" />
+        <territory name="East Argentina Sea Zone" water="true" />
+        <territory name="East Compass Sea Zone" water="true" />
+        <territory name="East Indies Sea Zone" water="true" />
+        <territory name="East Canada Sea Zone" water="true" />
+        <territory name="East Mediteranean Sea Zone" water="true" />
+        <territory name="East Pacific Sea Zone" water="true" />
+        <territory name="East US Sea Zone" water="true" />
+        <territory name="French Indo China Sea Zone" water="true" />
+        <territory name="Hawaii Sea Zone" water="true" />
+        <territory name="Indian Ocean Sea Zone" water="true" />
+        <territory name="Japan Sea Zone" water="true" />
+        <territory name="Karelia Sea Zone" water="true" />
+        <territory name="Kwangtung Sea Zone" water="true" />
+        <territory name="Mexico Sea Zone" water="true" />
+        <territory name="Midway Sea Zone" water="true" />
+        <territory name="Mozambique Sea Zone" water="true" />
+        <territory name="New Guinea Sea Zone" water="true" />
+        <territory name="New Zealand Sea Zone" water="true" />
+        <territory name="North Australia Sea Zone" water="true" />
+        <territory name="North Brazil Sea Zone" water="true" />
+        <territory name="North Sea Zone" water="true" />
+        <territory name="North Atlantic Sea Zone" water="true" />
+        <territory name="North Pacific Sea Zone" water="true" />
+        <territory name="Okinawa Sea Zone" water="true" />
+        <territory name="Peru Sea Zone" water="true" />
+        <territory name="Philippines Sea Zone" water="true" />
+        <territory name="Red Sea Zone" water="true" />
+        <territory name="Solomon Islands Sea Zone" water="true" />
+        <territory name="South Africa Sea Zone" water="true" />
+        <territory name="South Argentina Sea Zone" water="true" />
+        <territory name="South Australia Sea Zone" water="true" />
+        <territory name="South Brazil Sea Zone" water="true" />
+        <territory name="South Compass Sea Zone" water="true" />
+        <territory name="South East Madagascar Sea Zone" water="true" />
+        <territory name="South Pacific Sea Zone" water="true"/>
+        <territory name="South Atlantic Sea Zone" water="true" />
+        <territory name="Soviet Far East Sea Zone" water="true" />
+        <territory name="Wake Island Sea Zone" water="true" />
+        <territory name="West Africa Sea Zone" water="true" />
+        <territory name="West Compass Sea Zone" water="true" />
+        <territory name="West Australia Sea Zone" water="true" />
+        <territory name="West Canada Sea Zone" water="true" />
+        <territory name="West Mediteranean Sea Zone" water="true" />
+        <territory name="West Panama Sea Zone" water="true" />
+        <territory name="West Spain Sea Zone" water="true" />
+        <territory name="West US Sea Zone" water="true" />
+        <connection t1="East Canada Sea Zone" t2="East Canada" />
+        <connection t1="East Canada Sea Zone" t2="North Sea Zone" />
+        <connection t1="West Spain Sea Zone" t2="East Canada Sea Zone" />
+        <connection t1="North Atlantic Sea Zone" t2="East Canada Sea Zone" />
+        <connection t1="East Canada Sea Zone" t2="East US Sea Zone" />
+        <connection t1="East Canada Sea Zone" t2="West Canada" />
+        <connection t1="East Canada" t2="East US" />
+        <connection t1="East US" t2="East US Sea Zone" />
+        <connection t1="Carribean Sea Zone" t2="East US Sea Zone" />
+        <connection t1="Carribean Sea Zone" t2="North Atlantic Sea Zone" />
+        <connection t1="Carribean Sea Zone" t2="North Brazil Sea Zone" />
+        <connection t1="Carribean Sea Zone" t2="Columbia" />
+        <connection t1="Carribean Sea Zone" t2="Panama" />
+        <connection t1="Carribean Sea Zone" t2="Cuba" />
+        <connection t1="Columbia" t2="Panama" />
+        <connection t1="Columbia" t2="West Panama Sea Zone" />
+        <connection t1="Panama" t2="West Panama Sea Zone" />
+        <connection t1="Peru" t2="Peru Sea Zone" />
+        <connection t1="Peru" t2="Brazil" />
+        <connection t1="Peru" t2="Columbia" />
+        <connection t1="Columbia" t2="Brazil" />
+        <connection t1="West Panama Sea Zone" t2="Peru Sea Zone" />
+        <connection t1="West Panama Sea Zone" t2="Carribean Sea Zone" />
+        <connection t1="Peru" t2="Argentina-Chile" />
+        <connection t1="Peru Sea Zone" t2="Argentina-Chile" />
+        <connection t1="Peru Sea Zone" t2="South Argentina Sea Zone" />
+        <connection t1="Argentina-Chile" t2="Brazil" />
+        <connection t1="Argentina-Chile" t2="East Argentina Sea Zone" />
+        <connection t1="Argentina-Chile" t2="South Argentina Sea Zone" />
+        <connection t1="South Argentina Sea Zone" t2="East Argentina Sea Zone" />
+        <connection t1="South Argentina Sea Zone" t2="South Atlantic Sea Zone" />
+        <connection t1="East Argentina Sea Zone" t2="South Atlantic Sea Zone" />
+        <connection t1="South Argentina Sea Zone" t2="Antartic Sea Zone" />
+        <connection t1="East Argentina Sea Zone" t2="South Brazil Sea Zone" />
+        <connection t1="South Brazil Sea Zone" t2="Brazil" />
+        <connection t1="Brazil" t2="North Brazil Sea Zone" />
+        <connection t1="South Brazil Sea Zone" t2="South Atlantic Sea Zone" />
+        <connection t1="South Brazil Sea Zone" t2="West Africa Sea Zone" />
+        <connection t1="South Brazil Sea Zone" t2="Congo Sea Zone" />
+        <connection t1="South Brazil Sea Zone" t2="North Brazil Sea Zone" />
+        <connection t1="North Brazil Sea Zone" t2="North Atlantic Sea Zone" />
+        <connection t1="North Brazil Sea Zone" t2="West Africa Sea Zone" />
+        <connection t1="North Atlantic Sea Zone" t2="West Africa Sea Zone" />
+        <connection t1="North Atlantic Sea Zone" t2="West Spain Sea Zone" />
+        <connection t1="North Atlantic Sea Zone" t2="East US Sea Zone" />
+        <connection t1="Eire" t2="North Sea Zone" />
+        <connection t1="United Kingdom" t2="North Sea Zone" />
+        <connection t1="North Sea Zone" t2="West Spain Sea Zone" />
+        <connection t1="North Sea Zone" t2="Karelia Sea Zone" />
+        <connection t1="North Sea Zone" t2="West Europe" />
+        <connection t1="North Sea Zone" t2="Finland Norway" />
+        <connection t1="North Sea Zone" t2="Baltic Sea Zone" />
+        <connection t1="West Spain Sea Zone" t2="West Mediteranean Sea Zone" />
+        <connection t1="West Spain Sea Zone" t2="Spain" />
+        <connection t1="West Spain Sea Zone" t2="West Europe" />
+        <connection t1="West Spain Sea Zone" t2="Algeria" />
+        <connection t1="West Spain Sea Zone" t2="West Africa Sea Zone" />
+        <connection t1="West Africa Sea Zone" t2="Rio del Oro" />
+        <connection t1="West Africa Sea Zone" t2="French West Africa" />
+        <connection t1="West Africa Sea Zone" t2="Congo Sea Zone" />
+        <connection t1="Congo Sea Zone" t2="South Atlantic Sea Zone" />
+        <connection t1="Congo Sea Zone" t2="South Brazil Sea Zone" />
+        <connection t1="Congo Sea Zone" t2="French Equatorial Africa" />
+        <connection t1="Congo Sea Zone" t2="Congo" />
+        <connection t1="Congo Sea Zone" t2="Angola Sea Zone" />
+        <connection t1="South Atlantic Sea Zone" t2="Antartic Sea Zone" />
+        <connection t1="South Atlantic Sea Zone" t2="Angola Sea Zone" />
+        <connection t1="Angola Sea Zone" t2="South Africa" />
+        <connection t1="Angola Sea Zone" t2="South Africa Sea Zone" />
+        <connection t1="Angola Sea Zone" t2="Angola" />
+        <connection t1="Angola Sea Zone" t2="Antartic Sea Zone" />
+        <connection t1="Rio del Oro" t2="French West Africa" />
+        <connection t1="French West Africa" t2="Algeria" />
+        <connection t1="French West Africa" t2="French Equatorial Africa" />
+        <connection t1="Algeria" t2="West Mediteranean Sea Zone" />
+        <connection t1="Algeria" t2="Libya" />
+        <connection t1="Algeria" t2="French Equatorial Africa" />
+        <connection t1="Libya" t2="Central Mediteranean Sea Zone" />
+        <connection t1="Libya" t2="French Equatorial Africa" />
+        <connection t1="Libya" t2="Anglo Sudan Egypt" />
+        <connection t1="Anglo Sudan Egypt" t2="East Mediteranean Sea Zone" />
+        <connection t1="Anglo Sudan Egypt" t2="Red Sea Zone" />
+        <connection t1="Anglo Sudan Egypt" t2="Italian East Africa" />
+        <connection t1="Anglo Sudan Egypt" t2="French Equatorial Africa" />
+        <connection t1="Anglo Sudan Egypt" t2="Congo" />
+        <connection t1="Anglo Sudan Egypt" t2="Kenya-Rhodesia" />
+        <connection t1="Italian East Africa" t2="Kenya-Rhodesia" />
+        <connection t1="Italian East Africa" t2="Red Sea Zone" />
+        <connection t1="French Equatorial Africa" t2="Congo" />
+        <connection t1="Congo" t2="Angola" />
+        <connection t1="Congo" t2="Kenya-Rhodesia" />
+        <connection t1="Angola" t2="Kenya-Rhodesia" />
+        <connection t1="Kenya-Rhodesia" t2="South Africa" />
+        <connection t1="Angola" t2="South Africa" />
+        <connection t1="South Africa" t2="Mozambique" />
+        <connection t1="Mozambique" t2="Kenya-Rhodesia" />
+        <connection t1="South Africa Sea Zone" t2="South East Madagascar Sea Zone" />
+        <connection t1="South Africa" t2="South Africa Sea Zone" />
+        <connection t1="South Africa" t2="Mozambique Sea Zone" />
+        <connection t1="Mozambique" t2="Mozambique Sea Zone" />
+        <connection t1="Kenya-Rhodesia" t2="Mozambique Sea Zone" />
+        <connection t1="South Africa Sea Zone" t2="Madagascar" />
+        <connection t1="South East Madagascar Sea Zone" t2="Madagascar" />
+        <connection t1="Madagascar" t2="West Compass Sea Zone" />
+        <connection t1="Madagascar" t2="Mozambique Sea Zone" />
+        <connection t1="Gibraltar" t2="West Mediteranean Sea Zone" />
+        <connection t1="Spain" t2="West Europe" />
+        <connection t1="Spain" t2="West Mediteranean Sea Zone" />
+        <connection t1="West Europe" t2="West Mediteranean Sea Zone" />
+        <connection t1="West Europe" t2="Switzerland" />
+        <connection t1="Switzerland" t2="Germany" />
+        <connection t1="Switzerland" t2="South Europe" />
+        <connection t1="Germany" t2="West Europe" />
+        <connection t1="Karelia S.S.R." t2="Baltic Sea Zone" />
+        <connection t1="Germany" t2="Baltic Sea Zone" />
+        <connection t1="Germany" t2="South Europe" />
+        <connection t1="Germany" t2="East Europe" />
+        <connection t1="Finland Norway" t2="Sweden" />
+        <connection t1="Finland Norway" t2="Karelia S.S.R." />
+        <connection t1="Karelia S.S.R." t2="Karelia Sea Zone" />
+        <connection t1="Baltic Sea Zone" t2="Sweden" />
+        <connection t1="Baltic Sea Zone" t2="East Europe" />
+        <connection t1="Baltic Sea Zone" t2="Finland Norway" />
+        <connection t1="West Europe" t2="Baltic Sea Zone" />
+        <connection t1="South Europe" t2="Central Mediteranean Sea Zone" />
+        <connection t1="South Europe" t2="East Europe" />
+        <connection t1="West Europe" t2="South Europe" />
+        <connection t1="West Mediteranean Sea Zone" t2="Central Mediteranean Sea Zone" />
+        <connection t1="Central Mediteranean Sea Zone" t2="East Mediteranean Sea Zone" />
+        <connection t1="Central Mediteranean Sea Zone" t2="Black Sea Zone" />
+        <connection t1="East Mediteranean Sea Zone" t2="Syria Jordan" />
+        <connection t1="East Mediteranean Sea Zone" t2="Turkey" />
+        <connection t1="Black Sea Zone" t2="Turkey" />
+        <connection t1="Black Sea Zone" t2="Caucasus" />
+        <connection t1="Black Sea Zone" t2="East Europe" />
+        <connection t1="Black Sea Zone" t2="Ukraine S.S.R." />
+        <connection t1="Black Sea Zone" t2="East Mediteranean Sea Zone" />
+        <connection t1="Caspian Sea Zone" t2="Caucasus" />
+        <connection t1="Caspian Sea Zone" t2="Kazakh S.S.R." />
+        <connection t1="Caspian Sea Zone" t2="Persia" />
+        <connection t1="Caspian Sea Zone" t2="Russia" />
+        <connection t1="East Europe" t2="Ukraine S.S.R." />
+        <connection t1="East Europe" t2="Karelia S.S.R." />
+        <connection t1="Ukraine S.S.R." t2="Karelia S.S.R." />
+        <connection t1="Ukraine S.S.R." t2="Caucasus" />
+        <connection t1="Caucasus" t2="Karelia S.S.R." />
+        <connection t1="Caucasus" t2="Russia" />
+        <connection t1="Russia" t2="Kazakh S.S.R." />
+        <connection t1="Russia" t2="Novosibirsk" />
+        <connection t1="Russia" t2="Evenki National Okrug" />
+        <connection t1="Karelia S.S.R." t2="Russia" />
+        <connection t1="Gibraltar" t2="Spain" />
+        <connection t1="Anglo Sudan Egypt" t2="Syria Jordan" />
+        <connection t1="East Mediteranean Sea Zone" t2="Red Sea Zone" />
+        <connection t1="Syria Jordan" t2="Red Sea Zone" />
+        <connection t1="Saudi Arabia" t2="Red Sea Zone" />
+        <connection t1="Saudi Arabia" t2="Syria Jordan" />
+        <connection t1="Saudi Arabia" t2="Persia" />
+        <connection t1="Syria Jordan" t2="Persia" />
+        <connection t1="Syria Jordan" t2="Turkey" />
+        <connection t1="Turkey" t2="Persia" />
+        <connection t1="Caucasus" t2="Persia" />
+        <connection t1="Turkey" t2="Caucasus" />
+        <connection t1="Evenki National Okrug" t2="Yakut S.S.R." />
+        <connection t1="Evenki National Okrug" t2="Novosibirsk" />
+        <connection t1="Yakut S.S.R." t2="Soviet Far East" />
+        <connection t1="Yakut S.S.R." t2="Manchuria" />
+        <connection t1="Yakut S.S.R." t2="Mongolia" />
+        <connection t1="Kazakh S.S.R." t2="Novosibirsk" />
+        <connection t1="Kazakh S.S.R." t2="Persia" />
+        <connection t1="Kazakh S.S.R." t2="Afghanistan" />
+        <connection t1="Kazakh S.S.R." t2="Sinkiang" />
+        <connection t1="Novosibirsk" t2="Mongolia" />
+        <connection t1="Novosibirsk" t2="Sinkiang" />
+        <connection t1="Novosibirsk" t2="Yakut S.S.R." />
+        <connection t1="Soviet Far East" t2="Soviet Far East Sea Zone" />
+        <connection t1="Soviet Far East" t2="Manchuria" />
+        <connection t1="Mongolia" t2="Sinkiang" />
+        <connection t1="Mongolia" t2="China" />
+        <connection t1="Mongolia" t2="Manchuria" />
+        <connection t1="Persia" t2="Afghanistan" />
+        <connection t1="Afghanistan" t2="India" />
+        <connection t1="Afghanistan" t2="Sinkiang" />
+        <connection t1="Sinkiang" t2="India" />
+        <connection t1="Sinkiang" t2="China" />
+        <connection t1="Sinkiang" t2="French Indo China" />
+        <connection t1="China" t2="French Indo China" />
+        <connection t1="India" t2="Indian Ocean Sea Zone" />
+        <connection t1="India" t2="French Indo China" />
+        <connection t1="Manchuria" t2="Japan Sea Zone" />
+        <connection t1="China" t2="Manchuria" />
+        <connection t1="Manchuria" t2="Kwangtung" />
+        <connection t1="China" t2="Kwangtung" />
+        <connection t1="Kwangtung" t2="French Indo China" />
+        <connection t1="Kwangtung" t2="Kwangtung Sea Zone" />
+        <connection t1="French Indo China Sea Zone" t2="French Indo China" />
+        <connection t1="Persia" t2="India" />
+        <connection t1="Red Sea Zone" t2="Indian Ocean Sea Zone" />
+        <connection t1="Red Sea Zone" t2="West Compass Sea Zone" />
+        <connection t1="Mozambique Sea Zone" t2="Red Sea Zone" />
+        <connection t1="Red Sea Zone" t2="Persia" />
+        <connection t1="South Africa Sea Zone" t2="Mozambique Sea Zone" />
+        <connection t1="South East Madagascar Sea Zone" t2="West Compass Sea Zone" />
+        <connection t1="South East Madagascar Sea Zone" t2="South Compass Sea Zone" />
+        <connection t1="West Compass Sea Zone" t2="Mozambique Sea Zone" />
+        <connection t1="West Compass Sea Zone" t2="East Compass Sea Zone" />
+        <connection t1="West Compass Sea Zone" t2="South Compass Sea Zone" />
+        <connection t1="West Compass Sea Zone" t2="Indian Ocean Sea Zone" />
+        <connection t1="East Compass Sea Zone" t2="Indian Ocean Sea Zone" />
+        <connection t1="East Compass Sea Zone" t2="South Compass Sea Zone" />
+        <connection t1="East Compass Sea Zone" t2="South Australia Sea Zone" />
+        <connection t1="East Compass Sea Zone" t2="West Australia Sea Zone" />
+        <connection t1="East Compass Sea Zone" t2="East Indies Sea Zone" />
+        <connection t1="Indian Ocean Sea Zone" t2="French Indo China Sea Zone" />
+        <connection t1="Indian Ocean Sea Zone" t2="East Indies Sea Zone" />
+        <connection t1="South Australia Sea Zone" t2="West Australia Sea Zone" />
+        <connection t1="South Australia Sea Zone" t2="South Compass Sea Zone" />
+        <connection t1="South Australia Sea Zone" t2="New Zealand Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="South Australia Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="New Zealand Sea Zone" />
+        <connection t1="West Australia Sea Zone" t2="North Australia Sea Zone" />
+        <connection t1="West Australia Sea Zone" t2="East Indies Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="Solomon Islands Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="New Guinea Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="Borneo Sea Zone" />
+        <connection t1="West Australia Sea Zone" t2="Australia" />
+        <connection t1="Australia" t2="South Australia Sea Zone" />
+        <connection t1="Australia" t2="North Australia Sea Zone" />
+        <connection t1="New Zealand Sea Zone" t2="New Zealand" />
+        <connection t1="Solomon Islands Sea Zone" t2="New Zealand Sea Zone" />
+        <connection t1="New Zealand Sea Zone" t2="South Pacific Sea Zone" />
+        <connection t1="New Zealand Sea Zone" t2="East Pacific Sea Zone" />
+        <connection t1="South Pacific Sea Zone" t2="East Pacific Sea Zone" />
+        <connection t1="South Pacific Sea Zone" t2="Solomon Islands Sea Zone" />
+        <connection t1="South Pacific Sea Zone" t2="Hawaii Sea Zone" />
+        <connection t1="South Pacific Sea Zone" t2="Mexico Sea Zone" />
+        <connection t1="East Pacific Sea Zone" t2="Mexico Sea Zone" />
+        <connection t1="Soviet Far East Sea Zone" t2="Alaska Sea Zone" />
+        <connection t1="Alaska Sea Zone" t2="Alaska" />
+        <connection t1="Alaska Sea Zone" t2="West Canada Sea Zone" />
+        <connection t1="West Canada Sea Zone" t2="Alaska" />
+        <connection t1="West Canada Sea Zone" t2="West Canada" />
+        <connection t1="Alaska Sea Zone" t2="North Pacific Sea Zone" />
+        <connection t1="Alaska Sea Zone" t2="Midway Sea Zone" />
+        <connection t1="Midway" t2="Midway Sea Zone" />
+        <connection t1="Wake Island" t2="Wake Island Sea Zone" />
+        <connection t1="Okinawa" t2="Okinawa Sea Zone" />
+        <connection t1="Philippines" t2="Philippines Sea Zone" />
+        <connection t1="New Guinea" t2="New Guinea Sea Zone" />
+        <connection t1="Solomon Islands" t2="Solomon Islands Sea Zone" />
+        <connection t1="East Indies" t2="East Indies Sea Zone" />
+        <connection t1="Borneo Celebes" t2="Borneo Sea Zone" />
+        <connection t1="Japan" t2="Japan Sea Zone" />
+        <connection t1="Hawaiian Islands" t2="Hawaii Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="Soviet Far East Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="North Pacific Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="Okinawa Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="Philippines Sea Zone" />
+        <connection t1="Okinawa Sea Zone" t2="Philippines Sea Zone" />
+        <connection t1="Okinawa Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="Borneo Sea Zone" t2="Philippines Sea Zone" />
+        <connection t1="French Indo China Sea Zone" t2="Philippines Sea Zone" />
+        <connection t1="French Indo China Sea Zone" t2="Borneo Sea Zone" />
+        <connection t1="French Indo China Sea Zone" t2="Kwangtung Sea Zone" />
+        <connection t1="Philippines Sea Zone" t2="Kwangtung Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="North Pacific Sea Zone" t2="Midway Sea Zone" />
+        <connection t1="North Pacific Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="Midway Sea Zone" t2="Hawaii Sea Zone" />
+        <connection t1="Midway Sea Zone" t2="West US Sea Zone" />
+        <connection t1="Midway Sea Zone" t2="West Canada Sea Zone" />
+        <connection t1="West US Sea Zone" t2="Hawaii Sea Zone" />
+        <connection t1="Hawaii Sea Zone" t2="Mexico Sea Zone" />
+        <connection t1="Mexico Sea Zone" t2="Mexico" />
+        <connection t1="Mexico" t2="West US" />
+        <connection t1="West US" t2="West Canada" />
+        <connection t1="West US Sea Zone" t2="West US" />
+        <connection t1="Hawaii Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="Hawaii Sea Zone" t2="Solomon Islands Sea Zone" />
+        <connection t1="West Canada" t2="East Canada" />
+        <connection t1="West US" t2="East US" />
+        <connection t1="Mexico" t2="Panama" />
+        <connection t1="Mexico Sea Zone" t2="West Panama Sea Zone" />
+        <connection t1="East Pacific Sea Zone" t2="Peru Sea Zone" />
+        <connection t1="New Zealand Sea Zone" t2="South Argentina Sea Zone" />
+        <connection t1="Alaska" t2="West Canada" />
+        <connection t1="Peru Sea Zone" t2="New Zealand Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="East Indies Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Solomon Islands Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="Solomon Islands Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Okinawa Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Philippines Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Borneo Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="New Guinea Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Caroline Islands" />
+    </map>
+    <resourceList>
+        <resource name="PUs"/>
+    </resourceList>
+    <playerList>
+        <player name="Japanese" optional="false"/>
+        <player name="Germans" optional="false"/>
+        <player name="British" optional="false"/>
+        <player name="Chinese" optional="false"/>
+        <player name="Americans" optional="false"/>
+        <player name="Russians" optional="false"></player>
+        <alliance player="Americans" alliance="imperial"/>
+        <alliance player="British" alliance="imperial"/>
+        <alliance player="Chinese" alliance="imperial"/>
+        <alliance player="Russians" alliance="imperial"/>
+
+        <alliance player="Germans" alliance="Axis"/>
+        <alliance player="Japanese" alliance="Axis"/>
+    </playerList>
+    <unitList>
+        <unit name="infantry"/>
+        <unit name="armour"/>
+        <unit name="fighter"/>
+        <unit name="bomber"/>
+        <unit name="transport"/>
+        <unit name="battleship"/>
+        <unit name="carrier"/>
+        <unit name="submarine"/>
+        <unit name="factory"/>
+        <unit name="aaGun"/>
+    </unitList>
 <gamePlay>
-		<delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate"/>
-		<delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate"/>
-		<delegate name="battle" javaClass="games.strategy.triplea.delegate.BattleDelegate"/>
-		<delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate"/>
-		<delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate"/>
-		<delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate"/>
-		<delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>
-		<delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate"/>
-		<delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
-		<sequence>
+        <delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate"/>
+        <delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate"/>
+        <delegate name="battle" javaClass="games.strategy.triplea.delegate.BattleDelegate"/>
+        <delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate"/>
+        <delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate"/>
+        <delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate"/>
+        <delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>
+        <delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate"/>
+        <delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
+        <sequence>
 
-			<step name="gameInitDelegate" delegate="initDelegate"/>
+            <step name="gameInitDelegate" delegate="initDelegate"/>
 
-			<step name="britishTech" delegate="tech" player="British"/>
-			<step name="britishPurchase" delegate="purchase" player="British"/>
-			<step name="britishCombatMove" delegate="move" player="British"/>
-			<step name="britishBattle" delegate="battle" player="British"/>
-			<step name="britishNonCombatMove" delegate="move" player="British"/>
-			<step name="britishPlace" delegate="place" player="British"/>
-			<step name="britishEndTurn" delegate="endTurn" player="British"/>
+            <step name="britishTech" delegate="tech" player="British"/>
+            <step name="britishPurchase" delegate="purchase" player="British"/>
+            <step name="britishCombatMove" delegate="move" player="British"/>
+            <step name="britishBattle" delegate="battle" player="British"/>
+            <step name="britishNonCombatMove" delegate="move" player="British"/>
+            <step name="britishPlace" delegate="place" player="British"/>
+            <step name="britishEndTurn" delegate="endTurn" player="British"/>
 
-			<step name="japaneseTech" delegate="tech" player="Japanese"/>
-			<step name="japanesePurchase" delegate="purchase" player="Japanese"/>
-			<step name="japaneseCombatMove" delegate="move" player="Japanese"/>
-			<step name="japaneseBattle" delegate="battle" player="Japanese"/>
-			<step name="japaneseNonCombatMove" delegate="move" player="Japanese"/>
-			<step name="japanesePlace" delegate="place" player="Japanese"/>
-			<step name="japaneseEndTurn" delegate="endTurn" player="Japanese"/>
+            <step name="japaneseTech" delegate="tech" player="Japanese"/>
+            <step name="japanesePurchase" delegate="purchase" player="Japanese"/>
+            <step name="japaneseCombatMove" delegate="move" player="Japanese"/>
+            <step name="japaneseBattle" delegate="battle" player="Japanese"/>
+            <step name="japaneseNonCombatMove" delegate="move" player="Japanese"/>
+            <step name="japanesePlace" delegate="place" player="Japanese"/>
+            <step name="japaneseEndTurn" delegate="endTurn" player="Japanese"/>
 
-			<step name="americanTech" delegate="tech" player="Americans"/>
-			<step name="americanPurchase" delegate="purchase" player="Americans"/>
-			<step name="americanCombatMove" delegate="move" player="Americans"/>
-			<step name="americanBattle" delegate="battle" player="Americans"/>
-			<step name="americanNonCombatMove" delegate="move" player="Americans"/>
-			<step name="americanPlace" delegate="place" player="Americans"/>
-			<step name="americanEndTurn" delegate="endTurn" player="Americans"/>
-						
-			<step name="chinesePurchase" delegate="purchaseNoPU" player="Chinese"/>
-			<step name="chineseCombatMove" delegate="move" player="Chinese"/>
-			<step name="chineseBattle" delegate="battle" player="Chinese"/>
-			<step name="chineseNonCombatMove" delegate="move" player="Chinese"/>
-			<step name="chinesePlace" delegate="place" player="Chinese"/>
-			<step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese"/>
-			
-			<step name="russianTech" delegate="tech" player="Russians"/>
-			<step name="russianPurchase" delegate="purchase" player="Russians"/>
-			<step name="russianCombatMove" delegate="move" player="Russians"/>
-			<step name="russianBattle" delegate="battle" player="Russians"/>
-			<step name="russianNonCombatMove" delegate="move" player="Russians" display="Non Combat Move"/>
-			<step name="russianPlace" delegate="place" player="Russians"/>
-			<step name="russianEndTurn" delegate="endTurn" player="Russians"/>
-							
-		</sequence>
-	</gamePlay>
-	<production>
-		<productionRule name="buyInfantry">
-			<cost resource="PUs" quantity="3" />
-			<result resourceOrUnit="infantry" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyArmour">
-			<cost resource="PUs" quantity="5" />
-			<result resourceOrUnit="armour" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyFighter">
-			<cost resource="PUs" quantity="12" />
-			<result resourceOrUnit="fighter" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyBomber">
-			<cost resource="PUs" quantity="15" />
-			<result resourceOrUnit="bomber" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyTransport">
-			<cost resource="PUs" quantity="8" />
-			<result resourceOrUnit="transport" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyCarrier">
-			<cost resource="PUs" quantity="18" />
-			<result resourceOrUnit="carrier" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyBattleship">
-			<cost resource="PUs" quantity="24" />
-			<result resourceOrUnit="battleship" quantity="1"/>
-		</productionRule>
-		<productionRule name="buySubmarine">
-			<cost resource="PUs" quantity="8" />
-			<result resourceOrUnit="submarine" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyFactory">
-			<cost resource="PUs" quantity="15" />
-			<result resourceOrUnit="factory" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyAAGun">
-			<cost resource="PUs" quantity="5" />
-			<result resourceOrUnit="aaGun" quantity="1"/>
-		</productionRule>
+            <step name="americanTech" delegate="tech" player="Americans"/>
+            <step name="americanPurchase" delegate="purchase" player="Americans"/>
+            <step name="americanCombatMove" delegate="move" player="Americans"/>
+            <step name="americanBattle" delegate="battle" player="Americans"/>
+            <step name="americanNonCombatMove" delegate="move" player="Americans"/>
+            <step name="americanPlace" delegate="place" player="Americans"/>
+            <step name="americanEndTurn" delegate="endTurn" player="Americans"/>
 
-		<!-- advanced industrial production -->
-		<productionRule name="buyInfantryIndustrialTechnology">
-			<cost resource="PUs" quantity="2" />
-			<result resourceOrUnit="infantry" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyArmourIndustrialTechnology">
-			<cost resource="PUs" quantity="4" />
-			<result resourceOrUnit="armour" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyFighterIndustrialTechnology">
-			<cost resource="PUs" quantity="11" />
-			<result resourceOrUnit="fighter" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyBomberIndustrialTechnology">
-			<cost resource="PUs" quantity="14" />
-			<result resourceOrUnit="bomber" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyTransportIndustrialTechnology">
-			<cost resource="PUs" quantity="7" />
-			<result resourceOrUnit="transport" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyCarrierIndustrialTechnology">
-			<cost resource="PUs" quantity="17" />
-			<result resourceOrUnit="carrier" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyBattleshipIndustrialTechnology">
-			<cost resource="PUs" quantity="23" />
-			<result resourceOrUnit="battleship" quantity="1"/>
-		</productionRule>
-		<productionRule name="buySubmarineIndustrialTechnology">
-			<cost resource="PUs" quantity="7" />
-			<result resourceOrUnit="submarine" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyFactoryIndustrialTechnology">
-			<cost resource="PUs" quantity="14" />
-			<result resourceOrUnit="factory" quantity="1"/>
-		</productionRule>
-		<productionRule name="buyAAGunIndustrialTechnology">
-			<cost resource="PUs" quantity="4" />
-			<result resourceOrUnit="aaGun" quantity="1"/>
-		</productionRule>
+            <step name="chinesePurchase" delegate="purchaseNoPU" player="Chinese"/>
+            <step name="chineseCombatMove" delegate="move" player="Chinese"/>
+            <step name="chineseBattle" delegate="battle" player="Chinese"/>
+            <step name="chineseNonCombatMove" delegate="move" player="Chinese"/>
+            <step name="chinesePlace" delegate="place" player="Chinese"/>
+            <step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese"/>
 
-		<productionFrontier name="production">
-			<frontierRules name="buyInfantry"/>
-			<frontierRules name="buyArmour"/>
-			<frontierRules name="buyFighter"/>
-			<frontierRules name="buyBomber"/>
-			<frontierRules name="buyTransport"/>
-			<frontierRules name="buyCarrier"/>
-			<frontierRules name="buyBattleship"/>
-			<frontierRules name="buyAAGun"/>
-			<frontierRules name="buyFactory"/>	
-		</productionFrontier>
-		<productionFrontier name="productionIndustrialTechnology">
-			<frontierRules name="buyInfantryIndustrialTechnology"/>
-			<frontierRules name="buyArmourIndustrialTechnology"/>
-			<frontierRules name="buyFighterIndustrialTechnology"/>
-			<frontierRules name="buyBomberIndustrialTechnology"/>
-			<frontierRules name="buyTransportIndustrialTechnology"/>
-			<frontierRules name="buyBattleshipIndustrialTechnology"/>
-			<frontierRules name="buyCarrierIndustrialTechnology"/>
-			<frontierRules name="buyAAGunIndustrialTechnology"/>
-			<frontierRules name="buyFactoryIndustrialTechnology"/>	
-		</productionFrontier>
+            <step name="russianTech" delegate="tech" player="Russians"/>
+            <step name="russianPurchase" delegate="purchase" player="Russians"/>
+            <step name="russianCombatMove" delegate="move" player="Russians"/>
+            <step name="russianBattle" delegate="battle" player="Russians"/>
+            <step name="russianNonCombatMove" delegate="move" player="Russians" display="Non Combat Move"/>
+            <step name="russianPlace" delegate="place" player="Russians"/>
+            <step name="russianEndTurn" delegate="endTurn" player="Russians"/>
 
+        </sequence>
+    </gamePlay>
+    <production>
+        <productionRule name="buyInfantry">
+            <cost resource="PUs" quantity="3" />
+            <result resourceOrUnit="infantry" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyArmour">
+            <cost resource="PUs" quantity="5" />
+            <result resourceOrUnit="armour" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyFighter">
+            <cost resource="PUs" quantity="12" />
+            <result resourceOrUnit="fighter" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyBomber">
+            <cost resource="PUs" quantity="15" />
+            <result resourceOrUnit="bomber" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyTransport">
+            <cost resource="PUs" quantity="8" />
+            <result resourceOrUnit="transport" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyCarrier">
+            <cost resource="PUs" quantity="18" />
+            <result resourceOrUnit="carrier" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyBattleship">
+            <cost resource="PUs" quantity="24" />
+            <result resourceOrUnit="battleship" quantity="1"/>
+        </productionRule>
+        <productionRule name="buySubmarine">
+            <cost resource="PUs" quantity="8" />
+            <result resourceOrUnit="submarine" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyFactory">
+            <cost resource="PUs" quantity="15" />
+            <result resourceOrUnit="factory" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyAAGun">
+            <cost resource="PUs" quantity="5" />
+            <result resourceOrUnit="aaGun" quantity="1"/>
+        </productionRule>
 
-		<playerProduction player="British" frontier="production"/>
-		<playerProduction player="Japanese" frontier="production"/>
-		<playerProduction player="Americans" frontier="production"/>
+        <!-- advanced industrial production -->
+        <productionRule name="buyInfantryIndustrialTechnology">
+            <cost resource="PUs" quantity="2" />
+            <result resourceOrUnit="infantry" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyArmourIndustrialTechnology">
+            <cost resource="PUs" quantity="4" />
+            <result resourceOrUnit="armour" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyFighterIndustrialTechnology">
+            <cost resource="PUs" quantity="11" />
+            <result resourceOrUnit="fighter" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyBomberIndustrialTechnology">
+            <cost resource="PUs" quantity="14" />
+            <result resourceOrUnit="bomber" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyTransportIndustrialTechnology">
+            <cost resource="PUs" quantity="7" />
+            <result resourceOrUnit="transport" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyCarrierIndustrialTechnology">
+            <cost resource="PUs" quantity="17" />
+            <result resourceOrUnit="carrier" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyBattleshipIndustrialTechnology">
+            <cost resource="PUs" quantity="23" />
+            <result resourceOrUnit="battleship" quantity="1"/>
+        </productionRule>
+        <productionRule name="buySubmarineIndustrialTechnology">
+            <cost resource="PUs" quantity="7" />
+            <result resourceOrUnit="submarine" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyFactoryIndustrialTechnology">
+            <cost resource="PUs" quantity="14" />
+            <result resourceOrUnit="factory" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyAAGunIndustrialTechnology">
+            <cost resource="PUs" quantity="4" />
+            <result resourceOrUnit="aaGun" quantity="1"/>
+        </productionRule>
 
-	</production> 
-	<attachmentList>
-	    <attachment name="unitAttachment" 
-			 attachTo="infantry"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="1"/>
-			 <option name="transportCost" value="1"/>
-			 <option name="attack" value="1"/>
-			 <option name="defense" value="2"/>
-	    </attachment>
-	    <attachment name="unitAttachment" 
-			 attachTo="armour"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="2"/>
-			 <option name="transportCost" value="2"/>
-			 <option name="canBlitz" value="true"/>
-			 <option name="attack" value="3"/>
-			 <option name="defense" value="2"/>
-	    </attachment>
-	    <attachment name="unitAttachment" 
-			 attachTo="fighter"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="4"/>
-			 <option name="carrierCost" value="1"/>
-			 <option name="isAir" value="true"/>   
-			 <option name="attack" value="3"/>
-			 <option name="defense" value="4"/>
-	    </attachment>
-	    <attachment name="unitAttachment" 
-			 attachTo="bomber"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="6"/>
-			 <option name="isAir" value="true"/>
-			 <option name="attack" value="4"/>
-			 <option name="defense" value="1"/>
-			 <option name="isStrategicBomber" value="true"/>
-	    </attachment>
-	    <attachment name="unitAttachment" 
-			 attachTo="transport"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="2"/>
-			 <option name="isSea" value="true"/>   
-			 <option name="transportCapacity" value="2"/>   
-			 <option name="attack" value="0"/>
-			 <option name="defense" value="1"/>
-	    </attachment>
-	    <attachment name="unitAttachment" 
-			 attachTo="battleship"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="2"/>
-			 <option name="isSea" value="true"/>
-   			 <option name="attack" value="4"/>
-			 <option name="defense" value="4"/>
-			 <option name="canBombard" value="true"/>
-	    </attachment>
-	    <attachment name="unitAttachment" 
-			 attachTo="carrier"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="carrierCapacity" value="2"/>
-			 <option name="movement" value="2"/>
-			 <option name="isSea" value="true"/>   
-			 <option name="attack" value="1"/>
-			 <option name="defense" value="3"/>
-	    </attachment>
-	    <attachment name="unitAttachment" 
-			 attachTo="submarine"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="isSub" value="true"/>
-			 <option name="movement" value="2"/>
-			 <option name="isSea" value="true"/>   
-			 <option name="attack" value="2"/>
-			 <option name="defense" value="2"/>
-	    </attachment>
-
-	    <attachment name="unitAttachment" 
-			 attachTo="factory"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="isFactory" value="true"/>   
-	    </attachment>
-	    <attachment name="unitAttachment" 
-			 attachTo="aaGun"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="isAA" value="true"/>   
-			 <option name="transportCost" value="2"/>
-			 <option name="movement" value="1"/>
-	    </attachment>
- 
+        <productionFrontier name="production">
+            <frontierRules name="buyInfantry"/>
+            <frontierRules name="buyArmour"/>
+            <frontierRules name="buyFighter"/>
+            <frontierRules name="buyBomber"/>
+            <frontierRules name="buyTransport"/>
+            <frontierRules name="buyCarrier"/>
+            <frontierRules name="buyBattleship"/>
+            <frontierRules name="buyAAGun"/>
+            <frontierRules name="buyFactory"/>
+        </productionFrontier>
+        <productionFrontier name="productionIndustrialTechnology">
+            <frontierRules name="buyInfantryIndustrialTechnology"/>
+            <frontierRules name="buyArmourIndustrialTechnology"/>
+            <frontierRules name="buyFighterIndustrialTechnology"/>
+            <frontierRules name="buyBomberIndustrialTechnology"/>
+            <frontierRules name="buyTransportIndustrialTechnology"/>
+            <frontierRules name="buyBattleshipIndustrialTechnology"/>
+            <frontierRules name="buyCarrierIndustrialTechnology"/>
+            <frontierRules name="buyAAGunIndustrialTechnology"/>
+            <frontierRules name="buyFactoryIndustrialTechnology"/>
+        </productionFrontier>
 
 
+        <playerProduction player="British" frontier="production"/>
+        <playerProduction player="Japanese" frontier="production"/>
+        <playerProduction player="Americans" frontier="production"/>
 
-	    <attachment name="territoryAttachment"
-			 attachTo="United Kingdom"
-			 javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-			 type="territory">
-			 <option name="production" value="10"/>
-			 <option name="capital" value="British"/>
-			 <option name="originalFactory" value="true"/>
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-			 attachTo="Japan"
-			 javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-			 type="territory">
-			 <option name="production" value="10"/>
-			 <option name="capital" value="Japanese"/>
-			 <option name="originalFactory" value="true"/>
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Afghanistan"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Alaska"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Algeria"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Anglo Sudan Egypt"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Angola"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Argentina-Chile"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Australia"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Borneo Celebes"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Brazil"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Caroline Islands"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Caucasus"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="China"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Columbia"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Congo"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Cuba"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="East Canada"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="East Europe"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="East Indies"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="East US"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Eire"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Evenki National Okrug"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Finland Norway"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="French Equatorial Africa"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="French Indo China"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="French West Africa"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Germany"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Gibraltar"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Hawaiian Islands"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="India"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Italian East Africa"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Karelia S.S.R."
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Kazakh S.S.R."
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Kenya-Rhodesia"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Kwangtung"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Libya"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Madagascar"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Manchuria"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Mexico"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Midway"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Mongolia"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Mozambique"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="New Guinea"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="New Zealand"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Novosibirsk"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Okinawa"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Panama"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Persia"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Peru"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Philippines"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Rio del Oro"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Russia"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Saudi Arabia"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Sinkiang"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Solomon Islands"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="South Africa"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="South Europe"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Soviet Far East"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Spain"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Sweden"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Switzerland"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Syria Jordan"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Turkey"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Ukraine S.S.R."
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Wake Island"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="West Canada"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="West Europe"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="West US"
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    <attachment name="territoryAttachment" 
-		    attachTo="Yakut S.S.R."
-		    javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
-		    type="territory"
-	    >
-		    <option name="production" value="2" />
-	    </attachment>
-	    
-	    <attachment name="territoryAttachment" 
-	    	attachTo="Yunnan" 
-	    	javaClass="games.strategy.triplea.attachments.TerritoryAttachment" 
-	    	type="territory">
-			<option name="production" value="1"/>
-		</attachment>
+    </production>
+    <attachmentList>
+        <attachment name="unitAttachment"
+            attachTo="infantry"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="1"/>
+            <option name="transportCost" value="1"/>
+            <option name="attack" value="1"/>
+            <option name="defense" value="2"/>
+        </attachment>
+        <attachment name="unitAttachment"
+            attachTo="armour"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="2"/>
+            <option name="transportCost" value="2"/>
+            <option name="canBlitz" value="true"/>
+            <option name="attack" value="3"/>
+            <option name="defense" value="2"/>
+        </attachment>
+        <attachment name="unitAttachment"
+            attachTo="fighter"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="4"/>
+            <option name="carrierCost" value="1"/>
+            <option name="isAir" value="true"/>
+            <option name="attack" value="3"/>
+            <option name="defense" value="4"/>
+        </attachment>
+        <attachment name="unitAttachment"
+            attachTo="bomber"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="6"/>
+            <option name="isAir" value="true"/>
+            <option name="attack" value="4"/>
+            <option name="defense" value="1"/>
+            <option name="isStrategicBomber" value="true"/>
+        </attachment>
+        <attachment name="unitAttachment"
+            attachTo="transport"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="transportCapacity" value="2"/>
+            <option name="attack" value="0"/>
+            <option name="defense" value="1"/>
+        </attachment>
+        <attachment name="unitAttachment"
+            attachTo="battleship"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="4"/>
+            <option name="defense" value="4"/>
+            <option name="canBombard" value="true"/>
+        </attachment>
+        <attachment name="unitAttachment"
+            attachTo="carrier"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="carrierCapacity" value="2"/>
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="1"/>
+            <option name="defense" value="3"/>
+        </attachment>
+        <attachment name="unitAttachment"
+            attachTo="submarine"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="isSub" value="true"/>
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="2"/>
+            <option name="defense" value="2"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="factory"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="isFactory" value="true"/>
+        </attachment>
+        <attachment name="unitAttachment"
+            attachTo="aaGun"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="isAA" value="true"/>
+            <option name="transportCost" value="2"/>
+            <option name="movement" value="1"/>
+        </attachment>
+
+
+
+
+        <attachment name="territoryAttachment"
+            attachTo="United Kingdom"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory">
+            <option name="production" value="10"/>
+            <option name="capital" value="British"/>
+            <option name="originalFactory" value="true"/>
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Japan"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory">
+            <option name="production" value="10"/>
+            <option name="capital" value="Japanese"/>
+            <option name="originalFactory" value="true"/>
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Afghanistan"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Alaska"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Algeria"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Anglo Sudan Egypt"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Angola"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Argentina-Chile"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Australia"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Borneo Celebes"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Brazil"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Caroline Islands"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Caucasus"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="China"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Columbia"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Congo"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Cuba"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="East Canada"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="East Europe"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="East Indies"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="East US"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Eire"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Evenki National Okrug"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Finland Norway"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="French Equatorial Africa"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="French Indo China"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="French West Africa"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Germany"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Gibraltar"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Hawaiian Islands"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="India"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Italian East Africa"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Karelia S.S.R."
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Kazakh S.S.R."
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Kenya-Rhodesia"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Kwangtung"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Libya"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Madagascar"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Manchuria"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Mexico"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Midway"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Mongolia"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Mozambique"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="New Guinea"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="New Zealand"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Novosibirsk"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Okinawa"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Panama"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Persia"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Peru"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Philippines"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Rio del Oro"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Russia"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Saudi Arabia"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Sinkiang"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Solomon Islands"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="South Africa"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="South Europe"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Soviet Far East"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Spain"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Sweden"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Switzerland"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Syria Jordan"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Turkey"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Ukraine S.S.R."
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Wake Island"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="West Canada"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="West Europe"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="West US"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+        <attachment name="territoryAttachment"
+            attachTo="Yakut S.S.R."
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory"
+        >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"
+            attachTo="Yunnan"
+            javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
+            type="territory">
+            <option name="production" value="1"/>
+        </attachment>
 
 <!-- Chinese Rules -->
-				<attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="movementRestrictionTerritories" value="Yunnan:Manchuria:Kwangtung"/>
-                	<option name="movementRestrictionType" value="allowed"/>
-                	<option name="productionPerXTerritories" value="2"/>
-                	<option name="placementAnyTerritory" value="true"/>
-                	<option name="placementCapturedTerritory" value="true"/>
-                	<option name="placementPerTerritory" value="3"/>
+                <attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                    <option name="movementRestrictionTerritories" value="Yunnan:Manchuria:Kwangtung"/>
+                    <option name="movementRestrictionType" value="allowed"/>
+                    <option name="productionPerXTerritories" value="2"/>
+                    <option name="placementAnyTerritory" value="true"/>
+                    <option name="placementCapturedTerritory" value="true"/>
+                    <option name="placementPerTerritory" value="3"/>
                 </attachment>
 
 
-	</attachmentList>
-	<initialize>
+    </attachmentList>
+    <initialize>
 
-		<ownerInitialize>
-    			<territoryOwner territory="Japan" owner="Japanese"/>
-			
-			
-			<territoryOwner territory="Syria Jordan" owner="Japanese"/>
-			<territoryOwner territory="Congo" owner="Japanese"/>
-			<territoryOwner territory="Algeria" owner="Japanese"/>
-			<territoryOwner territory="Libya" owner="Japanese"/>
-			<territoryOwner territory="Brazil" owner="Japanese"/>		    
+        <ownerInitialize>
+            <territoryOwner territory="Japan" owner="Japanese"/>
 
-			<territoryOwner territory="United Kingdom" owner="British"/>
-			<territoryOwner territory="West Canada" owner="British"/>				
 
-			<territoryOwner territory="Anglo Sudan Egypt" owner="British"/>
-			<territoryOwner territory="Italian East Africa" owner="British"/>
-			<territoryOwner territory="Kenya-Rhodesia" owner="British"/>
-			<territoryOwner territory="French Equatorial Africa" owner="British"/>
+            <territoryOwner territory="Syria Jordan" owner="Japanese"/>
+            <territoryOwner territory="Congo" owner="Japanese"/>
+            <territoryOwner territory="Algeria" owner="Japanese"/>
+            <territoryOwner territory="Libya" owner="Japanese"/>
+            <territoryOwner territory="Brazil" owner="Japanese"/>
 
-			<territoryOwner territory="India" owner="Americans"/>
-			<territoryOwner territory="Yunnan" owner="Chinese"/>
+            <territoryOwner territory="United Kingdom" owner="British"/>
+            <territoryOwner territory="West Canada" owner="British"/>
 
-		</ownerInitialize>
-		<unitInitialize>
-			<!-- india -->
+            <territoryOwner territory="Anglo Sudan Egypt" owner="British"/>
+            <territoryOwner territory="Italian East Africa" owner="British"/>
+            <territoryOwner territory="Kenya-Rhodesia" owner="British"/>
+            <territoryOwner territory="French Equatorial Africa" owner="British"/>
 
-			<unitPlacement unitType="infantry" territory="India" quantity = "5" owner="Americans"/>
-			<unitPlacement unitType="fighter" territory="India" quantity = "3" owner="Americans"/>
-			<unitPlacement unitType="armour" territory="India" quantity = "2" owner="Americans"/>
-			
-			<unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese"/>
-    		<unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
-			<unitPlacement unitType="transport" territory="Japan Sea Zone" quantity="2" owner="Japanese"/>
-			<unitPlacement unitType="battleship" territory="Japan Sea Zone" quantity="1" owner="Japanese"/>
-			
+            <territoryOwner territory="India" owner="Americans"/>
+            <territoryOwner territory="Yunnan" owner="Chinese"/>
 
-			<!-- indian ocean-->
-			<unitPlacement unitType="transport" territory="Indian Ocean Sea Zone" quantity="2" owner="British"/>			
+        </ownerInitialize>
+        <unitInitialize>
+            <!-- india -->
 
-			<!-- near Britain-->
-			<unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British"/>
-			<unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British"/>
-			<unitPlacement unitType="transport" territory="North Sea Zone" quantity="2" owner="British"/>
-			<unitPlacement unitType="battleship" territory="North Sea Zone" quantity="1" owner="British" />
-			<unitPlacement unitType="infantry" territory="North Sea Zone" quantity="4" owner="British" />
-			<unitPlacement unitType="factory" territory="West Canada" quantity="1" owner="British"/>
-			
-			<!-- baltic sea-->
-			<unitPlacement unitType="submarine" territory="Baltic Sea Zone" quantity="1" owner="Germans"/>
-			<unitPlacement unitType="transport" territory="Baltic Sea Zone" quantity="1" owner="Germans"/>
-			
-			<!-- findland norway-->
-			<unitPlacement unitType="armour" territory="Finland Norway" quantity="1" owner="Germans" /> 
-			<unitPlacement unitType="infantry" territory="Finland Norway" quantity="3" owner="Germans" /> 
-			<unitPlacement unitType="fighter" territory="Finland Norway" quantity="1" owner="Germans" /> 
-			    
-			<!-- redSea-->
-			<unitPlacement unitType="transport" territory="Red Sea Zone" quantity="2" owner="British"/>			
-			<unitPlacement unitType="carrier" territory="Red Sea Zone" quantity="2" owner="British"/>			
+            <unitPlacement unitType="infantry" territory="India" quantity = "5" owner="Americans"/>
+            <unitPlacement unitType="fighter" territory="India" quantity = "3" owner="Americans"/>
+            <unitPlacement unitType="armour" territory="India" quantity = "2" owner="Americans"/>
 
-			
-			<!--egypt -->
-			<unitPlacement unitType="armour" territory="Anglo Sudan Egypt" quantity="6" owner="British"/>			
-			<unitPlacement unitType="fighter" territory="Anglo Sudan Egypt" quantity="6" owner="British"/>			
-			<unitPlacement unitType="bomber" territory="Anglo Sudan Egypt" quantity="6" owner="British"/>			
-			
-			<!-- east africa -->
-			<unitPlacement unitType="infantry" territory="Italian East Africa" quantity="2" owner="British"/>			
-			
-			<!-- equatorial africa -->
-			<unitPlacement unitType="infantry" territory="French Equatorial Africa" quantity="2" owner="British"/>			
-			<unitPlacement unitType="armour" territory="French Equatorial Africa" quantity="2" owner="British"/>			
+            <unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
+            <unitPlacement unitType="transport" territory="Japan Sea Zone" quantity="2" owner="Japanese"/>
+            <unitPlacement unitType="battleship" territory="Japan Sea Zone" quantity="1" owner="Japanese"/>
 
-			<!--congo sea-->
-			<unitPlacement unitType="transport" territory="Congo Sea Zone" quantity="2" owner="British"/>			
-			<unitPlacement unitType="carrier" territory="Congo Sea Zone" quantity="2" owner="British"/>			
-			<unitPlacement unitType="infantry" territory="Congo Sea Zone" quantity="4" owner="British"/>			
-			<unitPlacement unitType="fighter" territory="Congo Sea Zone" quantity="3" owner="British"/>			
 
-		
-			<!-- congo -->
-			<unitPlacement unitType="infantry" territory="Congo" quantity="4" owner="Japanese" />
-			<unitPlacement unitType="armour" territory="Congo" quantity="5" owner="Japanese" />
-			<unitPlacement unitType="aaGun" territory="Congo" quantity="1" owner="Japanese" />
-			<!-- syria -->
-			<unitPlacement unitType="infantry" territory="Syria Jordan" quantity="1" owner="Japanese" />
-			<!--algeria -->
-			<unitPlacement unitType="infantry" territory="Algeria" quantity="1" owner="Japanese" />
+            <!-- indian ocean-->
+            <unitPlacement unitType="transport" territory="Indian Ocean Sea Zone" quantity="2" owner="British"/>
 
-			<!-- south brazil sea zone -->
-			<unitPlacement unitType="submarine" territory="South Brazil Sea Zone" quantity="3" owner="Japanese" />
-			<unitPlacement unitType="battleship" territory="South Brazil Sea Zone" quantity="2" owner="Japanese" />
-			<unitPlacement unitType="carrier" territory="South Brazil Sea Zone" quantity="2" owner="Japanese" />
-			<unitPlacement unitType="fighter" territory="South Brazil Sea Zone" quantity="3" owner="Japanese" />
+            <!-- near Britain-->
+            <unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British"/>
+            <unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British"/>
+            <unitPlacement unitType="transport" territory="North Sea Zone" quantity="2" owner="British"/>
+            <unitPlacement unitType="battleship" territory="North Sea Zone" quantity="1" owner="British" />
+            <unitPlacement unitType="infantry" territory="North Sea Zone" quantity="4" owner="British" />
+            <unitPlacement unitType="factory" territory="West Canada" quantity="1" owner="British"/>
 
-			<unitPlacement unitType="fighter" territory="Yunnan" quantity = "1" owner="Americans"/>
-			<unitPlacement unitType="infantry" territory="Yunnan" quantity = "2" owner="Chinese"/>
+            <!-- baltic sea-->
+            <unitPlacement unitType="submarine" territory="Baltic Sea Zone" quantity="1" owner="Germans"/>
+            <unitPlacement unitType="transport" territory="Baltic Sea Zone" quantity="1" owner="Germans"/>
 
-			<heldUnits unitType="infantry" player="British" quantity="4"/>
-			<heldUnits unitType="factory" player="British" quantity="2"/>
-			<heldUnits unitType="aaGun" player="British" quantity="2"/>
-			<heldUnits unitType="transport" player="British" quantity="2"/>
-			
-			<heldUnits unitType="infantry" player="Chinese" quantity="6"/>
-			<heldUnits unitType="aaGun" player="Germans" quantity="6"/>
-			<heldUnits unitType="transport" player="Germans" quantity="1"/>
-		</unitInitialize>
-		<resourceInitialize>
-			<resourceGiven player="Japanese" resource="PUs" quantity="35"/>
-			<resourceGiven player="British" resource="PUs" quantity="35"/>
-			<resourceGiven player="Americans" resource="PUs" quantity="35"/>
+            <!-- findland norway-->
+            <unitPlacement unitType="armour" territory="Finland Norway" quantity="1" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="Finland Norway" quantity="3" owner="Germans" />
+            <unitPlacement unitType="fighter" territory="Finland Norway" quantity="1" owner="Germans" />
 
-		</resourceInitialize>
-	
-		
-	</initialize>
-	  <propertyList>                        
+            <!-- redSea-->
+            <unitPlacement unitType="transport" territory="Red Sea Zone" quantity="2" owner="British"/>
+            <unitPlacement unitType="carrier" territory="Red Sea Zone" quantity="2" owner="British"/>
 
-		<!-- OPTIONAL PROPERTIES -->                
-				<property name="Place in Any Territory" value="true" editable="false">
-                        <boolean/>
-                </property>
-                            
-				<property name="Unit Placement Per Territory Restricted" value="true" editable="false">
-                        <boolean/>
-                </property>
-				
-				<property name="neutralCharge" value="3" editable="false">
-						<number min="0" max="9999999"/>
-				</property>
-				
-				<property name="Heavy Bomber Dice Rolls" value="3" editable="false">
-						<number min="1" max="10"/>
-				</property>
-				
-	  </propertyList>
+
+            <!--egypt -->
+            <unitPlacement unitType="armour" territory="Anglo Sudan Egypt" quantity="6" owner="British"/>
+            <unitPlacement unitType="fighter" territory="Anglo Sudan Egypt" quantity="6" owner="British"/>
+            <unitPlacement unitType="bomber" territory="Anglo Sudan Egypt" quantity="6" owner="British"/>
+
+            <!-- east africa -->
+            <unitPlacement unitType="infantry" territory="Italian East Africa" quantity="2" owner="British"/>
+
+            <!-- equatorial africa -->
+            <unitPlacement unitType="infantry" territory="French Equatorial Africa" quantity="2" owner="British"/>
+            <unitPlacement unitType="armour" territory="French Equatorial Africa" quantity="2" owner="British"/>
+
+            <!--congo sea-->
+            <unitPlacement unitType="transport" territory="Congo Sea Zone" quantity="2" owner="British"/>
+            <unitPlacement unitType="carrier" territory="Congo Sea Zone" quantity="2" owner="British"/>
+            <unitPlacement unitType="infantry" territory="Congo Sea Zone" quantity="4" owner="British"/>
+            <unitPlacement unitType="fighter" territory="Congo Sea Zone" quantity="3" owner="British"/>
+
+
+            <!-- congo -->
+            <unitPlacement unitType="infantry" territory="Congo" quantity="4" owner="Japanese" />
+            <unitPlacement unitType="armour" territory="Congo" quantity="5" owner="Japanese" />
+            <unitPlacement unitType="aaGun" territory="Congo" quantity="1" owner="Japanese" />
+            <!-- syria -->
+            <unitPlacement unitType="infantry" territory="Syria Jordan" quantity="1" owner="Japanese" />
+            <!--algeria -->
+            <unitPlacement unitType="infantry" territory="Algeria" quantity="1" owner="Japanese" />
+
+            <!-- south brazil sea zone -->
+            <unitPlacement unitType="submarine" territory="South Brazil Sea Zone" quantity="3" owner="Japanese" />
+            <unitPlacement unitType="battleship" territory="South Brazil Sea Zone" quantity="2" owner="Japanese" />
+            <unitPlacement unitType="carrier" territory="South Brazil Sea Zone" quantity="2" owner="Japanese" />
+            <unitPlacement unitType="fighter" territory="South Brazil Sea Zone" quantity="3" owner="Japanese" />
+
+            <unitPlacement unitType="fighter" territory="Yunnan" quantity = "1" owner="Americans"/>
+            <unitPlacement unitType="infantry" territory="Yunnan" quantity = "2" owner="Chinese"/>
+
+            <heldUnits unitType="infantry" player="British" quantity="4"/>
+            <heldUnits unitType="factory" player="British" quantity="2"/>
+            <heldUnits unitType="aaGun" player="British" quantity="2"/>
+            <heldUnits unitType="transport" player="British" quantity="2"/>
+
+            <heldUnits unitType="infantry" player="Chinese" quantity="6"/>
+            <heldUnits unitType="aaGun" player="Germans" quantity="6"/>
+            <heldUnits unitType="transport" player="Germans" quantity="1"/>
+        </unitInitialize>
+        <resourceInitialize>
+            <resourceGiven player="Japanese" resource="PUs" quantity="35"/>
+            <resourceGiven player="British" resource="PUs" quantity="35"/>
+            <resourceGiven player="Americans" resource="PUs" quantity="35"/>
+
+        </resourceInitialize>
+
+
+    </initialize>
+    <propertyList>
+
+        <!-- OPTIONAL PROPERTIES -->
+        <property name="Place in Any Territory" value="true" editable="false">
+            <boolean/>
+        </property>
+
+        <property name="Unit Placement Per Territory Restricted" value="true" editable="false">
+            <boolean/>
+        </property>
+
+        <property name="neutralCharge" value="3" editable="false">
+            <number min="0" max="9999999"/>
+        </property>
+
+        <property name="Heavy Bomber Dice Rolls" value="3" editable="false">
+            <number min="1" max="10"/>
+        </property>
+
+    </propertyList>
 </game>

--- a/src/test/resources/GameExample.xml
+++ b/src/test/resources/GameExample.xml
@@ -3,104 +3,104 @@
 
 <game>
 
-	<info name="gameExample" version="1.0" />
-	
-	<loader javaClass="games.strategy.engine.xml.TestGameLoader"/>
-		
-	
-	<map>
-		<territory name="canada"/>
-		<territory name="us"/>
-		<territory name="atlantic" water="true"/>
-		<connection t1="canada" t2="us"/>
-	</map>
-	<resourceList>
-		<resource name="gold"/>
-		<resource name="silver"/>
-	</resourceList>
-	<playerList>
-		<player name="chretian" optional="true"/>
-		<player name="bush" optional="false"/>
-		<player name="castro" optional="false"/>
-		<alliance player="chretian" alliance="natp"/>
-		<alliance player="castro" alliance="natp"/>
+    <info name="gameExample" version="1.0" />
 
-	</playerList>
-	<unitList>
-		<unit name="inf"/>
-	</unitList>
-	<gamePlay>
-		<delegate name="battle" javaClass="games.strategy.engine.xml.TestDelegate"/>
-		<delegate name="move" javaClass="games.strategy.engine.xml.TestDelegate"/>
-		<sequence>
-			<step name="noPlayer" delegate="move" />
-			<step name="usMove" delegate="move" player="bush"/>
-			<step name="usFight" delegate="battle" player="bush"/>
-			<step name="canMove" delegate="move" player="chretian"/>
-			<step name="canFight" delegate="battle" player="chretian"/>
-		</sequence>
-	</gamePlay>
-	<production>
-		<productionRule name="infForGold">
-			<cost resource="gold" quantity="3" />
-			<result resourceOrUnit="inf" quantity="1"/>
-		</productionRule>
-		<productionRule name="infForSilver">
-			<cost resource="silver" quantity="5" />
-			<result resourceOrUnit="inf" quantity="1"/>
-		</productionRule>
-		<productionRule name="infForSilverAndGold">
-			<cost resource="silver" quantity="1" />
-			<cost resource="silver" quantity="1" />
-			<result resourceOrUnit="inf" quantity="5"/>
-		</productionRule>
-		<productionFrontier name="usProd">
-			<frontierRules name="infForGold"/>
-			<frontierRules name="infForSilver"/>
-		</productionFrontier>
-		<productionFrontier name="canProd">
-			<frontierRules name="infForSilverAndGold"/>
-		</productionFrontier>
-		<playerProduction player="bush" frontier="usProd" />
-		<playerProduction player="chretian" frontier="canProd" />		
-	</production> 
-
-	<attachmentList>
-		<attachment name="infAttachment" attachTo="inf" javaClass="games.strategy.engine.xml.TestAttachment" type="unitType">
-			<option name="value" value="inf"/>
-		</attachment>
-		<attachment name="resourceAttachment" attachTo="gold" javaClass="games.strategy.engine.xml.TestAttachment" type="resource">
-			<option name="value" value="gold"/>
-		</attachment>
-		<attachment name="territoryAttachment" attachTo="us" javaClass="games.strategy.engine.xml.TestAttachment" type="territory">
-			<option name="value" value="us of a"/>
-		</attachment>
-		<attachment name="playerAttachment" attachTo="chretian" javaClass="games.strategy.engine.xml.TestAttachment" type="player">
-			<option name="value" value="liberal"/>
-		</attachment>
-	</attachmentList>
-	<initialize>
-		<ownerInitialize>
-			<territoryOwner territory="us" owner="bush"/>
-			<territoryOwner territory="canada" owner="chretian"/>
-		</ownerInitialize>
-		<unitInitialize>
-			<unitPlacement unitType="inf" territory="canada" quantity="5" owner="chretian"/>
-			<unitPlacement unitType="inf" territory="us" quantity="150" owner="bush"/>
-			<heldUnits unitType="inf" player="bush" quantity="20"/>
-		</unitInitialize>
-		<resourceInitialize>
-			<resourceGiven player="chretian" resource="gold" quantity="100"/>
-			<resourceGiven player="chretian" resource="silver" quantity="200"/>
-		</resourceInitialize>
-	</initialize>
-		
+    <loader javaClass="games.strategy.engine.xml.TestGameLoader"/>
 
 
-	
+    <map>
+        <territory name="canada"/>
+        <territory name="us"/>
+        <territory name="atlantic" water="true"/>
+        <connection t1="canada" t2="us"/>
+    </map>
+    <resourceList>
+        <resource name="gold"/>
+        <resource name="silver"/>
+    </resourceList>
+    <playerList>
+        <player name="chretian" optional="true"/>
+        <player name="bush" optional="false"/>
+        <player name="castro" optional="false"/>
+        <alliance player="chretian" alliance="natp"/>
+        <alliance player="castro" alliance="natp"/>
+
+    </playerList>
+    <unitList>
+        <unit name="inf"/>
+    </unitList>
+    <gamePlay>
+        <delegate name="battle" javaClass="games.strategy.engine.xml.TestDelegate"/>
+        <delegate name="move" javaClass="games.strategy.engine.xml.TestDelegate"/>
+        <sequence>
+            <step name="noPlayer" delegate="move" />
+            <step name="usMove" delegate="move" player="bush"/>
+            <step name="usFight" delegate="battle" player="bush"/>
+            <step name="canMove" delegate="move" player="chretian"/>
+            <step name="canFight" delegate="battle" player="chretian"/>
+        </sequence>
+    </gamePlay>
+    <production>
+        <productionRule name="infForGold">
+            <cost resource="gold" quantity="3" />
+            <result resourceOrUnit="inf" quantity="1"/>
+        </productionRule>
+        <productionRule name="infForSilver">
+            <cost resource="silver" quantity="5" />
+            <result resourceOrUnit="inf" quantity="1"/>
+        </productionRule>
+        <productionRule name="infForSilverAndGold">
+            <cost resource="silver" quantity="1" />
+            <cost resource="silver" quantity="1" />
+            <result resourceOrUnit="inf" quantity="5"/>
+        </productionRule>
+        <productionFrontier name="usProd">
+            <frontierRules name="infForGold"/>
+            <frontierRules name="infForSilver"/>
+        </productionFrontier>
+        <productionFrontier name="canProd">
+            <frontierRules name="infForSilverAndGold"/>
+        </productionFrontier>
+        <playerProduction player="bush" frontier="usProd" />
+        <playerProduction player="chretian" frontier="canProd" />
+    </production>
+
+    <attachmentList>
+        <attachment name="infAttachment" attachTo="inf" javaClass="games.strategy.engine.xml.TestAttachment" type="unitType">
+            <option name="value" value="inf"/>
+        </attachment>
+        <attachment name="resourceAttachment" attachTo="gold" javaClass="games.strategy.engine.xml.TestAttachment" type="resource">
+            <option name="value" value="gold"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="us" javaClass="games.strategy.engine.xml.TestAttachment" type="territory">
+            <option name="value" value="us of a"/>
+        </attachment>
+        <attachment name="playerAttachment" attachTo="chretian" javaClass="games.strategy.engine.xml.TestAttachment" type="player">
+            <option name="value" value="liberal"/>
+        </attachment>
+    </attachmentList>
+    <initialize>
+        <ownerInitialize>
+            <territoryOwner territory="us" owner="bush"/>
+            <territoryOwner territory="canada" owner="chretian"/>
+        </ownerInitialize>
+        <unitInitialize>
+            <unitPlacement unitType="inf" territory="canada" quantity="5" owner="chretian"/>
+            <unitPlacement unitType="inf" territory="us" quantity="150" owner="bush"/>
+            <heldUnits unitType="inf" player="bush" quantity="20"/>
+        </unitInitialize>
+        <resourceInitialize>
+            <resourceGiven player="chretian" resource="gold" quantity="100"/>
+            <resourceGiven player="chretian" resource="silver" quantity="200"/>
+        </resourceInitialize>
+    </initialize>
+
+
+
+
 </game>
 
 
-				
-				
+
+
 

--- a/src/test/resources/Test.xml
+++ b/src/test/resources/Test.xml
@@ -3,97 +3,97 @@
 
 <game>
 
-	<info name="test" version="1.0.0" />
-	
-	<loader javaClass="games.strategy.engine.xml.TestGameLoader"/>
-	
-	<map>
-		<territory name="canada"/>
-		<territory name="greenland"/>
-		<territory name="us"/>
-		<connection t1="canada" t2="us"/>
-		<connection t1="canada" t2="greenland"/>
-	</map>
-	<resourceList>
-		<resource name="gold"/>
-		<resource name="silver"/>
-	</resourceList>
-	<playerList>
-		<player name="chretian" optional="true"/>
-		<player name="bush" optional="false"/>
-		<player name="castro" optional="false"/>
-		<alliance player="chretian" alliance="natp"/>
-		<alliance player="castro" alliance="natp"/>
-	</playerList>
-	<unitList>
-		<unit name="inf"/>
-	</unitList>
-	<gamePlay>
-		<delegate name="battle" javaClass="games.strategy.engine.xml.TestDelegate"/>
-		<delegate name="move" javaClass="games.strategy.engine.xml.TestDelegate"/>
-		<sequence>
-			<step name="noPlayer" delegate="move" />
-			<step name="usMove" delegate="move" player="bush"/>
-			<step name="usFight" delegate="battle" player="bush"/>
-			<step name="canMove" delegate="move" player="chretian"/>
-			<step name="canFight" delegate="battle" player="chretian"/>
-		</sequence>
-	</gamePlay>
-	<production>
-		<productionRule name="infForGold">
-			<cost resource="gold" quantity="3" />
-			<result resourceOrUnit="inf" quantity="1"/>
-		</productionRule>
-		<productionRule name="infForSilver">
-			<cost resource="silver" quantity="5" />
-			<result resourceOrUnit="inf" quantity="1"/>
-		</productionRule>
-		<productionRule name="infForSilverAndGold">
-			<cost resource="silver" quantity="1" />
-			<cost resource="silver" quantity="1" />
-			<result resourceOrUnit="inf" quantity="5"/>
-		</productionRule>
+    <info name="test" version="1.0.0" />
 
-		<productionFrontier name="usProd">
-			<frontierRules name="infForGold"/>
-			<frontierRules name="infForSilver"/>
-		</productionFrontier>
-		<productionFrontier name="canProd">
-			<frontierRules name="infForSilverAndGold"/>
-		</productionFrontier>
-		<playerProduction player="bush" frontier="usProd" />
-		<playerProduction player="chretian" frontier="canProd" />
-	</production> 
+    <loader javaClass="games.strategy.engine.xml.TestGameLoader"/>
 
-	<attachmentList>
-		<attachment name="infAttachment" attachTo="inf" javaClass="games.strategy.engine.xml.TestAttachment" type="unitType">
-			<option name="value" value="inf"/>
-		</attachment>
-		<attachment name="resourceAttachment" attachTo="gold" javaClass="games.strategy.engine.xml.TestAttachment" type="resource">
-			<option name="value" value="gold"/>
-		</attachment>
-		<attachment name="territoryAttachment" attachTo="us" javaClass="games.strategy.engine.xml.TestAttachment" type="territory">
-			<option name="value" value="us of a"/>
-		</attachment>
-		<attachment name="playerAttachment" attachTo="chretian" javaClass="games.strategy.engine.xml.TestAttachment" type="player">
-			<option name="value" value="liberal"/>
-		</attachment>
-	</attachmentList>
-	<initialize>
-		<ownerInitialize>
-			<territoryOwner territory="us" owner="bush"/>
-			<territoryOwner territory="greenland" owner="chretian"/>
-			<territoryOwner territory="canada" owner="chretian"/>
-		</ownerInitialize>
-		<unitInitialize>
-			<unitPlacement unitType="inf" territory="canada" quantity="5" />
-			<unitPlacement unitType="inf" territory="us" quantity="150" />
-			<heldUnits unitType="inf" player="bush" quantity="20"/>
-			<heldUnits unitType="inf" player="chretian" quantity="10"/>
-		</unitInitialize>
-		<resourceInitialize>
-			<resourceGiven player="chretian" resource="gold" quantity="100"/>
-			<resourceGiven player="chretian" resource="silver" quantity="200"/>
-		</resourceInitialize>
-	</initialize>
+    <map>
+        <territory name="canada"/>
+        <territory name="greenland"/>
+        <territory name="us"/>
+        <connection t1="canada" t2="us"/>
+        <connection t1="canada" t2="greenland"/>
+    </map>
+    <resourceList>
+        <resource name="gold"/>
+        <resource name="silver"/>
+    </resourceList>
+    <playerList>
+        <player name="chretian" optional="true"/>
+        <player name="bush" optional="false"/>
+        <player name="castro" optional="false"/>
+        <alliance player="chretian" alliance="natp"/>
+        <alliance player="castro" alliance="natp"/>
+    </playerList>
+    <unitList>
+        <unit name="inf"/>
+    </unitList>
+    <gamePlay>
+        <delegate name="battle" javaClass="games.strategy.engine.xml.TestDelegate"/>
+        <delegate name="move" javaClass="games.strategy.engine.xml.TestDelegate"/>
+        <sequence>
+            <step name="noPlayer" delegate="move" />
+            <step name="usMove" delegate="move" player="bush"/>
+            <step name="usFight" delegate="battle" player="bush"/>
+            <step name="canMove" delegate="move" player="chretian"/>
+            <step name="canFight" delegate="battle" player="chretian"/>
+        </sequence>
+    </gamePlay>
+    <production>
+        <productionRule name="infForGold">
+            <cost resource="gold" quantity="3" />
+            <result resourceOrUnit="inf" quantity="1"/>
+        </productionRule>
+        <productionRule name="infForSilver">
+            <cost resource="silver" quantity="5" />
+            <result resourceOrUnit="inf" quantity="1"/>
+        </productionRule>
+        <productionRule name="infForSilverAndGold">
+            <cost resource="silver" quantity="1" />
+            <cost resource="silver" quantity="1" />
+            <result resourceOrUnit="inf" quantity="5"/>
+        </productionRule>
+
+        <productionFrontier name="usProd">
+            <frontierRules name="infForGold"/>
+            <frontierRules name="infForSilver"/>
+        </productionFrontier>
+        <productionFrontier name="canProd">
+            <frontierRules name="infForSilverAndGold"/>
+        </productionFrontier>
+        <playerProduction player="bush" frontier="usProd" />
+        <playerProduction player="chretian" frontier="canProd" />
+    </production>
+
+    <attachmentList>
+        <attachment name="infAttachment" attachTo="inf" javaClass="games.strategy.engine.xml.TestAttachment" type="unitType">
+            <option name="value" value="inf"/>
+        </attachment>
+        <attachment name="resourceAttachment" attachTo="gold" javaClass="games.strategy.engine.xml.TestAttachment" type="resource">
+            <option name="value" value="gold"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="us" javaClass="games.strategy.engine.xml.TestAttachment" type="territory">
+            <option name="value" value="us of a"/>
+        </attachment>
+        <attachment name="playerAttachment" attachTo="chretian" javaClass="games.strategy.engine.xml.TestAttachment" type="player">
+            <option name="value" value="liberal"/>
+        </attachment>
+    </attachmentList>
+    <initialize>
+        <ownerInitialize>
+            <territoryOwner territory="us" owner="bush"/>
+            <territoryOwner territory="greenland" owner="chretian"/>
+            <territoryOwner territory="canada" owner="chretian"/>
+        </ownerInitialize>
+        <unitInitialize>
+            <unitPlacement unitType="inf" territory="canada" quantity="5" />
+            <unitPlacement unitType="inf" territory="us" quantity="150" />
+            <heldUnits unitType="inf" player="bush" quantity="20"/>
+            <heldUnits unitType="inf" player="chretian" quantity="10"/>
+        </unitInitialize>
+        <resourceInitialize>
+            <resourceGiven player="chretian" resource="gold" quantity="100"/>
+            <resourceGiven player="chretian" resource="silver" quantity="200"/>
+        </resourceInitialize>
+    </initialize>
 </game>

--- a/src/test/resources/big_world_1942_test.xml
+++ b/src/test/resources/big_world_1942_test.xml
@@ -6,8 +6,8 @@
         <info name="Big World : 1942" version="2.5"/>
 
         <loader javaClass="games.strategy.triplea.TripleA"/>
-		
-		<triplea minimumVersion="1.5"/>
+
+        <triplea minimumVersion="1.5"/>
 
         <map>
                 <!-- Territory Definitions -->
@@ -1245,7 +1245,7 @@
                         <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
                         
                         <!-- Bidding Phase -->
-			
+
                         <step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
                         <step name="russianBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
                         
@@ -2324,36 +2324,36 @@
                         <option name="victoryCity" value="1"/>
                     </attachment>
 
-			<!-- Canals -->
-			<attachment name="canalAttachment" attachTo="SZ 27 Aegean Sea" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				<option name="canalName" value="Dardanelles"/>
-				<option name="landTerritories" value="Western Turkey"/>
-			</attachment>
+            <!-- Canals -->
+            <attachment name="canalAttachment" attachTo="SZ 27 Aegean Sea" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                <option name="canalName" value="Dardanelles"/>
+                <option name="landTerritories" value="Western Turkey"/>
+            </attachment>
 
-			<attachment name="canalAttachment" attachTo="SZ 29 Black Sea" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				<option name="canalName" value="Dardanelles"/>
-				<option name="landTerritories" value="Western Turkey"/>
-			</attachment>
+            <attachment name="canalAttachment" attachTo="SZ 29 Black Sea" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                <option name="canalName" value="Dardanelles"/>
+                <option name="landTerritories" value="Western Turkey"/>
+            </attachment>
 
-			<attachment name="canalAttachment" attachTo="SZ 28 Eastern Mediterranean" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				<option name="canalName" value="Suez Canal"/>
-				<option name="landTerritories" value="Egypt:Syria"/>
-			</attachment>
+            <attachment name="canalAttachment" attachTo="SZ 28 Eastern Mediterranean" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                <option name="canalName" value="Suez Canal"/>
+                <option name="landTerritories" value="Egypt:Syria"/>
+            </attachment>
 
-			<attachment name="canalAttachment" attachTo="SZ 55 Red Sea" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				<option name="canalName" value="Suez Canal"/>
-				<option name="landTerritories" value="Egypt:Syria"/>
-			</attachment>
+            <attachment name="canalAttachment" attachTo="SZ 55 Red Sea" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                <option name="canalName" value="Suez Canal"/>
+                <option name="landTerritories" value="Egypt:Syria"/>
+            </attachment>
 
-			<attachment name="canalAttachment" attachTo="SZ 36 East Pacific" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				<option name="canalName" value="Panama Canal"/>
-				<option name="landTerritories" value="Central America"/>
-			</attachment>
+            <attachment name="canalAttachment" attachTo="SZ 36 East Pacific" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                <option name="canalName" value="Panama Canal"/>
+                <option name="landTerritories" value="Central America"/>
+            </attachment>
 
-			<attachment name="canalAttachment" attachTo="SZ 37 Caribbean Sea" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				<option name="canalName" value="Panama Canal"/>
-				<option name="landTerritories" value="Central America"/>
-			</attachment>
+            <attachment name="canalAttachment" attachTo="SZ 37 Caribbean Sea" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                <option name="canalName" value="Panama Canal"/>
+                <option name="landTerritories" value="Central America"/>
+            </attachment>
 
 
         </attachmentList>
@@ -2996,9 +2996,9 @@
         </initialize>
 
         <propertyList>
-		
-				<!-- Bids -->
-				<property name="Germans bid" value="0" editable="true">
+
+                <!-- Bids -->
+                <property name="Germans bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
                 
@@ -3022,78 +3022,78 @@
                         <number min="0" max="1000"/>
                 </property>
 
-		<property name="Projection of Power" value="false" editable="true">
-			<boolean/>
-		</property>
+        <property name="Projection of Power" value="false" editable="true">
+            <boolean/>
+        </property>
 
-		<property name="Axis Projection of Power VCs" value="14" editable="false">
-			<number min="13" max="21"/>
-		</property>
+        <property name="Axis Projection of Power VCs" value="14" editable="false">
+            <number min="13" max="21"/>
+        </property>
 
-		<property name="Allies Projection of Power VCs" value="14" editable="false">
-			<number min="13" max="21"/>
-		</property>
+        <property name="Allies Projection of Power VCs" value="14" editable="false">
+            <number min="13" max="21"/>
+        </property>
 
-		<property name="Honorable Surrender" value="false" editable="true">
-			<boolean/>
-		</property>
+        <property name="Honorable Surrender" value="false" editable="true">
+            <boolean/>
+        </property>
 
-		<property name="Axis Honorable Victory VCs" value="15" editable="false">
-			<number min="13" max="21"/>
-		</property>
+        <property name="Axis Honorable Victory VCs" value="15" editable="false">
+            <number min="13" max="21"/>
+        </property>
 
-		<property name="Allies Honorable Victory VCs" value="15" editable="false">
-			<number min="13" max="21"/>
-		</property>
+        <property name="Allies Honorable Victory VCs" value="15" editable="false">
+            <number min="13" max="21"/>
+        </property>
 
-		<property name="Total Victory" value="true" editable="true">
-			<boolean/>
-		</property>
+        <property name="Total Victory" value="true" editable="true">
+            <boolean/>
+        </property>
 
-		<property name="Axis Total Victory VCs" value="17" editable="false">
-			<number min="13" max="21"/>
-		</property>
+        <property name="Axis Total Victory VCs" value="17" editable="false">
+            <number min="13" max="21"/>
+        </property>
 
-		<property name="Allies Total Victory VCs" value="17" editable="false">
-			<number min="13" max="21"/>
-		</property>
-        
-				<!-- Low Luck -->
+        <property name="Allies Total Victory VCs" value="17" editable="false">
+            <number min="13" max="21"/>
+        </property>
+
+                <!-- Low Luck -->
 
                 <property name="Low Luck" value="false" editable="true">
                         <boolean/>
                 </property>
 
-				<property name="Low Luck for AntiAircraft" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Technology" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
-						<boolean/>
-				</property>
-                
-				<property name="Tech Development" value="true" editable="true">
+                <property name="Low Luck for AntiAircraft" value="false" editable="true">
                         <boolean/>
                 </property>
-				
-				<property name="Heavy Bomber Dice Rolls" value="2" editable="false">
+
+                <property name="Low Luck for Technology" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Tech Development" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Heavy Bomber Dice Rolls" value="2" editable="false">
                         <number min="2" max="3"/>
                 </property>
 
                 <property name="LHTR Heavy Bombers" value="true" editable="true">
-                	  <boolean/>
-                </property>
-				
-				<property name="Territory Turn Limit" value="true" editable="true">
                         <boolean/>
                 </property>
-				
-				<property name="Super Sub Defence Bonus" value="0" editable="true">
-					<number min="0" max="1"/>
+
+                <property name="Territory Turn Limit" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Super Sub Defence Bonus" value="0" editable="true">
+                        <number min="0" max="1"/>
                 </property>
 
                 <property name="Always on AA" value="true" editable="true">
@@ -3104,13 +3104,13 @@
                         <boolean/>
                 </property>
 
-				<property name="Units Repair Hits Start Turn" value="false" editable="true">
-						<boolean/>
-				</property>
+                <property name="Units Repair Hits Start Turn" value="false" editable="true">
+                        <boolean/>
+                </property>
 
                 <!-- Use WW2V2 Rules -->
 
-				<property name="WW2V2" value="true" editable="false">
+                <property name="WW2V2" value="true" editable="false">
                         <boolean/>
                 </property>
 
@@ -3118,7 +3118,7 @@
                         <boolean/>
                 </property>
 
-                
+
 
                 <property name="Two hit battleship" value="true" editable="false">
                         <boolean/>
@@ -3133,87 +3133,87 @@
                 </property>
 
                 <property name="LHTR Carrier production rules" value="false" editable="true">
-					<boolean/>
+                        <boolean/>
                 </property>
-				
-				<property name="Produce new fighters on old carriers" value="false" editable="false">
-					<boolean/>
-				</property>
 
-				<property name="Land existing fighters on new carriers" value="false" editable="false">
-						<boolean/>
-				</property>
-				
+                <property name="Produce new fighters on old carriers" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Land existing fighters on new carriers" value="false" editable="false">
+                        <boolean/>
+                </property>
+
                 <property name="Allied Air Dependents" value="true" editable="false">
-					<boolean/>
-				</property>
-				
-				<property name="neutralCharge" value="0"/>
+                        <boolean/>
+                </property>
+
+                <property name="neutralCharge" value="0"/>
 
                 <property name="maxFactoriesPerTerritory" value="1"/>
 
-				<property name="Kamikaze Airplanes" value="false" editable="true">
-					<boolean/>
-				</property>
+                <property name="Kamikaze Airplanes" value="false" editable="true">
+                        <boolean/>
+                </property>
 
-				<property name="Neutrals Are Blitzable" value="false" editable="true">
-						<boolean/>
-				</property>
+                <property name="Neutrals Are Blitzable" value="false" editable="true">
+                        <boolean/>
+                </property>
 
-				<property name="Neutral Flyover Allowed" value="false" editable="true">
-						<boolean/>
-				</property>
-				
-				
-				<property name="mapName" value="big_world" editable="false"/>
+                <property name="Neutral Flyover Allowed" value="false" editable="true">
+                        <boolean/>
+                </property>
 
-				<property name="notes">
-					<value>
-					<![CDATA[  
-					                <!-- Map Name: also used for map utils when asked -->
-               
-				
-				A scenario loosely based on the year 1942 of the global conflict of 1939-1945. In Europe, 
-				Germany has Leningrad besieged, <br>stands at the gates of Moscow and the verge of defeat 
-				at Stalingrad (Dec 1942). In the Pacific, Japan has expanded <br>explosively but faces the 
-				turning point at Midway (May 1942). 
-				
-				<br><br>
-				Standard TripleA 'WW2V2' + 'LHTR' bomber rules apply. 
-				However, there are also variant rules to consider.<br>Also 'LHTR' 
-				delayed tech activation is applied.<br>
-				<h2>Capitols</h2>
-				The capitols of the world powers are as follows: <br>  Russia - Moscow <br>  Germany - Eastern Germany <br> 
-				 Britain - England <br>  China - Western Sinkiang <br>  Japan - Southern Japan <br> 
-				  USA - Northeastern United States <br>
-				  
-				  <h2>Unit definitions</h2>Units have been revised in an 
-				  effort to bring better balance to the naval cost structure. This
-				   <br>includes the addition of a Cruiser unit, and downgrading of the Destroyer.
-				    Please note that with this change the Destroyer Bombard tech should be 
-				    replaced with a Cruiser Bombard tech, but as of this writing (2005-05-01)
-				     the required code changes have not been made. <br><br>Unit definitions (attack, defend, PU cost)<br> 
-				      infantry:   1, 2, 3 (special: artillery enhances attack to 2)<br>  artillery:  2, 2, 4
-				       (special: enhances infantry)<br>  armour:     3, 3, 5<br>  fighter:    3, 4, 10<br>  
-				       bomber:     4, 1, 14 (special: SBR)<br>  submarine:  2, 2, 8 (special: submerge, sneak attack)<br> 
-				        destroyer:  2, 2, 8 (special: ASW [subs cannot submerge, no sneak attack])<br>  cruiser:   
-				         3, 3, 10<br>  carrier:    1, 1, 14 (special: 2 fighters may land on a carrier)<br>  battleship:
-				          4, 4, 22 (special: 2 hits [same turn] to destroy, can shore bombard)<br>
-				
-				<br>
-				<br>Victory Conditions:
-				<br>Until Surrender, or
-				<br>Total Victory: 17 victory cities
-				<br>Honorable Surrender: 15 victory cities
-				<br>Projection of Power: 14 victory cities
-				<br>
-				<br>Notable changes since version 2.4:
-				<br>Iwo Gima, Guam, and Wake are now worth 1 pu each (and Japan starts with 3 more pu's).
-				<br>Addition of relief tiles, flags, victory cities, and other minor corrections to the xml.
-				
-					]]>	
-					</value>
-				</property>
+
+                <property name="mapName" value="big_world" editable="false"/>
+
+                <property name="notes">
+                    <value>
+                    <![CDATA[
+                                    <!-- Map Name: also used for map utils when asked -->
+
+
+                A scenario loosely based on the year 1942 of the global conflict of 1939-1945. In Europe,
+                Germany has Leningrad besieged, <br>stands at the gates of Moscow and the verge of defeat
+                at Stalingrad (Dec 1942). In the Pacific, Japan has expanded <br>explosively but faces the
+                turning point at Midway (May 1942).
+
+                <br><br>
+                Standard TripleA 'WW2V2' + 'LHTR' bomber rules apply.
+                However, there are also variant rules to consider.<br>Also 'LHTR'
+                delayed tech activation is applied.<br>
+                <h2>Capitols</h2>
+                The capitols of the world powers are as follows: <br>  Russia - Moscow <br>  Germany - Eastern Germany <br>
+                 Britain - England <br>  China - Western Sinkiang <br>  Japan - Southern Japan <br>
+                  USA - Northeastern United States <br>
+
+                  <h2>Unit definitions</h2>Units have been revised in an
+                  effort to bring better balance to the naval cost structure. This
+                   <br>includes the addition of a Cruiser unit, and downgrading of the Destroyer.
+                    Please note that with this change the Destroyer Bombard tech should be
+                    replaced with a Cruiser Bombard tech, but as of this writing (2005-05-01)
+                     the required code changes have not been made. <br><br>Unit definitions (attack, defend, PU cost)<br>
+                      infantry:   1, 2, 3 (special: artillery enhances attack to 2)<br>  artillery:  2, 2, 4
+                       (special: enhances infantry)<br>  armour:     3, 3, 5<br>  fighter:    3, 4, 10<br>
+                       bomber:     4, 1, 14 (special: SBR)<br>  submarine:  2, 2, 8 (special: submerge, sneak attack)<br>
+                        destroyer:  2, 2, 8 (special: ASW [subs cannot submerge, no sneak attack])<br>  cruiser:
+                         3, 3, 10<br>  carrier:    1, 1, 14 (special: 2 fighters may land on a carrier)<br>  battleship:
+                          4, 4, 22 (special: 2 hits [same turn] to destroy, can shore bombard)<br>
+
+                <br>
+                <br>Victory Conditions:
+                <br>Until Surrender, or
+                <br>Total Victory: 17 victory cities
+                <br>Honorable Surrender: 15 victory cities
+                <br>Projection of Power: 14 victory cities
+                <br>
+                <br>Notable changes since version 2.4:
+                <br>Iwo Gima, Guam, and Wake are now worth 1 pu each (and Japan starts with 3 more pu's).
+                <br>Addition of relief tiles, flags, victory cities, and other minor corrections to the xml.
+
+                    ]]>
+                    </value>
+                </property>
 
 
 

--- a/src/test/resources/iron_blitz_test.xml
+++ b/src/test/resources/iron_blitz_test.xml
@@ -3,1722 +3,1722 @@
 
 <game>
 
-	<info name="Classic: Iron Blitz 3rd Edition Test" version="1.9"/>
-	
-	<loader javaClass="games.strategy.triplea.TripleA"/>
-	
-	<triplea minimumVersion="1.6.1"/>
-	
-	<map>
-	    <territory name="Afghanistan"/>
-	    <territory name="Alaska"/>
-	    <territory name="Algeria"/>
-	    <territory name="Anglo Sudan Egypt"/>
-	    <territory name="Angola"/>
-	    <territory name="Argentina-Chile"/>
-	    <territory name="Australia"/>
-	    <territory name="Borneo Celebes"/>
-	    <territory name="Brazil"/>
-	    <territory name="Caroline Islands"/>
-	    <territory name="Caucasus"/>
-	    <territory name="China"/>
-	    <territory name="Columbia"/>
-	    <territory name="Congo"/>
-	    <territory name="Cuba"/>
-	    <territory name="East Indies"/>
-	    <territory name="East Canada"/>
-	    <territory name="East Europe"/>
-	    <territory name="East US"/>
-	    <territory name="Eire"/>
-	    <territory name="Evenki National Okrug"/>
-	    <territory name="Finland Norway"/>
-	    <territory name="French Equatorial Africa"/>
-	    <territory name="French Indo China"/>
-	    <territory name="French West Africa"/>
-	    <territory name="Germany"/>
-	    <territory name="Gibraltar"/>
-	    <territory name="Hawaiian Islands"/>
-	    <territory name="India"/>
-	    <territory name="Italian East Africa"/>
-	    <territory name="Japan"/>
-	    <territory name="Karelia S.S.R."/>
-	    <territory name="Kazakh S.S.R."/>
-	    <territory name="Kenya-Rhodesia"/>
-	    <territory name="Kwangtung"/>
-	    <territory name="Libya"/>
-	    <territory name="Madagascar"/>
-	    <territory name="Manchuria"/>
-	    <territory name="Mexico"/>
-	    <territory name="Midway"/>
-	    <territory name="Mongolia"/>
-	    <territory name="Mozambique"/>
-	    <territory name="New Guinea"/>
-	    <territory name="New Zealand"/>
-	    <territory name="Novosibirsk"/>
-	    <territory name="Okinawa"/>
-	    <territory name="Panama"/>
-	    <territory name="Persia"/>
-	    <territory name="Peru"/>
-	    <territory name="Philippines"/>
-	    <territory name="Rio del Oro"/>
-	    <territory name="Russia"/>
-	    <territory name="Saudi Arabia"/>
-	    <territory name="Sinkiang"/>
-	    <territory name="Solomon Islands"/>
-	    <territory name="South Africa"/>
-	    <territory name="South Europe"/>
-	    <territory name="Soviet Far East"/>
-	    <territory name="Spain"/>
-	    <territory name="Sweden"/>
-	    <territory name="Switzerland"/>
-	    <territory name="Syria Jordan"/>
-	    <territory name="Turkey"/>
-	    <territory name="Ukraine S.S.R."/>
-	    <territory name="United Kingdom"/>
-	    <territory name="Wake Island"/>
-	    <territory name="West Canada"/>
-	    <territory name="West Europe"/>
-	    <territory name="West US"/>
-	    <territory name="Yakut S.S.R."/>
-	    <territory name="Alaska Sea Zone" water="true" />
-	    <territory name="Angola Sea Zone" water="true" />
-	    <territory name="Antartic Sea Zone" water="true" />
-	    <territory name="Baltic Sea Zone" water="true" />
-	    <territory name="Black Sea Zone" water="true" />
-	    <territory name="Borneo Sea Zone" water="true" />
-	    <territory name="Carribean Sea Zone" water="true" />
-	    <territory name="Caroline Islands Sea Zone" water="true" />
-	    <territory name="Caspian Sea Zone" water="true" />
-	    <territory name="Central Mediteranean Sea Zone" water="true" />
-	    <territory name="Congo Sea Zone" water="true" />
-	    <territory name="East Argentina Sea Zone" water="true" />
-	    <territory name="East Compass Sea Zone" water="true" />
-	    <territory name="East Indies Sea Zone" water="true" />
-	    <territory name="East Canada Sea Zone" water="true" />
-	    <territory name="East Mediteranean Sea Zone" water="true" />
-	    <territory name="East Pacific Sea Zone" water="true" />
-	    <territory name="East US Sea Zone" water="true" />
-	    <territory name="French Indo China Sea Zone" water="true" />
-	    <territory name="Hawaii Sea Zone" water="true" />
-	    <territory name="Indian Ocean Sea Zone" water="true" />
-	    <territory name="Japan Sea Zone" water="true" />
-	    <territory name="Karelia Sea Zone" water="true" />
-	    <territory name="Kwangtung Sea Zone" water="true" />
-	    <territory name="Mexico Sea Zone" water="true" />
-	    <territory name="Midway Sea Zone" water="true" />
-	    <territory name="Mozambique Sea Zone" water="true" />
-	    <territory name="New Guinea Sea Zone" water="true" />
-	    <territory name="New Zealand Sea Zone" water="true" />
-	    <territory name="North Australia Sea Zone" water="true" />
-	    <territory name="North Brazil Sea Zone" water="true" />
-	    <territory name="North Sea Zone" water="true" />
-	    <territory name="North Atlantic Sea Zone" water="true" />
-	    <territory name="North Pacific Sea Zone" water="true" />
-	    <territory name="Okinawa Sea Zone" water="true" />
-	    <territory name="Peru Sea Zone" water="true" />
-	    <territory name="Philippines Sea Zone" water="true" />
-	    <territory name="Red Sea Zone" water="true" />
-	    <territory name="Solomon Islands Sea Zone" water="true" />
-	    <territory name="South Africa Sea Zone" water="true" />
-	    <territory name="South Argentina Sea Zone" water="true" />
-	    <territory name="South Australia Sea Zone" water="true" />
-	    <territory name="South Brazil Sea Zone" water="true" />
-	    <territory name="South Compass Sea Zone" water="true" />
-	    <territory name="South East Madagascar Sea Zone" water="true" />
-	    <territory name="South Pacific Sea Zone" water="true"/>
-	    <territory name="South Atlantic Sea Zone" water="true" />
-	    <territory name="Soviet Far East Sea Zone" water="true" />
-	    <territory name="Wake Island Sea Zone" water="true" />
-	    <territory name="West Africa Sea Zone" water="true" />
-	    <territory name="West Compass Sea Zone" water="true" />
-	    <territory name="West Australia Sea Zone" water="true" />
-	    <territory name="West Canada Sea Zone" water="true" />
-	    <territory name="West Mediteranean Sea Zone" water="true" />
-	    <territory name="West Panama Sea Zone" water="true" />
-	    <territory name="West Spain Sea Zone" water="true" />
-	    <territory name="West US Sea Zone" water="true" />
-	    <territory name="Gulf of Mexico Sea Zone" water="true" />
-		
-		
-		<!-- Connections -->
-		
-		<!-- this connection is optional 
-	    <connection t1="East Canada Sea Zone" t2="West Canada" />
-		-->
-		
-	    <connection t1="Gulf of Mexico Sea Zone" t2="West US" />
-	    <connection t1="Gulf of Mexico Sea Zone" t2="Mexico" />
-	    <connection t1="Gulf of Mexico Sea Zone" t2="East US Sea Zone" />
-	    <connection t1="Gulf of Mexico Sea Zone" t2="Carribean Sea Zone" />
-	    <connection t1="East Canada Sea Zone" t2="East Canada" />
-	    <connection t1="East Canada Sea Zone" t2="North Sea Zone" />
-	    <connection t1="West Spain Sea Zone" t2="East Canada Sea Zone" />
-	    <connection t1="North Atlantic Sea Zone" t2="East Canada Sea Zone" />
-	    <connection t1="East Canada Sea Zone" t2="East US Sea Zone" />
-	    <connection t1="East Canada" t2="East US" />
-	    <connection t1="East US" t2="East US Sea Zone" />
-	    <connection t1="Carribean Sea Zone" t2="East US Sea Zone" />
-	    <connection t1="Carribean Sea Zone" t2="North Atlantic Sea Zone" />
-	    <connection t1="Carribean Sea Zone" t2="North Brazil Sea Zone" />
-	    <connection t1="Carribean Sea Zone" t2="Columbia" />
-	    <connection t1="Carribean Sea Zone" t2="Panama" />
-	    <connection t1="Carribean Sea Zone" t2="Cuba" />
-	    <connection t1="Columbia" t2="Panama" />
-	    <connection t1="Columbia" t2="West Panama Sea Zone" />
-	    <connection t1="Panama" t2="West Panama Sea Zone" />
-	    <connection t1="Peru" t2="Peru Sea Zone" />
-	    <connection t1="Peru" t2="Brazil" />
-	    <connection t1="Peru" t2="Columbia" />
-	    <connection t1="Columbia" t2="Brazil" />
-	    <connection t1="West Panama Sea Zone" t2="Peru Sea Zone" />
-	    <connection t1="West Panama Sea Zone" t2="Carribean Sea Zone" />
-	    <connection t1="Peru" t2="Argentina-Chile" />
-	    <connection t1="Peru Sea Zone" t2="Argentina-Chile" />
-	    <connection t1="Peru Sea Zone" t2="South Argentina Sea Zone" />
-	    <connection t1="Argentina-Chile" t2="Brazil" />
-	    <connection t1="Argentina-Chile" t2="East Argentina Sea Zone" />
-	    <connection t1="Argentina-Chile" t2="South Argentina Sea Zone" />
-	    <connection t1="South Argentina Sea Zone" t2="East Argentina Sea Zone" />
-	    <connection t1="South Argentina Sea Zone" t2="South Atlantic Sea Zone" />
-	    <connection t1="East Argentina Sea Zone" t2="South Atlantic Sea Zone" />
-	    <connection t1="South Argentina Sea Zone" t2="Antartic Sea Zone" />
-	    <connection t1="East Argentina Sea Zone" t2="South Brazil Sea Zone" />
-	    <connection t1="South Brazil Sea Zone" t2="Brazil" />
-	    <connection t1="Brazil" t2="North Brazil Sea Zone" />
-	    <connection t1="South Brazil Sea Zone" t2="South Atlantic Sea Zone" />
-	    <connection t1="South Brazil Sea Zone" t2="West Africa Sea Zone" />
-	    <connection t1="South Brazil Sea Zone" t2="Congo Sea Zone" />
-	    <connection t1="South Brazil Sea Zone" t2="North Brazil Sea Zone" />
-	    <connection t1="North Brazil Sea Zone" t2="North Atlantic Sea Zone" />
-	    <connection t1="North Brazil Sea Zone" t2="West Africa Sea Zone" />
-	    <connection t1="North Atlantic Sea Zone" t2="West Africa Sea Zone" />
-	    <connection t1="North Atlantic Sea Zone" t2="West Spain Sea Zone" />
-	    <connection t1="North Atlantic Sea Zone" t2="East US Sea Zone" />
-	    <connection t1="Eire" t2="North Sea Zone" />
-	    <connection t1="United Kingdom" t2="North Sea Zone" />
-	    <connection t1="North Sea Zone" t2="West Spain Sea Zone" />
-	    <connection t1="North Sea Zone" t2="Karelia Sea Zone" />
-	    <connection t1="North Sea Zone" t2="West Europe" />
-	    <connection t1="North Sea Zone" t2="Finland Norway" />
-	    <connection t1="North Sea Zone" t2="Baltic Sea Zone" />
-	    <connection t1="West Europe" t2="Baltic Sea Zone" />
-	    <connection t1="West Spain Sea Zone" t2="West Mediteranean Sea Zone" />
-	    <connection t1="West Spain Sea Zone" t2="Spain" />
-	    <connection t1="West Spain Sea Zone" t2="West Europe" />
-	    <connection t1="West Spain Sea Zone" t2="Algeria" />
-	    <connection t1="West Spain Sea Zone" t2="West Africa Sea Zone" />
-	    <connection t1="West Africa Sea Zone" t2="Rio del Oro" />
-	    <connection t1="West Africa Sea Zone" t2="French West Africa" />
-	    <connection t1="West Africa Sea Zone" t2="Congo Sea Zone" />
-	    <connection t1="Congo Sea Zone" t2="South Atlantic Sea Zone" />
-	    <connection t1="Congo Sea Zone" t2="South Brazil Sea Zone" />
-	    <connection t1="Congo Sea Zone" t2="French Equatorial Africa" />
-	    <connection t1="Congo Sea Zone" t2="Congo" />
-	    <connection t1="Congo Sea Zone" t2="Angola Sea Zone" />
-	    <connection t1="South Atlantic Sea Zone" t2="Antartic Sea Zone" />
-	    <connection t1="South Atlantic Sea Zone" t2="Angola Sea Zone" />
-	    <connection t1="Angola Sea Zone" t2="South Africa" />
-	    <connection t1="Angola Sea Zone" t2="South Africa Sea Zone" />
-	    <connection t1="Angola Sea Zone" t2="Angola" />
-	    <connection t1="Angola Sea Zone" t2="Antartic Sea Zone" />
-	    <connection t1="Rio del Oro" t2="French West Africa" />
-	    <connection t1="French West Africa" t2="Algeria" />
-	    <connection t1="French West Africa" t2="French Equatorial Africa" />
-	    <connection t1="Algeria" t2="West Mediteranean Sea Zone" />
-	    <connection t1="Algeria" t2="Libya" />
-	    <connection t1="Algeria" t2="French Equatorial Africa" />
-	    <connection t1="Libya" t2="Central Mediteranean Sea Zone" />
-	    <connection t1="Libya" t2="French Equatorial Africa" />
-	    <connection t1="Libya" t2="Anglo Sudan Egypt" />
-	    <connection t1="Anglo Sudan Egypt" t2="East Mediteranean Sea Zone" />
-	    <connection t1="Anglo Sudan Egypt" t2="Red Sea Zone" />
-	    <connection t1="Anglo Sudan Egypt" t2="Italian East Africa" />
-	    <connection t1="Anglo Sudan Egypt" t2="French Equatorial Africa" />
-	    <connection t1="Anglo Sudan Egypt" t2="Congo" />
-	    <connection t1="Anglo Sudan Egypt" t2="Kenya-Rhodesia" />
-	    <connection t1="Italian East Africa" t2="Kenya-Rhodesia" />
-	    <connection t1="Italian East Africa" t2="Red Sea Zone" />
-	    <connection t1="French Equatorial Africa" t2="Congo" />
-	    <connection t1="Congo" t2="Angola" />
-	    <connection t1="Congo" t2="Kenya-Rhodesia" />
-	    <connection t1="Angola" t2="Kenya-Rhodesia" />
-	    <connection t1="Kenya-Rhodesia" t2="South Africa" />
-	    <connection t1="Angola" t2="South Africa" />
-	    <connection t1="South Africa" t2="Mozambique" />
-	    <connection t1="Mozambique" t2="Kenya-Rhodesia" />
-	    <connection t1="South Africa Sea Zone" t2="South East Madagascar Sea Zone" />
-	    <connection t1="South Africa" t2="South Africa Sea Zone" />
-	    <connection t1="South Africa" t2="Mozambique Sea Zone" />
-	    <connection t1="Mozambique" t2="Mozambique Sea Zone" />
-	    <connection t1="Kenya-Rhodesia" t2="Mozambique Sea Zone" />
-	    <connection t1="South Africa Sea Zone" t2="Madagascar" />
-	    <connection t1="South East Madagascar Sea Zone" t2="Madagascar" />
-	    <connection t1="Madagascar" t2="West Compass Sea Zone" />
-	    <connection t1="Madagascar" t2="Mozambique Sea Zone" />
-	    <connection t1="Gibraltar" t2="West Mediteranean Sea Zone" />
-	    <connection t1="Spain" t2="West Europe" />
-	    <connection t1="Spain" t2="West Mediteranean Sea Zone" />
-	    <connection t1="West Europe" t2="West Mediteranean Sea Zone" />
-	    <connection t1="West Europe" t2="Switzerland" />
-	    <connection t1="Switzerland" t2="Germany" />
-	    <connection t1="Switzerland" t2="South Europe" />
-	    <connection t1="Germany" t2="West Europe" />
-	    <connection t1="Karelia S.S.R." t2="Baltic Sea Zone" />
-	    <connection t1="Germany" t2="Baltic Sea Zone" />
-	    <connection t1="Germany" t2="South Europe" />
-	    <connection t1="Germany" t2="East Europe" />
-	    <connection t1="Finland Norway" t2="Sweden" />
-	    <connection t1="Finland Norway" t2="Karelia S.S.R." />
-	    <connection t1="Karelia S.S.R." t2="Karelia Sea Zone" />
-	    <connection t1="Baltic Sea Zone" t2="Sweden" />
-	    <connection t1="Baltic Sea Zone" t2="East Europe" />
-	    <connection t1="Baltic Sea Zone" t2="Finland Norway" />
-	    <connection t1="South Europe" t2="Central Mediteranean Sea Zone" />
-	    <connection t1="South Europe" t2="East Europe" />
-	    <connection t1="West Europe" t2="South Europe" />
-	    <connection t1="West Mediteranean Sea Zone" t2="Central Mediteranean Sea Zone" />
-	    <connection t1="Central Mediteranean Sea Zone" t2="East Mediteranean Sea Zone" />
-	    <connection t1="Central Mediteranean Sea Zone" t2="Black Sea Zone" />
-	    <connection t1="East Mediteranean Sea Zone" t2="Syria Jordan" />
-	    <connection t1="East Mediteranean Sea Zone" t2="Turkey" />
-	    <connection t1="Black Sea Zone" t2="Turkey" />
-	    <connection t1="Black Sea Zone" t2="Caucasus" />
-	    <connection t1="Black Sea Zone" t2="East Europe" />
-	    <connection t1="Black Sea Zone" t2="Ukraine S.S.R." />
-	    <connection t1="Black Sea Zone" t2="East Mediteranean Sea Zone" />
-	    <connection t1="Caspian Sea Zone" t2="Caucasus" />
-	    <connection t1="Caspian Sea Zone" t2="Kazakh S.S.R." />
-	    <connection t1="Caspian Sea Zone" t2="Persia" />
-	    <connection t1="Caspian Sea Zone" t2="Russia" />
-	    <connection t1="East Europe" t2="Ukraine S.S.R." />
-	    <connection t1="East Europe" t2="Karelia S.S.R." />
-	    <connection t1="Ukraine S.S.R." t2="Karelia S.S.R." />
-	    <connection t1="Ukraine S.S.R." t2="Caucasus" />
-	    <connection t1="Caucasus" t2="Karelia S.S.R." />
-	    <connection t1="Caucasus" t2="Russia" />
-	    <connection t1="Russia" t2="Kazakh S.S.R." />
-	    <connection t1="Russia" t2="Novosibirsk" />
-	    <connection t1="Russia" t2="Evenki National Okrug" />
-	    <connection t1="Karelia S.S.R." t2="Russia" />
-	    <connection t1="Gibraltar" t2="Spain" />
-	    <connection t1="Anglo Sudan Egypt" t2="Syria Jordan" />
-	    <connection t1="East Mediteranean Sea Zone" t2="Red Sea Zone" />
-	    <connection t1="Syria Jordan" t2="Red Sea Zone" />
-	    <connection t1="Saudi Arabia" t2="Red Sea Zone" />
-	    <connection t1="Saudi Arabia" t2="Syria Jordan" />
-	    <connection t1="Saudi Arabia" t2="Persia" />
-	    <connection t1="Syria Jordan" t2="Persia" />
-	    <connection t1="Syria Jordan" t2="Turkey" />
-	    <connection t1="Turkey" t2="Persia" />
-	    <connection t1="Caucasus" t2="Persia" />
-	    <connection t1="Turkey" t2="Caucasus" />
-	    <connection t1="Evenki National Okrug" t2="Yakut S.S.R." />
-	    <connection t1="Evenki National Okrug" t2="Novosibirsk" />
-	    <connection t1="Yakut S.S.R." t2="Soviet Far East" />
-	    <connection t1="Yakut S.S.R." t2="Manchuria" />
-	    <connection t1="Yakut S.S.R." t2="Mongolia" />
-	    <connection t1="Kazakh S.S.R." t2="Novosibirsk" />
-	    <connection t1="Kazakh S.S.R." t2="Persia" />
-	    <connection t1="Kazakh S.S.R." t2="Afghanistan" />
-	    <connection t1="Kazakh S.S.R." t2="Sinkiang" />
-	    <connection t1="Novosibirsk" t2="Mongolia" />
-	    <connection t1="Novosibirsk" t2="Sinkiang" />
-	    <connection t1="Novosibirsk" t2="Yakut S.S.R." />
-	    <connection t1="Soviet Far East" t2="Soviet Far East Sea Zone" />
-	    <connection t1="Soviet Far East" t2="Manchuria" />
-	    <connection t1="Mongolia" t2="Sinkiang" />
-	    <connection t1="Mongolia" t2="China" />
-	    <connection t1="Mongolia" t2="Manchuria" />
-	    <connection t1="Persia" t2="Afghanistan" />
-	    <connection t1="Afghanistan" t2="India" />
-	    <connection t1="Afghanistan" t2="Sinkiang" />
-	    <connection t1="Sinkiang" t2="India" />
-	    <connection t1="Sinkiang" t2="China" />
-	    <connection t1="Sinkiang" t2="French Indo China" />
-	    <connection t1="China" t2="French Indo China" />
-	    <connection t1="India" t2="Indian Ocean Sea Zone" />
-	    <connection t1="India" t2="French Indo China" />
-	    <connection t1="Manchuria" t2="Japan Sea Zone" />
-	    <connection t1="China" t2="Manchuria" />
-	    <connection t1="Manchuria" t2="Kwangtung" />
-	    <connection t1="China" t2="Kwangtung" />
-	    <connection t1="Kwangtung" t2="French Indo China" />
-	    <connection t1="Kwangtung" t2="Kwangtung Sea Zone" />
-	    <connection t1="French Indo China Sea Zone" t2="French Indo China" />
-	    <connection t1="Persia" t2="India" />
-	    <connection t1="Red Sea Zone" t2="Indian Ocean Sea Zone" />
-	    <connection t1="Red Sea Zone" t2="West Compass Sea Zone" />
-	    <connection t1="Mozambique Sea Zone" t2="Red Sea Zone" />
-	    <connection t1="Red Sea Zone" t2="Persia" />
-	    <connection t1="South Africa Sea Zone" t2="Mozambique Sea Zone" />
-	    <connection t1="South East Madagascar Sea Zone" t2="West Compass Sea Zone" />
-	    <connection t1="South East Madagascar Sea Zone" t2="South Compass Sea Zone" />
-	    <connection t1="West Compass Sea Zone" t2="Mozambique Sea Zone" />
-	    <connection t1="West Compass Sea Zone" t2="East Compass Sea Zone" />
-	    <connection t1="West Compass Sea Zone" t2="South Compass Sea Zone" />
-	    <connection t1="West Compass Sea Zone" t2="Indian Ocean Sea Zone" />
-	    <connection t1="East Compass Sea Zone" t2="Indian Ocean Sea Zone" />
-	    <connection t1="East Compass Sea Zone" t2="South Compass Sea Zone" />
-	    <connection t1="East Compass Sea Zone" t2="South Australia Sea Zone" />
-	    <connection t1="East Compass Sea Zone" t2="West Australia Sea Zone" />
-	    <connection t1="East Compass Sea Zone" t2="East Indies Sea Zone" />
-	    <connection t1="French Indo China Sea Zone" t2="East Indies Sea Zone" />
-	    <connection t1="Indian Ocean Sea Zone" t2="French Indo China Sea Zone" />
-	    <connection t1="Indian Ocean Sea Zone" t2="East Indies Sea Zone" />
-	    <connection t1="South Australia Sea Zone" t2="West Australia Sea Zone" />
-	    <connection t1="South Australia Sea Zone" t2="South Compass Sea Zone" />
-	    <connection t1="South Australia Sea Zone" t2="New Zealand Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="South Australia Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="New Zealand Sea Zone" />
-	    <connection t1="West Australia Sea Zone" t2="North Australia Sea Zone" />
-	    <connection t1="West Australia Sea Zone" t2="East Indies Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="Solomon Islands Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="New Guinea Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="Borneo Sea Zone" />
-	    <connection t1="West Australia Sea Zone" t2="Australia" />
-	    <connection t1="Australia" t2="South Australia Sea Zone" />
-	    <connection t1="Australia" t2="North Australia Sea Zone" />
-	    <connection t1="New Zealand Sea Zone" t2="New Zealand" />
-	    <connection t1="Solomon Islands Sea Zone" t2="New Zealand Sea Zone" />
-	    <connection t1="New Zealand Sea Zone" t2="South Pacific Sea Zone" />
-	    <connection t1="New Zealand Sea Zone" t2="East Pacific Sea Zone" />
-	    <connection t1="South Pacific Sea Zone" t2="East Pacific Sea Zone" />
-	    <connection t1="South Pacific Sea Zone" t2="Solomon Islands Sea Zone" />
-	    <connection t1="South Pacific Sea Zone" t2="Hawaii Sea Zone" />
-	    <connection t1="South Pacific Sea Zone" t2="Mexico Sea Zone" />
-	    <connection t1="East Pacific Sea Zone" t2="Mexico Sea Zone" />
-	    <connection t1="Soviet Far East Sea Zone" t2="Alaska Sea Zone" />
-	    <connection t1="Alaska Sea Zone" t2="Alaska" />
-	    <connection t1="Alaska Sea Zone" t2="West Canada Sea Zone" />
-	    <connection t1="West Canada Sea Zone" t2="Alaska" />
-	    <connection t1="West Canada Sea Zone" t2="West Canada" />
-	    <connection t1="Alaska Sea Zone" t2="North Pacific Sea Zone" />
-	    <connection t1="Alaska Sea Zone" t2="Midway Sea Zone" />
-	    <connection t1="Midway" t2="Midway Sea Zone" />
-	    <connection t1="Wake Island" t2="Wake Island Sea Zone" />
-	    <connection t1="Okinawa" t2="Okinawa Sea Zone" />
-	    <connection t1="Philippines" t2="Philippines Sea Zone" />
-	    <connection t1="New Guinea" t2="New Guinea Sea Zone" />
-	    <connection t1="Solomon Islands" t2="Solomon Islands Sea Zone" />
-	    <connection t1="East Indies" t2="East Indies Sea Zone" />
-	    <connection t1="Borneo Celebes" t2="Borneo Sea Zone" />
-	    <connection t1="Japan" t2="Japan Sea Zone" />
-	    <connection t1="Hawaiian Islands" t2="Hawaii Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="Soviet Far East Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="North Pacific Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="Okinawa Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="Philippines Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="Kwangtung Sea Zone" />
-	    <connection t1="Okinawa Sea Zone" t2="Philippines Sea Zone" />
-	    <connection t1="Okinawa Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="Borneo Sea Zone" t2="Philippines Sea Zone" />
-	    <connection t1="French Indo China Sea Zone" t2="Philippines Sea Zone" />
-	    <connection t1="French Indo China Sea Zone" t2="Borneo Sea Zone" />
-	    <connection t1="French Indo China Sea Zone" t2="Kwangtung Sea Zone" />
-	    <connection t1="Philippines Sea Zone" t2="Kwangtung Sea Zone" />
-	    <connection t1="Japan Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="North Pacific Sea Zone" t2="Midway Sea Zone" />
-	    <connection t1="North Pacific Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="Midway Sea Zone" t2="Hawaii Sea Zone" />
-	    <connection t1="Midway Sea Zone" t2="West US Sea Zone" />
-	    <connection t1="Midway Sea Zone" t2="West Canada Sea Zone" />
-	    <connection t1="West US Sea Zone" t2="Hawaii Sea Zone" />
-	    <connection t1="Hawaii Sea Zone" t2="Mexico Sea Zone" />
-	    <connection t1="Hawaii Sea Zone" t2="North Pacific Sea Zone" />
-	    <connection t1="Mexico Sea Zone" t2="Mexico" />
-	    <connection t1="Mexico" t2="West US" />
-	    <connection t1="West US" t2="West Canada" />
-	    <connection t1="West US Sea Zone" t2="West US" />
-	    <connection t1="West US Sea Zone" t2="Mexico Sea Zone" />
-	    <connection t1="West US Sea Zone" t2="West Canada" />
-	    <connection t1="West US Sea Zone" t2="West Canada Sea Zone" />
-	    <connection t1="Hawaii Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="Hawaii Sea Zone" t2="Solomon Islands Sea Zone" />
-	    <connection t1="West Canada" t2="East Canada" />
-	    <connection t1="West US" t2="East US" />
-	    <connection t1="Mexico" t2="Panama" />
-	    <connection t1="Mexico Sea Zone" t2="West Panama Sea Zone" />
-	    <connection t1="East Pacific Sea Zone" t2="Peru Sea Zone" />
-	    <connection t1="New Zealand Sea Zone" t2="South Argentina Sea Zone" />
-	    <connection t1="Alaska" t2="West Canada" />
-	    <connection t1="Peru Sea Zone" t2="New Zealand Sea Zone" />
-	    <connection t1="North Australia Sea Zone" t2="East Indies Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Solomon Islands Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="Solomon Islands Sea Zone" t2="Wake Island Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Okinawa Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Philippines Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Borneo Sea Zone" />
-	    <connection t1="East Indies Sea Zone" t2="Borneo Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="New Guinea Sea Zone" />
-	    <connection t1="Caroline Islands Sea Zone" t2="Caroline Islands" />
-	    <connection t1="Soviet Far East Sea Zone" t2="North Pacific Sea Zone" />
-	    <connection t1="Solomon Islands Sea Zone" t2="New Guinea Sea Zone" />	
-	    <connection t1="Borneo Sea Zone" t2="New Guinea Sea Zone" />	
-	</map>
-	
-	<resourceList>
-		<resource name="PUs"/>
-	</resourceList>
+    <info name="Classic: Iron Blitz 3rd Edition Test" version="1.9"/>
+
+    <loader javaClass="games.strategy.triplea.TripleA"/>
+
+    <triplea minimumVersion="1.6.1"/>
+
+    <map>
+        <territory name="Afghanistan"/>
+        <territory name="Alaska"/>
+        <territory name="Algeria"/>
+        <territory name="Anglo Sudan Egypt"/>
+        <territory name="Angola"/>
+        <territory name="Argentina-Chile"/>
+        <territory name="Australia"/>
+        <territory name="Borneo Celebes"/>
+        <territory name="Brazil"/>
+        <territory name="Caroline Islands"/>
+        <territory name="Caucasus"/>
+        <territory name="China"/>
+        <territory name="Columbia"/>
+        <territory name="Congo"/>
+        <territory name="Cuba"/>
+        <territory name="East Indies"/>
+        <territory name="East Canada"/>
+        <territory name="East Europe"/>
+        <territory name="East US"/>
+        <territory name="Eire"/>
+        <territory name="Evenki National Okrug"/>
+        <territory name="Finland Norway"/>
+        <territory name="French Equatorial Africa"/>
+        <territory name="French Indo China"/>
+        <territory name="French West Africa"/>
+        <territory name="Germany"/>
+        <territory name="Gibraltar"/>
+        <territory name="Hawaiian Islands"/>
+        <territory name="India"/>
+        <territory name="Italian East Africa"/>
+        <territory name="Japan"/>
+        <territory name="Karelia S.S.R."/>
+        <territory name="Kazakh S.S.R."/>
+        <territory name="Kenya-Rhodesia"/>
+        <territory name="Kwangtung"/>
+        <territory name="Libya"/>
+        <territory name="Madagascar"/>
+        <territory name="Manchuria"/>
+        <territory name="Mexico"/>
+        <territory name="Midway"/>
+        <territory name="Mongolia"/>
+        <territory name="Mozambique"/>
+        <territory name="New Guinea"/>
+        <territory name="New Zealand"/>
+        <territory name="Novosibirsk"/>
+        <territory name="Okinawa"/>
+        <territory name="Panama"/>
+        <territory name="Persia"/>
+        <territory name="Peru"/>
+        <territory name="Philippines"/>
+        <territory name="Rio del Oro"/>
+        <territory name="Russia"/>
+        <territory name="Saudi Arabia"/>
+        <territory name="Sinkiang"/>
+        <territory name="Solomon Islands"/>
+        <territory name="South Africa"/>
+        <territory name="South Europe"/>
+        <territory name="Soviet Far East"/>
+        <territory name="Spain"/>
+        <territory name="Sweden"/>
+        <territory name="Switzerland"/>
+        <territory name="Syria Jordan"/>
+        <territory name="Turkey"/>
+        <territory name="Ukraine S.S.R."/>
+        <territory name="United Kingdom"/>
+        <territory name="Wake Island"/>
+        <territory name="West Canada"/>
+        <territory name="West Europe"/>
+        <territory name="West US"/>
+        <territory name="Yakut S.S.R."/>
+        <territory name="Alaska Sea Zone" water="true" />
+        <territory name="Angola Sea Zone" water="true" />
+        <territory name="Antartic Sea Zone" water="true" />
+        <territory name="Baltic Sea Zone" water="true" />
+        <territory name="Black Sea Zone" water="true" />
+        <territory name="Borneo Sea Zone" water="true" />
+        <territory name="Carribean Sea Zone" water="true" />
+        <territory name="Caroline Islands Sea Zone" water="true" />
+        <territory name="Caspian Sea Zone" water="true" />
+        <territory name="Central Mediteranean Sea Zone" water="true" />
+        <territory name="Congo Sea Zone" water="true" />
+        <territory name="East Argentina Sea Zone" water="true" />
+        <territory name="East Compass Sea Zone" water="true" />
+        <territory name="East Indies Sea Zone" water="true" />
+        <territory name="East Canada Sea Zone" water="true" />
+        <territory name="East Mediteranean Sea Zone" water="true" />
+        <territory name="East Pacific Sea Zone" water="true" />
+        <territory name="East US Sea Zone" water="true" />
+        <territory name="French Indo China Sea Zone" water="true" />
+        <territory name="Hawaii Sea Zone" water="true" />
+        <territory name="Indian Ocean Sea Zone" water="true" />
+        <territory name="Japan Sea Zone" water="true" />
+        <territory name="Karelia Sea Zone" water="true" />
+        <territory name="Kwangtung Sea Zone" water="true" />
+        <territory name="Mexico Sea Zone" water="true" />
+        <territory name="Midway Sea Zone" water="true" />
+        <territory name="Mozambique Sea Zone" water="true" />
+        <territory name="New Guinea Sea Zone" water="true" />
+        <territory name="New Zealand Sea Zone" water="true" />
+        <territory name="North Australia Sea Zone" water="true" />
+        <territory name="North Brazil Sea Zone" water="true" />
+        <territory name="North Sea Zone" water="true" />
+        <territory name="North Atlantic Sea Zone" water="true" />
+        <territory name="North Pacific Sea Zone" water="true" />
+        <territory name="Okinawa Sea Zone" water="true" />
+        <territory name="Peru Sea Zone" water="true" />
+        <territory name="Philippines Sea Zone" water="true" />
+        <territory name="Red Sea Zone" water="true" />
+        <territory name="Solomon Islands Sea Zone" water="true" />
+        <territory name="South Africa Sea Zone" water="true" />
+        <territory name="South Argentina Sea Zone" water="true" />
+        <territory name="South Australia Sea Zone" water="true" />
+        <territory name="South Brazil Sea Zone" water="true" />
+        <territory name="South Compass Sea Zone" water="true" />
+        <territory name="South East Madagascar Sea Zone" water="true" />
+        <territory name="South Pacific Sea Zone" water="true"/>
+        <territory name="South Atlantic Sea Zone" water="true" />
+        <territory name="Soviet Far East Sea Zone" water="true" />
+        <territory name="Wake Island Sea Zone" water="true" />
+        <territory name="West Africa Sea Zone" water="true" />
+        <territory name="West Compass Sea Zone" water="true" />
+        <territory name="West Australia Sea Zone" water="true" />
+        <territory name="West Canada Sea Zone" water="true" />
+        <territory name="West Mediteranean Sea Zone" water="true" />
+        <territory name="West Panama Sea Zone" water="true" />
+        <territory name="West Spain Sea Zone" water="true" />
+        <territory name="West US Sea Zone" water="true" />
+        <territory name="Gulf of Mexico Sea Zone" water="true" />
 
 
-	
-	<playerList>
-		<!-- In turn order -->
-		<player name="Russians" optional="false"/>
-		<player name="Germans" optional="false"/>
-		<player name="British" optional="false"/>
-		<player name="Japanese" optional="false"/>
-		<player name="Americans" optional="false"/>
+        <!-- Connections -->
 
-		<!-- alliances -->
-		<alliance player="Germans" alliance="Axis"/>
-		<alliance player="Japanese" alliance="Axis"/>
+        <!-- this connection is optional
+        <connection t1="East Canada Sea Zone" t2="West Canada" />
+        -->
 
-		<alliance player="British" alliance="Allies"/>
-		<alliance player="Russians" alliance="Allies"/>
-		<alliance player="Americans" alliance="Allies"/>
-	</playerList>
-	
-	<unitList>
-		<unit name="infantry"/>
-		<unit name="marine"/>
-		<unit name="armour"/>
-		<unit name="fighter"/>
-		<unit name="bomber"/>
-		<unit name="transport"/>
-		<unit name="battleship"/>
-		<unit name="carrier"/>
-		<unit name="submarine"/>
-		<unit name="factory"/>
-		<unit name="aaGun"/>
-		<unit name="artillery"/>
-		<unit name="destroyer"/>
-	</unitList>
+        <connection t1="Gulf of Mexico Sea Zone" t2="West US" />
+        <connection t1="Gulf of Mexico Sea Zone" t2="Mexico" />
+        <connection t1="Gulf of Mexico Sea Zone" t2="East US Sea Zone" />
+        <connection t1="Gulf of Mexico Sea Zone" t2="Carribean Sea Zone" />
+        <connection t1="East Canada Sea Zone" t2="East Canada" />
+        <connection t1="East Canada Sea Zone" t2="North Sea Zone" />
+        <connection t1="West Spain Sea Zone" t2="East Canada Sea Zone" />
+        <connection t1="North Atlantic Sea Zone" t2="East Canada Sea Zone" />
+        <connection t1="East Canada Sea Zone" t2="East US Sea Zone" />
+        <connection t1="East Canada" t2="East US" />
+        <connection t1="East US" t2="East US Sea Zone" />
+        <connection t1="Carribean Sea Zone" t2="East US Sea Zone" />
+        <connection t1="Carribean Sea Zone" t2="North Atlantic Sea Zone" />
+        <connection t1="Carribean Sea Zone" t2="North Brazil Sea Zone" />
+        <connection t1="Carribean Sea Zone" t2="Columbia" />
+        <connection t1="Carribean Sea Zone" t2="Panama" />
+        <connection t1="Carribean Sea Zone" t2="Cuba" />
+        <connection t1="Columbia" t2="Panama" />
+        <connection t1="Columbia" t2="West Panama Sea Zone" />
+        <connection t1="Panama" t2="West Panama Sea Zone" />
+        <connection t1="Peru" t2="Peru Sea Zone" />
+        <connection t1="Peru" t2="Brazil" />
+        <connection t1="Peru" t2="Columbia" />
+        <connection t1="Columbia" t2="Brazil" />
+        <connection t1="West Panama Sea Zone" t2="Peru Sea Zone" />
+        <connection t1="West Panama Sea Zone" t2="Carribean Sea Zone" />
+        <connection t1="Peru" t2="Argentina-Chile" />
+        <connection t1="Peru Sea Zone" t2="Argentina-Chile" />
+        <connection t1="Peru Sea Zone" t2="South Argentina Sea Zone" />
+        <connection t1="Argentina-Chile" t2="Brazil" />
+        <connection t1="Argentina-Chile" t2="East Argentina Sea Zone" />
+        <connection t1="Argentina-Chile" t2="South Argentina Sea Zone" />
+        <connection t1="South Argentina Sea Zone" t2="East Argentina Sea Zone" />
+        <connection t1="South Argentina Sea Zone" t2="South Atlantic Sea Zone" />
+        <connection t1="East Argentina Sea Zone" t2="South Atlantic Sea Zone" />
+        <connection t1="South Argentina Sea Zone" t2="Antartic Sea Zone" />
+        <connection t1="East Argentina Sea Zone" t2="South Brazil Sea Zone" />
+        <connection t1="South Brazil Sea Zone" t2="Brazil" />
+        <connection t1="Brazil" t2="North Brazil Sea Zone" />
+        <connection t1="South Brazil Sea Zone" t2="South Atlantic Sea Zone" />
+        <connection t1="South Brazil Sea Zone" t2="West Africa Sea Zone" />
+        <connection t1="South Brazil Sea Zone" t2="Congo Sea Zone" />
+        <connection t1="South Brazil Sea Zone" t2="North Brazil Sea Zone" />
+        <connection t1="North Brazil Sea Zone" t2="North Atlantic Sea Zone" />
+        <connection t1="North Brazil Sea Zone" t2="West Africa Sea Zone" />
+        <connection t1="North Atlantic Sea Zone" t2="West Africa Sea Zone" />
+        <connection t1="North Atlantic Sea Zone" t2="West Spain Sea Zone" />
+        <connection t1="North Atlantic Sea Zone" t2="East US Sea Zone" />
+        <connection t1="Eire" t2="North Sea Zone" />
+        <connection t1="United Kingdom" t2="North Sea Zone" />
+        <connection t1="North Sea Zone" t2="West Spain Sea Zone" />
+        <connection t1="North Sea Zone" t2="Karelia Sea Zone" />
+        <connection t1="North Sea Zone" t2="West Europe" />
+        <connection t1="North Sea Zone" t2="Finland Norway" />
+        <connection t1="North Sea Zone" t2="Baltic Sea Zone" />
+        <connection t1="West Europe" t2="Baltic Sea Zone" />
+        <connection t1="West Spain Sea Zone" t2="West Mediteranean Sea Zone" />
+        <connection t1="West Spain Sea Zone" t2="Spain" />
+        <connection t1="West Spain Sea Zone" t2="West Europe" />
+        <connection t1="West Spain Sea Zone" t2="Algeria" />
+        <connection t1="West Spain Sea Zone" t2="West Africa Sea Zone" />
+        <connection t1="West Africa Sea Zone" t2="Rio del Oro" />
+        <connection t1="West Africa Sea Zone" t2="French West Africa" />
+        <connection t1="West Africa Sea Zone" t2="Congo Sea Zone" />
+        <connection t1="Congo Sea Zone" t2="South Atlantic Sea Zone" />
+        <connection t1="Congo Sea Zone" t2="South Brazil Sea Zone" />
+        <connection t1="Congo Sea Zone" t2="French Equatorial Africa" />
+        <connection t1="Congo Sea Zone" t2="Congo" />
+        <connection t1="Congo Sea Zone" t2="Angola Sea Zone" />
+        <connection t1="South Atlantic Sea Zone" t2="Antartic Sea Zone" />
+        <connection t1="South Atlantic Sea Zone" t2="Angola Sea Zone" />
+        <connection t1="Angola Sea Zone" t2="South Africa" />
+        <connection t1="Angola Sea Zone" t2="South Africa Sea Zone" />
+        <connection t1="Angola Sea Zone" t2="Angola" />
+        <connection t1="Angola Sea Zone" t2="Antartic Sea Zone" />
+        <connection t1="Rio del Oro" t2="French West Africa" />
+        <connection t1="French West Africa" t2="Algeria" />
+        <connection t1="French West Africa" t2="French Equatorial Africa" />
+        <connection t1="Algeria" t2="West Mediteranean Sea Zone" />
+        <connection t1="Algeria" t2="Libya" />
+        <connection t1="Algeria" t2="French Equatorial Africa" />
+        <connection t1="Libya" t2="Central Mediteranean Sea Zone" />
+        <connection t1="Libya" t2="French Equatorial Africa" />
+        <connection t1="Libya" t2="Anglo Sudan Egypt" />
+        <connection t1="Anglo Sudan Egypt" t2="East Mediteranean Sea Zone" />
+        <connection t1="Anglo Sudan Egypt" t2="Red Sea Zone" />
+        <connection t1="Anglo Sudan Egypt" t2="Italian East Africa" />
+        <connection t1="Anglo Sudan Egypt" t2="French Equatorial Africa" />
+        <connection t1="Anglo Sudan Egypt" t2="Congo" />
+        <connection t1="Anglo Sudan Egypt" t2="Kenya-Rhodesia" />
+        <connection t1="Italian East Africa" t2="Kenya-Rhodesia" />
+        <connection t1="Italian East Africa" t2="Red Sea Zone" />
+        <connection t1="French Equatorial Africa" t2="Congo" />
+        <connection t1="Congo" t2="Angola" />
+        <connection t1="Congo" t2="Kenya-Rhodesia" />
+        <connection t1="Angola" t2="Kenya-Rhodesia" />
+        <connection t1="Kenya-Rhodesia" t2="South Africa" />
+        <connection t1="Angola" t2="South Africa" />
+        <connection t1="South Africa" t2="Mozambique" />
+        <connection t1="Mozambique" t2="Kenya-Rhodesia" />
+        <connection t1="South Africa Sea Zone" t2="South East Madagascar Sea Zone" />
+        <connection t1="South Africa" t2="South Africa Sea Zone" />
+        <connection t1="South Africa" t2="Mozambique Sea Zone" />
+        <connection t1="Mozambique" t2="Mozambique Sea Zone" />
+        <connection t1="Kenya-Rhodesia" t2="Mozambique Sea Zone" />
+        <connection t1="South Africa Sea Zone" t2="Madagascar" />
+        <connection t1="South East Madagascar Sea Zone" t2="Madagascar" />
+        <connection t1="Madagascar" t2="West Compass Sea Zone" />
+        <connection t1="Madagascar" t2="Mozambique Sea Zone" />
+        <connection t1="Gibraltar" t2="West Mediteranean Sea Zone" />
+        <connection t1="Spain" t2="West Europe" />
+        <connection t1="Spain" t2="West Mediteranean Sea Zone" />
+        <connection t1="West Europe" t2="West Mediteranean Sea Zone" />
+        <connection t1="West Europe" t2="Switzerland" />
+        <connection t1="Switzerland" t2="Germany" />
+        <connection t1="Switzerland" t2="South Europe" />
+        <connection t1="Germany" t2="West Europe" />
+        <connection t1="Karelia S.S.R." t2="Baltic Sea Zone" />
+        <connection t1="Germany" t2="Baltic Sea Zone" />
+        <connection t1="Germany" t2="South Europe" />
+        <connection t1="Germany" t2="East Europe" />
+        <connection t1="Finland Norway" t2="Sweden" />
+        <connection t1="Finland Norway" t2="Karelia S.S.R." />
+        <connection t1="Karelia S.S.R." t2="Karelia Sea Zone" />
+        <connection t1="Baltic Sea Zone" t2="Sweden" />
+        <connection t1="Baltic Sea Zone" t2="East Europe" />
+        <connection t1="Baltic Sea Zone" t2="Finland Norway" />
+        <connection t1="South Europe" t2="Central Mediteranean Sea Zone" />
+        <connection t1="South Europe" t2="East Europe" />
+        <connection t1="West Europe" t2="South Europe" />
+        <connection t1="West Mediteranean Sea Zone" t2="Central Mediteranean Sea Zone" />
+        <connection t1="Central Mediteranean Sea Zone" t2="East Mediteranean Sea Zone" />
+        <connection t1="Central Mediteranean Sea Zone" t2="Black Sea Zone" />
+        <connection t1="East Mediteranean Sea Zone" t2="Syria Jordan" />
+        <connection t1="East Mediteranean Sea Zone" t2="Turkey" />
+        <connection t1="Black Sea Zone" t2="Turkey" />
+        <connection t1="Black Sea Zone" t2="Caucasus" />
+        <connection t1="Black Sea Zone" t2="East Europe" />
+        <connection t1="Black Sea Zone" t2="Ukraine S.S.R." />
+        <connection t1="Black Sea Zone" t2="East Mediteranean Sea Zone" />
+        <connection t1="Caspian Sea Zone" t2="Caucasus" />
+        <connection t1="Caspian Sea Zone" t2="Kazakh S.S.R." />
+        <connection t1="Caspian Sea Zone" t2="Persia" />
+        <connection t1="Caspian Sea Zone" t2="Russia" />
+        <connection t1="East Europe" t2="Ukraine S.S.R." />
+        <connection t1="East Europe" t2="Karelia S.S.R." />
+        <connection t1="Ukraine S.S.R." t2="Karelia S.S.R." />
+        <connection t1="Ukraine S.S.R." t2="Caucasus" />
+        <connection t1="Caucasus" t2="Karelia S.S.R." />
+        <connection t1="Caucasus" t2="Russia" />
+        <connection t1="Russia" t2="Kazakh S.S.R." />
+        <connection t1="Russia" t2="Novosibirsk" />
+        <connection t1="Russia" t2="Evenki National Okrug" />
+        <connection t1="Karelia S.S.R." t2="Russia" />
+        <connection t1="Gibraltar" t2="Spain" />
+        <connection t1="Anglo Sudan Egypt" t2="Syria Jordan" />
+        <connection t1="East Mediteranean Sea Zone" t2="Red Sea Zone" />
+        <connection t1="Syria Jordan" t2="Red Sea Zone" />
+        <connection t1="Saudi Arabia" t2="Red Sea Zone" />
+        <connection t1="Saudi Arabia" t2="Syria Jordan" />
+        <connection t1="Saudi Arabia" t2="Persia" />
+        <connection t1="Syria Jordan" t2="Persia" />
+        <connection t1="Syria Jordan" t2="Turkey" />
+        <connection t1="Turkey" t2="Persia" />
+        <connection t1="Caucasus" t2="Persia" />
+        <connection t1="Turkey" t2="Caucasus" />
+        <connection t1="Evenki National Okrug" t2="Yakut S.S.R." />
+        <connection t1="Evenki National Okrug" t2="Novosibirsk" />
+        <connection t1="Yakut S.S.R." t2="Soviet Far East" />
+        <connection t1="Yakut S.S.R." t2="Manchuria" />
+        <connection t1="Yakut S.S.R." t2="Mongolia" />
+        <connection t1="Kazakh S.S.R." t2="Novosibirsk" />
+        <connection t1="Kazakh S.S.R." t2="Persia" />
+        <connection t1="Kazakh S.S.R." t2="Afghanistan" />
+        <connection t1="Kazakh S.S.R." t2="Sinkiang" />
+        <connection t1="Novosibirsk" t2="Mongolia" />
+        <connection t1="Novosibirsk" t2="Sinkiang" />
+        <connection t1="Novosibirsk" t2="Yakut S.S.R." />
+        <connection t1="Soviet Far East" t2="Soviet Far East Sea Zone" />
+        <connection t1="Soviet Far East" t2="Manchuria" />
+        <connection t1="Mongolia" t2="Sinkiang" />
+        <connection t1="Mongolia" t2="China" />
+        <connection t1="Mongolia" t2="Manchuria" />
+        <connection t1="Persia" t2="Afghanistan" />
+        <connection t1="Afghanistan" t2="India" />
+        <connection t1="Afghanistan" t2="Sinkiang" />
+        <connection t1="Sinkiang" t2="India" />
+        <connection t1="Sinkiang" t2="China" />
+        <connection t1="Sinkiang" t2="French Indo China" />
+        <connection t1="China" t2="French Indo China" />
+        <connection t1="India" t2="Indian Ocean Sea Zone" />
+        <connection t1="India" t2="French Indo China" />
+        <connection t1="Manchuria" t2="Japan Sea Zone" />
+        <connection t1="China" t2="Manchuria" />
+        <connection t1="Manchuria" t2="Kwangtung" />
+        <connection t1="China" t2="Kwangtung" />
+        <connection t1="Kwangtung" t2="French Indo China" />
+        <connection t1="Kwangtung" t2="Kwangtung Sea Zone" />
+        <connection t1="French Indo China Sea Zone" t2="French Indo China" />
+        <connection t1="Persia" t2="India" />
+        <connection t1="Red Sea Zone" t2="Indian Ocean Sea Zone" />
+        <connection t1="Red Sea Zone" t2="West Compass Sea Zone" />
+        <connection t1="Mozambique Sea Zone" t2="Red Sea Zone" />
+        <connection t1="Red Sea Zone" t2="Persia" />
+        <connection t1="South Africa Sea Zone" t2="Mozambique Sea Zone" />
+        <connection t1="South East Madagascar Sea Zone" t2="West Compass Sea Zone" />
+        <connection t1="South East Madagascar Sea Zone" t2="South Compass Sea Zone" />
+        <connection t1="West Compass Sea Zone" t2="Mozambique Sea Zone" />
+        <connection t1="West Compass Sea Zone" t2="East Compass Sea Zone" />
+        <connection t1="West Compass Sea Zone" t2="South Compass Sea Zone" />
+        <connection t1="West Compass Sea Zone" t2="Indian Ocean Sea Zone" />
+        <connection t1="East Compass Sea Zone" t2="Indian Ocean Sea Zone" />
+        <connection t1="East Compass Sea Zone" t2="South Compass Sea Zone" />
+        <connection t1="East Compass Sea Zone" t2="South Australia Sea Zone" />
+        <connection t1="East Compass Sea Zone" t2="West Australia Sea Zone" />
+        <connection t1="East Compass Sea Zone" t2="East Indies Sea Zone" />
+        <connection t1="French Indo China Sea Zone" t2="East Indies Sea Zone" />
+        <connection t1="Indian Ocean Sea Zone" t2="French Indo China Sea Zone" />
+        <connection t1="Indian Ocean Sea Zone" t2="East Indies Sea Zone" />
+        <connection t1="South Australia Sea Zone" t2="West Australia Sea Zone" />
+        <connection t1="South Australia Sea Zone" t2="South Compass Sea Zone" />
+        <connection t1="South Australia Sea Zone" t2="New Zealand Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="South Australia Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="New Zealand Sea Zone" />
+        <connection t1="West Australia Sea Zone" t2="North Australia Sea Zone" />
+        <connection t1="West Australia Sea Zone" t2="East Indies Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="Solomon Islands Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="New Guinea Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="Borneo Sea Zone" />
+        <connection t1="West Australia Sea Zone" t2="Australia" />
+        <connection t1="Australia" t2="South Australia Sea Zone" />
+        <connection t1="Australia" t2="North Australia Sea Zone" />
+        <connection t1="New Zealand Sea Zone" t2="New Zealand" />
+        <connection t1="Solomon Islands Sea Zone" t2="New Zealand Sea Zone" />
+        <connection t1="New Zealand Sea Zone" t2="South Pacific Sea Zone" />
+        <connection t1="New Zealand Sea Zone" t2="East Pacific Sea Zone" />
+        <connection t1="South Pacific Sea Zone" t2="East Pacific Sea Zone" />
+        <connection t1="South Pacific Sea Zone" t2="Solomon Islands Sea Zone" />
+        <connection t1="South Pacific Sea Zone" t2="Hawaii Sea Zone" />
+        <connection t1="South Pacific Sea Zone" t2="Mexico Sea Zone" />
+        <connection t1="East Pacific Sea Zone" t2="Mexico Sea Zone" />
+        <connection t1="Soviet Far East Sea Zone" t2="Alaska Sea Zone" />
+        <connection t1="Alaska Sea Zone" t2="Alaska" />
+        <connection t1="Alaska Sea Zone" t2="West Canada Sea Zone" />
+        <connection t1="West Canada Sea Zone" t2="Alaska" />
+        <connection t1="West Canada Sea Zone" t2="West Canada" />
+        <connection t1="Alaska Sea Zone" t2="North Pacific Sea Zone" />
+        <connection t1="Alaska Sea Zone" t2="Midway Sea Zone" />
+        <connection t1="Midway" t2="Midway Sea Zone" />
+        <connection t1="Wake Island" t2="Wake Island Sea Zone" />
+        <connection t1="Okinawa" t2="Okinawa Sea Zone" />
+        <connection t1="Philippines" t2="Philippines Sea Zone" />
+        <connection t1="New Guinea" t2="New Guinea Sea Zone" />
+        <connection t1="Solomon Islands" t2="Solomon Islands Sea Zone" />
+        <connection t1="East Indies" t2="East Indies Sea Zone" />
+        <connection t1="Borneo Celebes" t2="Borneo Sea Zone" />
+        <connection t1="Japan" t2="Japan Sea Zone" />
+        <connection t1="Hawaiian Islands" t2="Hawaii Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="Soviet Far East Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="North Pacific Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="Okinawa Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="Philippines Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="Kwangtung Sea Zone" />
+        <connection t1="Okinawa Sea Zone" t2="Philippines Sea Zone" />
+        <connection t1="Okinawa Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="Borneo Sea Zone" t2="Philippines Sea Zone" />
+        <connection t1="French Indo China Sea Zone" t2="Philippines Sea Zone" />
+        <connection t1="French Indo China Sea Zone" t2="Borneo Sea Zone" />
+        <connection t1="French Indo China Sea Zone" t2="Kwangtung Sea Zone" />
+        <connection t1="Philippines Sea Zone" t2="Kwangtung Sea Zone" />
+        <connection t1="Japan Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="North Pacific Sea Zone" t2="Midway Sea Zone" />
+        <connection t1="North Pacific Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="Midway Sea Zone" t2="Hawaii Sea Zone" />
+        <connection t1="Midway Sea Zone" t2="West US Sea Zone" />
+        <connection t1="Midway Sea Zone" t2="West Canada Sea Zone" />
+        <connection t1="West US Sea Zone" t2="Hawaii Sea Zone" />
+        <connection t1="Hawaii Sea Zone" t2="Mexico Sea Zone" />
+        <connection t1="Hawaii Sea Zone" t2="North Pacific Sea Zone" />
+        <connection t1="Mexico Sea Zone" t2="Mexico" />
+        <connection t1="Mexico" t2="West US" />
+        <connection t1="West US" t2="West Canada" />
+        <connection t1="West US Sea Zone" t2="West US" />
+        <connection t1="West US Sea Zone" t2="Mexico Sea Zone" />
+        <connection t1="West US Sea Zone" t2="West Canada" />
+        <connection t1="West US Sea Zone" t2="West Canada Sea Zone" />
+        <connection t1="Hawaii Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="Hawaii Sea Zone" t2="Solomon Islands Sea Zone" />
+        <connection t1="West Canada" t2="East Canada" />
+        <connection t1="West US" t2="East US" />
+        <connection t1="Mexico" t2="Panama" />
+        <connection t1="Mexico Sea Zone" t2="West Panama Sea Zone" />
+        <connection t1="East Pacific Sea Zone" t2="Peru Sea Zone" />
+        <connection t1="New Zealand Sea Zone" t2="South Argentina Sea Zone" />
+        <connection t1="Alaska" t2="West Canada" />
+        <connection t1="Peru Sea Zone" t2="New Zealand Sea Zone" />
+        <connection t1="North Australia Sea Zone" t2="East Indies Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Solomon Islands Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="Solomon Islands Sea Zone" t2="Wake Island Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Okinawa Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Philippines Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Borneo Sea Zone" />
+        <connection t1="East Indies Sea Zone" t2="Borneo Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="New Guinea Sea Zone" />
+        <connection t1="Caroline Islands Sea Zone" t2="Caroline Islands" />
+        <connection t1="Soviet Far East Sea Zone" t2="North Pacific Sea Zone" />
+        <connection t1="Solomon Islands Sea Zone" t2="New Guinea Sea Zone" />
+        <connection t1="Borneo Sea Zone" t2="New Guinea Sea Zone" />
+    </map>
 
-	<gamePlay>
-		<delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate" display="Initializing Delegates"/>
-		<delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate" display="Research Technology"/>
-                <delegate name="tech_activation" javaClass="games.strategy.triplea.delegate.TechActivationDelegate" display="Activate Technology"/>
-		<delegate name="battle" javaClass="games.strategy.triplea.delegate.BattleDelegate" display="Combat"/>
-		<delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Combat Move"/>
-		<delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Units"/>
-		<delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
-		<delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate" display="Turn Complete"/>
-		<delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
+    <resourceList>
+        <resource name="PUs"/>
+    </resourceList>
 
-		<delegate name="placeBid" javaClass="games.strategy.triplea.delegate.BidPlaceDelegate" display="Bid Placement"/>
-		<delegate name="bid" javaClass="games.strategy.triplea.delegate.BidPurchaseDelegate" display="Bid Purchase"/>
-		
-		
-		<sequence>
 
-			<step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
 
-			<step name="russiansBid" delegate="bid" player="Russians" maxRunCount="1"/>
-			<step name="russiansBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
+    <playerList>
+        <!-- In turn order -->
+        <player name="Russians" optional="false"/>
+        <player name="Germans" optional="false"/>
+        <player name="British" optional="false"/>
+        <player name="Japanese" optional="false"/>
+        <player name="Americans" optional="false"/>
 
-			<step name="germansBid" delegate="bid" player="Germans" maxRunCount="1"/>
-			<step name="germansBidPlace" delegate="placeBid" player="Germans" maxRunCount="1"/>
+        <!-- alliances -->
+        <alliance player="Germans" alliance="Axis"/>
+        <alliance player="Japanese" alliance="Axis"/>
 
-			<step name="britishBid" delegate="bid" player="British" maxRunCount="1"/>
-			<step name="britishBidPlace" delegate="placeBid" player="British" maxRunCount="1"/>
+        <alliance player="British" alliance="Allies"/>
+        <alliance player="Russians" alliance="Allies"/>
+        <alliance player="Americans" alliance="Allies"/>
+    </playerList>
 
-			<step name="japaneseBid" delegate="bid" player="Japanese" maxRunCount="1"/>
-			<step name="japaneseBidPlace" delegate="placeBid" player="Japanese" maxRunCount="1"/>
+    <unitList>
+        <unit name="infantry"/>
+        <unit name="marine"/>
+        <unit name="armour"/>
+        <unit name="fighter"/>
+        <unit name="bomber"/>
+        <unit name="transport"/>
+        <unit name="battleship"/>
+        <unit name="carrier"/>
+        <unit name="submarine"/>
+        <unit name="factory"/>
+        <unit name="aaGun"/>
+        <unit name="artillery"/>
+        <unit name="destroyer"/>
+    </unitList>
 
-			<step name="americansBid" delegate="bid" player="Americans" maxRunCount="1"/>
-			<step name="americansBidPlace" delegate="placeBid" player="Americans" maxRunCount="1"/>
+    <gamePlay>
+        <delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate" display="Initializing Delegates"/>
+        <delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate" display="Research Technology"/>
+        <delegate name="tech_activation" javaClass="games.strategy.triplea.delegate.TechActivationDelegate" display="Activate Technology"/>
+        <delegate name="battle" javaClass="games.strategy.triplea.delegate.BattleDelegate" display="Combat"/>
+        <delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Combat Move"/>
+        <delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Units"/>
+        <delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
+        <delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate" display="Turn Complete"/>
+        <delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
 
-			<step name="russianTech" delegate="tech" player="Russians"/>
-                        <step name="russianTechActivation" delegate="tech_activation" player="Russians"/>
-			<step name="russianPurchase" delegate="purchase" player="Russians"/>
-			<step name="russianCombatMove" delegate="move" player="Russians"/>
-			<step name="russianBattle" delegate="battle" player="Russians"/>
-			<step name="russianNonCombatMove" delegate="move" player="Russians" display="Non Combat Move"/>
-			<step name="russianPlace" delegate="place" player="Russians"/>
-			<step name="russianEndTurn" delegate="endTurn" player="Russians"/>
+        <delegate name="placeBid" javaClass="games.strategy.triplea.delegate.BidPlaceDelegate" display="Bid Placement"/>
+        <delegate name="bid" javaClass="games.strategy.triplea.delegate.BidPurchaseDelegate" display="Bid Purchase"/>
 
-			<step name="germanTech" delegate="tech" player="Germans"/>
-                        <step name="germanTechActivation" delegate="tech_activation" player="Germans"/>
-			<step name="germanPurchase" delegate="purchase" player="Germans"/>
-			<step name="germanCombatMove" delegate="move" player="Germans"/>
-			<step name="germanBattle" delegate="battle" player="Germans"/>
-			<step name="germanNonCombatMove" delegate="move" player="Germans" display="Non Combat Move"/>
-			<step name="germanPlace" delegate="place" player="Germans"/>
-			<step name="germanEndTurn" delegate="endTurn" player="Germans"/>
 
-			<step name="britishTech" delegate="tech" player="British"/>
-                        <step name="britishTechActivation" delegate="tech_activation" player="British"/>
-			<step name="britishPurchase" delegate="purchase" player="British"/>
-			<step name="britishCombatMove" delegate="move" player="British"/>
-			<step name="britishBattle" delegate="battle" player="British"/>
-			<step name="britishNonCombatMove" delegate="move" player="British" display="Non Combat Move"/>
-			<step name="britishPlace" delegate="place" player="British"/>
-			<step name="britishEndTurn" delegate="endTurn" player="British"/>
+        <sequence>
 
-			<step name="japaneseTech" delegate="tech" player="Japanese"/>
-                        <step name="japaneseTechActivation" delegate="tech_activation" player="Japanese"/>
-			<step name="japanesePurchase" delegate="purchase" player="Japanese"/>
-			<step name="japaneseCombatMove" delegate="move" player="Japanese"/>
-			<step name="japaneseBattle" delegate="battle" player="Japanese"/>
-			<step name="japaneseNonCombatMove" delegate="move" player="Japanese" display="Non Combat Move"/>
-			<step name="japanesePlace" delegate="place" player="Japanese"/>
-			<step name="japaneseEndTurn" delegate="endTurn" player="Japanese"/>
+            <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
 
-			<step name="americanTech" delegate="tech" player="Americans"/>
-                        <step name="americanTechActivation" delegate="tech_activation" player="Americans"/>
-			<step name="americanPurchase" delegate="purchase" player="Americans"/>
-			<step name="americanCombatMove" delegate="move" player="Americans"/>
-			<step name="americanBattle" delegate="battle" player="Americans"/>
-			<step name="americanNonCombatMove" delegate="move" player="Americans" display="Non Combat Move"/>
-			<step name="americanPlace" delegate="place" player="Americans"/>
-			<step name="americanEndTurn" delegate="endTurn" player="Americans"/>
-			
-			<step name="endRoundStep" delegate="endRound"/>
-		</sequence>
-	</gamePlay>
+            <step name="russiansBid" delegate="bid" player="Russians" maxRunCount="1"/>
+            <step name="russiansBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
 
-	<production>
-		<productionRule name="buyInfantry">
-			<cost resource="PUs" quantity="3" />
-			<result resourceOrUnit="infantry" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyMarine">
-			<cost resource="PUs" quantity="4" />
-			<result resourceOrUnit="marine" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyArtillery">
-			<cost resource="PUs" quantity="4" />
-			<result resourceOrUnit="artillery" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyArmour">
-			<cost resource="PUs" quantity="5" />
-			<result resourceOrUnit="armour" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyFighter">
-			<cost resource="PUs" quantity="12" />
-			<result resourceOrUnit="fighter" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyBomber">
-			<cost resource="PUs" quantity="15" />
-			<result resourceOrUnit="bomber" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyTransport">
-			<cost resource="PUs" quantity="8" />
-			<result resourceOrUnit="transport" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyDestroyer">
-			<cost resource="PUs" quantity="8" />
-			<result resourceOrUnit="destroyer" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyCarrier">
-			<cost resource="PUs" quantity="18" />
-			<result resourceOrUnit="carrier" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyBattleship">
-			<cost resource="PUs" quantity="24" />
-			<result resourceOrUnit="battleship" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buySubmarine">
-			<cost resource="PUs" quantity="8" />
-			<result resourceOrUnit="submarine" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyFactory">
-			<cost resource="PUs" quantity="15" />
-			<result resourceOrUnit="factory" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyAAGun">
-			<cost resource="PUs" quantity="5" />
-			<result resourceOrUnit="aaGun" quantity="1"/>
-		</productionRule>
+            <step name="germansBid" delegate="bid" player="Germans" maxRunCount="1"/>
+            <step name="germansBidPlace" delegate="placeBid" player="Germans" maxRunCount="1"/>
 
-		<!-- advanced industrial production -->
-		<productionRule name="buyInfantryIndustrialTechnology">
-			<cost resource="PUs" quantity="2" />
-			<result resourceOrUnit="infantry" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyMarineIndustrialTechnology">
-			<cost resource="PUs" quantity="3" />
-			<result resourceOrUnit="marine" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyArtilleryIndustrialTechnology">
-			<cost resource="PUs" quantity="3" />
-			<result resourceOrUnit="artillery" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyArmourIndustrialTechnology">
-			<cost resource="PUs" quantity="4" />
-			<result resourceOrUnit="armour" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyFighterIndustrialTechnology">
-			<cost resource="PUs" quantity="11" />
-			<result resourceOrUnit="fighter" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyBomberIndustrialTechnology">
-			<cost resource="PUs" quantity="14" />
-			<result resourceOrUnit="bomber" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyTransportIndustrialTechnology">
-			<cost resource="PUs" quantity="7" />
-			<result resourceOrUnit="transport" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyDestroyerIndustrialTechnology">
-			<cost resource="PUs" quantity="7" />
-			<result resourceOrUnit="destroyer" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyCarrierIndustrialTechnology">
-			<cost resource="PUs" quantity="17" />
-			<result resourceOrUnit="carrier" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyBattleshipIndustrialTechnology">
-			<cost resource="PUs" quantity="23" />
-			<result resourceOrUnit="battleship" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buySubmarineIndustrialTechnology">
-			<cost resource="PUs" quantity="7" />
-			<result resourceOrUnit="submarine" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyFactoryIndustrialTechnology">
-			<cost resource="PUs" quantity="14" />
-			<result resourceOrUnit="factory" quantity="1"/>
-		</productionRule>
-		
-		<productionRule name="buyAAGunIndustrialTechnology">
-			<cost resource="PUs" quantity="4" />
-			<result resourceOrUnit="aaGun" quantity="1"/>
-		</productionRule>
+            <step name="britishBid" delegate="bid" player="British" maxRunCount="1"/>
+            <step name="britishBidPlace" delegate="placeBid" player="British" maxRunCount="1"/>
 
-		<productionFrontier name="production">
-			<frontierRules name="buyInfantry"/>
-			<frontierRules name="buyMarine"/>
-			<frontierRules name="buyArmour"/>
-			<frontierRules name="buyFighter"/>
-			<frontierRules name="buyBomber"/>
-			<frontierRules name="buyTransport"/>
-			<frontierRules name="buySubmarine"/>
-			<frontierRules name="buyDestroyer"/>
-			<frontierRules name="buyCarrier"/>
-			<frontierRules name="buyBattleship"/>
-			<frontierRules name="buyAAGun"/>
-			<frontierRules name="buyFactory"/>	
-		</productionFrontier>
-		
-		<productionFrontier name="productionIndustrialTechnology">
-			<frontierRules name="buyInfantryIndustrialTechnology"/>
-			<frontierRules name="buyMarineIndustrialTechnology"/>
-			<frontierRules name="buyArmourIndustrialTechnology"/>
-			<frontierRules name="buyFighterIndustrialTechnology"/>
-			<frontierRules name="buyBomberIndustrialTechnology"/>
-			<frontierRules name="buyTransportIndustrialTechnology"/>
-			<frontierRules name="buySubmarineIndustrialTechnology"/>
-			<frontierRules name="buyDestroyerIndustrialTechnology"/>
-			<frontierRules name="buyCarrierIndustrialTechnology"/>
-			<frontierRules name="buyBattleshipIndustrialTechnology"/>
-			<frontierRules name="buyAAGunIndustrialTechnology"/>
-			<frontierRules name="buyFactoryIndustrialTechnology"/>	
-		</productionFrontier>
+            <step name="japaneseBid" delegate="bid" player="Japanese" maxRunCount="1"/>
+            <step name="japaneseBidPlace" delegate="placeBid" player="Japanese" maxRunCount="1"/>
 
-		<playerProduction player="British" frontier="production"/>
-		<playerProduction player="Japanese" frontier="production"/>
-		<playerProduction player="Americans" frontier="production"/>
-		<playerProduction player="Germans" frontier="production"/>
-		<playerProduction player="Russians" frontier="production"/>
-	</production>
-	
-	<attachmentList>
-            <attachment name="techAttachment" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TechAttachment"
-	                   type="player">
-			   <option name="heavyBomber" value="false"/>
-			   <option name="jetPower" value="false"/>
-			   <option name="industrialTechnology" value="false"/>
-			   <option name="superSub" value="false"/>
-			   <option name="rocket" value="false"/>
-			   <option name="longRangeAir" value="false"/>
-	    </attachment>
+            <step name="americansBid" delegate="bid" player="Americans" maxRunCount="1"/>
+            <step name="americansBidPlace" delegate="placeBid" player="Americans" maxRunCount="1"/>
 
-	    <attachment name="techAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TechAttachment"
-	                   type="player">
-			   <option name="heavyBomber" value="false"/>
-			   <option name="jetPower" value="false"/>
-			   <option name="industrialTechnology" value="false"/>
-			   <option name="superSub" value="false"/>
-			   <option name="rocket" value="false"/>
-			   <option name="longRangeAir" value="false"/>
-	    </attachment>
+            <step name="russianTech" delegate="tech" player="Russians"/>
+            <step name="russianTechActivation" delegate="tech_activation" player="Russians"/>
+            <step name="russianPurchase" delegate="purchase" player="Russians"/>
+            <step name="russianCombatMove" delegate="move" player="Russians"/>
+            <step name="russianBattle" delegate="battle" player="Russians"/>
+            <step name="russianNonCombatMove" delegate="move" player="Russians" display="Non Combat Move"/>
+            <step name="russianPlace" delegate="place" player="Russians"/>
+            <step name="russianEndTurn" delegate="endTurn" player="Russians"/>
 
-	    <attachment name="techAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TechAttachment"
-	                   type="player">
-			   <option name="heavyBomber" value="false"/>
-			   <option name="jetPower" value="false"/>
-			   <option name="industrialTechnology" value="false"/>
-			   <option name="superSub" value="false"/>
-			   <option name="rocket" value="false"/>
-			   <option name="longRangeAir" value="false"/>
-	    </attachment>
+            <step name="germanTech" delegate="tech" player="Germans"/>
+            <step name="germanTechActivation" delegate="tech_activation" player="Germans"/>
+            <step name="germanPurchase" delegate="purchase" player="Germans"/>
+            <step name="germanCombatMove" delegate="move" player="Germans"/>
+            <step name="germanBattle" delegate="battle" player="Germans"/>
+            <step name="germanNonCombatMove" delegate="move" player="Germans" display="Non Combat Move"/>
+            <step name="germanPlace" delegate="place" player="Germans"/>
+            <step name="germanEndTurn" delegate="endTurn" player="Germans"/>
 
-	    <attachment name="techAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.TechAttachment"
-	                   type="player">
-			   <option name="heavyBomber" value="false"/>
-			   <option name="jetPower" value="false"/>
-			   <option name="industrialTechnology" value="false"/>
-			   <option name="superSub" value="false"/>
-			   <option name="rocket" value="false"/>
-			   <option name="longRangeAir" value="false"/>
-	    </attachment>
+            <step name="britishTech" delegate="tech" player="British"/>
+            <step name="britishTechActivation" delegate="tech_activation" player="British"/>
+            <step name="britishPurchase" delegate="purchase" player="British"/>
+            <step name="britishCombatMove" delegate="move" player="British"/>
+            <step name="britishBattle" delegate="battle" player="British"/>
+            <step name="britishNonCombatMove" delegate="move" player="British" display="Non Combat Move"/>
+            <step name="britishPlace" delegate="place" player="British"/>
+            <step name="britishEndTurn" delegate="endTurn" player="British"/>
 
-	    <attachment name="techAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TechAttachment"
-	                   type="player">
-			   <option name="heavyBomber" value="false"/>
-			   <option name="jetPower" value="false"/>
-			   <option name="industrialTechnology" value="false"/>
-			   <option name="superSub" value="false"/>
-			   <option name="rocket" value="false"/>
-			   <option name="longRangeAir" value="false"/>
-	    </attachment>
-	
-	    <attachment name="unitAttachment"
-			 attachTo="infantry"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="1"/>
-			 <option name="transportCost" value="1"/>
-			 <option name="attack" value="1"/>
-			 <option name="defense" value="2"/>
-			 <option name="artillerySupportable" value="true"/>
-	    </attachment>
+            <step name="japaneseTech" delegate="tech" player="Japanese"/>
+            <step name="japaneseTechActivation" delegate="tech_activation" player="Japanese"/>
+            <step name="japanesePurchase" delegate="purchase" player="Japanese"/>
+            <step name="japaneseCombatMove" delegate="move" player="Japanese"/>
+            <step name="japaneseBattle" delegate="battle" player="Japanese"/>
+            <step name="japaneseNonCombatMove" delegate="move" player="Japanese" display="Non Combat Move"/>
+            <step name="japanesePlace" delegate="place" player="Japanese"/>
+            <step name="japaneseEndTurn" delegate="endTurn" player="Japanese"/>
 
-		<attachment name="unitAttachment" 
-			 attachTo="marine"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="1"/>
-			 <option name="transportCost" value="1"/>
-			 <option name="attack" value="1"/>
-			 <option name="defense" value="2"/>
-			 <option name="isMarine" value="true"/>   
-			 <option name="artillerySupportable" value="true"/>
-		</attachment>
-	
-	    <attachment name="unitAttachment"
-			 attachTo="artillery"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="1"/>
-			 <option name="transportCost" value="1"/>
-			 <option name="attack" value="2"/>
-			 <option name="defense" value="2"/>
-			 <option name="artillery" value="true"/>
-	    </attachment>
-	
-	    <attachment name="unitAttachment"
-			 attachTo="armour"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="2"/>
-			 <option name="transportCost" value="2"/>
-			 <option name="canBlitz" value="true"/>
-			 <option name="attack" value="3"/>
-			 <option name="defense" value="2"/>
-	    </attachment>
-	
-	    <attachment name="unitAttachment"
-			 attachTo="fighter"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="4"/>
-			 <option name="carrierCost" value="1"/>
-			 <option name="isAir" value="true"/>
-			 <option name="attack" value="3"/>
-			 <option name="defense" value="4"/>
-	    </attachment>
-	
-	    <attachment name="unitAttachment"
-			 attachTo="bomber"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="6"/>
-			 <option name="isAir" value="true"/>
-			 <option name="attack" value="4"/>
-			 <option name="defense" value="1"/>
-			 <option name="isStrategicBomber" value="true"/>
-	    </attachment>
-	
-	    <attachment name="unitAttachment"
-			 attachTo="transport"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="2"/>
-			 <option name="isSea" value="true"/>
-			 <option name="transportCapacity" value="2"/>
-			 <option name="attack" value="0"/>
-			 <option name="defense" value="1"/>
-	    </attachment>
-	
-	    <attachment name="unitAttachment"
-			 attachTo="destroyer"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="2"/>
-			 <option name="isSea" value="true"/>
-			 <option name="attack" value="2"/>
-			 <option name="defense" value="2"/>
- 			 <!--<option name="isDestroyer" value="true"/>-->
-	    </attachment>
-	
-	    <attachment name="unitAttachment"
-			 attachTo="battleship"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="movement" value="2"/>
-			 <option name="isSea" value="true"/>
-   			 <option name="attack" value="4"/>
-			 <option name="defense" value="4"/>
-			 <option name="canBombard" value="true"/>
-			 <option name="hitPoints" value="1"/>
-            </attachment>
-		
-	    <attachment name="unitAttachment"
-			 attachTo="carrier"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="carrierCapacity" value="2"/>
-			 <option name="movement" value="2"/>
-			 <option name="isSea" value="true"/>
-			 <option name="attack" value="1"/>
-			 <option name="defense" value="3"/>
-	    </attachment>
-	
-	    <attachment name="unitAttachment"
-			 attachTo="submarine"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="isSub" value="true"/>
-			 <option name="movement" value="2"/>
-			 <option name="isSea" value="true"/>
-			 <option name="attack" value="2"/>
-			 <option name="defense" value="2"/>
-	    </attachment>
+            <step name="americanTech" delegate="tech" player="Americans"/>
+            <step name="americanTechActivation" delegate="tech_activation" player="Americans"/>
+            <step name="americanPurchase" delegate="purchase" player="Americans"/>
+            <step name="americanCombatMove" delegate="move" player="Americans"/>
+            <step name="americanBattle" delegate="battle" player="Americans"/>
+            <step name="americanNonCombatMove" delegate="move" player="Americans" display="Non Combat Move"/>
+            <step name="americanPlace" delegate="place" player="Americans"/>
+            <step name="americanEndTurn" delegate="endTurn" player="Americans"/>
 
-	    <attachment name="unitAttachment"
-			 attachTo="factory"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="isFactory" value="true"/>
-			 <option name="destroyedWhenCapturedFrom" value="Russians:Germans:British:Japanese:Americans"/>
-	    </attachment>
-	
-	    <attachment name="unitAttachment"
-			 attachTo="aaGun"
-			 javaClass="games.strategy.triplea.attachments.UnitAttachment"
-			 type="unitType">
-			 <option name="isAA" value="true"/>
-			 <option name="transportCost" value="2"/>
-			 <option name="movement" value="1"/>
-			 <option name="destroyedWhenCapturedFrom" value="Russians:Germans:British:Japanese:Americans"/>
-	    </attachment>
+            <step name="endRoundStep" delegate="endRound"/>
+        </sequence>
+    </gamePlay>
 
-	    <attachment name="territoryAttachment"  attachTo="Afghanistan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Alaska" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Algeria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Anglo Sudan Egypt" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Angola" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Argentina-Chile" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Australia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Borneo Celebes" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Brazil" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Caucasus" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="China" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Columbia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Congo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Cuba" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="East Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="East Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="East Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="East US" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="12" />
-                    <option name="originalFactory" value="true" />
-                    <option name="capital" value="Americans" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Eire" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Evenki National Okrug" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Finland Norway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="French Equatorial Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="French Indo China" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="French West Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="10" />
-                    <option name="originalFactory" value="true" />
-                    <option name="capital" value="Germans" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Gibraltar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Hawaiian Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="India" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Italian East Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="8" />
-                    <option name="originalFactory" value="true" />
-                    <option name="capital" value="Japanese" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Karelia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-                    <option name="originalFactory" value="true" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Kazakh S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Kenya-Rhodesia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Kwangtung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Libya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Madagascar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Manchuria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Mexico" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Midway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Mongolia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Mozambique" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="New Guinea" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="New Zealand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Novosibirsk" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Okinawa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Panama" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Persia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Peru" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Philippines" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Rio del Oro" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="8" />
-                    <option name="originalFactory" value="true" />
-                    <option name="capital" value="Russians" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Saudi Arabia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Sinkiang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Solomon Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="South Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="South Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="6" />
-                    <option name="originalFactory" value="true" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Soviet Far East" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Spain" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Sweden" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Switzerland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Syria Jordan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Turkey" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Ukraine S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="3" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="United Kingdom" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="8" />
-			<option name="originalFactory" value="true" />
-			<option name="capital" value="British" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Wake Island" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="0" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="West Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="1" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="West Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="6" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="West US" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="10" />
-                    <option name="originalFactory" value="true" />
-	    </attachment>
-	
-	    <attachment name="territoryAttachment"  attachTo="Yakut S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
-		    <option name="production" value="2" />
-	    </attachment>
-	
-	
-	    <!-- canals -->
-	    <attachment name="canalAttachment" attachTo="East Mediteranean Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-	    	<option name="canalName" value="Suez Canal"/>
-	    	<option name="landTerritories" value="Anglo Sudan Egypt:Syria Jordan"/>
-	    </attachment>
-	
-	    <attachment name="canalAttachment" attachTo="Red Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-	    	<option name="canalName" value="Suez Canal"/>
-	    	<option name="landTerritories" value="Anglo Sudan Egypt:Syria Jordan"/>
-	    </attachment>
-	
-   	    <attachment name="canalAttachment" attachTo="Carribean Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-	    	<option name="canalName" value="Panama Canal"/>
-	    	<option name="landTerritories" value="Panama"/>
-	    </attachment>
-	
-	    <attachment name="canalAttachment" attachTo="West Panama Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-	    	<option name="canalName" value="Panama Canal"/>
-	    	<option name="landTerritories" value="Panama"/>
-	    </attachment>
-	
-	
-		<attachment name="rulesAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-				<option name="movementRestrictionTerritories" value="Caucasus:Evenki National Okrug:Karelia S.S.R.:Kazakh S.S.R.:Novosibirsk:Russia:Soviet Far East:Yakut S.S.R."/>
-				<option name="movementRestrictionType" value="allowed"/>
-		</attachment>
-		
-		<attachment name="conditionAttachmentTurn1" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-				<option name="rounds" value="1-+"/>
-		</attachment>
-		
-		<attachment name="triggerAttachmentRussians_Can_Move" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-				<option name="conditions" value="conditionAttachmentTurn1"/>
-				<option name="when" value="after:russianBattle"/>
-				<option name="uses" value="1"/>
-				<option name="players" value="Russians"/>
-				<option name="playerAttachmentName" value="RulesAttachment" count="rulesAttachment"/>
-				<option name="playerProperty" value="movementRestrictionTerritories" count="-reset-"/>
-				<option name="playerProperty" value="movementRestrictionType" count="disallowed"/>
-		</attachment>
-	
-	</attachmentList>
-	
-	<initialize>
-		<ownerInitialize>
-		    <territoryOwner territory="Alaska" owner="Americans" />
-		    <territoryOwner territory="Algeria" owner="Germans" />
-		    <territoryOwner territory="Anglo Sudan Egypt" owner="British" />
-		    <territoryOwner territory="Australia" owner="British" />
-		    <territoryOwner territory="Borneo Celebes" owner="Japanese" />
-		    <territoryOwner territory="Brazil" owner="Americans" />
-		    <territoryOwner territory="Caroline Islands" owner="Japanese" />
-		    <territoryOwner territory="Caucasus" owner="Russians" />
-		    <territoryOwner territory="China" owner="Americans" />
-		    <territoryOwner territory="Congo" owner="British" />
-		    <territoryOwner territory="Cuba" owner="Americans" />
-		    <territoryOwner territory="East Indies" owner="Japanese" />
-		    <territoryOwner territory="East Canada" owner="British" />
-		    <territoryOwner territory="East Europe" owner="Germans" />
-		    <territoryOwner territory="East US" owner="Americans" />
-		    <territoryOwner territory="Evenki National Okrug" owner="Russians" />
-		    <territoryOwner territory="Finland Norway" owner="Germans" />
-		    <territoryOwner territory="French Equatorial Africa" owner="British" />
-		    <territoryOwner territory="French Indo China" owner="Japanese" />
-		    <territoryOwner territory="French West Africa" owner="British" />
-		    <territoryOwner territory="Germany" owner="Germans" />
-		    <territoryOwner territory="Gibraltar" owner="British" />
-		    <territoryOwner territory="Hawaiian Islands" owner="Americans" />
-		    <territoryOwner territory="India" owner="British" />
-		    <territoryOwner territory="Italian East Africa" owner="British" />
-		    <territoryOwner territory="Japan" owner="Japanese" />
-		    <territoryOwner territory="Karelia S.S.R." owner="Russians" />
-		    <territoryOwner territory="Kazakh S.S.R." owner="Russians" />
-		    <territoryOwner territory="Kenya-Rhodesia" owner="British" />
-		    <territoryOwner territory="Kwangtung" owner="Japanese" />
-		    <territoryOwner territory="Libya" owner="Germans" />
-		    <territoryOwner territory="Madagascar" owner="British" />
-		    <territoryOwner territory="Manchuria" owner="Japanese" />
-		    <territoryOwner territory="Mexico" owner="Americans" />
-		    <territoryOwner territory="Midway" owner="Americans" />
-		    <territoryOwner territory="New Guinea" owner="Japanese" />
-		    <territoryOwner territory="New Zealand" owner="British" />
-		    <territoryOwner territory="Novosibirsk" owner="Russians" />
-		    <territoryOwner territory="Okinawa" owner="Japanese" />
-		    <territoryOwner territory="Panama" owner="Americans" />
-		    <territoryOwner territory="Persia" owner="British" />
-		    <territoryOwner territory="Philippines" owner="Japanese" />
-		    <territoryOwner territory="Russia" owner="Russians" />
-		    <territoryOwner territory="Sinkiang" owner="Americans" />
-		    <territoryOwner territory="Solomon Islands" owner="Japanese" />
-		    <territoryOwner territory="South Africa" owner="British" />
-		    <territoryOwner territory="South Europe" owner="Germans" />
-		    <territoryOwner territory="Soviet Far East" owner="Russians" />
-		    <territoryOwner territory="Syria Jordan" owner="British" />
-		    <territoryOwner territory="Ukraine S.S.R." owner="Germans" />
-		    <territoryOwner territory="United Kingdom" owner="British" />
-		    <territoryOwner territory="Wake Island" owner="Japanese" />
-		    <territoryOwner territory="West Canada" owner="British" />
-		    <territoryOwner territory="West Europe" owner="Germans" />
-		    <territoryOwner territory="West US" owner="Americans" />
-		    <territoryOwner territory="Yakut S.S.R." owner="Russians" />
-		</ownerInitialize>
+    <production>
+        <productionRule name="buyInfantry">
+            <cost resource="PUs" quantity="3" />
+            <result resourceOrUnit="infantry" quantity="1"/>
+        </productionRule>
 
-		<unitInitialize>
-			<unitPlacement unitType="infantry" territory="Alaska" quantity="1" owner="Americans" />
-			<unitPlacement unitType="infantry" territory="Algeria" quantity="1" owner="Germans" />
-			<unitPlacement unitType="armour" territory="Anglo Sudan Egypt" quantity="1" owner="British" />
-			<unitPlacement unitType="infantry" territory="Anglo Sudan Egypt" quantity="1" owner="British" />
-			<unitPlacement unitType="infantry" territory="Australia" quantity="2" owner="British" />
-			<unitPlacement unitType="infantry" territory="Borneo Celebes" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="infantry" territory="Caroline Islands" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="infantry" territory="Caucasus" quantity="5" owner="Russians" />
-			<unitPlacement unitType="infantry" territory="China" quantity="2" owner="Americans" />
-			<unitPlacement unitType="fighter" territory="China" quantity="1" owner="Americans" />
-			<unitPlacement unitType="infantry" territory="East Indies" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="armour" territory="East Canada" quantity="1" owner="British" />
-			<unitPlacement unitType="armour" territory="East Europe" quantity="1" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="East Europe" quantity="3" owner="Germans" />
-			<unitPlacement unitType="fighter" territory="East Europe" quantity="1" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="East US" quantity="2" owner="Americans" />
-			<unitPlacement unitType="armour" territory="East US" quantity="1" owner="Americans" />
-			<unitPlacement unitType="fighter" territory="East US" quantity="1" owner="Americans" />
-			<unitPlacement unitType="bomber" territory="East US" quantity="1" owner="Americans" />
-			<unitPlacement unitType="factory" territory="East US" quantity="1" owner="Americans" />
-			<unitPlacement unitType="aaGun" territory="East US" quantity="1" owner="Americans" />
-			<unitPlacement unitType="infantry" territory="Evenki National Okrug" quantity="2" owner="Russians" />
-			<unitPlacement unitType="armour" territory="Finland Norway" quantity="1" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="Finland Norway" quantity="3" owner="Germans" />
-			<unitPlacement unitType="fighter" territory="Finland Norway" quantity="1" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="French Indo China" quantity="2" owner="Japanese" />
-			<unitPlacement unitType="fighter" territory="French Indo China" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="armour" territory="Germany" quantity="2" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="Germany" quantity="4" owner="Germans" />
-			<unitPlacement unitType="fighter" territory="Germany" quantity="1" owner="Germans" />
-			<unitPlacement unitType="bomber" territory="Germany" quantity="1" owner="Germans" />
-			<unitPlacement unitType="factory" territory="Germany" quantity="1" owner="Germans" />
-			<unitPlacement unitType="aaGun" territory="Germany" quantity="1" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="1" owner="Americans" />
-			<unitPlacement unitType="infantry" territory="India" quantity="2" owner="British" />
-			<unitPlacement unitType="fighter" territory="India" quantity="1" owner="British" />
-			<unitPlacement unitType="armour" territory="Japan" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="infantry" territory="Japan" quantity="3" owner="Japanese" />
-			<unitPlacement unitType="fighter" territory="Japan" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="bomber" territory="Japan" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="armour" territory="Karelia S.S.R." quantity="1" owner="Russians" />
-			<unitPlacement unitType="infantry" territory="Karelia S.S.R." quantity="3" owner="Russians" />
-			<unitPlacement unitType="fighter" territory="Karelia S.S.R." quantity="1" owner="Russians" />
-			<unitPlacement unitType="factory" territory="Karelia S.S.R." quantity="1" owner="Russians" />
-			<unitPlacement unitType="aaGun" territory="Karelia S.S.R." quantity="1" owner="Russians" />
-			<unitPlacement unitType="infantry" territory="Kwangtung" quantity="2" owner="Japanese" />
-			<unitPlacement unitType="armour" territory="Libya" quantity="1" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="Libya" quantity="1" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="Manchuria" quantity="3" owner="Japanese" />
-			<unitPlacement unitType="fighter" territory="Manchuria" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="infantry" territory="Midway" quantity="1" owner="Americans" />
-			<unitPlacement unitType="infantry" territory="New Guinea" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="infantry" territory="Okinawa" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="infantry" territory="Philippines" quantity="2" owner="Japanese" />
-			<unitPlacement unitType="fighter" territory="Philippines" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="armour" territory="Russia" quantity="2" owner="Russians" />
-			<unitPlacement unitType="infantry" territory="Russia" quantity="4" owner="Russians" />
-			<unitPlacement unitType="fighter" territory="Russia" quantity="1" owner="Russians" />
-			<unitPlacement unitType="factory" territory="Russia" quantity="1" owner="Russians" />
-			<unitPlacement unitType="aaGun" territory="Russia" quantity="1" owner="Russians" />
-			<unitPlacement unitType="infantry" territory="Sinkiang" quantity="2" owner="Americans" />
-			<unitPlacement unitType="infantry" territory="Solomon Islands" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="infantry" territory="South Africa" quantity="1" owner="British" />
-			<unitPlacement unitType="armour" territory="South Europe" quantity="1" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="South Europe" quantity="2" owner="Germans" />
-			<unitPlacement unitType="factory" territory="South Europe" quantity="1" owner="Germans" />
-			<unitPlacement unitType="aaGun" territory="South Europe" quantity="1" owner="Germans" />
-			<unitPlacement unitType="armour" territory="Soviet Far East" quantity="1" owner="Russians" />
-			<unitPlacement unitType="infantry" territory="Soviet Far East" quantity="2" owner="Russians" />
-			<unitPlacement unitType="infantry" territory="Syria Jordan" quantity="1" owner="British" />
-			<unitPlacement unitType="armour" territory="Ukraine S.S.R." quantity="2" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="Ukraine S.S.R." quantity="3" owner="Germans" />
-			<unitPlacement unitType="fighter" territory="Ukraine S.S.R." quantity="1" owner="Germans" />
-			<unitPlacement unitType="armour" territory="United Kingdom" quantity="1" owner="British" />
-			<unitPlacement unitType="infantry" territory="United Kingdom" quantity="2" owner="British" />
-			<unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British" />
-			<unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British" />
-			<unitPlacement unitType="fighter" territory="United Kingdom" quantity="2" owner="British" />
-			<unitPlacement unitType="bomber" territory="United Kingdom" quantity="1" owner="British" />
-			<unitPlacement unitType="infantry" territory="Wake Island" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="infantry" territory="West Canada" quantity="1" owner="British" />
-			<unitPlacement unitType="armour" territory="West Europe" quantity="2" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="West Europe" quantity="2" owner="Germans" />
-			<unitPlacement unitType="fighter" territory="West Europe" quantity="1" owner="Germans" />
-			<unitPlacement unitType="aaGun" territory="West Europe" quantity="1" owner="Germans" />
-			<unitPlacement unitType="infantry" territory="West US" quantity="2" owner="Americans" />
-			<unitPlacement unitType="fighter" territory="West US" quantity="1" owner="Americans" />
-			<unitPlacement unitType="factory" territory="West US" quantity="1" owner="Americans" />
-			<unitPlacement unitType="aaGun" territory="West US" quantity="1" owner="Americans" />
-			<unitPlacement unitType="infantry" territory="Yakut S.S.R." quantity="3" owner="Russians" />
-			<unitPlacement unitType="submarine" territory="Baltic Sea Zone" quantity="1" owner="Germans" />
-			<unitPlacement unitType="transport" territory="Baltic Sea Zone" quantity="1" owner="Germans" />
-			<unitPlacement unitType="fighter" territory="Caroline Islands Sea Zone" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="battleship" territory="Caroline Islands Sea Zone" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="carrier" territory="Caroline Islands Sea Zone" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="battleship" territory="Central Mediteranean Sea Zone" quantity="1" owner="Germans" />
-			<unitPlacement unitType="transport" territory="Central Mediteranean Sea Zone" quantity="1" owner="Germans" />
-			<unitPlacement unitType="transport" territory="East Canada Sea Zone" quantity="1" owner="British" />
-			<unitPlacement unitType="submarine" territory="East Mediteranean Sea Zone" quantity="1" owner="British" />
-			<unitPlacement unitType="transport" territory="East US Sea Zone" quantity="1" owner="Americans" />
-			<unitPlacement unitType="fighter" territory="Hawaii Sea Zone" quantity="1" owner="Americans" />
-			<unitPlacement unitType="submarine" territory="Hawaii Sea Zone" quantity="1" owner="Americans" />
-			<unitPlacement unitType="carrier" territory="Hawaii Sea Zone" quantity="1" owner="Americans" />
-			<unitPlacement unitType="transport" territory="Indian Ocean Sea Zone" quantity="1" owner="British" />
-			<unitPlacement unitType="battleship" territory="Japan Sea Zone" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="transport" territory="Japan Sea Zone" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="submarine" territory="Karelia Sea Zone" quantity="1" owner="Russians" />
-			<unitPlacement unitType="transport" territory="Karelia Sea Zone" quantity="1" owner="Russians" />
-			<unitPlacement unitType="battleship" territory="North Sea Zone" quantity="1" owner="British" />
-			<unitPlacement unitType="transport" territory="North Sea Zone" quantity="1" owner="British" />
-			<unitPlacement unitType="transport" territory="Philippines Sea Zone" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="submarine" territory="Solomon Islands Sea Zone" quantity="1" owner="Japanese" />
-			<unitPlacement unitType="battleship" territory="West Mediteranean Sea Zone" quantity="1" owner="British" />
-			<unitPlacement unitType="submarine" territory="West Spain Sea Zone" quantity="1" owner="Germans" />
-			<unitPlacement unitType="transport" territory="West US Sea Zone" quantity="1" owner="Americans" />
-			<unitPlacement unitType="battleship" territory="West US Sea Zone" quantity="1" owner="Americans" />
-		</unitInitialize>
-	
-		<resourceInitialize>
-			<resourceGiven player="Japanese" resource="PUs" quantity="25"/>
-			<resourceGiven player="British" resource="PUs" quantity="30"/>
-			<resourceGiven player="Americans" resource="PUs" quantity="36"/>
-			<resourceGiven player="Russians" resource="PUs" quantity="24"/>
-			<resourceGiven player="Germans" resource="PUs" quantity="32"/>
-		</resourceInitialize>
-	</initialize>
+        <productionRule name="buyMarine">
+            <cost resource="PUs" quantity="4" />
+            <result resourceOrUnit="marine" quantity="1"/>
+        </productionRule>
 
-	<propertyList>
-		<property name="Russians bid" value="0" editable="true">
-				<number min="0" max="1000"/>
-		</property>
-		
-		<property name="Germans bid" value="0" editable="true">
-			<number min="0" max="1000"/>
-		</property>
+        <productionRule name="buyArtillery">
+            <cost resource="PUs" quantity="4" />
+            <result resourceOrUnit="artillery" quantity="1"/>
+        </productionRule>
 
-		<property name="British bid" value="0" editable="true">
-				<number min="0" max="1000"/>
-		</property>
+        <productionRule name="buyArmour">
+            <cost resource="PUs" quantity="5" />
+            <result resourceOrUnit="armour" quantity="1"/>
+        </productionRule>
 
-		<property name="Japanese bid" value="0" editable="true">
-			<number min="0" max="1000"/>
-		</property>
+        <productionRule name="buyFighter">
+            <cost resource="PUs" quantity="12" />
+            <result resourceOrUnit="fighter" quantity="1"/>
+        </productionRule>
 
-		<property name="Americans bid" value="0" editable="true">
-				<number min="0" max="1000"/>
-		</property>
-		
-		<property name="Economic Victory" value="true" editable="true">
-            <boolean/>
+        <productionRule name="buyBomber">
+            <cost resource="PUs" quantity="15" />
+            <result resourceOrUnit="bomber" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyTransport">
+            <cost resource="PUs" quantity="8" />
+            <result resourceOrUnit="transport" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyDestroyer">
+            <cost resource="PUs" quantity="8" />
+            <result resourceOrUnit="destroyer" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyCarrier">
+            <cost resource="PUs" quantity="18" />
+            <result resourceOrUnit="carrier" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyBattleship">
+            <cost resource="PUs" quantity="24" />
+            <result resourceOrUnit="battleship" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buySubmarine">
+            <cost resource="PUs" quantity="8" />
+            <result resourceOrUnit="submarine" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyFactory">
+            <cost resource="PUs" quantity="15" />
+            <result resourceOrUnit="factory" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyAAGun">
+            <cost resource="PUs" quantity="5" />
+            <result resourceOrUnit="aaGun" quantity="1"/>
+        </productionRule>
+
+        <!-- advanced industrial production -->
+        <productionRule name="buyInfantryIndustrialTechnology">
+            <cost resource="PUs" quantity="2" />
+            <result resourceOrUnit="infantry" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyMarineIndustrialTechnology">
+            <cost resource="PUs" quantity="3" />
+            <result resourceOrUnit="marine" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyArtilleryIndustrialTechnology">
+            <cost resource="PUs" quantity="3" />
+            <result resourceOrUnit="artillery" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyArmourIndustrialTechnology">
+            <cost resource="PUs" quantity="4" />
+            <result resourceOrUnit="armour" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyFighterIndustrialTechnology">
+            <cost resource="PUs" quantity="11" />
+            <result resourceOrUnit="fighter" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyBomberIndustrialTechnology">
+            <cost resource="PUs" quantity="14" />
+            <result resourceOrUnit="bomber" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyTransportIndustrialTechnology">
+            <cost resource="PUs" quantity="7" />
+            <result resourceOrUnit="transport" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyDestroyerIndustrialTechnology">
+            <cost resource="PUs" quantity="7" />
+            <result resourceOrUnit="destroyer" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyCarrierIndustrialTechnology">
+            <cost resource="PUs" quantity="17" />
+            <result resourceOrUnit="carrier" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyBattleshipIndustrialTechnology">
+            <cost resource="PUs" quantity="23" />
+            <result resourceOrUnit="battleship" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buySubmarineIndustrialTechnology">
+            <cost resource="PUs" quantity="7" />
+            <result resourceOrUnit="submarine" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyFactoryIndustrialTechnology">
+            <cost resource="PUs" quantity="14" />
+            <result resourceOrUnit="factory" quantity="1"/>
+        </productionRule>
+
+        <productionRule name="buyAAGunIndustrialTechnology">
+            <cost resource="PUs" quantity="4" />
+            <result resourceOrUnit="aaGun" quantity="1"/>
+        </productionRule>
+
+        <productionFrontier name="production">
+            <frontierRules name="buyInfantry"/>
+            <frontierRules name="buyMarine"/>
+            <frontierRules name="buyArmour"/>
+            <frontierRules name="buyFighter"/>
+            <frontierRules name="buyBomber"/>
+            <frontierRules name="buyTransport"/>
+            <frontierRules name="buySubmarine"/>
+            <frontierRules name="buyDestroyer"/>
+            <frontierRules name="buyCarrier"/>
+            <frontierRules name="buyBattleship"/>
+            <frontierRules name="buyAAGun"/>
+            <frontierRules name="buyFactory"/>
+        </productionFrontier>
+
+        <productionFrontier name="productionIndustrialTechnology">
+            <frontierRules name="buyInfantryIndustrialTechnology"/>
+            <frontierRules name="buyMarineIndustrialTechnology"/>
+            <frontierRules name="buyArmourIndustrialTechnology"/>
+            <frontierRules name="buyFighterIndustrialTechnology"/>
+            <frontierRules name="buyBomberIndustrialTechnology"/>
+            <frontierRules name="buyTransportIndustrialTechnology"/>
+            <frontierRules name="buySubmarineIndustrialTechnology"/>
+            <frontierRules name="buyDestroyerIndustrialTechnology"/>
+            <frontierRules name="buyCarrierIndustrialTechnology"/>
+            <frontierRules name="buyBattleshipIndustrialTechnology"/>
+            <frontierRules name="buyAAGunIndustrialTechnology"/>
+            <frontierRules name="buyFactoryIndustrialTechnology"/>
+        </productionFrontier>
+
+        <playerProduction player="British" frontier="production"/>
+        <playerProduction player="Japanese" frontier="production"/>
+        <playerProduction player="Americans" frontier="production"/>
+        <playerProduction player="Germans" frontier="production"/>
+        <playerProduction player="Russians" frontier="production"/>
+    </production>
+
+    <attachmentList>
+        <attachment name="techAttachment" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TechAttachment"
+                       type="player">
+            <option name="heavyBomber" value="false"/>
+            <option name="jetPower" value="false"/>
+            <option name="industrialTechnology" value="false"/>
+            <option name="superSub" value="false"/>
+            <option name="rocket" value="false"/>
+            <option name="longRangeAir" value="false"/>
+        </attachment>
+
+        <attachment name="techAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TechAttachment"
+                       type="player">
+            <option name="heavyBomber" value="false"/>
+            <option name="jetPower" value="false"/>
+            <option name="industrialTechnology" value="false"/>
+            <option name="superSub" value="false"/>
+            <option name="rocket" value="false"/>
+            <option name="longRangeAir" value="false"/>
+        </attachment>
+
+        <attachment name="techAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TechAttachment"
+                       type="player">
+            <option name="heavyBomber" value="false"/>
+            <option name="jetPower" value="false"/>
+            <option name="industrialTechnology" value="false"/>
+            <option name="superSub" value="false"/>
+            <option name="rocket" value="false"/>
+            <option name="longRangeAir" value="false"/>
+        </attachment>
+
+        <attachment name="techAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.TechAttachment"
+                       type="player">
+            <option name="heavyBomber" value="false"/>
+            <option name="jetPower" value="false"/>
+            <option name="industrialTechnology" value="false"/>
+            <option name="superSub" value="false"/>
+            <option name="rocket" value="false"/>
+            <option name="longRangeAir" value="false"/>
+        </attachment>
+
+        <attachment name="techAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TechAttachment"
+                       type="player">
+            <option name="heavyBomber" value="false"/>
+            <option name="jetPower" value="false"/>
+            <option name="industrialTechnology" value="false"/>
+            <option name="superSub" value="false"/>
+            <option name="rocket" value="false"/>
+            <option name="longRangeAir" value="false"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="infantry"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="1"/>
+            <option name="transportCost" value="1"/>
+            <option name="attack" value="1"/>
+            <option name="defense" value="2"/>
+            <option name="artillerySupportable" value="true"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="marine"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="1"/>
+            <option name="transportCost" value="1"/>
+            <option name="attack" value="1"/>
+            <option name="defense" value="2"/>
+            <option name="isMarine" value="true"/>
+            <option name="artillerySupportable" value="true"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="artillery"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="1"/>
+            <option name="transportCost" value="1"/>
+            <option name="attack" value="2"/>
+            <option name="defense" value="2"/>
+            <option name="artillery" value="true"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="armour"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="2"/>
+            <option name="transportCost" value="2"/>
+            <option name="canBlitz" value="true"/>
+            <option name="attack" value="3"/>
+            <option name="defense" value="2"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="fighter"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="4"/>
+            <option name="carrierCost" value="1"/>
+            <option name="isAir" value="true"/>
+            <option name="attack" value="3"/>
+            <option name="defense" value="4"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="bomber"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="6"/>
+            <option name="isAir" value="true"/>
+            <option name="attack" value="4"/>
+            <option name="defense" value="1"/>
+            <option name="isStrategicBomber" value="true"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="transport"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="transportCapacity" value="2"/>
+            <option name="attack" value="0"/>
+            <option name="defense" value="1"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="destroyer"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="2"/>
+            <option name="defense" value="2"/>
+            <!--<option name="isDestroyer" value="true"/>-->
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="battleship"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="4"/>
+            <option name="defense" value="4"/>
+            <option name="canBombard" value="true"/>
+            <option name="hitPoints" value="1"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="carrier"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="carrierCapacity" value="2"/>
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="1"/>
+            <option name="defense" value="3"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="submarine"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="isSub" value="true"/>
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="2"/>
+            <option name="defense" value="2"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="factory"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="isFactory" value="true"/>
+            <option name="destroyedWhenCapturedFrom" value="Russians:Germans:British:Japanese:Americans"/>
+        </attachment>
+
+        <attachment name="unitAttachment"
+            attachTo="aaGun"
+            javaClass="games.strategy.triplea.attachments.UnitAttachment"
+            type="unitType">
+            <option name="isAA" value="true"/>
+            <option name="transportCost" value="2"/>
+            <option name="movement" value="1"/>
+            <option name="destroyedWhenCapturedFrom" value="Russians:Germans:British:Japanese:Americans"/>
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Afghanistan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Alaska" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Algeria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Anglo Sudan Egypt" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Angola" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Argentina-Chile" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Australia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Borneo Celebes" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Brazil" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Caucasus" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="China" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Columbia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Congo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Cuba" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="East Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="East Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="East Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="East US" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="12" />
+            <option name="originalFactory" value="true" />
+            <option name="capital" value="Americans" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Eire" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Evenki National Okrug" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Finland Norway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="French Equatorial Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="French Indo China" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="French West Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="10" />
+            <option name="originalFactory" value="true" />
+            <option name="capital" value="Germans" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Gibraltar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Hawaiian Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="India" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Italian East Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="8" />
+            <option name="originalFactory" value="true" />
+            <option name="capital" value="Japanese" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Karelia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+            <option name="originalFactory" value="true" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Kazakh S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Kenya-Rhodesia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Kwangtung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Libya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Madagascar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Manchuria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Mexico" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Midway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Mongolia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Mozambique" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="New Guinea" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="New Zealand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Novosibirsk" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Okinawa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Panama" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Persia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Peru" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Philippines" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Rio del Oro" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="8" />
+            <option name="originalFactory" value="true" />
+            <option name="capital" value="Russians" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Saudi Arabia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Sinkiang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Solomon Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="South Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="South Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="6" />
+            <option name="originalFactory" value="true" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Soviet Far East" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Spain" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Sweden" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Switzerland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Syria Jordan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Turkey" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Ukraine S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="3" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="United Kingdom" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="8" />
+            <option name="originalFactory" value="true" />
+            <option name="capital" value="British" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Wake Island" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="0" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="West Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="1" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="West Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="6" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="West US" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="10" />
+            <option name="originalFactory" value="true" />
+        </attachment>
+
+        <attachment name="territoryAttachment"  attachTo="Yakut S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory" >
+            <option name="production" value="2" />
+        </attachment>
+
+
+        <!-- canals -->
+        <attachment name="canalAttachment" attachTo="East Mediteranean Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+            <option name="canalName" value="Suez Canal"/>
+            <option name="landTerritories" value="Anglo Sudan Egypt:Syria Jordan"/>
+        </attachment>
+
+        <attachment name="canalAttachment" attachTo="Red Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+            <option name="canalName" value="Suez Canal"/>
+            <option name="landTerritories" value="Anglo Sudan Egypt:Syria Jordan"/>
+        </attachment>
+
+        <attachment name="canalAttachment" attachTo="Carribean Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+            <option name="canalName" value="Panama Canal"/>
+            <option name="landTerritories" value="Panama"/>
+        </attachment>
+
+        <attachment name="canalAttachment" attachTo="West Panama Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+            <option name="canalName" value="Panama Canal"/>
+            <option name="landTerritories" value="Panama"/>
+        </attachment>
+
+
+        <attachment name="rulesAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+            <option name="movementRestrictionTerritories" value="Caucasus:Evenki National Okrug:Karelia S.S.R.:Kazakh S.S.R.:Novosibirsk:Russia:Soviet Far East:Yakut S.S.R."/>
+            <option name="movementRestrictionType" value="allowed"/>
+        </attachment>
+
+        <attachment name="conditionAttachmentTurn1" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+            <option name="rounds" value="1-+"/>
+        </attachment>
+
+        <attachment name="triggerAttachmentRussians_Can_Move" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+            <option name="conditions" value="conditionAttachmentTurn1"/>
+            <option name="when" value="after:russianBattle"/>
+            <option name="uses" value="1"/>
+            <option name="players" value="Russians"/>
+            <option name="playerAttachmentName" value="RulesAttachment" count="rulesAttachment"/>
+            <option name="playerProperty" value="movementRestrictionTerritories" count="-reset-"/>
+            <option name="playerProperty" value="movementRestrictionType" count="disallowed"/>
+        </attachment>
+
+    </attachmentList>
+
+    <initialize>
+        <ownerInitialize>
+            <territoryOwner territory="Alaska" owner="Americans" />
+            <territoryOwner territory="Algeria" owner="Germans" />
+            <territoryOwner territory="Anglo Sudan Egypt" owner="British" />
+            <territoryOwner territory="Australia" owner="British" />
+            <territoryOwner territory="Borneo Celebes" owner="Japanese" />
+            <territoryOwner territory="Brazil" owner="Americans" />
+            <territoryOwner territory="Caroline Islands" owner="Japanese" />
+            <territoryOwner territory="Caucasus" owner="Russians" />
+            <territoryOwner territory="China" owner="Americans" />
+            <territoryOwner territory="Congo" owner="British" />
+            <territoryOwner territory="Cuba" owner="Americans" />
+            <territoryOwner territory="East Indies" owner="Japanese" />
+            <territoryOwner territory="East Canada" owner="British" />
+            <territoryOwner territory="East Europe" owner="Germans" />
+            <territoryOwner territory="East US" owner="Americans" />
+            <territoryOwner territory="Evenki National Okrug" owner="Russians" />
+            <territoryOwner territory="Finland Norway" owner="Germans" />
+            <territoryOwner territory="French Equatorial Africa" owner="British" />
+            <territoryOwner territory="French Indo China" owner="Japanese" />
+            <territoryOwner territory="French West Africa" owner="British" />
+            <territoryOwner territory="Germany" owner="Germans" />
+            <territoryOwner territory="Gibraltar" owner="British" />
+            <territoryOwner territory="Hawaiian Islands" owner="Americans" />
+            <territoryOwner territory="India" owner="British" />
+            <territoryOwner territory="Italian East Africa" owner="British" />
+            <territoryOwner territory="Japan" owner="Japanese" />
+            <territoryOwner territory="Karelia S.S.R." owner="Russians" />
+            <territoryOwner territory="Kazakh S.S.R." owner="Russians" />
+            <territoryOwner territory="Kenya-Rhodesia" owner="British" />
+            <territoryOwner territory="Kwangtung" owner="Japanese" />
+            <territoryOwner territory="Libya" owner="Germans" />
+            <territoryOwner territory="Madagascar" owner="British" />
+            <territoryOwner territory="Manchuria" owner="Japanese" />
+            <territoryOwner territory="Mexico" owner="Americans" />
+            <territoryOwner territory="Midway" owner="Americans" />
+            <territoryOwner territory="New Guinea" owner="Japanese" />
+            <territoryOwner territory="New Zealand" owner="British" />
+            <territoryOwner territory="Novosibirsk" owner="Russians" />
+            <territoryOwner territory="Okinawa" owner="Japanese" />
+            <territoryOwner territory="Panama" owner="Americans" />
+            <territoryOwner territory="Persia" owner="British" />
+            <territoryOwner territory="Philippines" owner="Japanese" />
+            <territoryOwner territory="Russia" owner="Russians" />
+            <territoryOwner territory="Sinkiang" owner="Americans" />
+            <territoryOwner territory="Solomon Islands" owner="Japanese" />
+            <territoryOwner territory="South Africa" owner="British" />
+            <territoryOwner territory="South Europe" owner="Germans" />
+            <territoryOwner territory="Soviet Far East" owner="Russians" />
+            <territoryOwner territory="Syria Jordan" owner="British" />
+            <territoryOwner territory="Ukraine S.S.R." owner="Germans" />
+            <territoryOwner territory="United Kingdom" owner="British" />
+            <territoryOwner territory="Wake Island" owner="Japanese" />
+            <territoryOwner territory="West Canada" owner="British" />
+            <territoryOwner territory="West Europe" owner="Germans" />
+            <territoryOwner territory="West US" owner="Americans" />
+            <territoryOwner territory="Yakut S.S.R." owner="Russians" />
+        </ownerInitialize>
+
+        <unitInitialize>
+            <unitPlacement unitType="infantry" territory="Alaska" quantity="1" owner="Americans" />
+            <unitPlacement unitType="infantry" territory="Algeria" quantity="1" owner="Germans" />
+            <unitPlacement unitType="armour" territory="Anglo Sudan Egypt" quantity="1" owner="British" />
+            <unitPlacement unitType="infantry" territory="Anglo Sudan Egypt" quantity="1" owner="British" />
+            <unitPlacement unitType="infantry" territory="Australia" quantity="2" owner="British" />
+            <unitPlacement unitType="infantry" territory="Borneo Celebes" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="infantry" territory="Caroline Islands" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="infantry" territory="Caucasus" quantity="5" owner="Russians" />
+            <unitPlacement unitType="infantry" territory="China" quantity="2" owner="Americans" />
+            <unitPlacement unitType="fighter" territory="China" quantity="1" owner="Americans" />
+            <unitPlacement unitType="infantry" territory="East Indies" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="armour" territory="East Canada" quantity="1" owner="British" />
+            <unitPlacement unitType="armour" territory="East Europe" quantity="1" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="East Europe" quantity="3" owner="Germans" />
+            <unitPlacement unitType="fighter" territory="East Europe" quantity="1" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="East US" quantity="2" owner="Americans" />
+            <unitPlacement unitType="armour" territory="East US" quantity="1" owner="Americans" />
+            <unitPlacement unitType="fighter" territory="East US" quantity="1" owner="Americans" />
+            <unitPlacement unitType="bomber" territory="East US" quantity="1" owner="Americans" />
+            <unitPlacement unitType="factory" territory="East US" quantity="1" owner="Americans" />
+            <unitPlacement unitType="aaGun" territory="East US" quantity="1" owner="Americans" />
+            <unitPlacement unitType="infantry" territory="Evenki National Okrug" quantity="2" owner="Russians" />
+            <unitPlacement unitType="armour" territory="Finland Norway" quantity="1" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="Finland Norway" quantity="3" owner="Germans" />
+            <unitPlacement unitType="fighter" territory="Finland Norway" quantity="1" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="French Indo China" quantity="2" owner="Japanese" />
+            <unitPlacement unitType="fighter" territory="French Indo China" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="armour" territory="Germany" quantity="2" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="Germany" quantity="4" owner="Germans" />
+            <unitPlacement unitType="fighter" territory="Germany" quantity="1" owner="Germans" />
+            <unitPlacement unitType="bomber" territory="Germany" quantity="1" owner="Germans" />
+            <unitPlacement unitType="factory" territory="Germany" quantity="1" owner="Germans" />
+            <unitPlacement unitType="aaGun" territory="Germany" quantity="1" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="1" owner="Americans" />
+            <unitPlacement unitType="infantry" territory="India" quantity="2" owner="British" />
+            <unitPlacement unitType="fighter" territory="India" quantity="1" owner="British" />
+            <unitPlacement unitType="armour" territory="Japan" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="infantry" territory="Japan" quantity="3" owner="Japanese" />
+            <unitPlacement unitType="fighter" territory="Japan" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="bomber" territory="Japan" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="armour" territory="Karelia S.S.R." quantity="1" owner="Russians" />
+            <unitPlacement unitType="infantry" territory="Karelia S.S.R." quantity="3" owner="Russians" />
+            <unitPlacement unitType="fighter" territory="Karelia S.S.R." quantity="1" owner="Russians" />
+            <unitPlacement unitType="factory" territory="Karelia S.S.R." quantity="1" owner="Russians" />
+            <unitPlacement unitType="aaGun" territory="Karelia S.S.R." quantity="1" owner="Russians" />
+            <unitPlacement unitType="infantry" territory="Kwangtung" quantity="2" owner="Japanese" />
+            <unitPlacement unitType="armour" territory="Libya" quantity="1" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="Libya" quantity="1" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="Manchuria" quantity="3" owner="Japanese" />
+            <unitPlacement unitType="fighter" territory="Manchuria" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="infantry" territory="Midway" quantity="1" owner="Americans" />
+            <unitPlacement unitType="infantry" territory="New Guinea" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="infantry" territory="Okinawa" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="infantry" territory="Philippines" quantity="2" owner="Japanese" />
+            <unitPlacement unitType="fighter" territory="Philippines" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="armour" territory="Russia" quantity="2" owner="Russians" />
+            <unitPlacement unitType="infantry" territory="Russia" quantity="4" owner="Russians" />
+            <unitPlacement unitType="fighter" territory="Russia" quantity="1" owner="Russians" />
+            <unitPlacement unitType="factory" territory="Russia" quantity="1" owner="Russians" />
+            <unitPlacement unitType="aaGun" territory="Russia" quantity="1" owner="Russians" />
+            <unitPlacement unitType="infantry" territory="Sinkiang" quantity="2" owner="Americans" />
+            <unitPlacement unitType="infantry" territory="Solomon Islands" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="infantry" territory="South Africa" quantity="1" owner="British" />
+            <unitPlacement unitType="armour" territory="South Europe" quantity="1" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="South Europe" quantity="2" owner="Germans" />
+            <unitPlacement unitType="factory" territory="South Europe" quantity="1" owner="Germans" />
+            <unitPlacement unitType="aaGun" territory="South Europe" quantity="1" owner="Germans" />
+            <unitPlacement unitType="armour" territory="Soviet Far East" quantity="1" owner="Russians" />
+            <unitPlacement unitType="infantry" territory="Soviet Far East" quantity="2" owner="Russians" />
+            <unitPlacement unitType="infantry" territory="Syria Jordan" quantity="1" owner="British" />
+            <unitPlacement unitType="armour" territory="Ukraine S.S.R." quantity="2" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="Ukraine S.S.R." quantity="3" owner="Germans" />
+            <unitPlacement unitType="fighter" territory="Ukraine S.S.R." quantity="1" owner="Germans" />
+            <unitPlacement unitType="armour" territory="United Kingdom" quantity="1" owner="British" />
+            <unitPlacement unitType="infantry" territory="United Kingdom" quantity="2" owner="British" />
+            <unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British" />
+            <unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British" />
+            <unitPlacement unitType="fighter" territory="United Kingdom" quantity="2" owner="British" />
+            <unitPlacement unitType="bomber" territory="United Kingdom" quantity="1" owner="British" />
+            <unitPlacement unitType="infantry" territory="Wake Island" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="infantry" territory="West Canada" quantity="1" owner="British" />
+            <unitPlacement unitType="armour" territory="West Europe" quantity="2" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="West Europe" quantity="2" owner="Germans" />
+            <unitPlacement unitType="fighter" territory="West Europe" quantity="1" owner="Germans" />
+            <unitPlacement unitType="aaGun" territory="West Europe" quantity="1" owner="Germans" />
+            <unitPlacement unitType="infantry" territory="West US" quantity="2" owner="Americans" />
+            <unitPlacement unitType="fighter" territory="West US" quantity="1" owner="Americans" />
+            <unitPlacement unitType="factory" territory="West US" quantity="1" owner="Americans" />
+            <unitPlacement unitType="aaGun" territory="West US" quantity="1" owner="Americans" />
+            <unitPlacement unitType="infantry" territory="Yakut S.S.R." quantity="3" owner="Russians" />
+            <unitPlacement unitType="submarine" territory="Baltic Sea Zone" quantity="1" owner="Germans" />
+            <unitPlacement unitType="transport" territory="Baltic Sea Zone" quantity="1" owner="Germans" />
+            <unitPlacement unitType="fighter" territory="Caroline Islands Sea Zone" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="battleship" territory="Caroline Islands Sea Zone" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="carrier" territory="Caroline Islands Sea Zone" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="battleship" territory="Central Mediteranean Sea Zone" quantity="1" owner="Germans" />
+            <unitPlacement unitType="transport" territory="Central Mediteranean Sea Zone" quantity="1" owner="Germans" />
+            <unitPlacement unitType="transport" territory="East Canada Sea Zone" quantity="1" owner="British" />
+            <unitPlacement unitType="submarine" territory="East Mediteranean Sea Zone" quantity="1" owner="British" />
+            <unitPlacement unitType="transport" territory="East US Sea Zone" quantity="1" owner="Americans" />
+            <unitPlacement unitType="fighter" territory="Hawaii Sea Zone" quantity="1" owner="Americans" />
+            <unitPlacement unitType="submarine" territory="Hawaii Sea Zone" quantity="1" owner="Americans" />
+            <unitPlacement unitType="carrier" territory="Hawaii Sea Zone" quantity="1" owner="Americans" />
+            <unitPlacement unitType="transport" territory="Indian Ocean Sea Zone" quantity="1" owner="British" />
+            <unitPlacement unitType="battleship" territory="Japan Sea Zone" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="transport" territory="Japan Sea Zone" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="submarine" territory="Karelia Sea Zone" quantity="1" owner="Russians" />
+            <unitPlacement unitType="transport" territory="Karelia Sea Zone" quantity="1" owner="Russians" />
+            <unitPlacement unitType="battleship" territory="North Sea Zone" quantity="1" owner="British" />
+            <unitPlacement unitType="transport" territory="North Sea Zone" quantity="1" owner="British" />
+            <unitPlacement unitType="transport" territory="Philippines Sea Zone" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="submarine" territory="Solomon Islands Sea Zone" quantity="1" owner="Japanese" />
+            <unitPlacement unitType="battleship" territory="West Mediteranean Sea Zone" quantity="1" owner="British" />
+            <unitPlacement unitType="submarine" territory="West Spain Sea Zone" quantity="1" owner="Germans" />
+            <unitPlacement unitType="transport" territory="West US Sea Zone" quantity="1" owner="Americans" />
+            <unitPlacement unitType="battleship" territory="West US Sea Zone" quantity="1" owner="Americans" />
+        </unitInitialize>
+
+        <resourceInitialize>
+            <resourceGiven player="Japanese" resource="PUs" quantity="25"/>
+            <resourceGiven player="British" resource="PUs" quantity="30"/>
+            <resourceGiven player="Americans" resource="PUs" quantity="36"/>
+            <resourceGiven player="Russians" resource="PUs" quantity="24"/>
+            <resourceGiven player="Germans" resource="PUs" quantity="32"/>
+        </resourceInitialize>
+    </initialize>
+
+    <propertyList>
+        <property name="Russians bid" value="0" editable="true">
+            <number min="0" max="1000"/>
         </property>
-				
-		<property name="Axis Economic Victory" value="84" editable="true">
-			<number min="70" max="147"/>
-		</property>
-				
-		<property name="Allies Economic Victory" value="140" editable="true">
-			<number min="90" max="147"/>
-		</property>
 
-		<property name="Low Luck" value="false" editable="true">
-			<boolean/>
-		</property>
+        <property name="Germans bid" value="0" editable="true">
+            <number min="0" max="1000"/>
+        </property>
 
-		<property name="Low Luck for AntiAircraft" value="false" editable="true">
-				<boolean/>
-		</property>
+        <property name="British bid" value="0" editable="true">
+            <number min="0" max="1000"/>
+        </property>
 
-		<property name="Low Luck for Technology" value="false" editable="true">
-				<boolean/>
-		</property>
+        <property name="Japanese bid" value="0" editable="true">
+            <number min="0" max="1000"/>
+        </property>
 
-		<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
-				<boolean/>
-		</property>
-				
-		<property name="Use Triggers" value="true" editable="false">
-				<boolean/>
-		</property>
-		
-		<property name="Movement By Territory Restricted" value="false" editable="true">
-				<boolean/>
-		</property>
-		
-		<property name="Units Can Be Destroyed Instead Of Captured" value ="false" editable="true">
-				<boolean/>
-		</property>
-				
-		<property name="Use Destroyers and Artillery" value="false" editable="true">
-			<boolean/>
-		</property>
-		
-		<property name="Tech Development" value="true" editable="true">
-			<boolean/>
-		</property>
+        <property name="Americans bid" value="0" editable="true">
+            <number min="0" max="1000"/>
+        </property>
 
-		<property name="Super Sub Defence Bonus" value="0" editable="true">
-				<number min="0" max="1"/>
-		</property>
-
-		<property name="Heavy Bomber Dice Rolls" value="3" editable="true">
-				<number min="2" max="3"/>
-		</property>
-		
-		<property name="LHTR Heavy Bombers" value="false" editable="true">
-				<boolean/>
-		</property>
-		
-		<property name="Territory Turn Limit" value="false" editable="true">
-				<boolean/>
-		</property>
-		
-		<property name="Always on AA" value="false" editable="true">
-			<boolean/>
-		</property>
-		
-		<property name="AA Territory Restricted" value="false" editable="false">
-				<boolean/>
-		</property>
-		
-		<property name="Choose AA Casualties" value="true" editable="true">
+        <property name="Economic Victory" value="true" editable="true">
             <boolean/>
         </property>
 
-		<property name="Multiple AA Per Territory" value="true" editable="true">
-				<boolean/>
-		</property>
-
-		<property name="Kamikaze Airplanes" value="false" editable="true">
-			<boolean/>
-		</property>
-		
-		<property name="Submarines Defending May Submerge Or Retreat" value="true" editable="true">
-				<boolean/>
-		</property>
-		
-		<property name="Submersible Subs" value="false" editable="true">
-			<boolean/>
-		</property>
-		
-		<property name="Two hit battleship" value="false" editable="true">
-			<boolean/>
-		</property>
-
-		<property name="Units Repair Hits End Turn" value="false" editable="true">
-			<boolean/>
-		</property>
-
-		<property name="Units Repair Hits Start Turn" value="false" editable="true">
-				<boolean/>
-		</property>
-
-		<property name="Shore Bombard Per Ground Unit Restricted" value="false" editable="true">
-				<boolean/>
-		</property>
-
-		<property name="Naval Bombard Casualties Return Fire" value="false" editable="true">
-				<boolean/>
-		</property>
-		
-		<property name="Partial Amphibious Retreat" value="false" editable="true">
-				<boolean/>
-		</property>
-
-		<property name="Attacker Retreat Planes" value="true" editable="true">
-				<boolean/>
-		</property>
-
-		<property name="Unplaced units live when not placed" value ="false" editable="false">
-				<boolean/>
-		</property>
-
-		<property name="Unit Placement In Enemy Seas" value="false" editable="true">
-				<boolean/>
-		</property>
-
-		<property name="Produce fighters on carriers" value="false" editable="true">
-			<boolean/>
-		</property>
-		
-		<property name="Move existing fighters to new carriers" value="false" editable="true">
-            <boolean/>
+        <property name="Axis Economic Victory" value="84" editable="true">
+            <number min="70" max="147"/>
         </property>
-		
-		<property name="LHTR Carrier production rules" value="false" editable="true">
-				<boolean/>
-		</property>
 
-		<property name="Surviving Air Move To Land" value="false" editable="false">
-				<boolean/>
-		</property>
-		
-		<property name="Allied Air Dependents" value="true" editable="false">
-			<boolean/>
-		</property>
+        <property name="Allies Economic Victory" value="140" editable="true">
+            <number min="90" max="147"/>
+        </property>
 
-		<property name="Air Attack Sub Restricted" value="false" editable="false">
-				<boolean/>
-		</property>
-		
-		<property name="Sub Control Sea Zone Restricted" value="false" editable="false">
+        <property name="Low Luck" value="false" editable="true">
             <boolean/>
         </property>
 
-		<property name="neutralCharge" value="3" editable="true">
-				<number min="0" max="9999999"/>
-		</property>
+        <property name="Low Luck for AntiAircraft" value="false" editable="true">
+            <boolean/>
+        </property>
 
-		<property name="Neutrals Are Impassable" value="false" editable="true">
-				<boolean/>
-		</property>
+        <property name="Low Luck for Technology" value="false" editable="true">
+            <boolean/>
+        </property>
 
-		<property name="maxFactoriesPerTerritory" value="1" editable="false">
-				<number min="1" max="100"/>
-		</property>
+        <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+            <boolean/>
+        </property>
 
-		<property name="mapName" value="Classic: Iron Blitz 3rd Edition Test" editable="false">
-				<string/>
-		</property>
+        <property name="Use Triggers" value="true" editable="false">
+            <boolean/>
+        </property>
+
+        <property name="Movement By Territory Restricted" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Units Can Be Destroyed Instead Of Captured" value ="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Use Destroyers and Artillery" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Tech Development" value="true" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Super Sub Defence Bonus" value="0" editable="true">
+            <number min="0" max="1"/>
+        </property>
+
+        <property name="Heavy Bomber Dice Rolls" value="3" editable="true">
+            <number min="2" max="3"/>
+        </property>
+
+        <property name="LHTR Heavy Bombers" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Territory Turn Limit" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Always on AA" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="AA Territory Restricted" value="false" editable="false">
+            <boolean/>
+        </property>
+
+        <property name="Choose AA Casualties" value="true" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Multiple AA Per Territory" value="true" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Kamikaze Airplanes" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Submarines Defending May Submerge Or Retreat" value="true" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Submersible Subs" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Two hit battleship" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Units Repair Hits End Turn" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Units Repair Hits Start Turn" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Shore Bombard Per Ground Unit Restricted" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Naval Bombard Casualties Return Fire" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Partial Amphibious Retreat" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Attacker Retreat Planes" value="true" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Unplaced units live when not placed" value ="false" editable="false">
+            <boolean/>
+        </property>
+
+        <property name="Unit Placement In Enemy Seas" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Produce fighters on carriers" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Move existing fighters to new carriers" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="LHTR Carrier production rules" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Surviving Air Move To Land" value="false" editable="false">
+            <boolean/>
+        </property>
+
+        <property name="Allied Air Dependents" value="true" editable="false">
+            <boolean/>
+        </property>
+
+        <property name="Air Attack Sub Restricted" value="false" editable="false">
+            <boolean/>
+        </property>
+
+        <property name="Sub Control Sea Zone Restricted" value="false" editable="false">
+            <boolean/>
+        </property>
+
+        <property name="neutralCharge" value="3" editable="true">
+            <number min="0" max="9999999"/>
+        </property>
+
+        <property name="Neutrals Are Impassable" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="maxFactoriesPerTerritory" value="1" editable="false">
+            <number min="1" max="100"/>
+        </property>
+
+        <property name="mapName" value="Classic: Iron Blitz 3rd Edition Test" editable="false">
+            <string/>
+        </property>
 
         <property name="notes">
-			<string/>
-        	<value><![CDATA[
-        	The Classic Iron Blitz 3rd Edition of a World War II game.
-			<br> Axis need to at the end of the round control 2 out of 3 allied capitols plus their own capitols to win OR get to 84 production at end of round.
-			<br> Allies need to control both Axis capitols plus their own capitols.
-			<br> (Optional rule: Allies win if they get to 110 production at end of round [to enable, change Allied economic victory from 140 to 110]).
-			<br>
-			<br>New Additions for Iron Blitz:
-			<br>Destroyers attack and defend at 2, and cost 8 PUs.  They do not have any special anti-submarine abilities.
-			<br>Marines attack at 1 (2 during Amphibious Assaults), and defend at 2, and cost 4 PUs.
-			<br>Optional rule: Russia may not attack during 1st turn (turn on game option: "Movement By Territory Restricted" for this).
-			<br>
-			<br>
-			<br>New Features in Third Edition Rules (over 2nd Edition):
-			<br>Defending submarines can submerge or retreat from combat. A submerged sub stays in the same sea zone until after combat when it re-surfaces.
-			<br>Fighters and Bombers can now retreat from an amphibious assult.
-			<br>Multiple AA guns in one territory are allowed.  However, only one AA gun per territory can fire per turn.
-			<br>You can now place naval units in a seazone occupied by enemy units. If you do, combat will occur during the opponent's next combat phase, unless they move out of the zone first.
-			<br>Western Canada no longer borders the Atlantic Ocean.  This keeps players from being able to move units from the Atlantic ocean directly into Western Canada.
-			<br>
-			<br>
-			<br>
-			<br>Explanation of Game Options:
-			<br>Bids = Money given before game starts, to purchase units with or keep for later.
-			<br>Economic Victory = You may win by reaching a certain production level by end of round.
-			<br>Low Luck = Add all the attack or defense powers together, divide by six, then roll for the remainder. The total is the number of hits you get.
-			<br>Movement By Territory Restricted = Russia will not be able to make any movements during the first Combat Movement Phase of Round 1 (they will be able to do noncombat movement though).
-			<br>Units Can Be Destroyed Instead Of Captured = Factories and AA Guns will be destroyed instead of captured.
-			<br>Use Destroyers and Artillery = All nations may now purchase destroyers (3/3/2/12 anti-sub naval unit) and artillery (2/2/1/4 supporter of infantry) units.
-			<br>Tech Development = Allow rolling for technology?
-			<br>Super Sub Defense Bonus = A defense bonus given to submarines when you have the super sub tech.
-			<br>Heavy Bomber Dice Rolls = Number of dice that Heavy Bombers will roll.
-			<br>LHTR Heavy Bombers = Bombers will select the best die that they roll, instead of using all dice. SBR adds 1 to the best die.
-			<br>Territory Turn Limit = Strategic Bombing Raids and Rockets can not deal more damage than the value of the territory, per turn.
-			<br>Always On AA = AA guns will fire when passed over, all the time.
-			<br>Choose AA Casualties = You get to pick your casualties for AA gun fire (if off, the casualties will be random).
-			<br>Multiple AA Per Territory = You can have more than 1 AA gun in each territory, but only 1 will fire at airplanes.
-			<br>Kamikaze Airplanes = Airplanes may use all their movement to get to battles, with no consideration for landing zones.
-			<br>Submarines Defending May Submerge Or Retreat = Defending subs may either submerge or retreat or stay in the battle.
-			<br>Submersible Subs = All submarines submerge by default, including attacking subs.
-			<br>Two Hit Battleship = All battleships have 2 hitpoints.
-			<br>Units repair at end/beginning of turn = Do battleships repair, and when?
-			<br>Shore Bombard Per Ground Unit Restricted = Bombardment is limited to the number of units offloading for the amphibious assault.
-			<br>Naval Bombard Casualties Return Fire = Bombardment casualties may return fire.
-			<br>Partial Amphibious Retreat = Non-Amphibious units may retreat from an amphibious assault.
-			<br>Attacker Retreat Planes = Attacking air units may retreat from an amphibious assault.
-			<br>Unit Placement In Enemy Seas = May place naval units in enemy occupied seazones.
-			<br>Produce Fighters On Carriers = When placing new carriers, you may also place new fighters on them.
-			<br>Move Existing Fighters to New Carriers = When placing new carriers, you may move an existing fighte to the carrier.
-			<br>LHTR Carrier Production Rules = You may place new fighters on new and old carriers, and also place new carriers under existing fighters in the seazone.
-			<br>Neutral Charge = Amount of money you will be charged for entering a neutral territory.
-			<br>Neutrals are Impassable = You may not enter a neutral territory.
-			<br>AI Bonus Income = Give the AI more money.
-			<br>AI Bonus Attack/Defense = Give the AI more attack/defense value (all their units).
-			<br>
-			<br>
-        	]]></value>        	
-        </property>		
-	</propertyList>
-	
+            <string/>
+            <value><![CDATA[
+            The Classic Iron Blitz 3rd Edition of a World War II game.
+            <br> Axis need to at the end of the round control 2 out of 3 allied capitols plus their own capitols to win OR get to 84 production at end of round.
+            <br> Allies need to control both Axis capitols plus their own capitols.
+            <br> (Optional rule: Allies win if they get to 110 production at end of round [to enable, change Allied economic victory from 140 to 110]).
+            <br>
+            <br>New Additions for Iron Blitz:
+            <br>Destroyers attack and defend at 2, and cost 8 PUs.  They do not have any special anti-submarine abilities.
+            <br>Marines attack at 1 (2 during Amphibious Assaults), and defend at 2, and cost 4 PUs.
+            <br>Optional rule: Russia may not attack during 1st turn (turn on game option: "Movement By Territory Restricted" for this).
+            <br>
+            <br>
+            <br>New Features in Third Edition Rules (over 2nd Edition):
+            <br>Defending submarines can submerge or retreat from combat. A submerged sub stays in the same sea zone until after combat when it re-surfaces.
+            <br>Fighters and Bombers can now retreat from an amphibious assult.
+            <br>Multiple AA guns in one territory are allowed.  However, only one AA gun per territory can fire per turn.
+            <br>You can now place naval units in a seazone occupied by enemy units. If you do, combat will occur during the opponent's next combat phase, unless they move out of the zone first.
+            <br>Western Canada no longer borders the Atlantic Ocean.  This keeps players from being able to move units from the Atlantic ocean directly into Western Canada.
+            <br>
+            <br>
+            <br>
+            <br>Explanation of Game Options:
+            <br>Bids = Money given before game starts, to purchase units with or keep for later.
+            <br>Economic Victory = You may win by reaching a certain production level by end of round.
+            <br>Low Luck = Add all the attack or defense powers together, divide by six, then roll for the remainder. The total is the number of hits you get.
+            <br>Movement By Territory Restricted = Russia will not be able to make any movements during the first Combat Movement Phase of Round 1 (they will be able to do noncombat movement though).
+            <br>Units Can Be Destroyed Instead Of Captured = Factories and AA Guns will be destroyed instead of captured.
+            <br>Use Destroyers and Artillery = All nations may now purchase destroyers (3/3/2/12 anti-sub naval unit) and artillery (2/2/1/4 supporter of infantry) units.
+            <br>Tech Development = Allow rolling for technology?
+            <br>Super Sub Defense Bonus = A defense bonus given to submarines when you have the super sub tech.
+            <br>Heavy Bomber Dice Rolls = Number of dice that Heavy Bombers will roll.
+            <br>LHTR Heavy Bombers = Bombers will select the best die that they roll, instead of using all dice. SBR adds 1 to the best die.
+            <br>Territory Turn Limit = Strategic Bombing Raids and Rockets can not deal more damage than the value of the territory, per turn.
+            <br>Always On AA = AA guns will fire when passed over, all the time.
+            <br>Choose AA Casualties = You get to pick your casualties for AA gun fire (if off, the casualties will be random).
+            <br>Multiple AA Per Territory = You can have more than 1 AA gun in each territory, but only 1 will fire at airplanes.
+            <br>Kamikaze Airplanes = Airplanes may use all their movement to get to battles, with no consideration for landing zones.
+            <br>Submarines Defending May Submerge Or Retreat = Defending subs may either submerge or retreat or stay in the battle.
+            <br>Submersible Subs = All submarines submerge by default, including attacking subs.
+            <br>Two Hit Battleship = All battleships have 2 hitpoints.
+            <br>Units repair at end/beginning of turn = Do battleships repair, and when?
+            <br>Shore Bombard Per Ground Unit Restricted = Bombardment is limited to the number of units offloading for the amphibious assault.
+            <br>Naval Bombard Casualties Return Fire = Bombardment casualties may return fire.
+            <br>Partial Amphibious Retreat = Non-Amphibious units may retreat from an amphibious assault.
+            <br>Attacker Retreat Planes = Attacking air units may retreat from an amphibious assault.
+            <br>Unit Placement In Enemy Seas = May place naval units in enemy occupied seazones.
+            <br>Produce Fighters On Carriers = When placing new carriers, you may also place new fighters on them.
+            <br>Move Existing Fighters to New Carriers = When placing new carriers, you may move an existing fighte to the carrier.
+            <br>LHTR Carrier Production Rules = You may place new fighters on new and old carriers, and also place new carriers under existing fighters in the seazone.
+            <br>Neutral Charge = Amount of money you will be charged for entering a neutral territory.
+            <br>Neutrals are Impassable = You may not enter a neutral territory.
+            <br>AI Bonus Income = Give the AI more money.
+            <br>AI Bonus Attack/Defense = Give the AI more attack/defense value (all their units).
+            <br>
+            <br>
+            ]]></value>
+        </property>
+    </propertyList>
+
 </game>

--- a/src/test/resources/lhtr_test.xml
+++ b/src/test/resources/lhtr_test.xml
@@ -560,7 +560,7 @@
                         <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
                         
                         <!-- Bidding Phase -->
-			
+
                         <step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
                         <step name="russianBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
                         
@@ -1282,30 +1282,30 @@
                   <attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                   </attachment>
-                  
-              	    <!-- canals -->
-    
-				    <attachment name="canalAttachment" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				    	<option name="canalName" value="Suez Canal"/>
-				    	<option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
-				    </attachment>
-				    
-				    <attachment name="canalAttachment" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				    	<option name="canalName" value="Suez Canal"/>
-				    	<option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
-				    </attachment>
-				    
-			   	    <attachment name="canalAttachment" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				    	<option name="canalName" value="Panama Canal"/>
-				    	<option name="landTerritories" value="Panama"/>
-				    </attachment>
-				    
-				    <attachment name="canalAttachment" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				    	<option name="canalName" value="Panama Canal"/>
-				    	<option name="landTerritories" value="Panama"/>
-				    </attachment>                  
+
+                    <!-- canals -->
+
+                    <attachment name="canalAttachment" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Suez Canal"/>
+                        <option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
+                    </attachment>
+
+                    <attachment name="canalAttachment" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Suez Canal"/>
+                        <option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
+                    </attachment>
+
+                    <attachment name="canalAttachment" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Panama Canal"/>
+                        <option name="landTerritories" value="Panama"/>
+                    </attachment>
+
+                    <attachment name="canalAttachment" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Panama Canal"/>
+                        <option name="landTerritories" value="Panama"/>
+                    </attachment>
         </attachmentList>
-        
+
         <initialize>
                 <ownerInitialize>
                         <!-- German Owned Territories -->
@@ -1558,8 +1558,8 @@
                 <property name="Russians bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
-				
-				<property name="Germans bid" value="0" editable="true">
+
+                <property name="Germans bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
 
@@ -1574,107 +1574,107 @@
                 <property name="Americans bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
-				
-				<!-- Victory Conditions -->
+
+                <!-- Victory Conditions -->
                 <property name="Projection of Power" value="false" editable="true">
-					<boolean/>
-				</property> 
-                
-				<property name="Axis Projection of Power VCs" value="8" editable="false">
-					<number min="8" max="12"/>
-				</property>
-				
-				<property name="Allies Projection of Power VCs" value="8" editable="false">
-					<number min="8" max="12"/>
-				</property>
-				
-				<property name="Honorable Surrender" value="true" editable="true">
-					<boolean/>
-				</property> 
-                
-				<property name="Axis Honorable Victory VCs" value="10" editable="false">
-					<number min="8" max="12"/>
-				</property>
-				
-				<property name="Allies Honorable Victory VCs" value="10" editable="false">
-					<number min="8" max="12"/>
-				</property>
-				
-				<property name="Total Victory" value="false" editable="true">
-					<boolean/>
-				</property> 
-                
-				<property name="Axis Total Victory VCs" value="12" editable="false">
-					<number min="8" max="12"/>
-				</property>
-				
-				<property name="Allies Total Victory VCs" value="12" editable="false">
-					<number min="8" max="12"/>
-				</property>
-				
-				<!-- Low Luck -->
-				<property name="Low Luck" value="false" editable="true">
+                    <boolean/>
+                </property>
+
+                <property name="Axis Projection of Power VCs" value="8" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <property name="Allies Projection of Power VCs" value="8" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <property name="Honorable Surrender" value="true" editable="true">
+                    <boolean/>
+                </property>
+
+                <property name="Axis Honorable Victory VCs" value="10" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <property name="Allies Honorable Victory VCs" value="10" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <property name="Total Victory" value="false" editable="true">
+                    <boolean/>
+                </property>
+
+                <property name="Axis Total Victory VCs" value="12" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <property name="Allies Total Victory VCs" value="12" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <!-- Low Luck -->
+                <property name="Low Luck" value="false" editable="true">
                         <boolean/>
                 </property>
 
-				<property name="Low Luck for AntiAircraft" value="false" editable="true">
-						<boolean/>
-				</property>
+                <property name="Low Luck for AntiAircraft" value="false" editable="true">
+                        <boolean/>
+                </property>
 
-				<property name="Low Luck for Technology" value="false" editable="true">
-						<boolean/>
-				</property>
+                <property name="Low Luck for Technology" value="false" editable="true">
+                        <boolean/>
+                </property>
 
-				<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
-						<boolean/>
-				</property>
-                
+                <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+                        <boolean/>
+                </property>
+
                 <property name="Tech Development" value="true" editable="true">
                         <boolean/>
                 </property>
 
-				<property name="Super Sub Defence Bonus" value="1" editable="false">
-						<number min="0" max="1"/>
-				</property>
-				
-				<property name="Heavy Bomber Dice Rolls" value="2" editable="false">
+                <property name="Super Sub Defence Bonus" value="1" editable="false">
+                        <number min="0" max="1"/>
+                </property>
+
+                <property name="Heavy Bomber Dice Rolls" value="2" editable="false">
                         <number min="2" max="3"/>
                 </property>
-                                
+
                 <property name="LHTR Heavy Bombers" value="true" editable="false">
-                	  <boolean/>
-                </property>
-				
-				<property name="Territory Turn Limit" value="true" editable="false">
                         <boolean/>
                 </property>
-				
-				<property name="Always on AA" value="false" editable="true">
+
+                <property name="Territory Turn Limit" value="true" editable="false">
                         <boolean/>
                 </property>
-                
-				<property name="Choose AA Casualties" value="false" editable="false">
+
+                <property name="Always on AA" value="false" editable="true">
                         <boolean/>
                 </property>
-				
-				<property name="Roll AA Individually" value="true" editable="false">
+
+                <property name="Choose AA Casualties" value="false" editable="false">
                         <boolean/>
                 </property>
-				
-				<property name="Kamikaze Airplanes" value="false" editable="true">
-					<boolean/>
-				</property>
-				
+
+                <property name="Roll AA Individually" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Kamikaze Airplanes" value="false" editable="true">
+                    <boolean/>
+                </property>
+
                 <property name="Units Repair Hits End Turn" value="true" editable="true">
                         <boolean/>
                 </property>
 
-				<property name="Units Repair Hits Start Turn" value="false" editable="true">
-						<boolean/>
-				</property>
+                <property name="Units Repair Hits Start Turn" value="false" editable="true">
+                        <boolean/>
+                </property>
 
                 <!-- Use WW2V2 Rules -->
-				<property name="WW2V2" value="true" editable="false">
+                <property name="WW2V2" value="true" editable="false">
                         <boolean/>
                 </property>
                 
@@ -1689,10 +1689,10 @@
                 <property name="Produce fighters on carriers" value="true" editable="false">
                         <boolean/>
                 </property>
-				
-				<property name="Allied Air Dependents" value="true" editable="false">
-					<boolean/>
-				</property>
+
+                <property name="Allied Air Dependents" value="true" editable="false">
+                    <boolean/>
+                </property>
 
                 <property name="LHTR Carrier production rules" value="true" editable="false">
                         <boolean/>
@@ -1700,42 +1700,42 @@
                 
                 <property name="neutralCharge" value="9999999"/>
 
-				<property name="Neutrals Are Impassable" value="true" editable="false">
-					<boolean/>
-				</property>
+                <property name="Neutrals Are Impassable" value="true" editable="false">
+                    <boolean/>
+                </property>
 
-				<property name="Neutrals Are Blitzable" value="false" editable="false">
-					<boolean/>
-				</property>
-                
+                <property name="Neutrals Are Blitzable" value="false" editable="false">
+                    <boolean/>
+                </property>
+
                 <property name="maxFactoriesPerTerritory" value="1"/>
-				
+
                 <property name="Sub Control Sea Zone Restricted" value="false" editable="false">
-                	<boolean/>
+                    <boolean/>
                 </property>
 
                 <!-- Map Name: also used for map utils when asked -->
                 <property name="mapName" value="World War II Revised LHTR Test" editable="false"/>
                 
                 <property name="notes">
-	        	<value><![CDATA[   
-		        	   	
-						A WW2V2 Revised mod that follows the popular LHTR rules. (Larry Harris Tournament Rules)
-					<br>
-					<br>NOTE: If playing with tech, do NOT research "Industrial Technology", as technically that is not one of the techs for this game, and it is also considered an unbalanced tech.
-					<br>
-					<br>Summary of Major Changes from normal Revised to LHTR:
-					<br>* AA guns do not fire if moved over during non-combat movement phase.
-					<br>* Strategic Bombing Raids and Rockets can not do more damage per territory than the value of that territory, per turn.
-					<br>* You can no longer move air units from a territory to the carrier when you place a new carrier, 
-							instead you must move those air units to the territory where the carrier will be placed during one of the movement phases, then place the carrier under it during placement phase.
-					<br>* You may place purchased air units on already existing carriers in sea zones adjacent to the factory, (and also still on purchased carriers), during placement phase.
-					<br>* Technology is given to the player at the end of their turn, instead of immediately after it is researched at the beginning of the turn.
-					<br>* Super Subs gives +1 attack and +1 defense, instead of just attack, to submarines.
-					<br>* Heavy Bombers allows bombers to roll 2 dice, and select the best one (instead of counting both), and if a strategic bombing raid, +1 is added onto the best die in order to calculate total damage.
-					<br>* No Industrial Technology tech
-					<br>
-	        	]]></value>        	       
-        		</property>
+                <value><![CDATA[
+
+                        A WW2V2 Revised mod that follows the popular LHTR rules. (Larry Harris Tournament Rules)
+                    <br>
+                    <br>NOTE: If playing with tech, do NOT research "Industrial Technology", as technically that is not one of the techs for this game, and it is also considered an unbalanced tech.
+                    <br>
+                    <br>Summary of Major Changes from normal Revised to LHTR:
+                    <br>* AA guns do not fire if moved over during non-combat movement phase.
+                    <br>* Strategic Bombing Raids and Rockets can not do more damage per territory than the value of that territory, per turn.
+                    <br>* You can no longer move air units from a territory to the carrier when you place a new carrier,
+                            instead you must move those air units to the territory where the carrier will be placed during one of the movement phases, then place the carrier under it during placement phase.
+                    <br>* You may place purchased air units on already existing carriers in sea zones adjacent to the factory, (and also still on purchased carriers), during placement phase.
+                    <br>* Technology is given to the player at the end of their turn, instead of immediately after it is researched at the beginning of the turn.
+                    <br>* Super Subs gives +1 attack and +1 defense, instead of just attack, to submarines.
+                    <br>* Heavy Bombers allows bombers to roll 2 dice, and select the best one (instead of counting both), and if a strategic bombing raid, +1 is added onto the best die in order to calculate total damage.
+                    <br>* No Industrial Technology tech
+                    <br>
+                ]]></value>
+                </property>
         </propertyList>
 </game>

--- a/src/test/resources/pacific_incomplete_test.xml
+++ b/src/test/resources/pacific_incomplete_test.xml
@@ -177,7 +177,7 @@ Coded by Iron__Cross
         <connection t1="Kiangsi" t2="Shantung"/>
         <connection t1="Shansi" t2="Sikang"/>
 
-		<connection t1="Shansi" t2="Kweichow"/>
+        <connection t1="Shansi" t2="Kweichow"/>
         <connection t1="Hopei" t2="Suiyuan"/>
         <connection t1="Hopei" t2="Kweichow"/>
         <connection t1="Hopei" t2="Anhwe"/>
@@ -372,8 +372,8 @@ Coded by Iron__Cross
         <connection t1="Hawaiian" t2="9 Sea Zone"/>
         <connection t1="Johnston" t2="10 Sea Zone"/>
         <connection t1="Line" t2="3 Sea Zone"/>
-		<connection t1="New Zealand" t2="13 Sea Zone"/>
-        
+        <connection t1="New Zealand" t2="13 Sea Zone"/>
+
         <!-- Shoreline Line connections -->
         
         <!-- Australia -->
@@ -530,11 +530,11 @@ Coded by Iron__Cross
                 maxRunCount="1"/>
             <step name="americanBidPlace" delegate="placeBid" player="Americans"
                 maxRunCount="1"/>
-            
-            		
-	    <!-- Japanese Game Sequence -->
-            
-            
+
+
+            <!-- Japanese Game Sequence -->
+
+
             <!--                        <step name="japaneseTech" delegate="tech" player="Japanese"/> -->
             <step name="japanesePurchase" delegate="purchase" player="Japanese"/>
             <step name="japaneseCombatMove" delegate="move" player="Japanese"/>
@@ -549,7 +549,7 @@ Coded by Iron__Cross
             
             <!--                        <step name="britishTech" delegate="tech" player="British"/>-->
             <step name="britishPurchase" delegate="purchase" player="British"/>
-			<!-- Added Australians -->
+            <!-- Added Australians -->
             <step name="australianPurchase" delegate="purchase" player="Australians"/>           
             <step name="britishCombatMove" delegate="move" player="British"/>
             <step name="britishBattle" delegate="battle" player="British"/>
@@ -563,8 +563,8 @@ Coded by Iron__Cross
 
             <!--Added Commonwealth PU transfer and end turn 
             <step name="commonwealthEndTurn" delegate="endTurn" player="Commonwealth"/>
-	    -->
-            
+            -->
+
             <!-- Chinese Game Sequence -->
             
             
@@ -777,8 +777,8 @@ Coded by Iron__Cross
         <playerProduction player="Americans" frontier="productionAmericans"/>
         
     </production>
-    
-		<!-- In order to accomodate Japanese DDs being able to transport a single Inf, 
+
+        <!-- In order to accomodate Japanese DDs being able to transport a single Inf,
         the transportCost of all land units will differ from other versions. -->    
     <attachmentList>
         
@@ -791,9 +791,9 @@ Coded by Iron__Cross
             <option name="defense" value="2"/>
             <option name="isMarine" value="true"/>
             <option name="artillerySupportable" value="true"/>
-			<!-- canBeGivenByTerritoryTo will allow a unit to be given from one player to another player, if it is in a territory with changeUnitOwners 
-				must be a list of Players who this unit can be given to.  example: value="Russians:Chinese" -->
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <!-- canBeGivenByTerritoryTo will allow a unit to be given from one player to another player, if it is in a territory with changeUnitOwners
+                must be a list of Players who this unit can be given to.  example: value="Russians:Chinese" -->
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="infantry"
@@ -805,7 +805,7 @@ Coded by Iron__Cross
             <option name="defense" value="2"/>
             <option name="artillerySupportable" value="true"/>
             <option name="isInfantry" value="true"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="artillery"
@@ -816,7 +816,7 @@ Coded by Iron__Cross
             <option name="attack" value="2"/>
             <option name="defense" value="2"/>
             <option name="artillery" value="true"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="armour"
@@ -827,7 +827,7 @@ Coded by Iron__Cross
             <option name="canBlitz" value="true"/>
             <option name="attack" value="3"/>
             <option name="defense" value="2"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="fighter"
@@ -838,7 +838,7 @@ Coded by Iron__Cross
             <option name="isAir" value="true"/>
             <option name="attack" value="3"/>
             <option name="defense" value="4"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="bomber"
@@ -849,7 +849,7 @@ Coded by Iron__Cross
             <option name="attack" value="4"/>
             <option name="defense" value="1"/>
             <option name="isStrategicBomber" value="true"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="transport"
@@ -860,7 +860,7 @@ Coded by Iron__Cross
             <option name="transportCapacity" value="8"/>
             <option name="attack" value="0"/>
             <option name="defense" value="0"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="battleship"
@@ -872,7 +872,7 @@ Coded by Iron__Cross
             <option name="defense" value="4"/>
             <option name="canBombard" value="true"/>
             <option name="hitPoints" value="2"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="destroyer"
@@ -885,7 +885,7 @@ Coded by Iron__Cross
             <option name="defense" value="3"/>
             <option name="canBombard" value="true"/>
             <option name="isDestroyer" value="true"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="carrier"
@@ -896,7 +896,7 @@ Coded by Iron__Cross
             <option name="isSea" value="true"/>
             <option name="attack" value="1"/>
             <option name="defense" value="3"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="submarine"
@@ -907,7 +907,7 @@ Coded by Iron__Cross
             <option name="isSea" value="true"/>
             <option name="attack" value="2"/>
             <option name="defense" value="2"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="unitAttachment" attachTo="factory"
@@ -922,7 +922,7 @@ Coded by Iron__Cross
             <option name="isAA" value="true"/>
             <option name="transportCost" value="3"/>
             <option name="movement" value="1"/>
-			<option name="canBeGivenByTerritoryTo" value="British"/>
+            <option name="canBeGivenByTerritoryTo" value="British"/>
         </attachment>
         
         <attachment name="territoryAttachment" attachTo="Canada"
@@ -985,7 +985,7 @@ Coded by Iron__Cross
             <!-- Added Australian capital-->
             <option name="capital" value="Australians"/>
             <option name="navalBase" value="true"/>
-			<option name="changeUnitOwners" value="British"/>
+            <option name="changeUnitOwners" value="British"/>
         </attachment>
         
         <attachment name="territoryAttachment" attachTo="Queensland"
@@ -1127,14 +1127,14 @@ Coded by Iron__Cross
             <option name="production" value="3"/>
             <option name="ConvoyRoute" value="true"/>
             <option name="ConvoyAttached" value="37 Sea Zone"/>
-			<option name="originalOwner" value="Chinese"/>
+            <option name="originalOwner" value="Chinese"/>
         </attachment>
         
         <attachment name="territoryAttachment" attachTo="Manchuria"
             javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
             type="territory">
             <option name="production" value="2"/>
-			<option name="originalOwner" value="Chinese"/>
+            <option name="originalOwner" value="Chinese"/>
         </attachment>
         
         <attachment name="territoryAttachment" attachTo="Korea"
@@ -1143,7 +1143,7 @@ Coded by Iron__Cross
             <option name="production" value="2"/>
             <option name="ConvoyRoute" value="true"/>
             <option name="ConvoyAttached" value="36 Sea Zone"/>
-			<option name="originalOwner" value="Chinese"/>
+            <option name="originalOwner" value="Chinese"/>
         </attachment>
         
         <attachment name="territoryAttachment" attachTo="Szechwan"
@@ -1355,7 +1355,7 @@ Coded by Iron__Cross
             javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
             type="territory">
             <option name="production" value="5"/>
-        </attachment>		
+        </attachment>
         <attachment name="territoryAttachment" attachTo="3 Sea Zone"
             javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
             type="territory">
@@ -1503,7 +1503,7 @@ Coded by Iron__Cross
             javaClass="games.strategy.triplea.attachments.TerritoryAttachment"
             type="territory">
             <option name="production" value="0"/>
-			<option name="changeUnitOwners" value="British"/>
+            <option name="changeUnitOwners" value="British"/>
         </attachment>        
         
         <attachment name="playerAttachment" attachTo="Japanese"
@@ -1525,27 +1525,27 @@ Coded by Iron__Cross
             <option name="giveUnitControl" value="British"/>
         </attachment>        
 
-		
-	<!--  Rules Restrictions -->
-	<attachment name="rulesAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-               	<option name="unlimitedProduction" value="true"/>
-		<option name="dominatingFirstRoundAttack" value="true"/>
-        </attachment>
-	<attachment name="rulesAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-               	<option name="unlimitedProduction" value="true"/>
-        </attachment>
-	<attachment name="rulesAttachment" attachTo="Australians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-               	<option name="unlimitedProduction" value="true"/>
-        </attachment>
-	<attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-               	<option name="unlimitedProduction" value="true"/>
-		<option name="placementInCapitalRestricted" value="true"/>	
-		<option name="negateDominatingFirstRoundAttack" value="true"/>
-        </attachment>
-	<attachment name="rulesAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-              	<option name="unlimitedProduction" value="true"/>
-        </attachment>			
-        
+
+    <!--  Rules Restrictions -->
+    <attachment name="rulesAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+        <option name="unlimitedProduction" value="true"/>
+        <option name="dominatingFirstRoundAttack" value="true"/>
+    </attachment>
+    <attachment name="rulesAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+        <option name="unlimitedProduction" value="true"/>
+    </attachment>
+    <attachment name="rulesAttachment" attachTo="Australians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+        <option name="unlimitedProduction" value="true"/>
+    </attachment>
+    <attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+        <option name="unlimitedProduction" value="true"/>
+        <option name="placementInCapitalRestricted" value="true"/>
+        <option name="negateDominatingFirstRoundAttack" value="true"/>
+    </attachment>
+    <attachment name="rulesAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+        <option name="unlimitedProduction" value="true"/>
+    </attachment>
+
     </attachmentList>
     
     <initialize>
@@ -1568,13 +1568,13 @@ Coded by Iron__Cross
             <territoryOwner territory="Shantung" owner="Japanese"/>
             <territoryOwner territory="Manchuria" owner="Japanese"/>
             <territoryOwner territory="Korea" owner="Japanese"/>
-            
-        	<!-- Add Japanese Convoy Routes here-->        
+
+            <!-- Add Japanese Convoy Routes here-->
             <territoryOwner territory="36 Sea Zone" owner="Japanese"/>
             <territoryOwner territory="37 Sea Zone" owner="Japanese"/>
             <territoryOwner territory="45 Sea Zone" owner="Japanese"/>    
-            
-        	<!-- Add Japanese Kamikaze Zones here-->        
+
+            <!-- Add Japanese Kamikaze Zones here-->
             <territoryOwner territory="23 Sea Zone" owner="Japanese"/>
             <territoryOwner territory="24 Sea Zone" owner="Japanese"/>
             <territoryOwner territory="25 Sea Zone" owner="Japanese"/> 
@@ -1608,8 +1608,8 @@ Coded by Iron__Cross
             <territoryOwner territory="New Hebrides" owner="Australians"/>
             <territoryOwner territory="Solomon" owner="Australians"/>
             <territoryOwner territory="Gilbert" owner="Australians"/>
-   			<territoryOwner territory="Johnston" owner="Australians"/>          
-            
+            <territoryOwner territory="Johnston" owner="Australians"/>
+
             <!-- Commonwealth owned Convoy Centers -->
             <!-- Code Needed to determine how to add this functionality -->
             <territoryOwner territory="52 Sea Zone" owner="Commonwealth"/>
@@ -1621,8 +1621,8 @@ Coded by Iron__Cross
             <territoryOwner territory="43 Sea Zone" owner="Australians"/>
             <territoryOwner territory="39 Sea Zone" owner="Australians"/>
             <territoryOwner territory="13 Sea Zone" owner="Australians"/>
-             
-        	<!-- Add British Convoy Routes here-->
+
+            <!-- Add British Convoy Routes here-->
             <territoryOwner territory="46 Sea Zone" owner="British"/>
             <territoryOwner territory="44 Sea Zone" owner="British"/>
             
@@ -1685,7 +1685,7 @@ Coded by Iron__Cross
                 owner="British"/>
             <unitPlacement unitType="infantry" territory="Queensland" quantity="2"
                 owner="British"/>
-			<!-- Changed to Australian ownership-->
+            <!-- Changed to Australian ownership-->
             <unitPlacement unitType="infantry" territory="New South Wales"
                 quantity="2" owner="British"/>
             <unitPlacement unitType="infantry" territory="Western Australia"
@@ -1924,8 +1924,8 @@ Coded by Iron__Cross
             
             <unitPlacement unitType="factory" territory="Szechwan" quantity="1"
                 owner="Chinese"/>
-				
-			<unitPlacement unitType="fighter" territory="Szechwan" quantity="1"
+
+            <unitPlacement unitType="fighter" territory="Szechwan" quantity="1"
                 owner="Chinese"/>
             
             <!-- American Land Placements -->
@@ -2028,7 +2028,7 @@ Coded by Iron__Cross
     </initialize>
     
     <propertyList>
-		<!-- Bids -->
+        <!-- Bids -->
         <property name="Japanese bid" value="0" editable="true">
             <number min="0" max="1000"/>
         </property>
@@ -2044,7 +2044,7 @@ Coded by Iron__Cross
         <property name="British bid" value="0" editable="true">
             <number min="0" max="1000"/>
         </property>
-		
+
         <property name="Australians bid" value="0" editable="true">
             <number min="0" max="1000"/>
         </property>
@@ -2054,18 +2054,18 @@ Coded by Iron__Cross
             <boolean/>
         </property>
 
-		<property name="Low Luck for AntiAircraft" value="false" editable="true">
-				<boolean/>
-		</property>
+        <property name="Low Luck for AntiAircraft" value="false" editable="true">
+            <boolean/>
+        </property>
 
-		<property name="Low Luck for Technology" value="false" editable="true">
-				<boolean/>
-		</property>
+        <property name="Low Luck for Technology" value="false" editable="true">
+            <boolean/>
+        </property>
 
-		<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
-				<boolean/>
-		</property>
-        
+        <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+            <boolean/>
+        </property>
+
         <!-- Use WW2V2 Rules -->
         <property name="WW2V2" value="true" editable="false">
             <boolean/>
@@ -2079,22 +2079,22 @@ Coded by Iron__Cross
             <boolean/>
         </property>
                 
-		<!--<property name="Choose AA Casualties" value="false" editable="false">
+        <!--<property name="Choose AA Casualties" value="false" editable="false">
             <boolean/>
         </property>
-				
-		<property name="Roll AA Individually" value="false" editable="false">
+
+        <property name="Roll AA Individually" value="false" editable="false">
             <boolean/>
         </property>-->
         
         <property name="Submersible Subs" value="true" editable="false">
             <boolean/>
         </property>
-        
-		<property name="Sub Control Sea Zone Restricted" value="false" editable="true">
+
+        <property name="Sub Control Sea Zone Restricted" value="false" editable="true">
              <boolean/>
         </property>
-		
+
         <property name="Heavy Bomber Dice Rolls" value="2" editable="false">
             <number min="2" max="3"/>
         </property>
@@ -2110,113 +2110,113 @@ Coded by Iron__Cross
         <property name="Move existing fighters to new carriers" value="true" editable="false">
             <boolean/>
         </property>
-				
+
         <property name="Allied Air Dependents" value="true" editable="false">
-			<boolean/>
-		</property>
-        
+            <boolean/>
+        </property>
+
         <property name="Units Repair Hits End Turn" value="true" editable="true">
             <boolean/>
         </property>
 
-		<property name="Units Repair Hits Start Turn" value="false" editable="true">
-			<boolean/>
-		</property>
-        
+        <property name="Units Repair Hits Start Turn" value="false" editable="true">
+            <boolean/>
+        </property>
+
         <property name="neutralCharge" value="9999999"/>
         
         <property name="maxFactoriesPerTerritory" value="1"/>
         
         <property name="Production Per Valued Territory Restricted" value="true" editable="false">
-        	<boolean/>
+            <boolean/>
         </property>
 
-		<property name="Occupied Territories" value="true" editable="false">
-        	<boolean/>
-		</property>
+        <property name="Occupied Territories" value="true" editable="false">
+            <boolean/>
+        </property>
 
-				<!-- allows a player to give units to another player if true. units must have canBeGivenByTerritory and territories must have changeUnitOwners and the players must have the player attachment giveUnitControl -->
-		<property name="Give Units By Territory" value ="true" editable="false">
-				<boolean/>
-		</property>
-		
-		<property name="Blitz Through Factories And AA Restricted" value="false" editable="true">
-                	<boolean/>
-                </property>
-				
-		<property name="Produce new fighters on old carriers" value="false" editable="true">
+        <!-- allows a player to give units to another player if true. units must have canBeGivenByTerritory and territories must have changeUnitOwners and the players must have the player attachment giveUnitControl -->
+        <property name="Give Units By Territory" value ="true" editable="false">
+            <boolean/>
+        </property>
+
+        <property name="Blitz Through Factories And AA Restricted" value="false" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Produce new fighters on old carriers" value="false" editable="true">
                         <boolean/>
                 </property>
-				
-		<property name="LHTR Carrier production rules" value="false" editable="true">
+
+        <property name="LHTR Carrier production rules" value="false" editable="true">
                         <boolean/>
                 </property>
-		
-		<property name="Naval Bombard Casualties Return Fire" value="true" editable="true">
+
+        <property name="Naval Bombard Casualties Return Fire" value="true" editable="true">
                         <boolean/>
                 </property>
-		
-		<property name="Air Attack Sub Restricted" value="true" editable="true">
-                	<boolean/>
-                </property>
-				
-		<property name="Neutrals Are Impassable" value="true" editable="false">
+
+        <property name="Air Attack Sub Restricted" value="true" editable="true">
+            <boolean/>
+        </property>
+
+        <property name="Neutrals Are Impassable" value="true" editable="false">
                         <boolean/>
                 </property>
-				
-		
+
+
         <!-- Map Name: also used for map utils when asked -->
         <property name="mapName" value="pacific test" editable="false"/>
-        
-		<!-- notes appear in the notes menu in the main screen, format as html -->
- 		
-		<property name="notes">
-			<value>
-			<![CDATA[  
-			
-				The original Pacific edition.
-			<br>
-			<br>
-			<br>At the beginning of the game, before the Japanese player purchases, the British and Australian players must allocate 12 pu between themselves.
-				Use the 'edit' function to give the British and Australian players some combination of PUs that add up to 12.
-			<br>These 12 PUs represent the Commonwealth Convoy Zones (there are 3 convoy zones, valued at 3, 4, and 5).
-			<br>Each round, at the end of the British/Australian turn, the British and Australian players must use the 'edit' function to give themselves some combination of PUs that
-				add up to the amount of Commonwealth Convoy Zones Production that the Allies control.
-			
-			<br>
-			<br>
 
-            
-				This current implementation of the WW2 Pacific conflict is still in alpha phase 
-				and has many features still to be supported as listed:  
-				<ul>
-					<li> CAP </li>
-					<li> (implemented) Airports/Seaports </li>
-					<li> (implemented) Convoy Centers  </li>
-					<li> (implemented) Convoy Routes </li>
-					<li> (implemented) Chinese purchase mechanics </li>
-					<li> (implemented) Marines </li>
-					<li> Chinese and USA same turn order (done on seperate turns for now) </li>
-					<li> (implemented) Seperate income for India and Australia </li>
-					<li> Commonwealth Convoy Center PU distribution</li>
-					<li> Special stratbombing rules (regular strat bombing rules applied) </li>
-					<li> (implemented) Japanese Victory Points</li>
-					<li> (implemented) Japanese special turn one attack</li>
-					<li> (implemented) Japanese DDs can transport a single Inf</li>
-					<li> (implemented) Special sub rules</li>
-					<li> Japanese Kamikazes</li>
-					<li> (implemented) Burma Road</li>
+        <!-- notes appear in the notes menu in the main screen, format as html -->
+
+        <property name="notes">
+            <value>
+            <![CDATA[
+
+                The original Pacific edition.
+            <br>
+            <br>
+            <br>At the beginning of the game, before the Japanese player purchases, the British and Australian players must allocate 12 pu between themselves.
+                Use the 'edit' function to give the British and Australian players some combination of PUs that add up to 12.
+            <br>These 12 PUs represent the Commonwealth Convoy Zones (there are 3 convoy zones, valued at 3, 4, and 5).
+            <br>Each round, at the end of the British/Australian turn, the British and Australian players must use the 'edit' function to give themselves some combination of PUs that
+                add up to the amount of Commonwealth Convoy Zones Production that the Allies control.
+
+            <br>
+            <br>
 
 
-				</ul>
-				
-				
-				Credits: Triple_Elk (base-line), iron__cross (integration), ComradeKev (special rules implementations)
-				
-				
-									]]>	
-					</value>
-				</property>
-				
+                This current implementation of the WW2 Pacific conflict is still in alpha phase
+                and has many features still to be supported as listed:
+                <ul>
+                    <li> CAP </li>
+                    <li> (implemented) Airports/Seaports </li>
+                    <li> (implemented) Convoy Centers  </li>
+                    <li> (implemented) Convoy Routes </li>
+                    <li> (implemented) Chinese purchase mechanics </li>
+                    <li> (implemented) Marines </li>
+                    <li> Chinese and USA same turn order (done on seperate turns for now) </li>
+                    <li> (implemented) Seperate income for India and Australia </li>
+                    <li> Commonwealth Convoy Center PU distribution</li>
+                    <li> Special stratbombing rules (regular strat bombing rules applied) </li>
+                    <li> (implemented) Japanese Victory Points</li>
+                    <li> (implemented) Japanese special turn one attack</li>
+                    <li> (implemented) Japanese DDs can transport a single Inf</li>
+                    <li> (implemented) Special sub rules</li>
+                    <li> Japanese Kamikazes</li>
+                    <li> (implemented) Burma Road</li>
+
+
+                </ul>
+
+
+                Credits: Triple_Elk (base-line), iron__cross (integration), ComradeKev (special rules implementations)
+
+
+                                    ]]>
+                    </value>
+                </property>
+
     </propertyList>
 </game>

--- a/src/test/resources/pact_of_steel_2_test.xml
+++ b/src/test/resources/pact_of_steel_2_test.xml
@@ -3,5526 +3,5526 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-		<info name="Pact of Steel 2 Test" version="3.6"/>
-		
-				<!-- A MOD of original POS by VEQRYN
-						The purpose is to provide a fun game that shows off all the new features of TripleA since 1.2.5.5
-						as well include documentation inside the xml in order to show map makers how to use all the new features.
-						If you have questions on how to use something, or think my documentation is not clear enough,
-						please go to the forum and make a post: http://triplea.sourceforge.net/mywiki/Forum
-				-->
-		
-		<!-- loader is required by all xmls.  some xmls may use a different loader, like a puzzle game -->
-		<loader javaClass="games.strategy.triplea.TripleA"/>
-		
-		<!-- triplea minimumVersion is the minimum version number of TripleA that can play this game.  Many new xmls require features not present in older versions of TripleA. Should be "xx.xx.xx.xx", "xx.xx.xx", "xx.xx", or "xx".
-				An example would be a map using 'isInfrastructure' unit property would need at least TripleA version "1.2.6", while a map using 'whenCapturedChangesInto' would need at least TripleA version "1.4" -->
-		<triplea minimumVersion="1.7"/>
-
-		<!-- diceSides defaults to 6 if not in the xml.  Can be set to any number between 1 and 200.  Setting diceSides to a number other than 6 can result in unexpected behavior. -->
-		<diceSides value="6"/>
-		
-		<map>
-				<!-- Territory Definitions -->
-				<territory name="Eastern Canada"/>
-				<territory name="Italy"/>
-				<territory name="Sicily"/>
-				<territory name="Sardinia"/>
-				<territory name="Central China"/>
-				<territory name="East Balkans"/>
-				<territory name="West Balkans"/>
-				<territory name="Greece"/>
-				<territory name="Germany"/>
-				<territory name="Midway"/>
-				<territory name="Greenland"/>
-				<territory name="Union of South Africa"/>
-				<territory name="Australia"/>
-				<territory name="Kenya"/>
-				<territory name="Manchuria"/>
-				<territory name="Alaska"/>
-				<territory name="Persia"/>
-				<territory name="French West Africa"/>
-				<territory name="Turkey"/>
-				<territory name="Belgian Congo"/>
-				<territory name="India"/>
-				<territory name="Soviet Far East"/>
-				<territory name="Mexico"/>
-				<territory name="Spain"/>
-				<territory name="Afghanistan"/>
-				<territory name="Philipine Islands"/>
-				<territory name="Archangel"/>
-				<territory name="Novisibirsk"/>
-				<territory name="Eire"/>
-				<territory name="Mozambique"/>
-				<territory name="Italian East Africa"/>
-				<territory name="Eastern Europe"/>
-				<territory name="Western United States"/>
-				<territory name="Karelia S.S.R."/>
-				<territory name="Kwangtung"/>
-				<territory name="Brazil"/>
-				<territory name="Borneo" />
-				<territory name="French Madagascar"/>
-				<territory name="Yakut S.S.R."/>
-				<territory name="Hawaiian Islands"/>
-				<territory name="East Indies"/>
-				<territory name="Saudia Arabia"/>
-				<territory name="Switzerland"/>
-				<territory name="Norway"/>
-				<territory name="French Indochina"/>
-				<territory name="West Indies"/>
-				<territory name="Kazakh S.S.R."/>
-				<territory name="Venezuala"/>
-				<territory name="Trans-Jordan"/>
-				<territory name="United Kingdom"/>
-				<territory name="Western Europe"/>
-				<territory name="Rio De Oro"/>
-				<territory name="Angloa"/>
-				<territory name="New Zealand"/>
-				<territory name="Sahara"/>
-				<territory name="French Equatorial Africa"/>
-				<territory name="Gibraltar"/>
-				<territory name="Solomon Islands"/>
-				<territory name="Caucus"/>
-				<territory name="Sinkiang"/>
-				<territory name="Algeria"/>
-				<territory name="Wake Island"/>
-				<territory name="Himilaya"/>
-				<territory name="Evanki National Okrug"/>
-				<territory name="Sweden"/>
-				<territory name="Libya"/>
-				<territory name="Ukraine S.S.R."/>
-				<territory name="Mongolia"/>
-				<territory name="West Russia"/>
-				<territory name="Peru"/>
-				<territory name="Eastern United States"/>
-				<territory name="Belorussia"/>
-				<territory name="Burytia S.S.R."/>
-				<territory name="Russia"/>
-				<territory name="Anglo Egypt"/>
-				<territory name="New Guinea"/>
-				<territory name="Okinawa"/>
-				<territory name="Panama"/>
-				<territory name="Western Canada"/>
-				<territory name="Central United States"/>
-				<territory name="Argentina"/>
-				<territory name="China"/>
-				<territory name="Japan"/>
-				<territory name="Caroline Islands"/>
-				<territory name="15B Sea Zone" water="true"/>
-				<territory name="28 Sea Zone" water="true"/>
-				<territory name="56 Sea Zone" water="true"/>
-				<territory name="7 Sea Zone" water="true"/>
-				<territory name="31 Sea Zone" water="true"/>
-				<territory name="27 Sea Zone" water="true"/>
-				<territory name="5 Sea Zone" water="true" />
-				<territory name="23 Sea Zone" water="true"/>
-				<territory name="53 Sea Zone" water="true"/>
-				<territory name="42 Sea Zone" water="true"/>
-				<territory name="59 Sea Zone" water="true"/>
-				<territory name="30 Sea Zone" water="true"/>
-				<territory name="50 Sea Zone" water="true"/>
-				<territory name="54 Sea Zone" water="true"/>
-				<territory name="43 Sea Zone" water="true"/>
-				<territory name="41 Sea Zone" water="true"/>
-				<territory name="4 Sea Zone" water="true"/>
-				<territory name="44 Sea Zone" water="true"/>
-				<territory name="11 Sea Zone" water="true"/>
-				<territory name="51 Sea Zone" water="true"/>
-				<territory name="25 Sea Zone" water="true"/>
-				<territory name="29 Sea Zone" water="true"/>
-				<territory name="34 Sea Zone" water="true"/>
-				<territory name="12 Sea Zone" water="true"/>
-				<territory name="32 Sea Zone" water="true"/>
-				<territory name="46 Sea Zone" water="true"/>
-				<territory name="63 Sea Zone" water="true"/>
-				<territory name="8 Sea Zone" water="true"/>
-				<territory name="26 Sea Zone" water="true"/>
-				<territory name="38 Sea Zone" water="true"/>
-				<territory name="3 Sea Zone" water="true"/>
-				<territory name="37 Sea Zone" water="true"/>
-				<territory name="6 Sea Zone" water="true"/>
-				<territory name="9 Sea Zone" water="true"/>
-				<territory name="61 Sea Zone" water="true"/>
-				<territory name="39 Sea Zone" water="true"/>
-				<territory name="36 Sea Zone" water="true"/>
-				<territory name="49 Sea Zone" water="true"/>
-				<territory name="64 Sea Zone" water="true"/>
-				<territory name="45 Sea Zone" water="true"/>
-				<territory name="57 Sea Zone" water="true"/>
-				<territory name="52 Sea Zone" water="true"/>
-				<territory name="1 Sea Zone" water="true"/>
-				<territory name="48 Sea Zone" water="true"/>
-				<territory name="17 Sea Zone" water="true"/>
-				<territory name="10 Sea Zone" water="true"/>
-				<territory name="15 Sea Zone" water="true"/>
-				<territory name="2 Sea Zone" water="true"/>
-				<territory name="33 Sea Zone" water="true"/>
-				<territory name="14 Sea Zone" water="true"/>
-				<territory name="13 Sea Zone" water="true"/>
-				<territory name="55 Sea Zone" water="true"/>
-				<territory name="35 Sea Zone" water="true"/>
-				<territory name="16 Sea Zone" water="true"/>
-				<territory name="19 Sea Zone" water="true"/>
-				<territory name="60 Sea Zone" water="true"/>
-				<territory name="62 Sea Zone" water="true"/>
-				<territory name="21 Sea Zone" water="true"/>
-				<territory name="22 Sea Zone" water="true"/>
-				<territory name="18 Sea Zone" water="true"/>
-				<territory name="47 Sea Zone" water="true"/>
-				<territory name="58 Sea Zone" water="true"/>
-				<territory name="40 Sea Zone" water="true"/>
-				<territory name="24 Sea Zone" water="true"/>
-				<territory name="20 Sea Zone" water="true"/>
-
-				<!-- Territory Connections -->
-				<connection t1="Italy" t2="Sicily"/>
-				<connection t1="Italy" t2="14 Sea Zone"/>
-				<connection t1="Italy" t2="West Balkans"/>
-				<connection t1="Italy" t2="Germany"/>
-				<connection t1="Italy" t2="Western Europe"/>
-				<connection t1="Sicily" t2="14 Sea Zone"/>
-				<connection t1="Sicily" t2="13 Sea Zone"/>
-				<connection t1="Sardinia" t2="13 Sea Zone"/>
-				<connection t1="Sardinia" t2="14 Sea Zone"/>
-				<connection t1="West Balkans" t2="Greece"/>
-				<connection t1="West Balkans" t2="East Balkans"/>
-				<connection t1="West Balkans" t2="Germany"/>
-				<connection t1="West Balkans" t2="14 Sea Zone"/>
-				<connection t1="Greece" t2="East Balkans"/>
-				<connection t1="Greece" t2="14 Sea Zone"/>
-				<connection t1="Greece" t2="15B Sea Zone"/>
-				<connection t1="15B Sea Zone" t2="14 Sea Zone"/>
-				<connection t1="15B Sea Zone" t2="15 Sea Zone"/>
-				<connection t1="15B Sea Zone" t2="16 Sea Zone"/>
-				<connection t1="15B Sea Zone" t2="East Balkans"/>
-				<connection t1="16 Sea Zone" t2="East Balkans"/>
-				<connection t1="Sweden" t2="Norway"/>
-				<connection t1="Sweden" t2="5 Sea Zone"/>
-				<connection t1="Switzerland" t2="Germany"/>
-				<connection t1="Switzerland" t2="Western Europe"/>
-				<connection t1="Switzerland" t2="Italy"/>
-				<connection t1="2 Sea Zone" t2="Eire"/>
-				<connection t1="12 Sea Zone" t2="Spain"/>
-				<connection t1="13 Sea Zone" t2="Spain"/>
-				<connection t1="15 Sea Zone" t2="Turkey"/>
-				<connection t1="16 Sea Zone" t2="Turkey"/>
-				<connection t1="17 Sea Zone" t2="Rio De Oro"/>
-				<connection t1="19 Sea Zone" t2="Venezuala"/>
-				<connection t1="20 Sea Zone" t2="Venezuala"/>
-				<connection t1="21 Sea Zone" t2="Peru"/>
-				<connection t1="21 Sea Zone" t2="Argentina"/>
-				<connection t1="25 Sea Zone" t2="Argentina"/>
-				<connection t1="27 Sea Zone" t2="Angloa"/>
-				<connection t1="33 Sea Zone" t2="Mozambique"/>
-				<connection t1="34 Sea Zone" t2="Saudia Arabia"/>
-				<connection t1="Panama" t2="Venezuala"/>
-				<connection t1="Venezuala" t2="Brazil"/>
-				<connection t1="Venezuala" t2="Peru"/>
-				<connection t1="Brazil" t2="Peru"/>
-				<connection t1="Brazil" t2="Argentina"/>
-				<connection t1="Peru" t2="Argentina"/>
-				<connection t1="Eire" t2="United Kingdom"/>
-				<connection t1="Gibraltar" t2="Spain"/>
-				<connection t1="Spain" t2="Western Europe"/>
-				<connection t1="Caucus" t2="Turkey"/>
-				<connection t1="Kazakh S.S.R." t2="Afghanistan"/>
-				<connection t1="Himilaya" t2="Afghanistan"/>
-				<connection t1="India" t2="Afghanistan"/>
-				<connection t1="India" t2="Himilaya"/>
-				<connection t1="Sinkiang" t2="Himilaya"/>
-				<connection t1="China" t2="Himilaya"/>
-				<connection t1="French Indochina" t2="Himilaya"/>
-				<connection t1="Novisibirsk" t2="Mongolia"/>
-				<connection t1="Sinkiang" t2="Mongolia"/>
-				<connection t1="Manchuria" t2="Mongolia"/>
-				<connection t1="China" t2="Mongolia"/>
-				<connection t1="Sinkiang" t2="Central China"/>
-				<connection t1="China" t2="Central China"/>
-				<connection t1="Central China" t2="Mongolia"/>
-				<connection t1="Central China" t2="Himilaya"/>
-				<connection t1="Yakut S.S.R." t2="Mongolia"/>
-				<connection t1="Burytia S.S.R." t2="Mongolia"/>
-				<connection t1="Persia" t2="Afghanistan"/>
-				<connection t1="Persia" t2="Turkey"/>
-				<connection t1="Trans-Jordan" t2="Turkey"/>
-				<connection t1="Trans-Jordan" t2="Saudia Arabia"/>
-				<connection t1="Anglo Egypt" t2="Sahara"/>
-				<connection t1="Libya" t2="Sahara"/>
-				<connection t1="Algeria" t2="Sahara"/>
-				<connection t1="French West Africa" t2="Sahara"/>
-				<connection t1="French Equatorial Africa" t2="Sahara"/>
-				<connection t1="French West Africa" t2="Rio De Oro"/>
-				<connection t1="Belgian Congo" t2="Angloa"/>
-				<connection t1="Kenya" t2="Angloa"/>
-				<connection t1="Kenya" t2="Mozambique"/>
-				<connection t1="Union of South Africa" t2="Angloa"/>
-				<connection t1="Union of South Africa" t2="Mozambique"/>
-				<connection t1="1 Sea Zone" t2="Eastern Canada" />
-				<connection t1="1 Sea Zone" t2="2 Sea Zone"/>
-				<connection t1="1 Sea Zone" t2="8 Sea Zone"/>
-				<connection t1="1 Sea Zone" t2="9 Sea Zone"/>
-				<connection t1="2 Sea Zone" t2="Greenland"/>
-				<connection t1="2 Sea Zone" t2="United Kingdom"/>
-				<connection t1="2 Sea Zone" t2="3 Sea Zone"/>
-				<connection t1="2 Sea Zone" t2="8 Sea Zone"/>
-				<connection t1="3 Sea Zone" t2="4 Sea Zone"/>
-				<connection t1="3 Sea Zone" t2="6 Sea Zone"/>
-				<connection t1="3 Sea Zone" t2="United Kingdom"/>
-				<connection t1="3 Sea Zone" t2="Norway"/>
-				<connection t1="4 Sea Zone" t2="Karelia S.S.R."/>
-				<connection t1="4 Sea Zone" t2="Archangel"/>
-				<connection t1="5 Sea Zone" t2="6 Sea Zone"/>
-				<connection t1="5 Sea Zone" t2="Norway"/>
-				<connection t1="5 Sea Zone" t2="Karelia S.S.R."/>
-				<connection t1="5 Sea Zone" t2="Eastern Europe"/>
-				<connection t1="5 Sea Zone" t2="Germany"/>
-				<connection t1="5 Sea Zone" t2="Western Europe"/>
-				<connection t1="6 Sea Zone" t2="7 Sea Zone"/>
-				<connection t1="6 Sea Zone" t2="United Kingdom"/>
-				<connection t1="6 Sea Zone" t2="Norway"/>
-				<connection t1="6 Sea Zone" t2="Western Europe"/>
-				<connection t1="7 Sea Zone" t2="8 Sea Zone"/>
-				<connection t1="7 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="7 Sea Zone" t2="United Kingdom"/>
-				<connection t1="7 Sea Zone" t2="Western Europe"/>
-				<connection t1="8 Sea Zone" t2="9 Sea Zone"/>
-				<connection t1="8 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="8 Sea Zone" t2="United Kingdom"/>
-				<connection t1="9 Sea Zone" t2="10 Sea Zone"/>
-				<connection t1="9 Sea Zone" t2="11 Sea Zone"/>
-				<connection t1="9 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="9 Sea Zone" t2="Eastern Canada"/>
-				<connection t1="10 Sea Zone" t2="11 Sea Zone"/>
-				<connection t1="10 Sea Zone" t2="19 Sea Zone"/>
-				<connection t1="10 Sea Zone" t2="Eastern United States"/>
-				<connection t1="10 Sea Zone" t2="Panama"/>
-				<connection t1="11 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="11 Sea Zone" t2="18 Sea Zone"/>
-				<connection t1="11 Sea Zone" t2="19 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="13 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="17 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="18 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="Algeria"/>
-				<connection t1="13 Sea Zone" t2="14 Sea Zone"/>
-				<connection t1="13 Sea Zone" t2="Gibraltar"/>
-				<connection t1="13 Sea Zone" t2="Western Europe"/>
-				<connection t1="13 Sea Zone" t2="Algeria"/>
-				<connection t1="14 Sea Zone" t2="15 Sea Zone"/>
-				<connection t1="14 Sea Zone" t2="Libya"/>
-				<connection t1="15 Sea Zone" t2="34 Sea Zone"/>
-				<connection t1="15 Sea Zone" t2="Trans-Jordan"/>
-				<connection t1="15 Sea Zone" t2="Anglo Egypt"/>
-				<connection t1="16 Sea Zone" t2="East Balkans"/>
-				<connection t1="16 Sea Zone" t2="Ukraine S.S.R."/>
-				<connection t1="16 Sea Zone" t2="Caucus"/>
-				<connection t1="17 Sea Zone" t2="18 Sea Zone"/>
-				<connection t1="17 Sea Zone" t2="22 Sea Zone"/>
-				<connection t1="17 Sea Zone" t2="23 Sea Zone"/>
-				<connection t1="17 Sea Zone" t2="French West Africa"/>
-				<connection t1="18 Sea Zone" t2="19 Sea Zone"/>
-				<connection t1="18 Sea Zone" t2="22 Sea Zone"/>
-				<connection t1="18 Sea Zone" t2="Brazil"/>
-				<connection t1="19 Sea Zone" t2="20 Sea Zone"/>
-				<connection t1="19 Sea Zone" t2="Panama"/>
-				<connection t1="19 Sea Zone" t2="West Indies"/>
-				<connection t1="20 Sea Zone" t2="21 Sea Zone"/>
-				<connection t1="20 Sea Zone" t2="54 Sea Zone"/>
-				<connection t1="20 Sea Zone" t2="Panama"/>
-				<connection t1="21 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="21 Sea Zone" t2="43 Sea Zone"/>
-				<connection t1="22 Sea Zone" t2="23 Sea Zone"/>
-				<connection t1="22 Sea Zone" t2="24 Sea Zone"/>
-				<connection t1="22 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="22 Sea Zone" t2="Brazil"/>
-				<connection t1="23 Sea Zone" t2="24 Sea Zone"/>
-				<connection t1="23 Sea Zone" t2="27 Sea Zone"/>
-				<connection t1="23 Sea Zone" t2="French Equatorial Africa"/>
-				<connection t1="23 Sea Zone" t2="Belgian Congo"/>
-				<connection t1="24 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="24 Sea Zone" t2="26 Sea Zone"/>
-				<connection t1="24 Sea Zone" t2="27 Sea Zone"/>
-				<connection t1="25 Sea Zone" t2="26 Sea Zone"/>
-				<connection t1="25 Sea Zone" t2="42 Sea Zone"/>
-				<connection t1="25 Sea Zone" t2="43 Sea Zone"/>
-				<connection t1="26 Sea Zone" t2="27 Sea Zone"/>
-				<connection t1="27 Sea Zone" t2="28 Sea Zone"/>
-				<connection t1="27 Sea Zone" t2="Union of South Africa"/>
-				<connection t1="28 Sea Zone" t2="29 Sea Zone"/>
-				<connection t1="28 Sea Zone" t2="33 Sea Zone"/>
-				<connection t1="28 Sea Zone" t2="Union of South Africa"/>
-				<connection t1="28 Sea Zone" t2="French Madagascar"/>
-				<connection t1="29 Sea Zone" t2="32 Sea Zone"/>
-				<connection t1="29 Sea Zone" t2="30 Sea Zone"/>
-				<connection t1="29 Sea Zone" t2="French Madagascar"/>
-				<connection t1="30 Sea Zone" t2="31 Sea Zone"/>
-				<connection t1="30 Sea Zone" t2="32 Sea Zone"/>
-				<connection t1="30 Sea Zone" t2="38 Sea Zone"/>
-				<connection t1="30 Sea Zone" t2="39 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="32 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="35 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="37 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="38 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="33 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="34 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="35 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="French Madagascar"/>
-				<connection t1="33 Sea Zone" t2="34 Sea Zone"/>
-				<connection t1="33 Sea Zone" t2="French Madagascar"/>
-				<connection t1="33 Sea Zone" t2="Kenya"/>
-				<connection t1="34 Sea Zone" t2="35 Sea Zone"/>
-				<connection t1="34 Sea Zone" t2="Italian East Africa"/>
-				<connection t1="34 Sea Zone" t2="Anglo Egypt"/>
-				<connection t1="34 Sea Zone" t2="Trans-Jordan"/>
-				<connection t1="34 Sea Zone" t2="Persia"/>
-				<connection t1="35 Sea Zone" t2="36 Sea Zone"/>
-				<connection t1="35 Sea Zone" t2="37 Sea Zone"/>
-				<connection t1="35 Sea Zone" t2="India"/>
-				<connection t1="36 Sea Zone" t2="37 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="49 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="59 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="French Indochina"/>
-				<connection t1="37 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="38 Sea Zone" t2="46 Sea Zone"/>
-				<connection t1="52 Sea Zone" t2="56 Sea Zone"/>
-				<connection t1="37 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="37 Sea Zone" t2="38 Sea Zone"/>
-				<connection t1="37 Sea Zone" t2="East Indies"/>
-				<connection t1="38 Sea Zone" t2="39 Sea Zone"/>
-				<connection t1="38 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="38 Sea Zone" t2="Australia"/>
-				<connection t1="39 Sea Zone" t2="40 Sea Zone"/>
-				<connection t1="39 Sea Zone" t2="Australia"/>
-				<connection t1="40 Sea Zone" t2="41 Sea Zone"/>
-				<connection t1="40 Sea Zone" t2="46 Sea Zone"/>
-				<connection t1="40 Sea Zone" t2="Australia"/>
-				<connection t1="41 Sea Zone" t2="46 Sea Zone"/>
-				<connection t1="41 Sea Zone" t2="45 Sea Zone"/>
-				<connection t1="41 Sea Zone" t2="42 Sea Zone"/>
-				<connection t1="41 Sea Zone" t2="44 Sea Zone"/>
-				<connection t1="41 Sea Zone" t2="New Zealand"/>
-				<connection t1="42 Sea Zone" t2="43 Sea Zone"/>
-				<connection t1="42 Sea Zone" t2="44 Sea Zone"/>
-				<connection t1="43 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="43 Sea Zone" t2="44 Sea Zone"/>
-				<connection t1="43 Sea Zone" t2="53 Sea Zone"/>
-				<connection t1="43 Sea Zone" t2="54 Sea Zone"/>
-				<connection t1="44 Sea Zone" t2="45 Sea Zone"/>
-				<connection t1="44 Sea Zone" t2="52 Sea Zone"/>
-				<connection t1="44 Sea Zone" t2="53 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="46 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="50 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="51 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="52 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="Solomon Islands"/>
-				<connection t1="46 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="Australia"/>
-				<connection t1="47 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="47 Sea Zone" t2="50 Sea Zone"/>
-				<connection t1="47 Sea Zone" t2="New Guinea"/>
-				<connection t1="48 Sea Zone" t2="49 Sea Zone"/>
-				<connection t1="48 Sea Zone" t2="50 Sea Zone"/>
-				<connection t1="48 Sea Zone" t2="Borneo"/>
-				<connection t1="49 Sea Zone" t2="50 Sea Zone"/>
-				<connection t1="49 Sea Zone" t2="58 Sea Zone"/>
-				<connection t1="49 Sea Zone" t2="59 Sea Zone"/>
-				<connection t1="49 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="49 Sea Zone" t2="Philipine Islands"/>
-				<connection t1="50 Sea Zone" t2="58 Sea Zone"/>
-				<connection t1="50 Sea Zone" t2="51 Sea Zone"/>
-				<connection t1="50 Sea Zone" t2="Caroline Islands"/>
-				<connection t1="51 Sea Zone" t2="52 Sea Zone"/>
-				<connection t1="51 Sea Zone" t2="58 Sea Zone"/>
-				<connection t1="51 Sea Zone" t2="57 Sea Zone"/>
-				<connection t1="51 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="51 Sea Zone" t2="Wake Island"/>
-				<connection t1="52 Sea Zone" t2="53 Sea Zone"/>
-				<connection t1="52 Sea Zone" t2="55 Sea Zone"/>
-				<connection t1="52 Sea Zone" t2="57 Sea Zone"/>
-				<connection t1="52 Sea Zone" t2="Hawaiian Islands"/>
-				<connection t1="53 Sea Zone" t2="54 Sea Zone"/>
-				<connection t1="53 Sea Zone" t2="55 Sea Zone"/>
-				<connection t1="54 Sea Zone" t2="55 Sea Zone"/>
-				<connection t1="54 Sea Zone" t2="Mexico"/>
-				<connection t1="54 Sea Zone" t2="Western United States"/>
-				<connection t1="55 Sea Zone" t2="56 Sea Zone"/>
-				<connection t1="55 Sea Zone" t2="64 Sea Zone"/>
-				<connection t1="55 Sea Zone" t2="Western United States"/>
-				<connection t1="55 Sea Zone" t2="Western Canada"/>
-				<connection t1="56 Sea Zone" t2="57 Sea Zone"/>
-				<connection t1="56 Sea Zone" t2="63 Sea Zone"/>
-				<connection t1="56 Sea Zone" t2="64 Sea Zone"/>
-				<connection t1="56 Sea Zone" t2="Midway"/>
-				<connection t1="57 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="62 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="63 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="Midway"/>
-				<connection t1="58 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="58 Sea Zone" t2="Okinawa"/>
-				<connection t1="59 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="59 Sea Zone" t2="61 Sea Zone"/>
-				<connection t1="59 Sea Zone" t2="Kwangtung"/>
-				<connection t1="60 Sea Zone" t2="61 Sea Zone"/>
-				<connection t1="60 Sea Zone" t2="62 Sea Zone"/>
-				<connection t1="60 Sea Zone" t2="Japan"/>
-				<connection t1="60 Sea Zone" t2="Burytia S.S.R."/>
-				<connection t1="61 Sea Zone" t2="Japan"/>
-				<connection t1="61 Sea Zone" t2="Manchuria"/>
-				<connection t1="62 Sea Zone" t2="63 Sea Zone"/>
-				<connection t1="62 Sea Zone" t2="Burytia S.S.R."/>
-				<connection t1="62 Sea Zone" t2="Soviet Far East"/>
-				<connection t1="63 Sea Zone" t2="64 Sea Zone"/>
-				<connection t1="63 Sea Zone" t2="Alaska"/>
-				<connection t1="63 Sea Zone" t2="Western Canada"/>
-				<connection t1="64 Sea Zone" t2="Alaska"/>
-				<connection t1="64 Sea Zone" t2="Western Canada"/>
-				<connection t1="Eastern Canada" t2="Eastern United States"/>
-				<connection t1="Eastern Canada" t2="Western Canada"/>
-				<connection t1="Eastern United States" t2="Central United States"/>
-				<connection t1="Central United States" t2="Western Canada"/>
-				<connection t1="Central United States" t2="Western United States"/>
-				<connection t1="Western United States" t2="Mexico"/>
-				<connection t1="Central United States" t2="Mexico"/>
-				<connection t1="Western United States" t2="Western Canada"/>
-				<connection t1="Western Canada" t2="Alaska"/>
-				<connection t1="Eastern United States" t2="Panama"/>
-				<connection t1="Panama" t2="Mexico"/>
-				<connection t1="Western Europe" t2="Germany"/>
-				<connection t1="Germany" t2="East Balkans"/>
-				<connection t1="Germany" t2="Eastern Europe"/>
-				<connection t1="East Balkans" t2="Eastern Europe"/>
-				<connection t1="East Balkans" t2="Ukraine S.S.R."/>
-				<connection t1="Eastern Europe" t2="Ukraine S.S.R."/>
-				<connection t1="Eastern Europe" t2="Belorussia"/>
-				<connection t1="Eastern Europe" t2="Karelia S.S.R."/>
-				<connection t1="Karelia S.S.R." t2="Norway"/>
-				<connection t1="Karelia S.S.R." t2="Belorussia"/>
-				<connection t1="Karelia S.S.R." t2="Archangel"/>
-				<connection t1="Karelia S.S.R." t2="West Russia"/>
-				<connection t1="Belorussia" t2="West Russia"/>
-				<connection t1="Belorussia" t2="Ukraine S.S.R." />
-				<connection t1="Ukraine S.S.R." t2="West Russia"/>
-				<connection t1="Ukraine S.S.R." t2="Caucus"/>
-				<connection t1="Caucus" t2="Persia"/>
-				<connection t1="Caucus" t2="West Russia"/>
-				<connection t1="Caucus" t2="Russia"/>
-				<connection t1="Caucus" t2="Kazakh S.S.R."/>
-				<connection t1="West Russia" t2="Russia"/>
-				<connection t1="West Russia" t2="Archangel"/>
-				<connection t1="Archangel" t2="Russia"/>
-				<connection t1="Russia" t2="Evanki National Okrug"/>
-				<connection t1="Russia" t2="Novisibirsk"/>
-				<connection t1="Russia" t2="Kazakh S.S.R."/>
-				<connection t1="Kazakh S.S.R." t2="Novisibirsk"/>
-				<connection t1="Kazakh S.S.R." t2="Sinkiang"/>
-				<connection t1="Kazakh S.S.R." t2="Persia"/>
-				<connection t1="India" t2="French Indochina"/>
-				<connection t1="Evanki National Okrug" t2="Yakut S.S.R."/>
-				<connection t1="Evanki National Okrug" t2="Novisibirsk"/>
-				<connection t1="Novisibirsk" t2="Yakut S.S.R."/>
-				<connection t1="Novisibirsk" t2="Sinkiang"/>
-				<connection t1="Yakut S.S.R." t2="Soviet Far East"/>
-				<connection t1="Yakut S.S.R." t2="Burytia S.S.R."/>
-				<connection t1="Burytia S.S.R." t2="Manchuria"/>
-				<connection t1="Burytia S.S.R." t2="Soviet Far East"/>
-				<connection t1="Manchuria" t2="China"/>
-				<connection t1="Manchuria" t2="Kwangtung"/>
-				<connection t1="Kwangtung" t2="China"/>
-				<connection t1="Kwangtung" t2="French Indochina"/>
-				<connection t1="China" t2="French Indochina"/>
-				<connection t1="Persia" t2="India"/>
-				<connection t1="Persia" t2="Trans-Jordan"/>
-				<connection t1="Trans-Jordan" t2="Anglo Egypt"/>
-				<connection t1="Anglo Egypt" t2="Libya"/>
-				<connection t1="Anglo Egypt" t2="Italian East Africa"/>
-				<connection t1="Anglo Egypt" t2="French Equatorial Africa"/>
-				<connection t1="Anglo Egypt" t2="Belgian Congo"/>
-				<connection t1="Libya" t2="Algeria"/>
-				<connection t1="French West Africa" t2="French Equatorial Africa"/>
-				<connection t1="French Equatorial Africa" t2="Belgian Congo"/>
-				<connection t1="Belgian Congo" t2="Italian East Africa"/>
-				<connection t1="Belgian Congo" t2="Kenya"/>
-				<connection t1="Italian East Africa" t2="Kenya"/>
-				<connection t1="Kenya" t2="Union of South Africa"/>
-				<!-- The order of t1 and t2 does not matter at all -->
-		</map>
-		
-
-
-		<resourceList>
-				<!-- PUs and techTokens are default supported resources. (all maps should use "PUs" as the default "money", as a map without PUs may fail. -->
-				<resource name="PUs"/>
-				<resource name="techTokens"/>
-				<!-- These are custom resources.
-				<resource name="Steel"/>
-				<resource name="Aluminium"/>
-				<resource name="Fuel"/>
-				<resource name="SuicideAttackTokens"/>-->
-				<!-- VPs are only semi-supported by the code as of right now. They are used for special pacific rules.
-				<resource name="VPs"/>-->
-		</resourceList>
-
-		<playerList>
-				<!-- In turn order (it is important that the players are listed in turn order)-->
-				<player name="Italians" optional="false"/>
-				<player name="Russians" optional="false"/>
-				<player name="Germans" optional="false"/>
-				<player name="British" optional="false"/>
-				<player name="Japanese" optional="false"/>
-				<player name="Americans" optional="false"/>
-				<player name="Chinese" optional="false"/>
-				<!-- optional just means 'does this player require a capital?'.  if a player is optional, some delegates may not work as expected for that player. -->
-
-				
-				
-				<!-- Alliances can have any name, not just axis and allies.  There can be more than 2 alliances -->
-				<!-- Since triplea version 1.3.3.0 it is preferred to use relationships instead of or in addition to alliances. If relationships are set, then alliances will only matter for the stats panel and any game option type victory conditions -->
-				<!-- Axis alliance -->
-				<alliance player="Germans" alliance="Axis"/>
-				<alliance player="Japanese" alliance="Axis"/>
-				<alliance player="Italians" alliance="Axis"/>
-				
-				<!-- Allies alliance -->
-				<alliance player="British" alliance="Allies"/>
-				<alliance player="Russians" alliance="Allies"/>
-				<alliance player="Americans" alliance="Allies"/>
-				<alliance player="Chinese" alliance="Allies"/>
-				
-		</playerList>
-
-		<unitList>
-				<unit name="infantry"/>
-				<unit name="artillery"/>
-				<unit name="armour"/>
-				<unit name="fighter"/>
-				<unit name="jp_fighter"/>
-				<unit name="bomber"/>
-				<unit name="air_transport"/>
-				<unit name="transport"/>
-				<unit name="jp_transport"/>
-				<unit name="submarine"/>
-				<unit name="midget_submarine"/>
-				<unit name="destroyer"/>
-				<unit name="jp_destroyer"/>
-				<unit name="cruiser"/>
-				<unit name="carrier"/>
-				<unit name="battleship"/>
-				<unit name="super_carrier"/>
-				<unit name="bunker"/>
-				<unit name="aaGun"/>
-				<unit name="factory"/>
-				<unit name="airfield"/>
-				<unit name="harbour"/>
-		</unitList>
-		
-		<!--	This is the list of relationshipTypes you can create between players -->
-		<!--	Each relationshipType you define here MUST have a RelationshipTypeAttachment to define this relationship 
-				Also each RelationshipTypeAttachment MUST have an archetype set to either: "allied", "neutral" or "war"
-				The following are examples, you can name them whatever you want.
-		-->
-		<relationshipTypes>
-				<relationshipType name="Allied"/>
-				<relationshipType name="War"/>
-				<relationshipType name="Neutrality"/>
-				<relationshipType name="NAP"/>
-				<relationshipType name="ColdWar"/>
-		</relationshipTypes>
-		
-		<territoryEffectList>
-				<territoryEffect name="mountain"/>
-				<!--<territoryEffect name="city"/>
-				<territoryEffect name="desert"/>
-				<territoryEffect name="forest"/>
-				<territoryEffect name="hill"/>
-				<territoryEffect name="marsh"/>
-				<territoryEffect name="sahara"/>-->
-		</territoryEffectList>
-
-		<gamePlay>
-				<!-- this currently is all the delegates triplea has.  not all are needed for a regular game though -->
-					<!-- purchaseNoPU buys 1 infantry for X number of territories controlled, rounding down. set X in player rules attachments -->
-					<!-- endTurnNoPU ends player's turn without giving them any PUs -->
-					<!-- placeNoAirCheck does everything normal 'place' does, except it does not kill any aircraft at the end of the turn -->
-				<delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate" display="Initializing Delegates"/>
-				<delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate" display="Research Technology"/>
-				<delegate name="tech_activation" javaClass="games.strategy.triplea.delegate.TechActivationDelegate" display="Activate Technology"/>
-				<delegate name="battle" javaClass="games.strategy.triplea.delegate.BattleDelegate" display="Combat"/>
-				<delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Combat Move"/>
-				<delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Units"/>
-				<!--<delegate name="placeNoAirCheck" javaClass="games.strategy.triplea.delegate.NoAirCheckPlaceDelegate" display="Place Units"/>-->
-				<delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
-				<delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>
-				<delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate" display="Turn Complete"/>
-				<delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
-				<delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
-				<delegate name="placeBid" javaClass="games.strategy.triplea.delegate.BidPlaceDelegate" display="Bid Placement"/>
-				<delegate name="bid" javaClass="games.strategy.triplea.delegate.BidPurchaseDelegate" display="Bid Purchase"/>
-				<delegate name="politics" javaClass="games.strategy.triplea.delegate.PoliticsDelegate" display="Politics"/>
-				
-				<!-- SpecialMoveDelegate delegate is for the new Airborne forces tech (similar to paratroopers). The delegate name has to end with "AirborneCombatMove" for it to work properly.
-				GamePlay Delegate:
-				<delegate name="specialCombatMove" javaClass="games.strategy.triplea.delegate.SpecialMoveDelegate" display="Special Move"/>
-				Sequence Step Example:
-				<step name="italianAirborneCombatMove" delegate="specialCombatMove" player="Italians" display="Airborne Attack Move"/>-->
-
-				<sequence>
-						<!-- It is very important that the "name" ends with the correct phrase, or else the game will not work properly.
-						Please end with ("xx" = faction name): xxBid, xxBidPlace, xxTech, xxPurchase, xxCombatMove, xxBattle, xxNonCombatMove, xxPlace, xxTechActivation, xxEndTurn  -->
-						
-						<!-- a "step" may also include an option called "stepProperty", which has "name" and "value" attributes.
-								These stepProperty options are not validated at all, so if you have a typo it will not be caught.
-								Currently allowed stepProperty options:
-									For any "EndTurn" delegate (such as EndTurnDelegate or NoPUEndTurnDelegate or etc):
-										skipPosting 		= true/false (default is false). Do we skip the Play-by-Email/Play-by-Forum turn summary and savegame Posting?
-										turnSummaryPlayers 	= a list of players, separated by colons ":"  default is the step player.  
-																Determines which players this forum posting turn summary will include (will only use all steps that touch this step, or touch the step that touches this step AND is owned by one of these listed players)
-						-->
-						
-						<step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
-
-						<!-- Bidding Phase -->
-						<step name="italiansBid" delegate="bid" player="Italians" maxRunCount="1"/>
-						<step name="italiansBidPlace" delegate="placeBid" player="Italians" maxRunCount="1"/>
-						<step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
-						<step name="russianBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
-						<step name="germanBid" delegate="bid" player="Germans" maxRunCount="1"/>
-						<step name="germanBidPlace" delegate="placeBid" player="Germans" maxRunCount="1"/>
-						<step name="britishBid" delegate="bid" player="British" maxRunCount="1"/>
-						<step name="britishBidPlace" delegate="placeBid" player="British" maxRunCount="1"/>
-						<step name="japaneseBid" delegate="bid" player="Japanese" maxRunCount="1"/>
-						<step name="japaneseBidPlace" delegate="placeBid" player="Japanese" maxRunCount="1"/>
-						<step name="americanBid" delegate="bid" player="Americans" maxRunCount="1"/>
-						<step name="americanBidPlace" delegate="placeBid" player="Americans" maxRunCount="1"/>
-						<step name="chineseBid" delegate="bid" player="Chinese" maxRunCount="1"/>
-						<step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
-
-						<!-- it is generally a good idea to put tech activation at the end of the turn, for balancing reasons -->
-						<!-- Italians Game Sequence -->
-						<step name="italianTech" delegate="tech" player="Italians"/>
-						<step name="italianPurchase" delegate="purchase" player="Italians"/>
-						<step name="italianPolitics" delegate="politics" player="Italians"/>
-						<step name="italianCombatMove" delegate="move" player="Italians"/>
-						<step name="italianBattle" delegate="battle" player="Italians"/>
-						<step name="italianNonCombatMove" delegate="move" player="Italians" display="Non Combat Move"/>
-						<step name="italianPlace" delegate="place" player="Italians"/>
-						<step name="italianTechActivation" delegate="tech_activation" player="Italians"/>
-						<step name="italianEndTurn" delegate="endTurn" player="Italians"/>
-
-						<!-- Russians Game Sequence -->
-						<step name="russianTech" delegate="tech" player="Russians"/>
-						<step name="russianPurchase" delegate="purchase" player="Russians"/>
-						<step name="russianPolitics" delegate="politics" player="Russians"/>
-						<step name="russianCombatMove" delegate="move" player="Russians"/>
-						<step name="russianBattle" delegate="battle" player="Russians"/>
-						<step name="russianNonCombatMove" delegate="move" player="Russians" display="Non Combat Move"/>
-						<step name="russianPlace" delegate="place" player="Russians"/>
-						<step name="russianTechActivation" delegate="tech_activation" player="Russians"/>
-						<step name="russianEndTurn" delegate="endTurn" player="Russians"/>
-
-						<!-- Germans Game Sequence -->
-						<step name="germanTech" delegate="tech" player="Germans"/>
-						<step name="germanPurchase" delegate="purchase" player="Germans"/>
-						<step name="germanPolitics" delegate="politics" player="Germans"/>
-						<step name="germanCombatMove" delegate="move" player="Germans"/>
-						<step name="germanBattle" delegate="battle" player="Germans"/>
-						<step name="germanNonCombatMove" delegate="move" player="Germans" display="Non Combat Move"/>
-						<step name="germanPlace" delegate="place" player="Germans"/>
-						<step name="germanTechActivation" delegate="tech_activation" player="Germans"/>
-						<step name="germanEndTurn" delegate="endTurn" player="Germans"/>
-
-						<!-- British Game Sequence -->
-						<step name="britishTech" delegate="tech" player="British"/>
-						<step name="britishPurchase" delegate="purchase" player="British"/>
-						<step name="britishPolitics" delegate="politics" player="British"/>
-						<step name="britishCombatMove" delegate="move" player="British"/>
-						<step name="britishBattle" delegate="battle" player="British"/>
-						<step name="britishNonCombatMove" delegate="move" player="British" display="Non Combat Move"/>
-						<step name="britishPlace" delegate="place" player="British"/>
-						<step name="britishTechActivation" delegate="tech_activation" player="British"/>
-						<step name="britishEndTurn" delegate="endTurn" player="British"/>
-
-						<!-- Japanese Game Sequence -->
-						<step name="japaneseTech" delegate="tech" player="Japanese"/>
-						<step name="japanesePurchase" delegate="purchase" player="Japanese"/>
-						<step name="japanesePolitics" delegate="politics" player="Japanese"/>
-						<step name="japaneseCombatMove" delegate="move" player="Japanese"/>
-						<step name="japaneseBattle" delegate="battle" player="Japanese"/>
-						<step name="japaneseNonCombatMove" delegate="move" player="Japanese" display="Non Combat Move"/>
-						<step name="japanesePlace" delegate="place" player="Japanese"/>
-						<step name="japaneseTechActivation" delegate="tech_activation" player="Japanese"/>
-						<step name="japaneseEndTurn" delegate="endTurn" player="Japanese">
-								<stepProperty name="skipPosting" value="false"/>
-						</step>
-
-						<!-- Americans Game Sequence -->
-						<step name="americanTech" delegate="tech" player="Americans"/>
-						<step name="americanPurchase" delegate="purchase" player="Americans"/>
-						<step name="americanPolitics" delegate="politics" player="Americans"/>
-						<step name="americanCombatMove" delegate="move" player="Americans"/>
-						<step name="americanBattle" delegate="battle" player="Americans"/>
-						<step name="americanNonCombatMove" delegate="move" player="Americans" display="Non Combat Move"/>
-						<step name="americanPlace" delegate="place" player="Americans"/>
-						<step name="americanTechActivation" delegate="tech_activation" player="Americans"/>
-						<!--<step name="americanEndTurn" delegate="endTurn" player="Americans"/>-->
-						<step name="americanEndTurn" delegate="endTurn" player="Americans">
-								<!--<stepProperty name="skipPosting" value="true"/>-->
-								<stepProperty name="turnSummaryPlayers" value="Americans"/>
-						</step>
-						
-						<!-- Chinese Game Sequence -->
-						<step name="chineseBurmaRoadPurchase" delegate="purchase" player="Chinese"/>
-						<step name="chinesePolitics" delegate="politics" player="Chinese"/>
-						<step name="chineseCombatMove" delegate="move" player="Chinese"/>
-						<step name="chineseBattle" delegate="battle" player="Chinese"/>
-						<step name="chineseNonCombatMove" delegate="move" player="Chinese" display="Non Combat Move"/>
-						<step name="chineseNoPUPurchase" delegate="purchaseNoPU" player="Chinese"/>
-						<step name="chinesePlace" delegate="place" player="Chinese"/>
-						<!--<step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese"/>-->
-						<step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese">
-								<stepProperty name="turnSummaryPlayers" value="Chinese"/>
-								<!--<stepProperty name="turnSummaryPlayers" value="Americans:Chinese"/>-->
-						</step>
-
-						<step name="endRoundStep" delegate="endRound"/>
-				</sequence>
-				
-				<!-- offset is used by the xml exporter to have a game begin in a round other than round 1. The default is zero if this attribute does not exist. -->
-				<offset round="0"/>
-				
-		</gamePlay>
-
-		<production>
-				<!-- Unit Production Cost -->
-				<productionRule name="buyInfantry">
-						<cost resource="PUs" quantity="3" />
-						<result resourceOrUnit="infantry" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyArtillery">
-						<cost resource="PUs" quantity="4" />
-						<!--<cost resource="Steel" quantity="2" />-->
-						<result resourceOrUnit="artillery" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyArmour">
-						<cost resource="PUs" quantity="5" />
-						<!--<cost resource="Steel" quantity="4" />
-						<cost resource="Aluminium" quantity="10" />-->
-						<result resourceOrUnit="armour" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyFighter">
-						<cost resource="PUs" quantity="10" />
-						<result resourceOrUnit="fighter" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyJP_Fighter">
-						<cost resource="PUs" quantity="10" />
-						<result resourceOrUnit="jp_fighter" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyJP_FighterKamikaze">
-						<cost resource="PUs" quantity="8" />
-						<result resourceOrUnit="jp_fighter" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyBomber">
-						<cost resource="PUs" quantity="12" />
-						<result resourceOrUnit="bomber" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyAir_Transport">
-						<cost resource="PUs" quantity="10" />
-						<result resourceOrUnit="air_transport" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyTransport">
-						<cost resource="PUs" quantity="7" />
-						<result resourceOrUnit="transport" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyJP_Transport">
-						<cost resource="PUs" quantity="7" />
-						<result resourceOrUnit="jp_transport" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyCarrier">
-						<cost resource="PUs" quantity="14" />
-						<result resourceOrUnit="carrier" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyDestroyer">
-						<cost resource="PUs" quantity="8" />
-						<result resourceOrUnit="destroyer" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyJP_Destroyer">
-						<cost resource="PUs" quantity="8" />
-						<result resourceOrUnit="jp_destroyer" quantity="1"/>
-				</productionRule>
-				
-				<productionRule name="buyCruiser">
-						<cost resource="PUs" quantity="12" />
-						<result resourceOrUnit="cruiser" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyBattleship">
-						<cost resource="PUs" quantity="20" />
-						<result resourceOrUnit="battleship" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buySuper_Carrier">
-						<cost resource="PUs" quantity="21" />
-						<result resourceOrUnit="super_carrier" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buySubmarine">
-						<cost resource="PUs" quantity="6" />
-						<result resourceOrUnit="submarine" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buySubmarineTech2">
-						<cost resource="PUs" quantity="7" />
-						<result resourceOrUnit="submarine" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buySubmarineTech3">
-						<cost resource="PUs" quantity="8" />
-						<result resourceOrUnit="submarine" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyMidget_Submarine">
-						<cost resource="PUs" quantity="4" />
-						<result resourceOrUnit="midget_submarine" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyBunker">
-						<cost resource="PUs" quantity="4" />
-						<result resourceOrUnit="bunker" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyFactory">
-						<cost resource="PUs" quantity="15" />
-						<result resourceOrUnit="factory" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyAirfield">
-						<cost resource="PUs" quantity="12" />
-						<result resourceOrUnit="airfield" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyHarbour">
-						<cost resource="PUs" quantity="12" />
-						<result resourceOrUnit="harbour" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyAAGun">
-						<cost resource="PUs" quantity="6" />
-						<result resourceOrUnit="aaGun" quantity="1"/>
-				</productionRule>
-
-				<!-- SHIPYARD PRICES -->
-						<!-- Shipyards production rules are only needed if you are using the "shipyards" tech AND have the shipyards game option ON. -->
-				<productionRule name="buyTransportShipyards">
-						<cost resource="PUs" quantity="6" />
-						<result resourceOrUnit="transport" quantity="1"/>
-				</productionRule>
-				
-				<productionRule name="buyJP_TransportShipyards">
-						<cost resource="PUs" quantity="6" />
-						<result resourceOrUnit="jp_transport" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyCarrierShipyards">
-						<cost resource="PUs" quantity="11" />
-						<result resourceOrUnit="carrier" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyDestroyerShipyards">
-						<cost resource="PUs" quantity="7" />
-						<result resourceOrUnit="destroyer" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyJP_DestroyerShipyards">
-						<cost resource="PUs" quantity="7" />
-						<result resourceOrUnit="jp_destroyer" quantity="1"/>
-				</productionRule>
-				
-				<productionRule name="buyCruiserShipyards">
-						<cost resource="PUs" quantity="10" />
-						<result resourceOrUnit="cruiser" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyBattleshipShipyards">
-						<cost resource="PUs" quantity="17" />
-						<result resourceOrUnit="battleship" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buySuper_CarrierShipyards">
-						<cost resource="PUs" quantity="17" />
-						<result resourceOrUnit="super_carrier" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buySubmarineShipyards">
-						<cost resource="PUs" quantity="5" />
-						<result resourceOrUnit="submarine" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buySubmarineTech2Shipyards">
-						<cost resource="PUs" quantity="6" />
-						<result resourceOrUnit="submarine" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buySubmarineTech3Shipyards">
-						<cost resource="PUs" quantity="7" />
-						<result resourceOrUnit="submarine" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyMidget_SubmarineShipyards">
-						<cost resource="PUs" quantity="3" />
-						<result resourceOrUnit="midget_submarine" quantity="1"/>
-				</productionRule>
-
-				<!-- Advanced Industrial Production -->
-						<!-- IndustrialTechnology production rules are only needed if you are using or plan to use the "industrialTechnology" tech.
-
-				<productionRule name="buyInfantryIndustrialTechnology">
-						<cost resource="PUs" quantity="3" />
-						<result resourceOrUnit="infantry" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyArtilleryIndustrialTechnology">
-						<cost resource="PUs" quantity="4" />
-						<result resourceOrUnit="artillery" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyArmourIndustrialTechnology">
-						<cost resource="PUs" quantity="5" />
-						<result resourceOrUnit="armour" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyFighterIndustrialTechnology">
-						<cost resource="PUs" quantity="9" />
-						<result resourceOrUnit="fighter" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyJP_FighterIndustrialTechnology">
-						<cost resource="PUs" quantity="9" />
-						<result resourceOrUnit="jp_fighter" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyBomberIndustrialTechnology">
-						<cost resource="PUs" quantity="11" />
-						<result resourceOrUnit="bomber" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyAir_TransportIndustrialTechnology">
-						<cost resource="PUs" quantity="9" />
-						<result resourceOrUnit="air_transport" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyTransportIndustrialTechnology">
-						<cost resource="PUs" quantity="6" />
-						<result resourceOrUnit="transport" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyJP_TransportIndustrialTechnology">
-						<cost resource="PUs" quantity="6" />
-						<result resourceOrUnit="jp_transport" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyCarrierIndustrialTechnology">
-						<cost resource="PUs" quantity="11" />
-						<result resourceOrUnit="carrier" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyDestroyerIndustrialTechnology">
-						<cost resource="PUs" quantity="7" />
-						<result resourceOrUnit="destroyer" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyJP_DestroyerIndustrialTechnology">
-						<cost resource="PUs" quantity="7" />
-						<result resourceOrUnit="jp_destroyer" quantity="1"/>
-				</productionRule>
-				
-				<productionRule name="buyCruiserIndustrialTechnology">
-						<cost resource="PUs" quantity="10" />
-						<result resourceOrUnit="cruiser" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyBattleshipIndustrialTechnology">
-						<cost resource="PUs" quantity="17" />
-						<result resourceOrUnit="battleship" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buySuper_CarrierIndustrialTechnology">
-						<cost resource="PUs" quantity="17" />
-						<result resourceOrUnit="super_carrier" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buySubmarineIndustrialTechnology">
-						<cost resource="PUs" quantity="5" />
-						<result resourceOrUnit="submarine" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyMidget_SubmarineIndustrialTechnology">
-						<cost resource="PUs" quantity="3" />
-						<result resourceOrUnit="midget_submarine" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyBunkerIndustrialTechnology">
-						<cost resource="PUs" quantity="4" />
-						<result resourceOrUnit="bunker" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyFactoryIndustrialTechnology">
-						<cost resource="PUs" quantity="13" />
-						<result resourceOrUnit="factory" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyAirfieldIndustrialTechnology">
-						<cost resource="PUs" quantity="10" />
-						<result resourceOrUnit="airfield" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyHarbourIndustrialTechnology">
-						<cost resource="PUs" quantity="10" />
-						<result resourceOrUnit="harbour" quantity="1"/>
-				</productionRule>
-
-				<productionRule name="buyAAGunIndustrialTechnology">
-						<cost resource="PUs" quantity="5" />
-						<result resourceOrUnit="aaGun" quantity="1"/>
-				</productionRule>
-				-->
-
-				<!-- Repair rules -->
-						<!-- if you use ww2v3 style factory damage, you need repair rules -->
-				<repairRule name="repairFactory">
-						<cost resource="PUs" quantity="1" />
-						<result resourceOrUnit="factory" quantity="1"/>
-				</repairRule>
-				<repairRule name="repairBunker">
-						<cost resource="PUs" quantity="1" />
-						<result resourceOrUnit="bunker" quantity="1"/>
-				</repairRule>
-				<repairRule name="repairAirfield">
-						<cost resource="PUs" quantity="1" />
-						<result resourceOrUnit="airfield" quantity="1"/>
-				</repairRule>
-				<repairRule name="repairHarbour">
-						<cost resource="PUs" quantity="1" />
-						<result resourceOrUnit="harbour" quantity="1"/>
-				</repairRule>
-
-				<repairRule name="repairFactoryIndustrialTechnology">
-						<cost resource="PUs" quantity="1" />
-						<result resourceOrUnit="factory" quantity="2"/>
-				</repairRule>
-				<repairRule name="repairBunkerIndustrialTechnology">
-						<cost resource="PUs" quantity="1" />
-						<result resourceOrUnit="bunker" quantity="2"/>
-				</repairRule>
-				<repairRule name="repairAirfieldIndustrialTechnology">
-						<cost resource="PUs" quantity="1" />
-						<result resourceOrUnit="airfield" quantity="2"/>
-				</repairRule>
-				<repairRule name="repairHarbourIndustrialTechnology">
-						<cost resource="PUs" quantity="1" />
-						<result resourceOrUnit="harbour" quantity="2"/>
-				</repairRule>
-
-				<repairFrontier name="repair">
-						<repairRules name="repairFactory"/>
-						<repairRules name="repairBunker"/>
-						<repairRules name="repairAirfield"/>
-						<repairRules name="repairHarbour"/>
-				</repairFrontier>
-
-				<repairFrontier name="repairIndustrialTechnology">
-						<repairRules name="repairFactoryIndustrialTechnology"/>
-						<repairRules name="repairBunkerIndustrialTechnology"/>
-						<repairRules name="repairAirfieldIndustrialTechnology"/>
-						<repairRules name="repairHarbourIndustrialTechnology"/>
-				</repairFrontier>
-
-				<!-- all players can use the same frontier, or you can have a different frontier for each player -->
-				<!-- only "production" (a single production frontier) is needed for most maps. if you use ww2v2 tech then you need IndustrialTechnology production, and if you use ww2v3 tech you need Shipyards -->
-				<!--<productionFrontier name="production">
-						<frontierRules name="buyInfantry"/>
-						<frontierRules name="buyArtillery"/>
-						<frontierRules name="buyArmour"/>
-						<frontierRules name="buyFighter"/>
-						<frontierRules name="buyBomber"/>
-						<frontierRules name="buyTransport"/>
-						<frontierRules name="buySubmarine"/>
-						<frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
-						<frontierRules name="buyCarrier"/>
-						<frontierRules name="buyBattleship"/>
-						<frontierRules name="buySuper_Carrier"/>
-						<frontierRules name="buyBunker"/>
-						<frontierRules name="buyAAGun"/>
-						<frontierRules name="buyFactory"/>
-						<frontierRules name="buyAirfield"/>
-						<frontierRules name="buyHarbour"/>
-				</productionFrontier>-->
-
-				<!--<productionFrontier name="productionIndustrialTechnology">
-						<frontierRules name="buyInfantryIndustrialTechnology"/>
-						<frontierRules name="buyArtilleryIndustrialTechnology"/>
-						<frontierRules name="buyArmourIndustrialTechnology"/>
-						<frontierRules name="buyFighterIndustrialTechnology"/>
-						<frontierRules name="buyBomberIndustrialTechnology"/>
-						<frontierRules name="buyTransportIndustrialTechnology"/>
-						<frontierRules name="buySubmarineIndustrialTechnology"/>
-						<frontierRules name="buyDestroyerIndustrialTechnology"/>
-						<frontierRules name="buyCruiserIndustrialTechnology"/>
-						<frontierRules name="buyCarrierIndustrialTechnology"/>
-						<frontierRules name="buyBattleshipIndustrialTechnology"/>
-						<frontierRules name="buySuper_CarrierIndustrialTechnology"/>
-						<frontierRules name="buyBunkerIndustrialTechnology"/>
-						<frontierRules name="buyAAGunIndustrialTechnology"/>
-						<frontierRules name="buyFactoryIndustrialTechnology"/>
-						<frontierRules name="buyAirfieldIndustrialTechnology"/>
-						<frontierRules name="buyHarbourIndustrialTechnology"/>
-				</productionFrontier>-->
-
-						<!-- Shipyards frontier rules are only needed if you are using the "shipyards" tech AND have the shipyards game option ON. If the shipyards game option is ON, then all players must use 1 frontier called "production".
-							If you want to use multiple production frontiers for different nations, then it is highly recommended you use triggers to add or remove productionRules instead of using the shipyard frontier. 
-				<productionFrontier name="productionShipyards">
-						<frontierRules name="buyTransportShipyards"/>
-						<frontierRules name="buySubmarineShipyards"/>
-						<frontierRules name="buyDestroyerShipyards"/>
-						<frontierRules name="buyCruiserShipyards"/>
-						<frontierRules name="buyCarrierShipyards"/>
-						<frontierRules name="buyBattleshipShipyards"/>
-						<frontierRules name="buySuper_CarrierShipyards"/>
-				</productionFrontier>-->
-
-				<productionFrontier name="Germans_production">
-						<frontierRules name="buyInfantry"/>
-						<frontierRules name="buyArtillery"/>
-						<frontierRules name="buyArmour"/>
-						<frontierRules name="buyFighter"/>
-						<frontierRules name="buyBomber"/>
-						<frontierRules name="buyTransport"/>
-						<frontierRules name="buySubmarine"/>
-						<frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
-						<frontierRules name="buyCarrier"/>
-						<frontierRules name="buyBattleship"/>
-						<frontierRules name="buySuper_Carrier"/>
-						<frontierRules name="buyBunker"/>
-						<frontierRules name="buyAAGun"/>
-						<frontierRules name="buyFactory"/>
-						<frontierRules name="buyAirfield"/>
-						<frontierRules name="buyHarbour"/>
-				</productionFrontier>
-
-				<productionFrontier name="Russians_production">
-						<frontierRules name="buyInfantry"/>
-						<frontierRules name="buyArtillery"/>
-						<frontierRules name="buyArmour"/>
-						<frontierRules name="buyFighter"/>
-						<frontierRules name="buyBomber"/>
-						<frontierRules name="buyTransport"/>
-						<frontierRules name="buySubmarine"/>
-						<frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
-						<frontierRules name="buyCarrier"/>
-						<frontierRules name="buyBattleship"/>
-						<frontierRules name="buySuper_Carrier"/>
-						<frontierRules name="buyBunker"/>
-						<frontierRules name="buyAAGun"/>
-						<frontierRules name="buyFactory"/>
-						<frontierRules name="buyAirfield"/>
-						<frontierRules name="buyHarbour"/>
-				</productionFrontier>
-
-				<productionFrontier name="Japanese_production">
-						<frontierRules name="buyInfantry"/>
-						<frontierRules name="buyArtillery"/>
-						<frontierRules name="buyArmour"/>
-						<frontierRules name="buyJP_Fighter"/>
-						<frontierRules name="buyBomber"/>
-						<frontierRules name="buyJP_Transport"/>
-						<frontierRules name="buySubmarine"/>
-						<frontierRules name="buyJP_Destroyer"/>
-						<frontierRules name="buyCruiser"/>
-						<frontierRules name="buyCarrier"/>
-						<frontierRules name="buyBattleship"/>
-						<frontierRules name="buySuper_Carrier"/>
-						<frontierRules name="buyBunker"/>
-						<frontierRules name="buyAAGun"/>
-						<frontierRules name="buyFactory"/>
-						<frontierRules name="buyAirfield"/>
-						<frontierRules name="buyHarbour"/>
-				</productionFrontier>
-
-				<productionFrontier name="British_production">
-						<frontierRules name="buyInfantry"/>
-						<frontierRules name="buyArtillery"/>
-						<frontierRules name="buyArmour"/>
-						<frontierRules name="buyFighter"/>
-						<frontierRules name="buyBomber"/>
-						<frontierRules name="buyTransport"/>
-						<frontierRules name="buySubmarine"/>
-						<frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
-						<frontierRules name="buyCarrier"/>
-						<frontierRules name="buyBattleship"/>
-						<frontierRules name="buySuper_Carrier"/>
-						<frontierRules name="buyBunker"/>
-						<frontierRules name="buyAAGun"/>
-						<frontierRules name="buyFactory"/>
-						<frontierRules name="buyAirfield"/>
-						<frontierRules name="buyHarbour"/>
-				</productionFrontier>
-
-				<productionFrontier name="Italians_production">
-						<frontierRules name="buyInfantry"/>
-						<frontierRules name="buyArtillery"/>
-						<frontierRules name="buyArmour"/>
-						<frontierRules name="buyFighter"/>
-						<frontierRules name="buyBomber"/>
-						<frontierRules name="buyTransport"/>
-						<frontierRules name="buySubmarine"/>
-						<frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
-						<frontierRules name="buyCarrier"/>
-						<frontierRules name="buyBattleship"/>
-						<frontierRules name="buySuper_Carrier"/>
-						<frontierRules name="buyBunker"/>
-						<frontierRules name="buyAAGun"/>
-						<frontierRules name="buyFactory"/>
-						<frontierRules name="buyAirfield"/>
-						<frontierRules name="buyHarbour"/>
-				</productionFrontier>
-
-				<!--<productionFrontier name="Chinese_production">
-						<frontierRules name="buyInfantry"/>
-						<frontierRules name="buyArtillery"/>
-						<frontierRules name="buyArmour"/>
-						<frontierRules name="buyFighter"/>
-						<frontierRules name="buyBomber"/>
-						<frontierRules name="buyTransport"/>
-						<frontierRules name="buySubmarine"/>
-						<frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
-						<frontierRules name="buyCarrier"/>
-						<frontierRules name="buyBattleship"/>
-						<frontierRules name="buySuper_Carrier"/>
-						<frontierRules name="buyBunker"/>
-						<frontierRules name="buyAAGun"/>
-						<frontierRules name="buyFactory"/>
-						<frontierRules name="buyAirfield"/>
-						<frontierRules name="buyHarbour"/>
-				</productionFrontier>-->
-
-				<productionFrontier name="Chinese_CutOff_production">
-						<frontierRules name="buyInfantry"/>
-						<frontierRules name="buyArtillery"/>
-				</productionFrontier>
-
-				<productionFrontier name="Chinese_BurmaRoad_production">
-						<frontierRules name="buyInfantry"/>
-						<frontierRules name="buyArtillery"/>
-						<frontierRules name="buyArmour"/>
-						<frontierRules name="buyFighter"/>
-				</productionFrontier>
-
-				<productionFrontier name="Americans_production">
-						<frontierRules name="buyInfantry"/>
-						<frontierRules name="buyArtillery"/>
-						<frontierRules name="buyArmour"/>
-						<frontierRules name="buyFighter"/>
-						<frontierRules name="buyBomber"/>
-						<frontierRules name="buyTransport"/>
-						<frontierRules name="buySubmarine"/>
-						<frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
-						<frontierRules name="buyCarrier"/>
-						<frontierRules name="buyBattleship"/>
-						<frontierRules name="buySuper_Carrier"/>
-						<frontierRules name="buyBunker"/>
-						<frontierRules name="buyAAGun"/>
-						<frontierRules name="buyFactory"/>
-						<frontierRules name="buyAirfield"/>
-						<frontierRules name="buyHarbour"/>
-				</productionFrontier>
-
-				<playerProduction player="Germans" frontier="Germans_production"/>
-				<playerProduction player="Russians" frontier="Russians_production"/>
-				<playerProduction player="Japanese" frontier="Japanese_production"/>
-				<playerProduction player="British" frontier="British_production"/>
-				<playerProduction player="Italians" frontier="Italians_production"/>
-				<playerProduction player="Chinese" frontier="Chinese_BurmaRoad_production"/>
-				<playerProduction player="Americans" frontier="Americans_production"/>
-
-				<playerRepair player="Germans" frontier="repair"/>
-				<playerRepair player="Russians" frontier="repair"/>
-				<playerRepair player="Japanese" frontier="repair"/>
-				<playerRepair player="British" frontier="repair"/>
-				<playerRepair player="Italians" frontier="repair"/>
-				<playerRepair player="Chinese" frontier="repair"/>
-				<playerRepair player="Americans" frontier="repair"/>
-
-		</production>
-
-		<technology>
-				<!-- list all available techs for this map, for all players possible -->
-				<technologies>
-						<!-- this is the current list of all HARDCODED techs that come with TripleA -->
-						<!-- (+1 attack to isSub) superSub requires all isSub units to have a "_ss" image variant -->
-						<techname name="superSub"/>
-						<!-- (+1 att or def for isAir non-isStrategicBomber) jetPower requires all non-isStrategicBomber units to have a "_jp" image variant (and "_lr_jp") -->
-						<techname name="jetPower"/>
-						<!-- (removes all sea units from "production" and adds "Shipyards" production rules.  Only currently works when all players use a production frontier called "production") -->
-						<techname name="shipyards"/>
-						<!-- (+1 attack for anti-air units) aARadar requires all isAA units to have a "_r" image variant (and "rockets_r" or "_rockets_r") -->
-						<techname name="aARadar"/>
-						<!-- (+2 movement for isAir) longRangeAir requires all isAir units to have a "_lr" image variant (and "_lr_jp" OR "_lr_hb") -->
-						<techname name="longRangeAir"/>
-						<!-- (+X dice rolls for isAir isStrategicBomber) heavyBomber requires all isStrategicBomber units to have a "_hb" image variant (and "_lr_hb") -->
-						<techname name="heavyBomber"/>
-						<!-- (doubles number of units supported by artillery, and optionally by other support types) -->
-						<techname name="improvedArtillerySupport"/>
-						<!-- (allows isAA and isRocket to shoot rockets) rocket requires all isAA units to have a "rockets" image variant if they are called "aaGun", and a "_rockets" if they are called anything else (and "rockets_r" or "_rockets_r") -->
-						<techname name="rocket"/>
-						<!-- (allows isAirTransport units to carry isAirTransportable units) -->
-						<techname name="paratroopers"/>
-						<!-- (gives +2 production slots to factories on territories worth at least 3, and halves the price of repairing) increasedFactoryProduction requires all isFactory units to have a "_it" image variant (and "_hit" and "_it_hit") -->
-						<techname name="increasedFactoryProduction"/>
-						<!-- (rolls a die at the end of the player's turn, adds that many PUs to their bank) -->
-						<techname name="warBonds"/>
-						<!-- (allows isLandTransport units to carry isInfantry units) -->
-						<techname name="mechanizedInfantry"/>
-						<!-- (destroyerBombard allows isDestroyer to bombard) this is an example of renaming a technology. the first part is the new name, the second is the old name (the hardcoded tech's name) -->
-						<techname name="destroyersCanBombard" tech="destroyerBombard"/>
-						<!-- (industrialTechnology replaces a users production frontier with one called productionIndustrialTechnology (and i don't use it in this map))
-						<techname name="industrialTechnology"/> -->
-						
-						<!-- below is a list of user created techs. they do nothing by themselves, but can be used a conditions for triggers. simply use a name that isn't already taken by a hardcoded tech -->
-						<techname name="reinforcedHulls"/>
-						<techname name="wolfPackTactics"/>
-				</technologies>
-				<!-- list all available techs for this player -->
-				<playerTech player="Italians">
-						<!-- Number of categories is unlimited. Use descriptive names, as they are shown to the player. You may have empty categories, if you plan on adding to them inside the game using triggers -->
-						<!-- At least minimum of 0 techs per category, max of 6 per category if using ww2v3-style random selection of techs, 
-								max is unlimited if using ww2v2-style selected techs (however, any number of techs per category greater than 6 will be unreachable by the dice chooser)  -->
-						<!-- please list techs in the order that they appear in the technoligies list, as doing otherwise may cause an error -->
-						<!-- you can have a technology listed more than once, if you want to increase the chance of getting it -->
-						<category name="Italian Technology">
-								<tech name="destroyersCanBombard"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="improvedArtillerySupport"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-						</category>
-				</playerTech>
-				<playerTech player="Russians">
-						<category name="Air and Naval Advances">
-								<tech name="destroyersCanBombard"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="improvedArtillerySupport"/>
-								<tech name="rocket"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-								<tech name="mechanizedInfantry"/>
-						</category>
-				</playerTech>
-				<playerTech player="Germans">
-						<category name="Air and Naval Advances">
-								<tech name="superSub"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="rocket"/>
-								<tech name="paratroopers"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="mechanizedInfantry"/>
-						</category>
-						<category name="Submarine Technology">
-								<!-- as you can see, this category is empty.  that is because we will add techs to this category later by triggers -->
-						</category>
-				</playerTech>
-				<playerTech player="British">
-						<category name="Air and Naval Advances">
-								<tech name="destroyersCanBombard"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="rocket"/>
-								<tech name="paratroopers"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-						</category>
-				</playerTech>
-				<playerTech player="Japanese">
-						<category name="Air and Naval Advances">
-								<tech name="superSub"/>
-								<tech name="jetPower"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="rocket"/>
-								<tech name="paratroopers"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-								<tech name="mechanizedInfantry"/>
-						</category>
-				</playerTech>
-				<playerTech player="Americans">
-						<category name="Air and Naval Advances">
-								<tech name="superSub"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="paratroopers"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-								<tech name="mechanizedInfantry"/>
-						</category>
-				</playerTech>
-				<playerTech player="Chinese">
-						<category name="Air and Naval Advances">
-								<tech name="superSub"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="rocket"/>
-								<tech name="paratroopers"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-								<tech name="mechanizedInfantry"/>
-						</category>
-				</playerTech>
-		</technology>
-
-		<attachmentList>
-		
+        <info name="Pact of Steel 2 Test" version="3.6"/>
+
+                <!-- A MOD of original POS by VEQRYN
+                        The purpose is to provide a fun game that shows off all the new features of TripleA since 1.2.5.5
+                        as well include documentation inside the xml in order to show map makers how to use all the new features.
+                        If you have questions on how to use something, or think my documentation is not clear enough,
+                        please go to the forum and make a post: http://triplea.sourceforge.net/mywiki/Forum
+                -->
+
+        <!-- loader is required by all xmls.  some xmls may use a different loader, like a puzzle game -->
+        <loader javaClass="games.strategy.triplea.TripleA"/>
+
+        <!-- triplea minimumVersion is the minimum version number of TripleA that can play this game.  Many new xmls require features not present in older versions of TripleA. Should be "xx.xx.xx.xx", "xx.xx.xx", "xx.xx", or "xx".
+                An example would be a map using 'isInfrastructure' unit property would need at least TripleA version "1.2.6", while a map using 'whenCapturedChangesInto' would need at least TripleA version "1.4" -->
+        <triplea minimumVersion="1.7"/>
+
+        <!-- diceSides defaults to 6 if not in the xml.  Can be set to any number between 1 and 200.  Setting diceSides to a number other than 6 can result in unexpected behavior. -->
+        <diceSides value="6"/>
+
+        <map>
+                <!-- Territory Definitions -->
+                <territory name="Eastern Canada"/>
+                <territory name="Italy"/>
+                <territory name="Sicily"/>
+                <territory name="Sardinia"/>
+                <territory name="Central China"/>
+                <territory name="East Balkans"/>
+                <territory name="West Balkans"/>
+                <territory name="Greece"/>
+                <territory name="Germany"/>
+                <territory name="Midway"/>
+                <territory name="Greenland"/>
+                <territory name="Union of South Africa"/>
+                <territory name="Australia"/>
+                <territory name="Kenya"/>
+                <territory name="Manchuria"/>
+                <territory name="Alaska"/>
+                <territory name="Persia"/>
+                <territory name="French West Africa"/>
+                <territory name="Turkey"/>
+                <territory name="Belgian Congo"/>
+                <territory name="India"/>
+                <territory name="Soviet Far East"/>
+                <territory name="Mexico"/>
+                <territory name="Spain"/>
+                <territory name="Afghanistan"/>
+                <territory name="Philipine Islands"/>
+                <territory name="Archangel"/>
+                <territory name="Novisibirsk"/>
+                <territory name="Eire"/>
+                <territory name="Mozambique"/>
+                <territory name="Italian East Africa"/>
+                <territory name="Eastern Europe"/>
+                <territory name="Western United States"/>
+                <territory name="Karelia S.S.R."/>
+                <territory name="Kwangtung"/>
+                <territory name="Brazil"/>
+                <territory name="Borneo" />
+                <territory name="French Madagascar"/>
+                <territory name="Yakut S.S.R."/>
+                <territory name="Hawaiian Islands"/>
+                <territory name="East Indies"/>
+                <territory name="Saudia Arabia"/>
+                <territory name="Switzerland"/>
+                <territory name="Norway"/>
+                <territory name="French Indochina"/>
+                <territory name="West Indies"/>
+                <territory name="Kazakh S.S.R."/>
+                <territory name="Venezuala"/>
+                <territory name="Trans-Jordan"/>
+                <territory name="United Kingdom"/>
+                <territory name="Western Europe"/>
+                <territory name="Rio De Oro"/>
+                <territory name="Angloa"/>
+                <territory name="New Zealand"/>
+                <territory name="Sahara"/>
+                <territory name="French Equatorial Africa"/>
+                <territory name="Gibraltar"/>
+                <territory name="Solomon Islands"/>
+                <territory name="Caucus"/>
+                <territory name="Sinkiang"/>
+                <territory name="Algeria"/>
+                <territory name="Wake Island"/>
+                <territory name="Himilaya"/>
+                <territory name="Evanki National Okrug"/>
+                <territory name="Sweden"/>
+                <territory name="Libya"/>
+                <territory name="Ukraine S.S.R."/>
+                <territory name="Mongolia"/>
+                <territory name="West Russia"/>
+                <territory name="Peru"/>
+                <territory name="Eastern United States"/>
+                <territory name="Belorussia"/>
+                <territory name="Burytia S.S.R."/>
+                <territory name="Russia"/>
+                <territory name="Anglo Egypt"/>
+                <territory name="New Guinea"/>
+                <territory name="Okinawa"/>
+                <territory name="Panama"/>
+                <territory name="Western Canada"/>
+                <territory name="Central United States"/>
+                <territory name="Argentina"/>
+                <territory name="China"/>
+                <territory name="Japan"/>
+                <territory name="Caroline Islands"/>
+                <territory name="15B Sea Zone" water="true"/>
+                <territory name="28 Sea Zone" water="true"/>
+                <territory name="56 Sea Zone" water="true"/>
+                <territory name="7 Sea Zone" water="true"/>
+                <territory name="31 Sea Zone" water="true"/>
+                <territory name="27 Sea Zone" water="true"/>
+                <territory name="5 Sea Zone" water="true" />
+                <territory name="23 Sea Zone" water="true"/>
+                <territory name="53 Sea Zone" water="true"/>
+                <territory name="42 Sea Zone" water="true"/>
+                <territory name="59 Sea Zone" water="true"/>
+                <territory name="30 Sea Zone" water="true"/>
+                <territory name="50 Sea Zone" water="true"/>
+                <territory name="54 Sea Zone" water="true"/>
+                <territory name="43 Sea Zone" water="true"/>
+                <territory name="41 Sea Zone" water="true"/>
+                <territory name="4 Sea Zone" water="true"/>
+                <territory name="44 Sea Zone" water="true"/>
+                <territory name="11 Sea Zone" water="true"/>
+                <territory name="51 Sea Zone" water="true"/>
+                <territory name="25 Sea Zone" water="true"/>
+                <territory name="29 Sea Zone" water="true"/>
+                <territory name="34 Sea Zone" water="true"/>
+                <territory name="12 Sea Zone" water="true"/>
+                <territory name="32 Sea Zone" water="true"/>
+                <territory name="46 Sea Zone" water="true"/>
+                <territory name="63 Sea Zone" water="true"/>
+                <territory name="8 Sea Zone" water="true"/>
+                <territory name="26 Sea Zone" water="true"/>
+                <territory name="38 Sea Zone" water="true"/>
+                <territory name="3 Sea Zone" water="true"/>
+                <territory name="37 Sea Zone" water="true"/>
+                <territory name="6 Sea Zone" water="true"/>
+                <territory name="9 Sea Zone" water="true"/>
+                <territory name="61 Sea Zone" water="true"/>
+                <territory name="39 Sea Zone" water="true"/>
+                <territory name="36 Sea Zone" water="true"/>
+                <territory name="49 Sea Zone" water="true"/>
+                <territory name="64 Sea Zone" water="true"/>
+                <territory name="45 Sea Zone" water="true"/>
+                <territory name="57 Sea Zone" water="true"/>
+                <territory name="52 Sea Zone" water="true"/>
+                <territory name="1 Sea Zone" water="true"/>
+                <territory name="48 Sea Zone" water="true"/>
+                <territory name="17 Sea Zone" water="true"/>
+                <territory name="10 Sea Zone" water="true"/>
+                <territory name="15 Sea Zone" water="true"/>
+                <territory name="2 Sea Zone" water="true"/>
+                <territory name="33 Sea Zone" water="true"/>
+                <territory name="14 Sea Zone" water="true"/>
+                <territory name="13 Sea Zone" water="true"/>
+                <territory name="55 Sea Zone" water="true"/>
+                <territory name="35 Sea Zone" water="true"/>
+                <territory name="16 Sea Zone" water="true"/>
+                <territory name="19 Sea Zone" water="true"/>
+                <territory name="60 Sea Zone" water="true"/>
+                <territory name="62 Sea Zone" water="true"/>
+                <territory name="21 Sea Zone" water="true"/>
+                <territory name="22 Sea Zone" water="true"/>
+                <territory name="18 Sea Zone" water="true"/>
+                <territory name="47 Sea Zone" water="true"/>
+                <territory name="58 Sea Zone" water="true"/>
+                <territory name="40 Sea Zone" water="true"/>
+                <territory name="24 Sea Zone" water="true"/>
+                <territory name="20 Sea Zone" water="true"/>
+
+                <!-- Territory Connections -->
+                <connection t1="Italy" t2="Sicily"/>
+                <connection t1="Italy" t2="14 Sea Zone"/>
+                <connection t1="Italy" t2="West Balkans"/>
+                <connection t1="Italy" t2="Germany"/>
+                <connection t1="Italy" t2="Western Europe"/>
+                <connection t1="Sicily" t2="14 Sea Zone"/>
+                <connection t1="Sicily" t2="13 Sea Zone"/>
+                <connection t1="Sardinia" t2="13 Sea Zone"/>
+                <connection t1="Sardinia" t2="14 Sea Zone"/>
+                <connection t1="West Balkans" t2="Greece"/>
+                <connection t1="West Balkans" t2="East Balkans"/>
+                <connection t1="West Balkans" t2="Germany"/>
+                <connection t1="West Balkans" t2="14 Sea Zone"/>
+                <connection t1="Greece" t2="East Balkans"/>
+                <connection t1="Greece" t2="14 Sea Zone"/>
+                <connection t1="Greece" t2="15B Sea Zone"/>
+                <connection t1="15B Sea Zone" t2="14 Sea Zone"/>
+                <connection t1="15B Sea Zone" t2="15 Sea Zone"/>
+                <connection t1="15B Sea Zone" t2="16 Sea Zone"/>
+                <connection t1="15B Sea Zone" t2="East Balkans"/>
+                <connection t1="16 Sea Zone" t2="East Balkans"/>
+                <connection t1="Sweden" t2="Norway"/>
+                <connection t1="Sweden" t2="5 Sea Zone"/>
+                <connection t1="Switzerland" t2="Germany"/>
+                <connection t1="Switzerland" t2="Western Europe"/>
+                <connection t1="Switzerland" t2="Italy"/>
+                <connection t1="2 Sea Zone" t2="Eire"/>
+                <connection t1="12 Sea Zone" t2="Spain"/>
+                <connection t1="13 Sea Zone" t2="Spain"/>
+                <connection t1="15 Sea Zone" t2="Turkey"/>
+                <connection t1="16 Sea Zone" t2="Turkey"/>
+                <connection t1="17 Sea Zone" t2="Rio De Oro"/>
+                <connection t1="19 Sea Zone" t2="Venezuala"/>
+                <connection t1="20 Sea Zone" t2="Venezuala"/>
+                <connection t1="21 Sea Zone" t2="Peru"/>
+                <connection t1="21 Sea Zone" t2="Argentina"/>
+                <connection t1="25 Sea Zone" t2="Argentina"/>
+                <connection t1="27 Sea Zone" t2="Angloa"/>
+                <connection t1="33 Sea Zone" t2="Mozambique"/>
+                <connection t1="34 Sea Zone" t2="Saudia Arabia"/>
+                <connection t1="Panama" t2="Venezuala"/>
+                <connection t1="Venezuala" t2="Brazil"/>
+                <connection t1="Venezuala" t2="Peru"/>
+                <connection t1="Brazil" t2="Peru"/>
+                <connection t1="Brazil" t2="Argentina"/>
+                <connection t1="Peru" t2="Argentina"/>
+                <connection t1="Eire" t2="United Kingdom"/>
+                <connection t1="Gibraltar" t2="Spain"/>
+                <connection t1="Spain" t2="Western Europe"/>
+                <connection t1="Caucus" t2="Turkey"/>
+                <connection t1="Kazakh S.S.R." t2="Afghanistan"/>
+                <connection t1="Himilaya" t2="Afghanistan"/>
+                <connection t1="India" t2="Afghanistan"/>
+                <connection t1="India" t2="Himilaya"/>
+                <connection t1="Sinkiang" t2="Himilaya"/>
+                <connection t1="China" t2="Himilaya"/>
+                <connection t1="French Indochina" t2="Himilaya"/>
+                <connection t1="Novisibirsk" t2="Mongolia"/>
+                <connection t1="Sinkiang" t2="Mongolia"/>
+                <connection t1="Manchuria" t2="Mongolia"/>
+                <connection t1="China" t2="Mongolia"/>
+                <connection t1="Sinkiang" t2="Central China"/>
+                <connection t1="China" t2="Central China"/>
+                <connection t1="Central China" t2="Mongolia"/>
+                <connection t1="Central China" t2="Himilaya"/>
+                <connection t1="Yakut S.S.R." t2="Mongolia"/>
+                <connection t1="Burytia S.S.R." t2="Mongolia"/>
+                <connection t1="Persia" t2="Afghanistan"/>
+                <connection t1="Persia" t2="Turkey"/>
+                <connection t1="Trans-Jordan" t2="Turkey"/>
+                <connection t1="Trans-Jordan" t2="Saudia Arabia"/>
+                <connection t1="Anglo Egypt" t2="Sahara"/>
+                <connection t1="Libya" t2="Sahara"/>
+                <connection t1="Algeria" t2="Sahara"/>
+                <connection t1="French West Africa" t2="Sahara"/>
+                <connection t1="French Equatorial Africa" t2="Sahara"/>
+                <connection t1="French West Africa" t2="Rio De Oro"/>
+                <connection t1="Belgian Congo" t2="Angloa"/>
+                <connection t1="Kenya" t2="Angloa"/>
+                <connection t1="Kenya" t2="Mozambique"/>
+                <connection t1="Union of South Africa" t2="Angloa"/>
+                <connection t1="Union of South Africa" t2="Mozambique"/>
+                <connection t1="1 Sea Zone" t2="Eastern Canada" />
+                <connection t1="1 Sea Zone" t2="2 Sea Zone"/>
+                <connection t1="1 Sea Zone" t2="8 Sea Zone"/>
+                <connection t1="1 Sea Zone" t2="9 Sea Zone"/>
+                <connection t1="2 Sea Zone" t2="Greenland"/>
+                <connection t1="2 Sea Zone" t2="United Kingdom"/>
+                <connection t1="2 Sea Zone" t2="3 Sea Zone"/>
+                <connection t1="2 Sea Zone" t2="8 Sea Zone"/>
+                <connection t1="3 Sea Zone" t2="4 Sea Zone"/>
+                <connection t1="3 Sea Zone" t2="6 Sea Zone"/>
+                <connection t1="3 Sea Zone" t2="United Kingdom"/>
+                <connection t1="3 Sea Zone" t2="Norway"/>
+                <connection t1="4 Sea Zone" t2="Karelia S.S.R."/>
+                <connection t1="4 Sea Zone" t2="Archangel"/>
+                <connection t1="5 Sea Zone" t2="6 Sea Zone"/>
+                <connection t1="5 Sea Zone" t2="Norway"/>
+                <connection t1="5 Sea Zone" t2="Karelia S.S.R."/>
+                <connection t1="5 Sea Zone" t2="Eastern Europe"/>
+                <connection t1="5 Sea Zone" t2="Germany"/>
+                <connection t1="5 Sea Zone" t2="Western Europe"/>
+                <connection t1="6 Sea Zone" t2="7 Sea Zone"/>
+                <connection t1="6 Sea Zone" t2="United Kingdom"/>
+                <connection t1="6 Sea Zone" t2="Norway"/>
+                <connection t1="6 Sea Zone" t2="Western Europe"/>
+                <connection t1="7 Sea Zone" t2="8 Sea Zone"/>
+                <connection t1="7 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="7 Sea Zone" t2="United Kingdom"/>
+                <connection t1="7 Sea Zone" t2="Western Europe"/>
+                <connection t1="8 Sea Zone" t2="9 Sea Zone"/>
+                <connection t1="8 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="8 Sea Zone" t2="United Kingdom"/>
+                <connection t1="9 Sea Zone" t2="10 Sea Zone"/>
+                <connection t1="9 Sea Zone" t2="11 Sea Zone"/>
+                <connection t1="9 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="9 Sea Zone" t2="Eastern Canada"/>
+                <connection t1="10 Sea Zone" t2="11 Sea Zone"/>
+                <connection t1="10 Sea Zone" t2="19 Sea Zone"/>
+                <connection t1="10 Sea Zone" t2="Eastern United States"/>
+                <connection t1="10 Sea Zone" t2="Panama"/>
+                <connection t1="11 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="11 Sea Zone" t2="18 Sea Zone"/>
+                <connection t1="11 Sea Zone" t2="19 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="13 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="17 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="18 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="Algeria"/>
+                <connection t1="13 Sea Zone" t2="14 Sea Zone"/>
+                <connection t1="13 Sea Zone" t2="Gibraltar"/>
+                <connection t1="13 Sea Zone" t2="Western Europe"/>
+                <connection t1="13 Sea Zone" t2="Algeria"/>
+                <connection t1="14 Sea Zone" t2="15 Sea Zone"/>
+                <connection t1="14 Sea Zone" t2="Libya"/>
+                <connection t1="15 Sea Zone" t2="34 Sea Zone"/>
+                <connection t1="15 Sea Zone" t2="Trans-Jordan"/>
+                <connection t1="15 Sea Zone" t2="Anglo Egypt"/>
+                <connection t1="16 Sea Zone" t2="East Balkans"/>
+                <connection t1="16 Sea Zone" t2="Ukraine S.S.R."/>
+                <connection t1="16 Sea Zone" t2="Caucus"/>
+                <connection t1="17 Sea Zone" t2="18 Sea Zone"/>
+                <connection t1="17 Sea Zone" t2="22 Sea Zone"/>
+                <connection t1="17 Sea Zone" t2="23 Sea Zone"/>
+                <connection t1="17 Sea Zone" t2="French West Africa"/>
+                <connection t1="18 Sea Zone" t2="19 Sea Zone"/>
+                <connection t1="18 Sea Zone" t2="22 Sea Zone"/>
+                <connection t1="18 Sea Zone" t2="Brazil"/>
+                <connection t1="19 Sea Zone" t2="20 Sea Zone"/>
+                <connection t1="19 Sea Zone" t2="Panama"/>
+                <connection t1="19 Sea Zone" t2="West Indies"/>
+                <connection t1="20 Sea Zone" t2="21 Sea Zone"/>
+                <connection t1="20 Sea Zone" t2="54 Sea Zone"/>
+                <connection t1="20 Sea Zone" t2="Panama"/>
+                <connection t1="21 Sea Zone" t2="25 Sea Zone"/>
+                <connection t1="21 Sea Zone" t2="43 Sea Zone"/>
+                <connection t1="22 Sea Zone" t2="23 Sea Zone"/>
+                <connection t1="22 Sea Zone" t2="24 Sea Zone"/>
+                <connection t1="22 Sea Zone" t2="25 Sea Zone"/>
+                <connection t1="22 Sea Zone" t2="Brazil"/>
+                <connection t1="23 Sea Zone" t2="24 Sea Zone"/>
+                <connection t1="23 Sea Zone" t2="27 Sea Zone"/>
+                <connection t1="23 Sea Zone" t2="French Equatorial Africa"/>
+                <connection t1="23 Sea Zone" t2="Belgian Congo"/>
+                <connection t1="24 Sea Zone" t2="25 Sea Zone"/>
+                <connection t1="24 Sea Zone" t2="26 Sea Zone"/>
+                <connection t1="24 Sea Zone" t2="27 Sea Zone"/>
+                <connection t1="25 Sea Zone" t2="26 Sea Zone"/>
+                <connection t1="25 Sea Zone" t2="42 Sea Zone"/>
+                <connection t1="25 Sea Zone" t2="43 Sea Zone"/>
+                <connection t1="26 Sea Zone" t2="27 Sea Zone"/>
+                <connection t1="27 Sea Zone" t2="28 Sea Zone"/>
+                <connection t1="27 Sea Zone" t2="Union of South Africa"/>
+                <connection t1="28 Sea Zone" t2="29 Sea Zone"/>
+                <connection t1="28 Sea Zone" t2="33 Sea Zone"/>
+                <connection t1="28 Sea Zone" t2="Union of South Africa"/>
+                <connection t1="28 Sea Zone" t2="French Madagascar"/>
+                <connection t1="29 Sea Zone" t2="32 Sea Zone"/>
+                <connection t1="29 Sea Zone" t2="30 Sea Zone"/>
+                <connection t1="29 Sea Zone" t2="French Madagascar"/>
+                <connection t1="30 Sea Zone" t2="31 Sea Zone"/>
+                <connection t1="30 Sea Zone" t2="32 Sea Zone"/>
+                <connection t1="30 Sea Zone" t2="38 Sea Zone"/>
+                <connection t1="30 Sea Zone" t2="39 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="32 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="35 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="37 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="38 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="33 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="34 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="35 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="French Madagascar"/>
+                <connection t1="33 Sea Zone" t2="34 Sea Zone"/>
+                <connection t1="33 Sea Zone" t2="French Madagascar"/>
+                <connection t1="33 Sea Zone" t2="Kenya"/>
+                <connection t1="34 Sea Zone" t2="35 Sea Zone"/>
+                <connection t1="34 Sea Zone" t2="Italian East Africa"/>
+                <connection t1="34 Sea Zone" t2="Anglo Egypt"/>
+                <connection t1="34 Sea Zone" t2="Trans-Jordan"/>
+                <connection t1="34 Sea Zone" t2="Persia"/>
+                <connection t1="35 Sea Zone" t2="36 Sea Zone"/>
+                <connection t1="35 Sea Zone" t2="37 Sea Zone"/>
+                <connection t1="35 Sea Zone" t2="India"/>
+                <connection t1="36 Sea Zone" t2="37 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="49 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="59 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="French Indochina"/>
+                <connection t1="37 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="38 Sea Zone" t2="46 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="56 Sea Zone"/>
+                <connection t1="37 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="37 Sea Zone" t2="38 Sea Zone"/>
+                <connection t1="37 Sea Zone" t2="East Indies"/>
+                <connection t1="38 Sea Zone" t2="39 Sea Zone"/>
+                <connection t1="38 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="38 Sea Zone" t2="Australia"/>
+                <connection t1="39 Sea Zone" t2="40 Sea Zone"/>
+                <connection t1="39 Sea Zone" t2="Australia"/>
+                <connection t1="40 Sea Zone" t2="41 Sea Zone"/>
+                <connection t1="40 Sea Zone" t2="46 Sea Zone"/>
+                <connection t1="40 Sea Zone" t2="Australia"/>
+                <connection t1="41 Sea Zone" t2="46 Sea Zone"/>
+                <connection t1="41 Sea Zone" t2="45 Sea Zone"/>
+                <connection t1="41 Sea Zone" t2="42 Sea Zone"/>
+                <connection t1="41 Sea Zone" t2="44 Sea Zone"/>
+                <connection t1="41 Sea Zone" t2="New Zealand"/>
+                <connection t1="42 Sea Zone" t2="43 Sea Zone"/>
+                <connection t1="42 Sea Zone" t2="44 Sea Zone"/>
+                <connection t1="43 Sea Zone" t2="25 Sea Zone"/>
+                <connection t1="43 Sea Zone" t2="44 Sea Zone"/>
+                <connection t1="43 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="43 Sea Zone" t2="54 Sea Zone"/>
+                <connection t1="44 Sea Zone" t2="45 Sea Zone"/>
+                <connection t1="44 Sea Zone" t2="52 Sea Zone"/>
+                <connection t1="44 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="46 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="50 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="51 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="52 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="Solomon Islands"/>
+                <connection t1="46 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="Australia"/>
+                <connection t1="47 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="47 Sea Zone" t2="50 Sea Zone"/>
+                <connection t1="47 Sea Zone" t2="New Guinea"/>
+                <connection t1="48 Sea Zone" t2="49 Sea Zone"/>
+                <connection t1="48 Sea Zone" t2="50 Sea Zone"/>
+                <connection t1="48 Sea Zone" t2="Borneo"/>
+                <connection t1="49 Sea Zone" t2="50 Sea Zone"/>
+                <connection t1="49 Sea Zone" t2="58 Sea Zone"/>
+                <connection t1="49 Sea Zone" t2="59 Sea Zone"/>
+                <connection t1="49 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="49 Sea Zone" t2="Philipine Islands"/>
+                <connection t1="50 Sea Zone" t2="58 Sea Zone"/>
+                <connection t1="50 Sea Zone" t2="51 Sea Zone"/>
+                <connection t1="50 Sea Zone" t2="Caroline Islands"/>
+                <connection t1="51 Sea Zone" t2="52 Sea Zone"/>
+                <connection t1="51 Sea Zone" t2="58 Sea Zone"/>
+                <connection t1="51 Sea Zone" t2="57 Sea Zone"/>
+                <connection t1="51 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="51 Sea Zone" t2="Wake Island"/>
+                <connection t1="52 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="55 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="57 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="Hawaiian Islands"/>
+                <connection t1="53 Sea Zone" t2="54 Sea Zone"/>
+                <connection t1="53 Sea Zone" t2="55 Sea Zone"/>
+                <connection t1="54 Sea Zone" t2="55 Sea Zone"/>
+                <connection t1="54 Sea Zone" t2="Mexico"/>
+                <connection t1="54 Sea Zone" t2="Western United States"/>
+                <connection t1="55 Sea Zone" t2="56 Sea Zone"/>
+                <connection t1="55 Sea Zone" t2="64 Sea Zone"/>
+                <connection t1="55 Sea Zone" t2="Western United States"/>
+                <connection t1="55 Sea Zone" t2="Western Canada"/>
+                <connection t1="56 Sea Zone" t2="57 Sea Zone"/>
+                <connection t1="56 Sea Zone" t2="63 Sea Zone"/>
+                <connection t1="56 Sea Zone" t2="64 Sea Zone"/>
+                <connection t1="56 Sea Zone" t2="Midway"/>
+                <connection t1="57 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="62 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="63 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="Midway"/>
+                <connection t1="58 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="58 Sea Zone" t2="Okinawa"/>
+                <connection t1="59 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="59 Sea Zone" t2="61 Sea Zone"/>
+                <connection t1="59 Sea Zone" t2="Kwangtung"/>
+                <connection t1="60 Sea Zone" t2="61 Sea Zone"/>
+                <connection t1="60 Sea Zone" t2="62 Sea Zone"/>
+                <connection t1="60 Sea Zone" t2="Japan"/>
+                <connection t1="60 Sea Zone" t2="Burytia S.S.R."/>
+                <connection t1="61 Sea Zone" t2="Japan"/>
+                <connection t1="61 Sea Zone" t2="Manchuria"/>
+                <connection t1="62 Sea Zone" t2="63 Sea Zone"/>
+                <connection t1="62 Sea Zone" t2="Burytia S.S.R."/>
+                <connection t1="62 Sea Zone" t2="Soviet Far East"/>
+                <connection t1="63 Sea Zone" t2="64 Sea Zone"/>
+                <connection t1="63 Sea Zone" t2="Alaska"/>
+                <connection t1="63 Sea Zone" t2="Western Canada"/>
+                <connection t1="64 Sea Zone" t2="Alaska"/>
+                <connection t1="64 Sea Zone" t2="Western Canada"/>
+                <connection t1="Eastern Canada" t2="Eastern United States"/>
+                <connection t1="Eastern Canada" t2="Western Canada"/>
+                <connection t1="Eastern United States" t2="Central United States"/>
+                <connection t1="Central United States" t2="Western Canada"/>
+                <connection t1="Central United States" t2="Western United States"/>
+                <connection t1="Western United States" t2="Mexico"/>
+                <connection t1="Central United States" t2="Mexico"/>
+                <connection t1="Western United States" t2="Western Canada"/>
+                <connection t1="Western Canada" t2="Alaska"/>
+                <connection t1="Eastern United States" t2="Panama"/>
+                <connection t1="Panama" t2="Mexico"/>
+                <connection t1="Western Europe" t2="Germany"/>
+                <connection t1="Germany" t2="East Balkans"/>
+                <connection t1="Germany" t2="Eastern Europe"/>
+                <connection t1="East Balkans" t2="Eastern Europe"/>
+                <connection t1="East Balkans" t2="Ukraine S.S.R."/>
+                <connection t1="Eastern Europe" t2="Ukraine S.S.R."/>
+                <connection t1="Eastern Europe" t2="Belorussia"/>
+                <connection t1="Eastern Europe" t2="Karelia S.S.R."/>
+                <connection t1="Karelia S.S.R." t2="Norway"/>
+                <connection t1="Karelia S.S.R." t2="Belorussia"/>
+                <connection t1="Karelia S.S.R." t2="Archangel"/>
+                <connection t1="Karelia S.S.R." t2="West Russia"/>
+                <connection t1="Belorussia" t2="West Russia"/>
+                <connection t1="Belorussia" t2="Ukraine S.S.R." />
+                <connection t1="Ukraine S.S.R." t2="West Russia"/>
+                <connection t1="Ukraine S.S.R." t2="Caucus"/>
+                <connection t1="Caucus" t2="Persia"/>
+                <connection t1="Caucus" t2="West Russia"/>
+                <connection t1="Caucus" t2="Russia"/>
+                <connection t1="Caucus" t2="Kazakh S.S.R."/>
+                <connection t1="West Russia" t2="Russia"/>
+                <connection t1="West Russia" t2="Archangel"/>
+                <connection t1="Archangel" t2="Russia"/>
+                <connection t1="Russia" t2="Evanki National Okrug"/>
+                <connection t1="Russia" t2="Novisibirsk"/>
+                <connection t1="Russia" t2="Kazakh S.S.R."/>
+                <connection t1="Kazakh S.S.R." t2="Novisibirsk"/>
+                <connection t1="Kazakh S.S.R." t2="Sinkiang"/>
+                <connection t1="Kazakh S.S.R." t2="Persia"/>
+                <connection t1="India" t2="French Indochina"/>
+                <connection t1="Evanki National Okrug" t2="Yakut S.S.R."/>
+                <connection t1="Evanki National Okrug" t2="Novisibirsk"/>
+                <connection t1="Novisibirsk" t2="Yakut S.S.R."/>
+                <connection t1="Novisibirsk" t2="Sinkiang"/>
+                <connection t1="Yakut S.S.R." t2="Soviet Far East"/>
+                <connection t1="Yakut S.S.R." t2="Burytia S.S.R."/>
+                <connection t1="Burytia S.S.R." t2="Manchuria"/>
+                <connection t1="Burytia S.S.R." t2="Soviet Far East"/>
+                <connection t1="Manchuria" t2="China"/>
+                <connection t1="Manchuria" t2="Kwangtung"/>
+                <connection t1="Kwangtung" t2="China"/>
+                <connection t1="Kwangtung" t2="French Indochina"/>
+                <connection t1="China" t2="French Indochina"/>
+                <connection t1="Persia" t2="India"/>
+                <connection t1="Persia" t2="Trans-Jordan"/>
+                <connection t1="Trans-Jordan" t2="Anglo Egypt"/>
+                <connection t1="Anglo Egypt" t2="Libya"/>
+                <connection t1="Anglo Egypt" t2="Italian East Africa"/>
+                <connection t1="Anglo Egypt" t2="French Equatorial Africa"/>
+                <connection t1="Anglo Egypt" t2="Belgian Congo"/>
+                <connection t1="Libya" t2="Algeria"/>
+                <connection t1="French West Africa" t2="French Equatorial Africa"/>
+                <connection t1="French Equatorial Africa" t2="Belgian Congo"/>
+                <connection t1="Belgian Congo" t2="Italian East Africa"/>
+                <connection t1="Belgian Congo" t2="Kenya"/>
+                <connection t1="Italian East Africa" t2="Kenya"/>
+                <connection t1="Kenya" t2="Union of South Africa"/>
+                <!-- The order of t1 and t2 does not matter at all -->
+        </map>
+
+
+
+        <resourceList>
+                <!-- PUs and techTokens are default supported resources. (all maps should use "PUs" as the default "money", as a map without PUs may fail. -->
+                <resource name="PUs"/>
+                <resource name="techTokens"/>
+                <!-- These are custom resources.
+                <resource name="Steel"/>
+                <resource name="Aluminium"/>
+                <resource name="Fuel"/>
+                <resource name="SuicideAttackTokens"/>-->
+                <!-- VPs are only semi-supported by the code as of right now. They are used for special pacific rules.
+                <resource name="VPs"/>-->
+        </resourceList>
+
+        <playerList>
+                <!-- In turn order (it is important that the players are listed in turn order)-->
+                <player name="Italians" optional="false"/>
+                <player name="Russians" optional="false"/>
+                <player name="Germans" optional="false"/>
+                <player name="British" optional="false"/>
+                <player name="Japanese" optional="false"/>
+                <player name="Americans" optional="false"/>
+                <player name="Chinese" optional="false"/>
+                <!-- optional just means 'does this player require a capital?'.  if a player is optional, some delegates may not work as expected for that player. -->
+
+
+
+                <!-- Alliances can have any name, not just axis and allies.  There can be more than 2 alliances -->
+                <!-- Since triplea version 1.3.3.0 it is preferred to use relationships instead of or in addition to alliances. If relationships are set, then alliances will only matter for the stats panel and any game option type victory conditions -->
+                <!-- Axis alliance -->
+                <alliance player="Germans" alliance="Axis"/>
+                <alliance player="Japanese" alliance="Axis"/>
+                <alliance player="Italians" alliance="Axis"/>
+
+                <!-- Allies alliance -->
+                <alliance player="British" alliance="Allies"/>
+                <alliance player="Russians" alliance="Allies"/>
+                <alliance player="Americans" alliance="Allies"/>
+                <alliance player="Chinese" alliance="Allies"/>
+
+        </playerList>
+
+        <unitList>
+                <unit name="infantry"/>
+                <unit name="artillery"/>
+                <unit name="armour"/>
+                <unit name="fighter"/>
+                <unit name="jp_fighter"/>
+                <unit name="bomber"/>
+                <unit name="air_transport"/>
+                <unit name="transport"/>
+                <unit name="jp_transport"/>
+                <unit name="submarine"/>
+                <unit name="midget_submarine"/>
+                <unit name="destroyer"/>
+                <unit name="jp_destroyer"/>
+                <unit name="cruiser"/>
+                <unit name="carrier"/>
+                <unit name="battleship"/>
+                <unit name="super_carrier"/>
+                <unit name="bunker"/>
+                <unit name="aaGun"/>
+                <unit name="factory"/>
+                <unit name="airfield"/>
+                <unit name="harbour"/>
+        </unitList>
+
+        <!--    This is the list of relationshipTypes you can create between players -->
+        <!--    Each relationshipType you define here MUST have a RelationshipTypeAttachment to define this relationship
+                Also each RelationshipTypeAttachment MUST have an archetype set to either: "allied", "neutral" or "war"
+                The following are examples, you can name them whatever you want.
+        -->
+        <relationshipTypes>
+                <relationshipType name="Allied"/>
+                <relationshipType name="War"/>
+                <relationshipType name="Neutrality"/>
+                <relationshipType name="NAP"/>
+                <relationshipType name="ColdWar"/>
+        </relationshipTypes>
+
+        <territoryEffectList>
+                <territoryEffect name="mountain"/>
+                <!--<territoryEffect name="city"/>
+                <territoryEffect name="desert"/>
+                <territoryEffect name="forest"/>
+                <territoryEffect name="hill"/>
+                <territoryEffect name="marsh"/>
+                <territoryEffect name="sahara"/>-->
+        </territoryEffectList>
+
+        <gamePlay>
+                <!-- this currently is all the delegates triplea has.  not all are needed for a regular game though -->
+                    <!-- purchaseNoPU buys 1 infantry for X number of territories controlled, rounding down. set X in player rules attachments -->
+                    <!-- endTurnNoPU ends player's turn without giving them any PUs -->
+                    <!-- placeNoAirCheck does everything normal 'place' does, except it does not kill any aircraft at the end of the turn -->
+                <delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate" display="Initializing Delegates"/>
+                <delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate" display="Research Technology"/>
+                <delegate name="tech_activation" javaClass="games.strategy.triplea.delegate.TechActivationDelegate" display="Activate Technology"/>
+                <delegate name="battle" javaClass="games.strategy.triplea.delegate.BattleDelegate" display="Combat"/>
+                <delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Combat Move"/>
+                <delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Units"/>
+                <!--<delegate name="placeNoAirCheck" javaClass="games.strategy.triplea.delegate.NoAirCheckPlaceDelegate" display="Place Units"/>-->
+                <delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
+                <delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>
+                <delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate" display="Turn Complete"/>
+                <delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
+                <delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
+                <delegate name="placeBid" javaClass="games.strategy.triplea.delegate.BidPlaceDelegate" display="Bid Placement"/>
+                <delegate name="bid" javaClass="games.strategy.triplea.delegate.BidPurchaseDelegate" display="Bid Purchase"/>
+                <delegate name="politics" javaClass="games.strategy.triplea.delegate.PoliticsDelegate" display="Politics"/>
+
+                <!-- SpecialMoveDelegate delegate is for the new Airborne forces tech (similar to paratroopers). The delegate name has to end with "AirborneCombatMove" for it to work properly.
+                GamePlay Delegate:
+                <delegate name="specialCombatMove" javaClass="games.strategy.triplea.delegate.SpecialMoveDelegate" display="Special Move"/>
+                Sequence Step Example:
+                <step name="italianAirborneCombatMove" delegate="specialCombatMove" player="Italians" display="Airborne Attack Move"/>-->
+
+                <sequence>
+                        <!-- It is very important that the "name" ends with the correct phrase, or else the game will not work properly.
+                        Please end with ("xx" = faction name): xxBid, xxBidPlace, xxTech, xxPurchase, xxCombatMove, xxBattle, xxNonCombatMove, xxPlace, xxTechActivation, xxEndTurn  -->
+
+                        <!-- a "step" may also include an option called "stepProperty", which has "name" and "value" attributes.
+                                These stepProperty options are not validated at all, so if you have a typo it will not be caught.
+                                Currently allowed stepProperty options:
+                                    For any "EndTurn" delegate (such as EndTurnDelegate or NoPUEndTurnDelegate or etc):
+                                        skipPosting         = true/false (default is false). Do we skip the Play-by-Email/Play-by-Forum turn summary and savegame Posting?
+                                        turnSummaryPlayers  = a list of players, separated by colons ":"  default is the step player.
+                                                                Determines which players this forum posting turn summary will include (will only use all steps that touch this step, or touch the step that touches this step AND is owned by one of these listed players)
+                        -->
+
+                        <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
+
+                        <!-- Bidding Phase -->
+                        <step name="italiansBid" delegate="bid" player="Italians" maxRunCount="1"/>
+                        <step name="italiansBidPlace" delegate="placeBid" player="Italians" maxRunCount="1"/>
+                        <step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
+                        <step name="russianBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
+                        <step name="germanBid" delegate="bid" player="Germans" maxRunCount="1"/>
+                        <step name="germanBidPlace" delegate="placeBid" player="Germans" maxRunCount="1"/>
+                        <step name="britishBid" delegate="bid" player="British" maxRunCount="1"/>
+                        <step name="britishBidPlace" delegate="placeBid" player="British" maxRunCount="1"/>
+                        <step name="japaneseBid" delegate="bid" player="Japanese" maxRunCount="1"/>
+                        <step name="japaneseBidPlace" delegate="placeBid" player="Japanese" maxRunCount="1"/>
+                        <step name="americanBid" delegate="bid" player="Americans" maxRunCount="1"/>
+                        <step name="americanBidPlace" delegate="placeBid" player="Americans" maxRunCount="1"/>
+                        <step name="chineseBid" delegate="bid" player="Chinese" maxRunCount="1"/>
+                        <step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
+
+                        <!-- it is generally a good idea to put tech activation at the end of the turn, for balancing reasons -->
+                        <!-- Italians Game Sequence -->
+                        <step name="italianTech" delegate="tech" player="Italians"/>
+                        <step name="italianPurchase" delegate="purchase" player="Italians"/>
+                        <step name="italianPolitics" delegate="politics" player="Italians"/>
+                        <step name="italianCombatMove" delegate="move" player="Italians"/>
+                        <step name="italianBattle" delegate="battle" player="Italians"/>
+                        <step name="italianNonCombatMove" delegate="move" player="Italians" display="Non Combat Move"/>
+                        <step name="italianPlace" delegate="place" player="Italians"/>
+                        <step name="italianTechActivation" delegate="tech_activation" player="Italians"/>
+                        <step name="italianEndTurn" delegate="endTurn" player="Italians"/>
+
+                        <!-- Russians Game Sequence -->
+                        <step name="russianTech" delegate="tech" player="Russians"/>
+                        <step name="russianPurchase" delegate="purchase" player="Russians"/>
+                        <step name="russianPolitics" delegate="politics" player="Russians"/>
+                        <step name="russianCombatMove" delegate="move" player="Russians"/>
+                        <step name="russianBattle" delegate="battle" player="Russians"/>
+                        <step name="russianNonCombatMove" delegate="move" player="Russians" display="Non Combat Move"/>
+                        <step name="russianPlace" delegate="place" player="Russians"/>
+                        <step name="russianTechActivation" delegate="tech_activation" player="Russians"/>
+                        <step name="russianEndTurn" delegate="endTurn" player="Russians"/>
+
+                        <!-- Germans Game Sequence -->
+                        <step name="germanTech" delegate="tech" player="Germans"/>
+                        <step name="germanPurchase" delegate="purchase" player="Germans"/>
+                        <step name="germanPolitics" delegate="politics" player="Germans"/>
+                        <step name="germanCombatMove" delegate="move" player="Germans"/>
+                        <step name="germanBattle" delegate="battle" player="Germans"/>
+                        <step name="germanNonCombatMove" delegate="move" player="Germans" display="Non Combat Move"/>
+                        <step name="germanPlace" delegate="place" player="Germans"/>
+                        <step name="germanTechActivation" delegate="tech_activation" player="Germans"/>
+                        <step name="germanEndTurn" delegate="endTurn" player="Germans"/>
+
+                        <!-- British Game Sequence -->
+                        <step name="britishTech" delegate="tech" player="British"/>
+                        <step name="britishPurchase" delegate="purchase" player="British"/>
+                        <step name="britishPolitics" delegate="politics" player="British"/>
+                        <step name="britishCombatMove" delegate="move" player="British"/>
+                        <step name="britishBattle" delegate="battle" player="British"/>
+                        <step name="britishNonCombatMove" delegate="move" player="British" display="Non Combat Move"/>
+                        <step name="britishPlace" delegate="place" player="British"/>
+                        <step name="britishTechActivation" delegate="tech_activation" player="British"/>
+                        <step name="britishEndTurn" delegate="endTurn" player="British"/>
+
+                        <!-- Japanese Game Sequence -->
+                        <step name="japaneseTech" delegate="tech" player="Japanese"/>
+                        <step name="japanesePurchase" delegate="purchase" player="Japanese"/>
+                        <step name="japanesePolitics" delegate="politics" player="Japanese"/>
+                        <step name="japaneseCombatMove" delegate="move" player="Japanese"/>
+                        <step name="japaneseBattle" delegate="battle" player="Japanese"/>
+                        <step name="japaneseNonCombatMove" delegate="move" player="Japanese" display="Non Combat Move"/>
+                        <step name="japanesePlace" delegate="place" player="Japanese"/>
+                        <step name="japaneseTechActivation" delegate="tech_activation" player="Japanese"/>
+                        <step name="japaneseEndTurn" delegate="endTurn" player="Japanese">
+                                <stepProperty name="skipPosting" value="false"/>
+                        </step>
+
+                        <!-- Americans Game Sequence -->
+                        <step name="americanTech" delegate="tech" player="Americans"/>
+                        <step name="americanPurchase" delegate="purchase" player="Americans"/>
+                        <step name="americanPolitics" delegate="politics" player="Americans"/>
+                        <step name="americanCombatMove" delegate="move" player="Americans"/>
+                        <step name="americanBattle" delegate="battle" player="Americans"/>
+                        <step name="americanNonCombatMove" delegate="move" player="Americans" display="Non Combat Move"/>
+                        <step name="americanPlace" delegate="place" player="Americans"/>
+                        <step name="americanTechActivation" delegate="tech_activation" player="Americans"/>
+                        <!--<step name="americanEndTurn" delegate="endTurn" player="Americans"/>-->
+                        <step name="americanEndTurn" delegate="endTurn" player="Americans">
+                                <!--<stepProperty name="skipPosting" value="true"/>-->
+                                <stepProperty name="turnSummaryPlayers" value="Americans"/>
+                        </step>
+
+                        <!-- Chinese Game Sequence -->
+                        <step name="chineseBurmaRoadPurchase" delegate="purchase" player="Chinese"/>
+                        <step name="chinesePolitics" delegate="politics" player="Chinese"/>
+                        <step name="chineseCombatMove" delegate="move" player="Chinese"/>
+                        <step name="chineseBattle" delegate="battle" player="Chinese"/>
+                        <step name="chineseNonCombatMove" delegate="move" player="Chinese" display="Non Combat Move"/>
+                        <step name="chineseNoPUPurchase" delegate="purchaseNoPU" player="Chinese"/>
+                        <step name="chinesePlace" delegate="place" player="Chinese"/>
+                        <!--<step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese"/>-->
+                        <step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese">
+                                <stepProperty name="turnSummaryPlayers" value="Chinese"/>
+                                <!--<stepProperty name="turnSummaryPlayers" value="Americans:Chinese"/>-->
+                        </step>
+
+                        <step name="endRoundStep" delegate="endRound"/>
+                </sequence>
+
+                <!-- offset is used by the xml exporter to have a game begin in a round other than round 1. The default is zero if this attribute does not exist. -->
+                <offset round="0"/>
+
+        </gamePlay>
+
+        <production>
+                <!-- Unit Production Cost -->
+                <productionRule name="buyInfantry">
+                        <cost resource="PUs" quantity="3" />
+                        <result resourceOrUnit="infantry" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyArtillery">
+                        <cost resource="PUs" quantity="4" />
+                        <!--<cost resource="Steel" quantity="2" />-->
+                        <result resourceOrUnit="artillery" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyArmour">
+                        <cost resource="PUs" quantity="5" />
+                        <!--<cost resource="Steel" quantity="4" />
+                        <cost resource="Aluminium" quantity="10" />-->
+                        <result resourceOrUnit="armour" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyFighter">
+                        <cost resource="PUs" quantity="10" />
+                        <result resourceOrUnit="fighter" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyJP_Fighter">
+                        <cost resource="PUs" quantity="10" />
+                        <result resourceOrUnit="jp_fighter" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyJP_FighterKamikaze">
+                        <cost resource="PUs" quantity="8" />
+                        <result resourceOrUnit="jp_fighter" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyBomber">
+                        <cost resource="PUs" quantity="12" />
+                        <result resourceOrUnit="bomber" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyAir_Transport">
+                        <cost resource="PUs" quantity="10" />
+                        <result resourceOrUnit="air_transport" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyTransport">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="transport" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyJP_Transport">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="jp_transport" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyCarrier">
+                        <cost resource="PUs" quantity="14" />
+                        <result resourceOrUnit="carrier" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyDestroyer">
+                        <cost resource="PUs" quantity="8" />
+                        <result resourceOrUnit="destroyer" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyJP_Destroyer">
+                        <cost resource="PUs" quantity="8" />
+                        <result resourceOrUnit="jp_destroyer" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyCruiser">
+                        <cost resource="PUs" quantity="12" />
+                        <result resourceOrUnit="cruiser" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyBattleship">
+                        <cost resource="PUs" quantity="20" />
+                        <result resourceOrUnit="battleship" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySuper_Carrier">
+                        <cost resource="PUs" quantity="21" />
+                        <result resourceOrUnit="super_carrier" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySubmarine">
+                        <cost resource="PUs" quantity="6" />
+                        <result resourceOrUnit="submarine" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySubmarineTech2">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="submarine" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySubmarineTech3">
+                        <cost resource="PUs" quantity="8" />
+                        <result resourceOrUnit="submarine" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyMidget_Submarine">
+                        <cost resource="PUs" quantity="4" />
+                        <result resourceOrUnit="midget_submarine" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyBunker">
+                        <cost resource="PUs" quantity="4" />
+                        <result resourceOrUnit="bunker" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyFactory">
+                        <cost resource="PUs" quantity="15" />
+                        <result resourceOrUnit="factory" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyAirfield">
+                        <cost resource="PUs" quantity="12" />
+                        <result resourceOrUnit="airfield" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyHarbour">
+                        <cost resource="PUs" quantity="12" />
+                        <result resourceOrUnit="harbour" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyAAGun">
+                        <cost resource="PUs" quantity="6" />
+                        <result resourceOrUnit="aaGun" quantity="1"/>
+                </productionRule>
+
+                <!-- SHIPYARD PRICES -->
+                        <!-- Shipyards production rules are only needed if you are using the "shipyards" tech AND have the shipyards game option ON. -->
+                <productionRule name="buyTransportShipyards">
+                        <cost resource="PUs" quantity="6" />
+                        <result resourceOrUnit="transport" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyJP_TransportShipyards">
+                        <cost resource="PUs" quantity="6" />
+                        <result resourceOrUnit="jp_transport" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyCarrierShipyards">
+                        <cost resource="PUs" quantity="11" />
+                        <result resourceOrUnit="carrier" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyDestroyerShipyards">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="destroyer" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyJP_DestroyerShipyards">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="jp_destroyer" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyCruiserShipyards">
+                        <cost resource="PUs" quantity="10" />
+                        <result resourceOrUnit="cruiser" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyBattleshipShipyards">
+                        <cost resource="PUs" quantity="17" />
+                        <result resourceOrUnit="battleship" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySuper_CarrierShipyards">
+                        <cost resource="PUs" quantity="17" />
+                        <result resourceOrUnit="super_carrier" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySubmarineShipyards">
+                        <cost resource="PUs" quantity="5" />
+                        <result resourceOrUnit="submarine" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySubmarineTech2Shipyards">
+                        <cost resource="PUs" quantity="6" />
+                        <result resourceOrUnit="submarine" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySubmarineTech3Shipyards">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="submarine" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyMidget_SubmarineShipyards">
+                        <cost resource="PUs" quantity="3" />
+                        <result resourceOrUnit="midget_submarine" quantity="1"/>
+                </productionRule>
+
+                <!-- Advanced Industrial Production -->
+                        <!-- IndustrialTechnology production rules are only needed if you are using or plan to use the "industrialTechnology" tech.
+
+                <productionRule name="buyInfantryIndustrialTechnology">
+                        <cost resource="PUs" quantity="3" />
+                        <result resourceOrUnit="infantry" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyArtilleryIndustrialTechnology">
+                        <cost resource="PUs" quantity="4" />
+                        <result resourceOrUnit="artillery" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyArmourIndustrialTechnology">
+                        <cost resource="PUs" quantity="5" />
+                        <result resourceOrUnit="armour" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyFighterIndustrialTechnology">
+                        <cost resource="PUs" quantity="9" />
+                        <result resourceOrUnit="fighter" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyJP_FighterIndustrialTechnology">
+                        <cost resource="PUs" quantity="9" />
+                        <result resourceOrUnit="jp_fighter" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyBomberIndustrialTechnology">
+                        <cost resource="PUs" quantity="11" />
+                        <result resourceOrUnit="bomber" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyAir_TransportIndustrialTechnology">
+                        <cost resource="PUs" quantity="9" />
+                        <result resourceOrUnit="air_transport" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyTransportIndustrialTechnology">
+                        <cost resource="PUs" quantity="6" />
+                        <result resourceOrUnit="transport" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyJP_TransportIndustrialTechnology">
+                        <cost resource="PUs" quantity="6" />
+                        <result resourceOrUnit="jp_transport" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyCarrierIndustrialTechnology">
+                        <cost resource="PUs" quantity="11" />
+                        <result resourceOrUnit="carrier" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyDestroyerIndustrialTechnology">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="destroyer" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyJP_DestroyerIndustrialTechnology">
+                        <cost resource="PUs" quantity="7" />
+                        <result resourceOrUnit="jp_destroyer" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyCruiserIndustrialTechnology">
+                        <cost resource="PUs" quantity="10" />
+                        <result resourceOrUnit="cruiser" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyBattleshipIndustrialTechnology">
+                        <cost resource="PUs" quantity="17" />
+                        <result resourceOrUnit="battleship" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySuper_CarrierIndustrialTechnology">
+                        <cost resource="PUs" quantity="17" />
+                        <result resourceOrUnit="super_carrier" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buySubmarineIndustrialTechnology">
+                        <cost resource="PUs" quantity="5" />
+                        <result resourceOrUnit="submarine" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyMidget_SubmarineIndustrialTechnology">
+                        <cost resource="PUs" quantity="3" />
+                        <result resourceOrUnit="midget_submarine" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyBunkerIndustrialTechnology">
+                        <cost resource="PUs" quantity="4" />
+                        <result resourceOrUnit="bunker" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyFactoryIndustrialTechnology">
+                        <cost resource="PUs" quantity="13" />
+                        <result resourceOrUnit="factory" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyAirfieldIndustrialTechnology">
+                        <cost resource="PUs" quantity="10" />
+                        <result resourceOrUnit="airfield" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyHarbourIndustrialTechnology">
+                        <cost resource="PUs" quantity="10" />
+                        <result resourceOrUnit="harbour" quantity="1"/>
+                </productionRule>
+
+                <productionRule name="buyAAGunIndustrialTechnology">
+                        <cost resource="PUs" quantity="5" />
+                        <result resourceOrUnit="aaGun" quantity="1"/>
+                </productionRule>
+                -->
+
+                <!-- Repair rules -->
+                        <!-- if you use ww2v3 style factory damage, you need repair rules -->
+                <repairRule name="repairFactory">
+                        <cost resource="PUs" quantity="1" />
+                        <result resourceOrUnit="factory" quantity="1"/>
+                </repairRule>
+                <repairRule name="repairBunker">
+                        <cost resource="PUs" quantity="1" />
+                        <result resourceOrUnit="bunker" quantity="1"/>
+                </repairRule>
+                <repairRule name="repairAirfield">
+                        <cost resource="PUs" quantity="1" />
+                        <result resourceOrUnit="airfield" quantity="1"/>
+                </repairRule>
+                <repairRule name="repairHarbour">
+                        <cost resource="PUs" quantity="1" />
+                        <result resourceOrUnit="harbour" quantity="1"/>
+                </repairRule>
+
+                <repairRule name="repairFactoryIndustrialTechnology">
+                        <cost resource="PUs" quantity="1" />
+                        <result resourceOrUnit="factory" quantity="2"/>
+                </repairRule>
+                <repairRule name="repairBunkerIndustrialTechnology">
+                        <cost resource="PUs" quantity="1" />
+                        <result resourceOrUnit="bunker" quantity="2"/>
+                </repairRule>
+                <repairRule name="repairAirfieldIndustrialTechnology">
+                        <cost resource="PUs" quantity="1" />
+                        <result resourceOrUnit="airfield" quantity="2"/>
+                </repairRule>
+                <repairRule name="repairHarbourIndustrialTechnology">
+                        <cost resource="PUs" quantity="1" />
+                        <result resourceOrUnit="harbour" quantity="2"/>
+                </repairRule>
+
+                <repairFrontier name="repair">
+                        <repairRules name="repairFactory"/>
+                        <repairRules name="repairBunker"/>
+                        <repairRules name="repairAirfield"/>
+                        <repairRules name="repairHarbour"/>
+                </repairFrontier>
+
+                <repairFrontier name="repairIndustrialTechnology">
+                        <repairRules name="repairFactoryIndustrialTechnology"/>
+                        <repairRules name="repairBunkerIndustrialTechnology"/>
+                        <repairRules name="repairAirfieldIndustrialTechnology"/>
+                        <repairRules name="repairHarbourIndustrialTechnology"/>
+                </repairFrontier>
+
+                <!-- all players can use the same frontier, or you can have a different frontier for each player -->
+                <!-- only "production" (a single production frontier) is needed for most maps. if you use ww2v2 tech then you need IndustrialTechnology production, and if you use ww2v3 tech you need Shipyards -->
+                <!--<productionFrontier name="production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                        <frontierRules name="buyArmour"/>
+                        <frontierRules name="buyFighter"/>
+                        <frontierRules name="buyBomber"/>
+                        <frontierRules name="buyTransport"/>
+                        <frontierRules name="buySubmarine"/>
+                        <frontierRules name="buyDestroyer"/>
+                        <frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCarrier"/>
+                        <frontierRules name="buyBattleship"/>
+                        <frontierRules name="buySuper_Carrier"/>
+                        <frontierRules name="buyBunker"/>
+                        <frontierRules name="buyAAGun"/>
+                        <frontierRules name="buyFactory"/>
+                        <frontierRules name="buyAirfield"/>
+                        <frontierRules name="buyHarbour"/>
+                </productionFrontier>-->
+
+                <!--<productionFrontier name="productionIndustrialTechnology">
+                        <frontierRules name="buyInfantryIndustrialTechnology"/>
+                        <frontierRules name="buyArtilleryIndustrialTechnology"/>
+                        <frontierRules name="buyArmourIndustrialTechnology"/>
+                        <frontierRules name="buyFighterIndustrialTechnology"/>
+                        <frontierRules name="buyBomberIndustrialTechnology"/>
+                        <frontierRules name="buyTransportIndustrialTechnology"/>
+                        <frontierRules name="buySubmarineIndustrialTechnology"/>
+                        <frontierRules name="buyDestroyerIndustrialTechnology"/>
+                        <frontierRules name="buyCruiserIndustrialTechnology"/>
+                        <frontierRules name="buyCarrierIndustrialTechnology"/>
+                        <frontierRules name="buyBattleshipIndustrialTechnology"/>
+                        <frontierRules name="buySuper_CarrierIndustrialTechnology"/>
+                        <frontierRules name="buyBunkerIndustrialTechnology"/>
+                        <frontierRules name="buyAAGunIndustrialTechnology"/>
+                        <frontierRules name="buyFactoryIndustrialTechnology"/>
+                        <frontierRules name="buyAirfieldIndustrialTechnology"/>
+                        <frontierRules name="buyHarbourIndustrialTechnology"/>
+                </productionFrontier>-->
+
+                        <!-- Shipyards frontier rules are only needed if you are using the "shipyards" tech AND have the shipyards game option ON. If the shipyards game option is ON, then all players must use 1 frontier called "production".
+                            If you want to use multiple production frontiers for different nations, then it is highly recommended you use triggers to add or remove productionRules instead of using the shipyard frontier.
+                <productionFrontier name="productionShipyards">
+                        <frontierRules name="buyTransportShipyards"/>
+                        <frontierRules name="buySubmarineShipyards"/>
+                        <frontierRules name="buyDestroyerShipyards"/>
+                        <frontierRules name="buyCruiserShipyards"/>
+                        <frontierRules name="buyCarrierShipyards"/>
+                        <frontierRules name="buyBattleshipShipyards"/>
+                        <frontierRules name="buySuper_CarrierShipyards"/>
+                </productionFrontier>-->
+
+                <productionFrontier name="Germans_production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                        <frontierRules name="buyArmour"/>
+                        <frontierRules name="buyFighter"/>
+                        <frontierRules name="buyBomber"/>
+                        <frontierRules name="buyTransport"/>
+                        <frontierRules name="buySubmarine"/>
+                        <frontierRules name="buyDestroyer"/>
+                        <frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCarrier"/>
+                        <frontierRules name="buyBattleship"/>
+                        <frontierRules name="buySuper_Carrier"/>
+                        <frontierRules name="buyBunker"/>
+                        <frontierRules name="buyAAGun"/>
+                        <frontierRules name="buyFactory"/>
+                        <frontierRules name="buyAirfield"/>
+                        <frontierRules name="buyHarbour"/>
+                </productionFrontier>
+
+                <productionFrontier name="Russians_production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                        <frontierRules name="buyArmour"/>
+                        <frontierRules name="buyFighter"/>
+                        <frontierRules name="buyBomber"/>
+                        <frontierRules name="buyTransport"/>
+                        <frontierRules name="buySubmarine"/>
+                        <frontierRules name="buyDestroyer"/>
+                        <frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCarrier"/>
+                        <frontierRules name="buyBattleship"/>
+                        <frontierRules name="buySuper_Carrier"/>
+                        <frontierRules name="buyBunker"/>
+                        <frontierRules name="buyAAGun"/>
+                        <frontierRules name="buyFactory"/>
+                        <frontierRules name="buyAirfield"/>
+                        <frontierRules name="buyHarbour"/>
+                </productionFrontier>
+
+                <productionFrontier name="Japanese_production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                        <frontierRules name="buyArmour"/>
+                        <frontierRules name="buyJP_Fighter"/>
+                        <frontierRules name="buyBomber"/>
+                        <frontierRules name="buyJP_Transport"/>
+                        <frontierRules name="buySubmarine"/>
+                        <frontierRules name="buyJP_Destroyer"/>
+                        <frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCarrier"/>
+                        <frontierRules name="buyBattleship"/>
+                        <frontierRules name="buySuper_Carrier"/>
+                        <frontierRules name="buyBunker"/>
+                        <frontierRules name="buyAAGun"/>
+                        <frontierRules name="buyFactory"/>
+                        <frontierRules name="buyAirfield"/>
+                        <frontierRules name="buyHarbour"/>
+                </productionFrontier>
+
+                <productionFrontier name="British_production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                        <frontierRules name="buyArmour"/>
+                        <frontierRules name="buyFighter"/>
+                        <frontierRules name="buyBomber"/>
+                        <frontierRules name="buyTransport"/>
+                        <frontierRules name="buySubmarine"/>
+                        <frontierRules name="buyDestroyer"/>
+                        <frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCarrier"/>
+                        <frontierRules name="buyBattleship"/>
+                        <frontierRules name="buySuper_Carrier"/>
+                        <frontierRules name="buyBunker"/>
+                        <frontierRules name="buyAAGun"/>
+                        <frontierRules name="buyFactory"/>
+                        <frontierRules name="buyAirfield"/>
+                        <frontierRules name="buyHarbour"/>
+                </productionFrontier>
+
+                <productionFrontier name="Italians_production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                        <frontierRules name="buyArmour"/>
+                        <frontierRules name="buyFighter"/>
+                        <frontierRules name="buyBomber"/>
+                        <frontierRules name="buyTransport"/>
+                        <frontierRules name="buySubmarine"/>
+                        <frontierRules name="buyDestroyer"/>
+                        <frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCarrier"/>
+                        <frontierRules name="buyBattleship"/>
+                        <frontierRules name="buySuper_Carrier"/>
+                        <frontierRules name="buyBunker"/>
+                        <frontierRules name="buyAAGun"/>
+                        <frontierRules name="buyFactory"/>
+                        <frontierRules name="buyAirfield"/>
+                        <frontierRules name="buyHarbour"/>
+                </productionFrontier>
+
+                <!--<productionFrontier name="Chinese_production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                        <frontierRules name="buyArmour"/>
+                        <frontierRules name="buyFighter"/>
+                        <frontierRules name="buyBomber"/>
+                        <frontierRules name="buyTransport"/>
+                        <frontierRules name="buySubmarine"/>
+                        <frontierRules name="buyDestroyer"/>
+                        <frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCarrier"/>
+                        <frontierRules name="buyBattleship"/>
+                        <frontierRules name="buySuper_Carrier"/>
+                        <frontierRules name="buyBunker"/>
+                        <frontierRules name="buyAAGun"/>
+                        <frontierRules name="buyFactory"/>
+                        <frontierRules name="buyAirfield"/>
+                        <frontierRules name="buyHarbour"/>
+                </productionFrontier>-->
+
+                <productionFrontier name="Chinese_CutOff_production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                </productionFrontier>
+
+                <productionFrontier name="Chinese_BurmaRoad_production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                        <frontierRules name="buyArmour"/>
+                        <frontierRules name="buyFighter"/>
+                </productionFrontier>
+
+                <productionFrontier name="Americans_production">
+                        <frontierRules name="buyInfantry"/>
+                        <frontierRules name="buyArtillery"/>
+                        <frontierRules name="buyArmour"/>
+                        <frontierRules name="buyFighter"/>
+                        <frontierRules name="buyBomber"/>
+                        <frontierRules name="buyTransport"/>
+                        <frontierRules name="buySubmarine"/>
+                        <frontierRules name="buyDestroyer"/>
+                        <frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCarrier"/>
+                        <frontierRules name="buyBattleship"/>
+                        <frontierRules name="buySuper_Carrier"/>
+                        <frontierRules name="buyBunker"/>
+                        <frontierRules name="buyAAGun"/>
+                        <frontierRules name="buyFactory"/>
+                        <frontierRules name="buyAirfield"/>
+                        <frontierRules name="buyHarbour"/>
+                </productionFrontier>
+
+                <playerProduction player="Germans" frontier="Germans_production"/>
+                <playerProduction player="Russians" frontier="Russians_production"/>
+                <playerProduction player="Japanese" frontier="Japanese_production"/>
+                <playerProduction player="British" frontier="British_production"/>
+                <playerProduction player="Italians" frontier="Italians_production"/>
+                <playerProduction player="Chinese" frontier="Chinese_BurmaRoad_production"/>
+                <playerProduction player="Americans" frontier="Americans_production"/>
+
+                <playerRepair player="Germans" frontier="repair"/>
+                <playerRepair player="Russians" frontier="repair"/>
+                <playerRepair player="Japanese" frontier="repair"/>
+                <playerRepair player="British" frontier="repair"/>
+                <playerRepair player="Italians" frontier="repair"/>
+                <playerRepair player="Chinese" frontier="repair"/>
+                <playerRepair player="Americans" frontier="repair"/>
+
+        </production>
+
+        <technology>
+                <!-- list all available techs for this map, for all players possible -->
+                <technologies>
+                        <!-- this is the current list of all HARDCODED techs that come with TripleA -->
+                        <!-- (+1 attack to isSub) superSub requires all isSub units to have a "_ss" image variant -->
+                        <techname name="superSub"/>
+                        <!-- (+1 att or def for isAir non-isStrategicBomber) jetPower requires all non-isStrategicBomber units to have a "_jp" image variant (and "_lr_jp") -->
+                        <techname name="jetPower"/>
+                        <!-- (removes all sea units from "production" and adds "Shipyards" production rules.  Only currently works when all players use a production frontier called "production") -->
+                        <techname name="shipyards"/>
+                        <!-- (+1 attack for anti-air units) aARadar requires all isAA units to have a "_r" image variant (and "rockets_r" or "_rockets_r") -->
+                        <techname name="aARadar"/>
+                        <!-- (+2 movement for isAir) longRangeAir requires all isAir units to have a "_lr" image variant (and "_lr_jp" OR "_lr_hb") -->
+                        <techname name="longRangeAir"/>
+                        <!-- (+X dice rolls for isAir isStrategicBomber) heavyBomber requires all isStrategicBomber units to have a "_hb" image variant (and "_lr_hb") -->
+                        <techname name="heavyBomber"/>
+                        <!-- (doubles number of units supported by artillery, and optionally by other support types) -->
+                        <techname name="improvedArtillerySupport"/>
+                        <!-- (allows isAA and isRocket to shoot rockets) rocket requires all isAA units to have a "rockets" image variant if they are called "aaGun", and a "_rockets" if they are called anything else (and "rockets_r" or "_rockets_r") -->
+                        <techname name="rocket"/>
+                        <!-- (allows isAirTransport units to carry isAirTransportable units) -->
+                        <techname name="paratroopers"/>
+                        <!-- (gives +2 production slots to factories on territories worth at least 3, and halves the price of repairing) increasedFactoryProduction requires all isFactory units to have a "_it" image variant (and "_hit" and "_it_hit") -->
+                        <techname name="increasedFactoryProduction"/>
+                        <!-- (rolls a die at the end of the player's turn, adds that many PUs to their bank) -->
+                        <techname name="warBonds"/>
+                        <!-- (allows isLandTransport units to carry isInfantry units) -->
+                        <techname name="mechanizedInfantry"/>
+                        <!-- (destroyerBombard allows isDestroyer to bombard) this is an example of renaming a technology. the first part is the new name, the second is the old name (the hardcoded tech's name) -->
+                        <techname name="destroyersCanBombard" tech="destroyerBombard"/>
+                        <!-- (industrialTechnology replaces a users production frontier with one called productionIndustrialTechnology (and i don't use it in this map))
+                        <techname name="industrialTechnology"/> -->
+
+                        <!-- below is a list of user created techs. they do nothing by themselves, but can be used a conditions for triggers. simply use a name that isn't already taken by a hardcoded tech -->
+                        <techname name="reinforcedHulls"/>
+                        <techname name="wolfPackTactics"/>
+                </technologies>
+                <!-- list all available techs for this player -->
+                <playerTech player="Italians">
+                        <!-- Number of categories is unlimited. Use descriptive names, as they are shown to the player. You may have empty categories, if you plan on adding to them inside the game using triggers -->
+                        <!-- At least minimum of 0 techs per category, max of 6 per category if using ww2v3-style random selection of techs,
+                                max is unlimited if using ww2v2-style selected techs (however, any number of techs per category greater than 6 will be unreachable by the dice chooser)  -->
+                        <!-- please list techs in the order that they appear in the technoligies list, as doing otherwise may cause an error -->
+                        <!-- you can have a technology listed more than once, if you want to increase the chance of getting it -->
+                        <category name="Italian Technology">
+                                <tech name="destroyersCanBombard"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                        </category>
+                </playerTech>
+                <playerTech player="Russians">
+                        <category name="Air and Naval Advances">
+                                <tech name="destroyersCanBombard"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="rocket"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                                <tech name="mechanizedInfantry"/>
+                        </category>
+                </playerTech>
+                <playerTech player="Germans">
+                        <category name="Air and Naval Advances">
+                                <tech name="superSub"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="rocket"/>
+                                <tech name="paratroopers"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="mechanizedInfantry"/>
+                        </category>
+                        <category name="Submarine Technology">
+                                <!-- as you can see, this category is empty.  that is because we will add techs to this category later by triggers -->
+                        </category>
+                </playerTech>
+                <playerTech player="British">
+                        <category name="Air and Naval Advances">
+                                <tech name="destroyersCanBombard"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="rocket"/>
+                                <tech name="paratroopers"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                        </category>
+                </playerTech>
+                <playerTech player="Japanese">
+                        <category name="Air and Naval Advances">
+                                <tech name="superSub"/>
+                                <tech name="jetPower"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="rocket"/>
+                                <tech name="paratroopers"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                                <tech name="mechanizedInfantry"/>
+                        </category>
+                </playerTech>
+                <playerTech player="Americans">
+                        <category name="Air and Naval Advances">
+                                <tech name="superSub"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="paratroopers"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                                <tech name="mechanizedInfantry"/>
+                        </category>
+                </playerTech>
+                <playerTech player="Chinese">
+                        <category name="Air and Naval Advances">
+                                <tech name="superSub"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="rocket"/>
+                                <tech name="paratroopers"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                                <tech name="mechanizedInfantry"/>
+                        </category>
+                </playerTech>
+        </technology>
+
+        <attachmentList>
+
 <!--  relationshipType Attachments -->
-	<!--  each PoliticalRelationship needs a relationshipTypeAttachment 
-			and each relationshipTypeAttachment needs an option: archetype that needs to be set to one of the following 3 values:
-			* "allied"
-			* "neutral"
-			* "war"
-			the archeType determines the default behaviour of this relationshipType that can be modified by setting other options.
-			Also the archeType determines the outcomes of isAllied, isNeutral and isWar query in the engine
-	-->
-	<!-- the following options are allowed for "relationshipTypeAttachment", (all options except for archeType only allow "true", "false", or "default")
-			archeType								values: "allied" or "war" or "neutral"
-			canMoveLandUnitsOverOwnedLand			values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war and allied can move into, while neutral can not
-			canMoveAirUnitsOverOwnedLand			values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war and allied can move into, while neutral can not
-			canLandAirUnitsOnOwnedLand				values: "true", "false", or "default". default setting is "default", and "default" means that archeType of allied only lets you land units in the player's territories
-			upkeepCost								values: "default", or any valid integer, or "percentage" with a count of a valid integer. Default = zero (0). This determines if there is a cost to maintain a relationship, which would be subtracted from PUs gained at end of turn.
-																examples: a cost of 1 PU per turn: <option name="upkeepCost" value="1"/> or <option name="upkeepCost" value="flat" count="1"/>, or a cost of 9% of your income per turn: <option name="upkeepCost" value="percentage" count="9"/>
-			alliancesCanChainTogether				values: "true", "false", or "default". can only be applied to a relationship that is archetype "allied", and only 1 relationship can have it. if true, any nations that reach this relationship will share both allies and enemies.
-			isDefaultWarPosition					values: "true", "false", or "default". can only be applied to a relationship that is archetype "war", and only 1 relationship can have it. if true, any nations that reach an alliance chaining relationship, will have their enemies who are not yet at war with, set to this relationship.
-			canTakeOverOwnedTerritory				values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war lets you take over territories.  By setting true, you can take over territories of an ally
-			givesBackOriginalTerritories			values: "true", "false", or "default". default setting is "default", and "default" means false. If true, at the end of each politics phase, any territories originally belonging to the other player will revert to that players control.
-			canMoveIntoDuringCombatMove				values: "true", "false", or "default". default setting is "default", and "default" means true. If false, you may not move into any territories owned by the other player during combat move, and must wait for non-combat move.
-			canMoveThroughCanals					values: "true", "false", or "default". default setting is "default", and "default" means that archeType of allied lets you move through canals. If true, you may move through a canal owned by the other player.
-			rocketsCanFlyOver						values: "true", "false", or "default". default setting is "default", and "default" means "true" which is that rockets may fly over everyone.
-	-->
+    <!--  each PoliticalRelationship needs a relationshipTypeAttachment
+            and each relationshipTypeAttachment needs an option: archetype that needs to be set to one of the following 3 values:
+            * "allied"
+            * "neutral"
+            * "war"
+            the archeType determines the default behaviour of this relationshipType that can be modified by setting other options.
+            Also the archeType determines the outcomes of isAllied, isNeutral and isWar query in the engine
+    -->
+    <!-- the following options are allowed for "relationshipTypeAttachment", (all options except for archeType only allow "true", "false", or "default")
+            archeType                               values: "allied" or "war" or "neutral"
+            canMoveLandUnitsOverOwnedLand           values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war and allied can move into, while neutral can not
+            canMoveAirUnitsOverOwnedLand            values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war and allied can move into, while neutral can not
+            canLandAirUnitsOnOwnedLand              values: "true", "false", or "default". default setting is "default", and "default" means that archeType of allied only lets you land units in the player's territories
+            upkeepCost                              values: "default", or any valid integer, or "percentage" with a count of a valid integer. Default = zero (0). This determines if there is a cost to maintain a relationship, which would be subtracted from PUs gained at end of turn.
+                                                                examples: a cost of 1 PU per turn: <option name="upkeepCost" value="1"/> or <option name="upkeepCost" value="flat" count="1"/>, or a cost of 9% of your income per turn: <option name="upkeepCost" value="percentage" count="9"/>
+            alliancesCanChainTogether               values: "true", "false", or "default". can only be applied to a relationship that is archetype "allied", and only 1 relationship can have it. if true, any nations that reach this relationship will share both allies and enemies.
+            isDefaultWarPosition                    values: "true", "false", or "default". can only be applied to a relationship that is archetype "war", and only 1 relationship can have it. if true, any nations that reach an alliance chaining relationship, will have their enemies who are not yet at war with, set to this relationship.
+            canTakeOverOwnedTerritory               values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war lets you take over territories.  By setting true, you can take over territories of an ally
+            givesBackOriginalTerritories            values: "true", "false", or "default". default setting is "default", and "default" means false. If true, at the end of each politics phase, any territories originally belonging to the other player will revert to that players control.
+            canMoveIntoDuringCombatMove             values: "true", "false", or "default". default setting is "default", and "default" means true. If false, you may not move into any territories owned by the other player during combat move, and must wait for non-combat move.
+            canMoveThroughCanals                    values: "true", "false", or "default". default setting is "default", and "default" means that archeType of allied lets you move through canals. If true, you may move through a canal owned by the other player.
+            rocketsCanFlyOver                       values: "true", "false", or "default". default setting is "default", and "default" means "true" which is that rockets may fly over everyone.
+    -->
 
-				<attachment name="relationshipTypeAttachment" attachTo="War" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="war"/>
-				</attachment>
+                <attachment name="relationshipTypeAttachment" attachTo="War" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="war"/>
+                </attachment>
 
-				<attachment name="relationshipTypeAttachment" attachTo="Allied" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="allied"/>
-						<option name="givesBackOriginalTerritories" value="true"/>
-				</attachment>
+                <attachment name="relationshipTypeAttachment" attachTo="Allied" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="allied"/>
+                        <option name="givesBackOriginalTerritories" value="true"/>
+                </attachment>
 
-				<attachment name="relationshipTypeAttachment" attachTo="Neutrality" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="neutral"/>
-				</attachment>
+                <attachment name="relationshipTypeAttachment" attachTo="Neutrality" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="neutral"/>
+                </attachment>
 
-				<attachment name="relationshipTypeAttachment" attachTo="NAP" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="neutral"/>
-				</attachment>
+                <attachment name="relationshipTypeAttachment" attachTo="NAP" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="neutral"/>
+                </attachment>
 
-				<attachment name="relationshipTypeAttachment" attachTo="ColdWar" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="neutral"/>
-				</attachment>
-							
+                <attachment name="relationshipTypeAttachment" attachTo="ColdWar" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="neutral"/>
+                </attachment>
+
 <!-- Tech Attachments -->
-	<!-- IF you are using custom technologies (generic techs), then ALL players need a tech attachment, even if it is an empty tech attachment, otherwise there will be errors
-	-->
-	<!-- the following options are allowed for "techAttachment".  These are not required, they only determine if a country starts with a tech or not.  All default to False.
-			techCost							values: the cost of buying tech rolls for this player, defaults to 5
-			superSub
-			jetPower
-			shipyards
-			aARadar
-			longRangeAir
-			heavyBomber
-			improvedArtillerySupport
-			rocket
-			paratroopers
-			increasedFactoryProduction
-			warBonds
-			mechanizedInfantry
-			destroyerBombard
-			industrialTechnology
-			
-	-->
-				<!-- Italians -->
-				<attachment name="techAttachment" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
-						<!-- techCost is optional, and defaults to 5 if missing.  techs default to false if missing -->
-						<option name="techCost" value="6"/>
-						<option name="superSub" value="false"/>
-						<option name="jetPower" value="false"/>
-						<option name="shipyards" value="false"/>
-						<option name="aARadar" value="false"/>
-						<option name="longRangeAir" value="false"/>
-						<option name="heavyBomber" value="false"/>
-						<option name="improvedArtillerySupport" value="false"/>
-						<option name="rocket" value="false"/>
-						<option name="paratroopers" value="false"/>
-						<option name="increasedFactoryProduction" value="false"/>
-						<option name="warBonds" value="false"/>
-						<option name="mechanizedInfantry" value="false"/>
-				</attachment>
-				
-				<!-- Russians -->
-				<attachment name="techAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
-						<option name="techCost" value="5"/>
-						<option name="superSub" value="false"/>
-						<option name="jetPower" value="false"/>
-						<option name="shipyards" value="false"/>
-						<option name="aARadar" value="false"/>
-						<option name="longRangeAir" value="false"/>
-						<option name="heavyBomber" value="false"/>
-						<option name="improvedArtillerySupport" value="false"/>
-						<option name="rocket" value="false"/>
-						<option name="paratroopers" value="false"/>
-						<option name="increasedFactoryProduction" value="false"/>
-						<option name="warBonds" value="false"/>
-						<option name="mechanizedInfantry" value="false"/>
-				</attachment>
-				
-				<!-- Germans -->
-				<attachment name="techAttachment" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
-						<option name="techCost" value="5"/>
-						<option name="superSub" value="false"/>
-						<option name="jetPower" value="false"/>
-						<option name="shipyards" value="false"/>
-						<option name="aARadar" value="false"/>
-						<option name="longRangeAir" value="false"/>
-						<option name="heavyBomber" value="false"/>
-						<option name="improvedArtillerySupport" value="false"/>
-						<option name="rocket" value="false"/>
-						<option name="paratroopers" value="false"/>
-						<option name="increasedFactoryProduction" value="false"/>
-						<option name="warBonds" value="false"/>
-						<option name="mechanizedInfantry" value="false"/>
-						<!-- Currently you are not yet allowed to set custom techs at the start of the game through here
-						<option name="reinforcedHulls" value="false"/>
-						<option name="wolfPackTactics" value="false"/>-->
-				</attachment>
+    <!-- IF you are using custom technologies (generic techs), then ALL players need a tech attachment, even if it is an empty tech attachment, otherwise there will be errors
+    -->
+    <!-- the following options are allowed for "techAttachment".  These are not required, they only determine if a country starts with a tech or not.  All default to False.
+            techCost                            values: the cost of buying tech rolls for this player, defaults to 5
+            superSub
+            jetPower
+            shipyards
+            aARadar
+            longRangeAir
+            heavyBomber
+            improvedArtillerySupport
+            rocket
+            paratroopers
+            increasedFactoryProduction
+            warBonds
+            mechanizedInfantry
+            destroyerBombard
+            industrialTechnology
 
-				<!-- British -->
-				<attachment name="techAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
-						<option name="techCost" value="5"/>
-						<option name="superSub" value="false"/>
-						<option name="jetPower" value="false"/>
-						<option name="shipyards" value="false"/>
-						<option name="aARadar" value="false"/>
-						<option name="longRangeAir" value="false"/>
-						<option name="heavyBomber" value="false"/>
-						<option name="improvedArtillerySupport" value="false"/>
-						<option name="rocket" value="false"/>
-						<option name="paratroopers" value="false"/>
-						<option name="increasedFactoryProduction" value="false"/>
-						<option name="warBonds" value="false"/>
-						<option name="mechanizedInfantry" value="false"/>
-				</attachment>
+    -->
+                <!-- Italians -->
+                <attachment name="techAttachment" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
+                        <!-- techCost is optional, and defaults to 5 if missing.  techs default to false if missing -->
+                        <option name="techCost" value="6"/>
+                        <option name="superSub" value="false"/>
+                        <option name="jetPower" value="false"/>
+                        <option name="shipyards" value="false"/>
+                        <option name="aARadar" value="false"/>
+                        <option name="longRangeAir" value="false"/>
+                        <option name="heavyBomber" value="false"/>
+                        <option name="improvedArtillerySupport" value="false"/>
+                        <option name="rocket" value="false"/>
+                        <option name="paratroopers" value="false"/>
+                        <option name="increasedFactoryProduction" value="false"/>
+                        <option name="warBonds" value="false"/>
+                        <option name="mechanizedInfantry" value="false"/>
+                </attachment>
 
-				<!-- Japanese -->
-				<attachment name="techAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
-						<option name="techCost" value="6"/>
-						<option name="superSub" value="false"/>
-						<option name="jetPower" value="false"/>
-						<option name="shipyards" value="false"/>
-						<option name="aARadar" value="false"/>
-						<option name="longRangeAir" value="false"/>
-						<option name="heavyBomber" value="false"/>
-						<option name="improvedArtillerySupport" value="false"/>
-						<option name="rocket" value="false"/>
-						<option name="paratroopers" value="false"/>
-						<option name="increasedFactoryProduction" value="false"/>
-						<option name="warBonds" value="false"/>
-						<option name="mechanizedInfantry" value="false"/>
-				</attachment>
+                <!-- Russians -->
+                <attachment name="techAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
+                        <option name="techCost" value="5"/>
+                        <option name="superSub" value="false"/>
+                        <option name="jetPower" value="false"/>
+                        <option name="shipyards" value="false"/>
+                        <option name="aARadar" value="false"/>
+                        <option name="longRangeAir" value="false"/>
+                        <option name="heavyBomber" value="false"/>
+                        <option name="improvedArtillerySupport" value="false"/>
+                        <option name="rocket" value="false"/>
+                        <option name="paratroopers" value="false"/>
+                        <option name="increasedFactoryProduction" value="false"/>
+                        <option name="warBonds" value="false"/>
+                        <option name="mechanizedInfantry" value="false"/>
+                </attachment>
 
-				<!-- Americans -->
-				<attachment name="techAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
-						<option name="techCost" value="4"/>
-						<option name="superSub" value="false"/>
-						<option name="jetPower" value="false"/>
-						<option name="shipyards" value="false"/>
-						<option name="aARadar" value="false"/>
-						<option name="longRangeAir" value="false"/>
-						<option name="heavyBomber" value="false"/>
-						<option name="improvedArtillerySupport" value="false"/>
-						<option name="rocket" value="false"/>
-						<option name="paratroopers" value="false"/>
-						<option name="increasedFactoryProduction" value="false"/>
-						<option name="warBonds" value="false"/>
-						<option name="mechanizedInfantry" value="false"/>
-				</attachment>
+                <!-- Germans -->
+                <attachment name="techAttachment" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
+                        <option name="techCost" value="5"/>
+                        <option name="superSub" value="false"/>
+                        <option name="jetPower" value="false"/>
+                        <option name="shipyards" value="false"/>
+                        <option name="aARadar" value="false"/>
+                        <option name="longRangeAir" value="false"/>
+                        <option name="heavyBomber" value="false"/>
+                        <option name="improvedArtillerySupport" value="false"/>
+                        <option name="rocket" value="false"/>
+                        <option name="paratroopers" value="false"/>
+                        <option name="increasedFactoryProduction" value="false"/>
+                        <option name="warBonds" value="false"/>
+                        <option name="mechanizedInfantry" value="false"/>
+                        <!-- Currently you are not yet allowed to set custom techs at the start of the game through here
+                        <option name="reinforcedHulls" value="false"/>
+                        <option name="wolfPackTactics" value="false"/>-->
+                </attachment>
 
-				<!-- Chinese -->
-				<attachment name="techAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
-						<option name="improvedArtillerySupport" value="false"/>
-						<!-- Even the Chinese, who can not roll for tech because they don't have a phase for it, must have a tech attachment because we are using custom techs,
-								so this here is an almost empty tech attachment.  Actually, we could fill it with more stuff, that is false or true, but 1 is enough.
-								Just because something is in this list doesn't mean we can get it.  Whether we can get it or not is determined by what is in "playerTech". -->
-				</attachment>
-				
-				
-				
+                <!-- British -->
+                <attachment name="techAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
+                        <option name="techCost" value="5"/>
+                        <option name="superSub" value="false"/>
+                        <option name="jetPower" value="false"/>
+                        <option name="shipyards" value="false"/>
+                        <option name="aARadar" value="false"/>
+                        <option name="longRangeAir" value="false"/>
+                        <option name="heavyBomber" value="false"/>
+                        <option name="improvedArtillerySupport" value="false"/>
+                        <option name="rocket" value="false"/>
+                        <option name="paratroopers" value="false"/>
+                        <option name="increasedFactoryProduction" value="false"/>
+                        <option name="warBonds" value="false"/>
+                        <option name="mechanizedInfantry" value="false"/>
+                </attachment>
+
+                <!-- Japanese -->
+                <attachment name="techAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
+                        <option name="techCost" value="6"/>
+                        <option name="superSub" value="false"/>
+                        <option name="jetPower" value="false"/>
+                        <option name="shipyards" value="false"/>
+                        <option name="aARadar" value="false"/>
+                        <option name="longRangeAir" value="false"/>
+                        <option name="heavyBomber" value="false"/>
+                        <option name="improvedArtillerySupport" value="false"/>
+                        <option name="rocket" value="false"/>
+                        <option name="paratroopers" value="false"/>
+                        <option name="increasedFactoryProduction" value="false"/>
+                        <option name="warBonds" value="false"/>
+                        <option name="mechanizedInfantry" value="false"/>
+                </attachment>
+
+                <!-- Americans -->
+                <attachment name="techAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
+                        <option name="techCost" value="4"/>
+                        <option name="superSub" value="false"/>
+                        <option name="jetPower" value="false"/>
+                        <option name="shipyards" value="false"/>
+                        <option name="aARadar" value="false"/>
+                        <option name="longRangeAir" value="false"/>
+                        <option name="heavyBomber" value="false"/>
+                        <option name="improvedArtillerySupport" value="false"/>
+                        <option name="rocket" value="false"/>
+                        <option name="paratroopers" value="false"/>
+                        <option name="increasedFactoryProduction" value="false"/>
+                        <option name="warBonds" value="false"/>
+                        <option name="mechanizedInfantry" value="false"/>
+                </attachment>
+
+                <!-- Chinese -->
+                <attachment name="techAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
+                        <option name="improvedArtillerySupport" value="false"/>
+                        <!-- Even the Chinese, who can not roll for tech because they don't have a phase for it, must have a tech attachment because we are using custom techs,
+                                so this here is an almost empty tech attachment.  Actually, we could fill it with more stuff, that is false or true, but 1 is enough.
+                                Just because something is in this list doesn't mean we can get it.  Whether we can get it or not is determined by what is in "playerTech". -->
+                </attachment>
+
+
+
 <!-- Unit Attachments -->
-	<!-- Certain units require extra graphical icons present, for when technology is researched or damage is done.  Here is a list, in order of what is needed:
-			Anything I list as "_something" means that you must have the units exact name in front of it, example: fighter_jp
-			if the unit is called "aaGun" then you need units called "rockets", "rockets_r", and "aaGun_r"
-			if the unit has "isAA", but is not exactly named "aaGun", then you need units called "_rockets" and "_r" and "_rockets_r"
-			if the unit has "isRocket", you need "_rockets"
-			if the unit has "isAAforCombatOnly" and/or "isAAforBombingThisUnitOnly", then you need "_r"
-			if the unit has "isAir", but not "isStrategicBomber", then you need "_lr", and "_jp", and "_lr_jp"
-			if the unit has "isAir", and is "isStrategicBomber", then you need "_lr", and "_hb", and "_lr_hb"
-			if the unit has "isSub", then you need "_ss"
-			if the unit has "isFactory", or is called "factory", then you need "_it", and "_it_hit"
-			if a unit can be damaged (by being a factory, or by having "canBeDamaged", then you will need "_hit"
-			if a unit can be disabled, then you will need "_disabled"
-	-->
-	<!-- the following options are allowed for "unitAttachment"
-			isAir								values: if a unit is air or not, defaults to false
-			isSea								values: if a unit is sea or not, defaults to false. any unit that is neither air or sea, is land
-			movement							values: the allowed movement of a unit, defaults to zero
-			attack								values: the attack value, where a rolled dice must be equal or less than to hit the enemy
-			defense								values: the defense value, where a rolled dice must be equal or less than to hit the enemy
-			isTwoHit							values: does the unit have 2 hitpoints. default is false, which means 1 hitpoint
-			
-			artillerySupportable				values: with the 'artillery' and 'unitSupportCount' ability, these three create a set of support attachments at the start of the game, 
-															allows the unit to receive support from an "artillery" unit (land, sea, or air are allowed)
-			artillery							values: with the 'artillerySupportable' and 'unitSupportCount' ability, these three create a set of support attachments at the start of the game,
-															artillery gives support (+1 attack) to "artillerySupportable" units (land, sea, or air are allowed)
-			unitSupportCount					values: with the 'artillerySupportable' and 'artillery' ability, these three create a set of support attachments at the start of the game,
-															unitSupportCount is the number of units that will be supported by the artillery, defaults to 1 if missing
-			attackRolls							values: number of rolls this unit gets on attack (default = 1)
-			defenseRolls						values: number of rolls this unit gets on defense (default = 1)
-			chooseBestRoll						values: true/false, whether we pick the best dice or use all dice rolls, when there is more than one roll (default false). When in Low Luck, we instead add +1 onto the power for each extra roll.
-			isMarine							values: gives the unit +1 attack if it is attacking amphibiously
-			canBlitz							values: allows the unit to move through multiple empty enemy territories in one turn
-			receivesAbilityWhenWith				values: gives a unit an ability when they are with, or on the same route as, another unit. currently only works with 'canBlitz'. example: value="canBlitz:armour"
-			canBeGivenByTerritoryTo				values: will allow a unit to be given from one player to another player, if it is in a territory with changeUnitOwners 
-															must be a list of Players who this unit can be given to.  example: value="Russians:Chinese"
-			canBeCapturedOnEnteringBy			values: will allow a unit to be captured from one player to another, if the specified player enters a territory with captureUnitOnEnteringBy
-															must be a list of Players who this unit can be given to.  example: value="Russians:Chinese"
-			canInvadeOnlyFrom					values: is a colon dilimited list of the transporting units which this unit can perform amphibious assaults from. 
-															A unit which can not perform amphibious assaults may instead disembark during non-combat
-															can be set to "all", or "none", or a list of some transports. if this option is not present, it defaults to "all"
-			isInfantry							values: allows the unit to be transported by 'isLandTransport' IF you have mechanizedInfantry technology
-			isLandTransport						values: allows the unit to transport "isInfantry" on a one-to-one basis, if you have the mechanizedInfantry technology
-			isAirTransportable					values: allows the unit to be transported by an "isAirTransport" unit, IF you have paratroopers technology
-			isAirTransport						values: allows an air unit to carry land units when you have paratroopers tech
-			transportCost						values: the space this unit takes up in a transport
-			transportCapacity					values: the amount of space of land units this unit can carry. can be used with sea or air units, except that air units will also require isAirTransport.
-			isCombatTransport					values: considers a unit to be a combat sea unit, even if it has transport capacity, for the purposes of convoys and restricted attack on transports
-			isAirTransportable							values: does nothing
-			isInfantry						values: does nothing
-			
-			canScramble							values: allows the aircraft to enter a surrounding sea zone if the enemy is doing an attack on or from the surrounding sea zone
-			maxScrambleDistance					values: the distance out an aircraft can scramble. anything higher than 1 is not supported well at this point.
-			isSuicide							values: makes a unit die before combat begins, however they do get to roll
-			isKamikaze							values: allows an air unit to use up all of its movement to go to a battle
-			isStrategicBomber					values: allows a unit to bombing factories and canBeDamaged units
-			bombingMaxDieSides					values: is the max dice sides for a strategic bombing or rocket attack.  the default is to use the diceSides for the map.  this property is optional and is only used when you have "Use Bombing Max Dice Sides And Bonus" turned on.  this property is no longer affected by "Low Luck for Bombing and Territory Damage".
-			bombingBonus						values: is a number added to the die rolled, to give the total cost [displayed as a new die rolled], for strategic bombing and rockets only.  this property is optional (default is zero) and is only used when you have "Use Bombing Max Dice Sides And Bonus" turned on.  this property is no longer affected by "Low Luck for Bombing and Territory Damage".
-															example: if you want a unit to throw a 12 sided die, then add 4 onto the result, you would do: <option name="bombingMaxDieSides" value="12"/> and <option name="bombingBonus" value="4"/>
-			bombingTargets						values: is a list of units that this unit may strategic bomb or rocket attack.  if not present, then all units that can be damaged are legal targets. example: <option name="bombingTargets" value="factory:bunker:airfield:harbour"/>
-			carrierCost							values: the space this unit takes up when sitting on a carrier
-			carrierCapacity						values: the amount of space or air unit this unit can carry.
-			
-			canBombard							values: allows a sea unit to bombard the enemy during an amphibious assault
-			bombard								values: the value this unit bombards at. defaults to the attack value of the unit if missing
-			blockade							values: allows the unit to do damage up to the value of land territories surrounding a blockade zone, to the enemy's income
-			isDestroyer							values: cancels out an isSub unit's first strike and submerge abilities, and allows it to be hit by air units if using ww2v3 rules
-			isSub								values: allows the unit to roll dice before other units, and submerge or retreat from battle even on defense, and if using ww2v3 rules not be hit by air unless the enemy has an isDestroyer
-			
-			canBeDamaged						values: sets if a unit can be attacked by strategic bombing raids or by rockets.  isFactory also allows these things
-			maxDamage							values: is the total bombing damage the unit can take (defaults to 2 if not set).  If a factory, and canProduceXUnits = -1 or is missing then maxDamage will be a multiple of the territory value (maxDamage defaults to 2 if canProduceXUnits = -1), otherwise it will be a set number 
-															So for example, if the unit isFactory Or canProduceUnits, And canProduceXUnits = -1, And maxDamage = 3, THEN you will be able to do 3x the territory value in damage to this unit. 
-															If However, canProduceXUnits = 2, and maxDamage = 3, then you can do up to 3 damage to this unit.
-			maxOperationalDamage				values: is used with certain features like isAirBase, repairsUnits, and givesMovement to determine if those features work or not based on the current damage of this unit. A disabled unit will not participate in combat too.  Does Not work with isFactory or canProduceUnits.
-			canDieFromReachingMaxDamage			values: means that if this unit reaches its maxDamage, then it will die.  maxDamage must be larger than zero
-			isInfrastructure					values: means a unit does not participate in combat, and they will be captured if the attacker is successful
-			destroyedWhenCapturedFrom			values: is a list of players who destroy a non-combat unit instead of letting it be captured.  destroyedWhenCapturedFrom just takes the value input then adds "FROM:" to the beginning, then calls destroyedWhenCapturedBy with the new value.
-			destroyedWhenCapturedBy				values: is a list of the players who destroy this non-combat unit instead of capturing it.  all non-combat units are normally captured by default. is a colon delimited list of player names.
-															You can prefix them with single instance of "BY:" or "FROM:" in order to determine if it is being captured by, or captured from, that determines if the unit is destroyed.
-															examples: <option name="destroyedWhenCapturedBy" value="BY:Chinese:Japanese"/> and <option name="destroyedWhenCapturedBy" value="FROM:Russians:Chinese"/>
-			whenCapturedChangesInto				values: allows a unit to change into a different unit when captured from a specific player to a specific player.  "fromPlayer:toPlayer:transferAttributes:unitType:numberOfUnits".  accepts "any" instead of a player name. allows multiple.
-															examples: <option name="whenCapturedChangesInto" value="any:any:true:Minor_Factory:1"/> and <option name="whenCapturedChangesInto" value="Russians:Germans:false:gold:3:lumber:1"/>
-			isAirBase							values: allows units with canScramble to scramble from a territory with this unit
-			maxScrambleCount					values: max number of units which can scramble from this air base. defaults to infinite.
-			givesMovement						values: allows a unit to give movement to other units.  must be an integer, followed by a colon ":", followed by the name of the unit
-			repairsUnits						values: is a colon delimited list of all the units this unit can repair. units to be repaired must be in the same territory as this unit. 
-															unless the unit being repaired is sea, and the unit repairing it is land, in which case the sea unit must be adjacent to the land unit 
-															example: option name="repairsUnits" value="battleship:super_carrier"
-			whenCombatDamaged					values: this property lets you set certain behaviors for when this unit is damaged. the value is the effect, while the count is the damage from where to where. (example: <option name="whenCombatDamaged" value="unitsMayNotLandOnCarrier" count="1:2"/>)
-															units start at zero combat damage, and usually die at 1 damage. some units have 2 hp, so you can use this with 1:1 to say that when a unit has 1 damage they have this effect.
-															currently only allows: unitsMayNotLandOnCarrier, unitsMayNotLeaveAlliedCarrier
-			canIntercept						values: allows this unit to participate in air battles, as a defending unit
-			canEscort							values: allows this unit to participate in air battles, as an attacking unit
-			airDefense							values: defense value of interceptor
-			airAttack							values: attack value of escort
-			fuelCost							values: fuelCost is a list of at least one resource that get used up for each point of movementCost a unit does.  (can have multiple). example: <option name="fuelCost" value="Fuel" count="5"/> and <option name="fuelCost" value="PUs" count="1"/>
-	
-	production related:
-			isFactory							values: just sets: canBeDamaged, isInfrastructure, canProduceUnits, isConstruction, constructionType = "factory", maxConstructionsPerTypePerTerr = 1, constructionsPerTerrPerTypePerTurn = 1
-															isFactory is no longer its own variable. Instead isFactory just sets the above variables. setting is factory will possibly overwrite those variables, so do not use it if you are planning to set those variables to something else.
-															allows a unit to produce other units, not participate in combat, be placed anywhere you owned at the beginning of the turn, be capturable, and be damaged by rockets and raids
-			canProduceXUnits					values: allows a factory-type unit to produce a set amount of units no matter where it is located.  if -1 then it will produce at the value of the territory where it is.  
-															if greater than -1, you must have "maxDamage" set to some number if the unit is also "canBeDamaged" or "isFactory".  defaults to -1 if missing
-			canProduceUnits						values: allows a unit to be a factory, without all the other things that come with being a factory (like capturable, land, non-combat, etc).  So if you want flying factories, go ahead. Just don't complain if you get errors.
-			createsUnitsList					values: is a list of units that this unit will create every turn at the end of the turn. can have multiple instances
-			createsResourcesList				values: is a list of resources that this unit will create every turn at the end of the turn. can have multiple instances
-	
-	placement related:
-			maxBuiltPerPlayer					values: is the number of this unit that can be BUILT by a player.  If they have fewer than this number they can build more, if they have more than this number they can not build more 
-															[this does not cause excess ones to disappear, and the player can still capture more and more of them if they are capturable]
-			canOnlyBePlacedInTerritoryValuedAtX	values: the minimum territory value to place the unit there. defaults to "-1" which means anywhere
-			unitPlacementRestrictions			values: a list of territories where this unit can not be built. list can contain any number of territories, including sea zones .
-															every unit may have a list, and the lists may be different for each unit. default is no list.  
-															the list may be turned on/off with "Unit Placement Restrictions" game property
-			unitPlacementOnlyAllowedIn			values: is the direct inverse of unitPlacementRestrictions
-			requiresUnits						values: is a list of units required to be present in the territory in order for you to build this unit there.  Can have multiple instances. Only one instance needs to be true in order to build.
-															examples: <option name="requiresUnits" value="CombatEngineer:Truck"/> would mean we need at least one CombatEngineer AND at least one Truck in order to build there.  
-															If after that line we had a second line saying <option name="requiresUnits" value="SuperEngineer"/> then it would mean OR we need at least one SuperEngineer.
-			consumesUnits						values: requires that a unit be present in a territory, then when this unit is placed the other units are destroyed / upgraded into this unit.  Can have multiple instances of this, which means it consumes multiple types of units.
-			isConstruction						values: allows the unit to be placed in territories that don't contain factories. only "constructionsPerTerrPerTypePerTurn" contructions of "constructionType" may be placed per territory per turn. 
-															may have only "maxConstructionsPerTypePerTerr" constructions Total per territory with/without a factory unless you enable "More Constructions with/without Factory", which will allow up a total number of up to the territory value
-															and "Unlimited Constructions" game property allows unlimited constructions total in a territory
-			constructionType					values: is just a unique string which identifies what kind of construction this. 
-															if two or more constructions have the exact same constructionType (and the same PerType rules), then they will follow the same rules for placement.
-															example: if you have little_bunker and big_bunker both as type "bunker", with constructionsPerTerrPerTypePerTurn=2, then you could place 2 littles, or 2 bigs, or 1 little and 1 big in a territory 
-															if you do not want this unit to be effected by the global properties "More Constructions with/without Factory" and "Unlimited Constructions", then make sure the type ends in "structure". example: "harbour_structure"
-			constructionsPerTerrPerTypePerTurn	values: is how many of this type you can place in a territory every turn
-			maxConstructionsPerTypePerTerr		values: is how many max of this type may be in a territory. this must be greater than constructionsPerTerrPerTypePerTurn
-															if "More Constructions with/without Factory" = true, then the minimum will be either maxConstructionsPerTypePerTerr or the PU value of the territory (whichever number is greater) in territories with/without factories
-															if "Unlimited Constructions" = true, then this number becomes 10000
-			special								values:	a colon delimited list of possible options for this unit.  Currently only supports: "canOnlyPlaceInOriginalTerritories"
-	
-	aa related:
-			isAA								values: just sets isAAmovement, isAAforCombatOnly, isAAforBombingThisUnitOnly, isAAforFlyOverOnly, isInfrastructure, and isRocket to true. (allows a unit to shoot at air units before combat starts and not participate in the rest of combat, have certain movement restrictions, and be capturable)
-			isAAmovement						values: just sets canNotMoveDuringCombatMove to "true", and only for aa guns it will set the stacking limits (movementLimit, attackingLimit, placementLimit) to "1:allied" when playing by classic rules
-			attackAA							values: the value that an isAA unit will attack at, for shooting at air units before battle
-			attackAAmaxDieSides					values: sets the dice sides for aa guns.  defaults to whatever you chose above in diceSides (or 6 if you didn't choose).  All units with the same typeAA must have the same dice sides.
-															Be Warned that all aa attack values (including with Radar and without Radar), MUST divide into attackAAmaxDieSides without remainders, or else there WILL be errors in LowLuck!
-			maxAAattacks						values: sets how many times this unit may fire its AA guns. Defaults to -1, which means infinite. If not infinite, then aa guns can stack.
-															(If you have multiple aa of the same type-group in a territory, and they have different attack values or dicesides, and different maxAAattacks, then what happens is that the engine will roll for the best attack/diceSides and for the best maxAAattacks, even if that is two different units
-															For example, if you have an aa gun that has infinite attacks and rolls a 4/20, and you have another gun with only one attack and rolls 3/6, then you will end up rolling infinite times at 3/6.  This might be fixed in the future.)
-			mayOverStackAA						values: sets if this unit may fire aa more times than there are aircraft (default = false).
-			isAAforCombatOnly					values: allows this unit to be an AA gun for normal combat only.  it will not defend against strategic bombing raids.
-			isAAforBombingThisUnitOnly			values: allows this unit to be an AA gun only when this unit is directly attacked by a strategic bombing raid (currently defends against all strategic bombing attacks in this territory, not just against this unit).  it will not defend against a normal attack.
-			isAAforFlyOverOnly					values: allows this unit to be an AA gun only when being flown over. if the air unit moves into this territory and stays, then this will not fire.
-															isAAforFlyOverOnly will only work if "AA Territory Restricted" is turned off, and will normally only fire during combat move and not during noncombat move, unless you also turn on "Always on AA".
-			typeAA								values: any string which identifies this type-group of aa guns. Only 1 aa gun per group may fire (unless you've set maxAAattacks). (defaults to "AA")
-														Warning: all units with the same typeAA must have the same dice sides, or else you will experience weird results.
-			targetsAA							values: a list of unit types which this aa gun can hit. (defaults to all air units) (any aa guns in the same group should have the same targetsAA)
-			willNotFireIfPresent				values: a list of unit types for which if they are present in the battle, this aa gun will not fire.
-			isRocket							values: allows this unit to become a rocket if the player has the rocket technology.  If the unit is named exactly "aaGun" then it will require an image called "rockets".  If the unit is named anything else, then it will require an image with "_rockets" appended to its original name
-			canNotMoveDuringCombatMove			values: true or false, defaults to false, does not allow this unit to move during 'combat move phase'
-			movementLimit						values: only affects normal movement. the count is equal to the number of this unit allowed per territory, and the value is equal to "owned" (we are only counting units owned by each player), or "allied" (allied too), or "total" (which counts enemy units too)
-			attackingLimit						values: only affects movement into enemy territory/units. the count is equal to the number of this unit allowed per territory, and the value is equal to "owned" (we are only counting units owned by each player), or "allied" (allied too), or "total" (which counts enemy units too)
-			placementLimit						values: only affects placement. the count is equal to the number of this unit allowed per territory, and the value is equal to "owned" (we are only counting units owned by each player), or "allied" (allied too), or "total" (which counts enemy units too)
-															example: <option name="placementLimit" value="allied" count="1"/>
-			
-	-->
+    <!-- Certain units require extra graphical icons present, for when technology is researched or damage is done.  Here is a list, in order of what is needed:
+            Anything I list as "_something" means that you must have the units exact name in front of it, example: fighter_jp
+            if the unit is called "aaGun" then you need units called "rockets", "rockets_r", and "aaGun_r"
+            if the unit has "isAA", but is not exactly named "aaGun", then you need units called "_rockets" and "_r" and "_rockets_r"
+            if the unit has "isRocket", you need "_rockets"
+            if the unit has "isAAforCombatOnly" and/or "isAAforBombingThisUnitOnly", then you need "_r"
+            if the unit has "isAir", but not "isStrategicBomber", then you need "_lr", and "_jp", and "_lr_jp"
+            if the unit has "isAir", and is "isStrategicBomber", then you need "_lr", and "_hb", and "_lr_hb"
+            if the unit has "isSub", then you need "_ss"
+            if the unit has "isFactory", or is called "factory", then you need "_it", and "_it_hit"
+            if a unit can be damaged (by being a factory, or by having "canBeDamaged", then you will need "_hit"
+            if a unit can be disabled, then you will need "_disabled"
+    -->
+    <!-- the following options are allowed for "unitAttachment"
+            isAir                               values: if a unit is air or not, defaults to false
+            isSea                               values: if a unit is sea or not, defaults to false. any unit that is neither air or sea, is land
+            movement                            values: the allowed movement of a unit, defaults to zero
+            attack                              values: the attack value, where a rolled dice must be equal or less than to hit the enemy
+            defense                             values: the defense value, where a rolled dice must be equal or less than to hit the enemy
+            isTwoHit                            values: does the unit have 2 hitpoints. default is false, which means 1 hitpoint
 
-				<!-- Infantry -->
-				<attachment name="unitAttachment" attachTo="infantry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="1"/>
-						<option name="transportCost" value="2"/>
-						<!-- isInfantry allows the unit to be transported by 'isLandTransport' IF you have mechanizedInfantry technology -->
-						<option name="isInfantry" value="true"/>
-						<!-- isMarine gives the unit +1 attack if it is attacking amphibiously -->
-						<!-- <option name="isMarine" value="true"/> -->
-						<option name="attack" value="1"/>
-						<option name="defense" value="2"/>
-						<!-- artillerySupportable allows the unit to receive support from an "artillery" unit (land, sea, or air are allowed) -->
-						<option name="artillerySupportable" value="true"/>
-						<!-- isAirTransportable allows the unit to be transported by an "isAirTransport" unit, IF you have paratroopers technology -->
-						<option name="isAirTransportable" value="true"/>
-						<!-- canBeGivenByTerritoryTo will allow a unit to be given from one player to another player, if it is in a territory with changeUnitOwners 
-								must be a list of Players who this unit can be given to.  example: value="Russians:Chinese" -->
-						<option name="canBeGivenByTerritoryTo" value="Russians"/>
-						<!-- canBeCapturedOnEnteringBy will allow a unit to be captured from one player to another, if the specified player enters a territory with captureUnitOnEnteringBy
-								must be a list of Players who this unit can be given to.  example: value="Russians:Chinese" 
-						<option name="canBeCapturedOnEnteringBy" value="Americans:British"/>-->
-						<!-- isAirTransportable and isInfantry currently do NOTHING, and are only kept for backwards compatibility
-						<option name="isAirTransportable" value="false"/>
-						<option name="isInfantry" value="false"/> -->
-				</attachment>
-				
-				
-				<!-- Artillery -->
-				<attachment name="unitAttachment" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="1"/>
-						<option name="transportCost" value="3"/>
-						<option name="attack" value="2"/>
-						<option name="defense" value="2"/>
-						<!-- artillery gives support (+1 attack) to "artillerySupportable" units (land, sea, or air are allowed) -->
-						<option name="artillery" value="true"/>
-						<!-- unitSupportCount is the number of units that will be supported by the artillery, defaults to 1 if missing -->
-						<option name="unitSupportCount" value="1"/>
-						<option name="canBeGivenByTerritoryTo" value="Russians"/>
-						<option name="isAirTransportable" value="true"/>
-						<!-- canInvadeOnlyFrom is a colon dilimited list of the transporting units which this unit can perform amphibious assaults from. 
-								A unit which can not perform amphibious assaults may instead disembark during non-combat
-								can be set to "all", or "none", or a list of some transports. if this option is not present, it defaults to "all" -->
-						<option name="canInvadeOnlyFrom" value="transport:jp_transport:air_transport:super_carrier"/>
-						<!-- fuelCost is a list of at least one resource that get used up for each point of movementCost a unit does
-						<option name="fuelCost" value="Fuel" count="5"/>
-						<option name="fuelCost" value="PUs" count="1"/>-->
-				</attachment>
+            artillerySupportable                values: with the 'artillery' and 'unitSupportCount' ability, these three create a set of support attachments at the start of the game,
+                                                            allows the unit to receive support from an "artillery" unit (land, sea, or air are allowed)
+            artillery                           values: with the 'artillerySupportable' and 'unitSupportCount' ability, these three create a set of support attachments at the start of the game,
+                                                            artillery gives support (+1 attack) to "artillerySupportable" units (land, sea, or air are allowed)
+            unitSupportCount                    values: with the 'artillerySupportable' and 'artillery' ability, these three create a set of support attachments at the start of the game,
+                                                            unitSupportCount is the number of units that will be supported by the artillery, defaults to 1 if missing
+            attackRolls                         values: number of rolls this unit gets on attack (default = 1)
+            defenseRolls                        values: number of rolls this unit gets on defense (default = 1)
+            chooseBestRoll                      values: true/false, whether we pick the best dice or use all dice rolls, when there is more than one roll (default false). When in Low Luck, we instead add +1 onto the power for each extra roll.
+            isMarine                            values: gives the unit +1 attack if it is attacking amphibiously
+            canBlitz                            values: allows the unit to move through multiple empty enemy territories in one turn
+            receivesAbilityWhenWith             values: gives a unit an ability when they are with, or on the same route as, another unit. currently only works with 'canBlitz'. example: value="canBlitz:armour"
+            canBeGivenByTerritoryTo             values: will allow a unit to be given from one player to another player, if it is in a territory with changeUnitOwners
+                                                            must be a list of Players who this unit can be given to.  example: value="Russians:Chinese"
+            canBeCapturedOnEnteringBy           values: will allow a unit to be captured from one player to another, if the specified player enters a territory with captureUnitOnEnteringBy
+                                                            must be a list of Players who this unit can be given to.  example: value="Russians:Chinese"
+            canInvadeOnlyFrom                   values: is a colon dilimited list of the transporting units which this unit can perform amphibious assaults from.
+                                                            A unit which can not perform amphibious assaults may instead disembark during non-combat
+                                                            can be set to "all", or "none", or a list of some transports. if this option is not present, it defaults to "all"
+            isInfantry                          values: allows the unit to be transported by 'isLandTransport' IF you have mechanizedInfantry technology
+            isLandTransport                     values: allows the unit to transport "isInfantry" on a one-to-one basis, if you have the mechanizedInfantry technology
+            isAirTransportable                  values: allows the unit to be transported by an "isAirTransport" unit, IF you have paratroopers technology
+            isAirTransport                      values: allows an air unit to carry land units when you have paratroopers tech
+            transportCost                       values: the space this unit takes up in a transport
+            transportCapacity                   values: the amount of space of land units this unit can carry. can be used with sea or air units, except that air units will also require isAirTransport.
+            isCombatTransport                   values: considers a unit to be a combat sea unit, even if it has transport capacity, for the purposes of convoys and restricted attack on transports
+            isAirTransportable                  values: does nothing
+            isInfantry                          values: does nothing
 
-				<!-- Armour -->
-				<attachment name="unitAttachment" attachTo="armour" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="2"/>
-						<option name="transportCost" value="3"/>
-						<!-- canBlitz allows the unit to move through multiple empty enemy territories in one turn -->
-						<option name="canBlitz" value="true"/>
-						<option name="attack" value="3"/>
-						<option name="defense" value="3"/>
-						<!-- isLandTransport allows the unit to transport "isInfantry" on a one-to-one basis, if you have the mechanizedInfantry technology -->
-						<option name="isLandTransport" value="true"/>
-						<option name="canBeGivenByTerritoryTo" value="Russians"/>
-						<!-- consumesUnits requires that a unit be present in a territory, then when this unit is placed the other units are destroyed / upgraded into this unit.  Can have multiple instances of this, which means it consumes multiple types of units.
-						<option name="consumesUnits" value="2:infantry"/>
-						<option name="consumesUnits" value="1:artillery"/>-->
-						<option name="isAirTransportable" value="true"/>
-						<!-- receivesAbilityWhenWith gives a unit an ability when they are with, or on the same route as, another unit 
-						<option name="receivesAbilityWhenWith" value="canBlitz:armour"/>-->
-				</attachment>
+            canScramble                         values: allows the aircraft to enter a surrounding sea zone if the enemy is doing an attack on or from the surrounding sea zone
+            maxScrambleDistance                 values: the distance out an aircraft can scramble. anything higher than 1 is not supported well at this point.
+            isSuicide                           values: makes a unit die before combat begins, however they do get to roll
+            isKamikaze                          values: allows an air unit to use up all of its movement to go to a battle
+            isStrategicBomber                   values: allows a unit to bombing factories and canBeDamaged units
+            bombingMaxDieSides                  values: is the max dice sides for a strategic bombing or rocket attack.  the default is to use the diceSides for the map.  this property is optional and is only used when you have "Use Bombing Max Dice Sides And Bonus" turned on.  this property is no longer affected by "Low Luck for Bombing and Territory Damage".
+            bombingBonus                        values: is a number added to the die rolled, to give the total cost [displayed as a new die rolled], for strategic bombing and rockets only.  this property is optional (default is zero) and is only used when you have "Use Bombing Max Dice Sides And Bonus" turned on.  this property is no longer affected by "Low Luck for Bombing and Territory Damage".
+                                                            example: if you want a unit to throw a 12 sided die, then add 4 onto the result, you would do: <option name="bombingMaxDieSides" value="12"/> and <option name="bombingBonus" value="4"/>
+            bombingTargets                      values: is a list of units that this unit may strategic bomb or rocket attack.  if not present, then all units that can be damaged are legal targets. example: <option name="bombingTargets" value="factory:bunker:airfield:harbour"/>
+            carrierCost                         values: the space this unit takes up when sitting on a carrier
+            carrierCapacity                     values: the amount of space or air unit this unit can carry.
 
-				<!-- Fighter -->
-				<attachment name="unitAttachment" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="4"/>
-						<option name="carrierCost" value="1"/>
-						<option name="isAir" value="true"/>
-						<option name="attack" value="3"/>
-						<option name="defense" value="4"/>
-						<!-- canScramble and maxScrambleDistance are properties for scrambling. allows the aircraft to enter a surrounding sea zone if the enemy is doing an attack on or from the surrounding sea zone -->
-						<option name="canScramble" value="true"/>
-						<option name="maxScrambleDistance" value="1"/>
-						<option name="canIntercept" value="true"/>
-						<option name="canEscort" value="true"/>
-						<option name="airDefense" value="2"/>
-						<option name="airAttack" value="2"/>
-				</attachment>
-				
-				<attachment name="unitAttachment" attachTo="jp_fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="4"/>
-						<option name="carrierCost" value="1"/>
-						<option name="isAir" value="true"/>
-						<option name="attack" value="3"/>
-						<option name="defense" value="4"/>
-						<option name="canScramble" value="true"/>
-						<option name="maxScrambleDistance" value="1"/>
-						<!-- isSuicide makes a unit die before combat begins, however they do get to roll -->
-						<!--<option name="isSuicide" value="true"/>-->
-						<!-- isKamikaze allows an air unit to use up all of its movement to go to a battle -->
-						<!--<option name="isKamikaze" value="true"/>-->
-						<option name="canIntercept" value="true"/>
-						<option name="canEscort" value="true"/>
-						<option name="airDefense" value="2"/>
-						<option name="airAttack" value="2"/>
-				</attachment>
+            canBombard                          values: allows a sea unit to bombard the enemy during an amphibious assault
+            bombard                             values: the value this unit bombards at. defaults to the attack value of the unit if missing
+            blockade                            values: allows the unit to do damage up to the value of land territories surrounding a blockade zone, to the enemy's income
+            isDestroyer                         values: cancels out an isSub unit's first strike and submerge abilities, and allows it to be hit by air units if using ww2v3 rules
+            isSub                               values: allows the unit to roll dice before other units, and submerge or retreat from battle even on defense, and if using ww2v3 rules not be hit by air unless the enemy has an isDestroyer
 
-				<!-- Bomber -->
-				<attachment name="unitAttachment" attachTo="bomber" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="6"/>
-						<option name="isAir" value="true"/>
-						<option name="attack" value="4"/>
-						<option name="defense" value="1"/>
-						<!-- isStrategicBomber allows a unit to bombing factories and canBeDamaged units -->
-						<option name="isStrategicBomber" value="true"/>
-						<!-- transportCapacity + isAirTransport can be used for transporting units IF you have the paratroopers technology -->
-						<option name="transportCapacity" value="2"/>
-						<option name="isAirTransport" value="true"/>
-						<option name="airAttack" value="1"/>
-						<!--<option name="bombingMaxDieSides" value="6"/>
-						<option name="bombingBonus" value="0"/>-->
-				</attachment>
+            canBeDamaged                        values: sets if a unit can be attacked by strategic bombing raids or by rockets.  isFactory also allows these things
+            maxDamage                           values: is the total bombing damage the unit can take (defaults to 2 if not set).  If a factory, and canProduceXUnits = -1 or is missing then maxDamage will be a multiple of the territory value (maxDamage defaults to 2 if canProduceXUnits = -1), otherwise it will be a set number
+                                                            So for example, if the unit isFactory Or canProduceUnits, And canProduceXUnits = -1, And maxDamage = 3, THEN you will be able to do 3x the territory value in damage to this unit.
+                                                            If However, canProduceXUnits = 2, and maxDamage = 3, then you can do up to 3 damage to this unit.
+            maxOperationalDamage                values: is used with certain features like isAirBase, repairsUnits, and givesMovement to determine if those features work or not based on the current damage of this unit. A disabled unit will not participate in combat too.  Does Not work with isFactory or canProduceUnits.
+            canDieFromReachingMaxDamage         values: means that if this unit reaches its maxDamage, then it will die.  maxDamage must be larger than zero
+            isInfrastructure                    values: means a unit does not participate in combat, and they will be captured if the attacker is successful
+            destroyedWhenCapturedFrom           values: is a list of players who destroy a non-combat unit instead of letting it be captured.  destroyedWhenCapturedFrom just takes the value input then adds "FROM:" to the beginning, then calls destroyedWhenCapturedBy with the new value.
+            destroyedWhenCapturedBy             values: is a list of the players who destroy this non-combat unit instead of capturing it.  all non-combat units are normally captured by default. is a colon delimited list of player names.
+                                                            You can prefix them with single instance of "BY:" or "FROM:" in order to determine if it is being captured by, or captured from, that determines if the unit is destroyed.
+                                                            examples: <option name="destroyedWhenCapturedBy" value="BY:Chinese:Japanese"/> and <option name="destroyedWhenCapturedBy" value="FROM:Russians:Chinese"/>
+            whenCapturedChangesInto             values: allows a unit to change into a different unit when captured from a specific player to a specific player.  "fromPlayer:toPlayer:transferAttributes:unitType:numberOfUnits".  accepts "any" instead of a player name. allows multiple.
+                                                            examples: <option name="whenCapturedChangesInto" value="any:any:true:Minor_Factory:1"/> and <option name="whenCapturedChangesInto" value="Russians:Germans:false:gold:3:lumber:1"/>
+            isAirBase                           values: allows units with canScramble to scramble from a territory with this unit
+            maxScrambleCount                    values: max number of units which can scramble from this air base. defaults to infinite.
+            givesMovement                       values: allows a unit to give movement to other units.  must be an integer, followed by a colon ":", followed by the name of the unit
+            repairsUnits                        values: is a colon delimited list of all the units this unit can repair. units to be repaired must be in the same territory as this unit.
+                                                            unless the unit being repaired is sea, and the unit repairing it is land, in which case the sea unit must be adjacent to the land unit
+                                                            example: option name="repairsUnits" value="battleship:super_carrier"
+            whenCombatDamaged                   values: this property lets you set certain behaviors for when this unit is damaged. the value is the effect, while the count is the damage from where to where. (example: <option name="whenCombatDamaged" value="unitsMayNotLandOnCarrier" count="1:2"/>)
+                                                            units start at zero combat damage, and usually die at 1 damage. some units have 2 hp, so you can use this with 1:1 to say that when a unit has 1 damage they have this effect.
+                                                            currently only allows: unitsMayNotLandOnCarrier, unitsMayNotLeaveAlliedCarrier
+            canIntercept                        values: allows this unit to participate in air battles, as a defending unit
+            canEscort                           values: allows this unit to participate in air battles, as an attacking unit
+            airDefense                          values: defense value of interceptor
+            airAttack                           values: attack value of escort
+            fuelCost                            values: fuelCost is a list of at least one resource that get used up for each point of movementCost a unit does.  (can have multiple). example: <option name="fuelCost" value="Fuel" count="5"/> and <option name="fuelCost" value="PUs" count="1"/>
 
-				<!-- Air_Transport -->
-				<attachment name="unitAttachment" attachTo="air_transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="4"/>
-						<option name="isAir" value="true"/>
-						<option name="attack" value="0"/>
-						<option name="defense" value="0"/>
-						<!-- transportCapacity + isAirTransport can be used for transporting units IF you have the paratroopers technology -->
-						<option name="transportCapacity" value="6"/>
-						<option name="isAirTransport" value="true"/>
-				</attachment>
+    production related:
+            isFactory                           values: just sets: canBeDamaged, isInfrastructure, canProduceUnits, isConstruction, constructionType = "factory", maxConstructionsPerTypePerTerr = 1, constructionsPerTerrPerTypePerTurn = 1
+                                                            isFactory is no longer its own variable. Instead isFactory just sets the above variables. setting is factory will possibly overwrite those variables, so do not use it if you are planning to set those variables to something else.
+                                                            allows a unit to produce other units, not participate in combat, be placed anywhere you owned at the beginning of the turn, be capturable, and be damaged by rockets and raids
+            canProduceXUnits                    values: allows a factory-type unit to produce a set amount of units no matter where it is located.  if -1 then it will produce at the value of the territory where it is.
+                                                            if greater than -1, you must have "maxDamage" set to some number if the unit is also "canBeDamaged" or "isFactory".  defaults to -1 if missing
+            canProduceUnits                     values: allows a unit to be a factory, without all the other things that come with being a factory (like capturable, land, non-combat, etc).  So if you want flying factories, go ahead. Just don't complain if you get errors.
+            createsUnitsList                    values: is a list of units that this unit will create every turn at the end of the turn. can have multiple instances
+            createsResourcesList                values: is a list of resources that this unit will create every turn at the end of the turn. can have multiple instances
 
-				<!-- Transport -->
-				<attachment name="unitAttachment" attachTo="transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="2"/>
-						<option name="isSea" value="true"/>
-						<option name="transportCapacity" value="5"/>
-						<!-- attack and defense must be zero if you are using ww2v3 style transport rules (transports can not be used as fodder, etc.) -->
-						<option name="attack" value="0"/>
-						<option name="defense" value="0"/>
-				</attachment>
-				
-				<attachment name="unitAttachment" attachTo="jp_transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="2"/>
-						<option name="isSea" value="true"/>
-						<option name="transportCapacity" value="5"/>
-						<option name="attack" value="0"/>
-						<option name="defense" value="0"/>
-				</attachment>
+    placement related:
+            maxBuiltPerPlayer                   values: is the number of this unit that can be BUILT by a player.  If they have fewer than this number they can build more, if they have more than this number they can not build more
+                                                            [this does not cause excess ones to disappear, and the player can still capture more and more of them if they are capturable]
+            canOnlyBePlacedInTerritoryValuedAtX values: the minimum territory value to place the unit there. defaults to "-1" which means anywhere
+            unitPlacementRestrictions           values: a list of territories where this unit can not be built. list can contain any number of territories, including sea zones .
+                                                            every unit may have a list, and the lists may be different for each unit. default is no list.
+                                                            the list may be turned on/off with "Unit Placement Restrictions" game property
+            unitPlacementOnlyAllowedIn          values: is the direct inverse of unitPlacementRestrictions
+            requiresUnits                       values: is a list of units required to be present in the territory in order for you to build this unit there.  Can have multiple instances. Only one instance needs to be true in order to build.
+                                                            examples: <option name="requiresUnits" value="CombatEngineer:Truck"/> would mean we need at least one CombatEngineer AND at least one Truck in order to build there.
+                                                            If after that line we had a second line saying <option name="requiresUnits" value="SuperEngineer"/> then it would mean OR we need at least one SuperEngineer.
+            consumesUnits                       values: requires that a unit be present in a territory, then when this unit is placed the other units are destroyed / upgraded into this unit.  Can have multiple instances of this, which means it consumes multiple types of units.
+            isConstruction                      values: allows the unit to be placed in territories that don't contain factories. only "constructionsPerTerrPerTypePerTurn" contructions of "constructionType" may be placed per territory per turn.
+                                                            may have only "maxConstructionsPerTypePerTerr" constructions Total per territory with/without a factory unless you enable "More Constructions with/without Factory", which will allow up a total number of up to the territory value
+                                                            and "Unlimited Constructions" game property allows unlimited constructions total in a territory
+            constructionType                    values: is just a unique string which identifies what kind of construction this.
+                                                            if two or more constructions have the exact same constructionType (and the same PerType rules), then they will follow the same rules for placement.
+                                                            example: if you have little_bunker and big_bunker both as type "bunker", with constructionsPerTerrPerTypePerTurn=2, then you could place 2 littles, or 2 bigs, or 1 little and 1 big in a territory
+                                                            if you do not want this unit to be effected by the global properties "More Constructions with/without Factory" and "Unlimited Constructions", then make sure the type ends in "structure". example: "harbour_structure"
+            constructionsPerTerrPerTypePerTurn  values: is how many of this type you can place in a territory every turn
+            maxConstructionsPerTypePerTerr      values: is how many max of this type may be in a territory. this must be greater than constructionsPerTerrPerTypePerTurn
+                                                            if "More Constructions with/without Factory" = true, then the minimum will be either maxConstructionsPerTypePerTerr or the PU value of the territory (whichever number is greater) in territories with/without factories
+                                                            if "Unlimited Constructions" = true, then this number becomes 10000
+            special                             values:    a colon delimited list of possible options for this unit.  Currently only supports: "canOnlyPlaceInOriginalTerritories"
 
-				<!-- Battle Ship -->
-				<attachment name="unitAttachment" attachTo="battleship" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="2"/>
-						<option name="isSea" value="true"/>
-						<option name="attack" value="4"/>
-						<option name="defense" value="4"/>
-						<option name="hitPoints" value="2"/>
-						<option name="canBombard" value="true"/>
-						<!-- bombard defaults to the attack value of the unit if missing -->
-						<option name="bombard" value="4"/>
-						<!-- blockade allows the unit to do damage up to the value of land territories surrounding a blockade zone, to the enemy's income -->
-						<option name="blockade" value="1"/>
-				</attachment>
-				
-				<!-- Cruiser -->
-				<attachment name="unitAttachment" attachTo="cruiser" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="2"/>
-						<option name="isSea" value="true"/>
-						<option name="attack" value="3"/>
-						<option name="defense" value="3"/>
-						<option name="canBombard" value="true"/>
-						<option name="hitPoints" value="1"/>
-						<option name="bombard" value="3"/>
-						<option name="blockade" value="1"/>
-				</attachment>
+    aa related:
+            isAA                                values: just sets isAAmovement, isAAforCombatOnly, isAAforBombingThisUnitOnly, isAAforFlyOverOnly, isInfrastructure, and isRocket to true. (allows a unit to shoot at air units before combat starts and not participate in the rest of combat, have certain movement restrictions, and be capturable)
+            isAAmovement                        values: just sets canNotMoveDuringCombatMove to "true", and only for aa guns it will set the stacking limits (movementLimit, attackingLimit, placementLimit) to "1:allied" when playing by classic rules
+            attackAA                            values: the value that an isAA unit will attack at, for shooting at air units before battle
+            attackAAmaxDieSides                 values: sets the dice sides for aa guns.  defaults to whatever you chose above in diceSides (or 6 if you didn't choose).  All units with the same typeAA must have the same dice sides.
+                                                            Be Warned that all aa attack values (including with Radar and without Radar), MUST divide into attackAAmaxDieSides without remainders, or else there WILL be errors in LowLuck!
+            maxAAattacks                        values: sets how many times this unit may fire its AA guns. Defaults to -1, which means infinite. If not infinite, then aa guns can stack.
+                                                            (If you have multiple aa of the same type-group in a territory, and they have different attack values or dicesides, and different maxAAattacks, then what happens is that the engine will roll for the best attack/diceSides and for the best maxAAattacks, even if that is two different units
+                                                            For example, if you have an aa gun that has infinite attacks and rolls a 4/20, and you have another gun with only one attack and rolls 3/6, then you will end up rolling infinite times at 3/6.  This might be fixed in the future.)
+            mayOverStackAA                      values: sets if this unit may fire aa more times than there are aircraft (default = false).
+            isAAforCombatOnly                   values: allows this unit to be an AA gun for normal combat only.  it will not defend against strategic bombing raids.
+            isAAforBombingThisUnitOnly          values: allows this unit to be an AA gun only when this unit is directly attacked by a strategic bombing raid (currently defends against all strategic bombing attacks in this territory, not just against this unit).  it will not defend against a normal attack.
+            isAAforFlyOverOnly                  values: allows this unit to be an AA gun only when being flown over. if the air unit moves into this territory and stays, then this will not fire.
+                                                            isAAforFlyOverOnly will only work if "AA Territory Restricted" is turned off, and will normally only fire during combat move and not during noncombat move, unless you also turn on "Always on AA".
+            typeAA                              values: any string which identifies this type-group of aa guns. Only 1 aa gun per group may fire (unless you've set maxAAattacks). (defaults to "AA")
+                                                        Warning: all units with the same typeAA must have the same dice sides, or else you will experience weird results.
+            targetsAA                           values: a list of unit types which this aa gun can hit. (defaults to all air units) (any aa guns in the same group should have the same targetsAA)
+            willNotFireIfPresent                values: a list of unit types for which if they are present in the battle, this aa gun will not fire.
+            isRocket                            values: allows this unit to become a rocket if the player has the rocket technology.  If the unit is named exactly "aaGun" then it will require an image called "rockets".  If the unit is named anything else, then it will require an image with "_rockets" appended to its original name
+            canNotMoveDuringCombatMove          values: true or false, defaults to false, does not allow this unit to move during 'combat move phase'
+            movementLimit                       values: only affects normal movement. the count is equal to the number of this unit allowed per territory, and the value is equal to "owned" (we are only counting units owned by each player), or "allied" (allied too), or "total" (which counts enemy units too)
+            attackingLimit                      values: only affects movement into enemy territory/units. the count is equal to the number of this unit allowed per territory, and the value is equal to "owned" (we are only counting units owned by each player), or "allied" (allied too), or "total" (which counts enemy units too)
+            placementLimit                      values: only affects placement. the count is equal to the number of this unit allowed per territory, and the value is equal to "owned" (we are only counting units owned by each player), or "allied" (allied too), or "total" (which counts enemy units too)
+                                                            example: <option name="placementLimit" value="allied" count="1"/>
 
-				<!-- Destroyer -->
-				<attachment name="unitAttachment" attachTo="destroyer" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="2"/>
-						<option name="isSea" value="true"/>
-						<option name="attack" value="2"/>
-						<option name="defense" value="2"/>
-						<!-- isDestroyer does a number of things, all of which target units that are isSub -->
-						<option name="isDestroyer" value="true"/>
-						<option name="blockade" value="1"/>
-				</attachment>
-				
-				<attachment name="unitAttachment" attachTo="jp_destroyer" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="2"/>
-						<option name="isSea" value="true"/>
-						<option name="attack" value="2"/>
-						<option name="defense" value="2"/>
-						<option name="isDestroyer" value="true"/>
-						<option name="blockade" value="1"/>
-						<!--<option name="transportCapacity" value="2"/>-->
-				</attachment>
+    -->
 
-				<!-- Carrier -->
-				<attachment name="unitAttachment" attachTo="carrier" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="carrierCapacity" value="2"/>
-						<option name="movement" value="2"/>
-						<option name="isSea" value="true"/>
-						<option name="attack" value="1"/>
-						<option name="defense" value="2"/>
-						<option name="blockade" value="1"/>
-				</attachment>
+                <!-- Infantry -->
+                <attachment name="unitAttachment" attachTo="infantry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="1"/>
+                        <option name="transportCost" value="2"/>
+                        <!-- isInfantry allows the unit to be transported by 'isLandTransport' IF you have mechanizedInfantry technology -->
+                        <option name="isInfantry" value="true"/>
+                        <!-- isMarine gives the unit +1 attack if it is attacking amphibiously -->
+                        <!-- <option name="isMarine" value="true"/> -->
+                        <option name="attack" value="1"/>
+                        <option name="defense" value="2"/>
+                        <!-- artillerySupportable allows the unit to receive support from an "artillery" unit (land, sea, or air are allowed) -->
+                        <option name="artillerySupportable" value="true"/>
+                        <!-- isAirTransportable allows the unit to be transported by an "isAirTransport" unit, IF you have paratroopers technology -->
+                        <option name="isAirTransportable" value="true"/>
+                        <!-- canBeGivenByTerritoryTo will allow a unit to be given from one player to another player, if it is in a territory with changeUnitOwners
+                                must be a list of Players who this unit can be given to.  example: value="Russians:Chinese" -->
+                        <option name="canBeGivenByTerritoryTo" value="Russians"/>
+                        <!-- canBeCapturedOnEnteringBy will allow a unit to be captured from one player to another, if the specified player enters a territory with captureUnitOnEnteringBy
+                                must be a list of Players who this unit can be given to.  example: value="Russians:Chinese"
+                        <option name="canBeCapturedOnEnteringBy" value="Americans:British"/>-->
+                        <!-- isAirTransportable and isInfantry currently do NOTHING, and are only kept for backwards compatibility
+                        <option name="isAirTransportable" value="false"/>
+                        <option name="isInfantry" value="false"/> -->
+                </attachment>
 
-				<!-- Super_Carrier -->
-				<attachment name="unitAttachment" attachTo="super_carrier" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="carrierCapacity" value="2"/>
-						<option name="movement" value="2"/>
-						<option name="isSea" value="true"/>
-						<option name="attack" value="1"/>
-						<option name="defense" value="3"/>
-						<option name="blockade" value="2"/>
-						<option name="transportCapacity" value="5"/>
-						<!-- isCombatTransport tells the engine that this sea unit can transport but can fight too. units will not be able to move through it like they would a transport, and it can be taken casualty during battle as normal -->
-						<option name="isCombatTransport" value="true"/>
-						<!--<option name="hitPoints" value="2"/>-->
-						<!-- whenCombatDamaged means that when this unit has x:y damage on it, it will have this effect
-						<option name="whenCombatDamaged" value="unitsMayNotLandOnCarrier" count="1:2"/>
-						<option name="whenCombatDamaged" value="unitsMayNotLeaveAlliedCarrier" count="1:2"/>-->
-				</attachment>
 
-				<!-- Submarine -->
-				<attachment name="unitAttachment" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<!-- isSub usually allows a unit to do first strikes and submerge and move under non-isDestroyer units, but all of these are subject to global game properties -->
-						<option name="isSub" value="true"/>
-						<option name="movement" value="2"/>
-						<option name="isSea" value="true"/>
-						<option name="attack" value="2"/>
-						<option name="defense" value="1"/>
-						<option name="blockade" value="2"/>
-				</attachment>
-				
-				<!-- Midget Submarine -->
-				<attachment name="unitAttachment" attachTo="midget_submarine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="isSub" value="true"/>
-						<option name="movement" value="2"/>
-						<option name="isSea" value="true"/>
-						<option name="attack" value="3"/>
-						<option name="defense" value="2"/>
-						<option name="blockade" value="1"/>
-						<!-- isSuicide makes a unit die before combat begins, however they do get to roll -->
-						<option name="isSuicide" value="true"/>
-				</attachment>
-				
-				<!-- Bunker -->
-				<attachment name="unitAttachment" attachTo="bunker" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="movement" value="0"/>
-						<option name="attack" value="0"/>
-						<option name="defense" value="4"/>
-						<!-- canBeDamaged sets if a unit can be attacked by strategic bombing raids or by rockets.  isFactory also allows these things -->
-						<option name="canBeDamaged" value="true"/>
-						<!-- maxDamage is the total damage the unit can take.  If a factory, and canProduceXUnits = -1 or is missing then maxDamage will be a multiple of the territory value (maxDamage defaults to 2 if canProduceXUnits = -1), otherwise it will be a set number 
-								So for example, if the unit isFactory Or canProduceUnits, And canProduceXUnits = -1, And maxDamage = 3, THEN you will be able to do 3x the territory value in damage to this unit. If However, canProduceXUnits = 2, and maxDamage = 3, then you can do up to 3 damage to this unit. -->
-						<option name="maxDamage" value="4"/>
-						<!-- maxOperationalDamage is used with certain features like isAirBase, repairsUnits, and givesMovement to determine if those features work or not based on the current damage of this unit. A disabled unit will not participate in combat too.  Does Not work with isFactory or canProduceUnits. -->
-						<option name="maxOperationalDamage" value="0"/>
-						<!-- isConstruction allows the unit to be placed in territories that don't contain factories. only "constructionsPerTerrPerTypePerTurn" contructions of "constructionType" may be placed per territory per turn. 
-								may have only "maxConstructionsPerTypePerTerr" constructions Total per territory with/without a factory unless you enable "More Constructions with/without Factory", which will allow up a total number of up to the territory value
-								and "Unlimited Constructions" game property allows unlimited constructions total in a territory -->
-						<option name="isConstruction" value="true"/>
-						<!-- constructionType is just a unique string which identifies what kind of construction this. 
-								if two or more constructions have the exact same constructionType (and the same PerType rules), then they will follow the same rules for placement.
-								example: if you have little_bunker and big_bunker both as type "bunker", with constructionsPerTerrPerTypePerTurn=2, then you could place 2 littles, or 2 bigs, or 1 little and 1 big in a territory 
-								if you do not want this unit to be effected by the global properties "More Constructions with/without Factory" and "Unlimited Constructions", then make sure the type ends in "structure". example: "harbour_structure" -->
-						<option name="constructionType" value="bunker"/>
-						<!-- constructionsPerTerrPerTypePerTurn is how many of this type you can place in a territory every turn -->
-						<option name="constructionsPerTerrPerTypePerTurn" value="1"/>
-						<!-- maxConstructionsPerTypePerTerr is how many max of this type may be in a territory. this must be greater than constructionsPerTerrPerTypePerTurn
-								if "More Constructions with/without Factory" = true, then the minimum will be either maxConstructionsPerTypePerTerr or the PU value of the territory (whichever number is greater) in territories with/without factories
-								if "Unlimited Constructions" = true, then this number becomes 10000 -->
-						<option name="maxConstructionsPerTypePerTerr" value="1"/>
-						<!--<option name="hitPoints" value="2"/>-->
-						<!-- canDieFromReachingMaxDamage means that if this unit reaches its maxDamage, then it will die.  maxDamage must be larger than zero -->
-						<option name="canDieFromReachingMaxDamage" value="true"/>
-						<!-- requiresUnits is a list of units required to be present in the territory in order for you to build this unit there.  Can have multiple instances. Only one instance needs to be true in order to build. -->
-						<option name="requiresUnits" value="fighter:bomber:air_transport"/>
-						<option name="requiresUnits" value="factory"/>
-						<option name="requiresUnits" value="airfield"/>
-						<option name="requiresUnits" value="harbour"/>
-						<option name="requiresUnits" value="infantry"/>
-						<option name="requiresUnits" value="artillery"/>
-						<option name="requiresUnits" value="armour"/>
-						<option name="requiresUnits" value="aaGun"/>
-				</attachment>
-				
-				<!-- Airfield -->
-				<attachment name="unitAttachment" attachTo="airfield" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<!-- isInfrastructure means a unit does not participate in combat, and they will be captured if the attacker is successful -->
-						<option name="isInfrastructure" value="true"/>
-						<option name="canBeDamaged" value="true"/>
-						<option name="maxDamage" value="6"/>
-						<option name="maxOperationalDamage" value="2"/>
-						<!-- isAirBase allows units with canScramble to scramble from a territory with this unit -->
-						<option name="isAirBase" value="true"/>
-						<option name="isConstruction" value="true"/>
-						<option name="constructionType" value="airfield_structure"/>
-						<option name="constructionsPerTerrPerTypePerTurn" value="1"/>
-						<option name="maxConstructionsPerTypePerTerr" value="1"/>
-						<!-- destroyedWhenCapturedBy is a list of the players who destroy this non-combat unit instead of capturing it.  all non-combat units are normally captured by default 
-								is a colon delimited list. example: value="Chinese:Russians" -->
-						<option name="destroyedWhenCapturedBy" value="Chinese"/>
-						<!-- givesMovement allows a unit to give movement to other units.  must be an integer, followed by a colon ":", followed by the name of the unit -->
-						<option name="givesMovement" value="1:fighter"/>
-						<option name="givesMovement" value="1:jp_fighter"/>
-						<option name="givesMovement" value="1:bomber"/>
-						<option name="givesMovement" value="1:air_transport"/>
-						<!--<option name="isAAforBombingThisUnitOnly" value="true"/>-->
-						<!--<option name="whenCapturedChangesInto" value="any:Italians:false:aaGun:2:infantry:1"/>
-						<option name="whenCapturedChangesInto" value="Russians:any:true:factory:1"/>-->
-				</attachment>
-				
-				<!-- Harbour -->
-				<attachment name="unitAttachment" attachTo="harbour" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="isInfrastructure" value="true"/>
-						<option name="canBeDamaged" value="true"/>
-						<option name="maxDamage" value="6"/>
-						<option name="maxOperationalDamage" value="2"/>
-						<!-- repairsUnits is a colon delimited list of all the units this unit can repair. units to be repaired must be in the same territory as this unit. 
-								unless the unit being repaired is sea, and the unit repairing it is land, in which case the sea unit must be adjacent to the land unit 
-								example: option name="repairsUnits" value="battleship:super_carrier" -->
-						<option name="repairsUnits" value="battleship"/>
-						<option name="isConstruction" value="true"/>
-						<option name="constructionType" value="harbour_structure"/>
-						<option name="constructionsPerTerrPerTypePerTurn" value="1"/>
-						<option name="maxConstructionsPerTypePerTerr" value="1"/>
-						<option name="destroyedWhenCapturedBy" value="Chinese"/>
-						<!--<option name="givesMovement" value="1:transport"/>
-						<option name="givesMovement" value="1:jp_transport"/>-->
-						<!--<option name="givesMovement" value="1:midget_submarine"/>-->
-						<option name="givesMovement" value="1:submarine"/>
-						<option name="givesMovement" value="1:destroyer"/>
-						<option name="givesMovement" value="1:jp_destroyer"/>
-						<option name="givesMovement" value="1:cruiser"/>
-						<option name="givesMovement" value="1:carrier"/>
-						<option name="givesMovement" value="1:battleship"/>
-						<option name="givesMovement" value="1:super_carrier"/>
-						<!--<option name="isAAforBombingThisUnitOnly" value="true"/>-->
-				</attachment>
-				
-				<!-- Factory -->
-				<attachment name="unitAttachment" attachTo="factory" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<!-- isFactory units can have movement, but not much else -->
-						<option name="isFactory" value="true"/>
-						<!--<option name="maxDamage" value="-1"/>-->
-						<!-- unitPlacementRestrictions are a list of territories where this unit can not be built. list can contain any number of territories, including sea zones .
-								every unit may have a list, and the lists may be different for each unit. default is no list.  
-								the list may be turned on/off with "Unit Placement Restrictions" game property -->
-						<option name="unitPlacementRestrictions" value="Midway:Greenland:Gibraltar:Solomon Islands:Wake Island:Caroline Islands"/>
-						<!-- canOnlyBePlacedInTerritoryValuedAtX means the minimum territory value to place the unit there. defaults to "-1" which means anywhere -->
-						<option name="canOnlyBePlacedInTerritoryValuedAtX" value="2"/>
-						<!-- maxBuiltPerPlayer is the number of this unit that can be BUILT by a player.  If they have fewer than this number they can build more, 
-								if they have more than this number they can not build more [this does not cause excess ones to disappear, and the player can still capture more and more of them if they are capturable] -->
-						<option name="maxBuiltPerPlayer" value="3"/>
-						<option name="destroyedWhenCapturedBy" value="Chinese"/>
-						<!-- unitPlacementOnlyAllowedIn is the direct inverse of unitPlacementRestrictions
-						<option name="unitPlacementOnlyAllowedIn" value="Germany:East Balkans"/>-->
-						<!-- canProduceXUnits allows a factory-type unit to produce a set amount of units no matter where it is located.  if -1 then it will produce at the value of the territory where it is.  
-								if greater than -1, you must have "maxDamage" set to some number if the unit is also "canBeDamaged" or "isFactory".  defaults to -1 if missing -->
-						<option name="canProduceXUnits" value="-1"/>
-						<!-- canProduceUnits allows a unit to be a factory, without all the other things that come with being a factory (like capturable, land, non-combat, etc).  So if you want flying factories, go ahead. Just don't complain if you get errors. 
-						<option name="canProduceUnits" value="true"/>-->
-						<!-- createsUnitsList is a list of units that this unit will create every turn at the end of the turn. can have multiple instances
-						<option name="createsUnitsList" value="2:infantry"/>
-						<option name="createsUnitsList" value="1:artillery"/>-->
-						<!-- createsResourcesList is a list of resources that this unit will create every turn at the end of the turn. can have multiple instances 
-						<option name="createsResourcesList" value="3:PUs"/>
-						<option name="createsResourcesList" value="2:techTokens"/>-->
-						<!-- special allows for some different options for the unit.
-						<option name="special" value="canOnlyPlaceInOriginalTerritories"/>-->
-				</attachment>
+                <!-- Artillery -->
+                <attachment name="unitAttachment" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="1"/>
+                        <option name="transportCost" value="3"/>
+                        <option name="attack" value="2"/>
+                        <option name="defense" value="2"/>
+                        <!-- artillery gives support (+1 attack) to "artillerySupportable" units (land, sea, or air are allowed) -->
+                        <option name="artillery" value="true"/>
+                        <!-- unitSupportCount is the number of units that will be supported by the artillery, defaults to 1 if missing -->
+                        <option name="unitSupportCount" value="1"/>
+                        <option name="canBeGivenByTerritoryTo" value="Russians"/>
+                        <option name="isAirTransportable" value="true"/>
+                        <!-- canInvadeOnlyFrom is a colon dilimited list of the transporting units which this unit can perform amphibious assaults from.
+                                A unit which can not perform amphibious assaults may instead disembark during non-combat
+                                can be set to "all", or "none", or a list of some transports. if this option is not present, it defaults to "all" -->
+                        <option name="canInvadeOnlyFrom" value="transport:jp_transport:air_transport:super_carrier"/>
+                        <!-- fuelCost is a list of at least one resource that get used up for each point of movementCost a unit does
+                        <option name="fuelCost" value="Fuel" count="5"/>
+                        <option name="fuelCost" value="PUs" count="1"/>-->
+                </attachment>
 
-				<!-- AA Gun -->
-				<attachment name="unitAttachment" attachTo="aaGun" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						<option name="isAA" value="true"/>
-						<option name="transportCost" value="3"/>
-						<option name="movement" value="1"/>
-						<option name="destroyedWhenCapturedBy" value="Chinese"/>
-						<option name="destroyedWhenCapturedFrom" value="Russians"/>
-						<!-- destroyedWhenCapturedBy and destroyedWhenCapturedFrom let a unit be destroyed instead of captured.  They can be a colon delimited list of players. 
-								You can prefix them with single instance of "BY:" or "FROM:" in order to determine if it is being captured by, or captured from, that determines if the unit is destroyed. 
-								destroyedWhenCapturedFrom just takes the value input then adds "FROM:" to the beginning, then calls destroyedWhenCapturedBy with the new value.
-						<option name="destroyedWhenCapturedBy" value="BY:Chinese:Japanese"/>
-						<option name="destroyedWhenCapturedBy" value="FROM:Russians:Chinese"/>-->
-						<!--<option name="bombingMaxDieSides" value="6"/>
-						<option name="bombingBonus" value="0"/>-->
-						<!-- attackAA sets the value the AA will attack at (radar adds 1 if this is not 0). Defaults to 1.  Can not be more than half the diceSides (even with radar)-->
-						<option name="attackAA" value="1"/>
-						<!-- attackAAmaxDieSides sets the dice sides for aa guns.  defaults to whatever you chose above in diceSides (or 6 if you didn't choose).  
-								Be Warned that all aa attack values (including with Radar and without Radar), MUST divide into attackAAmaxDieSides without remainders, or else there WILL be errors in LowLuck! -->
-						<option name="attackAAmaxDieSides" value="6"/>
-						<!-- isAAforCombatOnly allows this unit to be an AA gun for normal combat only.  it will not defend against strategic bombing raids 
-						<option name="isAAforCombatOnly" value="true"/>-->
-						<!-- isAAforBombingThisUnitOnly allows this unit to be an AA gun only when this unit is directly attacked by a strategic bombing raid (currently defends against all strategic bombing attacks in this territory, not just against this unit).  it will not defend against a normal attack 
-						<option name="isAAforBombingThisUnitOnly" value="true"/>-->
-						<!-- isRocket allows this unit to become a rocket if the player has the rocket technology.  If the unit is named exactly "aaGun" then it will require an image called "rockets".  If the unit is named anything else, then it will require an image with "_rockets" appended to its original name.
-						<option name="isRocket" value="true"/>-->
-						<!-- canNotMoveDuringCombatMove does not allow movement during 'combat move phase'
-						<option name="canNotMoveDuringCombatMove" value="true"/>-->
-						<!-- movementLimit / attackingLimit / placementLimit sets a maximum for the number of this unit in any territory. value can be "owned", "allied", or "total".
-						<option name="movementLimit" value="allied" count="1"/>-->
-						<!-- typeAA sets what group this aaGun is considered to fire with. only 1 aa gun per group may fire.
-						<option name="typeAA" value="aaGun"/>-->
-						<!-- targetsAA sets what this aaGun can shoot at. a guns in the same group must have the same targets
-						<option name="targetsAA" value="fighter:jp_fighter:bomber:air_transport"/>-->
-						<!-- maxAAattacks sets the max number of attacks this aa gun can perform. defaults to -1 which means infinite. if not infinite, then aa guns can stack.
-						<option name="maxAAattacks" value="-1"/>-->
-				</attachment>
-				
-				
+                <!-- Armour -->
+                <attachment name="unitAttachment" attachTo="armour" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="2"/>
+                        <option name="transportCost" value="3"/>
+                        <!-- canBlitz allows the unit to move through multiple empty enemy territories in one turn -->
+                        <option name="canBlitz" value="true"/>
+                        <option name="attack" value="3"/>
+                        <option name="defense" value="3"/>
+                        <!-- isLandTransport allows the unit to transport "isInfantry" on a one-to-one basis, if you have the mechanizedInfantry technology -->
+                        <option name="isLandTransport" value="true"/>
+                        <option name="canBeGivenByTerritoryTo" value="Russians"/>
+                        <!-- consumesUnits requires that a unit be present in a territory, then when this unit is placed the other units are destroyed / upgraded into this unit.  Can have multiple instances of this, which means it consumes multiple types of units.
+                        <option name="consumesUnits" value="2:infantry"/>
+                        <option name="consumesUnits" value="1:artillery"/>-->
+                        <option name="isAirTransportable" value="true"/>
+                        <!-- receivesAbilityWhenWith gives a unit an ability when they are with, or on the same route as, another unit
+                        <option name="receivesAbilityWhenWith" value="canBlitz:armour"/>-->
+                </attachment>
+
+                <!-- Fighter -->
+                <attachment name="unitAttachment" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="4"/>
+                        <option name="carrierCost" value="1"/>
+                        <option name="isAir" value="true"/>
+                        <option name="attack" value="3"/>
+                        <option name="defense" value="4"/>
+                        <!-- canScramble and maxScrambleDistance are properties for scrambling. allows the aircraft to enter a surrounding sea zone if the enemy is doing an attack on or from the surrounding sea zone -->
+                        <option name="canScramble" value="true"/>
+                        <option name="maxScrambleDistance" value="1"/>
+                        <option name="canIntercept" value="true"/>
+                        <option name="canEscort" value="true"/>
+                        <option name="airDefense" value="2"/>
+                        <option name="airAttack" value="2"/>
+                </attachment>
+
+                <attachment name="unitAttachment" attachTo="jp_fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="4"/>
+                        <option name="carrierCost" value="1"/>
+                        <option name="isAir" value="true"/>
+                        <option name="attack" value="3"/>
+                        <option name="defense" value="4"/>
+                        <option name="canScramble" value="true"/>
+                        <option name="maxScrambleDistance" value="1"/>
+                        <!-- isSuicide makes a unit die before combat begins, however they do get to roll -->
+                        <!--<option name="isSuicide" value="true"/>-->
+                        <!-- isKamikaze allows an air unit to use up all of its movement to go to a battle -->
+                        <!--<option name="isKamikaze" value="true"/>-->
+                        <option name="canIntercept" value="true"/>
+                        <option name="canEscort" value="true"/>
+                        <option name="airDefense" value="2"/>
+                        <option name="airAttack" value="2"/>
+                </attachment>
+
+                <!-- Bomber -->
+                <attachment name="unitAttachment" attachTo="bomber" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="6"/>
+                        <option name="isAir" value="true"/>
+                        <option name="attack" value="4"/>
+                        <option name="defense" value="1"/>
+                        <!-- isStrategicBomber allows a unit to bombing factories and canBeDamaged units -->
+                        <option name="isStrategicBomber" value="true"/>
+                        <!-- transportCapacity + isAirTransport can be used for transporting units IF you have the paratroopers technology -->
+                        <option name="transportCapacity" value="2"/>
+                        <option name="isAirTransport" value="true"/>
+                        <option name="airAttack" value="1"/>
+                        <!--<option name="bombingMaxDieSides" value="6"/>
+                        <option name="bombingBonus" value="0"/>-->
+                </attachment>
+
+                <!-- Air_Transport -->
+                <attachment name="unitAttachment" attachTo="air_transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="4"/>
+                        <option name="isAir" value="true"/>
+                        <option name="attack" value="0"/>
+                        <option name="defense" value="0"/>
+                        <!-- transportCapacity + isAirTransport can be used for transporting units IF you have the paratroopers technology -->
+                        <option name="transportCapacity" value="6"/>
+                        <option name="isAirTransport" value="true"/>
+                </attachment>
+
+                <!-- Transport -->
+                <attachment name="unitAttachment" attachTo="transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="2"/>
+                        <option name="isSea" value="true"/>
+                        <option name="transportCapacity" value="5"/>
+                        <!-- attack and defense must be zero if you are using ww2v3 style transport rules (transports can not be used as fodder, etc.) -->
+                        <option name="attack" value="0"/>
+                        <option name="defense" value="0"/>
+                </attachment>
+
+                <attachment name="unitAttachment" attachTo="jp_transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="2"/>
+                        <option name="isSea" value="true"/>
+                        <option name="transportCapacity" value="5"/>
+                        <option name="attack" value="0"/>
+                        <option name="defense" value="0"/>
+                </attachment>
+
+                <!-- Battle Ship -->
+                <attachment name="unitAttachment" attachTo="battleship" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="2"/>
+                        <option name="isSea" value="true"/>
+                        <option name="attack" value="4"/>
+                        <option name="defense" value="4"/>
+                        <option name="hitPoints" value="2"/>
+                        <option name="canBombard" value="true"/>
+                        <!-- bombard defaults to the attack value of the unit if missing -->
+                        <option name="bombard" value="4"/>
+                        <!-- blockade allows the unit to do damage up to the value of land territories surrounding a blockade zone, to the enemy's income -->
+                        <option name="blockade" value="1"/>
+                </attachment>
+
+                <!-- Cruiser -->
+                <attachment name="unitAttachment" attachTo="cruiser" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="2"/>
+                        <option name="isSea" value="true"/>
+                        <option name="attack" value="3"/>
+                        <option name="defense" value="3"/>
+                        <option name="canBombard" value="true"/>
+                        <option name="hitPoints" value="1"/>
+                        <option name="bombard" value="3"/>
+                        <option name="blockade" value="1"/>
+                </attachment>
+
+                <!-- Destroyer -->
+                <attachment name="unitAttachment" attachTo="destroyer" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="2"/>
+                        <option name="isSea" value="true"/>
+                        <option name="attack" value="2"/>
+                        <option name="defense" value="2"/>
+                        <!-- isDestroyer does a number of things, all of which target units that are isSub -->
+                        <option name="isDestroyer" value="true"/>
+                        <option name="blockade" value="1"/>
+                </attachment>
+
+                <attachment name="unitAttachment" attachTo="jp_destroyer" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="2"/>
+                        <option name="isSea" value="true"/>
+                        <option name="attack" value="2"/>
+                        <option name="defense" value="2"/>
+                        <option name="isDestroyer" value="true"/>
+                        <option name="blockade" value="1"/>
+                        <!--<option name="transportCapacity" value="2"/>-->
+                </attachment>
+
+                <!-- Carrier -->
+                <attachment name="unitAttachment" attachTo="carrier" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="carrierCapacity" value="2"/>
+                        <option name="movement" value="2"/>
+                        <option name="isSea" value="true"/>
+                        <option name="attack" value="1"/>
+                        <option name="defense" value="2"/>
+                        <option name="blockade" value="1"/>
+                </attachment>
+
+                <!-- Super_Carrier -->
+                <attachment name="unitAttachment" attachTo="super_carrier" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="carrierCapacity" value="2"/>
+                        <option name="movement" value="2"/>
+                        <option name="isSea" value="true"/>
+                        <option name="attack" value="1"/>
+                        <option name="defense" value="3"/>
+                        <option name="blockade" value="2"/>
+                        <option name="transportCapacity" value="5"/>
+                        <!-- isCombatTransport tells the engine that this sea unit can transport but can fight too. units will not be able to move through it like they would a transport, and it can be taken casualty during battle as normal -->
+                        <option name="isCombatTransport" value="true"/>
+                        <!--<option name="hitPoints" value="2"/>-->
+                        <!-- whenCombatDamaged means that when this unit has x:y damage on it, it will have this effect
+                        <option name="whenCombatDamaged" value="unitsMayNotLandOnCarrier" count="1:2"/>
+                        <option name="whenCombatDamaged" value="unitsMayNotLeaveAlliedCarrier" count="1:2"/>-->
+                </attachment>
+
+                <!-- Submarine -->
+                <attachment name="unitAttachment" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <!-- isSub usually allows a unit to do first strikes and submerge and move under non-isDestroyer units, but all of these are subject to global game properties -->
+                        <option name="isSub" value="true"/>
+                        <option name="movement" value="2"/>
+                        <option name="isSea" value="true"/>
+                        <option name="attack" value="2"/>
+                        <option name="defense" value="1"/>
+                        <option name="blockade" value="2"/>
+                </attachment>
+
+                <!-- Midget Submarine -->
+                <attachment name="unitAttachment" attachTo="midget_submarine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="isSub" value="true"/>
+                        <option name="movement" value="2"/>
+                        <option name="isSea" value="true"/>
+                        <option name="attack" value="3"/>
+                        <option name="defense" value="2"/>
+                        <option name="blockade" value="1"/>
+                        <!-- isSuicide makes a unit die before combat begins, however they do get to roll -->
+                        <option name="isSuicide" value="true"/>
+                </attachment>
+
+                <!-- Bunker -->
+                <attachment name="unitAttachment" attachTo="bunker" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="movement" value="0"/>
+                        <option name="attack" value="0"/>
+                        <option name="defense" value="4"/>
+                        <!-- canBeDamaged sets if a unit can be attacked by strategic bombing raids or by rockets.  isFactory also allows these things -->
+                        <option name="canBeDamaged" value="true"/>
+                        <!-- maxDamage is the total damage the unit can take.  If a factory, and canProduceXUnits = -1 or is missing then maxDamage will be a multiple of the territory value (maxDamage defaults to 2 if canProduceXUnits = -1), otherwise it will be a set number
+                                So for example, if the unit isFactory Or canProduceUnits, And canProduceXUnits = -1, And maxDamage = 3, THEN you will be able to do 3x the territory value in damage to this unit. If However, canProduceXUnits = 2, and maxDamage = 3, then you can do up to 3 damage to this unit. -->
+                        <option name="maxDamage" value="4"/>
+                        <!-- maxOperationalDamage is used with certain features like isAirBase, repairsUnits, and givesMovement to determine if those features work or not based on the current damage of this unit. A disabled unit will not participate in combat too.  Does Not work with isFactory or canProduceUnits. -->
+                        <option name="maxOperationalDamage" value="0"/>
+                        <!-- isConstruction allows the unit to be placed in territories that don't contain factories. only "constructionsPerTerrPerTypePerTurn" contructions of "constructionType" may be placed per territory per turn.
+                                may have only "maxConstructionsPerTypePerTerr" constructions Total per territory with/without a factory unless you enable "More Constructions with/without Factory", which will allow up a total number of up to the territory value
+                                and "Unlimited Constructions" game property allows unlimited constructions total in a territory -->
+                        <option name="isConstruction" value="true"/>
+                        <!-- constructionType is just a unique string which identifies what kind of construction this.
+                                if two or more constructions have the exact same constructionType (and the same PerType rules), then they will follow the same rules for placement.
+                                example: if you have little_bunker and big_bunker both as type "bunker", with constructionsPerTerrPerTypePerTurn=2, then you could place 2 littles, or 2 bigs, or 1 little and 1 big in a territory
+                                if you do not want this unit to be effected by the global properties "More Constructions with/without Factory" and "Unlimited Constructions", then make sure the type ends in "structure". example: "harbour_structure" -->
+                        <option name="constructionType" value="bunker"/>
+                        <!-- constructionsPerTerrPerTypePerTurn is how many of this type you can place in a territory every turn -->
+                        <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+                        <!-- maxConstructionsPerTypePerTerr is how many max of this type may be in a territory. this must be greater than constructionsPerTerrPerTypePerTurn
+                                if "More Constructions with/without Factory" = true, then the minimum will be either maxConstructionsPerTypePerTerr or the PU value of the territory (whichever number is greater) in territories with/without factories
+                                if "Unlimited Constructions" = true, then this number becomes 10000 -->
+                        <option name="maxConstructionsPerTypePerTerr" value="1"/>
+                        <!--<option name="hitPoints" value="2"/>-->
+                        <!-- canDieFromReachingMaxDamage means that if this unit reaches its maxDamage, then it will die.  maxDamage must be larger than zero -->
+                        <option name="canDieFromReachingMaxDamage" value="true"/>
+                        <!-- requiresUnits is a list of units required to be present in the territory in order for you to build this unit there.  Can have multiple instances. Only one instance needs to be true in order to build. -->
+                        <option name="requiresUnits" value="fighter:bomber:air_transport"/>
+                        <option name="requiresUnits" value="factory"/>
+                        <option name="requiresUnits" value="airfield"/>
+                        <option name="requiresUnits" value="harbour"/>
+                        <option name="requiresUnits" value="infantry"/>
+                        <option name="requiresUnits" value="artillery"/>
+                        <option name="requiresUnits" value="armour"/>
+                        <option name="requiresUnits" value="aaGun"/>
+                </attachment>
+
+                <!-- Airfield -->
+                <attachment name="unitAttachment" attachTo="airfield" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <!-- isInfrastructure means a unit does not participate in combat, and they will be captured if the attacker is successful -->
+                        <option name="isInfrastructure" value="true"/>
+                        <option name="canBeDamaged" value="true"/>
+                        <option name="maxDamage" value="6"/>
+                        <option name="maxOperationalDamage" value="2"/>
+                        <!-- isAirBase allows units with canScramble to scramble from a territory with this unit -->
+                        <option name="isAirBase" value="true"/>
+                        <option name="isConstruction" value="true"/>
+                        <option name="constructionType" value="airfield_structure"/>
+                        <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+                        <option name="maxConstructionsPerTypePerTerr" value="1"/>
+                        <!-- destroyedWhenCapturedBy is a list of the players who destroy this non-combat unit instead of capturing it.  all non-combat units are normally captured by default
+                                is a colon delimited list. example: value="Chinese:Russians" -->
+                        <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                        <!-- givesMovement allows a unit to give movement to other units.  must be an integer, followed by a colon ":", followed by the name of the unit -->
+                        <option name="givesMovement" value="1:fighter"/>
+                        <option name="givesMovement" value="1:jp_fighter"/>
+                        <option name="givesMovement" value="1:bomber"/>
+                        <option name="givesMovement" value="1:air_transport"/>
+                        <!--<option name="isAAforBombingThisUnitOnly" value="true"/>-->
+                        <!--<option name="whenCapturedChangesInto" value="any:Italians:false:aaGun:2:infantry:1"/>
+                        <option name="whenCapturedChangesInto" value="Russians:any:true:factory:1"/>-->
+                </attachment>
+
+                <!-- Harbour -->
+                <attachment name="unitAttachment" attachTo="harbour" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="isInfrastructure" value="true"/>
+                        <option name="canBeDamaged" value="true"/>
+                        <option name="maxDamage" value="6"/>
+                        <option name="maxOperationalDamage" value="2"/>
+                        <!-- repairsUnits is a colon delimited list of all the units this unit can repair. units to be repaired must be in the same territory as this unit.
+                                unless the unit being repaired is sea, and the unit repairing it is land, in which case the sea unit must be adjacent to the land unit
+                                example: option name="repairsUnits" value="battleship:super_carrier" -->
+                        <option name="repairsUnits" value="battleship"/>
+                        <option name="isConstruction" value="true"/>
+                        <option name="constructionType" value="harbour_structure"/>
+                        <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+                        <option name="maxConstructionsPerTypePerTerr" value="1"/>
+                        <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                        <!--<option name="givesMovement" value="1:transport"/>
+                        <option name="givesMovement" value="1:jp_transport"/>-->
+                        <!--<option name="givesMovement" value="1:midget_submarine"/>-->
+                        <option name="givesMovement" value="1:submarine"/>
+                        <option name="givesMovement" value="1:destroyer"/>
+                        <option name="givesMovement" value="1:jp_destroyer"/>
+                        <option name="givesMovement" value="1:cruiser"/>
+                        <option name="givesMovement" value="1:carrier"/>
+                        <option name="givesMovement" value="1:battleship"/>
+                        <option name="givesMovement" value="1:super_carrier"/>
+                        <!--<option name="isAAforBombingThisUnitOnly" value="true"/>-->
+                </attachment>
+
+                <!-- Factory -->
+                <attachment name="unitAttachment" attachTo="factory" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <!-- isFactory units can have movement, but not much else -->
+                        <option name="isFactory" value="true"/>
+                        <!--<option name="maxDamage" value="-1"/>-->
+                        <!-- unitPlacementRestrictions are a list of territories where this unit can not be built. list can contain any number of territories, including sea zones .
+                                every unit may have a list, and the lists may be different for each unit. default is no list.
+                                the list may be turned on/off with "Unit Placement Restrictions" game property -->
+                        <option name="unitPlacementRestrictions" value="Midway:Greenland:Gibraltar:Solomon Islands:Wake Island:Caroline Islands"/>
+                        <!-- canOnlyBePlacedInTerritoryValuedAtX means the minimum territory value to place the unit there. defaults to "-1" which means anywhere -->
+                        <option name="canOnlyBePlacedInTerritoryValuedAtX" value="2"/>
+                        <!-- maxBuiltPerPlayer is the number of this unit that can be BUILT by a player.  If they have fewer than this number they can build more,
+                                if they have more than this number they can not build more [this does not cause excess ones to disappear, and the player can still capture more and more of them if they are capturable] -->
+                        <option name="maxBuiltPerPlayer" value="3"/>
+                        <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                        <!-- unitPlacementOnlyAllowedIn is the direct inverse of unitPlacementRestrictions
+                        <option name="unitPlacementOnlyAllowedIn" value="Germany:East Balkans"/>-->
+                        <!-- canProduceXUnits allows a factory-type unit to produce a set amount of units no matter where it is located.  if -1 then it will produce at the value of the territory where it is.
+                                if greater than -1, you must have "maxDamage" set to some number if the unit is also "canBeDamaged" or "isFactory".  defaults to -1 if missing -->
+                        <option name="canProduceXUnits" value="-1"/>
+                        <!-- canProduceUnits allows a unit to be a factory, without all the other things that come with being a factory (like capturable, land, non-combat, etc).  So if you want flying factories, go ahead. Just don't complain if you get errors.
+                        <option name="canProduceUnits" value="true"/>-->
+                        <!-- createsUnitsList is a list of units that this unit will create every turn at the end of the turn. can have multiple instances
+                        <option name="createsUnitsList" value="2:infantry"/>
+                        <option name="createsUnitsList" value="1:artillery"/>-->
+                        <!-- createsResourcesList is a list of resources that this unit will create every turn at the end of the turn. can have multiple instances
+                        <option name="createsResourcesList" value="3:PUs"/>
+                        <option name="createsResourcesList" value="2:techTokens"/>-->
+                        <!-- special allows for some different options for the unit.
+                        <option name="special" value="canOnlyPlaceInOriginalTerritories"/>-->
+                </attachment>
+
+                <!-- AA Gun -->
+                <attachment name="unitAttachment" attachTo="aaGun" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                        <option name="isAA" value="true"/>
+                        <option name="transportCost" value="3"/>
+                        <option name="movement" value="1"/>
+                        <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                        <option name="destroyedWhenCapturedFrom" value="Russians"/>
+                        <!-- destroyedWhenCapturedBy and destroyedWhenCapturedFrom let a unit be destroyed instead of captured.  They can be a colon delimited list of players.
+                                You can prefix them with single instance of "BY:" or "FROM:" in order to determine if it is being captured by, or captured from, that determines if the unit is destroyed.
+                                destroyedWhenCapturedFrom just takes the value input then adds "FROM:" to the beginning, then calls destroyedWhenCapturedBy with the new value.
+                        <option name="destroyedWhenCapturedBy" value="BY:Chinese:Japanese"/>
+                        <option name="destroyedWhenCapturedBy" value="FROM:Russians:Chinese"/>-->
+                        <!--<option name="bombingMaxDieSides" value="6"/>
+                        <option name="bombingBonus" value="0"/>-->
+                        <!-- attackAA sets the value the AA will attack at (radar adds 1 if this is not 0). Defaults to 1.  Can not be more than half the diceSides (even with radar)-->
+                        <option name="attackAA" value="1"/>
+                        <!-- attackAAmaxDieSides sets the dice sides for aa guns.  defaults to whatever you chose above in diceSides (or 6 if you didn't choose).
+                                Be Warned that all aa attack values (including with Radar and without Radar), MUST divide into attackAAmaxDieSides without remainders, or else there WILL be errors in LowLuck! -->
+                        <option name="attackAAmaxDieSides" value="6"/>
+                        <!-- isAAforCombatOnly allows this unit to be an AA gun for normal combat only.  it will not defend against strategic bombing raids
+                        <option name="isAAforCombatOnly" value="true"/>-->
+                        <!-- isAAforBombingThisUnitOnly allows this unit to be an AA gun only when this unit is directly attacked by a strategic bombing raid (currently defends against all strategic bombing attacks in this territory, not just against this unit).  it will not defend against a normal attack
+                        <option name="isAAforBombingThisUnitOnly" value="true"/>-->
+                        <!-- isRocket allows this unit to become a rocket if the player has the rocket technology.  If the unit is named exactly "aaGun" then it will require an image called "rockets".  If the unit is named anything else, then it will require an image with "_rockets" appended to its original name.
+                        <option name="isRocket" value="true"/>-->
+                        <!-- canNotMoveDuringCombatMove does not allow movement during 'combat move phase'
+                        <option name="canNotMoveDuringCombatMove" value="true"/>-->
+                        <!-- movementLimit / attackingLimit / placementLimit sets a maximum for the number of this unit in any territory. value can be "owned", "allied", or "total".
+                        <option name="movementLimit" value="allied" count="1"/>-->
+                        <!-- typeAA sets what group this aaGun is considered to fire with. only 1 aa gun per group may fire.
+                        <option name="typeAA" value="aaGun"/>-->
+                        <!-- targetsAA sets what this aaGun can shoot at. a guns in the same group must have the same targets
+                        <option name="targetsAA" value="fighter:jp_fighter:bomber:air_transport"/>-->
+                        <!-- maxAAattacks sets the max number of attacks this aa gun can perform. defaults to -1 which means infinite. if not infinite, then aa guns can stack.
+                        <option name="maxAAattacks" value="-1"/>-->
+                </attachment>
+
+
 <!-- Territory Attachments -->
-	<!-- <option name="unitProduction" value="x"/> must be placed under <option name="production" value="x"/> if it is being used. 
-			This is because a recent update to TripleA had the setting of 'production' automatically set 'unitProduction' to be equal to it. 
-			If you want to set "production" without also setting "unitProduction", then please use "productionOnly" -->
-	<!-- the following options are allowed for "territoryAttachment"
-			production								values: the PU production of the territory. also sets unitProduction to the same value.
-			productionOnly							values: this sets "production" without setting "unitProduction"
-			unitProduction							values: unitProduction is complex and has 2 uses, depending on how you plan on dealing with damage. Defaults to whatever "production" is, so please set it after you set "production"
-																1. 	First use is used only with ww2v3 factory damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to a Territory, not to a Unit.
-																		This decides the damage the territory starts at.  If unitProduction is less than production, then the territory starts damaged.  If they are equal, then the territory is not damaged. 
-																2. 	Second use is used with newer maps which are using the new damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to an individual Unit instead of a Territory.
-																		When used with these rules, "unitProduction" lets you set the unit production potential of a territory, separate from the production. This means a territory with unitProduction = 2 will be able to produce 2 units there, regardless of if production is 0 or 20.
-																		(The damage potential of these units will normally be 2x the unitProduction, but this can be set individually by creative use of maxDamage and canProduceXUnits)
-			resources								values: the amount we will get, then the name of the resource. example: value="2:steel"
-			isImpassable							values: true or false, is this territory not passable?
-			capital									values: the capital of a player, and player's can have multiple capitals.  all players except for optional players require a capital. 
-																capital uses an image located in the "flags" folder of a map called "<nation>_large.png", and the location is determined in a file called "capitols.txt" in the map's root directory
-			victoryCity								values: a victory city is typically used for victory conditions
-																victoryCity uses an image located in the "misc" folder of a map called "vc.png", and the location is determined in a file called "vc.txt" in the map's root directory
-			originalFactory							values: means that the original controller of the territory may produce infinite units there, however if it is captured the opponent may only produce as normal, not infinite units
-			originalOwner							values: allows a territory to revert to this player's control if liberated by an ally
-			navalBase								values: works according to original pacific rules: it increases the non-combat movement of naval units by +1 IF they go from friendly naval base TO friendly naval base
-			airBase									values: works according to original pacific rules: it allows free movement between the land territory and any connecting water territories, 
-																which potentially gives an air units +2 movement if they move from airbase to airbase and both airbases have water connecting to them on the route (or are islands)
-			captureUnitOnEnteringBy					values: allows some players to have their units change to another player's control, if they are located in territories with this attachment, and the specified player captures this territory
-																it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans"
-			changeUnitOwners						values: allows some players to have their units change to another player's control, if they are located in territories with this attachment 
-																it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans"
-			convoyRoute								values: true or false. Is this territory part of a Convoy route. (meaning, if this territory Either REQUIRES other territories to be owned, or is REQUIRED BY other territories to be owned).
-			convoyAttached							values: a colon (":") delimited list of the territories this convoy is route is using (list of territories This territory REQUIRES). This can be empty if this territory does not require any other territories but is required by other territories.
-																At least one of the attached territories must be owned by a friendly to collect income from this territory.
-			blockadeZone							values: true or false, can this territory be blockaded by neighboring sea zones?
-			kamikazeZone							values: true or false, does nothing right now, but it will put a symbol on the map (the kamikazeZone symbol must be in the flags folder and be named "<owner_name>_fade"
-			territoryEffect							values: adds a territoryEffect to a territory, can have multiple
-			whenCapturedByGoesTo					values: the player that captures the territory, then the player that will get the territory, separated by a colon.  Can have multiple. For example: value="Americans:Russians"
-			
-	-->
-				
-				<attachment name="territoryAttachment" attachTo="West Balkans" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-						<!-- resources allow you to use custom resource production for a territory.
-						<option name="resources" value="1:Steel"/>
-						<option name="resources" value="1:Aluminium"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Greece" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-						<!-- captureUnitOnEnteringBy allows some players to have their units change to another player's control, if they are located in territories with this attachment, and the specified player captures this territory
-								it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans" 
-						<option name="captureUnitOnEnteringBy" value="Americans:British"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Sicily" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Sardinia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-						<!-- convoyRoute and convoyAttached are for setting a territory to require another territory in order to collect income. at least one of the listed territories must be owned by a friendly to collect income from this territory.
-						<option name="convoyRoute" value="true"/>
-						<option name="convoyAttached" value="14 Sea Zone:13 Sea Zone"/> -->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Eastern Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment"  type="territory">
-						<option name="production" value="14"/>
-						<!-- capital uses an image located in the "flags" folder of a map called "<nation>_large.png", and the location is determined in a file called "capitols.txt" in the map's root directory -->
-						<option name="capital" value="Germans"/>
-						<!-- victoryCity uses an image located in the "misc" folder of a map called "vc.png", and the location is determined in a file called "vc.txt" in the map's root directory -->
-						<option name="victoryCity" value="1"/>
-						<!--- originalFactory means that the original controller of the territory may produce infinite units there, however if it is captured the opponent may only produce as normal, not infinite units 
-						<option name="originalFactory" value="true"/> -->
-						<!-- navalBase territory attachment works according to original pacific rules: it increases the non-combat movement of naval units by +1 IF they go from friendly naval base TO friendly naval base
-						<option name="navalBase" value="true"/> -->
-						<!-- airBase territory attachment works according to original pacific rules: it allows free movement between the land territory and any connecting water territories, 
-								which potentially gives an air units +2 movement if they move from airbase to airbase and both airbases have water connecting to them on the route (or are islands)
-						<option name="airBase" value="true"/> -->
-						<!-- unitProduction is complex and has 2 uses, depending on how you plan on dealing with damage. 
-									(setting "production" sets "unitProduction" at the same time to be equal, therefore unitProduction defaults to production if it is not set, or if it is set before production. 
-									If you want unitProduction to be different, please set it after you set production.)
-							1. 	First use is used only with ww2v3 factory damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to a Territory, not to a Unit.
-									This decides the damage the territory starts at.  If unitProduction is less than production, then the territory starts damaged.  If they are equal, then the territory is not damaged. 
-							2. 	Second use is used with newer maps which are using the new damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to an individual Unit instead of a Territory.
-									When used with these rules, "unitProduction" lets you set the unit production potential of a territory, separate from the production. This means a territory with unitProduction = 2 will be able to produce 2 units there, regardless of if production is 0 or 20.
-									The damage potential of these units will normally be 2x the unitProduction, but this can be set individually by creative use of maxDamage and canProduceXUnits.
-								Must be placed UNDER 'production' in the xml, because 'production' automatically sets 'unitProduction' to be equal otherwise.
-						<option name="unitProduction" value="14"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Midway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Greenland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Union of South Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Australia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Kenya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Manchuria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-						<!-- originalOwner allows a territory to revert to that player's control if liberated by an ally -->
-						<option name="originalOwner" value="Chinese"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Alaska" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Persia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="French West Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Turkey" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Belgian Congo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="India" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Soviet Far East" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<!-- Italian Capital -->
-				<attachment name="territoryAttachment" attachTo="Italy" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="8"/>
-						<option name="capital" value="Italians"/>
-						<option name="victoryCity" value="1"/>
-						<!--<option name="unitProduction" value="8"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Mexico" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Spain" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Afghanistan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Philipine Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Archangel" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-						<!-- changeUnitOwners allows some players to have their units change to another player's control, if they are located in territories with this attachment 
-								it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans" -->
-						<option name="changeUnitOwners" value="Russians"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Novisibirsk" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Eire" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Mozambique" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Italian East Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Eastern Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="4"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Western United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="10"/>
-						<option name="victoryCity" value="1"/>
-						<!--<option name="unitProduction" value="10"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Karelia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-						<option name="victoryCity" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Kwangtung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
-						<option name="originalOwner" value="Chinese"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Brazil" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Borneo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="4"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="French Madagascar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Yakut S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Hawaiian Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-						<option name="victoryCity" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="East Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="4"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Saudia Arabia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Switzerland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Norway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-						<option name="convoyRoute" value="true"/>
-						<option name="convoyAttached" value="5 Sea Zone:6 Sea Zone"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="French Indochina" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="West Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Kazakh S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Venezuala" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Trans-Jordan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<!-- British Capital -->
-				<attachment name="territoryAttachment" attachTo="United Kingdom" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="8"/>
-						<option name="capital" value="British"/>
-						<option name="victoryCity" value="1"/>
-						<!--<option name="unitProduction" value="8"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Western Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="6"/>
-						<option name="victoryCity" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Rio De Oro" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Angloa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="New Zealand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Sahara" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="French Equatorial Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Gibraltar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Solomon Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Caucus" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="4"/>
-						<option name="victoryCity" value="1"/>
-						<!--<option name="unitProduction" value="4"/>-->
-						<!-- you can have multiple capitals per country, and can modify if they capture or destroy their PUs, and how many capitals are needed for that to happen -->
-						<!--<option name="capital" value="Russians"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Sinkiang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Algeria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="East Balkans" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-						<!--<option name="unitProduction" value="3"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Wake Island" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Himilaya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-						<option name="capital" value="Chinese"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Evanki National Okrug" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-						<!--<option name="capital" value="Russians"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Sweden" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Libya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Ukraine S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="3"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Mongolia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="West Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-						<option name="whenCapturedByGoesTo" value="Americans:Russians"/>
-						<option name="whenCapturedByGoesTo" value="British:Russians"/>
-						<option name="whenCapturedByGoesTo" value="Chinese:Russians"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Peru" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<!-- American Capital -->
-				<attachment name="territoryAttachment" attachTo="Eastern United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="12"/>
-						<option name="capital" value="Americans"/>
-						<option name="victoryCity" value="1"/>
-						<!--<option name="unitProduction" value="12"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Belorussia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Burytia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<!-- Russian Capital -->
-				<attachment name="territoryAttachment" attachTo="Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="8"/>
-						<option name="capital" value="Russians"/>
-						<option name="victoryCity" value="1"/>
-						<!--<option name="unitProduction" value="8"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Anglo Egypt" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="New Guinea" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Okinawa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Panama" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Western Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Central United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="4"/>
-						<!--<option name="territoryEffect" value="mountain"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Argentina" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="China" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Central China" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-				</attachment>
-
-				<!-- Japanese Capital -->
-				<attachment name="territoryAttachment" attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="8"/>
-						<option name="capital" value="Japanese"/>
-						<option name="victoryCity" value="1"/>
-						<!--<option name="unitProduction" value="8"/>-->
-				</attachment>
-
-				<attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-				</attachment>
-				
-				<!-- Convoy Centers, Convoy Routes, Blockade Zones -->
-				<!-- Convoy Routes must be attached to both the Requiring territory and the Required territory. Sea convoys can have income too, and if they do then they operate just like Convoy Centers for the income
-				<attachment name="territoryAttachment" attachTo="13 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="convoyRoute" value="true"/>
-						<option name="convoyAttached" value=""/>
-				</attachment>
-				<attachment name="territoryAttachment" attachTo="14 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-						<option name="convoyRoute" value="true"/>
-						<option name="convoyAttached" value=""/>
-				</attachment> -->
-				<attachment name="territoryAttachment" attachTo="5 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-						<!-- Sea zone 5 is part of the convoyRoute of Norway (Norway has it listed under convoyAttached), so Sea zone 5 must have convoyRoute = true -->
-						<option name="convoyRoute" value="true"/>
-						<!-- Sea zone 5 has an income of 2 for Germany, but it does not Require ownership of another territory in order to get the income, so "convoyAttached" is blank -->
-						<option name="convoyAttached" value=""/>
-				</attachment>
-				<attachment name="territoryAttachment" attachTo="6 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="convoyRoute" value="true"/>
-				</attachment>
-				
-				<!-- Convoy Centers are simply sea zones with income. if you control your convoy zone, you get the income from it, but if an enemy takes the zone they do not get any income, they just deny you the income. can only be entered during combat movement -->
-				<attachment name="territoryAttachment" attachTo="3 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-						<option name="originalOwner" value="Russians"/>
-				</attachment>
-				<attachment name="territoryAttachment" attachTo="4 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-				</attachment>
-				
-				<!-- Blockade Zones are areas where if the enemy has ships there, they subtract money from each of the connecting land territories up to the value of the territory. 
-						if there are many enemy ships, you will collect no income from the connecting land territories. should be set to zero production otherwise they become convoy zones too -->
-				<attachment name="territoryAttachment" attachTo="37 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-				</attachment>
-				<attachment name="territoryAttachment" attachTo="47 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-				</attachment>
-				<attachment name="territoryAttachment" attachTo="48 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-				</attachment>
-				<attachment name="territoryAttachment" attachTo="49 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-						<!-- kamikazeZone does nothing right now, but it will put a symbol on the map (the kamikazeZone symbol must be in the flags folder and be named "<owner_name>_fade"
-						<option name="kamikazeZone" value="true"/>-->
-				</attachment>
-				<attachment name="territoryAttachment" attachTo="58 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-				</attachment>
-
-				
-				
+    <!-- <option name="unitProduction" value="x"/> must be placed under <option name="production" value="x"/> if it is being used.
+            This is because a recent update to TripleA had the setting of 'production' automatically set 'unitProduction' to be equal to it.
+            If you want to set "production" without also setting "unitProduction", then please use "productionOnly" -->
+    <!-- the following options are allowed for "territoryAttachment"
+            production                              values: the PU production of the territory. also sets unitProduction to the same value.
+            productionOnly                          values: this sets "production" without setting "unitProduction"
+            unitProduction                          values: unitProduction is complex and has 2 uses, depending on how you plan on dealing with damage. Defaults to whatever "production" is, so please set it after you set "production"
+                                                                1.     First use is used only with ww2v3 factory damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to a Territory, not to a Unit.
+                                                                        This decides the damage the territory starts at.  If unitProduction is less than production, then the territory starts damaged.  If they are equal, then the territory is not damaged.
+                                                                2.     Second use is used with newer maps which are using the new damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to an individual Unit instead of a Territory.
+                                                                        When used with these rules, "unitProduction" lets you set the unit production potential of a territory, separate from the production. This means a territory with unitProduction = 2 will be able to produce 2 units there, regardless of if production is 0 or 20.
+                                                                        (The damage potential of these units will normally be 2x the unitProduction, but this can be set individually by creative use of maxDamage and canProduceXUnits)
+            resources                               values: the amount we will get, then the name of the resource. example: value="2:steel"
+            isImpassable                            values: true or false, is this territory not passable?
+            capital                                 values: the capital of a player, and player's can have multiple capitals.  all players except for optional players require a capital.
+                                                                capital uses an image located in the "flags" folder of a map called "<nation>_large.png", and the location is determined in a file called "capitols.txt" in the map's root directory
+            victoryCity                             values: a victory city is typically used for victory conditions
+                                                                victoryCity uses an image located in the "misc" folder of a map called "vc.png", and the location is determined in a file called "vc.txt" in the map's root directory
+            originalFactory                         values: means that the original controller of the territory may produce infinite units there, however if it is captured the opponent may only produce as normal, not infinite units
+            originalOwner                           values: allows a territory to revert to this player's control if liberated by an ally
+            navalBase                               values: works according to original pacific rules: it increases the non-combat movement of naval units by +1 IF they go from friendly naval base TO friendly naval base
+            airBase                                 values: works according to original pacific rules: it allows free movement between the land territory and any connecting water territories,
+                                                                which potentially gives an air units +2 movement if they move from airbase to airbase and both airbases have water connecting to them on the route (or are islands)
+            captureUnitOnEnteringBy                 values: allows some players to have their units change to another player's control, if they are located in territories with this attachment, and the specified player captures this territory
+                                                                it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans"
+            changeUnitOwners                        values: allows some players to have their units change to another player's control, if they are located in territories with this attachment
+                                                                it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans"
+            convoyRoute                             values: true or false. Is this territory part of a Convoy route. (meaning, if this territory Either REQUIRES other territories to be owned, or is REQUIRED BY other territories to be owned).
+            convoyAttached                          values: a colon (":") delimited list of the territories this convoy is route is using (list of territories This territory REQUIRES). This can be empty if this territory does not require any other territories but is required by other territories.
+                                                                At least one of the attached territories must be owned by a friendly to collect income from this territory.
+            blockadeZone                            values: true or false, can this territory be blockaded by neighboring sea zones?
+            kamikazeZone                            values: true or false, does nothing right now, but it will put a symbol on the map (the kamikazeZone symbol must be in the flags folder and be named "<owner_name>_fade"
+            territoryEffect                         values: adds a territoryEffect to a territory, can have multiple
+            whenCapturedByGoesTo                    values: the player that captures the territory, then the player that will get the territory, separated by a colon.  Can have multiple. For example: value="Americans:Russians"
+
+    -->
+
+                <attachment name="territoryAttachment" attachTo="West Balkans" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <!-- resources allow you to use custom resource production for a territory.
+                        <option name="resources" value="1:Steel"/>
+                        <option name="resources" value="1:Aluminium"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Greece" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <!-- captureUnitOnEnteringBy allows some players to have their units change to another player's control, if they are located in territories with this attachment, and the specified player captures this territory
+                                it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans"
+                        <option name="captureUnitOnEnteringBy" value="Americans:British"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Sicily" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Sardinia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <!-- convoyRoute and convoyAttached are for setting a territory to require another territory in order to collect income. at least one of the listed territories must be owned by a friendly to collect income from this territory.
+                        <option name="convoyRoute" value="true"/>
+                        <option name="convoyAttached" value="14 Sea Zone:13 Sea Zone"/> -->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Eastern Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment"  type="territory">
+                        <option name="production" value="14"/>
+                        <!-- capital uses an image located in the "flags" folder of a map called "<nation>_large.png", and the location is determined in a file called "capitols.txt" in the map's root directory -->
+                        <option name="capital" value="Germans"/>
+                        <!-- victoryCity uses an image located in the "misc" folder of a map called "vc.png", and the location is determined in a file called "vc.txt" in the map's root directory -->
+                        <option name="victoryCity" value="1"/>
+                        <!--- originalFactory means that the original controller of the territory may produce infinite units there, however if it is captured the opponent may only produce as normal, not infinite units
+                        <option name="originalFactory" value="true"/> -->
+                        <!-- navalBase territory attachment works according to original pacific rules: it increases the non-combat movement of naval units by +1 IF they go from friendly naval base TO friendly naval base
+                        <option name="navalBase" value="true"/> -->
+                        <!-- airBase territory attachment works according to original pacific rules: it allows free movement between the land territory and any connecting water territories,
+                                which potentially gives an air units +2 movement if they move from airbase to airbase and both airbases have water connecting to them on the route (or are islands)
+                        <option name="airBase" value="true"/> -->
+                        <!-- unitProduction is complex and has 2 uses, depending on how you plan on dealing with damage.
+                                    (setting "production" sets "unitProduction" at the same time to be equal, therefore unitProduction defaults to production if it is not set, or if it is set before production.
+                                    If you want unitProduction to be different, please set it after you set production.)
+                            1.     First use is used only with ww2v3 factory damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to a Territory, not to a Unit.
+                                    This decides the damage the territory starts at.  If unitProduction is less than production, then the territory starts damaged.  If they are equal, then the territory is not damaged.
+                            2.     Second use is used with newer maps which are using the new damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to an individual Unit instead of a Territory.
+                                    When used with these rules, "unitProduction" lets you set the unit production potential of a territory, separate from the production. This means a territory with unitProduction = 2 will be able to produce 2 units there, regardless of if production is 0 or 20.
+                                    The damage potential of these units will normally be 2x the unitProduction, but this can be set individually by creative use of maxDamage and canProduceXUnits.
+                                Must be placed UNDER 'production' in the xml, because 'production' automatically sets 'unitProduction' to be equal otherwise.
+                        <option name="unitProduction" value="14"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Midway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Greenland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Union of South Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Australia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Kenya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Manchuria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <!-- originalOwner allows a territory to revert to that player's control if liberated by an ally -->
+                        <option name="originalOwner" value="Chinese"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Alaska" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Persia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="French West Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Turkey" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Belgian Congo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="India" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Soviet Far East" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <!-- Italian Capital -->
+                <attachment name="territoryAttachment" attachTo="Italy" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="8"/>
+                        <option name="capital" value="Italians"/>
+                        <option name="victoryCity" value="1"/>
+                        <!--<option name="unitProduction" value="8"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Mexico" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Spain" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Afghanistan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Philipine Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Archangel" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <!-- changeUnitOwners allows some players to have their units change to another player's control, if they are located in territories with this attachment
+                                it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans" -->
+                        <option name="changeUnitOwners" value="Russians"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Novisibirsk" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Eire" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Mozambique" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Italian East Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Eastern Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Western United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="10"/>
+                        <option name="victoryCity" value="1"/>
+                        <!--<option name="unitProduction" value="10"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Karelia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Kwangtung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="1"/>
+                        <option name="originalOwner" value="Chinese"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Brazil" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Borneo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="French Madagascar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Yakut S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Hawaiian Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="East Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Saudia Arabia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Switzerland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Norway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="convoyRoute" value="true"/>
+                        <option name="convoyAttached" value="5 Sea Zone:6 Sea Zone"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="French Indochina" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="West Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Kazakh S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Venezuala" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Trans-Jordan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <!-- British Capital -->
+                <attachment name="territoryAttachment" attachTo="United Kingdom" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="8"/>
+                        <option name="capital" value="British"/>
+                        <option name="victoryCity" value="1"/>
+                        <!--<option name="unitProduction" value="8"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Western Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                        <option name="victoryCity" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Rio De Oro" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Angloa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="New Zealand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Sahara" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="French Equatorial Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Gibraltar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Solomon Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Caucus" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                        <option name="victoryCity" value="1"/>
+                        <!--<option name="unitProduction" value="4"/>-->
+                        <!-- you can have multiple capitals per country, and can modify if they capture or destroy their PUs, and how many capitals are needed for that to happen -->
+                        <!--<option name="capital" value="Russians"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Sinkiang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Algeria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="East Balkans" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <!--<option name="unitProduction" value="3"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Wake Island" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Himilaya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                        <option name="capital" value="Chinese"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Evanki National Okrug" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <!--<option name="capital" value="Russians"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Sweden" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Libya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Ukraine S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Mongolia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="West Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="whenCapturedByGoesTo" value="Americans:Russians"/>
+                        <option name="whenCapturedByGoesTo" value="British:Russians"/>
+                        <option name="whenCapturedByGoesTo" value="Chinese:Russians"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Peru" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <!-- American Capital -->
+                <attachment name="territoryAttachment" attachTo="Eastern United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="12"/>
+                        <option name="capital" value="Americans"/>
+                        <option name="victoryCity" value="1"/>
+                        <!--<option name="unitProduction" value="12"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Belorussia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Burytia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <!-- Russian Capital -->
+                <attachment name="territoryAttachment" attachTo="Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="8"/>
+                        <option name="capital" value="Russians"/>
+                        <option name="victoryCity" value="1"/>
+                        <!--<option name="unitProduction" value="8"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Anglo Egypt" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="New Guinea" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Okinawa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Panama" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Western Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Central United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                        <!--<option name="territoryEffect" value="mountain"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Argentina" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="China" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Central China" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                </attachment>
+
+                <!-- Japanese Capital -->
+                <attachment name="territoryAttachment" attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="8"/>
+                        <option name="capital" value="Japanese"/>
+                        <option name="victoryCity" value="1"/>
+                        <!--<option name="unitProduction" value="8"/>-->
+                </attachment>
+
+                <attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                </attachment>
+
+                <!-- Convoy Centers, Convoy Routes, Blockade Zones -->
+                <!-- Convoy Routes must be attached to both the Requiring territory and the Required territory. Sea convoys can have income too, and if they do then they operate just like Convoy Centers for the income
+                <attachment name="territoryAttachment" attachTo="13 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="convoyRoute" value="true"/>
+                        <option name="convoyAttached" value=""/>
+                </attachment>
+                <attachment name="territoryAttachment" attachTo="14 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="convoyRoute" value="true"/>
+                        <option name="convoyAttached" value=""/>
+                </attachment> -->
+                <attachment name="territoryAttachment" attachTo="5 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <!-- Sea zone 5 is part of the convoyRoute of Norway (Norway has it listed under convoyAttached), so Sea zone 5 must have convoyRoute = true -->
+                        <option name="convoyRoute" value="true"/>
+                        <!-- Sea zone 5 has an income of 2 for Germany, but it does not Require ownership of another territory in order to get the income, so "convoyAttached" is blank -->
+                        <option name="convoyAttached" value=""/>
+                </attachment>
+                <attachment name="territoryAttachment" attachTo="6 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="convoyRoute" value="true"/>
+                </attachment>
+
+                <!-- Convoy Centers are simply sea zones with income. if you control your convoy zone, you get the income from it, but if an enemy takes the zone they do not get any income, they just deny you the income. can only be entered during combat movement -->
+                <attachment name="territoryAttachment" attachTo="3 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="originalOwner" value="Russians"/>
+                </attachment>
+                <attachment name="territoryAttachment" attachTo="4 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                </attachment>
+
+                <!-- Blockade Zones are areas where if the enemy has ships there, they subtract money from each of the connecting land territories up to the value of the territory.
+                        if there are many enemy ships, you will collect no income from the connecting land territories. should be set to zero production otherwise they become convoy zones too -->
+                <attachment name="territoryAttachment" attachTo="37 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                </attachment>
+                <attachment name="territoryAttachment" attachTo="47 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                </attachment>
+                <attachment name="territoryAttachment" attachTo="48 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                </attachment>
+                <attachment name="territoryAttachment" attachTo="49 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                        <!-- kamikazeZone does nothing right now, but it will put a symbol on the map (the kamikazeZone symbol must be in the flags folder and be named "<owner_name>_fade"
+                        <option name="kamikazeZone" value="true"/>-->
+                </attachment>
+                <attachment name="territoryAttachment" attachTo="58 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                </attachment>
+
+
+
 <!-- Canals -->
-		<!-- You may have multiple canalAttachment's per territory, so long as they have different names that start with "canalAttachment".
-			Each "canal" must consist of 2 attachments attached to the connected sea (or land) zones. -->
-		<!-- The following options are allowed for "canalAttachmentXXX" (all canal attachments need identical attachments attached to the 2 sea zones involved). 
-				canalName							values: any string name for the canal. must match its counterpart attachment.
-				landTerritories						values: a colon (":") delimited list of the territories that make up this canal. must match its counterpart attachment. Can be any number of territories, but at least 1 territory.
-				excludedUnits						values: an optional list of all the units that will NOT be validated by the canal. If left blank, then all Air units will not be validated. Can also be set to "NONE" or "ALL".
-															example: <option name="excludedUnits" value="submarine:fighter:bomber:air_transport"/>
-		-->
-				<attachment name="canalAttachmentSuez" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-						<option name="canalName" value="Suez Canal"/>
-						<option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
-				</attachment>
-			
-				<attachment name="canalAttachmentSuez" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-						<option name="canalName" value="Suez Canal"/>
-						<option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
-				</attachment>
-			
-				<attachment name="canalAttachmentPanama" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-						<option name="canalName" value="Panama Canal"/>
-						<option name="landTerritories" value="Panama"/>
-				</attachment>
-			
-				<attachment name="canalAttachmentPanama" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-						<option name="canalName" value="Panama Canal"/>
-						<option name="landTerritories" value="Panama"/>
-				</attachment>
-				
-				
-				
-				
+        <!-- You may have multiple canalAttachment's per territory, so long as they have different names that start with "canalAttachment".
+            Each "canal" must consist of 2 attachments attached to the connected sea (or land) zones. -->
+        <!-- The following options are allowed for "canalAttachmentXXX" (all canal attachments need identical attachments attached to the 2 sea zones involved).
+                canalName                           values: any string name for the canal. must match its counterpart attachment.
+                landTerritories                     values: a colon (":") delimited list of the territories that make up this canal. must match its counterpart attachment. Can be any number of territories, but at least 1 territory.
+                excludedUnits                       values: an optional list of all the units that will NOT be validated by the canal. If left blank, then all Air units will not be validated. Can also be set to "NONE" or "ALL".
+                                                            example: <option name="excludedUnits" value="submarine:fighter:bomber:air_transport"/>
+        -->
+                <attachment name="canalAttachmentSuez" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Suez Canal"/>
+                        <option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
+                </attachment>
+
+                <attachment name="canalAttachmentSuez" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Suez Canal"/>
+                        <option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
+                </attachment>
+
+                <attachment name="canalAttachmentPanama" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Panama Canal"/>
+                        <option name="landTerritories" value="Panama"/>
+                </attachment>
+
+                <attachment name="canalAttachmentPanama" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Panama Canal"/>
+                        <option name="landTerritories" value="Panama"/>
+                </attachment>
+
+
+
+
 <!-- Territory Effects -->
-		<!-- the following options are allowed for "territoryEffectAttachment"
-				combatOffenseEffect					values: the name of the unit, and the count of how much offense you want to give this unit
-				combatDefenseEffect					values: the name of the unit, and the count of how much defense you want to give this unit
-				noBlitz								values: the names of the units that can't blitz through this territoryEffect, can be multiple units (separated by a colon ":")
-				unitsNotAllowed 					values: the names of the units that are not allowed into or through this territoryEffect, can be multiple units (separated by a colon ":")
-				
-		-->
-				<attachment name="territoryEffectAttachment" attachTo="mountain" javaClass="games.strategy.triplea.attachments.TerritoryEffectAttachment" type="territoryEffect">
-						<option name="combatOffenseEffect" value="infantry" count="1"/>
-						<option name="combatDefenseEffect" value="armour" count="-2"/>
-						<option name="noBlitz" value="armour"/>
-						<option name="unitsNotAllowed" value="armour"/>
-				</attachment>
-				
-				
-				
-				
+        <!-- the following options are allowed for "territoryEffectAttachment"
+                combatOffenseEffect                 values: the name of the unit, and the count of how much offense you want to give this unit
+                combatDefenseEffect                 values: the name of the unit, and the count of how much defense you want to give this unit
+                noBlitz                             values: the names of the units that can't blitz through this territoryEffect, can be multiple units (separated by a colon ":")
+                unitsNotAllowed                     values: the names of the units that are not allowed into or through this territoryEffect, can be multiple units (separated by a colon ":")
+
+        -->
+                <attachment name="territoryEffectAttachment" attachTo="mountain" javaClass="games.strategy.triplea.attachments.TerritoryEffectAttachment" type="territoryEffect">
+                        <option name="combatOffenseEffect" value="infantry" count="1"/>
+                        <option name="combatDefenseEffect" value="armour" count="-2"/>
+                        <option name="noBlitz" value="armour"/>
+                        <option name="unitsNotAllowed" value="armour"/>
+                </attachment>
+
+
+
+
 <!-- Support Attachments -->
-		<!-- the following options are allowed for "supportAttachmentXXX" (must be unique names!)
-				unitType							values: the name of the unit (or units in a : delimited list) TO BE SUPPORTED BY THE ATTACHED UNIT (attached unit is "attachTO"). 
-															If you are changing the properties of a unit, then unitType should be the same as attachTo
-				faction								values: "allied" or "enemy" (enemy not yet coded, does nothing right now)
-				side								values: "offence" or "defence", support when attacking or defending, can be both (example: value="offence:defence")
-				dice								values: "strength" or "rolls", may be a list of both (rolls not yet coded, does nothing right now)
-				bonus								values: how much to add to strength or roll
-				number								values: how many units to be supported
-				bonusType							values: the name of the bonus, any string. any bonus with the same name will not stack, any bonus with a different name will stack
-															Please us the string "ArtyOld" if do not want your bonus to stack with normal artillery (ie: do not want the bonus to stack with any unit with the normal artillery attachment: <option name="artillery" value="true"/>)
-				players								values: names of players in a list, if missing defaults to no players, and if no players it means this support will not be active at start of game (can be activated later by a trigger) (example: value="Germans:Italians")
-				impArtTech							values: "true" or "false", does this support get doubled by the improvedArtillery technology?
-		-->
-	
-				<!--<attachment name="supportAttachmentRussiansArtillery1" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-						<option name="unitType" value="infantry"/>
-						<option name="faction" value="allied"/>
-						<option name="side" value="offence"/>
-						<option name="dice" value="strength"/>
-						<option name="bonus" value="1"/>
-						<option name="number" value="1"/>
-						<option name="bonusType" value="ArtyOld"/>
-						<option name="impArtTech" value="true"/>
-				</attachment>-->
-				
-				<attachment name="supportAttachmentRussiansArtillery2" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-						<option name="unitType" value="infantry"/>
-						<option name="faction" value="allied"/>
-						<option name="side" value="offence"/>
-						<option name="dice" value="strength"/>
-						<option name="bonus" value="1"/>
-						<option name="number" value="2"/>
-						<option name="bonusType" value="ArtyNew"/>
-						<option name="impArtTech" value="true"/>
-						<!--<option name="players" value="Russians:British"/>-->
-				</attachment>
-				
-				<attachment name="supportAttachmentFighter" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-						<option name="unitType" value="infantry"/>
-						<option name="faction" value="allied"/>
-						<option name="side" value="offence"/>
-						<option name="dice" value="strength"/>
-						<option name="bonus" value="1"/>
-						<option name="number" value="1"/>
-						<option name="bonusType" value="combined_arms"/>
-						<option name="impArtTech" value="false"/>
-				</attachment>
-				
-				<attachment name="supportAttachmentSubmarineReinforcedHulls" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-						<option name="unitType" value="submarine"/>
-						<option name="faction" value="allied"/>
-						<option name="side" value="defence"/>
-						<option name="dice" value="strength"/>
-						<option name="bonus" value="2"/>
-						<option name="number" value="1"/>
-						<option name="bonusType" value="hulls"/>
-						<option name="impArtTech" value="false"/>
-				</attachment>
-				
-				<attachment name="supportAttachmentSubmarineWolfPackTacticsOffence" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-						<option name="unitType" value="submarine"/>
-						<option name="faction" value="allied"/>
-						<option name="side" value="offence"/>
-						<option name="dice" value="strength"/>
-						<option name="bonus" value="1"/>
-						<option name="number" value="1"/>
-						<option name="bonusType" value="tactics1"/>
-						<option name="impArtTech" value="false"/>
-				</attachment>
-				
-				<!--<attachment name="supportAttachmentSubmarineWolfPackTacticsDefence" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-						<option name="unitType" value="submarine"/>
-						<option name="faction" value="allied"/>
-						<option name="side" value="defence"/>
-						<option name="dice" value="strength"/>
-						<option name="bonus" value="1"/>
-						<option name="number" value="1"/>
-						<option name="bonusType" value="tactics2"/>
-						<option name="impArtTech" value="false"/>
-				</attachment>-->
+        <!-- the following options are allowed for "supportAttachmentXXX" (must be unique names!)
+                unitType                            values: the name of the unit (or units in a : delimited list) TO BE SUPPORTED BY THE ATTACHED UNIT (attached unit is "attachTO").
+                                                            If you are changing the properties of a unit, then unitType should be the same as attachTo
+                faction                             values: "allied" or "enemy" (enemy not yet coded, does nothing right now)
+                side                                values: "offence" or "defence", support when attacking or defending, can be both (example: value="offence:defence")
+                dice                                values: "strength" or "rolls", may be a list of both (rolls not yet coded, does nothing right now)
+                bonus                               values: how much to add to strength or roll
+                number                              values: how many units to be supported
+                bonusType                           values: the name of the bonus, any string. any bonus with the same name will not stack, any bonus with a different name will stack
+                                                            Please us the string "ArtyOld" if do not want your bonus to stack with normal artillery (ie: do not want the bonus to stack with any unit with the normal artillery attachment: <option name="artillery" value="true"/>)
+                players                             values: names of players in a list, if missing defaults to no players, and if no players it means this support will not be active at start of game (can be activated later by a trigger) (example: value="Germans:Italians")
+                impArtTech                          values: "true" or "false", does this support get doubled by the improvedArtillery technology?
+        -->
+
+                <!--<attachment name="supportAttachmentRussiansArtillery1" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                        <option name="unitType" value="infantry"/>
+                        <option name="faction" value="allied"/>
+                        <option name="side" value="offence"/>
+                        <option name="dice" value="strength"/>
+                        <option name="bonus" value="1"/>
+                        <option name="number" value="1"/>
+                        <option name="bonusType" value="ArtyOld"/>
+                        <option name="impArtTech" value="true"/>
+                </attachment>-->
+
+                <attachment name="supportAttachmentRussiansArtillery2" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                        <option name="unitType" value="infantry"/>
+                        <option name="faction" value="allied"/>
+                        <option name="side" value="offence"/>
+                        <option name="dice" value="strength"/>
+                        <option name="bonus" value="1"/>
+                        <option name="number" value="2"/>
+                        <option name="bonusType" value="ArtyNew"/>
+                        <option name="impArtTech" value="true"/>
+                        <!--<option name="players" value="Russians:British"/>-->
+                </attachment>
+
+                <attachment name="supportAttachmentFighter" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                        <option name="unitType" value="infantry"/>
+                        <option name="faction" value="allied"/>
+                        <option name="side" value="offence"/>
+                        <option name="dice" value="strength"/>
+                        <option name="bonus" value="1"/>
+                        <option name="number" value="1"/>
+                        <option name="bonusType" value="combined_arms"/>
+                        <option name="impArtTech" value="false"/>
+                </attachment>
+
+                <attachment name="supportAttachmentSubmarineReinforcedHulls" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                        <option name="unitType" value="submarine"/>
+                        <option name="faction" value="allied"/>
+                        <option name="side" value="defence"/>
+                        <option name="dice" value="strength"/>
+                        <option name="bonus" value="2"/>
+                        <option name="number" value="1"/>
+                        <option name="bonusType" value="hulls"/>
+                        <option name="impArtTech" value="false"/>
+                </attachment>
+
+                <attachment name="supportAttachmentSubmarineWolfPackTacticsOffence" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                        <option name="unitType" value="submarine"/>
+                        <option name="faction" value="allied"/>
+                        <option name="side" value="offence"/>
+                        <option name="dice" value="strength"/>
+                        <option name="bonus" value="1"/>
+                        <option name="number" value="1"/>
+                        <option name="bonusType" value="tactics1"/>
+                        <option name="impArtTech" value="false"/>
+                </attachment>
+
+                <!--<attachment name="supportAttachmentSubmarineWolfPackTacticsDefence" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                        <option name="unitType" value="submarine"/>
+                        <option name="faction" value="allied"/>
+                        <option name="side" value="defence"/>
+                        <option name="dice" value="strength"/>
+                        <option name="bonus" value="1"/>
+                        <option name="number" value="1"/>
+                        <option name="bonusType" value="tactics2"/>
+                        <option name="impArtTech" value="false"/>
+                </attachment>-->
 
 <!--  National Objectives -->
-	<!-- all Objective Attachments, Conditions, Triggers, Rules, etc, must have a unique name (if you don't use unique names, you may get funny results with your trigger attachments, or even java errors) -->
-	<!-- the following options are allowed for "objectiveAttachmentXXX" (and also for "conditionAttachmentXXX").  all options below have an "AND" relationship with each other.
-			conditions							values: any objectiveAttachment or conditionAttachment, can be any player's attachment (must have unique names!), tested during attached player's turn
-															can be in a delimited list for an AND relationship (example: value="conditionAttachmentGermans3a:conditionAttachmentGermans3b")
-															any condition which includes other conditions, is considered a meta-condition, and it must come AFTER any conditions that it includes.
-			conditionType 						values: AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the "conditions" option.
-														AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
-														conditionType only affects the conditions listed under the option name="conditions", and does not affect any additional things also present.
-			invert								values: true or false. default if missing is false. if true, this attachment's condition will be reversed (does not reverse the effect). 
-														This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
-			objectiveValue						values: any integer number of PUs to be given (example: value="4")
-			uses								values: integer for the maximum number of times it should be awarded. if missing it defaults to infinity. Only applies to objectiveValue, and does NOT determine if the conditions is true or false.
-			switch								values: "true" or "false" (default is true).  This is just a simple on/off switch, which gives map makers some memory function for their conditions.
-			turns								values: which turns this will be checked on (example: value="1:4:6-8:11-+" means turns 1,4,6,7,8,11,and all turns after 11)
-			relationship						values: a relationship that needs to be present in the game: "player1:player2:relationship" (will set #rounds to -1 by default) OR "player1:player2:relationship:numberOfRoundsThisRelationshipMustExistForMinimum"
-														for example: "Japan:China:War" or "Japan:China:War:-1" or "Japan:China:War:3".  It will accept "anyWar", "anyNeutral" and "anyAllied" as well.
-			battle								values: checks if there has been a battle in the territory. Format is "attacker:defender:battleType:rounds:territory1", where attacker, defender, and battleType can all be "any", and rounds can be "currentRound". 
-														Territories can be any number of territories, and if more than one territory is listed then if any of them are true, it will return true.  You can also have multiple instances.
-														example: <option name="battle" value="any:Japanese:any:2-3:Manchuria"/> or <option name="battle" value="Russians:Japanese:any:currentRound:Manchuria:Jehol:Chahar:Suiyuyan:Kansu"/>
-			
-			count								values: the number required to satisfy a rule. if missing, it defaults to ALL (unless specified). it can also be set to "each", which will act as "1" for the purposes of being a condition, but will multiply the bonus (do not use multiple options if you are using each).
-		the below options use count:
-			destroyedTUV						values: count=an amount of TUV that the attached player must destroy. value=currentRound/allRounds. This is not counting neutral (null) player, and is based on the cost for the defender to buy the units.
-														Be sure to check this condition only after the player's battle phase is completely over, since the data is only recorded after all battles are done. example: value="currentRound" count="20"
-			atWarPlayers						values: player names, in a : delimited list (example: value="Germans:Italians:Japanese" count="2" means that you must be at war with 2 of the 3 listed players). if count is zero, then you must be at war with none.
-			techs								values: any list of technologies, : delimited (if count = zero, then must have exactly zero technologies [if count is missing, defaults to zero])
-			directOwnershipTerritories			values: "original", "originalNoWater", "enemy", or a : delimited list of territories
-			alliedOwnershipTerritories			values: "original", "originalNoWater", "enemy", or a : delimited list of territories (alliedOwnershipTerritories DOES count both owned and allied)
-			directExclusionTerritories 			values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
-			alliedExclusionTerritories			values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories (alliedExclusionTerritories does NOT count owned units, it only counts allied units)
-			enemyExclusionTerritories			values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
-			enemySurfaceExclusionTerritories	values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
-			directPresenceTerritories 			values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
-			alliedPresenceTerritories 			values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories (alliedPresenceTerritories DOES count both owned units and allied units)
-			enemyPresenceTerritories 			values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
-			unitPresence 						values: "ANY" or the exact name or names of the units, and the number of that unit.  (example: value="infantry" count="2", or: value="ANY" count="3", or: value="infantry:artillery:armour" count="3")
-														unitPresence can be put in multiple times. Its purpose is to specify the units for presence and excluded territories. If missing, then presence needs only 1 of any unit, and excluded needs to be completely devoid of units
-														For an "AND" relationship between the required units, put them in separately. For an "OR" relationship, put them in on one line with a colon separating them.
-														It can be used in conjunction with directPresenceTerritories, alliedPresenceTerritories, enemyPresenceTerritories, directExclusionTerritories, alliedExclusionTerritories, enemyExclusionTerritories, enemySurfaceExclusionTerritories
-														If used with an exclusion, then the number of units of that type must be less than or equal the count.  (Use count="0" if you want no units of that type in the territories) (can not use "each" for count here).
-			players								values: players is used with any of the territory lists above. players defaults to the 'attachTo' player if missing.  When used with directOwnershipTerritories/PresenceTerritories it allows you to specify who must own the selected territories in an OR relationship.
-														example: if we were to say <option name="players" value="Germans:Italians"/> and use it with directOwnershipTerritories, then it means that either Germans or Italians or both must own those territories. (thus you can use this to exclude some allies)
-			
-	-->
-		<!-- German Objectives -->
-				<attachment name="objectiveAttachmentGermans1_EasternEurope" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="alliedOwnershipTerritories" value="East Balkans:Eastern Europe:Ukraine S.S.R.:Belorussia:West Russia:Norway:Karelia S.S.R.:Archangel:Caucus" count="7"/>
-				</attachment>
+    <!-- all Objective Attachments, Conditions, Triggers, Rules, etc, must have a unique name (if you don't use unique names, you may get funny results with your trigger attachments, or even java errors) -->
+    <!-- the following options are allowed for "objectiveAttachmentXXX" (and also for "conditionAttachmentXXX").  all options below have an "AND" relationship with each other.
+            conditions                          values: any objectiveAttachment or conditionAttachment, can be any player's attachment (must have unique names!), tested during attached player's turn
+                                                        can be in a delimited list for an AND relationship (example: value="conditionAttachmentGermans3a:conditionAttachmentGermans3b")
+                                                        any condition which includes other conditions, is considered a meta-condition, and it must come AFTER any conditions that it includes.
+            conditionType                       values: AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the "conditions" option.
+                                                        AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
+                                                        conditionType only affects the conditions listed under the option name="conditions", and does not affect any additional things also present.
+            invert                              values: true or false. default if missing is false. if true, this attachment's condition will be reversed (does not reverse the effect).
+                                                        This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
+            objectiveValue                      values: any integer number of PUs to be given (example: value="4")
+            uses                                values: integer for the maximum number of times it should be awarded. if missing it defaults to infinity. Only applies to objectiveValue, and does NOT determine if the conditions is true or false.
+            switch                              values: "true" or "false" (default is true).  This is just a simple on/off switch, which gives map makers some memory function for their conditions.
+            turns                               values: which turns this will be checked on (example: value="1:4:6-8:11-+" means turns 1,4,6,7,8,11,and all turns after 11)
+            relationship                        values: a relationship that needs to be present in the game: "player1:player2:relationship" (will set #rounds to -1 by default) OR "player1:player2:relationship:numberOfRoundsThisRelationshipMustExistForMinimum"
+                                                        for example: "Japan:China:War" or "Japan:China:War:-1" or "Japan:China:War:3".  It will accept "anyWar", "anyNeutral" and "anyAllied" as well.
+            battle                              values: checks if there has been a battle in the territory. Format is "attacker:defender:battleType:rounds:territory1", where attacker, defender, and battleType can all be "any", and rounds can be "currentRound".
+                                                        Territories can be any number of territories, and if more than one territory is listed then if any of them are true, it will return true.  You can also have multiple instances.
+                                                        example: <option name="battle" value="any:Japanese:any:2-3:Manchuria"/> or <option name="battle" value="Russians:Japanese:any:currentRound:Manchuria:Jehol:Chahar:Suiyuyan:Kansu"/>
 
-				<attachment name="objectiveAttachmentGermans2_BalticSea" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="enemySurfaceExclusionTerritories" value="5 Sea Zone:6 Sea Zone:7 Sea Zone" count="3"/>
-						<option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
-				</attachment>
+            count                               values: the number required to satisfy a rule. if missing, it defaults to ALL (unless specified). it can also be set to "each", which will act as "1" for the purposes of being a condition, but will multiply the bonus (do not use multiple options if you are using each).
+        the below options use count:
+            destroyedTUV                        values: count=an amount of TUV that the attached player must destroy. value=currentRound/allRounds. This is not counting neutral (null) player, and is based on the cost for the defender to buy the units.
+                                                        Be sure to check this condition only after the player's battle phase is completely over, since the data is only recorded after all battles are done. example: value="currentRound" count="20"
+            atWarPlayers                        values: player names, in a : delimited list (example: value="Germans:Italians:Japanese" count="2" means that you must be at war with 2 of the 3 listed players). if count is zero, then you must be at war with none.
+            techs                               values: any list of technologies, : delimited (if count = zero, then must have exactly zero technologies [if count is missing, defaults to zero])
+            directOwnershipTerritories          values: "original", "originalNoWater", "enemy", or a : delimited list of territories
+            alliedOwnershipTerritories          values: "original", "originalNoWater", "enemy", or a : delimited list of territories (alliedOwnershipTerritories DOES count both owned and allied)
+            directExclusionTerritories          values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
+            alliedExclusionTerritories          values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories (alliedExclusionTerritories does NOT count owned units, it only counts allied units)
+            enemyExclusionTerritories           values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
+            enemySurfaceExclusionTerritories    values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
+            directPresenceTerritories           values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
+            alliedPresenceTerritories           values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories (alliedPresenceTerritories DOES count both owned units and allied units)
+            enemyPresenceTerritories            values: "original", "originalNoWater", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
+            unitPresence                        values: "ANY" or the exact name or names of the units, and the number of that unit.  (example: value="infantry" count="2", or: value="ANY" count="3", or: value="infantry:artillery:armour" count="3")
+                                                        unitPresence can be put in multiple times. Its purpose is to specify the units for presence and excluded territories. If missing, then presence needs only 1 of any unit, and excluded needs to be completely devoid of units
+                                                        For an "AND" relationship between the required units, put them in separately. For an "OR" relationship, put them in on one line with a colon separating them.
+                                                        It can be used in conjunction with directPresenceTerritories, alliedPresenceTerritories, enemyPresenceTerritories, directExclusionTerritories, alliedExclusionTerritories, enemyExclusionTerritories, enemySurfaceExclusionTerritories
+                                                        If used with an exclusion, then the number of units of that type must be less than or equal the count.  (Use count="0" if you want no units of that type in the territories) (can not use "each" for count here).
+            players                             values: players is used with any of the territory lists above. players defaults to the 'attachTo' player if missing.  When used with directOwnershipTerritories/PresenceTerritories it allows you to specify who must own the selected territories in an OR relationship.
+                                                        example: if we were to say <option name="players" value="Germans:Italians"/> and use it with directOwnershipTerritories, then it means that either Germans or Italians or both must own those territories. (thus you can use this to exclude some allies)
 
-		<!-- Russian Objectives -->
-				<attachment name="objectiveAttachmentRussians1_EasternEurope" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="directOwnershipTerritories" value="Norway:Eastern Europe:East Balkans:Ukraine S.S.R.:Belorussia" count="3"/>
-				</attachment>
-				
-				<attachment name="objectiveAttachmentRussians2_LendLease" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="alliedOwnershipTerritories" value="Archangel" count="1"/>
-						<option name="alliedExclusionTerritories" value="controlledNoWater"/>
-				</attachment>
+    -->
+        <!-- German Objectives -->
+                <attachment name="objectiveAttachmentGermans1_EasternEurope" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="alliedOwnershipTerritories" value="East Balkans:Eastern Europe:Ukraine S.S.R.:Belorussia:West Russia:Norway:Karelia S.S.R.:Archangel:Caucus" count="7"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentRussians3_HardAdvance" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="2"/>
-						<option name="directOwnershipTerritories" value="Norway:East Balkans" count="1"/>
-						<option name="uses" value="1"/>
-						<option name="atWarPlayers" value="Germans:Italians:Japanese" count="2"/>
-				</attachment>
+                <attachment name="objectiveAttachmentGermans2_BalticSea" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="enemySurfaceExclusionTerritories" value="5 Sea Zone:6 Sea Zone:7 Sea Zone" count="3"/>
+                        <option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
+                </attachment>
 
-		<!-- Japanese Objectives -->
-				<attachment name="objectiveAttachmentJapanese1_ControlOfAsia" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="alliedOwnershipTerritories" value="India:French Indochina:Kwangtung:Manchuria:China:Central China:Sinkiang" count="7"/>
-				</attachment>
+        <!-- Russian Objectives -->
+                <attachment name="objectiveAttachmentRussians1_EasternEurope" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="directOwnershipTerritories" value="Norway:Eastern Europe:East Balkans:Ukraine S.S.R.:Belorussia" count="3"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentJapanese2_ControlOfPacific" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="alliedOwnershipTerritories" value="Alaska:East Indies:Borneo:Philipine Islands:New Guinea:Solomon Islands:Caroline Islands:Australia:New Zealand:Okinawa:Wake Island:Hawaiian Islands:Midway" count="10"/>
-				</attachment>
+                <attachment name="objectiveAttachmentRussians2_LendLease" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="alliedOwnershipTerritories" value="Archangel" count="1"/>
+                        <option name="alliedExclusionTerritories" value="controlledNoWater"/>
+                </attachment>
 
-		<!-- British Objectives -->
-				<attachment name="objectiveAttachmentBritish1_PacificCounterAttack" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="directOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Okinawa" count="1"/>
-				</attachment>
+                <attachment name="objectiveAttachmentRussians3_HardAdvance" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="2"/>
+                        <option name="directOwnershipTerritories" value="Norway:East Balkans" count="1"/>
+                        <option name="uses" value="1"/>
+                        <option name="atWarPlayers" value="Germans:Italians:Japanese" count="2"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentBritish2_Africa" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="alliedOwnershipTerritories" value="Gibraltar:Algeria:Libya:Anglo Egypt:Trans-Jordan:Persia:French West Africa:French Equatorial Africa:Italian East Africa:Belgian Congo:Kenya" count="9"/>
-				</attachment>
+        <!-- Japanese Objectives -->
+                <attachment name="objectiveAttachmentJapanese1_ControlOfAsia" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="alliedOwnershipTerritories" value="India:French Indochina:Kwangtung:Manchuria:China:Central China:Sinkiang" count="7"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentBritish3_SeatOfEmpire" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="alliedOwnershipTerritories" value="Union of South Africa:India:Australia" count="3"/>
-				</attachment>
+                <attachment name="objectiveAttachmentJapanese2_ControlOfPacific" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="alliedOwnershipTerritories" value="Alaska:East Indies:Borneo:Philipine Islands:New Guinea:Solomon Islands:Caroline Islands:Australia:New Zealand:Okinawa:Wake Island:Hawaiian Islands:Midway" count="10"/>
+                </attachment>
 
-		<!-- Italian Objectives -->
-				<attachment name="objectiveAttachmentItalians1_TheMed" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="alliedOwnershipTerritories" value="Western Europe:Sardinia:Sicily:West Balkans:Greece:Algeria:Libya:Anglo Egypt:Trans-Jordan:Italian East Africa:Gibraltar" count="8"/>
-						<option name="enemySurfaceExclusionTerritories" value="13 Sea Zone:14 Sea Zone:15 Sea Zone:15B Sea Zone" count="4"/>
-				</attachment>
+        <!-- British Objectives -->
+                <attachment name="objectiveAttachmentBritish1_PacificCounterAttack" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="directOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Okinawa" count="1"/>
+                </attachment>
 
-		<!-- American Objectives -->
-				<attachment name="objectiveAttachmentAmericans2_TheAtlantic" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="alliedOwnershipTerritories" value="Western Europe:Sardinia:Sicily:Italy:Greece:West Balkans:Algeria:Libya" count="3"/>
-						<option name="enemySurfaceExclusionTerritories" value="1 Sea Zone:2 Sea Zone:7 Sea Zone:8 Sea Zone:9 Sea Zone:10 Sea Zone:11 Sea Zone:12 Sea Zone:13 Sea Zone:14 Sea Zone" count="10"/>
-				</attachment>
+                <attachment name="objectiveAttachmentBritish2_Africa" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="alliedOwnershipTerritories" value="Gibraltar:Algeria:Libya:Anglo Egypt:Trans-Jordan:Persia:French West Africa:French Equatorial Africa:Italian East Africa:Belgian Congo:Kenya" count="9"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentAmericans3_ThePacific" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="alliedOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Australia:New Zealand:Okinawa:Wake Island:Philipine Islands:Alaska:Hawaiian Islands:Midway" count="6"/>
-				</attachment>
+                <attachment name="objectiveAttachmentBritish3_SeatOfEmpire" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="alliedOwnershipTerritories" value="Union of South Africa:India:Australia" count="3"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentAmericans1_WarPhase1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="2"/>
-						<option name="rounds" value="2-3"/>
-				</attachment>
+        <!-- Italian Objectives -->
+                <attachment name="objectiveAttachmentItalians1_TheMed" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="alliedOwnershipTerritories" value="Western Europe:Sardinia:Sicily:West Balkans:Greece:Algeria:Libya:Anglo Egypt:Trans-Jordan:Italian East Africa:Gibraltar" count="8"/>
+                        <option name="enemySurfaceExclusionTerritories" value="13 Sea Zone:14 Sea Zone:15 Sea Zone:15B Sea Zone" count="4"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentAmericans1_WarPhase2" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="rounds" value="4-5"/>
-				</attachment>
+        <!-- American Objectives -->
+                <attachment name="objectiveAttachmentAmericans2_TheAtlantic" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="alliedOwnershipTerritories" value="Western Europe:Sardinia:Sicily:Italy:Greece:West Balkans:Algeria:Libya" count="3"/>
+                        <option name="enemySurfaceExclusionTerritories" value="1 Sea Zone:2 Sea Zone:7 Sea Zone:8 Sea Zone:9 Sea Zone:10 Sea Zone:11 Sea Zone:12 Sea Zone:13 Sea Zone:14 Sea Zone" count="10"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentAmericans1_WarPhase3" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="6"/>
-						<option name="rounds" value="6-7"/>
-				</attachment>
+                <attachment name="objectiveAttachmentAmericans3_ThePacific" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="alliedOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Australia:New Zealand:Okinawa:Wake Island:Philipine Islands:Alaska:Hawaiian Islands:Midway" count="6"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentAmericans1_WarPhase4" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="8"/>
-						<option name="rounds" value="8-9"/>
-				</attachment>
+                <attachment name="objectiveAttachmentAmericans1_WarPhase1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="2"/>
+                        <option name="rounds" value="2-3"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentAmericans1_WarPhase5" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="10"/>
-						<option name="rounds" value="10-+"/>
-				</attachment>
+                <attachment name="objectiveAttachmentAmericans1_WarPhase2" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="rounds" value="4-5"/>
+                </attachment>
 
-				<!--<attachment name="objectiveAttachmentAmericans8" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="12"/>
-						<option name="rounds" value="12-13"/>
-				</attachment>
+                <attachment name="objectiveAttachmentAmericans1_WarPhase3" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="6"/>
+                        <option name="rounds" value="6-7"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentAmericans9" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="14"/>
-						<option name="rounds" value="14-15"/>
-				</attachment>
+                <attachment name="objectiveAttachmentAmericans1_WarPhase4" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="8"/>
+                        <option name="rounds" value="8-9"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentAmericans10" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="16"/>
-						<option name="rounds" value="16-17"/>
-				</attachment>
+                <attachment name="objectiveAttachmentAmericans1_WarPhase5" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="10"/>
+                        <option name="rounds" value="10-+"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentAmericans11" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="18"/>
-						<option name="rounds" value="18-19"/>
-				</attachment>
+                <!--<attachment name="objectiveAttachmentAmericans8" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="12"/>
+                        <option name="rounds" value="12-13"/>
+                </attachment>
 
-				<attachment name="objectiveAttachmentAmericans12" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="20"/>
-						<option name="rounds" value="20-+"/>
-				</attachment>-->
+                <attachment name="objectiveAttachmentAmericans9" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="14"/>
+                        <option name="rounds" value="14-15"/>
+                </attachment>
 
-		<!-- Chinese Objectives -->
-				<attachment name="objectiveAttachmentChinese2_BurmaRoad" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="alliedOwnershipTerritories" value="Sinkiang:Central China:India" count="3"/>
-				</attachment>
-				
+                <attachment name="objectiveAttachmentAmericans10" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="16"/>
+                        <option name="rounds" value="16-17"/>
+                </attachment>
+
+                <attachment name="objectiveAttachmentAmericans11" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="18"/>
+                        <option name="rounds" value="18-19"/>
+                </attachment>
+
+                <attachment name="objectiveAttachmentAmericans12" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="20"/>
+                        <option name="rounds" value="20-+"/>
+                </attachment>-->
+
+        <!-- Chinese Objectives -->
+                <attachment name="objectiveAttachmentChinese2_BurmaRoad" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="alliedOwnershipTerritories" value="Sinkiang:Central China:India" count="3"/>
+                </attachment>
+
 <!-- Conditions -->
-		<!-- Conditions follow the same rules as national objectives. both conditions and objectives must be BEFORE any triggers in the XML -->
-		<!-- Victory Conditions -->
-				<attachment name="conditionAttachmentAxisVictory1" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="United Kingdom:Russia:Germany:Japan" count="4"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentAlliesVictory1" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Germany:Japan:United Kingdom:Eastern United States" count="4"/>
-				</attachment>
-	
-	
-		<!-- Germans Conditions -->
-				<attachment name="conditionAttachmentGermans1" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="4:5"/>
-						<option name="enemySurfaceExclusionTerritories" value="5 Sea Zone:6 Sea Zone:7 Sea Zone" count="3"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermans2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3:4"/>
-						<option name="alliedOwnershipTerritories" value="East Balkans:Eastern Europe:Ukraine S.S.R.:Belorussia:Karelia S.S.R.:Archangel:Caucus" count="6"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermans3a" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3:4"/>
-						<option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermans3b" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3:4"/>
-						<option name="alliedOwnershipTerritories" value="Norway" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermansParatroopers" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="paratroopers" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermansSuperSubs" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="superSub" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermansReinforcedHulls" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="reinforcedHulls" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermansWolfPackTactics" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="wolfPackTactics" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermansShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="shipyards" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermansShipyardsInvert" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="shipyards" count="1"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermansSubmarineTech2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansReinforcedHulls:conditionAttachmentGermansWolfPackTactics"/>
-						<option name="conditionType" value="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentGermansSubmarineTech3" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansReinforcedHulls:conditionAttachmentGermansWolfPackTactics"/>
-						<option name="conditionType" value="2-3"/>
-				</attachment>
-				
-		<!-- Japanese Conditions -->
-				<attachment name="conditionAttachmentJapanese1a" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Sinkiang:India:Burytia S.S.R." count="1"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapanese1b" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3:4"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapanese2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3:4:5"/>
-						<option name="alliedOwnershipTerritories" value="Australia:India:Sinkiang" count="3"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapanese3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="1-2:3:4-+"/>
-						<option name="directOwnershipTerritories" value="original"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapanese4" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="directOwnershipTerritories" value="Burytia S.S.R.:Soviet Far East:Yakut S.S.R.:Evanki National Okrug:Novisibirsk:Kazakh S.S.R.:Caucus:Russia:Archangel:Karelia S.S.R." count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapaneseParatroopers" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="paratroopers" count="1"/>
-				</attachment>
-				
-				<!--<attachment name="conditionAttachmentJapaneseMidget1" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Okinawa:Philipine Islands" count="2"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapaneseMidget2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="6"/>
-						<option name="invert" value="true"/>
-				</attachment>-->
-				
-				<attachment name="conditionAttachmentJapaneseMidget" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Okinawa:Philipine Islands:East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="7"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapaneseKamikaze1" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Philipine Islands" count="1"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapaneseKamikaze2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Okinawa:East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="7"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapaneseBattleships" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="directPresenceTerritories" value="map" count="1"/>
-						<option name="unitPresence" value="battleship" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapaneseCarriers" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="directPresenceTerritories" value="map" count="1"/>
-						<option name="unitPresence" value="carrier" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentJapaneseShipyards" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="shipyards" count="1"/>
-				</attachment>
-				
-		<!-- Italians Conditions -->
-				<attachment name="conditionAttachmentItalians1" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3:4"/>
-						<option name="alliedOwnershipTerritories" value="Algeria:Libya:Anglo Egypt:Trans-Jordan" count="4"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentItaliansParatroopers" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="paratroopers" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentItaliansShipyards" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="shipyards" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentItalianTurn2" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="2"/>
-				</attachment>
-				<attachment name="conditionAttachmentItalianTurn1" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="1"/>
-				</attachment>
-				
-				
-		<!-- Americans Conditions -->
-				<attachment name="conditionAttachmentAmericans1_WarPhase" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="2-+"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentAmericans1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3-5"/>
-						<option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentAmericans2" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3-5"/>
-						<option name="alliedOwnershipTerritories" value="Alaska:Wake Island:Hawaiian Islands:Midway" count="4"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentAmericans3a" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="1-8"/>
-						<option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentAmericans3b" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="1:2:3-7:8"/>
-						<option name="alliedOwnershipTerritories" value="Alaska:Wake Island:Hawaiian Islands:Midway" count="4"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentAmericans4" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="jetPower:warBonds" count="2"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentAmericansParatroopers" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="paratroopers" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentAmericansShipyards" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="shipyards" count="1"/>
-				</attachment>
-				
-		<!-- British Conditions -->
-				<attachment name="conditionAttachmentBritish2" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3:4"/>
-						<option name="alliedOwnershipTerritories" value="Union of South Africa:Gibraltar:Anglo Egypt:India:Australia" count="4"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentBritishParatroopers" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="paratroopers" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentBritishShipyards" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="shipyards" count="1"/>
-				</attachment>
-				
-		<!-- Russians Conditions -->
-				<attachment name="conditionAttachmentRussians2" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3:4"/>
-						<option name="alliedOwnershipTerritories" value="Karelia S.S.R.:Caucus" count="2"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentRussiansNeutralAmericans" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="relationship" value="Russians:Americans:anyNeutral"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentRussiansNeutralJapan" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="relationship" value="Japanese:Russians:anyNeutral"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentRussiansNeutralJapanTurn5plus" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="5-+"/>
-						<option name="relationship" value="Japanese:Russians:anyNeutral"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentRussiansNeutralItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="relationship" value="Italians:Russians:anyNeutral:1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentRussiansWarItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="relationship" value="Italians:Russians:anyWar:1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentRussiansNeutralItaliansFor2Turns" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="relationship" value="Italians:Russians:anyNeutral:2"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentChineseNeutralItalians" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="relationship" value="Italians:Chinese:anyNeutral"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentRussians3" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Burytia S.S.R." count="1"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentRussiansParatroopers" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="paratroopers" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentRussiansShipyards" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="shipyards" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentRussianCapitalLost" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Russia" count="1"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-		<!-- Chinese Conditions -->
-				<attachment name="conditionAttachmentChinese3" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="enemyExclusionTerritories" value="Sinkiang:Central China:China:Manchuria:Kwangtung:French Indochina" count="3"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentChinese4" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Japan" count="1"/>
-				</attachment>
-				
-				<!--<attachment name="conditionAttachmentChineseParatroopers" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="paratroopers" count="1"/>
-				</attachment>
-				
-				<attachment name="conditionAttachmentChineseShipyards" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="techs" value="shipyards" count="1"/>
-				</attachment>-->
-				
-				
+        <!-- Conditions follow the same rules as national objectives. both conditions and objectives must be BEFORE any triggers in the XML -->
+        <!-- Victory Conditions -->
+                <attachment name="conditionAttachmentAxisVictory1" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="United Kingdom:Russia:Germany:Japan" count="4"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentAlliesVictory1" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Germany:Japan:United Kingdom:Eastern United States" count="4"/>
+                </attachment>
+
+
+        <!-- Germans Conditions -->
+                <attachment name="conditionAttachmentGermans1" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="4:5"/>
+                        <option name="enemySurfaceExclusionTerritories" value="5 Sea Zone:6 Sea Zone:7 Sea Zone" count="3"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermans2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3:4"/>
+                        <option name="alliedOwnershipTerritories" value="East Balkans:Eastern Europe:Ukraine S.S.R.:Belorussia:Karelia S.S.R.:Archangel:Caucus" count="6"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermans3a" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3:4"/>
+                        <option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermans3b" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3:4"/>
+                        <option name="alliedOwnershipTerritories" value="Norway" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermansParatroopers" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="paratroopers" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermansSuperSubs" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="superSub" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermansReinforcedHulls" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="reinforcedHulls" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermansWolfPackTactics" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="wolfPackTactics" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermansShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="shipyards" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermansShipyardsInvert" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="shipyards" count="1"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermansSubmarineTech2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansReinforcedHulls:conditionAttachmentGermansWolfPackTactics"/>
+                        <option name="conditionType" value="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentGermansSubmarineTech3" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansReinforcedHulls:conditionAttachmentGermansWolfPackTactics"/>
+                        <option name="conditionType" value="2-3"/>
+                </attachment>
+
+        <!-- Japanese Conditions -->
+                <attachment name="conditionAttachmentJapanese1a" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Sinkiang:India:Burytia S.S.R." count="1"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapanese1b" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3:4"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapanese2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3:4:5"/>
+                        <option name="alliedOwnershipTerritories" value="Australia:India:Sinkiang" count="3"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapanese3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="1-2:3:4-+"/>
+                        <option name="directOwnershipTerritories" value="original"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapanese4" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="directOwnershipTerritories" value="Burytia S.S.R.:Soviet Far East:Yakut S.S.R.:Evanki National Okrug:Novisibirsk:Kazakh S.S.R.:Caucus:Russia:Archangel:Karelia S.S.R." count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapaneseParatroopers" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="paratroopers" count="1"/>
+                </attachment>
+
+                <!--<attachment name="conditionAttachmentJapaneseMidget1" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Okinawa:Philipine Islands" count="2"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapaneseMidget2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="6"/>
+                        <option name="invert" value="true"/>
+                </attachment>-->
+
+                <attachment name="conditionAttachmentJapaneseMidget" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Okinawa:Philipine Islands:East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="7"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapaneseKamikaze1" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Philipine Islands" count="1"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapaneseKamikaze2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Okinawa:East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="7"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapaneseBattleships" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="directPresenceTerritories" value="map" count="1"/>
+                        <option name="unitPresence" value="battleship" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapaneseCarriers" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="directPresenceTerritories" value="map" count="1"/>
+                        <option name="unitPresence" value="carrier" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentJapaneseShipyards" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="shipyards" count="1"/>
+                </attachment>
+
+        <!-- Italians Conditions -->
+                <attachment name="conditionAttachmentItalians1" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3:4"/>
+                        <option name="alliedOwnershipTerritories" value="Algeria:Libya:Anglo Egypt:Trans-Jordan" count="4"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentItaliansParatroopers" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="paratroopers" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentItaliansShipyards" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="shipyards" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentItalianTurn2" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="2"/>
+                </attachment>
+                <attachment name="conditionAttachmentItalianTurn1" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="1"/>
+                </attachment>
+
+
+        <!-- Americans Conditions -->
+                <attachment name="conditionAttachmentAmericans1_WarPhase" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="2-+"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentAmericans1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3-5"/>
+                        <option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentAmericans2" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3-5"/>
+                        <option name="alliedOwnershipTerritories" value="Alaska:Wake Island:Hawaiian Islands:Midway" count="4"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentAmericans3a" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="1-8"/>
+                        <option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentAmericans3b" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="1:2:3-7:8"/>
+                        <option name="alliedOwnershipTerritories" value="Alaska:Wake Island:Hawaiian Islands:Midway" count="4"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentAmericans4" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="jetPower:warBonds" count="2"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentAmericansParatroopers" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="paratroopers" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentAmericansShipyards" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="shipyards" count="1"/>
+                </attachment>
+
+        <!-- British Conditions -->
+                <attachment name="conditionAttachmentBritish2" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3:4"/>
+                        <option name="alliedOwnershipTerritories" value="Union of South Africa:Gibraltar:Anglo Egypt:India:Australia" count="4"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentBritishParatroopers" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="paratroopers" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentBritishShipyards" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="shipyards" count="1"/>
+                </attachment>
+
+        <!-- Russians Conditions -->
+                <attachment name="conditionAttachmentRussians2" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3:4"/>
+                        <option name="alliedOwnershipTerritories" value="Karelia S.S.R.:Caucus" count="2"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentRussiansNeutralAmericans" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="relationship" value="Russians:Americans:anyNeutral"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentRussiansNeutralJapan" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="relationship" value="Japanese:Russians:anyNeutral"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentRussiansNeutralJapanTurn5plus" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="5-+"/>
+                        <option name="relationship" value="Japanese:Russians:anyNeutral"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentRussiansNeutralItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="relationship" value="Italians:Russians:anyNeutral:1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentRussiansWarItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="relationship" value="Italians:Russians:anyWar:1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentRussiansNeutralItaliansFor2Turns" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="relationship" value="Italians:Russians:anyNeutral:2"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentChineseNeutralItalians" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="relationship" value="Italians:Chinese:anyNeutral"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentRussians3" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Burytia S.S.R." count="1"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentRussiansParatroopers" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="paratroopers" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentRussiansShipyards" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="shipyards" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentRussianCapitalLost" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Russia" count="1"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+        <!-- Chinese Conditions -->
+                <attachment name="conditionAttachmentChinese3" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="enemyExclusionTerritories" value="Sinkiang:Central China:China:Manchuria:Kwangtung:French Indochina" count="3"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentChinese4" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Japan" count="1"/>
+                </attachment>
+
+                <!--<attachment name="conditionAttachmentChineseParatroopers" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="paratroopers" count="1"/>
+                </attachment>
+
+                <attachment name="conditionAttachmentChineseShipyards" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="techs" value="shipyards" count="1"/>
+                </attachment>-->
+
+
 <!-- Triggers -->
-	<!-- Triggers with "uses" will use up a single 'use' every round that they are used.  So a trigger that gives a player a tech, adds units to a territory, changes a relationship, and sends a notification to a player,
-				will use up a Single (1) use, assuming those four actions were done in a single round (as determined by the endRound phase [EndRoundDelegate])-->
-	<!-- the following options are allowed for "triggerAttachmentXXX"
-			conditions							values: any objectiveAttachment or conditionAttachment, can be any player's attachment (must have unique names!), tested during attached player's turn
-															can be in a delimited list for an AND relationship (example: value="conditionAttachmentGermans3a:conditionAttachmentGermans3b")
-			conditionType 						values: AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the trigger. 
-														AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
-			invert 								values: true or false. default if missing is false. if true, the condition will be reversed (does not reverse the effect)
-														This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
-			uses 								values: integer for the maximum number of times it should be awarded. if missing it defaults to infinity
-			when								values: this is a value of when the trigger should fire. it is optional, and if left out the trigger will fire at its default time. "before/after:name-of-step" (example: value="after:chineseEndTurn")
-														FYI: if your triggers are displaying odd behavior, MAKE SURE WHEN IS SET. complex triggers can experience unexpected behavior if 'when' is not set.
-			chance								values: "x:y", where x = to hit, and y = dice sides.  So "1:6" = 16.7% chance, while "3:10" = 30% chance
-			victory								values: the string message from notifications.properties to be displayed if the condition is true.
-			notification						values: this is a popup window containing a message that will be given to the current player. "name-of-entry-in-notifications.properties" or "message"
-															both "victory" and "notification" will look in the "notifications.properties" in your maps root folder for a string with the value's name, and then it will use whatever is to the right of the = sign.
-			resource							values: "PUs" or "techTokens" or any valid resource, given at end of turn phase.  "resource" will be affected by "each" in a condition statement.
-			resourceCount						values: the number of specified resource to be given
-			placement							values: places units at beginning of combat movement phase. first in list is territory to be placed it, then list of units, then count.  "placement" will be affected by "each" in a condition statement.
-														(example: value="Moscow:artillery:infantry" count="2" [if count is missing, defaults to 1])
-			removeUnits							values: removes up to that number of the desired unit, at the beginning of the combat move phase. "removeUnits" will be affected by "each" in a condition statement.
-														removeUnits list is done the same way as placement, but allows the option of "all" in place of the territory name, and also "all" in place of the unit type, such as value="all:all", or "Moscow:all", or "all:infantry". example: <option name="removeUnits" value="all:infantry" count="1"/>
-			purchase							values: adds listed units to user's purchase at beginning of purchase phase (example: value="infantry:destroyer" count="3").  "purchase" will be affected by "each" in a condition statement.
-			tech								values: the names of any technology to be given to the active or specified player. given at end of tech activation phase. (example: value="rocket:longRangeAir")
-			availableTech						values: the name of the category to be added to, followed by the names of the technologies to add to it. (example: value="airCategory:longRangeAir:jetPower:superHeavyBomber")
-														If prefixed with "-" then it will remove the tech from that category (if the player already has the tech, it will do nothing).
-			frontier							values: name of a production frontier, changes the player's production frontier to BE the one listed, at beginning of the purchase phase. (does not add the production to the current list, is a new list completely)
-			productionRule						values: the name of the frontier, and then the name of the production rule you want to add or remove from a frontier, at beginning of the purchase phase.
-														If prefixed with "-" then it will remove the production rule instead of adding it. (example: value="Germans_production:buySuper_Carrier" or value="Germans_production:-buyEarly_Fighter")
-			support								values: name of support attachment, adds specified player to the list of players a supportAttachment supports. Can be a list. (example: value="supportAttachmentGermans1AwesomeArtillery")
-														If prefixed with "-" then it will remove that player from the support attachment (example: value="-supportAttachmentArtyOldartillery")
-			relationshipChange					values: the change in relationship for these players, format: "player1:player2:oldRelation:newRelation" example: "Russians:Americans:coldWar:allOutWar"
-														oldRelation may be "any", "anyWar", "anyNeutral", "anyAllied", or an actual relationshipType used in this xml
-														You can enter multiple relationshipChanges in the trigger and it will perform every change in the trigger which is valid.
-			activateTrigger						values: This will fire another named trigger. Format: "triggerName:numberOfTimes:useUses:testUses:testConditions:testChance". "activateTrigger" will be affected by "each" in a condition statement.
-														triggerName is the name of the trigger to fire, numberOfTimes is the number of times to fire that trigger, useUses makes sure the firing uses up a "use" at the end of this round, and the tests test the trigger before firing.
-														example: value="triggerAttachmentRussians5_FarEastReserves:1:false:false:false:false"
-			changeOwnership						values: This will change the ownership of the territory, either directly or by conquering the territory (there is a difference). Format is "territoryName:oldOwner:newOwner:booleanCaptured?".  territoryName can be "all", and oldOwner can be "any". Can have multiple instances.
-														examples: <option name="changeOwnership" value="South France:Germans:VichyFrench:false"/> or <option name="changeOwnership" value="all:Mongolians:Russians:true"/> or <option name="changeOwnership" value="Danzig:any:Germans:false"/>
-			
-		For the following, you are actually changing raw data in the engine by calling the setters in the same way the engine does when it parses the xml.  The following are not validated at all, so if you don't use them correctly you will probably cause the engine to crash mid-game.
-		You may prefix the property count portion with "-reset-" if you wish to clear out the data in an array first (example: <option name="unitProperty" value="requiresUnits" count="-reset-factory:hangar"/> )
-		To further explain, certain options replace/overwrite when you set them.  For example, "attack", or "invert", will overwrite when you set it with something new. Other properties, like "requiresUnits", or "productionRule", will add more items to a list every time you set it.
-		Unless otherwise specified, all options overwrite when set.
-			players								values: the names of the players to give these things to. if missing, defaults to attached player. (example: value="Germans:Italians"). Also used as list of players affected by a playerProperty change.
-			playerAttachmentName				values: the type of attachment (PlayerAttachment, TriggerAttachment, RulesAttachment, TechAttachment, PoliticalActionAttachment) and the exact full name of the attachment to be changed. 
-															(example: value="RulesAttachment" count="rulesAttachment"). Defaults to PlayerAttachment if missing.
-			playerProperty						values: the name of any actual attachment property, with a count equal to the property's values (examples: value="destroysPUs" count="true"). (requires players to be set, otherwise it uses the attached player)
-			unitType							values: the exact names of the unit to be affected by a unitProperty change (example: value="cruiser:super_cruiser")
-			unitAttachmentName					values: the type of attachment (UnitAttachment, UnitSupportAttachment) and the exact full name of the attachment to be changed. Defaults to UnitAttachment if missing.
-			unitProperty						values: the name of any actual attachment property, with a count equal to the property's values (examples: value="attack" count="4", or value="isAir" count="true"), requires unitType declared
-														Something to note is that <option name="artillery" value="true"/> AND <option name="artillerySupportable" value="true"/> AND <option name="unitSupportCount" value="1"/> are all converted into a support attachment when the game starts, 
-															so adding or removing them as unit properties will do nothing (the bonusType for them is "ArtyOld", and the supportAttachment name is "supportAttachmentArtyOld<nameofUnit>") unitProperty changes are done for ALL players who use that unitType, 
-															regardless of the player specified in the trigger. In order to have a unitType+unitProperty change only affect certain players and not others, you need to make a new unit type for those players (ie: rename the unit for those players only)
-			territories							values: the exact names of the territories to be affected by a territoryProperty change (example: value="Germany:Italy")
-			territoryAttachmentName				values: the type of attachment (TerritoryAttachment, CanalAttachment) and the exact full name of the attachment to be changed. Defaults to TerritoryAttachment if missing.
-			territoryProperty					values: the name of any actual attachment property, with a count equal to the property's values (examples: value="production" count="4", or value="victoryCity" count="true"), requires territories declared
-			relationshipTypes					values: the exact names of the relationshipType to be affected by a relationshipTypeProperty change
-			relationshipTypeAttachmentName		values: the type of attachment (RelationshipTypeAttachment) and the exact full name of the attachment to be changed. Defaults to RelationshipTypeAttachment if missing.
-			relationshipTypeProperty			values: the name of any actual attachment property, with a count equal to the property's values, requires relationshipTypes declared
-			territoryEffects					values: the exact names of the territoryEffects to be affected by a territoryEffectProperty change
-			territoryEffectAttachmentName		values: the type of attachment (TerritoryEffectAttachment) and the exact full name of the attachment to be changed. Defaults to TerritoryEffectAttachment if missing.
-			territoryEffectProperty				values: the name of any actual attachment property, with a count equal to the property's values, requires territoryEffects declared
-			
-	-->
-		<!-- Clarification on how "each" works.  (Each is just a way to simplify writing national objectives, conditions, and triggers. It does not do anything extra that you could not do before)
-				Lets say you have this objective:
-					<attachment name="objectiveAttachmentRussians1_EasternEuropeMegaIncome" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-							<option name="objectiveValue" value="4"/>
-							<option name="directOwnershipTerritories" value="Norway:Eastern Europe:East Balkans:Ukraine S.S.R.:Belorussia" count="each"/>
-					</attachment>
-				What would happen is that "Russians" would get 4 PUs for EACH territory in that list that satisfied directOwnershipTerritories.
-				If you used it as a condition statement, then it would act as 1 for the purposes of returning true/false (in other words, own at least 1 territory and the condition would be true).
-				Now lets say you have this trigger:
-					<attachment name="triggerAttachmentRussians5_FarEastReserves" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-							<option name="conditions" value="objectiveAttachmentRussians1_EasternEuropeMegaIncome"/>
-							<option name="placement" value="Russia:infantry" count="2"/>
-					</attachment>
-				This trigger would add 2 infantry to russia for each territory inside the condition objectiveAttachmentRussians1_EasternEuropeMegaIncome that is true.
-				IF you have more than 1 condition with Each, then the trigger will use the largest Each.  If you have a meta-condition (a condition that contains other conditions), the trigger will NOT look inside the conditions inside the meta-condition.
-				Since it would be meaningless to, for example, change a relation to the same thing 10 times in a row, Each only works with the following kinds of triggers:
-				resource, placement, removeUnits, purchase
-		-->
-		<!-- Clarification on changing properties and resetting/clearing of properties. (Any property not in this list overwrites itself if you set it multiple times)
-				The following attachments may have MULTIPLE instances, meaning that they are adding to some variable, meaning that they may be cleared/reset by triggers if you want to (by prefixing with "-reset-"):
-				Unit Attachments:
-					canBeGivenByTerritoryTo
-					canBeCapturedOnEnteringBy
-					destroyedWhenCapturedBy
-					requiresUnits
-					givesMovement
-					consumesUnits
-					createsUnitsList
-					createsResourcesList
-					receivesAbilityWhenWith
-					whenCapturedChangesInto
-					special
-					fuelCost
-					targetsAA
-					willNotFireIfPresent
-					bombingTargets
-					
-				Unit Support Attachments:
-					players
-					
-				Territory Attachments:
-					changeUnitOwners
-					captureUnitOnEnteringBy
-					territoryEffect
-					whenCapturedByGoesTo
-					convoyAttached
-					
-				Territory Effect Attachments:
-					combatDefenseEffect
-					combatOffenseEffect
-					
-				Player Attachments:
-					giveUnitControl
-					captureUnitOnEnteringBy
-					shareTechnology
-					helpPayTechCost
-					suicideAttackResources
-					suicideAttackTargets
-					movementLimit
-					attackingLimit
-					placementLimit
-					
-				Objectives & Condition Attachments:
-					conditions
-					unitPresence
-					relationship
-					players
-					battle
-				
-				Rules Attachments:
-					productionPerXTerritories
-					
-				Trigger Attachments:
-					conditions
-					productionRule
-					tech
-					availableTech
-					placement
-					purchase
-					support
-					relationshipChange
-					activateTrigger
-					changeOwnership
-					
-					players
-					playerProperty
-					unitType
-					unitProperty
-					territories
-					territoryProperty
-					relationshipTypes
-					relationshipTypeProperty
-					territoryEffects
-					territoryEffectProperty
-					
-				Political Action Attachments:
-					conditions
-					relationshipChange
-					actionAccept
-					
-				Canal Attachments:
-					excludedUnits
-					
-				Tech Ability Attachments:
-					attackBonus
-					defenseBonus
-					movementBonus
-					radarBonus
-					airAttackBonus
-					airDefenseBonus
-					productionBonus
-					rocketDiceNumber
-					unitAbilitiesGained
-					airborneCapacity
-					airborneTypes
-					airborneBases
-					airborneTargettedByAA
-					attackRollsBonus
-					defenseRollsBonus
-					bombingBonus
-					
-		-->
-		<!-- Victory Triggers -->
-						<!-- Victory Triggers can be attached to anyone. Only 1 is needed per victory condition -->
-				<attachment name="triggerAttachmentAxisVictory1_CapitalControl" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAxisVictory1"/>
-						<!--<option name="when" value="after:chineseEndTurn"/>-->
-						<!-- both "victory" and "notification" will look in the "notifications.properties" in your maps root folder for a string with the value's name, and then it will use whatever is to the right of the = sign.-->
-						<option name="victory" value="AXIS_VICTORY"/>
-						<!-- "players" when used with "victory" set which players are the winner. this is important for stats generation and for future use -->
-						<option name="players" value="Germans:Italians:Japanese"/>
-				</attachment>
-				
-				<attachment name="triggerAttachmentAlliesVictory1_CapitalControl" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAlliesVictory1"/>
-						<option name="when" value="after:chineseEndTurn"/>
-						<option name="victory" value="ALLIES_VICTORY"/>
-						<option name="players" value="Russians:British:Americans:Chinese"/>
-				</attachment>
-	
-		<!-- Germans Triggers -->
-				<attachment name="triggerAttachmentGermans3_SuperSubs" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermans1"/>
-						<option name="tech" value="superSub"/>
-						<option name="uses" value="1"/>
-				</attachment>
+    <!-- Triggers with "uses" will use up a single 'use' every round that they are used.  So a trigger that gives a player a tech, adds units to a territory, changes a relationship, and sends a notification to a player,
+                will use up a Single (1) use, assuming those four actions were done in a single round (as determined by the endRound phase [EndRoundDelegate])-->
+    <!-- the following options are allowed for "triggerAttachmentXXX"
+            conditions                          values: any objectiveAttachment or conditionAttachment, can be any player's attachment (must have unique names!), tested during attached player's turn
+                                                            can be in a delimited list for an AND relationship (example: value="conditionAttachmentGermans3a:conditionAttachmentGermans3b")
+            conditionType                       values: AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the trigger.
+                                                        AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
+            invert                              values: true or false. default if missing is false. if true, the condition will be reversed (does not reverse the effect)
+                                                        This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
+            uses                                values: integer for the maximum number of times it should be awarded. if missing it defaults to infinity
+            when                                values: this is a value of when the trigger should fire. it is optional, and if left out the trigger will fire at its default time. "before/after:name-of-step" (example: value="after:chineseEndTurn")
+                                                        FYI: if your triggers are displaying odd behavior, MAKE SURE WHEN IS SET. complex triggers can experience unexpected behavior if 'when' is not set.
+            chance                              values: "x:y", where x = to hit, and y = dice sides.  So "1:6" = 16.7% chance, while "3:10" = 30% chance
+            victory                             values: the string message from notifications.properties to be displayed if the condition is true.
+            notification                        values: this is a popup window containing a message that will be given to the current player. "name-of-entry-in-notifications.properties" or "message"
+                                                            both "victory" and "notification" will look in the "notifications.properties" in your maps root folder for a string with the value's name, and then it will use whatever is to the right of the = sign.
+            resource                            values: "PUs" or "techTokens" or any valid resource, given at end of turn phase.  "resource" will be affected by "each" in a condition statement.
+            resourceCount                       values: the number of specified resource to be given
+            placement                           values: places units at beginning of combat movement phase. first in list is territory to be placed it, then list of units, then count.  "placement" will be affected by "each" in a condition statement.
+                                                        (example: value="Moscow:artillery:infantry" count="2" [if count is missing, defaults to 1])
+            removeUnits                         values: removes up to that number of the desired unit, at the beginning of the combat move phase. "removeUnits" will be affected by "each" in a condition statement.
+                                                        removeUnits list is done the same way as placement, but allows the option of "all" in place of the territory name, and also "all" in place of the unit type, such as value="all:all", or "Moscow:all", or "all:infantry". example: <option name="removeUnits" value="all:infantry" count="1"/>
+            purchase                            values: adds listed units to user's purchase at beginning of purchase phase (example: value="infantry:destroyer" count="3").  "purchase" will be affected by "each" in a condition statement.
+            tech                                values: the names of any technology to be given to the active or specified player. given at end of tech activation phase. (example: value="rocket:longRangeAir")
+            availableTech                       values: the name of the category to be added to, followed by the names of the technologies to add to it. (example: value="airCategory:longRangeAir:jetPower:superHeavyBomber")
+                                                        If prefixed with "-" then it will remove the tech from that category (if the player already has the tech, it will do nothing).
+            frontier                            values: name of a production frontier, changes the player's production frontier to BE the one listed, at beginning of the purchase phase. (does not add the production to the current list, is a new list completely)
+            productionRule                      values: the name of the frontier, and then the name of the production rule you want to add or remove from a frontier, at beginning of the purchase phase.
+                                                        If prefixed with "-" then it will remove the production rule instead of adding it. (example: value="Germans_production:buySuper_Carrier" or value="Germans_production:-buyEarly_Fighter")
+            support                             values: name of support attachment, adds specified player to the list of players a supportAttachment supports. Can be a list. (example: value="supportAttachmentGermans1AwesomeArtillery")
+                                                        If prefixed with "-" then it will remove that player from the support attachment (example: value="-supportAttachmentArtyOldartillery")
+            relationshipChange                  values: the change in relationship for these players, format: "player1:player2:oldRelation:newRelation" example: "Russians:Americans:coldWar:allOutWar"
+                                                        oldRelation may be "any", "anyWar", "anyNeutral", "anyAllied", or an actual relationshipType used in this xml
+                                                        You can enter multiple relationshipChanges in the trigger and it will perform every change in the trigger which is valid.
+            activateTrigger                     values: This will fire another named trigger. Format: "triggerName:numberOfTimes:useUses:testUses:testConditions:testChance". "activateTrigger" will be affected by "each" in a condition statement.
+                                                        triggerName is the name of the trigger to fire, numberOfTimes is the number of times to fire that trigger, useUses makes sure the firing uses up a "use" at the end of this round, and the tests test the trigger before firing.
+                                                        example: value="triggerAttachmentRussians5_FarEastReserves:1:false:false:false:false"
+            changeOwnership                     values: This will change the ownership of the territory, either directly or by conquering the territory (there is a difference). Format is "territoryName:oldOwner:newOwner:booleanCaptured?".  territoryName can be "all", and oldOwner can be "any". Can have multiple instances.
+                                                        examples: <option name="changeOwnership" value="South France:Germans:VichyFrench:false"/> or <option name="changeOwnership" value="all:Mongolians:Russians:true"/> or <option name="changeOwnership" value="Danzig:any:Germans:false"/>
 
-				<attachment name="triggerAttachmentGermans4_MechanizedInfantry" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermans2"/>
-						<option name="tech" value="mechanizedInfantry"/>
-						<option name="uses" value="1"/>
-				</attachment>
+        For the following, you are actually changing raw data in the engine by calling the setters in the same way the engine does when it parses the xml.  The following are not validated at all, so if you don't use them correctly you will probably cause the engine to crash mid-game.
+        You may prefix the property count portion with "-reset-" if you wish to clear out the data in an array first (example: <option name="unitProperty" value="requiresUnits" count="-reset-factory:hangar"/> )
+        To further explain, certain options replace/overwrite when you set them.  For example, "attack", or "invert", will overwrite when you set it with something new. Other properties, like "requiresUnits", or "productionRule", will add more items to a list every time you set it.
+        Unless otherwise specified, all options overwrite when set.
+            players                             values: the names of the players to give these things to. if missing, defaults to attached player. (example: value="Germans:Italians"). Also used as list of players affected by a playerProperty change.
+            playerAttachmentName                values: the type of attachment (PlayerAttachment, TriggerAttachment, RulesAttachment, TechAttachment, PoliticalActionAttachment) and the exact full name of the attachment to be changed.
+                                                            (example: value="RulesAttachment" count="rulesAttachment"). Defaults to PlayerAttachment if missing.
+            playerProperty                      values: the name of any actual attachment property, with a count equal to the property's values (examples: value="destroysPUs" count="true"). (requires players to be set, otherwise it uses the attached player)
+            unitType                            values: the exact names of the unit to be affected by a unitProperty change (example: value="cruiser:super_cruiser")
+            unitAttachmentName                  values: the type of attachment (UnitAttachment, UnitSupportAttachment) and the exact full name of the attachment to be changed. Defaults to UnitAttachment if missing.
+            unitProperty                        values: the name of any actual attachment property, with a count equal to the property's values (examples: value="attack" count="4", or value="isAir" count="true"), requires unitType declared
+                                                            Something to note is that <option name="artillery" value="true"/> AND <option name="artillerySupportable" value="true"/> AND <option name="unitSupportCount" value="1"/> are all converted into a support attachment when the game starts,
+                                                            so adding or removing them as unit properties will do nothing (the bonusType for them is "ArtyOld", and the supportAttachment name is "supportAttachmentArtyOld<nameofUnit>") unitProperty changes are done for ALL players who use that unitType,
+                                                            regardless of the player specified in the trigger. In order to have a unitType+unitProperty change only affect certain players and not others, you need to make a new unit type for those players (ie: rename the unit for those players only)
+            territories                         values: the exact names of the territories to be affected by a territoryProperty change (example: value="Germany:Italy")
+            territoryAttachmentName             values: the type of attachment (TerritoryAttachment, CanalAttachment) and the exact full name of the attachment to be changed. Defaults to TerritoryAttachment if missing.
+            territoryProperty                   values: the name of any actual attachment property, with a count equal to the property's values (examples: value="production" count="4", or value="victoryCity" count="true"), requires territories declared
+            relationshipTypes                   values: the exact names of the relationshipType to be affected by a relationshipTypeProperty change
+            relationshipTypeAttachmentName      values: the type of attachment (RelationshipTypeAttachment) and the exact full name of the attachment to be changed. Defaults to RelationshipTypeAttachment if missing.
+            relationshipTypeProperty            values: the name of any actual attachment property, with a count equal to the property's values, requires relationshipTypes declared
+            territoryEffects                    values: the exact names of the territoryEffects to be affected by a territoryEffectProperty change
+            territoryEffectAttachmentName       values: the type of attachment (TerritoryEffectAttachment) and the exact full name of the attachment to be changed. Defaults to TerritoryEffectAttachment if missing.
+            territoryEffectProperty             values: the name of any actual attachment property, with a count equal to the property's values, requires territoryEffects declared
 
-				<attachment name="triggerAttachmentGermans5_Rockets" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermans3a:conditionAttachmentGermans3b"/>
-						<option name="conditionType" value="AND"/>
-						<option name="tech" value="rocket"/>
-						<option name="uses" value="1"/>
-				</attachment>
+    -->
+        <!-- Clarification on how "each" works.  (Each is just a way to simplify writing national objectives, conditions, and triggers. It does not do anything extra that you could not do before)
+                Lets say you have this objective:
+                    <attachment name="objectiveAttachmentRussians1_EasternEuropeMegaIncome" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                            <option name="objectiveValue" value="4"/>
+                            <option name="directOwnershipTerritories" value="Norway:Eastern Europe:East Balkans:Ukraine S.S.R.:Belorussia" count="each"/>
+                    </attachment>
+                What would happen is that "Russians" would get 4 PUs for EACH territory in that list that satisfied directOwnershipTerritories.
+                If you used it as a condition statement, then it would act as 1 for the purposes of returning true/false (in other words, own at least 1 territory and the condition would be true).
+                Now lets say you have this trigger:
+                    <attachment name="triggerAttachmentRussians5_FarEastReserves" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                            <option name="conditions" value="objectiveAttachmentRussians1_EasternEuropeMegaIncome"/>
+                            <option name="placement" value="Russia:infantry" count="2"/>
+                    </attachment>
+                This trigger would add 2 infantry to russia for each territory inside the condition objectiveAttachmentRussians1_EasternEuropeMegaIncome that is true.
+                IF you have more than 1 condition with Each, then the trigger will use the largest Each.  If you have a meta-condition (a condition that contains other conditions), the trigger will NOT look inside the conditions inside the meta-condition.
+                Since it would be meaningless to, for example, change a relation to the same thing 10 times in a row, Each only works with the following kinds of triggers:
+                resource, placement, removeUnits, purchase
+        -->
+        <!-- Clarification on changing properties and resetting/clearing of properties. (Any property not in this list overwrites itself if you set it multiple times)
+                The following attachments may have MULTIPLE instances, meaning that they are adding to some variable, meaning that they may be cleared/reset by triggers if you want to (by prefixing with "-reset-"):
+                Unit Attachments:
+                    canBeGivenByTerritoryTo
+                    canBeCapturedOnEnteringBy
+                    destroyedWhenCapturedBy
+                    requiresUnits
+                    givesMovement
+                    consumesUnits
+                    createsUnitsList
+                    createsResourcesList
+                    receivesAbilityWhenWith
+                    whenCapturedChangesInto
+                    special
+                    fuelCost
+                    targetsAA
+                    willNotFireIfPresent
+                    bombingTargets
 
-				<attachment name="triggerAttachmentAmericans5_British4_Paratroopers" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAmericans1"/>
-						<option name="tech" value="paratroopers"/>
-						<option name="players" value="Americans:British"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                Unit Support Attachments:
+                    players
 
-				<attachment name="triggerAttachmentAmericans7_WarBonds" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAmericans3a:conditionAttachmentAmericans3b"/>
-						<option name="tech" value="warBonds"/>
-						<option name="players" value="Americans"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                Territory Attachments:
+                    changeUnitOwners
+                    captureUnitOnEnteringBy
+                    territoryEffect
+                    whenCapturedByGoesTo
+                    convoyAttached
 
-				<attachment name="triggerAttachmentGermansParatroopersCanProduce" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansParatroopers"/>
-						<option name="productionRule" value="Germans_production:buyAir_Transport"/>
-				</attachment>
+                Territory Effect Attachments:
+                    combatDefenseEffect
+                    combatOffenseEffect
 
-				<attachment name="triggerAttachmentGermansSuperSubs1_NewSubmarineTech" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansSuperSubs"/>
-						<option name="availableTech" value="Submarine Technology:reinforcedHulls:wolfPackTactics"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                Player Attachments:
+                    giveUnitControl
+                    captureUnitOnEnteringBy
+                    shareTechnology
+                    helpPayTechCost
+                    suicideAttackResources
+                    suicideAttackTargets
+                    movementLimit
+                    attackingLimit
+                    placementLimit
 
-				<attachment name="triggerAttachmentGermansSuperSubs2_NewItalianTechAvailable" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansSuperSubs"/>
-						<option name="availableTech" value="Italian Technology:reinforcedHulls:-shipyards"/>
-						<option name="uses" value="1"/>
-						<option name="players" value="Italians"/>
-				</attachment>
+                Objectives & Condition Attachments:
+                    conditions
+                    unitPresence
+                    relationship
+                    players
+                    battle
 
-				<attachment name="triggerAttachmentGermansReinforcedHulls" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansReinforcedHulls"/>
-						<option name="support" value="supportAttachmentSubmarineReinforcedHulls"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                Rules Attachments:
+                    productionPerXTerritories
 
-				<attachment name="triggerAttachmentGermansWolfPackTactics" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansWolfPackTactics"/>
-						<option name="support" value="supportAttachmentSubmarineWolfPackTacticsOffence"/>
-						<!--<option name="support" value="supportAttachmentSubmarineWolfPackTacticsDefence"/>-->
-						<option name="uses" value="1"/>
-				</attachment>
+                Trigger Attachments:
+                    conditions
+                    productionRule
+                    tech
+                    availableTech
+                    placement
+                    purchase
+                    support
+                    relationshipChange
+                    activateTrigger
+                    changeOwnership
 
-				<attachment name="triggerAttachmentGermansShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansShipyards"/>
-						<option name="productionRule" value="Germans_production:-buyTransport"/>
-						<option name="productionRule" value="Germans_production:-buySubmarine"/>
-						<option name="productionRule" value="Germans_production:-buyDestroyer"/>
-						<option name="productionRule" value="Germans_production:-buyCruiser"/>
-						<option name="productionRule" value="Germans_production:-buyCarrier"/>
-						<option name="productionRule" value="Germans_production:-buyBattleship"/>
-						<option name="productionRule" value="Germans_production:-buySuper_Carrier"/>
-						<option name="productionRule" value="Germans_production:buyTransportShipyards"/>
-						<option name="productionRule" value="Germans_production:buySubmarineShipyards"/>
-						<option name="productionRule" value="Germans_production:buyDestroyerShipyards"/>
-						<option name="productionRule" value="Germans_production:buyCruiserShipyards"/>
-						<option name="productionRule" value="Germans_production:buyCarrierShipyards"/>
-						<option name="productionRule" value="Germans_production:buyBattleshipShipyards"/>
-						<option name="productionRule" value="Germans_production:buySuper_CarrierShipyards"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                    players
+                    playerProperty
+                    unitType
+                    unitProperty
+                    territories
+                    territoryProperty
+                    relationshipTypes
+                    relationshipTypeProperty
+                    territoryEffects
+                    territoryEffectProperty
 
-				<attachment name="triggerAttachmentGermansSubmarineTech2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansSubmarineTech2:conditionAttachmentGermansShipyardsInvert"/>
-						<option name="productionRule" value="Germans_production:-buySubmarine"/>
-						<option name="productionRule" value="Germans_production:buySubmarineTech2"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                Political Action Attachments:
+                    conditions
+                    relationshipChange
+                    actionAccept
 
-				<attachment name="triggerAttachmentGermansSubmarineTech3" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansSubmarineTech3:conditionAttachmentGermansShipyardsInvert"/>
-						<option name="productionRule" value="Germans_production:-buySubmarine"/>
-						<option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
-						<option name="productionRule" value="Germans_production:buySubmarineTech3"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                Canal Attachments:
+                    excludedUnits
 
-				<attachment name="triggerAttachmentGermansSubmarineTech2AndShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansSubmarineTech2:conditionAttachmentGermansShipyards"/>
-						<option name="productionRule" value="Germans_production:-buySubmarine"/>
-						<option name="productionRule" value="Germans_production:-buySubmarineShipyards"/>
-						<option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
-						<option name="productionRule" value="Germans_production:buySubmarineTech2Shipyards"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                Tech Ability Attachments:
+                    attackBonus
+                    defenseBonus
+                    movementBonus
+                    radarBonus
+                    airAttackBonus
+                    airDefenseBonus
+                    productionBonus
+                    rocketDiceNumber
+                    unitAbilitiesGained
+                    airborneCapacity
+                    airborneTypes
+                    airborneBases
+                    airborneTargettedByAA
+                    attackRollsBonus
+                    defenseRollsBonus
+                    bombingBonus
 
-				<attachment name="triggerAttachmentGermansSubmarineTech3AndShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansSubmarineTech3:conditionAttachmentGermansShipyards"/>
-						<option name="productionRule" value="Germans_production:-buySubmarine"/>
-						<option name="productionRule" value="Germans_production:-buySubmarineShipyards"/>
-						<option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
-						<option name="productionRule" value="Germans_production:-buySubmarineTech3"/>
-						<option name="productionRule" value="Germans_production:-buySubmarineTech2Shipyards"/>
-						<option name="productionRule" value="Germans_production:buySubmarineTech3Shipyards"/>
-						<option name="uses" value="1"/>
-				</attachment>
-				
-		<!-- Japanese Triggers -->
-				<attachment name="triggerAttachmentJapanese3_TokyoExpress" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapanese1a:conditionAttachmentJapanese1b"/>
-						<option name="unitType" value="jp_destroyer"/>
-						<option name="unitProperty" value="transportCapacity" count="2"/>
-						<option name="unitProperty" value="isCombatTransport" count="true"/>
-						<option name="uses" value="1"/>
-				</attachment>
+        -->
+        <!-- Victory Triggers -->
+                        <!-- Victory Triggers can be attached to anyone. Only 1 is needed per victory condition -->
+                <attachment name="triggerAttachmentAxisVictory1_CapitalControl" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAxisVictory1"/>
+                        <!--<option name="when" value="after:chineseEndTurn"/>-->
+                        <!-- both "victory" and "notification" will look in the "notifications.properties" in your maps root folder for a string with the value's name, and then it will use whatever is to the right of the = sign.-->
+                        <option name="victory" value="AXIS_VICTORY"/>
+                        <!-- "players" when used with "victory" set which players are the winner. this is important for stats generation and for future use -->
+                        <option name="players" value="Germans:Italians:Japanese"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentJapanese4_ArmyControlOfNavy" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapanese2"/>
-						<option name="unitType" value="jp_transport"/>
-						<option name="unitProperty" value="transportCapacity" count="6"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentAlliesVictory1_CapitalControl" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAlliesVictory1"/>
+                        <option name="when" value="after:chineseEndTurn"/>
+                        <option name="victory" value="ALLIES_VICTORY"/>
+                        <option name="players" value="Russians:British:Americans:Chinese"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentJapanese5_ForTheEmperor" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapanese3"/>
-						<option name="placement" value="61 Sea Zone:midget_submarine"/>
-						<option name="uses" value="1"/>
-				</attachment>
+        <!-- Germans Triggers -->
+                <attachment name="triggerAttachmentGermans3_SuperSubs" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermans1"/>
+                        <option name="tech" value="superSub"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentJapaneseParatroopersCanProduce" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapaneseParatroopers"/>
-						<option name="productionRule" value="Japanese_production:buyAir_Transport"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermans4_MechanizedInfantry" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermans2"/>
+                        <option name="tech" value="mechanizedInfantry"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentJapanese6_MidgetSubCanProduce" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapaneseMidget"/>
-						<option name="productionRule" value="Japanese_production:buyMidget_Submarine"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermans5_Rockets" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermans3a:conditionAttachmentGermans3b"/>
+                        <option name="conditionType" value="AND"/>
+                        <option name="tech" value="rocket"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentJapanese7_KamikazeRecruits" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapaneseKamikaze1:conditionAttachmentJapaneseKamikaze2"/>
-						<option name="productionRule" value="Japanese_production:-buyJP_Fighter"/>
-						<option name="productionRule" value="Japanese_production:buyJP_FighterKamikaze"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentAmericans5_British4_Paratroopers" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAmericans1"/>
+                        <option name="tech" value="paratroopers"/>
+                        <option name="players" value="Americans:British"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-						<!-- since unit property changes occur at end of turn, we have this trigger as attached to British so that it happens at the end of their turn (British go right before Japan does) -->
-				<attachment name="triggerAttachmentJapanese7_KamikazeAttack" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapaneseKamikaze1:conditionAttachmentJapaneseKamikaze2"/>
-						<option name="unitType" value="jp_fighter"/>
-						<option name="unitProperty" value="attack" count="5"/>
-						<option name="unitProperty" value="defense" count="3"/>
-						<option name="unitProperty" value="movement" count="3"/>
-						<option name="unitProperty" value="isSuicide" count="true"/>
-						<option name="unitProperty" value="isKamikaze" count="true"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentAmericans7_WarBonds" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAmericans3a:conditionAttachmentAmericans3b"/>
+                        <option name="tech" value="warBonds"/>
+                        <option name="players" value="Americans"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentJapaneseShipyards" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapaneseShipyards"/>
-						<option name="productionRule" value="Japanese_production:-buyTransport"/>
-						<option name="productionRule" value="Japanese_production:-buySubmarine"/>
-						<option name="productionRule" value="Japanese_production:-buyDestroyer"/>
-						<option name="productionRule" value="Japanese_production:-buyCruiser"/>
-						<option name="productionRule" value="Japanese_production:-buyCarrier"/>
-						<option name="productionRule" value="Japanese_production:-buyBattleship"/>
-						<option name="productionRule" value="Japanese_production:-buySuper_Carrier"/>
-						<option name="productionRule" value="Japanese_production:buyTransportShipyards"/>
-						<option name="productionRule" value="Japanese_production:buySubmarineShipyards"/>
-						<option name="productionRule" value="Japanese_production:buyDestroyerShipyards"/>
-						<option name="productionRule" value="Japanese_production:buyCruiserShipyards"/>
-						<option name="productionRule" value="Japanese_production:buyCarrierShipyards"/>
-						<option name="productionRule" value="Japanese_production:buyBattleshipShipyards"/>
-						<option name="productionRule" value="Japanese_production:buySuper_CarrierShipyards"/>
-						<option name="uses" value="1"/>
-				</attachment>
-				
-		<!-- Italians Triggers -->
-				<!-- on turn 2 italy will go automatically to war with Russia 
-				<attachment name="triggerAttachmentItaliansWarRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentItalianTurn2"/>
-						<option name="relationshipChange" value="Italians:Russians:any:War"/>					
-				</attachment>-->
-				
-				
-				<attachment name="triggerAttachmentItalians2_NorthAfrica" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentItalians1"/>
-						<option name="purchase" value="cruiser" count="1"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermansParatroopersCanProduce" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansParatroopers"/>
+                        <option name="productionRule" value="Germans_production:buyAir_Transport"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentItaliansParatroopersCanProduce" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentItaliansParatroopers"/>
-						<option name="productionRule" value="Italians_production:buyAir_Transport"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermansSuperSubs1_NewSubmarineTech" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansSuperSubs"/>
+                        <option name="availableTech" value="Submarine Technology:reinforcedHulls:wolfPackTactics"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentItaliansReinforcedHulls" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermansReinforcedHulls"/>
-						<option name="support" value="supportAttachmentSubmarineReinforcedHulls"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermansSuperSubs2_NewItalianTechAvailable" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansSuperSubs"/>
+                        <option name="availableTech" value="Italian Technology:reinforcedHulls:-shipyards"/>
+                        <option name="uses" value="1"/>
+                        <option name="players" value="Italians"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentItaliansShipyards" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentItaliansShipyards"/>
-						<option name="productionRule" value="Italians_production:-buyTransport"/>
-						<option name="productionRule" value="Italians_production:-buySubmarine"/>
-						<option name="productionRule" value="Italians_production:-buyDestroyer"/>
-						<option name="productionRule" value="Italians_production:-buyCruiser"/>
-						<option name="productionRule" value="Italians_production:-buyCarrier"/>
-						<option name="productionRule" value="Italians_production:-buyBattleship"/>
-						<option name="productionRule" value="Italians_production:-buySuper_Carrier"/>
-						<option name="productionRule" value="Italians_production:buyTransportShipyards"/>
-						<option name="productionRule" value="Italians_production:buySubmarineShipyards"/>
-						<option name="productionRule" value="Italians_production:buyDestroyerShipyards"/>
-						<option name="productionRule" value="Italians_production:buyCruiserShipyards"/>
-						<option name="productionRule" value="Italians_production:buyCarrierShipyards"/>
-						<option name="productionRule" value="Italians_production:buyBattleshipShipyards"/>
-						<option name="productionRule" value="Italians_production:buySuper_CarrierShipyards"/>
-						<option name="uses" value="1"/>
-				</attachment>
-				
-				<!--  these triggers are notificationtriggers 
-				<attachment name="triggerItalyTurn1CombatMoveNotification" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentItalianTurn1"/>
-						<option name="when" value="before:italianCombatMove"/>
-						<option name="notification" value="ITALY_TURN1_BEFORE_CM"/>
-				</attachment>
-				
-				<attachment name="triggerItalyTurn1AfterBattleNotification" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentItalianTurn1"/>
-						<option name="when" value="after:italianBattle"/>
-						<option name="notification" value="ITALY_TURN1_AFTER_BATTLE"/>
-				</attachment>-->
-				
-				
-		<!-- Americans Triggers -->
-				<!--<attachment name="triggerAttachmentAmericans1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentGermans3a:conditionAttachmentAmericans1"/>
-						<option name="tech" value="paratroopers"/>
-						<option name="uses" value="1"/>
-				</attachment>-->
+                <attachment name="triggerAttachmentGermansReinforcedHulls" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansReinforcedHulls"/>
+                        <option name="support" value="supportAttachmentSubmarineReinforcedHulls"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentAmericans6_TheTurningPointInThePacific" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAmericans2"/>
-						<option name="tech" value="shipyards"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermansWolfPackTactics" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansWolfPackTactics"/>
+                        <option name="support" value="supportAttachmentSubmarineWolfPackTacticsOffence"/>
+                        <!--<option name="support" value="supportAttachmentSubmarineWolfPackTacticsDefence"/>-->
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentAmericans8_TacticalAirUse" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAmericans4"/>
-						<option name="support" value="supportAttachmentFighter"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermansShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansShipyards"/>
+                        <option name="productionRule" value="Germans_production:-buyTransport"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarine"/>
+                        <option name="productionRule" value="Germans_production:-buyDestroyer"/>
+                        <option name="productionRule" value="Germans_production:-buyCruiser"/>
+                        <option name="productionRule" value="Germans_production:-buyCarrier"/>
+                        <option name="productionRule" value="Germans_production:-buyBattleship"/>
+                        <option name="productionRule" value="Germans_production:-buySuper_Carrier"/>
+                        <option name="productionRule" value="Germans_production:buyTransportShipyards"/>
+                        <option name="productionRule" value="Germans_production:buySubmarineShipyards"/>
+                        <option name="productionRule" value="Germans_production:buyDestroyerShipyards"/>
+                        <option name="productionRule" value="Germans_production:buyCruiserShipyards"/>
+                        <option name="productionRule" value="Germans_production:buyCarrierShipyards"/>
+                        <option name="productionRule" value="Germans_production:buyBattleshipShipyards"/>
+                        <option name="productionRule" value="Germans_production:buySuper_CarrierShipyards"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-						<!-- Here we want to see if Japan has Either Zero Battleships or Zero Carriers. So we set the relationship to AND, and then invert it.  So !X = (A && B)  becomes  X = !(A && B)  becomes  X = (!A || !B) -->
-				<attachment name="triggerAttachmentAmericans4_JapaneseCapitalShipsSunk" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapaneseCarriers:conditionAttachmentJapaneseBattleships"/>
-						<option name="conditionType" value="AND"/>
-						<option name="invert" value="true"/>
-						<option name="resource" value="PUs"/>
-						<option name="resourceCount" value="4"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermansSubmarineTech2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansSubmarineTech2:conditionAttachmentGermansShipyardsInvert"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarine"/>
+                        <option name="productionRule" value="Germans_production:buySubmarineTech2"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentAmericansParatroopersCanProduce" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAmericansParatroopers"/>
-						<option name="productionRule" value="Americans_production:buyAir_Transport"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermansSubmarineTech3" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansSubmarineTech3:conditionAttachmentGermansShipyardsInvert"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarine"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
+                        <option name="productionRule" value="Germans_production:buySubmarineTech3"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentAmericansShipyards" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAmericansShipyards"/>
-						<option name="productionRule" value="Americans_production:-buyTransport"/>
-						<option name="productionRule" value="Americans_production:-buySubmarine"/>
-						<option name="productionRule" value="Americans_production:-buyDestroyer"/>
-						<option name="productionRule" value="Americans_production:-buyCruiser"/>
-						<option name="productionRule" value="Americans_production:-buyCarrier"/>
-						<option name="productionRule" value="Americans_production:-buyBattleship"/>
-						<option name="productionRule" value="Americans_production:-buySuper_Carrier"/>
-						<option name="productionRule" value="Americans_production:buyTransportShipyards"/>
-						<option name="productionRule" value="Americans_production:buySubmarineShipyards"/>
-						<option name="productionRule" value="Americans_production:buyDestroyerShipyards"/>
-						<option name="productionRule" value="Americans_production:buyCruiserShipyards"/>
-						<option name="productionRule" value="Americans_production:buyCarrierShipyards"/>
-						<option name="productionRule" value="Americans_production:buyBattleshipShipyards"/>
-						<option name="productionRule" value="Americans_production:buySuper_CarrierShipyards"/>
-						<option name="uses" value="1"/>
-				</attachment>
-				
-		<!-- British Triggers -->
-				<attachment name="triggerAttachmentBritish5_CentersOfPower" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentBritish2"/>
-						<option name="tech" value="aARadar"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermansSubmarineTech2AndShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansSubmarineTech2:conditionAttachmentGermansShipyards"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarine"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarineShipyards"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
+                        <option name="productionRule" value="Germans_production:buySubmarineTech2Shipyards"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentBritishParatroopersCanProduce" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentBritishParatroopers"/>
-						<option name="productionRule" value="British_production:buyAir_Transport"/>
-				</attachment>
+                <attachment name="triggerAttachmentGermansSubmarineTech3AndShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansSubmarineTech3:conditionAttachmentGermansShipyards"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarine"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarineShipyards"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarineTech3"/>
+                        <option name="productionRule" value="Germans_production:-buySubmarineTech2Shipyards"/>
+                        <option name="productionRule" value="Germans_production:buySubmarineTech3Shipyards"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentBritishShipyards" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentBritishShipyards"/>
-						<option name="productionRule" value="British_production:-buyTransport"/>
-						<option name="productionRule" value="British_production:-buySubmarine"/>
-						<option name="productionRule" value="British_production:-buyDestroyer"/>
-						<option name="productionRule" value="British_production:-buyCruiser"/>
-						<option name="productionRule" value="British_production:-buyCarrier"/>
-						<option name="productionRule" value="British_production:-buyBattleship"/>
-						<option name="productionRule" value="British_production:-buySuper_Carrier"/>
-						<option name="productionRule" value="British_production:buyTransportShipyards"/>
-						<option name="productionRule" value="British_production:buySubmarineShipyards"/>
-						<option name="productionRule" value="British_production:buyDestroyerShipyards"/>
-						<option name="productionRule" value="British_production:buyCruiserShipyards"/>
-						<option name="productionRule" value="British_production:buyCarrierShipyards"/>
-						<option name="productionRule" value="British_production:buyBattleshipShipyards"/>
-						<option name="productionRule" value="British_production:buySuper_CarrierShipyards"/>
-						<option name="uses" value="1"/>
-				</attachment>
-				
-		<!-- Russians Triggers and Conditions -->
-				
-				<attachment name="triggerRussiansCapitalLost" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussianCapitalLost"/>
-						<option name="when" value="before:russianPurchase"/>
-						<option name="notification" value="RUSSIAN_CAPITAL_LOST"/>
-						<option name="uses" value="1"/>
-				</attachment>
-				
-				<!-- when Italy is at War with Russia, Russia will automatically go to war with Japan from any Neutral stance 
-				<attachment name="triggerAttachmentRussiansWarJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansNeutralItalians"/>
-						<option name="relationshipChange" value="Russians:Japanese:anyNeutral:War"/>
-				</attachment>-->
-				
-				<!-- when Italy is at War with Russia, Russia will automatically go to war with Germany from exactly Neutral state
-				<attachment name="triggerAttachmentRussiansWarGermans" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansNeutralItalians"/>
-						<option name="relationshipChange" value="Russians:Germans:Neutrality:War"/>
-				</attachment>-->
-				
-				<attachment name="triggerAttachmentRussians3_RecoveredGermanTech" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="objectiveAttachmentRussians3_HardAdvance"/>
-						<option name="resource" value="techTokens"/>
-						<option name="resourceCount" value="2"/>
-						<option name="uses" value="1"/>
-				</attachment>
+        <!-- Japanese Triggers -->
+                <attachment name="triggerAttachmentJapanese3_TokyoExpress" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapanese1a:conditionAttachmentJapanese1b"/>
+                        <option name="unitType" value="jp_destroyer"/>
+                        <option name="unitProperty" value="transportCapacity" count="2"/>
+                        <option name="unitProperty" value="isCombatTransport" count="true"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentRussians4a_LeningradAndStalingrad" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussians2"/>
-						<option name="support" value="supportAttachmentRussiansArtillery2"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentJapanese4_ArmyControlOfNavy" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapanese2"/>
+                        <option name="unitType" value="jp_transport"/>
+                        <option name="unitProperty" value="transportCapacity" count="6"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentRussians4b_LeningradAndStalingrad" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussians2"/>
-						<option name="players" value="Russians"/>
-						<option name="support" value="-supportAttachmentArtyOldartillery"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentJapanese5_ForTheEmperor" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapanese3"/>
+                        <option name="placement" value="61 Sea Zone:midget_submarine"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentRussians5_FarEastReserves" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapanese4"/>
-						<option name="placement" value="Yakut S.S.R.:infantry" count="3"/>
-						<option name="uses" value="1"/>
-				</attachment>
+                <attachment name="triggerAttachmentJapaneseParatroopersCanProduce" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapaneseParatroopers"/>
+                        <option name="productionRule" value="Japanese_production:buyAir_Transport"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentRussiansParatroopersCanProduce" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansParatroopers"/>
-						<option name="productionRule" value="Russians_production:buyAir_Transport"/>
-				</attachment>
+                <attachment name="triggerAttachmentJapanese6_MidgetSubCanProduce" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapaneseMidget"/>
+                        <option name="productionRule" value="Japanese_production:buyMidget_Submarine"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentRussiansShipyards" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansShipyards"/>
-						<option name="productionRule" value="Russians_production:-buyTransport"/>
-						<option name="productionRule" value="Russians_production:-buySubmarine"/>
-						<option name="productionRule" value="Russians_production:-buyDestroyer"/>
-						<option name="productionRule" value="Russians_production:-buyCruiser"/>
-						<option name="productionRule" value="Russians_production:-buyCarrier"/>
-						<option name="productionRule" value="Russians_production:-buyBattleship"/>
-						<option name="productionRule" value="Russians_production:-buySuper_Carrier"/>
-						<option name="productionRule" value="Russians_production:buyTransportShipyards"/>
-						<option name="productionRule" value="Russians_production:buySubmarineShipyards"/>
-						<option name="productionRule" value="Russians_production:buyDestroyerShipyards"/>
-						<option name="productionRule" value="Russians_production:buyCruiserShipyards"/>
-						<option name="productionRule" value="Russians_production:buyCarrierShipyards"/>
-						<option name="productionRule" value="Russians_production:buyBattleshipShipyards"/>
-						<option name="productionRule" value="Russians_production:buySuper_CarrierShipyards"/>
-						<option name="uses" value="1"/>
-				</attachment>
-				
-				<attachment name="triggerAttachmentRussiansWarJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansNeutralJapanTurn5plus"/>
-						<option name="relationshipChange" value="Russians:Japanese:anyNeutral:War"/>
-						<option name="notification" value="RUSSIANS_AT_WAR_WITH_JAPAN"/>
-						<option name="when" value="before:russianPolitics"/>
-				</attachment>
-				
-		<!-- Chinese Triggers and Conditions -->
-				<attachment name="triggerAttachmentChinese2a_BurmaRoadOpen" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="objectiveAttachmentChinese2_BurmaRoad"/>
-						<option name="frontier" value="Chinese_BurmaRoad_production"/>
-				</attachment>
-				
-				<attachment name="triggerAttachmentChinese2b_BurmaRoadClosed" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="objectiveAttachmentChinese2_BurmaRoad"/>
-						<option name="frontier" value="Chinese_CutOff_production"/>
-						<option name="invert" value="true"/>
-				</attachment>
-				
-				<attachment name="triggerAttachmentChinese3_MilitiaRisingUp" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentChinese3"/>
-						<option name="placement" value="Sinkiang:infantry"/>
-				</attachment>
-				
-				<attachment name="triggerAttachmentChinese4_ChineseOverrunTheirBorders" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentChinese4"/>
-						<option name="uses" value="1"/>
-						<option name="players" value="Chinese"/>
-						<option name="playerAttachmentName" value="RulesAttachment" count="rulesAttachment"/>
-						<option name="playerProperty" value="movementRestrictionTerritories" count="-reset-"/>
-						<option name="playerProperty" value="movementRestrictionType" count="disallowed"/>
-						<option name="playerProperty" value="productionPerXTerritories" count="-reset-3:infantry"/>
-						<option name="playerProperty" value="productionPerXTerritories" count="10:transport"/>
-						<option name="playerProperty" value="placementAnySeaZone" count="true"/>
-				</attachment>
+                <attachment name="triggerAttachmentJapanese7_KamikazeRecruits" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapaneseKamikaze1:conditionAttachmentJapaneseKamikaze2"/>
+                        <option name="productionRule" value="Japanese_production:-buyJP_Fighter"/>
+                        <option name="productionRule" value="Japanese_production:buyJP_FighterKamikaze"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<!--<attachment name="triggerAttachmentChineseParatroopersCanProduce" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentChineseParatroopers"/>
-						<option name="productionRule" value="Germans_production:buyAir_Transport"/>
-				</attachment>
+                        <!-- since unit property changes occur at end of turn, we have this trigger as attached to British so that it happens at the end of their turn (British go right before Japan does) -->
+                <attachment name="triggerAttachmentJapanese7_KamikazeAttack" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapaneseKamikaze1:conditionAttachmentJapaneseKamikaze2"/>
+                        <option name="unitType" value="jp_fighter"/>
+                        <option name="unitProperty" value="attack" count="5"/>
+                        <option name="unitProperty" value="defense" count="3"/>
+                        <option name="unitProperty" value="movement" count="3"/>
+                        <option name="unitProperty" value="isSuicide" count="true"/>
+                        <option name="unitProperty" value="isKamikaze" count="true"/>
+                        <option name="uses" value="1"/>
+                </attachment>
 
-				<attachment name="triggerAttachmentChineseShipyards" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentChineseShipyards"/>
-						<option name="productionRule" value="Chinese_production:-buyTransport"/>
-						<option name="productionRule" value="Chinese_production:-buySubmarine"/>
-						<option name="productionRule" value="Chinese_production:-buyDestroyer"/>
-						<option name="productionRule" value="Chinese_production:-buyCruiser"/>
-						<option name="productionRule" value="Chinese_production:-buyCarrier"/>
-						<option name="productionRule" value="Chinese_production:-buyBattleship"/>
-						<option name="productionRule" value="Chinese_production:-buySuper_Carrier"/>
-						<option name="productionRule" value="Chinese_production:buyTransportShipyards"/>
-						<option name="productionRule" value="Chinese_production:buySubmarineShipyards"/>
-						<option name="productionRule" value="Chinese_production:buyDestroyerShipyards"/>
-						<option name="productionRule" value="Chinese_production:buyCruiserShipyards"/>
-						<option name="productionRule" value="Chinese_production:buyCarrierShipyards"/>
-						<option name="productionRule" value="Chinese_production:buyBattleshipShipyards"/>
-						<option name="productionRule" value="Chinese_production:buySuper_CarrierShipyards"/>
-						<option name="uses" value="1"/>
-				</attachment>-->
-				
+                <attachment name="triggerAttachmentJapaneseShipyards" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapaneseShipyards"/>
+                        <option name="productionRule" value="Japanese_production:-buyTransport"/>
+                        <option name="productionRule" value="Japanese_production:-buySubmarine"/>
+                        <option name="productionRule" value="Japanese_production:-buyDestroyer"/>
+                        <option name="productionRule" value="Japanese_production:-buyCruiser"/>
+                        <option name="productionRule" value="Japanese_production:-buyCarrier"/>
+                        <option name="productionRule" value="Japanese_production:-buyBattleship"/>
+                        <option name="productionRule" value="Japanese_production:-buySuper_Carrier"/>
+                        <option name="productionRule" value="Japanese_production:buyTransportShipyards"/>
+                        <option name="productionRule" value="Japanese_production:buySubmarineShipyards"/>
+                        <option name="productionRule" value="Japanese_production:buyDestroyerShipyards"/>
+                        <option name="productionRule" value="Japanese_production:buyCruiserShipyards"/>
+                        <option name="productionRule" value="Japanese_production:buyCarrierShipyards"/>
+                        <option name="productionRule" value="Japanese_production:buyBattleshipShipyards"/>
+                        <option name="productionRule" value="Japanese_production:buySuper_CarrierShipyards"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+        <!-- Italians Triggers -->
+                <!-- on turn 2 italy will go automatically to war with Russia
+                <attachment name="triggerAttachmentItaliansWarRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentItalianTurn2"/>
+                        <option name="relationshipChange" value="Italians:Russians:any:War"/>
+                </attachment>-->
+
+
+                <attachment name="triggerAttachmentItalians2_NorthAfrica" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentItalians1"/>
+                        <option name="purchase" value="cruiser" count="1"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentItaliansParatroopersCanProduce" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentItaliansParatroopers"/>
+                        <option name="productionRule" value="Italians_production:buyAir_Transport"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentItaliansReinforcedHulls" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermansReinforcedHulls"/>
+                        <option name="support" value="supportAttachmentSubmarineReinforcedHulls"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentItaliansShipyards" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentItaliansShipyards"/>
+                        <option name="productionRule" value="Italians_production:-buyTransport"/>
+                        <option name="productionRule" value="Italians_production:-buySubmarine"/>
+                        <option name="productionRule" value="Italians_production:-buyDestroyer"/>
+                        <option name="productionRule" value="Italians_production:-buyCruiser"/>
+                        <option name="productionRule" value="Italians_production:-buyCarrier"/>
+                        <option name="productionRule" value="Italians_production:-buyBattleship"/>
+                        <option name="productionRule" value="Italians_production:-buySuper_Carrier"/>
+                        <option name="productionRule" value="Italians_production:buyTransportShipyards"/>
+                        <option name="productionRule" value="Italians_production:buySubmarineShipyards"/>
+                        <option name="productionRule" value="Italians_production:buyDestroyerShipyards"/>
+                        <option name="productionRule" value="Italians_production:buyCruiserShipyards"/>
+                        <option name="productionRule" value="Italians_production:buyCarrierShipyards"/>
+                        <option name="productionRule" value="Italians_production:buyBattleshipShipyards"/>
+                        <option name="productionRule" value="Italians_production:buySuper_CarrierShipyards"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <!--  these triggers are notificationtriggers
+                <attachment name="triggerItalyTurn1CombatMoveNotification" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentItalianTurn1"/>
+                        <option name="when" value="before:italianCombatMove"/>
+                        <option name="notification" value="ITALY_TURN1_BEFORE_CM"/>
+                </attachment>
+
+                <attachment name="triggerItalyTurn1AfterBattleNotification" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentItalianTurn1"/>
+                        <option name="when" value="after:italianBattle"/>
+                        <option name="notification" value="ITALY_TURN1_AFTER_BATTLE"/>
+                </attachment>-->
+
+
+        <!-- Americans Triggers -->
+                <!--<attachment name="triggerAttachmentAmericans1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentGermans3a:conditionAttachmentAmericans1"/>
+                        <option name="tech" value="paratroopers"/>
+                        <option name="uses" value="1"/>
+                </attachment>-->
+
+                <attachment name="triggerAttachmentAmericans6_TheTurningPointInThePacific" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAmericans2"/>
+                        <option name="tech" value="shipyards"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentAmericans8_TacticalAirUse" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAmericans4"/>
+                        <option name="support" value="supportAttachmentFighter"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                        <!-- Here we want to see if Japan has Either Zero Battleships or Zero Carriers. So we set the relationship to AND, and then invert it.  So !X = (A && B)  becomes  X = !(A && B)  becomes  X = (!A || !B) -->
+                <attachment name="triggerAttachmentAmericans4_JapaneseCapitalShipsSunk" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapaneseCarriers:conditionAttachmentJapaneseBattleships"/>
+                        <option name="conditionType" value="AND"/>
+                        <option name="invert" value="true"/>
+                        <option name="resource" value="PUs"/>
+                        <option name="resourceCount" value="4"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentAmericansParatroopersCanProduce" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAmericansParatroopers"/>
+                        <option name="productionRule" value="Americans_production:buyAir_Transport"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentAmericansShipyards" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAmericansShipyards"/>
+                        <option name="productionRule" value="Americans_production:-buyTransport"/>
+                        <option name="productionRule" value="Americans_production:-buySubmarine"/>
+                        <option name="productionRule" value="Americans_production:-buyDestroyer"/>
+                        <option name="productionRule" value="Americans_production:-buyCruiser"/>
+                        <option name="productionRule" value="Americans_production:-buyCarrier"/>
+                        <option name="productionRule" value="Americans_production:-buyBattleship"/>
+                        <option name="productionRule" value="Americans_production:-buySuper_Carrier"/>
+                        <option name="productionRule" value="Americans_production:buyTransportShipyards"/>
+                        <option name="productionRule" value="Americans_production:buySubmarineShipyards"/>
+                        <option name="productionRule" value="Americans_production:buyDestroyerShipyards"/>
+                        <option name="productionRule" value="Americans_production:buyCruiserShipyards"/>
+                        <option name="productionRule" value="Americans_production:buyCarrierShipyards"/>
+                        <option name="productionRule" value="Americans_production:buyBattleshipShipyards"/>
+                        <option name="productionRule" value="Americans_production:buySuper_CarrierShipyards"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+        <!-- British Triggers -->
+                <attachment name="triggerAttachmentBritish5_CentersOfPower" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentBritish2"/>
+                        <option name="tech" value="aARadar"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentBritishParatroopersCanProduce" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentBritishParatroopers"/>
+                        <option name="productionRule" value="British_production:buyAir_Transport"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentBritishShipyards" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentBritishShipyards"/>
+                        <option name="productionRule" value="British_production:-buyTransport"/>
+                        <option name="productionRule" value="British_production:-buySubmarine"/>
+                        <option name="productionRule" value="British_production:-buyDestroyer"/>
+                        <option name="productionRule" value="British_production:-buyCruiser"/>
+                        <option name="productionRule" value="British_production:-buyCarrier"/>
+                        <option name="productionRule" value="British_production:-buyBattleship"/>
+                        <option name="productionRule" value="British_production:-buySuper_Carrier"/>
+                        <option name="productionRule" value="British_production:buyTransportShipyards"/>
+                        <option name="productionRule" value="British_production:buySubmarineShipyards"/>
+                        <option name="productionRule" value="British_production:buyDestroyerShipyards"/>
+                        <option name="productionRule" value="British_production:buyCruiserShipyards"/>
+                        <option name="productionRule" value="British_production:buyCarrierShipyards"/>
+                        <option name="productionRule" value="British_production:buyBattleshipShipyards"/>
+                        <option name="productionRule" value="British_production:buySuper_CarrierShipyards"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+        <!-- Russians Triggers and Conditions -->
+
+                <attachment name="triggerRussiansCapitalLost" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussianCapitalLost"/>
+                        <option name="when" value="before:russianPurchase"/>
+                        <option name="notification" value="RUSSIAN_CAPITAL_LOST"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <!-- when Italy is at War with Russia, Russia will automatically go to war with Japan from any Neutral stance
+                <attachment name="triggerAttachmentRussiansWarJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansNeutralItalians"/>
+                        <option name="relationshipChange" value="Russians:Japanese:anyNeutral:War"/>
+                </attachment>-->
+
+                <!-- when Italy is at War with Russia, Russia will automatically go to war with Germany from exactly Neutral state
+                <attachment name="triggerAttachmentRussiansWarGermans" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansNeutralItalians"/>
+                        <option name="relationshipChange" value="Russians:Germans:Neutrality:War"/>
+                </attachment>-->
+
+                <attachment name="triggerAttachmentRussians3_RecoveredGermanTech" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="objectiveAttachmentRussians3_HardAdvance"/>
+                        <option name="resource" value="techTokens"/>
+                        <option name="resourceCount" value="2"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentRussians4a_LeningradAndStalingrad" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussians2"/>
+                        <option name="support" value="supportAttachmentRussiansArtillery2"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentRussians4b_LeningradAndStalingrad" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussians2"/>
+                        <option name="players" value="Russians"/>
+                        <option name="support" value="-supportAttachmentArtyOldartillery"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentRussians5_FarEastReserves" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapanese4"/>
+                        <option name="placement" value="Yakut S.S.R.:infantry" count="3"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentRussiansParatroopersCanProduce" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansParatroopers"/>
+                        <option name="productionRule" value="Russians_production:buyAir_Transport"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentRussiansShipyards" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansShipyards"/>
+                        <option name="productionRule" value="Russians_production:-buyTransport"/>
+                        <option name="productionRule" value="Russians_production:-buySubmarine"/>
+                        <option name="productionRule" value="Russians_production:-buyDestroyer"/>
+                        <option name="productionRule" value="Russians_production:-buyCruiser"/>
+                        <option name="productionRule" value="Russians_production:-buyCarrier"/>
+                        <option name="productionRule" value="Russians_production:-buyBattleship"/>
+                        <option name="productionRule" value="Russians_production:-buySuper_Carrier"/>
+                        <option name="productionRule" value="Russians_production:buyTransportShipyards"/>
+                        <option name="productionRule" value="Russians_production:buySubmarineShipyards"/>
+                        <option name="productionRule" value="Russians_production:buyDestroyerShipyards"/>
+                        <option name="productionRule" value="Russians_production:buyCruiserShipyards"/>
+                        <option name="productionRule" value="Russians_production:buyCarrierShipyards"/>
+                        <option name="productionRule" value="Russians_production:buyBattleshipShipyards"/>
+                        <option name="productionRule" value="Russians_production:buySuper_CarrierShipyards"/>
+                        <option name="uses" value="1"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentRussiansWarJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansNeutralJapanTurn5plus"/>
+                        <option name="relationshipChange" value="Russians:Japanese:anyNeutral:War"/>
+                        <option name="notification" value="RUSSIANS_AT_WAR_WITH_JAPAN"/>
+                        <option name="when" value="before:russianPolitics"/>
+                </attachment>
+
+        <!-- Chinese Triggers and Conditions -->
+                <attachment name="triggerAttachmentChinese2a_BurmaRoadOpen" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="objectiveAttachmentChinese2_BurmaRoad"/>
+                        <option name="frontier" value="Chinese_BurmaRoad_production"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentChinese2b_BurmaRoadClosed" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="objectiveAttachmentChinese2_BurmaRoad"/>
+                        <option name="frontier" value="Chinese_CutOff_production"/>
+                        <option name="invert" value="true"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentChinese3_MilitiaRisingUp" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentChinese3"/>
+                        <option name="placement" value="Sinkiang:infantry"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentChinese4_ChineseOverrunTheirBorders" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentChinese4"/>
+                        <option name="uses" value="1"/>
+                        <option name="players" value="Chinese"/>
+                        <option name="playerAttachmentName" value="RulesAttachment" count="rulesAttachment"/>
+                        <option name="playerProperty" value="movementRestrictionTerritories" count="-reset-"/>
+                        <option name="playerProperty" value="movementRestrictionType" count="disallowed"/>
+                        <option name="playerProperty" value="productionPerXTerritories" count="-reset-3:infantry"/>
+                        <option name="playerProperty" value="productionPerXTerritories" count="10:transport"/>
+                        <option name="playerProperty" value="placementAnySeaZone" count="true"/>
+                </attachment>
+
+                <!--<attachment name="triggerAttachmentChineseParatroopersCanProduce" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentChineseParatroopers"/>
+                        <option name="productionRule" value="Germans_production:buyAir_Transport"/>
+                </attachment>
+
+                <attachment name="triggerAttachmentChineseShipyards" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentChineseShipyards"/>
+                        <option name="productionRule" value="Chinese_production:-buyTransport"/>
+                        <option name="productionRule" value="Chinese_production:-buySubmarine"/>
+                        <option name="productionRule" value="Chinese_production:-buyDestroyer"/>
+                        <option name="productionRule" value="Chinese_production:-buyCruiser"/>
+                        <option name="productionRule" value="Chinese_production:-buyCarrier"/>
+                        <option name="productionRule" value="Chinese_production:-buyBattleship"/>
+                        <option name="productionRule" value="Chinese_production:-buySuper_Carrier"/>
+                        <option name="productionRule" value="Chinese_production:buyTransportShipyards"/>
+                        <option name="productionRule" value="Chinese_production:buySubmarineShipyards"/>
+                        <option name="productionRule" value="Chinese_production:buyDestroyerShipyards"/>
+                        <option name="productionRule" value="Chinese_production:buyCruiserShipyards"/>
+                        <option name="productionRule" value="Chinese_production:buyCarrierShipyards"/>
+                        <option name="productionRule" value="Chinese_production:buyBattleshipShipyards"/>
+                        <option name="productionRule" value="Chinese_production:buySuper_CarrierShipyards"/>
+                        <option name="uses" value="1"/>
+                </attachment>-->
+
 <!--  Rules Restrictions (must have the exact name of "rulesAttachment"-->
-		<!-- the following options are allowed for "playerAttachment"
-				movementRestrictionType						values: "allowed" or "disallowed", affects the list movementRestrictionTerritories. defaults to null
-				movementRestrictionTerritories				values: a colon (":") delimited list of territories that the player either can not move into, or can not move outside of
-				productionPerXTerritories					values: gives units to a player as part of NoPuPurchase delegate.  You can have multiple instances of productionPerXTerritories.
-																		value = the name of the unit, and count = the number of territories you need to get 1 of that unit.  if the name of the unit is missing, it defaults to "infantry"
-				placementAnyTerritory						values: "true" or "false", can you place in any LAND territory you owned at the beginning of the turn?
-				placementAnySeaZone							values: "true" or "false", can you place in any SEA territory beside a LAND territory you owned at the beginning of the turn?
-				placementCapturedTerritory					values: "true" or "false", can you place in territory you captured this turn?
-				placementPerTerritory						values: governs if you can or can not place in that territory, based on the number of owned units in that territory.  You may place in any territory with LESS units than the given value
-																		A value greater than Zero is required to be able to produce infinite units (or infinite up to maxPlacePerTerritory, which you can set too)
-				maxPlacePerTerritory						values: governs the max you may place per turn per territory (can override factory rules and infinite placement rules)
-				unlimitedProduction							values: will turn off warnings about purchasing more units than you can place. does not actually do anything to the game.
-				dominatingFirstRoundAttack					values: means that the very first round of the game, all enemies defend on a "1" instead of their normal defense.
-				negateDominatingFirstRoundAttack			values: means that this player is not affected by the dominatingFirstRoundAttack
-				placementInCapitalRestricted				values: means that the player may only place units in their capitol
-		-->
-		<!-- Chinese Rules -->
-				<attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="movementRestrictionTerritories" value="Sinkiang:Central China:China:Manchuria:Kwangtung:French Indochina"/>
-						<option name="movementRestrictionType" value="allowed"/>
-						<!-- productionPerXTerritories gives units to a player as part of NoPuPurchase delegate.  You can have multiple instances of productionPerXTerritories.
-								value = the name of the unit, and count = the number of territories you need to get 1 of that unit.  if the name of the unit is missing, it defaults to "infantry" -->
-						<option name="productionPerXTerritories" value="infantry" count="2"/>
-						<!--<option name="productionPerXTerritories" value="fighter" count="6"/>-->
-						<!-- if you are using productionPerXTerritories, you can have only territories worth at least 1 pu count towards the X by setting the game property "Production Per Valued Territory Restricted". 
-								the amount produced will be increased by 1 infantry if you are using PacificTheater and you control territories called "India", "Burma", "Yunnan", "Szechwan" -->
-						<option name="placementAnyTerritory" value="true"/>
-						<option name="placementCapturedTerritory" value="true"/>
-						<!-- placementPerTerritory governs if you can or can not place in that territory, based on the number of owned units in that territory.  You may place in any territory with LESS units than the given value
-								A value greater than Zero is required to be able to produce infinite units (or infinite up to maxPlacePerTerritory, which you can set too) -->
-						<option name="placementPerTerritory" value="4"/>
-						<!-- maxPlacePerTerritory governs the max you may place per turn per territory (can override factory rules and infinite placement rules) -->
-						<option name="maxPlacePerTerritory" value="2"/>
-						<option name="unlimitedProduction" value="true"/>
-						<!-- dominatingFirstRoundAttack means that the very first round of the game, all enemies defend on a "1" instead of their normal defense. negateDominatingFirstRoundAttack means that this player is not affected by the dominatingFirstRoundAttack
-						<option name="dominatingFirstRoundAttack" value="true"/>
-						<option name="negateDominatingFirstRoundAttack" value="true"/> -->
-						<!-- placementInCapitalRestricted means that the player may only place units in their capitol
-						<option name="placementInCapitalRestricted" value="true"/> -->
-				</attachment>
-				
+        <!-- the following options are allowed for "playerAttachment"
+                movementRestrictionType                     values: "allowed" or "disallowed", affects the list movementRestrictionTerritories. defaults to null
+                movementRestrictionTerritories              values: a colon (":") delimited list of territories that the player either can not move into, or can not move outside of
+                productionPerXTerritories                   values: gives units to a player as part of NoPuPurchase delegate.  You can have multiple instances of productionPerXTerritories.
+                                                                        value = the name of the unit, and count = the number of territories you need to get 1 of that unit.  if the name of the unit is missing, it defaults to "infantry"
+                placementAnyTerritory                       values: "true" or "false", can you place in any LAND territory you owned at the beginning of the turn?
+                placementAnySeaZone                         values: "true" or "false", can you place in any SEA territory beside a LAND territory you owned at the beginning of the turn?
+                placementCapturedTerritory                  values: "true" or "false", can you place in territory you captured this turn?
+                placementPerTerritory                       values: governs if you can or can not place in that territory, based on the number of owned units in that territory.  You may place in any territory with LESS units than the given value
+                                                                        A value greater than Zero is required to be able to produce infinite units (or infinite up to maxPlacePerTerritory, which you can set too)
+                maxPlacePerTerritory                        values: governs the max you may place per turn per territory (can override factory rules and infinite placement rules)
+                unlimitedProduction                         values: will turn off warnings about purchasing more units than you can place. does not actually do anything to the game.
+                dominatingFirstRoundAttack                  values: means that the very first round of the game, all enemies defend on a "1" instead of their normal defense.
+                negateDominatingFirstRoundAttack            values: means that this player is not affected by the dominatingFirstRoundAttack
+                placementInCapitalRestricted                values: means that the player may only place units in their capitol
+        -->
+        <!-- Chinese Rules -->
+                <attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="movementRestrictionTerritories" value="Sinkiang:Central China:China:Manchuria:Kwangtung:French Indochina"/>
+                        <option name="movementRestrictionType" value="allowed"/>
+                        <!-- productionPerXTerritories gives units to a player as part of NoPuPurchase delegate.  You can have multiple instances of productionPerXTerritories.
+                                value = the name of the unit, and count = the number of territories you need to get 1 of that unit.  if the name of the unit is missing, it defaults to "infantry" -->
+                        <option name="productionPerXTerritories" value="infantry" count="2"/>
+                        <!--<option name="productionPerXTerritories" value="fighter" count="6"/>-->
+                        <!-- if you are using productionPerXTerritories, you can have only territories worth at least 1 pu count towards the X by setting the game property "Production Per Valued Territory Restricted".
+                                the amount produced will be increased by 1 infantry if you are using PacificTheater and you control territories called "India", "Burma", "Yunnan", "Szechwan" -->
+                        <option name="placementAnyTerritory" value="true"/>
+                        <option name="placementCapturedTerritory" value="true"/>
+                        <!-- placementPerTerritory governs if you can or can not place in that territory, based on the number of owned units in that territory.  You may place in any territory with LESS units than the given value
+                                A value greater than Zero is required to be able to produce infinite units (or infinite up to maxPlacePerTerritory, which you can set too) -->
+                        <option name="placementPerTerritory" value="4"/>
+                        <!-- maxPlacePerTerritory governs the max you may place per turn per territory (can override factory rules and infinite placement rules) -->
+                        <option name="maxPlacePerTerritory" value="2"/>
+                        <option name="unlimitedProduction" value="true"/>
+                        <!-- dominatingFirstRoundAttack means that the very first round of the game, all enemies defend on a "1" instead of their normal defense. negateDominatingFirstRoundAttack means that this player is not affected by the dominatingFirstRoundAttack
+                        <option name="dominatingFirstRoundAttack" value="true"/>
+                        <option name="negateDominatingFirstRoundAttack" value="true"/> -->
+                        <!-- placementInCapitalRestricted means that the player may only place units in their capitol
+                        <option name="placementInCapitalRestricted" value="true"/> -->
+                </attachment>
+
 <!-- Player Attachments -->
-		<!-- the following options are allowed for "playerAttachment"
-				giveUnitControl						values: allow multiple players to give units to multiple other players, if those units are in a designated territory 
-																must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
-				captureUnitOnEnteringBy				values: allows multiple players to let their units be captured by multiple other players, if those units are in a designated territory and a designated player captures that territory
-																must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
-				shareTechnology						values: automatically gives all technologies this player has to all players in the list, during tech activation phase. must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
-				helpPayTechCost						values: allows the players in the list to help this player pay for the cost of technology.
-				destroysPUs							values: means that when this player loses their capital, their PUs are destroyed instead of captured (defaults to false = capture the PUs)
-				retainCapitalNumber					values: means that we do not lose our money if we still control at least this many of our capitals (defaults to 1). 
-																If a player has no playerAttachment, then it defaults to X, where X = total number of capitals (ie: you lose your money if a single capital is captured)
-				retainCapitalProduceNumber			values: is similar to above, but only affect gaining income and producing units (probably should be less than or equal to retainCapitalNumber) 
-																If a player has no playerAttachment, then it defaults to 1 (ie: you keep collecting and producing units so long as you control at least 1 capital)
-				suicideAttackResources				values: the first value is the resource we wish to use for the suicide attacks, and the count is the attack value each of that resource has when used in Kamikaze Suicide Attacks
-																The attacks happen during an opponents turn at the beginning of the battle step, so for example Japan may launch these attacks after the American combat move. The attacks target specific warships for destruction.
-																These attacks only occur in territories that are designated as kamikazeZone, and the attacks will be done by the original owner of that territory (owner when the game started, make sure to set it in the ownerInitialize)
-																Currently the attacks only target units owned by the current player, and must be surface warships (not subs, not transports) [I plan to let you specify which units later, and let you target land units too].
-																examples: <option name="suicideAttackResources" value="SuicideAttackTokens" count="2"/>
-				suicideAttackTargets				values: a colon delimited list of the units that this player may target during a Kamikaze Suicide Attack. If not set, then it defaults to all surface combat sea units.
-																examples: <option name="suicideAttackTargets" value="battleship:carrier"/>
-				vps									values: not sure if it works
-				captureVps							values: not sure if it works
-				movementLimit						values: only affects normal movement. count equal to the maximum number of units allowed in a territory. value must start with "owned", "allied", or "total", then after that is a colon delimited list of units or the word "all".
-																You may have multiple instances of this, per player. example: <option name="movementLimit" value="owned:Battleship:Battlecruiser:Cruiser:Destroyer:Submarine:Transport" count="4"/>
-				attackingLimit						values: only affects movement into enemy territory/units. count equal to the maximum number of units allowed in a territory. value must start with "owned", "allied", or "total", then after that is a colon delimited list of units or the word "all".
-																You may have multiple instances of this, per player. example: <option name="attackingLimit" value="owned:Battleship:Battlecruiser:Cruiser:Destroyer:Submarine:Transport" count="4"/>
-				placementLimit						values: only affects placement. count equal to the maximum number of units allowed in a territory. value must start with "owned", "allied", or "total", then after that is a colon delimited list of units or the word "all".
-																You may have multiple instances of this, per player. example: <option name="placementLimit" value="owned:Battleship:Battlecruiser:Cruiser:Destroyer:Submarine:Transport" count="4"/>
-		-->
-				<!-- Currently "vps" and "captureVps" do not work. if they work in the future they will follow original pacific rules
-				<attachment name="playerAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
-						<option name="vps" value="0"/>
-						<option name="captureVps" value="0"/>
-				</attachment> -->
-				
-				<attachment name="playerAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
-						<!-- destroysPUs means that when this player loses their capital, their PUs are destroyed instead of captured (defaults to false = capture the PUs) -->
-						<option name="destroysPUs" value="true"/>
-						<!-- retainCapitalNumber means that we do not lose our money if we still control at least this many of our capitals (defaults to 1). 
-							If a player has no playerAttachment, then it defaults to X, where X = total number of capitals (ie: you lose your money if a single capital is captured) -->
-						<!-- <option name="retainCapitalNumber" value="2"/> -->
-						<!-- retainCapitalProduceNumber is similar to above, but only affect gaining income and producing units (probably should be less than or equal to retainCapitalNumber) 
-							If a player has no playerAttachment, then it defaults to 1 (ie: you keep collecting and producing units so long as you control at least 1 capital) -->
-						<!-- <option name="retainCapitalProduceNumber" value="1"/> -->
-				</attachment>
-				
-				<attachment name="playerAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
-						<!-- giveUnitControl allow multiple players to give units to multiple other players, if those units are in a designated territory 
-								must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"-->
-						<option name="giveUnitControl" value="Russians"/>
-				</attachment>
-				
-				<!--<attachment name="playerAttachment" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
-						<- captureUnitOnEnteringBy allows multiple players to let their units be captured by multiple other players, if those units are in a designated territory and a designated player captures that territory
-							must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
-						<option name="captureUnitOnEnteringBy" value="Americans:British"/>
-				</attachment>-->
-				
+        <!-- the following options are allowed for "playerAttachment"
+                giveUnitControl                     values: allow multiple players to give units to multiple other players, if those units are in a designated territory
+                                                                must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
+                captureUnitOnEnteringBy             values: allows multiple players to let their units be captured by multiple other players, if those units are in a designated territory and a designated player captures that territory
+                                                                must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
+                shareTechnology                     values: automatically gives all technologies this player has to all players in the list, during tech activation phase. must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
+                helpPayTechCost                     values: allows the players in the list to help this player pay for the cost of technology.
+                destroysPUs                         values: means that when this player loses their capital, their PUs are destroyed instead of captured (defaults to false = capture the PUs)
+                retainCapitalNumber                 values: means that we do not lose our money if we still control at least this many of our capitals (defaults to 1).
+                                                                If a player has no playerAttachment, then it defaults to X, where X = total number of capitals (ie: you lose your money if a single capital is captured)
+                retainCapitalProduceNumber          values: is similar to above, but only affect gaining income and producing units (probably should be less than or equal to retainCapitalNumber)
+                                                                If a player has no playerAttachment, then it defaults to 1 (ie: you keep collecting and producing units so long as you control at least 1 capital)
+                suicideAttackResources              values: the first value is the resource we wish to use for the suicide attacks, and the count is the attack value each of that resource has when used in Kamikaze Suicide Attacks
+                                                                The attacks happen during an opponents turn at the beginning of the battle step, so for example Japan may launch these attacks after the American combat move. The attacks target specific warships for destruction.
+                                                                These attacks only occur in territories that are designated as kamikazeZone, and the attacks will be done by the original owner of that territory (owner when the game started, make sure to set it in the ownerInitialize)
+                                                                Currently the attacks only target units owned by the current player, and must be surface warships (not subs, not transports) [I plan to let you specify which units later, and let you target land units too].
+                                                                examples: <option name="suicideAttackResources" value="SuicideAttackTokens" count="2"/>
+                suicideAttackTargets                values: a colon delimited list of the units that this player may target during a Kamikaze Suicide Attack. If not set, then it defaults to all surface combat sea units.
+                                                                examples: <option name="suicideAttackTargets" value="battleship:carrier"/>
+                vps                                 values: not sure if it works
+                captureVps                          values: not sure if it works
+                movementLimit                       values: only affects normal movement. count equal to the maximum number of units allowed in a territory. value must start with "owned", "allied", or "total", then after that is a colon delimited list of units or the word "all".
+                                                                You may have multiple instances of this, per player. example: <option name="movementLimit" value="owned:Battleship:Battlecruiser:Cruiser:Destroyer:Submarine:Transport" count="4"/>
+                attackingLimit                      values: only affects movement into enemy territory/units. count equal to the maximum number of units allowed in a territory. value must start with "owned", "allied", or "total", then after that is a colon delimited list of units or the word "all".
+                                                                You may have multiple instances of this, per player. example: <option name="attackingLimit" value="owned:Battleship:Battlecruiser:Cruiser:Destroyer:Submarine:Transport" count="4"/>
+                placementLimit                      values: only affects placement. count equal to the maximum number of units allowed in a territory. value must start with "owned", "allied", or "total", then after that is a colon delimited list of units or the word "all".
+                                                                You may have multiple instances of this, per player. example: <option name="placementLimit" value="owned:Battleship:Battlecruiser:Cruiser:Destroyer:Submarine:Transport" count="4"/>
+        -->
+                <!-- Currently "vps" and "captureVps" do not work. if they work in the future they will follow original pacific rules
+                <attachment name="playerAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
+                        <option name="vps" value="0"/>
+                        <option name="captureVps" value="0"/>
+                </attachment> -->
+
+                <attachment name="playerAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
+                        <!-- destroysPUs means that when this player loses their capital, their PUs are destroyed instead of captured (defaults to false = capture the PUs) -->
+                        <option name="destroysPUs" value="true"/>
+                        <!-- retainCapitalNumber means that we do not lose our money if we still control at least this many of our capitals (defaults to 1).
+                            If a player has no playerAttachment, then it defaults to X, where X = total number of capitals (ie: you lose your money if a single capital is captured) -->
+                        <!-- <option name="retainCapitalNumber" value="2"/> -->
+                        <!-- retainCapitalProduceNumber is similar to above, but only affect gaining income and producing units (probably should be less than or equal to retainCapitalNumber)
+                            If a player has no playerAttachment, then it defaults to 1 (ie: you keep collecting and producing units so long as you control at least 1 capital) -->
+                        <!-- <option name="retainCapitalProduceNumber" value="1"/> -->
+                </attachment>
+
+                <attachment name="playerAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
+                        <!-- giveUnitControl allow multiple players to give units to multiple other players, if those units are in a designated territory
+                                must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"-->
+                        <option name="giveUnitControl" value="Russians"/>
+                </attachment>
+
+                <!--<attachment name="playerAttachment" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
+                        <- captureUnitOnEnteringBy allows multiple players to let their units be captured by multiple other players, if those units are in a designated territory and a designated player captures that territory
+                            must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
+                        <option name="captureUnitOnEnteringBy" value="Americans:British"/>
+                </attachment>-->
+
 <!-- Political Action Attachments -->
-		<!-- the following options are allowed for "politicalActionAttachmentXXX"
-				conditions							value: 	this is a colon delimited list of conditions, and this politicalActionAttachment is only active (thus can be performed) if this returns true
-				conditionType 						value: 	AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the trigger. 
-															AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
-				invert 								value: 	true or false. default if missing is false. if true, the condition will be reversed (does not reverse the effect)
-															This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
-				relationshipChange					value: 	the relationshipType that will exist after the action is succesful between the player and the otherPlayer format: "player1:player2:relationship"
-															You can add multiple relationshipchanges per attachment
-				chance								value: 	diceroll:dicesides to hit for this action to succeed for example "1:6" for the action to succeed 1 out of 6 times
-				costPU								value: 	ammount of PU you will be charged to attempt this action
-				text								value: 	a KEY referring to politicstext.properties to indicate the texts used for regarding this action
-				actionAccept						value: 	a list of players that must accept this action before it takes effect (handy for peacetreaties)
-				attemptsPerTurn						value: 	the number of times this action can be attempted per round (default: 1)
-		-->
-				<attachment name="politicalActionAttachmentItaliansDeclareWarOnRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansNeutralItaliansFor2Turns"/>
-						<option name="relationshipChange" value="Italians:Russians:War"/>
-						<option name="text" value="ITALY_DECLAREWAR_RUSSIA"/>
-						<option name="chance" value="6:6"/>
-						<option name="costPU" value="0"/>
-						<option name="attemptsPerTurn" value="1"/>
-				</attachment>
-				<attachment name="politicalActionAttachmentItaliansProposeCeasefireRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansWarItalians"/>
-						<option name="relationshipChange" value="Italians:Russians:Neutrality"/>
-						<option name="text" value="ITALY_PROPOSEPEACE_RUSSIA"/>
-						<option name="chance" value="6:6"/>
-						<option name="costPU" value="0"/>
-						<option name="actionAccept" value="Russians"/>
-						<option name="attemptsPerTurn" value="1"/>
-				</attachment>
-				<attachment name="politicalActionAttachmentItaliansDeclareWarOnChineseAndAmericans" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentChineseNeutralItalians"/>
-						<option name="relationshipChange" value="Italians:Chinese:War"/>
-						<option name="relationshipChange" value="Italians:Americans:War"/>
-						<option name="text" value="ITALY_DECLAREWAR_CHINA_USA"/>
-						<option name="chance" value="2:6"/>
-						<option name="costPU" value="0"/>
-						<option name="attemptsPerTurn" value="1"/>
-				</attachment>
-				<attachment name="politicalActionAttachmentJapaneseDeclareWarOnRussians" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansNeutralJapan"/>
-						<option name="relationshipChange" value="Japanese:Russians:War"/>
-						<option name="text" value="JAPANESE_DECLAREWAR_RUSSIANS"/>
-						<option name="chance" value="6:6"/>
-						<option name="costPU" value="0"/>
-						<option name="attemptsPerTurn" value="1"/>
-				</attachment>
-				<attachment name="politicalActionAttachmentRussiansDeclareWarOnItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansNeutralItaliansFor2Turns"/>
-						<option name="relationshipChange" value="Italians:Russians:War"/>
-						<option name="text" value="RUSSIANS_DECLAREWAR_ITALIANS"/>
-						<option name="chance" value="6:6"/>
-						<option name="costPU" value="0"/>
-						<option name="attemptsPerTurn" value="1"/>
-				</attachment>
-				<attachment name="politicalActionAttachmentRussiansDeclareWarOnJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansNeutralJapan"/>
-						<option name="relationshipChange" value="Japanese:Russians:War"/>
-						<option name="text" value="RUSSIANS_DECLAREWAR_JAPANESE"/>
-						<option name="chance" value="6:6"/>
-						<option name="costPU" value="0"/>
-						<option name="attemptsPerTurn" value="1"/>
-				</attachment>
-				<attachment name="politicalActionAttachmentRussiansAllyWithAmericansAndBritish" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
-						<option name="relationshipChange" value="Americans:Russians:Allied"/>
-						<option name="relationshipChange" value="British:Russians:Allied"/>
-						<option name="text" value="RUSSIANS_ALLY_AMERICANS_BRITISH"/>
-						<option name="chance" value="6:6"/>
-						<option name="costPU" value="1"/>
-						<option name="attemptsPerTurn" value="1"/>
-						<option name="actionAccept" value="Americans:British"/>
-				</attachment>
-				<attachment name="politicalActionAttachmentBritishAndAmericansAllyWithRussians" attachTo="British" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
-						<option name="relationshipChange" value="Americans:Russians:Allied"/>
-						<option name="relationshipChange" value="British:Russians:Allied"/>
-						<option name="text" value="AMERICANS_BRITISH_ALLY_RUSSIANS"/>
-						<option name="chance" value="6:6"/>
-						<option name="costPU" value="2"/>
-						<option name="attemptsPerTurn" value="1"/>
-						<option name="actionAccept" value="Russians"/>
-				</attachment>
-				<attachment name="politicalActionAttachmentAmericansAndBritishAllyWithRussians" attachTo="Americans" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
-						<option name="relationshipChange" value="Americans:Russians:Allied"/>
-						<option name="relationshipChange" value="British:Russians:Allied"/>
-						<option name="text" value="AMERICANS_BRITISH_ALLY_RUSSIANS"/>
-						<option name="chance" value="6:6"/>
-						<option name="costPU" value="3"/>
-						<option name="attemptsPerTurn" value="1"/>
-						<option name="actionAccept" value="Russians"/>
-				</attachment>
-				
-				
-				
+        <!-- the following options are allowed for "politicalActionAttachmentXXX"
+                conditions                          value:     this is a colon delimited list of conditions, and this politicalActionAttachment is only active (thus can be performed) if this returns true
+                conditionType                       value:     AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the trigger.
+                                                                AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
+                invert                              value:     true or false. default if missing is false. if true, the condition will be reversed (does not reverse the effect)
+                                                                This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
+                relationshipChange                  value:     the relationshipType that will exist after the action is succesful between the player and the otherPlayer format: "player1:player2:relationship"
+                                                                You can add multiple relationshipchanges per attachment
+                chance                              value:     diceroll:dicesides to hit for this action to succeed for example "1:6" for the action to succeed 1 out of 6 times
+                costPU                              value:     ammount of PU you will be charged to attempt this action
+                text                                value:     a KEY referring to politicstext.properties to indicate the texts used for regarding this action
+                actionAccept                        value:     a list of players that must accept this action before it takes effect (handy for peacetreaties)
+                attemptsPerTurn                     value:     the number of times this action can be attempted per round (default: 1)
+        -->
+                <attachment name="politicalActionAttachmentItaliansDeclareWarOnRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansNeutralItaliansFor2Turns"/>
+                        <option name="relationshipChange" value="Italians:Russians:War"/>
+                        <option name="text" value="ITALY_DECLAREWAR_RUSSIA"/>
+                        <option name="chance" value="6:6"/>
+                        <option name="costPU" value="0"/>
+                        <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentItaliansProposeCeasefireRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansWarItalians"/>
+                        <option name="relationshipChange" value="Italians:Russians:Neutrality"/>
+                        <option name="text" value="ITALY_PROPOSEPEACE_RUSSIA"/>
+                        <option name="chance" value="6:6"/>
+                        <option name="costPU" value="0"/>
+                        <option name="actionAccept" value="Russians"/>
+                        <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentItaliansDeclareWarOnChineseAndAmericans" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentChineseNeutralItalians"/>
+                        <option name="relationshipChange" value="Italians:Chinese:War"/>
+                        <option name="relationshipChange" value="Italians:Americans:War"/>
+                        <option name="text" value="ITALY_DECLAREWAR_CHINA_USA"/>
+                        <option name="chance" value="2:6"/>
+                        <option name="costPU" value="0"/>
+                        <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentJapaneseDeclareWarOnRussians" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansNeutralJapan"/>
+                        <option name="relationshipChange" value="Japanese:Russians:War"/>
+                        <option name="text" value="JAPANESE_DECLAREWAR_RUSSIANS"/>
+                        <option name="chance" value="6:6"/>
+                        <option name="costPU" value="0"/>
+                        <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentRussiansDeclareWarOnItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansNeutralItaliansFor2Turns"/>
+                        <option name="relationshipChange" value="Italians:Russians:War"/>
+                        <option name="text" value="RUSSIANS_DECLAREWAR_ITALIANS"/>
+                        <option name="chance" value="6:6"/>
+                        <option name="costPU" value="0"/>
+                        <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentRussiansDeclareWarOnJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansNeutralJapan"/>
+                        <option name="relationshipChange" value="Japanese:Russians:War"/>
+                        <option name="text" value="RUSSIANS_DECLAREWAR_JAPANESE"/>
+                        <option name="chance" value="6:6"/>
+                        <option name="costPU" value="0"/>
+                        <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentRussiansAllyWithAmericansAndBritish" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
+                        <option name="relationshipChange" value="Americans:Russians:Allied"/>
+                        <option name="relationshipChange" value="British:Russians:Allied"/>
+                        <option name="text" value="RUSSIANS_ALLY_AMERICANS_BRITISH"/>
+                        <option name="chance" value="6:6"/>
+                        <option name="costPU" value="1"/>
+                        <option name="attemptsPerTurn" value="1"/>
+                        <option name="actionAccept" value="Americans:British"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentBritishAndAmericansAllyWithRussians" attachTo="British" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
+                        <option name="relationshipChange" value="Americans:Russians:Allied"/>
+                        <option name="relationshipChange" value="British:Russians:Allied"/>
+                        <option name="text" value="AMERICANS_BRITISH_ALLY_RUSSIANS"/>
+                        <option name="chance" value="6:6"/>
+                        <option name="costPU" value="2"/>
+                        <option name="attemptsPerTurn" value="1"/>
+                        <option name="actionAccept" value="Russians"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentAmericansAndBritishAllyWithRussians" attachTo="Americans" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
+                        <option name="relationshipChange" value="Americans:Russians:Allied"/>
+                        <option name="relationshipChange" value="British:Russians:Allied"/>
+                        <option name="text" value="AMERICANS_BRITISH_ALLY_RUSSIANS"/>
+                        <option name="chance" value="6:6"/>
+                        <option name="costPU" value="3"/>
+                        <option name="attemptsPerTurn" value="1"/>
+                        <option name="actionAccept" value="Russians"/>
+                </attachment>
+
+
+
 <!-- Tech Ability Attachment -->
-		<!-- Custom (Generic) Techs that name a hard coded tech (ie: we are changing the name of a hardcoded tech) may NOT have a tech ability attachment.  If you want a tech ability attachment for your tech, either use a custom (generic) tech, or do not rename a hard coded tech. -->
-		<!-- the following options are allowed for "techAbilityAttachment"
-				attackBonus									value:	gives some amount of attack to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
-				defenseBonus								value:	gives some amount of defense to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
-				movementBonus								value:	gives some amount of movement to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
-				radarBonus									value:	gives some amount of radar aa attack to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
-				airAttackBonus								value:	gives some amount of air escort attack to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
-				airDefenseBonus								value:	gives some amount of air interceptor defense to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
-				productionBonus								value:	gives some amount of production to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
-				minimumTerritoryValueForProductionBonus 	value:	sets the minimum value of a territory that a factory units must be in to receive the production bonus.  must be an integer (default -1) between -1 and 10000.  If multiple techs, the lowest is chosen.
-				repairDiscount								value:	sets the discount to repairing.  must be an integer (default -1) between 0 and 100.  Effects from multiple techs are added together.
-				warBondDiceSides							value:	sets how large the dice are which are rolled to determine the war bonds bonus.  must be an integer (default -1) between 0 and 200. Effects from multiple techs are added together.
-				warBondDiceNumber							value:	sets how many dice get rolled for war bonds.  must be an integer (default 0) between 0 and 100.  Effects from multiple techs are added together.
-				rocketDiceNumber							value:	sets the number of rocket rolls for each rocket.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
-				rocketDistance								value:	sets the maximum distance rockets travel for the map.  must be an integer (default 0) between 0 and 100.  Effects from multiple techs are added together.
-				rocketNumberPerTerritory					value:	sets the maximum number of rocket rolls per territory.  must be an integer (default 0) between 0 and 200.  Effects from multiple techs are added together.
-				unitAbilitiesGained							value:	allows unit types to gain abilities through this tech.  must be the name of the unit, followed by a colon ":", followed by all the abilities gained (separated by colons).  currently allows only "canBlitz" and "canBombard".  Effects from multiple techs are added together.
-				airborneForces								value:	"true" or "false", does this tech allow the owner to start making airborne movements?  At least 1 tech must have this as true, for it to be turned on.
-				airborneCapacity							value:	gives some amount of capacity to an airborne base, for the number of units that can be launched from there.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
-				airborneTypes								value:	sets which units are airborne type units, therefore which units get to move.  must be a list of unit types, separated by a colon ":". Effects from multiple techs are added together.
-				airborneDistance							value:	sets the maximum distance for moving any airborne type unit. must be an integer (default 0) between 0 and 100.  Effects from multiple techs are added together.
-				airborneBases								value:	sets which units are airborne base units, therefore which units are required at the start territory.  must be a list of unit types, separated by a colon ":". Effects from multiple techs are added together.
-				airborneTargettedByAA						value:	sets which airborne units are subject to AA gun fire, and by what aa types. First is the "targetsAA" that can hit these units, and next is a list of units hit by it. Effects from multiple techs are added together.
-				attackRollsBonus							value:	sets how many extra rolls this unit gets on attack. Effects from multiple techs are added together.
-				defenseRollsBonus							value:	sets how many extra rolls this unit gets on defense. Effects from multiple techs are added together.
-				bombingBonus								value:	gives an extra amount of damage to strategic bombing raids, after all dice have been rolled, per unit (not per die). Effects from multiple techs are added together.
-				
-				
-		-->
-				<attachment name="techAbilityAttachment" attachTo="longRangeAir" javaClass="games.strategy.triplea.attachments.TechAbilityAttachment" type="technology">
-						<option name="movementBonus" value="1:fighter"/>
-						<option name="movementBonus" value="1:jp_fighter"/>
-						<option name="movementBonus" value="1:bomber"/>
-						<option name="movementBonus" value="1:air_transport"/>
-				</attachment>
-
-		</attachmentList>
-
-		
-		<initialize>
-				<ownerInitialize>
-						<!-- Italian Owned Territories -->
-						<territoryOwner territory="Libya" owner="Italians"/>
-						<territoryOwner territory="Italy" owner="Italians"/>
-						<territoryOwner territory="West Balkans" owner="Italians"/>
-						<territoryOwner territory="Greece" owner="Italians"/>
-						<territoryOwner territory="Sicily" owner="Italians"/>
-						<territoryOwner territory="Sardinia" owner="Italians"/>
-
-						<!-- German Owned Territories -->
-						<territoryOwner territory="Algeria" owner="Germans"/>
-						<territoryOwner territory="Western Europe" owner="Germans"/>
-						<territoryOwner territory="Germany" owner="Germans"/>
-						<territoryOwner territory="Norway" owner="Germans"/>
-						<territoryOwner territory="East Balkans" owner="Germans"/>
-						<territoryOwner territory="Ukraine S.S.R." owner="Germans"/>
-						<territoryOwner territory="Eastern Europe" owner="Germans"/>
-						<territoryOwner territory="Belorussia" owner="Germans"/>
-						<territoryOwner territory="West Russia" owner="Germans"/>
-					
-						<territoryOwner territory="5 Sea Zone" owner="Germans"/>
-						<territoryOwner territory="6 Sea Zone" owner="Germans"/>
-
-						<!-- Russian Owned Territories -->
-						<territoryOwner territory="Karelia S.S.R." owner="Russians"/>
-						<territoryOwner territory="Archangel" owner="Russians"/>
-						<territoryOwner territory="Russia" owner="Russians"/>
-						<territoryOwner territory="Caucus" owner="Russians"/>
-						<territoryOwner territory="Kazakh S.S.R." owner="Russians"/>
-						<territoryOwner territory="Novisibirsk" owner="Russians"/>
-						<territoryOwner territory="Evanki National Okrug" owner="Russians"/>
-						<territoryOwner territory="Yakut S.S.R." owner="Russians"/>
-						<territoryOwner territory="Soviet Far East" owner="Russians"/>
-						<territoryOwner territory="Burytia S.S.R." owner="Russians"/>
-					
-						<territoryOwner territory="3 Sea Zone" owner="Germans"/>
-						<territoryOwner territory="4 Sea Zone" owner="Russians"/>
-
-						<!-- British Owned Territories -->
-						<territoryOwner territory="United Kingdom" owner="British"/>
-						<territoryOwner territory="Western Canada" owner="British"/>
-						<territoryOwner territory="Eastern Canada" owner="British"/>
-						<territoryOwner territory="French West Africa" owner="British"/>
-						<territoryOwner territory="French Equatorial Africa" owner="British"/>
-						<territoryOwner territory="Anglo Egypt" owner="British"/>
-						<territoryOwner territory="Italian East Africa" owner="British"/>
-						<territoryOwner territory="Belgian Congo" owner="British"/>
-						<territoryOwner territory="Kenya" owner="British"/>
-						<territoryOwner territory="Union of South Africa" owner="British"/>
-						<territoryOwner territory="French Madagascar" owner="British"/>
-						<territoryOwner territory="Trans-Jordan" owner="British"/>
-						<territoryOwner territory="Persia" owner="British"/>
-						<territoryOwner territory="India" owner="British"/>
-						<territoryOwner territory="Australia" owner="British"/>
-						<territoryOwner territory="New Zealand" owner="British"/>
-						<territoryOwner territory="Gibraltar" owner="British"/>
-
-						<!-- Japanese Owned Territories -->
-						<territoryOwner territory="Japan" owner="Japanese"/>
-						<territoryOwner territory="Kwangtung" owner="Japanese"/>
-						<territoryOwner territory="French Indochina" owner="Japanese"/>
-						<territoryOwner territory="Manchuria" owner="Japanese"/>
-						<territoryOwner territory="East Indies" owner="Japanese"/>
-						<territoryOwner territory="Borneo" owner="Japanese"/>
-						<territoryOwner territory="New Guinea" owner="Japanese"/>
-						<territoryOwner territory="Philipine Islands" owner="Japanese"/>
-						<territoryOwner territory="Caroline Islands" owner="Japanese"/>
-						<territoryOwner territory="Solomon Islands" owner="Japanese"/>
-						<territoryOwner territory="Okinawa" owner="Japanese"/>
-						<territoryOwner territory="Wake Island" owner="Japanese"/>
-					
-						<!--<territoryOwner territory="37 Sea Zone" owner="Japanese"/>
-						<territoryOwner territory="47 Sea Zone" owner="Japanese"/>
-						<territoryOwner territory="48 Sea Zone" owner="Japanese"/>
-						<territoryOwner territory="49 Sea Zone" owner="Japanese"/>
-						<territoryOwner territory="58 Sea Zone" owner="Japanese"/>-->
-
-						<!-- American Owned Territories -->
-						<territoryOwner territory="Western United States" owner="Americans"/>
-						<territoryOwner territory="Eastern United States" owner="Americans"/>
-						<territoryOwner territory="Central United States" owner="Americans"/>
-						<territoryOwner territory="Midway" owner="Americans"/>
-						<territoryOwner territory="Hawaiian Islands" owner="Americans"/>
-						<territoryOwner territory="Mexico" owner="Americans"/>
-						<territoryOwner territory="Brazil" owner="Americans"/>
-						<territoryOwner territory="Alaska" owner="Americans"/>
-						<territoryOwner territory="West Indies" owner="Americans"/>
-						<territoryOwner territory="Panama" owner="Americans"/>
-						<territoryOwner territory="Greenland" owner="Americans"/>
-						
-						<!-- Chinese Owned Territories -->
-						<territoryOwner territory="China" owner="Chinese"/>
-						<territoryOwner territory="Central China" owner="Chinese"/>
-						<territoryOwner territory="Sinkiang" owner="Chinese"/>
-						<territoryOwner territory="Himilaya" owner="Chinese"/>
-				</ownerInitialize>
-
-				<unitInitialize>
-						<!-- Russian Unit Placements -->
-						<unitPlacement unitType="infantry" territory="Karelia S.S.R." quantity="3" owner="Russians"/>
-						<unitPlacement unitType="fighter" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
-						<unitPlacement unitType="armour" territory="Archangel" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="artillery" territory="Archangel" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Archangel" quantity="2" owner="Russians"/>
-						<unitPlacement unitType="factory" territory="Caucus" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="aaGun" territory="Caucus" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="artillery" territory="Caucus" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Caucus" quantity="3" owner="Russians"/>
-						<unitPlacement unitType="armour" territory="Caucus" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="factory" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="aaGun" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Russia" quantity="3" owner="Russians"/>
-						<unitPlacement unitType="artillery" territory="Russia" quantity="2" owner="Russians"/>
-						<unitPlacement unitType="armour" territory="Russia" quantity="2" owner="Russians"/>
-						<unitPlacement unitType="fighter" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Evanki National Okrug" quantity="2" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Novisibirsk" quantity="3" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Yakut S.S.R." quantity="2" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Soviet Far East" quantity="2" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Burytia S.S.R." quantity="2" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Kazakh S.S.R." quantity="2" owner="Russians"/>
-						<unitPlacement unitType="submarine" territory="4 Sea Zone" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="cruiser" territory="16 Sea Zone" quantity="1" owner="Russians"/>
-
-						<!-- Italian Unit Placements -->
-						<unitPlacement unitType="cruiser" territory="14 Sea Zone" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="transport" territory="14 Sea Zone" quantity="2" owner="Italians"/>
-						<unitPlacement unitType="battleship" territory="14 Sea Zone" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="Libya" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="artillery" territory="Libya" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="aaGun" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="armour" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="fighter" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="factory" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="Italy" quantity="3" owner="Italians"/>
-						<unitPlacement unitType="artillery" territory="Greece" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="West Balkans" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="Sicily" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="Sardinia" quantity="1" owner="Italians"/>
-
-						<!-- German Unit Placements -->
-						<unitPlacement unitType="aaGun" territory="Western Europe" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Western Europe" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Western Europe" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Western Europe" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Algeria" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Algeria" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="factory" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="aaGun" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Germany" quantity="4" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Germany" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="bomber" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Norway" quantity="3" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Norway" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="East Balkans" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="factory" territory="East Balkans" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="aaGun" territory="East Balkans" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="East Balkans" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="East Balkans" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Eastern Europe" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Eastern Europe" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Eastern Europe" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="artillery" territory="Eastern Europe" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="artillery" territory="Ukraine S.S.R." quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Ukraine S.S.R." quantity="3" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Ukraine S.S.R." quantity="1" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Ukraine S.S.R." quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Belorussia" quantity="3" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="West Russia" quantity="3" owner="Germans"/>
-						<unitPlacement unitType="artillery" territory="West Russia" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="West Russia" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="transport" territory="5 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="battleship" territory="5 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="destroyer" territory="5 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="submarine" territory="5 Sea Zone" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="submarine" territory="7 Sea Zone" quantity="1" owner="Germans"/>
-
-						<!-- British Unit Placements -->
-						<unitPlacement unitType="armour" territory="Eastern Canada" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="United Kingdom" quantity="4" owner="British"/>
-						<unitPlacement unitType="artillery" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="armour" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="fighter" territory="United Kingdom" quantity="2" owner="British"/>
-						<unitPlacement unitType="bomber" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Persia" quantity="2" owner="British"/>
-						<unitPlacement unitType="aaGun" territory="India" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="India" quantity="3" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Trans-Jordan" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Anglo Egypt" quantity="2" owner="British"/>
-						<unitPlacement unitType="armour" territory="Anglo Egypt" quantity="1" owner="British"/>
-						<unitPlacement unitType="fighter" territory="Anglo Egypt" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Italian East Africa" quantity="1" owner="British"/>
-						<unitPlacement unitType="artillery" territory="Italian East Africa" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Union of South Africa" quantity="1" owner="British"/>
-						<unitPlacement unitType="armour" territory="Union of South Africa" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Australia" quantity="3" owner="British"/>
-						<unitPlacement unitType="infantry" territory="New Zealand" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Western Canada" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="French Madagascar" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="1 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="1 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="1 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="battleship" territory="2 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="2 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="battleship" territory="13 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="cruiser" territory="15 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="carrier" territory="35 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="35 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="fighter" territory="35 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="cruiser" territory="35 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="40 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="cruiser" territory="40 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="40 Sea Zone" quantity="1" owner="British"/>
-
-						<!-- Japanese Unit Placements -->
-						<unitPlacement unitType="jp_fighter" territory="Manchuria" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Manchuria" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Kwangtung" quantity="3" owner="Japanese"/>
-						<unitPlacement unitType="jp_fighter" territory="French Indochina" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="French Indochina" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Solomon Islands" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="New Guinea" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Borneo" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="East Indies" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Philipine Islands" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Caroline Islands" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Okinawa" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Wake Island" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Japan" quantity="4" owner="Japanese"/>
-						<unitPlacement unitType="artillery" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="armour" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="jp_fighter" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="bomber" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="battleship" territory="37 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="jp_fighter" territory="37 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="carrier" territory="37 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="jp_transport" territory="50 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="jp_transport" territory="60 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="battleship" territory="60 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="submarine" territory="61 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="jp_fighter" territory="50 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="cruiser" territory="50 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="carrier" territory="50 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="submarine" territory="45 Sea Zone" quantity="1" owner="Japanese"/>
-
-						<!-- American Unit Placements -->
-						<unitPlacement unitType="factory" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="armour" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="aaGun" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Eastern United States" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="artillery" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="bomber" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Midway" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="aaGun" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Alaska" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="aaGun" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="factory" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Western United States" quantity="3" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Central United States" quantity="3" owner="Americans"/>
-						<unitPlacement unitType="armour" territory="Central United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="transport" territory="10 Sea Zone" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="55 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="battleship" territory="55 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="transport" territory="55 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="56 Sea Zone" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="carrier" territory="56 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="submarine" territory="56 Sea Zone" quantity="1" owner="Americans"/>
-						
-						<!-- Chinese Unit Placements -->
-						<unitPlacement unitType="infantry" territory="China" quantity="2" owner="Chinese"/>
-						<unitPlacement unitType="fighter" territory="China" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="artillery" territory="Central China" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Sinkiang" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Central China" quantity="1" owner="Chinese"/>
-				</unitInitialize>
-
-				<resourceInitialize>
-						<!-- these do not have to match the production of the game starting out, they can be any number -->
-						<resourceGiven player="Japanese" resource="PUs" quantity="30"/>
-						<resourceGiven player="British" resource="PUs" quantity="33"/>
-						<resourceGiven player="Americans" resource="PUs" quantity="37"/>
-						<resourceGiven player="Russians" resource="PUs" quantity="26"/>
-						<resourceGiven player="Germans" resource="PUs" quantity="40"/>
-						<resourceGiven player="Italians" resource="PUs" quantity="16"/>
-						<resourceGiven player="Chinese" resource="PUs" quantity="0"/>
-						
-						<!-- custom resources below
-						<resourceGiven player="Italians" resource="Steel" quantity="20"/>
-						<resourceGiven player="Italians" resource="Aluminium" quantity="30"/>
-						<resourceGiven player="Italians" resource="Fuel" quantity="20"/>-->
-				</resourceInitialize>
-
-				<relationshipInitialize>
-						<!-- the order of player1 and player2 does not matter. roundValue is only used for conditions and can be positive or negative (use "1" if you don't know what you are doing).
-								having them listed twice in different orders will just have the later one overwrite the earlier one.
-								Make sure you cover all possibilities! (the number of possibilities is equal to the triangular number sequence: 1,3,6,10,15,21,28,36,45,55,66,78,91,105,120)
-						-->
-						
-						<relationship type="Allied" player1="Italians" player2="Germans" roundValue="1"/>
-						<relationship type="Allied" player1="Italians" player2="Japanese" roundValue="1"/>
-						<relationship type="Allied" player1="Germans" player2="Japanese" roundValue="1"/>
-
-						<relationship type="Neutrality" player1="Russians" player2="British" roundValue="1"/>
-						<relationship type="Neutrality" player1="Russians" player2="Americans" roundValue="1"/>
-						<relationship type="Allied" player1="Russians" player2="Chinese" roundValue="1"/>
-						<relationship type="Allied" player1="Americans" player2="British" roundValue="1"/>
-						<relationship type="Allied" player1="Americans" player2="Chinese" roundValue="1"/>
-						<relationship type="Allied" player1="British" player2="Chinese" roundValue="1"/>
-
-						<relationship type="War" player1="British" player2="Germans" roundValue="1"/>
-						<relationship type="War" player1="British" player2="Italians" roundValue="1"/>
-						<relationship type="War" player1="British" player2="Japanese" roundValue="1"/>
-
-						<relationship type="War" player1="Americans" player2="Germans" roundValue="1"/>
-						<relationship type="War" player1="Americans" player2="Italians" roundValue="1"/>
-						<relationship type="War" player1="Americans" player2="Japanese" roundValue="1"/>
-
-						<relationship type="War" player1="Russians" player2="Germans" roundValue="1"/>
-						<relationship type="War" player1="Russians" player2="Italians" roundValue="-1"/>
-						<relationship type="Neutrality" player1="Russians" player2="Japanese" roundValue="1"/>
-						<!--<relationship type="Neutrality" player1="Russians" player2="Germans" roundValue="1"/>
-						<relationship type="Allied" player1="Russians" player2="Italians" roundValue="1"/>
-						<relationship type="Neutrality" player1="Russians" player2="Japanese" roundValue="1"/>-->
-
-						<relationship type="War" player1="Chinese" player2="Germans" roundValue="1"/>
-						<relationship type="War" player1="Chinese" player2="Italians" roundValue="1"/>
-						<relationship type="War" player1="Chinese" player2="Japanese" roundValue="1"/>
-				</relationshipInitialize>
-
-		</initialize>
-
-		<propertyList>
-		<!--	From TripleA 1.5 and onward, ALL properties must be strongly TYPED.  (your map may or may not work if you do not make your properties Type-Safe)
-				Allowed values:
-					boolean
-					number
-					string
-					file
-					list
-					color
-				
-				Examples:
-					INSTEAD OF:
-						<property name="mapName" value="the_pact_of_steel" editable="false"/>
-
-					DO THIS:
-						<property name="mapName" value="the_pact_of_steel" editable="false">
-								<string/>
-						</property>
-
-
-					INSTEAD OF:
-						<property name="maxFactoriesPerTerritory" value="1"/>
-
-					DO THIS:
-						<property name="maxFactoriesPerTerritory" value="1" editable="false">
-								<number min="1" max="100"/>
-						</property>
-
-
-					INSTEAD OF:
-						<property name="Produce fighters on carriers" value="true"/>
-
-					DO THIS:
-						<property name="Produce fighters on carriers" value="true" editable="false">
-								<boolean/>
-						</property>
-
-
-
-					INSTEAD OF:
-						<property name="notes">
-								<value>Your game notes go here.</value>
-						</property>
-
-					DO THIS:
-						<property name="notes">
-								<string/>
-								<value>
-									<![CDATA[
-										<br>Your game notes go here.
-									]]>
-								</value>
-						</property>
-		-->
-		
-				<!-- PLEASE KEEP YOUR PROPERTIES IN THIS ORDER!!! -->
-				<!-- TYPICAL OPTIONAL PROPERTIES -->
-				<!-- Bidding -->
-				<property name="Italians bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Russians bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Germans bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="British bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Japanese bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Americans bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Chinese bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-				
-				<!-- victory options -->
-				<property name="Projection of Power" value="true" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- format of "<alliance> <Name of Victory Condition>" -->
-				<property name="Axis Projection of Power VCs" value="11" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Allies Projection of Power VCs" value="11" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Honorable Surrender" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Axis Honorable Victory VCs" value="12" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Allies Honorable Victory VCs" value="12" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Total Victory" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Axis Total Victory VCs" value="15" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Allies Total Victory VCs" value="15" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Economic Victory" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Axis Economic Victory" value="120" editable="false">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Allies Economic Victory" value="120" editable="false">
-						<number min="0" max="1000"/>
-				</property>
-
-						<!-- Triggered Victory is a victory condition set by a trigger, using a condition or national objective -->
-				<property name="Triggered Victory" value="true" editable="true">
-						<boolean/>
-				</property>
-				<!-- End of Victory Conditions, rest of typical changed properties below -->
-
-				<property name="Low Luck" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for AntiAircraft" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Technology" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Use Politics" value="true" editable="true">
-						<boolean/>
-				</property>
-				
-						<!-- If this is set, it adds or subtracks from any conditions that require a relationship to last for X rounds -->
-				<property name="Relationships Last Extra Rounds" value="0" editable="true">
-						<number min="-1" max="2"/>
-				</property>
-
-				<property name="Alliances Can Chain Together" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="National Objectives" value="true" editable="true">
-						<boolean/>
-				</property>
-				
-				<property name="Use Triggers" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Tech Development" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Remove All Tech Tokens At End Of Turn" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Super Sub Defence Bonus" value="0" editable="true">
-						<number min="0" max="1"/>
-				</property>
-
-						<!-- All units with multiple dice rolls, will be forced to select the best die rolled instead of using all dice. -->
-				<property name="LHTR Heavy Bombers" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Heavy Bomber Dice Rolls" value="2" editable="false">
-						<number min="2" max="3"/>
-				</property>
-
-				<property name="Paratroopers Can Move During Non Combat" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Paratroopers Can Attack Deep Into Enemy Territory" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Always on AA" value="false" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- Kamikaze Airplanes will allow all air units on the map to use all their movement to get to a battle -->
-				<property name="Kamikaze Airplanes" value="false" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- Use Kamikaze Suicide Attacks allows a player to use resources designated in player attachments to make special attacks -->
-				<property name="Use Kamikaze Suicide Attacks" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- Kamikaze Suicide Attacks Done By Current Territory Owner allows you to have the current owner perform the suicide attacks, instead of the original owner -->
-				<property name="Kamikaze Suicide Attacks Done By Current Territory Owner" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- Kamikaze Suicide Attacks Only Where Battles Are has the attacks only occur only when there are amphibious battles from that territory, or a battle in that territory -->
-				<property name="Kamikaze Suicide Attacks Only Where Battles Are" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Units Repair Hits End Turn" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Units Repair Hits Start Turn" value="false" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- in order to repair, a unit must in the presence of a unit with "repairsUnits" unit attachment -->
-				<property name="Two HitPoint Units Require Repair Facilities" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<!-- Display Options -->
-						<!-- Multiply PUs will multiply all PUs gained or lost during a turn. It will not yet multiply costs of units or any other costs, or starting PUs -->
-				<property name="Multiply PUs" value="1" editable="false">
-						<number min="1" max="10"/>
-				</property>
-
-				<property name="Selectable Zero Movement Units" value="false" editable="false">
-						<boolean/>
-				</property>
-				<!-- END OF TYPICAL OPTIONAL PROPERTIES -->
-
-				<!-- rules and tech -->
-						<!-- ww2v2 rules override many individual rules to create revised rules
-				<property name="WW2V2" value="false" editable="false">
-						<boolean/>
-				</property> -->
-
-				<property name="WW2V3" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="WW2V3 Tech Model" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Selectable Tech Roll" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Use Shipyards turns on the shipyards tech's old way of doing things, which requires that all nations use the same production frontiers. A new way of doing shipywards will require triggers and is currently being coded -->
-				<property name="Use Shipyards" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Scramble Rules In Effect" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scrambled Units Return To Base" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scramble To Sea Only" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scramble From Island Only" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scramble To Any Amphibious Assault" value="true" editable="true">
-						<boolean/>
-				</property>
-				
-				<property name="Airborne Attacks Only In Existing Battles" value="true" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="Airborne Attacks Only In Enemy Territories" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- if true we will not use the "classic" rule of getting a single rocket attack for the whole round, and instead get a rocket attack for each rocket we have -->
-				<property name="All Rockets Attack" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- if true allows infinite attacks against a factory by many rockets, if false,will only allow a max of 1 rocket to attack each factory -->
-				<property name="Rocket Attacks Per Factory Infinite" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Rockets Can Fly Over Impassables" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Pacific Theater does 4 things: allows nations to gain VictoryPoints by capturing PUs, allows Strategic Bombing to destroy VPs,
-								allows NoPU purchases (ww2v3 does also), and allows an additional purchase in NOPU purchases if you control the Burma Road
-				<property name="Pacific Theater" value="false" editable="false">
-						<boolean/>
-				</property>-->
-
-				<!-- These require an associated value in the attachments section above-->
-				<property name="Movement By Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Production Per X Territories Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- only territories with a production value of 1 or more may count towards the production per x territories -->
-				<property name="Production Per Valued Territory Restricted" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement Per Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Place in Any Territory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unplaced units live when not placed" value ="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- allows a player to give units to another player if true. units must have canBeGivenByTerritory and territories must have changeUnitOwners and the players must have the player attachment giveUnitControl -->
-				<property name="Give Units By Territory" value ="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- allows a player to let its units be captured by another player if true, when the territory is captured. units must have canBeCapturedOnEnteringBy and territories must have captureUnitOnEnteringBy and the players must have the player attachment captureUnitOnEnteringBy -->
-				<property name="Capture Units On Entering Territory" value ="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- if "Capture Units On Entering Territory" is true, then the units can either be captured (default) or destroyed (only if this property below is true: "On Entering Units Destroyed Instead Of Captured") -->
-				<property name="On Entering Units Destroyed Instead Of Captured" value ="false" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- specific rules -->
-				<!-- land related -->
-						<!-- if true, units with destroyedWhenCapturedBy will be destroyed instead of captured. only applies to non-combat units, since combat units die in combat -->
-				<property name="Units Can Be Destroyed Instead Of Captured" value ="true" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- allows units to change into other units using the whenCapturedChangesInto ability -->
-				<property name="Units Can Be Changed On Capture" value ="true" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- if true you may have a number of constructions up to the value of the territory, in territories with factories -->
-				<property name="More Constructions with Factory" value="false" editable="true">
-						<boolean/>
-				</property>
-				
-						<!-- if true you may have a number of constructions up to the value of the territory, in territories without factories -->
-				<property name="More Constructions without Factory" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Unlimited Constructions" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Blitz Through Factories And AA Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- will roll dice for each type of aircraft separately -->
-				<property name="Roll AA Individually" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- random aa casualties lets the engine choose casualties randomly, and allows you to lose 2 bombers if you attack with 2 bombers and some fighters. I do not recommend using this property
-				<property name="Random AA Casualties" value="false" editable="false">
-						<boolean/>
-				</property>-->
-
-				<property name="Choose AA Casualties" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- will only roll aa if aaGun is in the territory getting attacked or bombed -->
-				<property name="AA Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- will cause the isAAforFlyOverOnly to shoot for the last step in a movement, instead of just everything but the end. -->
-				<property name="Force AA Attacks For Last Step Of Fly Over" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Multiple AA Per Territory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- if false, (all property default to false), then units killed by suicide units can return fire.  if true, they can not return fire -->
-				<property name="Suicide and Munition Casualties Restricted" value="false" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- if suicide units act like normal units on defense, except that they can not die to attacks by other suicide units -->
-				<property name="Defending Suicide and Munition Units Do Not Fire" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Units May Give Bonus Movement allows units with givesMovement to give other units bonus movement-->
-				<property name="Units May Give Bonus Movement" value="true" editable="true">
-						<boolean/>
-				</property>
-				
-				<!-- sea related -->
-				<property name="Partial Amphibious Retreat" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- a subset of partial amphibious retreat, allows attacker to withdraw planes -->
-				<property name="Attacker Retreat Planes" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Shore Bombard Per Ground Unit Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Naval Bombard Casualties Return Fire" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- required for all maps, ensures allied aircraft on carriers that are attacking don't attack also -->
-				<property name="Allied Air Dependents" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Surviving Air Move To Land" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Air Attack Sub Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- transports may not unload to multiple territories -->
-				<property name="Transport Restricted Unload" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Ignore Transport In Movement" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Transport Casualties Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unescorted Transport Dies" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- If enabled, transports can capture convoy zones. -->
-				<property name="Transport Control Sea Zone" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- Submarines stop transports from doing amphibious assault unless there is at least 1 owned warship in the sea zone -->
-				<property name="Submarines Prevent Unescorted Amphibious Assaults" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Ignore Sub In Movement" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Defending Subs Sneak Attack" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Sub Retreat Before Battle" value="true" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- Submarines Defending May Submerge Or Retreat will allow defending submarines to retreat to friendly sea zones or submerge -->
-				<property name="Submarines Defending May Submerge Or Retreat" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Submersible Subs" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Sub Control Sea Zone Restricted should be FALSE if there are any convoy zones! If true, subs will not be able to capture convoy zones. -->
-				<property name="Sub Control Sea Zone Restricted" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Subs Can End NonCombat Move With Enemies allows submarines to end their noncombat movement in a sea zone containing any enemy units, including enemy subs -->
-				<property name="Subs Can End NonCombat Move With Enemies" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- if true, naval units may not move into convoy zones or controlled sea zones during non-combat moves -->
-				<property name="Naval Units May Not NonCombat Move Into Controlled Sea Zones" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Only affects units exactly called "battleship" -->
-				<property name="Two hit battleship" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- If false, blockades will deal set amount of damage per unit. If true, a 6 sided die will be rolled for each damage point, with that being the damage, except rolls higher than 3 will be ignored -->
-				<property name="Convoy Blockades Roll Dice For Cost" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- production related -->
-				<property name="Produce fighters on carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Produce new fighters on old carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Move existing fighters to new carriers" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Land existing fighters on new carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- LHTR Carrier rules enable 'Produce fighters on carriers', and 'Produce new fighters on old carriers', and 'Land existing fighters on new carriers', AND it will disable 'Move existing fighters to new carriers' -->
-				<property name="LHTR Carrier production rules" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement In Enemy Seas" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- used to add destroyers and artillery to the ww2v1 map
-				<property name="Use Destroyers and Artillery" value="false" editable="false">
-						<boolean/>
-				</property>-->
-
-						<!-- may only bomb or rocket a factory to a max of its territory value per turn (the individual two parts are below) -->
-				<property name="Territory Turn Limit" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Limit SBR Damage Per Turn" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Limit Rocket Damage Per Turn" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="maxFactoriesPerTerritory" value="1" editable="false">
-						<number min="1" max="100"/>
-				</property>
-
-						<!-- Placement Restricted By Factory warns the player whenever they try to produce more units than their factories can handle (can be turned off for individual players using rules attachments for unlimitedProduction -->
-				<property name="Placement Restricted By Factory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Unit Placement Restrictions are restrictions on the placement of units: unitPlacementRestrictions, unitPlacementOnlyAllowedIn, canOnlyBePlacedInTerritoryValuedAtX, requiresUnits, -->
-				<property name="Unit Placement Restrictions" value="true" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- Allows Strategic Bombing Raids to have Escort aircraft and also be Intercepted by the defender -->
-				<property name="Raids May Be Preceeded By Air Battles" value="true" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- Damage From Bombing Done To Units Instead Of Territories has Strategic Bombing and Rockets do damage to a territory rather than directly to the player's PUs (the bank) -->
-				<property name="Damage From Bombing Done To Units Instead Of Territories" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Damage From Bombing Done To Units Instead Of Territories has Strategic Bombing and Rockets do damage to a specific unit rather than directly to the player's PUs or to a territory.  You must have "Damage From Bombing Done To Units Instead Of Territories" false for this to work -->
-				<property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- Allows all units that cause strategic bombing raid or rocket damage, to use "bombingMaxDieSides" and "bombingBonus" -->
-				<property name="Use Bombing Max Dice Sides And Bonus" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- similar to TTL, except that it is per rocket/aircraft instead of per turn -->
-				<property name="Limit SBR Damage To Factory Production" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- allows the loss of a victory point for every 10 sbr damage per turn
-				<property name="SBR Victory Points" value="false" editable="false">
-						<boolean/>
-				</property>-->
-
-				<!-- Neutrals related -->
-						<!-- amount of money subtracted to attack a neutral territory, (set neutrals charge to zero if you plan on attacking neutrals) -->
-				<property name="neutralCharge" value="9999999" editable="false">
-						<number min="0" max="9999999"/>
-				</property>
-
-				<property name="Neutrals Are Impassable" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Neutrals Are Blitzable" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Neutral Flyover Allowed" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-				<!-- AI related -->
-				<property name="AI Bonus Income Flat Rate" value="0" editable="true">
-						<number min="-10" max="30"/>
-				</property>
-				
-				<property name="AI Bonus Income Percentage" value="20" editable="true">
-						<number min="-30" max="120"/>
-				</property>
-				
-				<property name="AI Bonus Attack" value="0" editable="true">
-						<number min="0" max="2"/>
-				</property>
-				
-				<property name="AI Bonus Defense" value="0" editable="true">
-						<number min="0" max="2"/>
-				</property>
-
-				<!-- Map Name: also used for map utils when asked (MUST exactly match the folder or zip name of your map (do not include the .zip of course). May point to another map folder if you are making a mod of that map) -->
-				<property name="mapName" value="Pact of Steel 2 Test" editable="false">
-						<string/>
-				</property>
-
-				<!-- notes appear in the notes menu in the main screen, format as html -->
-				<property name="notes">
-						<string/>
-						<value>
-						<![CDATA[
-							
-							<h2>Pact of Steel 2</h2>
-							<br>A mod of POS by Veqryn
-							<br>
-							<br>The purpose of this map is to provide a fun map that shows off all the newest features TripleA has to offer.
-							<br>
-							<br>This map uses the ww2v3 + LHTR rules as a base, expanding it with various upgrades like triggered bonuses, air scrambling, etc.
-							<br>
-							<br>
-							<br><b>New things:</b>
-							<br>1. Sea Zones 3 and 4, are Russian Convoy Centers. If Russia controls it, they get the income from it. If someone else controls it, that player gets no income from it, but they deny the income to Russia. It can not be captured during non-combat phase.
-							<br>2. Sea Zones 5 and 6, are Convoy Routes. They are linked to the land territory of Norway. At least one Convoy Zone must be controlled by the same power that controls the land territory for that power to gain the income from the land territory. 
-									They can not be captured during non-combat phase. If more than 1 route is linked to a single land territory, only 1 route needs to be controlled to get the income from land territory. Routes can have PU values just like convoy centers.
-							<br>3. Sea Zones 37, 47, 48, 49, 58, are Blockade Zones. Each enemy warship in these zones reduces the income of touching land territories by 1 per warship, 2 per normal submarine.
-							<br>4. Air_Transport is an air unit that specializes in dropping off units, has 4 movement, and can carry into battle or drop off in a friendly territory any 2-3 units. Enabled when you get "paratroopers" tech.
-							<br>5. Super_Carrier is a beefed up carrier that can also transport 1 infantry and 1 other land unit like a tank or artillery. It has only 1 hitpoint, just like normal carriers and cruisers.
-							<br>6. Midget_Submarine is a Japanese only unit with 3 attack, 2 defence, and 2 movement (costs 4). If it attacks or defends it will die after shooting (it is a suicide unit). Japan can purchase them after certain conditions are met, and they don't receive bonus movement from harbours.
-							<br>7. Kamikaze Fighters are what Japanese fighters turn into if certain conditions are met.  They have 5 attack, 3 defense, and 3 movement (cost 8), and they are allowed to use up all their movement to go to a battle, 
-										do not require a landing zone for movement, and they will die after rolling their dice.
-							<br>8. Airfield gives +1 movement to air units, and allows fighters to scramble to defend surrounding sea zones if you turn on "Scramble Rules In Effect". Can receive up to 6 damage, and stops working when having more than 2 damage.
-							<br>9. Harbour gives +1 movement to warships, and are needed to repair Battleships if you turn on "Two HitPoint Units Require Repair Facilities". Can receive up to 6 damage, and stops working when having more than 2 damage.
-							<br>10. Bunkers are defensive units that can also be bombed/rocketted, will not participate in battle if damaged, and will die if they reach 4 damage.  
-										They may be placed in any territory you owned at the beginning of the turn (just like Factories, Airfields, and Harbours) where you also have a land unit, but there is a limit of 1 per territory.
-							<br>11. New Technologies: reinforcedHulls (gives +2 defense to subs), and wolfPackTactics (gives +1 att). Available to Germans after they get superSubs.
-							<br>12. Each nation may only purchase factories up to 3 total, if a nation controls more than 3 they can not purchase new factories (they can keep capturing new ones though).
-							<br>13. Politics phase: alliances and states of war are now dynamic and can be changed in game.  Japan and Russia start out in a state of Neutrality towards each other, while Russia, America and the UK also start out as neutral towards each other.  
-										Japan and Russia will go to war on the 5th turn if they are still neutral by then.  Italy and Russia have the option of declaring a 2 round ceasefire.
-							<br>14. Strategic Bombing Raids can now have an Air battle preceeding the raid. Fighters escorting the bombers, and any defending interceptors fire at 2, while the bombers fire at 1.  The battle only lasts 1 round.
-							<br>15. Long Range Aircraft tech now only increases movement by 1.
-							<br>
-							<br>
-							<br>
-							<b>National Objectives</b><br>
-							<i>Germany: Lebensraum-</i><br>
-							+4 PUs if Axis control 7 out of 9 of
-								East Balkans, Eastern Europe, Ukraine S.S.R., Belorussia, West Russia, Norway, Karelia S.S.R., Archangel, Caucus<br>
-							+4 PUs if Axis control Western Europe, AND there are NO enemy surface ships in 3 out of 3 of sea zones 5, 6, and 7<br>
-							* Germany gains Super Subs if at the end of their 4th or 5th turn, there are NO enemy surface ships in 3 out of 3 of
-								sea zones 5, 6, and 7<br>
-							* Germany gains Mechanized Infantry if at the end of their 3rd or 4th turn, the Axis control 6 out of 7 of
-								East Balkans, Eastern Europe, Ukraine S.S.R., Belorussia, Karelia S.S.R., Archangel, Caucus<br>
-							* Germany gains Rockets if at the end of their 3rd or 4th turn, the Axis do NOT control Western Europe, but DO control Norway<br>
-							* Germany has access to additional submarine technology if they get superSubs, and getting superSubs also gives access to reinforcedHulls to Italians (in place of Shipyards)<br>
-							<br>
-							<i>Japan: The Greater East Asia Co-Prosperity Sphere-</i><br>
-							+4 PUs if Axis control 7 out of 7 of India, French Indochina, Kwangtung, Manchuria, China, Central China, Sinkiang<br>
-							+4 PUs if Axis control 10 out of 13 of Alaska, East Indies, Borneo, Philipine Islands, New Guinea, Solomon Islands,
-								Caroline Islands, Australia, New Zealand, Okinawa, Wake Island, Hawaiian Islands, Midway<br>
-							* Japan's destroyers gain the ability to transport a single infantry If on the 3rd or 4th turn, the Axis do NOT control ANY of
-								Sinkiang, India, Burytia S.S.R.<br>
-							* Japan's transports gain an additional capacity of 1 (allowing 3 infantry or 2 tanks/artillery per transport) If at the end of their 3rd, 4th, or 5th turns,
-								Japan controls 3 out of 3 of Australia, India, Sinkiang<br>
-							* Japan gains, only once, a single additional midget_submarine in sz61 If it loses control over any of its original territories<br>
-							* Japan gains the ability to produce midget_submarines If it loses control over 2 of its islands: Okinawa, Philipine Islands, East Indies, Borneo, New Guinea, Solomon Islands, Caroline Islands, Wake Island<br>
-							* Japan gains the ability to produce kamikaze fighters, and all their current fighters turn into kamikaze fighters 
-								If it loses control over 2 of its islands, one of which being Philipine Islands (note that this objective may or may not be wanted, depending on the situation)<br>
-							<br>
-							<i>Italy: Mare Nostrum-</i><br>
-							+4 PUs if Axis control 8 out of 11 of
-								Western Europe, Sardinia, Sicily, West Balkans, Greece, Algeria, Libya, Anglo Egypt, Trans-Jordan, Italian East Africa, Gibraltar
-								AND no enemy surface ships in sea zones 13, 14, 15, and 15B<br>
-							* Italy gains, only once, a free purchase of a cruiser If at the beginning of their 3rd or 4th turn the Axis control 4 out of 4 of
-								Algeria, Libya, Anglo Egypt, Trans-Jordan<br>
-							<br>
-							<i>United States: The Arsenal of Democracy-</i><br>
-							+2-10 PUs, starting on turn 2 America will begin making +2 income as America's war-time economy ramps up. This will increase by +2 more every 2 turns, so that turn 4 will begin making +4, turn 6 will make +6, and so on until +10 is reached<br>
-							+4 PUs if Allies control 3 out of 8 of Western Europe, Sardinia, Sicily, Italy, Greece, West Balkans, Algeria, Libya
-								AND no enemy surface ships in sea zones 1, 2, 7, 8, 9, 10, 11, 12, 13, and 14<br>
-							+4 PUs if Allies controls 6 out of 13 of Alaska, East Indies, Borneo, Philipine Islands, New Guinea, Solomon Islands, Caroline Islands,
-								Australia, New Zealand, Okinawa, Wake Island, Hawaiian Islands, Midway<br>
-							+4 PUs if Japan has no Battleships OR no Carriers at the end of USA's turn<br>
-							* USA gains Paratroopers if at the end of Germany's 3rd, 4th or 5th turns, the Allies control Western Europe<br>
-							* USA gains Improved Shipyards if at the end of their 3rd, 4th or 5th turns, USA controls 4 out of 4 of
-								Alaska, Wake Island, Hawaiian Islands, Midway<br>
-							* USA gains War Bonds if at any time before the end of the 8th turn, the above 2 conditions are met at the end of Germany's turn<br>
-							* USA's fighter's gain the ability to support infantry, stackable with artillery, IF at any time the USA has 2 out of 2 of War Bonds and Jet Power technologies<br>
-							* USA can give land units to Russia by landing them in Archangel<br>
-							<br>
-							<i>United Kingdom: The British Empire-</i><br>
-							+4 PUs if the UK controls 1 out of 6 of East Indies, Borneo, New Guinea, Solomon Islands, Caroline Islands, Okinawa<br>
-							+4 PUs if Allies control 9 out of 11 of Gibraltar, Algeria, Libya, Anglo Egypt, Trans-Jordan, Persia, French West Africa,
-								French Equatorial Africa, Italian East Africa, Belgian Congo, Kenya<br>
-							+4 PUs if Allies control 3 out of 3 of Union of South Africa, India, Australia<br>
-							* UK gains Paratroopers if at the end of Germany's 3rd, 4th or 5th turns, the Allies control Western Europe<br>
-							* UK gains AA Radar if at the end their 3rd or 4th turn, the Allies control 4 out of 5 of
-								Union of South Africa, Gibraltar, Anglo Egypt, India, Australia<br>
-							<br>
-							<i>Soviet Union: The Great Patriotic War-</i><br>
-							+4 PUs if Soviets control 3 out of 5 of Norway, Eastern Europe, East Balkans, Ukraine S.S.R., Belorussia<br>
-							+4 PUs if Soviets control Archangel and no allied forces in Soviet controlled land territories<br>
-							+2 PUs AND +2 Tech Token, only once, if Soviets control Norway or East Balkans<br>
-							* Soviet's artillery gain the ability to support 2 infantry on attack If at the end of their 3rd or 4th turn, the Soviets control
-								Karelia S.S.R. and Caucus (this effect can be doubled to 4 infantry supported if Russia gets Improved Artillery technology)<br>
-							* Soviets gain, only once, an additional 3 infantry in Yakut S.S.R. if at the beginning of their turn, Japan controls any original Russian territory<br>
-							* Soviets gain control of any American land units that are in Archangel at the end of America's turn<br>
-							* Soviets have double chance of getting Improved Artillery when rolling for tech<br>
-							* Soviets destroy their industrial production (PUs) instead of letting it be captured, when they lose their capital<br>
-							* Soviets destroy their AA Guns instead of letting them be captured<br>
-							<br>
-							<i>China: Chinese Resistance & The Flying Tigers </i><br>
-							+1 infantry for every two territories controlled by China at the end of her turn, rounded up. May only place a max of 2 units per territory per turn. 
-								All units must be place in a territory with less than 4 Chinese units<br>
-							+4 PUs and the ability to produce extra units, if Allies control Sinkiang, Central China, India.
-								May use this money to produce a limited selection of units. May purchase tanks and fighters if these territories are controlled.<br>
-							* China gains 1 infantry in Sinkiang if at the beginning of their turn, there are no enemy units in 3 out of 6 of
-								Sinkiang, Central China, China, Manchuria, Kwangtung, French Indochina. This unit is given at the beginning of combat move step, and can not be moved until next turn.<br>
-							* No Chinese Units, including the Chinese Fighter may leave Chinese territory: Sinkiang, Central China, China, Manchuria, Kwangtung, French Indochina
-								(this means no entering sea zones), unless the Japanese capital has fallen once<br>
-							* Chinese destroy any non-combat units they would otherwise capture (factories, aa guns, harbours, airfields)<br>
-							<br>
-							<br>
-							<b>Technology</b><br>
-							*** Air/Naval Tech ***<br>
-							SUPER SUBS- submarine units get +1 attack<br>
-							JET POWER- fighters and air transports get +1 attack<br>
-							IMPROVED SHIPYARDS- naval units are cheaper<br>
-							AA RADAR- AA hit on 2 or less<br>
-							LONG RANGE AIRCRAFT- aircraft range increased by 1<br>
-							HEAVY BOMBER- roll 2 dice for each bomber attack (if LHTR enabled: rolls 2 dice and selects the best one, StratBombing adds one to result)<br>
-							<br>
-							*** Land/Production Tech ***<br>
-							IMPROVED ARTILLERY SUPPORT- artillery support 2 infantry (double the support given)<br>
-							ROCKETS- AA conduct rocket attacks for 1d6 damage to production (each factory may only be targetted once per turn by one rocket, and only 1 rocket in each territory may fire)<br>
-							PARATROOPERS- each bomber may carry 1 infantry into combat (must stop in first enemy territory it reaches)<br>
-							INCREASED FACTORY PRODUCTION- factories produce 2 additional units (if territory value is 3 or greater), repairs 1/2 price<br>
-							WAR BONDS- collect an 1d6 extra PUs each turn<br>
-							MECHANIZED INFANTRY- tanks may carry 1 infantry each for 2 spaces<br>
-							<br>
-							*** Submarine Technology ***<br>
-							REINFORCED HULLS- submarines get +2 defense (only shows up in battles)<br>
-							WOLF PACK TACTICS- submarines get +1 attack and +1 defense (only shows up in battles)<br>
-							<br>
-							<br>Each nation has at least one technology that they can not research. This is shown by a "-" in the research tab. 
-								The Germans can't research War Bonds, Japanese can't get Shipyards, Russians can't get Paratroopers, 
-								British can't get Mechanized Inf, Americans can't get Rockets, and Italians can't get about half of the techs.
-								Also, UK, Russia, and Italy get Destroyers Bombard instead of Super Subs.
-							<br>
-							<br>
-							<b>Victory Conditions</b><br>
-							Total Victory - 15 Victory Cities<br>
-							Projection of Power - 11 Victory Cities<br>
-							Axis can achieve a Triggered Victory by controlling all 4 of Germany, Japan, United Kingdom, and Russia.<br>
-							Allies can achieve a Triggered Victory by controlling all 4 of United Kingdom, Eastern United States, Germany, and Japan.<br>
-							<br>
-							<br>
-							<br>
-							<br><b>Major Differences Between ww2v2 revised and ww2v3</b>
-							<br>1.  In ww2v2 transport units are just like any other unit, and can be used as fodder by being taken casualty first in combat, however in ww2v3 style rules, transports have no defense power and may only be taken casualty after all other non-transport ships are dead.
-							<br>2.  In ww2v2, you can build fighters on carriers if you build both at the same time, and if you build a carrier you can move existing fighters to carriers when you build a carrier in the adjacent sea zone. In ww2v3, you can build new fighters onto existing
-									carriers as well as new carriers, but you may not move existing fighters onto new carriers, as instead you can non-combat move the fighters to where the carrier will be built, then place the carrier under it.
-							<br>3.  In ww2v2, when you strategic bomb or rocket a factory, you immediately reduce the enemy's PUs. In ww2v3, you do damage to the factory, up to twice the value of the territory. 
-									Each point of damage reduces the number of units that can be produced there by 1. The player may repair the damage during their purchase phase.
-							<br>4.  In ww2v2, when you fly over a territory with an AA Gun, the gun gets to fire at each aircraft. In ww2v3, the AA Gun only fires when you attack or bomb the territory it is in.
-							<br>5.  In ww2v2, submarines and transports block the movement of other sea units. In ww2v3, submarines and transports do not block the movement of other sea units, and may be bypassed or attacked.
-							<br>6.  In ww2v2, technology is rolled for, and if you miss nothing happens. In ww2v3, you buy tech tokens, and at the beginning of your turn you roll for each of your tokens. If you roll a 6, you discard all tokens and roll a second time to see which technology you get.
-							<br>7.  In ww2v2, no land units may retreat from an amphibious assault. In ww2v3, the non-amphibious units may retreat.
-							<br>8.  In ww2v2, bombardment immediately kills units, and you are allowed infinite bombardments. In ww2v3, a unit hit by bombard may return fire against the attacking units before dying, and the number of bombards is limited to the number of land units being dropped off from that sea zone.
-							<br>9.  In ww2v2, air units can hit submarines. In ww2v3, an owned destroyer must be present for air units to hit submarines.
-							<br>10. In ww2v2, submarines may choose to submerge at the end of each round of combat. In ww2v3, they may choose to submerge before each round of combat (and consequently, you can't kill them without a destroyer).
-							<br>11. In ww2v2, submarines fire at the beginning of combat, and if there is no enemy destroyer then any casualties are removed immediately. In ww2v3, submarines get their surprise strike both on offense and defense, and both can be nullified by the presence of an enemy destroyer
-									(so in ww2v3, if attacking an enemy sub, the attacker with a sub + destroyer, who's sub hits, would immediately kill the defending sub with no chance for it to return fire).
-							<br>
-							<br>
-							<br><b>Differences for LHTR rules</b>
-							<br>1. Technology is activated during the Place-Units phase (at the end of the turn rather then the beginning).
-							<br>2. Heavy Bombers roll 2 dice, selecting best one. If strategic bombing, select best of two dice, then add '1' to the result.
-							<br>3. Super Subs get a bonus of '1' to defense in addition to the bonus of '1' to attack.
-							<br>4. LHTR uses same fighter-carrier rules, and aaGun rules, as ww2v3.
-							<br>
-							<br>
-							<br><b>Generic How-To-Play</b>
-							<br>The game is made up of rounds, during a round each player gets to do a number of steps/phases.
-							<br>The phases are, in order: Research Technology, Repair Factories and Purchase Units, Combat Movement, Resolve Battles, Non-Combat Movement, Place Units.
-							<br>At the beginning of your turn, you purchase units. At the end of the turn, you get to place those units in territories you own that have a factory.
-							<br>During Combat Movment, you move any units to attack enemy units and territories. During Non-Combat Movement, you may move any units that have movement left (attacking an enemy remove any movement of land and sea units, but not air units).
-							<br>Battles happen by use of dice. A unit has a certain attack power, and you roll a dice for each unit. If your dice is equal or less than the attack power of the unit, you have scored a hit.
-								So for example, a tank attacks on 3. For it, you will roll a single die, and if you score 1-3 on the die you have hit the enemy, while if you score 4-6 you have missed the enemy. An infantry defends on 2, so a roll of 1-2 is a hit, while 3-6 are misses.
-							<br>After the attacker has rolled dice for each of his units, the defender tallies the total number of 'hits' and then selects which of his defending units will die later. After this, the defender rolls for his units and the attacker selects which of his units will die.
-								When both have finished rolling, the units selected to die are removed from the game. If there are no more attackers left, then the defender has won, and if there are no more defenders left, then the attacker has won and he moves his remaining attacking units into that territory.
-								If both players have units left still, the attack may choose to play another round of battle, or retreat all his remaining forces to a territory where at least one of his forces came from.
-							<br>Players must work with their allies to destroy the enemies, with the game ending when one side surrenders or certain conditions are met (like having captured a clear majority of the major cities).
-							<br>
-							<br>
-							<br>Credits for original POS:
-							<br>Triplelk, DMA02, Iron Cross, Aibrahim, SGB, KC1189, Zero Pilot, Tactics, Underdog
-							<br>A mod by Veqryn
-							<br>Many of the new properties and options were coded by Veqryn.
-							<br>A personal thank you to Squid Daddy and ComradeKev for coding some of the new features that this map shows off
-							<br>Relief Tiles by Conarymor.
-							<br>Only actual unit changes: some destroyers turned into cruisers, and a German destroyer added to sz5, German sub in sz8 moved to sz7.
-							<br>The AIs are meant to be bad at this map, please don't tell me the AIs are bad at this map.
-						]]>
-						</value>
-				</property>
-		</propertyList>
+        <!-- Custom (Generic) Techs that name a hard coded tech (ie: we are changing the name of a hardcoded tech) may NOT have a tech ability attachment.  If you want a tech ability attachment for your tech, either use a custom (generic) tech, or do not rename a hard coded tech. -->
+        <!-- the following options are allowed for "techAbilityAttachment"
+                attackBonus                                 value:    gives some amount of attack to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
+                defenseBonus                                value:    gives some amount of defense to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
+                movementBonus                               value:    gives some amount of movement to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
+                radarBonus                                  value:    gives some amount of radar aa attack to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
+                airAttackBonus                              value:    gives some amount of air escort attack to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
+                airDefenseBonus                             value:    gives some amount of air interceptor defense to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
+                productionBonus                             value:    gives some amount of production to these units.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
+                minimumTerritoryValueForProductionBonus     value:    sets the minimum value of a territory that a factory units must be in to receive the production bonus.  must be an integer (default -1) between -1 and 10000.  If multiple techs, the lowest is chosen.
+                repairDiscount                              value:    sets the discount to repairing.  must be an integer (default -1) between 0 and 100.  Effects from multiple techs are added together.
+                warBondDiceSides                            value:    sets how large the dice are which are rolled to determine the war bonds bonus.  must be an integer (default -1) between 0 and 200. Effects from multiple techs are added together.
+                warBondDiceNumber                           value:    sets how many dice get rolled for war bonds.  must be an integer (default 0) between 0 and 100.  Effects from multiple techs are added together.
+                rocketDiceNumber                            value:    sets the number of rocket rolls for each rocket.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
+                rocketDistance                              value:    sets the maximum distance rockets travel for the map.  must be an integer (default 0) between 0 and 100.  Effects from multiple techs are added together.
+                rocketNumberPerTerritory                    value:    sets the maximum number of rocket rolls per territory.  must be an integer (default 0) between 0 and 200.  Effects from multiple techs are added together.
+                unitAbilitiesGained                         value:    allows unit types to gain abilities through this tech.  must be the name of the unit, followed by a colon ":", followed by all the abilities gained (separated by colons).  currently allows only "canBlitz" and "canBombard".  Effects from multiple techs are added together.
+                airborneForces                              value:    "true" or "false", does this tech allow the owner to start making airborne movements?  At least 1 tech must have this as true, for it to be turned on.
+                airborneCapacity                            value:    gives some amount of capacity to an airborne base, for the number of units that can be launched from there.  must be an integer, followed by a colon ":", followed by the name of the unit.  Effects from multiple techs are added together.
+                airborneTypes                               value:    sets which units are airborne type units, therefore which units get to move.  must be a list of unit types, separated by a colon ":". Effects from multiple techs are added together.
+                airborneDistance                            value:    sets the maximum distance for moving any airborne type unit. must be an integer (default 0) between 0 and 100.  Effects from multiple techs are added together.
+                airborneBases                               value:    sets which units are airborne base units, therefore which units are required at the start territory.  must be a list of unit types, separated by a colon ":". Effects from multiple techs are added together.
+                airborneTargettedByAA                       value:    sets which airborne units are subject to AA gun fire, and by what aa types. First is the "targetsAA" that can hit these units, and next is a list of units hit by it. Effects from multiple techs are added together.
+                attackRollsBonus                            value:    sets how many extra rolls this unit gets on attack. Effects from multiple techs are added together.
+                defenseRollsBonus                           value:    sets how many extra rolls this unit gets on defense. Effects from multiple techs are added together.
+                bombingBonus                                value:    gives an extra amount of damage to strategic bombing raids, after all dice have been rolled, per unit (not per die). Effects from multiple techs are added together.
+
+
+        -->
+                <attachment name="techAbilityAttachment" attachTo="longRangeAir" javaClass="games.strategy.triplea.attachments.TechAbilityAttachment" type="technology">
+                        <option name="movementBonus" value="1:fighter"/>
+                        <option name="movementBonus" value="1:jp_fighter"/>
+                        <option name="movementBonus" value="1:bomber"/>
+                        <option name="movementBonus" value="1:air_transport"/>
+                </attachment>
+
+        </attachmentList>
+
+
+        <initialize>
+                <ownerInitialize>
+                        <!-- Italian Owned Territories -->
+                        <territoryOwner territory="Libya" owner="Italians"/>
+                        <territoryOwner territory="Italy" owner="Italians"/>
+                        <territoryOwner territory="West Balkans" owner="Italians"/>
+                        <territoryOwner territory="Greece" owner="Italians"/>
+                        <territoryOwner territory="Sicily" owner="Italians"/>
+                        <territoryOwner territory="Sardinia" owner="Italians"/>
+
+                        <!-- German Owned Territories -->
+                        <territoryOwner territory="Algeria" owner="Germans"/>
+                        <territoryOwner territory="Western Europe" owner="Germans"/>
+                        <territoryOwner territory="Germany" owner="Germans"/>
+                        <territoryOwner territory="Norway" owner="Germans"/>
+                        <territoryOwner territory="East Balkans" owner="Germans"/>
+                        <territoryOwner territory="Ukraine S.S.R." owner="Germans"/>
+                        <territoryOwner territory="Eastern Europe" owner="Germans"/>
+                        <territoryOwner territory="Belorussia" owner="Germans"/>
+                        <territoryOwner territory="West Russia" owner="Germans"/>
+
+                        <territoryOwner territory="5 Sea Zone" owner="Germans"/>
+                        <territoryOwner territory="6 Sea Zone" owner="Germans"/>
+
+                        <!-- Russian Owned Territories -->
+                        <territoryOwner territory="Karelia S.S.R." owner="Russians"/>
+                        <territoryOwner territory="Archangel" owner="Russians"/>
+                        <territoryOwner territory="Russia" owner="Russians"/>
+                        <territoryOwner territory="Caucus" owner="Russians"/>
+                        <territoryOwner territory="Kazakh S.S.R." owner="Russians"/>
+                        <territoryOwner territory="Novisibirsk" owner="Russians"/>
+                        <territoryOwner territory="Evanki National Okrug" owner="Russians"/>
+                        <territoryOwner territory="Yakut S.S.R." owner="Russians"/>
+                        <territoryOwner territory="Soviet Far East" owner="Russians"/>
+                        <territoryOwner territory="Burytia S.S.R." owner="Russians"/>
+
+                        <territoryOwner territory="3 Sea Zone" owner="Germans"/>
+                        <territoryOwner territory="4 Sea Zone" owner="Russians"/>
+
+                        <!-- British Owned Territories -->
+                        <territoryOwner territory="United Kingdom" owner="British"/>
+                        <territoryOwner territory="Western Canada" owner="British"/>
+                        <territoryOwner territory="Eastern Canada" owner="British"/>
+                        <territoryOwner territory="French West Africa" owner="British"/>
+                        <territoryOwner territory="French Equatorial Africa" owner="British"/>
+                        <territoryOwner territory="Anglo Egypt" owner="British"/>
+                        <territoryOwner territory="Italian East Africa" owner="British"/>
+                        <territoryOwner territory="Belgian Congo" owner="British"/>
+                        <territoryOwner territory="Kenya" owner="British"/>
+                        <territoryOwner territory="Union of South Africa" owner="British"/>
+                        <territoryOwner territory="French Madagascar" owner="British"/>
+                        <territoryOwner territory="Trans-Jordan" owner="British"/>
+                        <territoryOwner territory="Persia" owner="British"/>
+                        <territoryOwner territory="India" owner="British"/>
+                        <territoryOwner territory="Australia" owner="British"/>
+                        <territoryOwner territory="New Zealand" owner="British"/>
+                        <territoryOwner territory="Gibraltar" owner="British"/>
+
+                        <!-- Japanese Owned Territories -->
+                        <territoryOwner territory="Japan" owner="Japanese"/>
+                        <territoryOwner territory="Kwangtung" owner="Japanese"/>
+                        <territoryOwner territory="French Indochina" owner="Japanese"/>
+                        <territoryOwner territory="Manchuria" owner="Japanese"/>
+                        <territoryOwner territory="East Indies" owner="Japanese"/>
+                        <territoryOwner territory="Borneo" owner="Japanese"/>
+                        <territoryOwner territory="New Guinea" owner="Japanese"/>
+                        <territoryOwner territory="Philipine Islands" owner="Japanese"/>
+                        <territoryOwner territory="Caroline Islands" owner="Japanese"/>
+                        <territoryOwner territory="Solomon Islands" owner="Japanese"/>
+                        <territoryOwner territory="Okinawa" owner="Japanese"/>
+                        <territoryOwner territory="Wake Island" owner="Japanese"/>
+
+                        <!--<territoryOwner territory="37 Sea Zone" owner="Japanese"/>
+                        <territoryOwner territory="47 Sea Zone" owner="Japanese"/>
+                        <territoryOwner territory="48 Sea Zone" owner="Japanese"/>
+                        <territoryOwner territory="49 Sea Zone" owner="Japanese"/>
+                        <territoryOwner territory="58 Sea Zone" owner="Japanese"/>-->
+
+                        <!-- American Owned Territories -->
+                        <territoryOwner territory="Western United States" owner="Americans"/>
+                        <territoryOwner territory="Eastern United States" owner="Americans"/>
+                        <territoryOwner territory="Central United States" owner="Americans"/>
+                        <territoryOwner territory="Midway" owner="Americans"/>
+                        <territoryOwner territory="Hawaiian Islands" owner="Americans"/>
+                        <territoryOwner territory="Mexico" owner="Americans"/>
+                        <territoryOwner territory="Brazil" owner="Americans"/>
+                        <territoryOwner territory="Alaska" owner="Americans"/>
+                        <territoryOwner territory="West Indies" owner="Americans"/>
+                        <territoryOwner territory="Panama" owner="Americans"/>
+                        <territoryOwner territory="Greenland" owner="Americans"/>
+
+                        <!-- Chinese Owned Territories -->
+                        <territoryOwner territory="China" owner="Chinese"/>
+                        <territoryOwner territory="Central China" owner="Chinese"/>
+                        <territoryOwner territory="Sinkiang" owner="Chinese"/>
+                        <territoryOwner territory="Himilaya" owner="Chinese"/>
+                </ownerInitialize>
+
+                <unitInitialize>
+                        <!-- Russian Unit Placements -->
+                        <unitPlacement unitType="infantry" territory="Karelia S.S.R." quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="fighter" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="armour" territory="Archangel" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="artillery" territory="Archangel" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Archangel" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="factory" territory="Caucus" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Caucus" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="artillery" territory="Caucus" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Caucus" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="armour" territory="Caucus" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="factory" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Russia" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="artillery" territory="Russia" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="armour" territory="Russia" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="fighter" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Evanki National Okrug" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Novisibirsk" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Yakut S.S.R." quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Soviet Far East" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Burytia S.S.R." quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Kazakh S.S.R." quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="submarine" territory="4 Sea Zone" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="cruiser" territory="16 Sea Zone" quantity="1" owner="Russians"/>
+
+                        <!-- Italian Unit Placements -->
+                        <unitPlacement unitType="cruiser" territory="14 Sea Zone" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="transport" territory="14 Sea Zone" quantity="2" owner="Italians"/>
+                        <unitPlacement unitType="battleship" territory="14 Sea Zone" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="Libya" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="artillery" territory="Libya" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="aaGun" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="armour" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="fighter" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="factory" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="Italy" quantity="3" owner="Italians"/>
+                        <unitPlacement unitType="artillery" territory="Greece" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="West Balkans" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="Sicily" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="Sardinia" quantity="1" owner="Italians"/>
+
+                        <!-- German Unit Placements -->
+                        <unitPlacement unitType="aaGun" territory="Western Europe" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Western Europe" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Western Europe" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Western Europe" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Algeria" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Algeria" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="factory" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="aaGun" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Germany" quantity="4" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Germany" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="bomber" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Norway" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Norway" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="East Balkans" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="factory" territory="East Balkans" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="aaGun" territory="East Balkans" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="East Balkans" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="East Balkans" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Eastern Europe" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Eastern Europe" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Eastern Europe" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Eastern Europe" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Ukraine S.S.R." quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Ukraine S.S.R." quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Ukraine S.S.R." quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Ukraine S.S.R." quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Belorussia" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="West Russia" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="West Russia" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="West Russia" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="transport" territory="5 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="battleship" territory="5 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="destroyer" territory="5 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="submarine" territory="5 Sea Zone" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="submarine" territory="7 Sea Zone" quantity="1" owner="Germans"/>
+
+                        <!-- British Unit Placements -->
+                        <unitPlacement unitType="armour" territory="Eastern Canada" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="United Kingdom" quantity="4" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="armour" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="United Kingdom" quantity="2" owner="British"/>
+                        <unitPlacement unitType="bomber" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Persia" quantity="2" owner="British"/>
+                        <unitPlacement unitType="aaGun" territory="India" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="India" quantity="3" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Trans-Jordan" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Anglo Egypt" quantity="2" owner="British"/>
+                        <unitPlacement unitType="armour" territory="Anglo Egypt" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="Anglo Egypt" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Italian East Africa" quantity="1" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="Italian East Africa" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Union of South Africa" quantity="1" owner="British"/>
+                        <unitPlacement unitType="armour" territory="Union of South Africa" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Australia" quantity="3" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="New Zealand" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Western Canada" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="French Madagascar" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="1 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="1 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="1 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="battleship" territory="2 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="2 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="battleship" territory="13 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="cruiser" territory="15 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="carrier" territory="35 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="35 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="35 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="cruiser" territory="35 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="40 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="cruiser" territory="40 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="40 Sea Zone" quantity="1" owner="British"/>
+
+                        <!-- Japanese Unit Placements -->
+                        <unitPlacement unitType="jp_fighter" territory="Manchuria" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Manchuria" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Kwangtung" quantity="3" owner="Japanese"/>
+                        <unitPlacement unitType="jp_fighter" territory="French Indochina" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="French Indochina" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Solomon Islands" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="New Guinea" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Borneo" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="East Indies" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Philipine Islands" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Caroline Islands" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Okinawa" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Wake Island" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Japan" quantity="4" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="armour" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="jp_fighter" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="bomber" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="battleship" territory="37 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="jp_fighter" territory="37 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="37 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="jp_transport" territory="50 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="jp_transport" territory="60 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="battleship" territory="60 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="submarine" territory="61 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="jp_fighter" territory="50 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="cruiser" territory="50 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="50 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="submarine" territory="45 Sea Zone" quantity="1" owner="Japanese"/>
+
+                        <!-- American Unit Placements -->
+                        <unitPlacement unitType="factory" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="armour" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="aaGun" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Eastern United States" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="artillery" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="bomber" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Midway" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="aaGun" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Alaska" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="aaGun" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="factory" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Western United States" quantity="3" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Central United States" quantity="3" owner="Americans"/>
+                        <unitPlacement unitType="armour" territory="Central United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="10 Sea Zone" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="55 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="battleship" territory="55 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="55 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="56 Sea Zone" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="carrier" territory="56 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="submarine" territory="56 Sea Zone" quantity="1" owner="Americans"/>
+
+                        <!-- Chinese Unit Placements -->
+                        <unitPlacement unitType="infantry" territory="China" quantity="2" owner="Chinese"/>
+                        <unitPlacement unitType="fighter" territory="China" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="artillery" territory="Central China" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Sinkiang" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Central China" quantity="1" owner="Chinese"/>
+                </unitInitialize>
+
+                <resourceInitialize>
+                        <!-- these do not have to match the production of the game starting out, they can be any number -->
+                        <resourceGiven player="Japanese" resource="PUs" quantity="30"/>
+                        <resourceGiven player="British" resource="PUs" quantity="33"/>
+                        <resourceGiven player="Americans" resource="PUs" quantity="37"/>
+                        <resourceGiven player="Russians" resource="PUs" quantity="26"/>
+                        <resourceGiven player="Germans" resource="PUs" quantity="40"/>
+                        <resourceGiven player="Italians" resource="PUs" quantity="16"/>
+                        <resourceGiven player="Chinese" resource="PUs" quantity="0"/>
+
+                        <!-- custom resources below
+                        <resourceGiven player="Italians" resource="Steel" quantity="20"/>
+                        <resourceGiven player="Italians" resource="Aluminium" quantity="30"/>
+                        <resourceGiven player="Italians" resource="Fuel" quantity="20"/>-->
+                </resourceInitialize>
+
+                <relationshipInitialize>
+                        <!-- the order of player1 and player2 does not matter. roundValue is only used for conditions and can be positive or negative (use "1" if you don't know what you are doing).
+                                having them listed twice in different orders will just have the later one overwrite the earlier one.
+                                Make sure you cover all possibilities! (the number of possibilities is equal to the triangular number sequence: 1,3,6,10,15,21,28,36,45,55,66,78,91,105,120)
+                        -->
+
+                        <relationship type="Allied" player1="Italians" player2="Germans" roundValue="1"/>
+                        <relationship type="Allied" player1="Italians" player2="Japanese" roundValue="1"/>
+                        <relationship type="Allied" player1="Germans" player2="Japanese" roundValue="1"/>
+
+                        <relationship type="Neutrality" player1="Russians" player2="British" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Russians" player2="Americans" roundValue="1"/>
+                        <relationship type="Allied" player1="Russians" player2="Chinese" roundValue="1"/>
+                        <relationship type="Allied" player1="Americans" player2="British" roundValue="1"/>
+                        <relationship type="Allied" player1="Americans" player2="Chinese" roundValue="1"/>
+                        <relationship type="Allied" player1="British" player2="Chinese" roundValue="1"/>
+
+                        <relationship type="War" player1="British" player2="Germans" roundValue="1"/>
+                        <relationship type="War" player1="British" player2="Italians" roundValue="1"/>
+                        <relationship type="War" player1="British" player2="Japanese" roundValue="1"/>
+
+                        <relationship type="War" player1="Americans" player2="Germans" roundValue="1"/>
+                        <relationship type="War" player1="Americans" player2="Italians" roundValue="1"/>
+                        <relationship type="War" player1="Americans" player2="Japanese" roundValue="1"/>
+
+                        <relationship type="War" player1="Russians" player2="Germans" roundValue="1"/>
+                        <relationship type="War" player1="Russians" player2="Italians" roundValue="-1"/>
+                        <relationship type="Neutrality" player1="Russians" player2="Japanese" roundValue="1"/>
+                        <!--<relationship type="Neutrality" player1="Russians" player2="Germans" roundValue="1"/>
+                        <relationship type="Allied" player1="Russians" player2="Italians" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Russians" player2="Japanese" roundValue="1"/>-->
+
+                        <relationship type="War" player1="Chinese" player2="Germans" roundValue="1"/>
+                        <relationship type="War" player1="Chinese" player2="Italians" roundValue="1"/>
+                        <relationship type="War" player1="Chinese" player2="Japanese" roundValue="1"/>
+                </relationshipInitialize>
+
+        </initialize>
+
+        <propertyList>
+        <!--    From TripleA 1.5 and onward, ALL properties must be strongly TYPED.  (your map may or may not work if you do not make your properties Type-Safe)
+                Allowed values:
+                    boolean
+                    number
+                    string
+                    file
+                    list
+                    color
+
+                Examples:
+                    INSTEAD OF:
+                        <property name="mapName" value="the_pact_of_steel" editable="false"/>
+
+                    DO THIS:
+                        <property name="mapName" value="the_pact_of_steel" editable="false">
+                                <string/>
+                        </property>
+
+
+                    INSTEAD OF:
+                        <property name="maxFactoriesPerTerritory" value="1"/>
+
+                    DO THIS:
+                        <property name="maxFactoriesPerTerritory" value="1" editable="false">
+                                <number min="1" max="100"/>
+                        </property>
+
+
+                    INSTEAD OF:
+                        <property name="Produce fighters on carriers" value="true"/>
+
+                    DO THIS:
+                        <property name="Produce fighters on carriers" value="true" editable="false">
+                                <boolean/>
+                        </property>
+
+
+
+                    INSTEAD OF:
+                        <property name="notes">
+                                <value>Your game notes go here.</value>
+                        </property>
+
+                    DO THIS:
+                        <property name="notes">
+                                <string/>
+                                <value>
+                                    <![CDATA[
+                                        <br>Your game notes go here.
+                                    ]]>
+                                </value>
+                        </property>
+        -->
+
+                <!-- PLEASE KEEP YOUR PROPERTIES IN THIS ORDER!!! -->
+                <!-- TYPICAL OPTIONAL PROPERTIES -->
+                <!-- Bidding -->
+                <property name="Italians bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Russians bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Germans bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="British bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Japanese bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Americans bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Chinese bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <!-- victory options -->
+                <property name="Projection of Power" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- format of "<alliance> <Name of Victory Condition>" -->
+                <property name="Axis Projection of Power VCs" value="11" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Allies Projection of Power VCs" value="11" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Honorable Surrender" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Axis Honorable Victory VCs" value="12" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Allies Honorable Victory VCs" value="12" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Total Victory" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Axis Total Victory VCs" value="15" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Allies Total Victory VCs" value="15" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Economic Victory" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Axis Economic Victory" value="120" editable="false">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Allies Economic Victory" value="120" editable="false">
+                        <number min="0" max="1000"/>
+                </property>
+
+                        <!-- Triggered Victory is a victory condition set by a trigger, using a condition or national objective -->
+                <property name="Triggered Victory" value="true" editable="true">
+                        <boolean/>
+                </property>
+                <!-- End of Victory Conditions, rest of typical changed properties below -->
+
+                <property name="Low Luck" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for AntiAircraft" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Technology" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Use Politics" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- If this is set, it adds or subtracks from any conditions that require a relationship to last for X rounds -->
+                <property name="Relationships Last Extra Rounds" value="0" editable="true">
+                        <number min="-1" max="2"/>
+                </property>
+
+                <property name="Alliances Can Chain Together" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="National Objectives" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Use Triggers" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Tech Development" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Remove All Tech Tokens At End Of Turn" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Super Sub Defence Bonus" value="0" editable="true">
+                        <number min="0" max="1"/>
+                </property>
+
+                        <!-- All units with multiple dice rolls, will be forced to select the best die rolled instead of using all dice. -->
+                <property name="LHTR Heavy Bombers" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Heavy Bomber Dice Rolls" value="2" editable="false">
+                        <number min="2" max="3"/>
+                </property>
+
+                <property name="Paratroopers Can Move During Non Combat" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Paratroopers Can Attack Deep Into Enemy Territory" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Always on AA" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- Kamikaze Airplanes will allow all air units on the map to use all their movement to get to a battle -->
+                <property name="Kamikaze Airplanes" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- Use Kamikaze Suicide Attacks allows a player to use resources designated in player attachments to make special attacks -->
+                <property name="Use Kamikaze Suicide Attacks" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Kamikaze Suicide Attacks Done By Current Territory Owner allows you to have the current owner perform the suicide attacks, instead of the original owner -->
+                <property name="Kamikaze Suicide Attacks Done By Current Territory Owner" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Kamikaze Suicide Attacks Only Where Battles Are has the attacks only occur only when there are amphibious battles from that territory, or a battle in that territory -->
+                <property name="Kamikaze Suicide Attacks Only Where Battles Are" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Units Repair Hits End Turn" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Units Repair Hits Start Turn" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- in order to repair, a unit must in the presence of a unit with "repairsUnits" unit attachment -->
+                <property name="Two HitPoint Units Require Repair Facilities" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <!-- Display Options -->
+                        <!-- Multiply PUs will multiply all PUs gained or lost during a turn. It will not yet multiply costs of units or any other costs, or starting PUs -->
+                <property name="Multiply PUs" value="1" editable="false">
+                        <number min="1" max="10"/>
+                </property>
+
+                <property name="Selectable Zero Movement Units" value="false" editable="false">
+                        <boolean/>
+                </property>
+                <!-- END OF TYPICAL OPTIONAL PROPERTIES -->
+
+                <!-- rules and tech -->
+                        <!-- ww2v2 rules override many individual rules to create revised rules
+                <property name="WW2V2" value="false" editable="false">
+                        <boolean/>
+                </property> -->
+
+                <property name="WW2V3" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="WW2V3 Tech Model" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Selectable Tech Roll" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Use Shipyards turns on the shipyards tech's old way of doing things, which requires that all nations use the same production frontiers. A new way of doing shipywards will require triggers and is currently being coded -->
+                <property name="Use Shipyards" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble Rules In Effect" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scrambled Units Return To Base" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble To Sea Only" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble From Island Only" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble To Any Amphibious Assault" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Airborne Attacks Only In Existing Battles" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Airborne Attacks Only In Enemy Territories" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if true we will not use the "classic" rule of getting a single rocket attack for the whole round, and instead get a rocket attack for each rocket we have -->
+                <property name="All Rockets Attack" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if true allows infinite attacks against a factory by many rockets, if false,will only allow a max of 1 rocket to attack each factory -->
+                <property name="Rocket Attacks Per Factory Infinite" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Rockets Can Fly Over Impassables" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Pacific Theater does 4 things: allows nations to gain VictoryPoints by capturing PUs, allows Strategic Bombing to destroy VPs,
+                                allows NoPU purchases (ww2v3 does also), and allows an additional purchase in NOPU purchases if you control the Burma Road
+                <property name="Pacific Theater" value="false" editable="false">
+                        <boolean/>
+                </property>-->
+
+                <!-- These require an associated value in the attachments section above-->
+                <property name="Movement By Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Production Per X Territories Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- only territories with a production value of 1 or more may count towards the production per x territories -->
+                <property name="Production Per Valued Territory Restricted" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement Per Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Place in Any Territory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unplaced units live when not placed" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- allows a player to give units to another player if true. units must have canBeGivenByTerritory and territories must have changeUnitOwners and the players must have the player attachment giveUnitControl -->
+                <property name="Give Units By Territory" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- allows a player to let its units be captured by another player if true, when the territory is captured. units must have canBeCapturedOnEnteringBy and territories must have captureUnitOnEnteringBy and the players must have the player attachment captureUnitOnEnteringBy -->
+                <property name="Capture Units On Entering Territory" value ="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if "Capture Units On Entering Territory" is true, then the units can either be captured (default) or destroyed (only if this property below is true: "On Entering Units Destroyed Instead Of Captured") -->
+                <property name="On Entering Units Destroyed Instead Of Captured" value ="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- specific rules -->
+                <!-- land related -->
+                        <!-- if true, units with destroyedWhenCapturedBy will be destroyed instead of captured. only applies to non-combat units, since combat units die in combat -->
+                <property name="Units Can Be Destroyed Instead Of Captured" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- allows units to change into other units using the whenCapturedChangesInto ability -->
+                <property name="Units Can Be Changed On Capture" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if true you may have a number of constructions up to the value of the territory, in territories with factories -->
+                <property name="More Constructions with Factory" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- if true you may have a number of constructions up to the value of the territory, in territories without factories -->
+                <property name="More Constructions without Factory" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Unlimited Constructions" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Blitz Through Factories And AA Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- will roll dice for each type of aircraft separately -->
+                <property name="Roll AA Individually" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- random aa casualties lets the engine choose casualties randomly, and allows you to lose 2 bombers if you attack with 2 bombers and some fighters. I do not recommend using this property
+                <property name="Random AA Casualties" value="false" editable="false">
+                        <boolean/>
+                </property>-->
+
+                <property name="Choose AA Casualties" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- will only roll aa if aaGun is in the territory getting attacked or bombed -->
+                <property name="AA Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- will cause the isAAforFlyOverOnly to shoot for the last step in a movement, instead of just everything but the end. -->
+                <property name="Force AA Attacks For Last Step Of Fly Over" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Multiple AA Per Territory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if false, (all property default to false), then units killed by suicide units can return fire.  if true, they can not return fire -->
+                <property name="Suicide and Munition Casualties Restricted" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- if suicide units act like normal units on defense, except that they can not die to attacks by other suicide units -->
+                <property name="Defending Suicide and Munition Units Do Not Fire" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Units May Give Bonus Movement allows units with givesMovement to give other units bonus movement-->
+                <property name="Units May Give Bonus Movement" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <!-- sea related -->
+                <property name="Partial Amphibious Retreat" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- a subset of partial amphibious retreat, allows attacker to withdraw planes -->
+                <property name="Attacker Retreat Planes" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Shore Bombard Per Ground Unit Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Naval Bombard Casualties Return Fire" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- required for all maps, ensures allied aircraft on carriers that are attacking don't attack also -->
+                <property name="Allied Air Dependents" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Surviving Air Move To Land" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Air Attack Sub Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- transports may not unload to multiple territories -->
+                <property name="Transport Restricted Unload" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Ignore Transport In Movement" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Transport Casualties Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unescorted Transport Dies" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- If enabled, transports can capture convoy zones. -->
+                <property name="Transport Control Sea Zone" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Submarines stop transports from doing amphibious assault unless there is at least 1 owned warship in the sea zone -->
+                <property name="Submarines Prevent Unescorted Amphibious Assaults" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Ignore Sub In Movement" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Defending Subs Sneak Attack" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Sub Retreat Before Battle" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Submarines Defending May Submerge Or Retreat will allow defending submarines to retreat to friendly sea zones or submerge -->
+                <property name="Submarines Defending May Submerge Or Retreat" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Submersible Subs" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Sub Control Sea Zone Restricted should be FALSE if there are any convoy zones! If true, subs will not be able to capture convoy zones. -->
+                <property name="Sub Control Sea Zone Restricted" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Subs Can End NonCombat Move With Enemies allows submarines to end their noncombat movement in a sea zone containing any enemy units, including enemy subs -->
+                <property name="Subs Can End NonCombat Move With Enemies" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if true, naval units may not move into convoy zones or controlled sea zones during non-combat moves -->
+                <property name="Naval Units May Not NonCombat Move Into Controlled Sea Zones" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Only affects units exactly called "battleship" -->
+                <property name="Two hit battleship" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- If false, blockades will deal set amount of damage per unit. If true, a 6 sided die will be rolled for each damage point, with that being the damage, except rolls higher than 3 will be ignored -->
+                <property name="Convoy Blockades Roll Dice For Cost" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- production related -->
+                <property name="Produce fighters on carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Produce new fighters on old carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Move existing fighters to new carriers" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Land existing fighters on new carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- LHTR Carrier rules enable 'Produce fighters on carriers', and 'Produce new fighters on old carriers', and 'Land existing fighters on new carriers', AND it will disable 'Move existing fighters to new carriers' -->
+                <property name="LHTR Carrier production rules" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement In Enemy Seas" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- used to add destroyers and artillery to the ww2v1 map
+                <property name="Use Destroyers and Artillery" value="false" editable="false">
+                        <boolean/>
+                </property>-->
+
+                        <!-- may only bomb or rocket a factory to a max of its territory value per turn (the individual two parts are below) -->
+                <property name="Territory Turn Limit" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Limit SBR Damage Per Turn" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Limit Rocket Damage Per Turn" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="maxFactoriesPerTerritory" value="1" editable="false">
+                        <number min="1" max="100"/>
+                </property>
+
+                        <!-- Placement Restricted By Factory warns the player whenever they try to produce more units than their factories can handle (can be turned off for individual players using rules attachments for unlimitedProduction -->
+                <property name="Placement Restricted By Factory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Unit Placement Restrictions are restrictions on the placement of units: unitPlacementRestrictions, unitPlacementOnlyAllowedIn, canOnlyBePlacedInTerritoryValuedAtX, requiresUnits, -->
+                <property name="Unit Placement Restrictions" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Allows Strategic Bombing Raids to have Escort aircraft and also be Intercepted by the defender -->
+                <property name="Raids May Be Preceeded By Air Battles" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- Damage From Bombing Done To Units Instead Of Territories has Strategic Bombing and Rockets do damage to a territory rather than directly to the player's PUs (the bank) -->
+                <property name="Damage From Bombing Done To Units Instead Of Territories" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Damage From Bombing Done To Units Instead Of Territories has Strategic Bombing and Rockets do damage to a specific unit rather than directly to the player's PUs or to a territory.  You must have "Damage From Bombing Done To Units Instead Of Territories" false for this to work -->
+                <property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Allows all units that cause strategic bombing raid or rocket damage, to use "bombingMaxDieSides" and "bombingBonus" -->
+                <property name="Use Bombing Max Dice Sides And Bonus" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- similar to TTL, except that it is per rocket/aircraft instead of per turn -->
+                <property name="Limit SBR Damage To Factory Production" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- allows the loss of a victory point for every 10 sbr damage per turn
+                <property name="SBR Victory Points" value="false" editable="false">
+                        <boolean/>
+                </property>-->
+
+                <!-- Neutrals related -->
+                        <!-- amount of money subtracted to attack a neutral territory, (set neutrals charge to zero if you plan on attacking neutrals) -->
+                <property name="neutralCharge" value="9999999" editable="false">
+                        <number min="0" max="9999999"/>
+                </property>
+
+                <property name="Neutrals Are Impassable" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Neutrals Are Blitzable" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Neutral Flyover Allowed" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- AI related -->
+                <property name="AI Bonus Income Flat Rate" value="0" editable="true">
+                        <number min="-10" max="30"/>
+                </property>
+
+                <property name="AI Bonus Income Percentage" value="20" editable="true">
+                        <number min="-30" max="120"/>
+                </property>
+
+                <property name="AI Bonus Attack" value="0" editable="true">
+                        <number min="0" max="2"/>
+                </property>
+
+                <property name="AI Bonus Defense" value="0" editable="true">
+                        <number min="0" max="2"/>
+                </property>
+
+                <!-- Map Name: also used for map utils when asked (MUST exactly match the folder or zip name of your map (do not include the .zip of course). May point to another map folder if you are making a mod of that map) -->
+                <property name="mapName" value="Pact of Steel 2 Test" editable="false">
+                        <string/>
+                </property>
+
+                <!-- notes appear in the notes menu in the main screen, format as html -->
+                <property name="notes">
+                        <string/>
+                        <value>
+                        <![CDATA[
+
+                            <h2>Pact of Steel 2</h2>
+                            <br>A mod of POS by Veqryn
+                            <br>
+                            <br>The purpose of this map is to provide a fun map that shows off all the newest features TripleA has to offer.
+                            <br>
+                            <br>This map uses the ww2v3 + LHTR rules as a base, expanding it with various upgrades like triggered bonuses, air scrambling, etc.
+                            <br>
+                            <br>
+                            <br><b>New things:</b>
+                            <br>1. Sea Zones 3 and 4, are Russian Convoy Centers. If Russia controls it, they get the income from it. If someone else controls it, that player gets no income from it, but they deny the income to Russia. It can not be captured during non-combat phase.
+                            <br>2. Sea Zones 5 and 6, are Convoy Routes. They are linked to the land territory of Norway. At least one Convoy Zone must be controlled by the same power that controls the land territory for that power to gain the income from the land territory.
+                                    They can not be captured during non-combat phase. If more than 1 route is linked to a single land territory, only 1 route needs to be controlled to get the income from land territory. Routes can have PU values just like convoy centers.
+                            <br>3. Sea Zones 37, 47, 48, 49, 58, are Blockade Zones. Each enemy warship in these zones reduces the income of touching land territories by 1 per warship, 2 per normal submarine.
+                            <br>4. Air_Transport is an air unit that specializes in dropping off units, has 4 movement, and can carry into battle or drop off in a friendly territory any 2-3 units. Enabled when you get "paratroopers" tech.
+                            <br>5. Super_Carrier is a beefed up carrier that can also transport 1 infantry and 1 other land unit like a tank or artillery. It has only 1 hitpoint, just like normal carriers and cruisers.
+                            <br>6. Midget_Submarine is a Japanese only unit with 3 attack, 2 defence, and 2 movement (costs 4). If it attacks or defends it will die after shooting (it is a suicide unit). Japan can purchase them after certain conditions are met, and they don't receive bonus movement from harbours.
+                            <br>7. Kamikaze Fighters are what Japanese fighters turn into if certain conditions are met.  They have 5 attack, 3 defense, and 3 movement (cost 8), and they are allowed to use up all their movement to go to a battle,
+                                        do not require a landing zone for movement, and they will die after rolling their dice.
+                            <br>8. Airfield gives +1 movement to air units, and allows fighters to scramble to defend surrounding sea zones if you turn on "Scramble Rules In Effect". Can receive up to 6 damage, and stops working when having more than 2 damage.
+                            <br>9. Harbour gives +1 movement to warships, and are needed to repair Battleships if you turn on "Two HitPoint Units Require Repair Facilities". Can receive up to 6 damage, and stops working when having more than 2 damage.
+                            <br>10. Bunkers are defensive units that can also be bombed/rocketted, will not participate in battle if damaged, and will die if they reach 4 damage.
+                                        They may be placed in any territory you owned at the beginning of the turn (just like Factories, Airfields, and Harbours) where you also have a land unit, but there is a limit of 1 per territory.
+                            <br>11. New Technologies: reinforcedHulls (gives +2 defense to subs), and wolfPackTactics (gives +1 att). Available to Germans after they get superSubs.
+                            <br>12. Each nation may only purchase factories up to 3 total, if a nation controls more than 3 they can not purchase new factories (they can keep capturing new ones though).
+                            <br>13. Politics phase: alliances and states of war are now dynamic and can be changed in game.  Japan and Russia start out in a state of Neutrality towards each other, while Russia, America and the UK also start out as neutral towards each other.
+                                        Japan and Russia will go to war on the 5th turn if they are still neutral by then.  Italy and Russia have the option of declaring a 2 round ceasefire.
+                            <br>14. Strategic Bombing Raids can now have an Air battle preceeding the raid. Fighters escorting the bombers, and any defending interceptors fire at 2, while the bombers fire at 1.  The battle only lasts 1 round.
+                            <br>15. Long Range Aircraft tech now only increases movement by 1.
+                            <br>
+                            <br>
+                            <br>
+                            <b>National Objectives</b><br>
+                            <i>Germany: Lebensraum-</i><br>
+                            +4 PUs if Axis control 7 out of 9 of
+                                East Balkans, Eastern Europe, Ukraine S.S.R., Belorussia, West Russia, Norway, Karelia S.S.R., Archangel, Caucus<br>
+                            +4 PUs if Axis control Western Europe, AND there are NO enemy surface ships in 3 out of 3 of sea zones 5, 6, and 7<br>
+                            * Germany gains Super Subs if at the end of their 4th or 5th turn, there are NO enemy surface ships in 3 out of 3 of
+                                sea zones 5, 6, and 7<br>
+                            * Germany gains Mechanized Infantry if at the end of their 3rd or 4th turn, the Axis control 6 out of 7 of
+                                East Balkans, Eastern Europe, Ukraine S.S.R., Belorussia, Karelia S.S.R., Archangel, Caucus<br>
+                            * Germany gains Rockets if at the end of their 3rd or 4th turn, the Axis do NOT control Western Europe, but DO control Norway<br>
+                            * Germany has access to additional submarine technology if they get superSubs, and getting superSubs also gives access to reinforcedHulls to Italians (in place of Shipyards)<br>
+                            <br>
+                            <i>Japan: The Greater East Asia Co-Prosperity Sphere-</i><br>
+                            +4 PUs if Axis control 7 out of 7 of India, French Indochina, Kwangtung, Manchuria, China, Central China, Sinkiang<br>
+                            +4 PUs if Axis control 10 out of 13 of Alaska, East Indies, Borneo, Philipine Islands, New Guinea, Solomon Islands,
+                                Caroline Islands, Australia, New Zealand, Okinawa, Wake Island, Hawaiian Islands, Midway<br>
+                            * Japan's destroyers gain the ability to transport a single infantry If on the 3rd or 4th turn, the Axis do NOT control ANY of
+                                Sinkiang, India, Burytia S.S.R.<br>
+                            * Japan's transports gain an additional capacity of 1 (allowing 3 infantry or 2 tanks/artillery per transport) If at the end of their 3rd, 4th, or 5th turns,
+                                Japan controls 3 out of 3 of Australia, India, Sinkiang<br>
+                            * Japan gains, only once, a single additional midget_submarine in sz61 If it loses control over any of its original territories<br>
+                            * Japan gains the ability to produce midget_submarines If it loses control over 2 of its islands: Okinawa, Philipine Islands, East Indies, Borneo, New Guinea, Solomon Islands, Caroline Islands, Wake Island<br>
+                            * Japan gains the ability to produce kamikaze fighters, and all their current fighters turn into kamikaze fighters
+                                If it loses control over 2 of its islands, one of which being Philipine Islands (note that this objective may or may not be wanted, depending on the situation)<br>
+                            <br>
+                            <i>Italy: Mare Nostrum-</i><br>
+                            +4 PUs if Axis control 8 out of 11 of
+                                Western Europe, Sardinia, Sicily, West Balkans, Greece, Algeria, Libya, Anglo Egypt, Trans-Jordan, Italian East Africa, Gibraltar
+                                AND no enemy surface ships in sea zones 13, 14, 15, and 15B<br>
+                            * Italy gains, only once, a free purchase of a cruiser If at the beginning of their 3rd or 4th turn the Axis control 4 out of 4 of
+                                Algeria, Libya, Anglo Egypt, Trans-Jordan<br>
+                            <br>
+                            <i>United States: The Arsenal of Democracy-</i><br>
+                            +2-10 PUs, starting on turn 2 America will begin making +2 income as America's war-time economy ramps up. This will increase by +2 more every 2 turns, so that turn 4 will begin making +4, turn 6 will make +6, and so on until +10 is reached<br>
+                            +4 PUs if Allies control 3 out of 8 of Western Europe, Sardinia, Sicily, Italy, Greece, West Balkans, Algeria, Libya
+                                AND no enemy surface ships in sea zones 1, 2, 7, 8, 9, 10, 11, 12, 13, and 14<br>
+                            +4 PUs if Allies controls 6 out of 13 of Alaska, East Indies, Borneo, Philipine Islands, New Guinea, Solomon Islands, Caroline Islands,
+                                Australia, New Zealand, Okinawa, Wake Island, Hawaiian Islands, Midway<br>
+                            +4 PUs if Japan has no Battleships OR no Carriers at the end of USA's turn<br>
+                            * USA gains Paratroopers if at the end of Germany's 3rd, 4th or 5th turns, the Allies control Western Europe<br>
+                            * USA gains Improved Shipyards if at the end of their 3rd, 4th or 5th turns, USA controls 4 out of 4 of
+                                Alaska, Wake Island, Hawaiian Islands, Midway<br>
+                            * USA gains War Bonds if at any time before the end of the 8th turn, the above 2 conditions are met at the end of Germany's turn<br>
+                            * USA's fighter's gain the ability to support infantry, stackable with artillery, IF at any time the USA has 2 out of 2 of War Bonds and Jet Power technologies<br>
+                            * USA can give land units to Russia by landing them in Archangel<br>
+                            <br>
+                            <i>United Kingdom: The British Empire-</i><br>
+                            +4 PUs if the UK controls 1 out of 6 of East Indies, Borneo, New Guinea, Solomon Islands, Caroline Islands, Okinawa<br>
+                            +4 PUs if Allies control 9 out of 11 of Gibraltar, Algeria, Libya, Anglo Egypt, Trans-Jordan, Persia, French West Africa,
+                                French Equatorial Africa, Italian East Africa, Belgian Congo, Kenya<br>
+                            +4 PUs if Allies control 3 out of 3 of Union of South Africa, India, Australia<br>
+                            * UK gains Paratroopers if at the end of Germany's 3rd, 4th or 5th turns, the Allies control Western Europe<br>
+                            * UK gains AA Radar if at the end their 3rd or 4th turn, the Allies control 4 out of 5 of
+                                Union of South Africa, Gibraltar, Anglo Egypt, India, Australia<br>
+                            <br>
+                            <i>Soviet Union: The Great Patriotic War-</i><br>
+                            +4 PUs if Soviets control 3 out of 5 of Norway, Eastern Europe, East Balkans, Ukraine S.S.R., Belorussia<br>
+                            +4 PUs if Soviets control Archangel and no allied forces in Soviet controlled land territories<br>
+                            +2 PUs AND +2 Tech Token, only once, if Soviets control Norway or East Balkans<br>
+                            * Soviet's artillery gain the ability to support 2 infantry on attack If at the end of their 3rd or 4th turn, the Soviets control
+                                Karelia S.S.R. and Caucus (this effect can be doubled to 4 infantry supported if Russia gets Improved Artillery technology)<br>
+                            * Soviets gain, only once, an additional 3 infantry in Yakut S.S.R. if at the beginning of their turn, Japan controls any original Russian territory<br>
+                            * Soviets gain control of any American land units that are in Archangel at the end of America's turn<br>
+                            * Soviets have double chance of getting Improved Artillery when rolling for tech<br>
+                            * Soviets destroy their industrial production (PUs) instead of letting it be captured, when they lose their capital<br>
+                            * Soviets destroy their AA Guns instead of letting them be captured<br>
+                            <br>
+                            <i>China: Chinese Resistance & The Flying Tigers </i><br>
+                            +1 infantry for every two territories controlled by China at the end of her turn, rounded up. May only place a max of 2 units per territory per turn.
+                                All units must be place in a territory with less than 4 Chinese units<br>
+                            +4 PUs and the ability to produce extra units, if Allies control Sinkiang, Central China, India.
+                                May use this money to produce a limited selection of units. May purchase tanks and fighters if these territories are controlled.<br>
+                            * China gains 1 infantry in Sinkiang if at the beginning of their turn, there are no enemy units in 3 out of 6 of
+                                Sinkiang, Central China, China, Manchuria, Kwangtung, French Indochina. This unit is given at the beginning of combat move step, and can not be moved until next turn.<br>
+                            * No Chinese Units, including the Chinese Fighter may leave Chinese territory: Sinkiang, Central China, China, Manchuria, Kwangtung, French Indochina
+                                (this means no entering sea zones), unless the Japanese capital has fallen once<br>
+                            * Chinese destroy any non-combat units they would otherwise capture (factories, aa guns, harbours, airfields)<br>
+                            <br>
+                            <br>
+                            <b>Technology</b><br>
+                            *** Air/Naval Tech ***<br>
+                            SUPER SUBS- submarine units get +1 attack<br>
+                            JET POWER- fighters and air transports get +1 attack<br>
+                            IMPROVED SHIPYARDS- naval units are cheaper<br>
+                            AA RADAR- AA hit on 2 or less<br>
+                            LONG RANGE AIRCRAFT- aircraft range increased by 1<br>
+                            HEAVY BOMBER- roll 2 dice for each bomber attack (if LHTR enabled: rolls 2 dice and selects the best one, StratBombing adds one to result)<br>
+                            <br>
+                            *** Land/Production Tech ***<br>
+                            IMPROVED ARTILLERY SUPPORT- artillery support 2 infantry (double the support given)<br>
+                            ROCKETS- AA conduct rocket attacks for 1d6 damage to production (each factory may only be targetted once per turn by one rocket, and only 1 rocket in each territory may fire)<br>
+                            PARATROOPERS- each bomber may carry 1 infantry into combat (must stop in first enemy territory it reaches)<br>
+                            INCREASED FACTORY PRODUCTION- factories produce 2 additional units (if territory value is 3 or greater), repairs 1/2 price<br>
+                            WAR BONDS- collect an 1d6 extra PUs each turn<br>
+                            MECHANIZED INFANTRY- tanks may carry 1 infantry each for 2 spaces<br>
+                            <br>
+                            *** Submarine Technology ***<br>
+                            REINFORCED HULLS- submarines get +2 defense (only shows up in battles)<br>
+                            WOLF PACK TACTICS- submarines get +1 attack and +1 defense (only shows up in battles)<br>
+                            <br>
+                            <br>Each nation has at least one technology that they can not research. This is shown by a "-" in the research tab.
+                                The Germans can't research War Bonds, Japanese can't get Shipyards, Russians can't get Paratroopers,
+                                British can't get Mechanized Inf, Americans can't get Rockets, and Italians can't get about half of the techs.
+                                Also, UK, Russia, and Italy get Destroyers Bombard instead of Super Subs.
+                            <br>
+                            <br>
+                            <b>Victory Conditions</b><br>
+                            Total Victory - 15 Victory Cities<br>
+                            Projection of Power - 11 Victory Cities<br>
+                            Axis can achieve a Triggered Victory by controlling all 4 of Germany, Japan, United Kingdom, and Russia.<br>
+                            Allies can achieve a Triggered Victory by controlling all 4 of United Kingdom, Eastern United States, Germany, and Japan.<br>
+                            <br>
+                            <br>
+                            <br>
+                            <br><b>Major Differences Between ww2v2 revised and ww2v3</b>
+                            <br>1.  In ww2v2 transport units are just like any other unit, and can be used as fodder by being taken casualty first in combat, however in ww2v3 style rules, transports have no defense power and may only be taken casualty after all other non-transport ships are dead.
+                            <br>2.  In ww2v2, you can build fighters on carriers if you build both at the same time, and if you build a carrier you can move existing fighters to carriers when you build a carrier in the adjacent sea zone. In ww2v3, you can build new fighters onto existing
+                                    carriers as well as new carriers, but you may not move existing fighters onto new carriers, as instead you can non-combat move the fighters to where the carrier will be built, then place the carrier under it.
+                            <br>3.  In ww2v2, when you strategic bomb or rocket a factory, you immediately reduce the enemy's PUs. In ww2v3, you do damage to the factory, up to twice the value of the territory.
+                                    Each point of damage reduces the number of units that can be produced there by 1. The player may repair the damage during their purchase phase.
+                            <br>4.  In ww2v2, when you fly over a territory with an AA Gun, the gun gets to fire at each aircraft. In ww2v3, the AA Gun only fires when you attack or bomb the territory it is in.
+                            <br>5.  In ww2v2, submarines and transports block the movement of other sea units. In ww2v3, submarines and transports do not block the movement of other sea units, and may be bypassed or attacked.
+                            <br>6.  In ww2v2, technology is rolled for, and if you miss nothing happens. In ww2v3, you buy tech tokens, and at the beginning of your turn you roll for each of your tokens. If you roll a 6, you discard all tokens and roll a second time to see which technology you get.
+                            <br>7.  In ww2v2, no land units may retreat from an amphibious assault. In ww2v3, the non-amphibious units may retreat.
+                            <br>8.  In ww2v2, bombardment immediately kills units, and you are allowed infinite bombardments. In ww2v3, a unit hit by bombard may return fire against the attacking units before dying, and the number of bombards is limited to the number of land units being dropped off from that sea zone.
+                            <br>9.  In ww2v2, air units can hit submarines. In ww2v3, an owned destroyer must be present for air units to hit submarines.
+                            <br>10. In ww2v2, submarines may choose to submerge at the end of each round of combat. In ww2v3, they may choose to submerge before each round of combat (and consequently, you can't kill them without a destroyer).
+                            <br>11. In ww2v2, submarines fire at the beginning of combat, and if there is no enemy destroyer then any casualties are removed immediately. In ww2v3, submarines get their surprise strike both on offense and defense, and both can be nullified by the presence of an enemy destroyer
+                                    (so in ww2v3, if attacking an enemy sub, the attacker with a sub + destroyer, who's sub hits, would immediately kill the defending sub with no chance for it to return fire).
+                            <br>
+                            <br>
+                            <br><b>Differences for LHTR rules</b>
+                            <br>1. Technology is activated during the Place-Units phase (at the end of the turn rather then the beginning).
+                            <br>2. Heavy Bombers roll 2 dice, selecting best one. If strategic bombing, select best of two dice, then add '1' to the result.
+                            <br>3. Super Subs get a bonus of '1' to defense in addition to the bonus of '1' to attack.
+                            <br>4. LHTR uses same fighter-carrier rules, and aaGun rules, as ww2v3.
+                            <br>
+                            <br>
+                            <br><b>Generic How-To-Play</b>
+                            <br>The game is made up of rounds, during a round each player gets to do a number of steps/phases.
+                            <br>The phases are, in order: Research Technology, Repair Factories and Purchase Units, Combat Movement, Resolve Battles, Non-Combat Movement, Place Units.
+                            <br>At the beginning of your turn, you purchase units. At the end of the turn, you get to place those units in territories you own that have a factory.
+                            <br>During Combat Movment, you move any units to attack enemy units and territories. During Non-Combat Movement, you may move any units that have movement left (attacking an enemy remove any movement of land and sea units, but not air units).
+                            <br>Battles happen by use of dice. A unit has a certain attack power, and you roll a dice for each unit. If your dice is equal or less than the attack power of the unit, you have scored a hit.
+                                So for example, a tank attacks on 3. For it, you will roll a single die, and if you score 1-3 on the die you have hit the enemy, while if you score 4-6 you have missed the enemy. An infantry defends on 2, so a roll of 1-2 is a hit, while 3-6 are misses.
+                            <br>After the attacker has rolled dice for each of his units, the defender tallies the total number of 'hits' and then selects which of his defending units will die later. After this, the defender rolls for his units and the attacker selects which of his units will die.
+                                When both have finished rolling, the units selected to die are removed from the game. If there are no more attackers left, then the defender has won, and if there are no more defenders left, then the attacker has won and he moves his remaining attacking units into that territory.
+                                If both players have units left still, the attack may choose to play another round of battle, or retreat all his remaining forces to a territory where at least one of his forces came from.
+                            <br>Players must work with their allies to destroy the enemies, with the game ending when one side surrenders or certain conditions are met (like having captured a clear majority of the major cities).
+                            <br>
+                            <br>
+                            <br>Credits for original POS:
+                            <br>Triplelk, DMA02, Iron Cross, Aibrahim, SGB, KC1189, Zero Pilot, Tactics, Underdog
+                            <br>A mod by Veqryn
+                            <br>Many of the new properties and options were coded by Veqryn.
+                            <br>A personal thank you to Squid Daddy and ComradeKev for coding some of the new features that this map shows off
+                            <br>Relief Tiles by Conarymor.
+                            <br>Only actual unit changes: some destroyers turned into cruisers, and a German destroyer added to sz5, German sub in sz8 moved to sz7.
+                            <br>The AIs are meant to be bad at this map, please don't tell me the AIs are bad at this map.
+                        ]]>
+                        </value>
+                </property>
+        </propertyList>
 </game>

--- a/src/test/resources/revised_test.xml
+++ b/src/test/resources/revised_test.xml
@@ -560,7 +560,7 @@
                         <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
                         
                         <!-- Bidding Phase -->
-			
+
                         <step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
                         <step name="russianBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
                         
@@ -1282,29 +1282,29 @@
                   <attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                   </attachment>
-                  
-                  
-              	    <!-- canals -->
-    
-				    <attachment name="canalAttachment" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				    	<option name="canalName" value="Suez Canal"/>
-				    	<option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
-				    </attachment>
-				    
-				    <attachment name="canalAttachment" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				    	<option name="canalName" value="Suez Canal"/>
-				    	<option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
-				    </attachment>
-				    
-			   	    <attachment name="canalAttachment" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				    	<option name="canalName" value="Panama Canal"/>
-				    	<option name="landTerritories" value="Panama"/>
-				    </attachment>
-				    
-				    <attachment name="canalAttachment" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-				    	<option name="canalName" value="Panama Canal"/>
-				    	<option name="landTerritories" value="Panama"/>
-				    </attachment>                  
+
+
+                    <!-- canals -->
+
+                    <attachment name="canalAttachment" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Suez Canal"/>
+                        <option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
+                    </attachment>
+
+                    <attachment name="canalAttachment" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Suez Canal"/>
+                        <option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
+                    </attachment>
+
+                    <attachment name="canalAttachment" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Panama Canal"/>
+                        <option name="landTerritories" value="Panama"/>
+                    </attachment>
+
+                    <attachment name="canalAttachment" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                        <option name="canalName" value="Panama Canal"/>
+                        <option name="landTerritories" value="Panama"/>
+                    </attachment>
         </attachmentList>
         
         <initialize>
@@ -1559,8 +1559,8 @@
                 <property name="Russians bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
-				
-				<property name="Germans bid" value="0" editable="true">
+
+                <property name="Germans bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
 
@@ -1575,73 +1575,73 @@
                 <property name="Americans bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
-				
-				<!-- Victory Conditions -->
-				<property name="Projection of Power" value="true" editable="true">
-					<boolean/>
-				</property>
 
-				<property name="Axis Projection of Power VCs" value="9" editable="false">
-					<number min="8" max="12"/>
-				</property>
-
-				<property name="Allies Projection of Power VCs" value="9" editable="false">
-					<number min="8" max="12"/>
-				</property>
-
-				<property name="Honorable Surrender" value="false" editable="true">
-					<boolean/>
-				</property>
-
-				<property name="Axis Honorable Victory VCs" value="10" editable="false">
-					<number min="8" max="12"/>
-				</property>
-
-				<property name="Allies Honorable Victory VCs" value="10" editable="false">
-					<number min="8" max="12"/>
-				</property>
-
-				<property name="Total Victory" value="false" editable="true">
-					<boolean/>
-				</property>
-
-				<property name="Axis Total Victory VCs" value="12" editable="false">
-					<number min="8" max="12"/>
-				</property>
-
-				<property name="Allies Total Victory VCs" value="12" editable="false">
-					<number min="8" max="12"/>
-				</property>
-
-				<!-- Low Luck -->
-				<property name="Low Luck" value="false" editable="true">
-					<boolean/>
-				</property>
-
-				<property name="Low Luck for AntiAircraft" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Technology" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
-						<boolean/>
-				</property>
-				
-                <property name="Tech Development" value="true" editable="true">
-                	<boolean/>
+                <!-- Victory Conditions -->
+                <property name="Projection of Power" value="true" editable="true">
+                    <boolean/>
                 </property>
 
-				<property name="Super Sub Defence Bonus" value="0" editable="true">
-						<number min="0" max="1"/>
-				</property>
-				
-				<property name="LHTR Heavy Bombers" value="false" editable="true">
-					<boolean/>
-				</property>
-                
+                <property name="Axis Projection of Power VCs" value="9" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <property name="Allies Projection of Power VCs" value="9" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <property name="Honorable Surrender" value="false" editable="true">
+                    <boolean/>
+                </property>
+
+                <property name="Axis Honorable Victory VCs" value="10" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <property name="Allies Honorable Victory VCs" value="10" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <property name="Total Victory" value="false" editable="true">
+                    <boolean/>
+                </property>
+
+                <property name="Axis Total Victory VCs" value="12" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <property name="Allies Total Victory VCs" value="12" editable="false">
+                    <number min="8" max="12"/>
+                </property>
+
+                <!-- Low Luck -->
+                <property name="Low Luck" value="false" editable="true">
+                    <boolean/>
+                </property>
+
+                <property name="Low Luck for AntiAircraft" value="false" editable="true">
+                    <boolean/>
+                </property>
+
+                <property name="Low Luck for Technology" value="false" editable="true">
+                    <boolean/>
+                </property>
+
+                <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+                    <boolean/>
+                </property>
+
+                <property name="Tech Development" value="true" editable="true">
+                    <boolean/>
+                </property>
+
+                <property name="Super Sub Defence Bonus" value="0" editable="true">
+                    <number min="0" max="1"/>
+                </property>
+
+                <property name="LHTR Heavy Bombers" value="false" editable="true">
+                    <boolean/>
+                </property>
+
                 <property name="Heavy Bomber Dice Rolls" value="2" editable="true">
                         <number min="2" max="10"/>
                 </property>
@@ -1654,28 +1654,28 @@
                         <boolean/>
                 </property>
 
-				<property name="Choose AA Casualties" value="false" editable="true">
-					<boolean/>
-				</property>
+                <property name="Choose AA Casualties" value="false" editable="true">
+                    <boolean/>
+                </property>
 
-				<property name="Roll AA Individually" value="true" editable="false">
-					<boolean/>
-				</property>
-                
-				<property name="Kamikaze Airplanes" value="false" editable="true">
-					<boolean/>
-				</property>
-                
+                <property name="Roll AA Individually" value="true" editable="false">
+                    <boolean/>
+                </property>
+
+                <property name="Kamikaze Airplanes" value="false" editable="true">
+                    <boolean/>
+                </property>
+
                 <property name="Units Repair Hits End Turn" value="true" editable="true">
                         <boolean/>
                 </property>
 
-				<property name="Units Repair Hits Start Turn" value="false" editable="true">
-						<boolean/>
-				</property>
+                <property name="Units Repair Hits Start Turn" value="false" editable="true">
+                    <boolean/>
+                </property>
 
                 <!-- Use WW2V2 Rules -->
-				<property name="WW2V2" value="true" editable="false">
+                <property name="WW2V2" value="true" editable="false">
                         <boolean/>
                 </property>
                 
@@ -1691,42 +1691,42 @@
                         <boolean/>
                 </property>
 
-				<property name="Move existing fighters to new carriers" value="true" editable="false">
-					<boolean/>
-				</property>
+                <property name="Move existing fighters to new carriers" value="true" editable="false">
+                    <boolean/>
+                </property>
 
                 <property name="LHTR Carrier production rules" value="false" editable="true">
                         <boolean/>
                 </property>
 
-				<property name="Allied Air Dependents" value="true" editable="false">
-					<boolean/>
-				</property>
+                <property name="Allied Air Dependents" value="true" editable="false">
+                    <boolean/>
+                </property>
 
                 <property name="neutralCharge" value="9999999"/>
 
-				<property name="Neutrals Are Impassable" value="true" editable="false">
-					<boolean/>
-				</property>
+                <property name="Neutrals Are Impassable" value="true" editable="false">
+                    <boolean/>
+                </property>
 
-				<property name="Neutrals Are Blitzable" value="false" editable="false">
-					<boolean/>
-				</property>
-                
+                <property name="Neutrals Are Blitzable" value="false" editable="false">
+                    <boolean/>
+                </property>
+
                 <property name="maxFactoriesPerTerritory" value="1"/>
-				
+
                 <property name="Sub Control Sea Zone Restricted" value="false" editable="false">
-                	<boolean/>
+                    <boolean/>
                 </property>
 
                 <!-- Map Name: also used for map utils when asked -->
                 <property name="mapName" value="World War II Revised Test" editable="false"/>
                 
                 <property name="notes">
-		        	<value><![CDATA[       
-		        	
-		        	A revised version of the basic rule set.
-		        	]]></value>        	       
-        		</property>	
-        </propertyList>        
+                    <value><![CDATA[
+
+                    A revised version of the basic rule set.
+                    ]]></value>
+                </property>
+        </propertyList>
 </game>

--- a/src/test/resources/victory_test.xml
+++ b/src/test/resources/victory_test.xml
@@ -5,10 +5,10 @@
 <game>
         <info name="victory test" version="3.3"/>
         <loader javaClass="games.strategy.triplea.TripleA"/>
-		
-		
-		<diceSides value="6"/>
-		
+
+
+        <diceSides value="6"/>
+
         <map>
                 <!-- Territory Definitions -->
                 <territory name="Eastern Canada"/>
@@ -182,7 +182,7 @@
                 <connection t1="15B Sea Zone" t2="15 Sea Zone"/>
                 <connection t1="15B Sea Zone" t2="16 Sea Zone"/>
                 <connection t1="15B Sea Zone" t2="East Balkans"/>
-				<connection t1="16 Sea Zone" t2="East Balkans"/>
+                <connection t1="16 Sea Zone" t2="East Balkans"/>
                 <connection t1="Sweden" t2="Norway"/>
                 <connection t1="Sweden" t2="5 Sea Zone"/>
                 <connection t1="Switzerland" t2="Germany"/>
@@ -533,17 +533,17 @@
                 <connection t1="Italian East Africa" t2="Kenya"/>
                 <connection t1="Kenya" t2="Union of South Africa"/>
         </map>
-        
+
 
 
         <resourceList>
-				<!-- PUs and techTokens are default supported resources. (all maps should use "PUs" as the default "money", as a map without PUs may fail. -->
+                <!-- PUs and techTokens are default supported resources. (all maps should use "PUs" as the default "money", as a map without PUs may fail. -->
                 <resource name="PUs"/>
                 <resource name="techTokens"/>
-				<resource name="Fuel"/>
-				<resource name="Ore"/>
-				<resource name="FairyDust"/>
-				
+                <resource name="Fuel"/>
+                <resource name="Ore"/>
+                <resource name="FairyDust"/>
+
         </resourceList>
 
         <playerList>
@@ -555,25 +555,25 @@
                 <player name="Japanese" optional="false"/>
                 <player name="Americans" optional="false"/>
                 <player name="Chinese" optional="false"/>
-				<!-- optional just means 'does this player require a capital?'.  if a player is optional, some delegates may not work as expected for that player. -->
+                <!-- optional just means 'does this player require a capital?'.  if a player is optional, some delegates may not work as expected for that player. -->
 
-				
-				
-				<!-- alliances can have any name, not just axis and allies.  there can be more than 2 alliances -->
+
+
+                <!-- alliances can have any name, not just axis and allies.  there can be more than 2 alliances -->
                 <!-- Axis alliance -->
                 <!--  since triplea version 1.3.3.0 it is preferred to use relationships instead of alliances If relationships are set, then alliances will only matter for the stats panel and any game option type victory conditions -->
                 <alliance player="Germans" alliance="Axis"/>
                 <alliance player="Japanese" alliance="Axis"/>
                 <alliance player="Italians" alliance="Axis"/>
-				
+
                 <!-- Allies alliance -->
                 <!--  since triplea version 1.3.3.0 it is preferred to use relationships instead of alliances. If relationships are set, then alliances will only matter for the stats panel and any game option type victory conditions -->
                 <alliance player="British" alliance="Allies"/>
                 <alliance player="Russians" alliance="Allies"/>
                 <alliance player="Americans" alliance="Allies"/>
                 <alliance player="Chinese" alliance="Allies"/>
-                
-                
+
+
         </playerList>
 
         <unitList>
@@ -591,7 +591,7 @@
                 <unit name="midget_submarine"/>
                 <unit name="destroyer"/>
                 <unit name="jp_destroyer"/>
-				<unit name="cruiser"/>
+                <unit name="cruiser"/>
                 <unit name="carrier"/>
                 <unit name="battleship"/>
                 <unit name="super_carrier"/>
@@ -601,33 +601,33 @@
                 <unit name="airfield"/>
                 <unit name="harbour"/>
         </unitList>
-		
+
         <!--  this is the list of relationshipTypes you can create between players -->
-        <!--  each relationshipType you define here MUST have a RelationshipTypeAttachment to define this relationship 
+        <!--  each relationshipType you define here MUST have a RelationshipTypeAttachment to define this relationship
               also each RelationshipTypeAttachment MUST have an archetype set to either: "allied", "neutral" or "war"
         -->
-		<relationshipTypes>
-				<relationshipType name="Allied"/>
-				<relationshipType name="War"/>
-				<relationshipType name="Neutrality"/>
-				<relationshipType name="NAP"/>
-				<relationshipType name="ColdWar"/>
-		</relationshipTypes>
-		
-		<territoryEffectList>
-        	<territoryEffect name="mountain"/>
-			<!--<territoryEffect name="city"/>
-			<territoryEffect name="desert"/>
-			<territoryEffect name="forest"/>
-			<territoryEffect name="hill"/>
-			<territoryEffect name="marsh"/>
-			<territoryEffect name="sahara"/>-->
+        <relationshipTypes>
+                <relationshipType name="Allied"/>
+                <relationshipType name="War"/>
+                <relationshipType name="Neutrality"/>
+                <relationshipType name="NAP"/>
+                <relationshipType name="ColdWar"/>
+        </relationshipTypes>
+
+        <territoryEffectList>
+            <territoryEffect name="mountain"/>
+            <!--<territoryEffect name="city"/>
+            <territoryEffect name="desert"/>
+            <territoryEffect name="forest"/>
+            <territoryEffect name="hill"/>
+            <territoryEffect name="marsh"/>
+            <territoryEffect name="sahara"/>-->
         </territoryEffectList>
 
         <gamePlay>
-				<!-- this currently is all the delegates triplea has.  not all are needed for a regular game though -->
-					<!-- purchaseNoPU buys 1 infantry for X number of territories controlled, rounding down. set X in player rules attachments -->
-					<!-- endTurnNoPU ends player's turn without giving them any PUs -->
+                <!-- this currently is all the delegates triplea has.  not all are needed for a regular game though -->
+                    <!-- purchaseNoPU buys 1 infantry for X number of territories controlled, rounding down. set X in player rules attachments -->
+                    <!-- endTurnNoPU ends player's turn without giving them any PUs -->
                 <delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate" display="Initializing Delegates"/>
                 <delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate" display="Research Technology"/>
                 <delegate name="tech_activation" javaClass="games.strategy.triplea.delegate.TechActivationDelegate" display="Activate Technology"/>
@@ -635,19 +635,19 @@
                 <delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Combat Move"/>
                 <delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Units"/>
                 <delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
-				<delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>
+                <delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>
                 <delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate" display="Turn Complete"/>
-				<delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
+                <delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
                 <delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
                 <delegate name="placeBid" javaClass="games.strategy.triplea.delegate.BidPlaceDelegate" display="Bid Placement"/>
                 <delegate name="bid" javaClass="games.strategy.triplea.delegate.BidPurchaseDelegate" display="Bid Purchase"/>
                 <delegate name="politics" javaClass="games.strategy.triplea.delegate.PoliticsDelegate" display="Politics"/>
-                
+
 
                 <sequence>
-					<!-- it is very important that the "name" ends with the correct phrase, or else the game will not work properly.
-						 Please end with ("xx" = faction name): xxBid, xxBidPlace, xxTech, xxPurchase, xxCombatMove, xxBattle, xxNonCombatMove, xxPlace, xxTechActivation, xxEndTurn  -->
-						 
+                    <!-- it is very important that the "name" ends with the correct phrase, or else the game will not work properly.
+                         Please end with ("xx" = faction name): xxBid, xxBidPlace, xxTech, xxPurchase, xxCombatMove, xxBattle, xxNonCombatMove, xxPlace, xxTechActivation, xxEndTurn  -->
+
                         <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
 
                         <!-- Bidding Phase -->
@@ -663,10 +663,10 @@
                         <step name="japaneseBidPlace" delegate="placeBid" player="Japanese" maxRunCount="1"/>
                         <step name="americanBid" delegate="bid" player="Americans" maxRunCount="1"/>
                         <step name="americanBidPlace" delegate="placeBid" player="Americans" maxRunCount="1"/>
-						<step name="chineseBid" delegate="bid" player="Chinese" maxRunCount="1"/>
-						<step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
+                        <step name="chineseBid" delegate="bid" player="Chinese" maxRunCount="1"/>
+                        <step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
 
-						<!-- it is generally a good idea to put tech activation at the end of the turn, for balancing reasons -->
+                        <!-- it is generally a good idea to put tech activation at the end of the turn, for balancing reasons -->
                         <!-- Italians Game Sequence -->
                         <step name="italianTech" delegate="tech" player="Italians"/>
                         <step name="italianPurchase" delegate="purchase" player="Italians"/>
@@ -732,16 +732,16 @@
                         <step name="americanPlace" delegate="place" player="Americans"/>
                         <step name="americanTechActivation" delegate="tech_activation" player="Americans"/>
                         <step name="americanEndTurn" delegate="endTurn" player="Americans"/>
-						
-						<!-- Chinese Game Sequence -->
-						<step name="chineseBurmaRoadPurchase" delegate="purchase" player="Chinese"/>
+
+                        <!-- Chinese Game Sequence -->
+                        <step name="chineseBurmaRoadPurchase" delegate="purchase" player="Chinese"/>
                         <step name="chinesePolitics" delegate="politics" player="Chinese"/>
-						<step name="chineseCombatMove" delegate="move" player="Chinese"/>
-						<step name="chineseBattle" delegate="battle" player="Chinese"/>
-						<step name="chineseNonCombatMove" delegate="move" player="Chinese" display="Non Combat Move"/>
-						<step name="chineseNoPUPurchase" delegate="purchaseNoPU" player="Chinese"/>
-						<step name="chinesePlace" delegate="place" player="Chinese"/>
-						<step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese"/>
+                        <step name="chineseCombatMove" delegate="move" player="Chinese"/>
+                        <step name="chineseBattle" delegate="battle" player="Chinese"/>
+                        <step name="chineseNonCombatMove" delegate="move" player="Chinese" display="Non Combat Move"/>
+                        <step name="chineseNoPUPurchase" delegate="purchaseNoPU" player="Chinese"/>
+                        <step name="chinesePlace" delegate="place" player="Chinese"/>
+                        <step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese"/>
 
                         <step name="endRoundStep" delegate="endRound"/>
                 </sequence>
@@ -763,23 +763,23 @@
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="armour" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArmourtest">
                         <cost resource="PUs" quantity="5" />
                         <cost resource="Ore" quantity="5" />
                         <result resourceOrUnit="armour" quantity="1"/>
                 </productionRule>
-                
+
                  <productionRule name="buyArmourtest2">
                         <cost resource="FairyDust" quantity="5" />
                         <result resourceOrUnit="armour" quantity="1"/>
                 </productionRule>
-                
+
                     <productionRule name="buyArmourtest3">
                         <cost resource="Ore" quantity="5" />
                         <result resourceOrUnit="armour" quantity="1"/>
                 </productionRule>
-                
+
                  <productionRule name="buyMotorized">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="motorized" quantity="1"/>
@@ -834,8 +834,8 @@
                         <cost resource="PUs" quantity="8" />
                         <result resourceOrUnit="jp_destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiser">
+
+                <productionRule name="buyCruiser">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
@@ -896,12 +896,12 @@
                 </productionRule>
 
                 <!-- SHIPYARD PRICES -->
-					<!-- Shipyards production rules are only needed if you are using the "shipyards" tech AND have the shipyards game option ON. -->
+                    <!-- Shipyards production rules are only needed if you are using the "shipyards" tech AND have the shipyards game option ON. -->
                 <productionRule name="buyTransportShipyards">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="transport" quantity="1"/>
                 </productionRule>
-				
+
                 <productionRule name="buyJP_TransportShipyards">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="jp_transport" quantity="1"/>
@@ -921,8 +921,8 @@
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="jp_destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiserShipyards">
+
+                <productionRule name="buyCruiserShipyards">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
@@ -958,7 +958,7 @@
                 </productionRule>
 
                 <!-- Advanced Industrial Production -->
-					<!-- IndustrialTechnology production rules are only needed if you are using or plan to use the "industrialTechnology" tech.
+                    <!-- IndustrialTechnology production rules are only needed if you are using or plan to use the "industrialTechnology" tech.
 
                 <productionRule name="buyInfantryIndustrialTechnology">
                         <cost resource="PUs" quantity="3" />
@@ -1019,8 +1019,8 @@
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="jp_destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiserIndustrialTechnology">
+
+                <productionRule name="buyCruiserIndustrialTechnology">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
@@ -1069,10 +1069,10 @@
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="aaGun" quantity="1"/>
                 </productionRule>
-				-->
+                -->
 
                <!-- Repair rules -->
-					<!-- if you use ww2v3 style factory damage, you need repair rules -->
+                    <!-- if you use ww2v3 style factory damage, you need repair rules -->
                 <repairRule name="repairFactory">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory" quantity="1"/>
@@ -1108,21 +1108,21 @@
                 </repairRule>
 
                 <repairFrontier name="repair">
-                	<repairRules name="repairFactory"/>
-                	<repairRules name="repairBunker"/>
-                	<repairRules name="repairAirfield"/>
-                	<repairRules name="repairHarbour"/>
+                    <repairRules name="repairFactory"/>
+                    <repairRules name="repairBunker"/>
+                    <repairRules name="repairAirfield"/>
+                    <repairRules name="repairHarbour"/>
                 </repairFrontier>
 
                 <repairFrontier name="repairIndustrialTechnology">
-                	<repairRules name="repairFactoryIndustrialTechnology"/>
-                	<repairRules name="repairBunkerIndustrialTechnology"/>
-                	<repairRules name="repairAirfieldIndustrialTechnology"/>
-                	<repairRules name="repairHarbourIndustrialTechnology"/>
+                    <repairRules name="repairFactoryIndustrialTechnology"/>
+                    <repairRules name="repairBunkerIndustrialTechnology"/>
+                    <repairRules name="repairAirfieldIndustrialTechnology"/>
+                    <repairRules name="repairHarbourIndustrialTechnology"/>
                 </repairFrontier>
 
-				<!-- all players can use the same frontier, or you can have a different frontier for each player -->
-				<!-- only "production" (a single production frontier) is needed for most maps. if you use ww2v2 tech then you need IndustrialTechnology production, and if you use ww2v3 tech you need Shipyards -->
+                <!-- all players can use the same frontier, or you can have a different frontier for each player -->
+                <!-- only "production" (a single production frontier) is needed for most maps. if you use ww2v2 tech then you need IndustrialTechnology production, and if you use ww2v3 tech you need Shipyards -->
                 <!--<productionFrontier name="production">
                         <frontierRules name="buyInfantry"/>
                         <frontierRules name="buyArtillery"/>
@@ -1132,7 +1132,7 @@
                         <frontierRules name="buyTransport"/>
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buySuper_Carrier"/>
@@ -1152,7 +1152,7 @@
                         <frontierRules name="buyTransportIndustrialTechnology"/>
                         <frontierRules name="buySubmarineIndustrialTechnology"/>
                         <frontierRules name="buyDestroyerIndustrialTechnology"/>
-						<frontierRules name="buyCruiserIndustrialTechnology"/>
+                        <frontierRules name="buyCruiserIndustrialTechnology"/>
                         <frontierRules name="buyCarrierIndustrialTechnology"/>
                         <frontierRules name="buyBattleshipIndustrialTechnology"/>
                         <frontierRules name="buySuper_CarrierIndustrialTechnology"/>
@@ -1163,13 +1163,13 @@
                         <frontierRules name="buyHarbourIndustrialTechnology"/>
                 </productionFrontier>-->
 
-					<!-- Shipyards frontier rules are only needed if you are using the "shipyards" tech AND have the shipyards game option ON. If the shipyards game option is ON, then all players must use 1 frontier called "production".
-							If you want to use multiple production frontiers for different nations, then it is highly recommended you use triggers to add or remove productionRules instead of using the shipyard frontier. 
+                    <!-- Shipyards frontier rules are only needed if you are using the "shipyards" tech AND have the shipyards game option ON. If the shipyards game option is ON, then all players must use 1 frontier called "production".
+                            If you want to use multiple production frontiers for different nations, then it is highly recommended you use triggers to add or remove productionRules instead of using the shipyard frontier.
                 <productionFrontier name="productionShipyards">
                         <frontierRules name="buyTransportShipyards"/>
                         <frontierRules name="buySubmarineShipyards"/>
                         <frontierRules name="buyDestroyerShipyards"/>
-						<frontierRules name="buyCruiserShipyards"/>
+                        <frontierRules name="buyCruiserShipyards"/>
                         <frontierRules name="buyCarrierShipyards"/>
                         <frontierRules name="buyBattleshipShipyards"/>
                         <frontierRules name="buySuper_CarrierShipyards"/>
@@ -1184,7 +1184,7 @@
                         <frontierRules name="buyTransport"/>
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buySuper_Carrier"/>
@@ -1204,7 +1204,7 @@
                         <frontierRules name="buyTransport"/>
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buySuper_Carrier"/>
@@ -1224,7 +1224,7 @@
                         <frontierRules name="buyJP_Transport"/>
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyJP_Destroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buySuper_Carrier"/>
@@ -1244,7 +1244,7 @@
                         <frontierRules name="buyTransport"/>
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buySuper_Carrier"/>
@@ -1265,7 +1265,7 @@
                         <frontierRules name="buyTransport"/>
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buySuper_Carrier"/>
@@ -1285,7 +1285,7 @@
                         <frontierRules name="buyTransport"/>
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buySuper_Carrier"/>
@@ -1317,7 +1317,7 @@
                         <frontierRules name="buyTransport"/>
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buySuper_Carrier"/>
@@ -1329,256 +1329,256 @@
                 </productionFrontier>
 
                 <playerProduction player="Germans" frontier="Germans_production"/>
-				<playerProduction player="Russians" frontier="Russians_production"/>
-				<playerProduction player="Japanese" frontier="Japanese_production"/>
-				<playerProduction player="British" frontier="British_production"/>
+                <playerProduction player="Russians" frontier="Russians_production"/>
+                <playerProduction player="Japanese" frontier="Japanese_production"/>
+                <playerProduction player="British" frontier="British_production"/>
                 <playerProduction player="Italians" frontier="Italians_production"/>
-				<playerProduction player="Chinese" frontier="Chinese_BurmaRoad_production"/>
+                <playerProduction player="Chinese" frontier="Chinese_BurmaRoad_production"/>
                 <playerProduction player="Americans" frontier="Americans_production"/>
 
                 <playerRepair player="Germans" frontier="repair"/>
-				<playerRepair player="Russians" frontier="repair"/>
-				<playerRepair player="Japanese" frontier="repair"/>
-				<playerRepair player="British" frontier="repair"/>
+                <playerRepair player="Russians" frontier="repair"/>
+                <playerRepair player="Japanese" frontier="repair"/>
+                <playerRepair player="British" frontier="repair"/>
                 <playerRepair player="Italians" frontier="repair"/>
-				<playerRepair player="Chinese" frontier="repair"/>
+                <playerRepair player="Chinese" frontier="repair"/>
                 <playerRepair player="Americans" frontier="repair"/>
 
         </production>
 
-		<technology>
-				<!-- list all available techs for this map, for all players possible -->
-				<technologies>
-						<!-- this is the current list of all HARDCODED techs that come with TripleA -->
-						<!-- (+1 attack to isSub) superSub requires all isSub units to have a "_ss" image variant -->
-						<techname name="superSub"/>
-						<!-- (+1 att or def for isAir non-isStrategicBomber) jetPower requires all non-isStrategicBomber units to have a "_jp" image variant (and "_lr_jp") -->
-						<techname name="jetPower"/>
-						<!-- (removes all sea units from "production" and adds "Shipyards" production rules.  Only currently works when all players use a production frontier called "production") -->
-						<techname name="shipyards"/>
-						<!-- (+1 attack for anti-air units) aARadar requires all isAA units to have a "_r" image variant (and "rockets_r" or "_rockets_r") -->
-						<techname name="aARadar"/>
-						<!-- (+2 movement for isAir) longRangeAir requires all isAir units to have a "_lr" image variant (and "_lr_jp" OR "_lr_hb") -->
-						<techname name="longRangeAir"/>
-						<!-- (+X dice rolls for isAir isStrategicBomber) heavyBomber requires all isStrategicBomber units to have a "_hb" image variant (and "_lr_hb") -->
-						<techname name="heavyBomber"/>
-						<!-- (doubles number of units supported by artillery, and optionally by other support types) -->
-						<techname name="improvedArtillerySupport"/>
-						<!-- (allows isAA and isRocket to shoot rockets) rocket requires all isAA units to have a "rockets" image variant if they are called "aaGun", and a "_rockets" if they are called anything else (and "rockets_r" or "_rockets_r") -->
-						<techname name="rocket"/>
-						<!-- (allows isAirTransport units to carry isAirTransportable units) -->
-						<techname name="paratroopers"/>
-						<!-- (gives +2 production slots to factories on territories worth at least 3, and halves the price of repairing) increasedFactoryProduction requires all isFactory units to have a "_it" image variant (and "_hit" and "_it_hit") -->
-						<techname name="increasedFactoryProduction"/>
-						<!-- (rolls a die at the end of the player's turn, adds that many PUs to their bank) -->
-						<techname name="warBonds"/>
-						<!-- (allows isLandTransport units to carry isInfantry units) -->
-						<techname name="mechanizedInfantry"/>
-						<!-- (destroyerBombard allows isDestroyer to bombard) this is an example of renaming a technology. the first part is the new name, the second is the old name (the hardcoded tech's name) -->
-						<techname name="destroyersCanBombard" tech="destroyerBombard"/>
-						<!-- (industrialTechnology replaces a users production frontier with one called productionIndustrialTechnology (and i don't use it in this map))
-						<techname name="industrialTechnology"/> -->
-						
-						<!-- below is a list of user created techs. they do nothing by themselves, but can be used a conditions for triggers. simply use a name that isn't already taken by a hardcoded tech -->
-						<techname name="reinforcedHulls"/>
-						<techname name="wolfPackTactics"/>
-				</technologies>
-				<!-- list all available techs for this player -->
-				<playerTech player="Italians">
-						<!-- Number of categories is unlimited. Use descriptive names, as they are shown to the player. You may have empty categories, if you plan on adding to them inside the game using triggers -->
-						<!-- At least minimum of 0 techs per category, max of 6 per category if using ww2v3-style random selection of techs, 
-								max is unlimited if using ww2v2-style selected techs (however, any number of techs per category greater than 6 will be unreachable by the dice chooser)  -->
-						<!-- please list techs in the order that they appear in the technoligies list, as doing otherwise may cause an error -->
-						<!-- you can have a technology listed more than once, if you want to increase the chance of getting it -->
-						<category name="Italian Technology">
-								<tech name="destroyersCanBombard"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="improvedArtillerySupport"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-						</category>
-				</playerTech>
-				<playerTech player="Russians">
-						<category name="Air and Naval Advances">
-								<tech name="destroyersCanBombard"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="improvedArtillerySupport"/>
-								<tech name="rocket"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-								<tech name="mechanizedInfantry"/>
-						</category>
-				</playerTech>
-				<playerTech player="Germans">
-						<category name="Air and Naval Advances">
-								<tech name="superSub"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="rocket"/>
-								<tech name="paratroopers"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="mechanizedInfantry"/>
-						</category>
-						<category name="Submarine Technology">
-								<!-- as you can see, this category is empty.  that is because we will add techs to this category later by triggers -->
-						</category>
-				</playerTech>
-				<playerTech player="British">
-						<category name="Air and Naval Advances">
-								<tech name="destroyersCanBombard"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="rocket"/>
-								<tech name="paratroopers"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-						</category>
-				</playerTech>
-				<playerTech player="Japanese">
-						<category name="Air and Naval Advances">
-								<tech name="superSub"/>
-								<tech name="jetPower"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="rocket"/>
-								<tech name="paratroopers"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-								<tech name="mechanizedInfantry"/>
-						</category>
-				</playerTech>
-				<playerTech player="Americans">
-						<category name="Air and Naval Advances">
-								<tech name="superSub"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="paratroopers"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-								<tech name="mechanizedInfantry"/>
-						</category>
-				</playerTech>
-				<playerTech player="Chinese">
-						<category name="Air and Naval Advances">
-								<tech name="superSub"/>
-								<tech name="jetPower"/>
-								<tech name="shipyards"/>
-								<tech name="aARadar"/>
-								<tech name="longRangeAir"/>
-								<tech name="heavyBomber"/>
-						</category>
-						<category name="Land and Production Advances">
-								<tech name="improvedArtillerySupport"/>
-								<tech name="rocket"/>
-								<tech name="paratroopers"/>
-								<tech name="increasedFactoryProduction"/>
-								<tech name="warBonds"/>
-								<tech name="mechanizedInfantry"/>
-						</category>
-				</playerTech>
-		</technology>
+        <technology>
+                <!-- list all available techs for this map, for all players possible -->
+                <technologies>
+                        <!-- this is the current list of all HARDCODED techs that come with TripleA -->
+                        <!-- (+1 attack to isSub) superSub requires all isSub units to have a "_ss" image variant -->
+                        <techname name="superSub"/>
+                        <!-- (+1 att or def for isAir non-isStrategicBomber) jetPower requires all non-isStrategicBomber units to have a "_jp" image variant (and "_lr_jp") -->
+                        <techname name="jetPower"/>
+                        <!-- (removes all sea units from "production" and adds "Shipyards" production rules.  Only currently works when all players use a production frontier called "production") -->
+                        <techname name="shipyards"/>
+                        <!-- (+1 attack for anti-air units) aARadar requires all isAA units to have a "_r" image variant (and "rockets_r" or "_rockets_r") -->
+                        <techname name="aARadar"/>
+                        <!-- (+2 movement for isAir) longRangeAir requires all isAir units to have a "_lr" image variant (and "_lr_jp" OR "_lr_hb") -->
+                        <techname name="longRangeAir"/>
+                        <!-- (+X dice rolls for isAir isStrategicBomber) heavyBomber requires all isStrategicBomber units to have a "_hb" image variant (and "_lr_hb") -->
+                        <techname name="heavyBomber"/>
+                        <!-- (doubles number of units supported by artillery, and optionally by other support types) -->
+                        <techname name="improvedArtillerySupport"/>
+                        <!-- (allows isAA and isRocket to shoot rockets) rocket requires all isAA units to have a "rockets" image variant if they are called "aaGun", and a "_rockets" if they are called anything else (and "rockets_r" or "_rockets_r") -->
+                        <techname name="rocket"/>
+                        <!-- (allows isAirTransport units to carry isAirTransportable units) -->
+                        <techname name="paratroopers"/>
+                        <!-- (gives +2 production slots to factories on territories worth at least 3, and halves the price of repairing) increasedFactoryProduction requires all isFactory units to have a "_it" image variant (and "_hit" and "_it_hit") -->
+                        <techname name="increasedFactoryProduction"/>
+                        <!-- (rolls a die at the end of the player's turn, adds that many PUs to their bank) -->
+                        <techname name="warBonds"/>
+                        <!-- (allows isLandTransport units to carry isInfantry units) -->
+                        <techname name="mechanizedInfantry"/>
+                        <!-- (destroyerBombard allows isDestroyer to bombard) this is an example of renaming a technology. the first part is the new name, the second is the old name (the hardcoded tech's name) -->
+                        <techname name="destroyersCanBombard" tech="destroyerBombard"/>
+                        <!-- (industrialTechnology replaces a users production frontier with one called productionIndustrialTechnology (and i don't use it in this map))
+                        <techname name="industrialTechnology"/> -->
+
+                        <!-- below is a list of user created techs. they do nothing by themselves, but can be used a conditions for triggers. simply use a name that isn't already taken by a hardcoded tech -->
+                        <techname name="reinforcedHulls"/>
+                        <techname name="wolfPackTactics"/>
+                </technologies>
+                <!-- list all available techs for this player -->
+                <playerTech player="Italians">
+                        <!-- Number of categories is unlimited. Use descriptive names, as they are shown to the player. You may have empty categories, if you plan on adding to them inside the game using triggers -->
+                        <!-- At least minimum of 0 techs per category, max of 6 per category if using ww2v3-style random selection of techs,
+                                max is unlimited if using ww2v2-style selected techs (however, any number of techs per category greater than 6 will be unreachable by the dice chooser)  -->
+                        <!-- please list techs in the order that they appear in the technoligies list, as doing otherwise may cause an error -->
+                        <!-- you can have a technology listed more than once, if you want to increase the chance of getting it -->
+                        <category name="Italian Technology">
+                                <tech name="destroyersCanBombard"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                        </category>
+                </playerTech>
+                <playerTech player="Russians">
+                        <category name="Air and Naval Advances">
+                                <tech name="destroyersCanBombard"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="rocket"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                                <tech name="mechanizedInfantry"/>
+                        </category>
+                </playerTech>
+                <playerTech player="Germans">
+                        <category name="Air and Naval Advances">
+                                <tech name="superSub"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="rocket"/>
+                                <tech name="paratroopers"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="mechanizedInfantry"/>
+                        </category>
+                        <category name="Submarine Technology">
+                                <!-- as you can see, this category is empty.  that is because we will add techs to this category later by triggers -->
+                        </category>
+                </playerTech>
+                <playerTech player="British">
+                        <category name="Air and Naval Advances">
+                                <tech name="destroyersCanBombard"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="rocket"/>
+                                <tech name="paratroopers"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                        </category>
+                </playerTech>
+                <playerTech player="Japanese">
+                        <category name="Air and Naval Advances">
+                                <tech name="superSub"/>
+                                <tech name="jetPower"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="rocket"/>
+                                <tech name="paratroopers"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                                <tech name="mechanizedInfantry"/>
+                        </category>
+                </playerTech>
+                <playerTech player="Americans">
+                        <category name="Air and Naval Advances">
+                                <tech name="superSub"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="paratroopers"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                                <tech name="mechanizedInfantry"/>
+                        </category>
+                </playerTech>
+                <playerTech player="Chinese">
+                        <category name="Air and Naval Advances">
+                                <tech name="superSub"/>
+                                <tech name="jetPower"/>
+                                <tech name="shipyards"/>
+                                <tech name="aARadar"/>
+                                <tech name="longRangeAir"/>
+                                <tech name="heavyBomber"/>
+                        </category>
+                        <category name="Land and Production Advances">
+                                <tech name="improvedArtillerySupport"/>
+                                <tech name="rocket"/>
+                                <tech name="paratroopers"/>
+                                <tech name="increasedFactoryProduction"/>
+                                <tech name="warBonds"/>
+                                <tech name="mechanizedInfantry"/>
+                        </category>
+                </playerTech>
+        </technology>
 
         <attachmentList>
-        
+
 <!--  relationshipType Attachments -->
-	<!--  each PoliticalRelationship needs a relationshipTypeAttachment 
-			and each relationshipTypeAttachment needs an option: archetype that needs to be set to one of the following 3 values:
-			* "allied"
-			* "neutral"
-			* "war"
-			the archeType determines the default behaviour of this relationshipType that can be modified by setting other options.
-			Also the archeType determines the outcomes of isAllied, isNeutral and isWar query in the engine
-	-->
-	<!-- the following options are allowed for "relationshipTypeAttachment", (all options except for archeType only allow "true", "false", or "default")
-			archeType								values: "allied" or "war" or "neutral"
-			canMoveLandUnitsOverOwnedLand			values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war and allied can move into, while neutral can not
-			canMoveAirUnitsOverOwnedLand			values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war and allied can move into, while neutral can not
-			canLandAirUnitsOnOwnedLand				values: "true", "false", or "default". default setting is "default", and "default" means that archeType of allied only lets you land units in the player's territories
-			upkeepCost								values: "default", or any valid integer, or "percentage" with a count of a valid integer. Default = zero (0). This determines if there is a cost to maintain a relationship, which would be subtracted from PUs gained at end of turn.
-																examples: a cost of 1 PU per turn: <option name="upkeepCost" value="1"/> or <option name="upkeepCost" value="flat" count="1"/>, or a cost of 9% of your income per turn: <option name="upkeepCost" value="percentage" count="9"/>
-			alliancesCanChainTogether				values: "true", "false", or "default". can only be applied to a relationship that is archetype "allied", and only 1 relationship can have it. if true, any nations that reach this relationship will share both allies and enemies.
-			isDefaultWarPosition					values: "true", "false", or "default". can only be applied to a relationship that is archetype "war", and only 1 relationship can have it. if true, any nations that reach an alliance chaining relationship, will have their enemies who are not yet at war with, set to this relationship.
-			canTakeOverOwnedTerritory				values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war lets you take over territories.  By setting true, you can take over territories of an ally
-			givesBackOriginalTerritories			values: "true", "false", or "default". default setting is "default", and "default" means false. If true, at the end of each politics phase, any territories originally belonging to the other player will revert to that players control.
-	-->
+    <!--  each PoliticalRelationship needs a relationshipTypeAttachment
+            and each relationshipTypeAttachment needs an option: archetype that needs to be set to one of the following 3 values:
+            * "allied"
+            * "neutral"
+            * "war"
+            the archeType determines the default behaviour of this relationshipType that can be modified by setting other options.
+            Also the archeType determines the outcomes of isAllied, isNeutral and isWar query in the engine
+    -->
+    <!-- the following options are allowed for "relationshipTypeAttachment", (all options except for archeType only allow "true", "false", or "default")
+            archeType                               values: "allied" or "war" or "neutral"
+            canMoveLandUnitsOverOwnedLand           values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war and allied can move into, while neutral can not
+            canMoveAirUnitsOverOwnedLand            values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war and allied can move into, while neutral can not
+            canLandAirUnitsOnOwnedLand              values: "true", "false", or "default". default setting is "default", and "default" means that archeType of allied only lets you land units in the player's territories
+            upkeepCost                              values: "default", or any valid integer, or "percentage" with a count of a valid integer. Default = zero (0). This determines if there is a cost to maintain a relationship, which would be subtracted from PUs gained at end of turn.
+                                                                examples: a cost of 1 PU per turn: <option name="upkeepCost" value="1"/> or <option name="upkeepCost" value="flat" count="1"/>, or a cost of 9% of your income per turn: <option name="upkeepCost" value="percentage" count="9"/>
+            alliancesCanChainTogether               values: "true", "false", or "default". can only be applied to a relationship that is archetype "allied", and only 1 relationship can have it. if true, any nations that reach this relationship will share both allies and enemies.
+            isDefaultWarPosition                    values: "true", "false", or "default". can only be applied to a relationship that is archetype "war", and only 1 relationship can have it. if true, any nations that reach an alliance chaining relationship, will have their enemies who are not yet at war with, set to this relationship.
+            canTakeOverOwnedTerritory               values: "true", "false", or "default". default setting is "default", and "default" means that archeType of war lets you take over territories.  By setting true, you can take over territories of an ally
+            givesBackOriginalTerritories            values: "true", "false", or "default". default setting is "default", and "default" means false. If true, at the end of each politics phase, any territories originally belonging to the other player will revert to that players control.
+    -->
 
-				<attachment name="relationshipTypeAttachment" attachTo="War" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="war"/>
-				</attachment>
+                <attachment name="relationshipTypeAttachment" attachTo="War" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="war"/>
+                </attachment>
 
-				<attachment name="relationshipTypeAttachment" attachTo="Allied" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="allied"/>
-						<option name="givesBackOriginalTerritories" value="true"/>
-				</attachment>
+                <attachment name="relationshipTypeAttachment" attachTo="Allied" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="allied"/>
+                        <option name="givesBackOriginalTerritories" value="true"/>
+                </attachment>
 
-				<attachment name="relationshipTypeAttachment" attachTo="Neutrality" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="neutral"/>
-				</attachment>
+                <attachment name="relationshipTypeAttachment" attachTo="Neutrality" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="neutral"/>
+                </attachment>
 
-				<attachment name="relationshipTypeAttachment" attachTo="NAP" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="neutral"/>
-				</attachment>
+                <attachment name="relationshipTypeAttachment" attachTo="NAP" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="neutral"/>
+                </attachment>
 
-				<attachment name="relationshipTypeAttachment" attachTo="ColdWar" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="neutral"/>
-				</attachment>
-							
+                <attachment name="relationshipTypeAttachment" attachTo="ColdWar" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="neutral"/>
+                </attachment>
+
 <!-- Tech Attachments -->
-	<!-- IF you are using custom technologies (generic techs), then ALL players need a tech attachment, even if it is an empty tech attachment, otherwise there will be errors
-	-->
-	<!-- the following options are allowed for "techAttachment".  These are not required, they only determine if a country starts with a tech or not.  All default to False.
-			techCost							values: the cost of buying tech rolls for this player, defaults to 5
-			superSub
-			jetPower
-			shipyards
-			aARadar
-			longRangeAir
-			heavyBomber
-			improvedArtillerySupport
-			rocket
-			paratroopers
-			increasedFactoryProduction
-			warBonds
-			mechanizedInfantry
-			destroyerBombard
-			industrialTechnology
-			
-	-->
-        		<!-- Germans -->
+    <!-- IF you are using custom technologies (generic techs), then ALL players need a tech attachment, even if it is an empty tech attachment, otherwise there will be errors
+    -->
+    <!-- the following options are allowed for "techAttachment".  These are not required, they only determine if a country starts with a tech or not.  All default to False.
+            techCost                            values: the cost of buying tech rolls for this player, defaults to 5
+            superSub
+            jetPower
+            shipyards
+            aARadar
+            longRangeAir
+            heavyBomber
+            improvedArtillerySupport
+            rocket
+            paratroopers
+            increasedFactoryProduction
+            warBonds
+            mechanizedInfantry
+            destroyerBombard
+            industrialTechnology
+
+    -->
+                <!-- Germans -->
                 <attachment name="techAttachment" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
-						<!-- techCost is optional, and defaults to 5 if missing.  techs default to false if missing -->
+                        <!-- techCost is optional, and defaults to 5 if missing.  techs default to false if missing -->
                         <option name="techCost" value="5"/>
-						<option name="superSub" value="false"/>
+                        <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
                         <option name="shipyards" value="false"/>
                         <option name="aARadar" value="false"/>
@@ -1591,11 +1591,11 @@
                         <option name="warBonds" value="false"/>
                         <option name="mechanizedInfantry" value="false"/>
                 </attachment>
-				
-				<!-- Russians -->
+
+                <!-- Russians -->
                 <attachment name="techAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="techCost" value="5"/>
-						<option name="superSub" value="false"/>
+                        <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
                         <option name="shipyards" value="false"/>
                         <option name="aARadar" value="false"/>
@@ -1612,7 +1612,7 @@
                 <!-- Japanese -->
                 <attachment name="techAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="techCost" value="6"/>
-						<option name="superSub" value="false"/>
+                        <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
                         <option name="shipyards" value="false"/>
                         <option name="aARadar" value="false"/>
@@ -1629,7 +1629,7 @@
                 <!-- British -->
                 <attachment name="techAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="techCost" value="5"/>
-						<option name="superSub" value="false"/>
+                        <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
                         <option name="shipyards" value="false"/>
                         <option name="aARadar" value="false"/>
@@ -1642,11 +1642,11 @@
                         <option name="warBonds" value="false"/>
                         <option name="mechanizedInfantry" value="false"/>
                 </attachment>
-				
-				<!-- Italians -->
+
+                <!-- Italians -->
                 <attachment name="techAttachment" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="techCost" value="6"/>
-						<option name="superSub" value="false"/>
+                        <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
                         <option name="shipyards" value="false"/>
                         <option name="aARadar" value="false"/>
@@ -1663,7 +1663,7 @@
                 <!-- Americans -->
                 <attachment name="techAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="techCost" value="4"/>
-						<option name="superSub" value="false"/>
+                        <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
                         <option name="shipyards" value="false"/>
                         <option name="aARadar" value="false"/>
@@ -1680,223 +1680,223 @@
                 <!-- Chinese -->
                 <attachment name="techAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="improvedArtillerySupport" value="false"/>
-						<!-- even the chinese, who can not roll for tech because they don't have a phase for it, must have a tech attachment because we are using custom techs,
-								so this here is an almost empty tech attachment.  actually, we could fill it with more stuff, that is false or true, but 1 is enough
-								just because something is in this list doesn't mean we can get it.  whether we can get it or not is determined by what is in "playerTech" -->
+                        <!-- even the chinese, who can not roll for tech because they don't have a phase for it, must have a tech attachment because we are using custom techs,
+                                so this here is an almost empty tech attachment.  actually, we could fill it with more stuff, that is false or true, but 1 is enough
+                                just because something is in this list doesn't mean we can get it.  whether we can get it or not is determined by what is in "playerTech" -->
                 </attachment>
-				
-				
-				
+
+
+
 <!-- Unit Attachments -->
-	<!-- Certain units require extra graphical icons present, for when technology is researched or damage is done.  Here is a list, in order of what is needed:
-			Anything I list as "_something" means that you must have the units exact name in front of it, example: fighter_jp
-			if the unit is called "aaGun" then you need units called "rockets", "rockets_r", and "aaGun_r"
-			if the unit has "isAA", but is not exactly named "aaGun", then you need units called "_rockets" and "_r" and "_rockets_r"
-			if the unit has "isRocket", you need "_rockets"
-			if the unit has "isAAforCombatOnly" and/or "isAAforBombingThisUnitOnly", then you need "_r"
-			if the unit has "isAir", but not "isStrategicBomber", then you need "_lr", and "_jp", and "_lr_jp"
-			if the unit has "isAir", and is "isStrategicBomber", then you need "_lr", and "_hb", and "_lr_hb"
-			if the unit has "isSub", then you need "_ss"
-			if the unit has "isFactory", or is called "factory", then you need "_it", and "_it_hit"
-			if a unit can be damaged (by being a factory, or by having "canBeDamaged", then you will need "_hit"
-			if a unit can be disabled, then you will need "_disabled"
-	-->
-	<!-- the following options are allowed for "unitAttachment"
-			isAir								values: if a unit is air or not, defaults to false
-			isSea								values: if a unit is sea or not, defaults to false. any unit that is neither air or sea, is land
-			movement							values: the allowed movement of a unit, defaults to zero
-			attack								values: the attack value, where a rolled dice must be equal or less than to hit the enemy
-			defense								values: the defense value, where a rolled dice must be equal or less than to hit the enemy
-			isTwoHit							values: does the unit have 2 hitpoints. default is false, which means 1 hitpoint
-			
-			artillerySupportable				values: with the 'artillery' and 'unitSupportCount' ability, these three create a set of support attachments at the start of the game, 
-															allows the unit to receive support from an "artillery" unit (land, sea, or air are allowed)
-			artillery							values: with the 'artillerySupportable' and 'unitSupportCount' ability, these three create a set of support attachments at the start of the game,
-															artillery gives support (+1 attack) to "artillerySupportable" units (land, sea, or air are allowed)
-			unitSupportCount					values: with the 'artillerySupportable' and 'artillery' ability, these three create a set of support attachments at the start of the game,
-															unitSupportCount is the number of units that will be supported by the artillery, defaults to 1 if missing
-			isMarine							values: gives the unit +1 attack if it is attacking amphibiously
-			canBlitz							values: allows the unit to move through multiple empty enemy territories in one turn
-			receivesAbilityWhenWith				values: gives a unit an ability when they are with, or on the same route as, another unit. currently only works with 'canBlitz'. example: value="canBlitz:armour"
-			canBeGivenByTerritoryTo				values: will allow a unit to be given from one player to another player, if it is in a territory with changeUnitOwners 
-															must be a list of Players who this unit can be given to.  example: value="Russians:Chinese"
-			canBeCapturedOnEnteringBy			values: will allow a unit to be captured from one player to another, if the specified player enters a territory with captureUnitOnEnteringBy
-															must be a list of Players who this unit can be given to.  example: value="Russians:Chinese"
-			canInvadeOnlyFrom					values: is a colon dilimited list of the transporting units which this unit can perform amphibious assaults from. 
-															A unit which can not perform amphibious assaults may instead disembark during non-combat
-															can be set to "all", or "none", or a list of some transports. if this option is not present, it defaults to "all"
-			isInfantry							values: allows the unit to be transported by 'isLandTransport' IF you have mechanizedInfantry technology
-			isLandTransport						values: allows the unit to transport "isInfantry" on a one-to-one basis, if you have the mechanizedInfantry technology
-			isAirTransportable					values: allows the unit to be transported by an "isAirTransport" unit, IF you have paratroopers technology
-			isAirTransport						values: allows an air unit to carry land units when you have paratroopers tech
-			transportCost						values: the space this unit takes up in a transport
-			transportCapacity					values: the amount of space of land units this unit can carry. can be used with sea or air units, except that air units will also require isAirTransport.
-			isCombatTransport					values: considers a unit to be a combat sea unit, even if it has transport capacity, for the purposes of convoys and restricted attack on transports
-			isAirTransportable							values: does nothing
-			isInfantry						values: does nothing
-			
-			canScramble							values: allows the aircraft to enter a surrounding sea zone if the enemy is doing an attack on or from the surrounding sea zone
-			maxScrambleDistance					values: the distance out an aircraft can scramble. anything higher than 1 is not supported well at this point.
-			isSuicide							values: makes a unit die before combat begins, however they do get to roll
-			isKamikaze							values: allows an air unit to use up all of its movement to go to a battle
-			isStrategicBomber					values: allows a unit to bombing factories and canBeDamaged units
-			bombingMaxDieSides					values: is the max dice sides for a strategic bombing or rocket attack.  if you want to lower the luck involved, use bombing bonus and lower the max dice sides.  This property is optional, and only turns on when you have LL for bombing turned on.
-															example: if you want to have either a 3 or 4 rolled, then set maxDieSides to 2, and the Bonus to 2.  this means you will roll a 2 sided die (results are either "1" or "2") and add "2" to the result (so you get "3" or "4")
-			bombingBonus						values: is a number added to the die rolled, to give the total cost [displayed as a new die rolled], for strategic bombing and rockets only.  This property is optional, and only turns on when you have LL for bombing turned on.
-			carrierCost							values: the space this unit takes up when sitting on a carrier
-			carrierCapacity						values: the amount of space or air unit this unit can carry.
-			
-			canBombard							values: allows a sea unit to bombard the enemy during an amphibious assault
-			bombard								values: the value this unit bombards at. defaults to the attack value of the unit if missing
-			blockade							values: allows the unit to do damage up to the value of land territories surrounding a blockade zone, to the enemy's income
-			isDestroyer							values: cancels out an isSub unit's first strike and submerge abilities, and allows it to be hit by air units if using ww2v3 rules
-			isSub								values: allows the unit to roll dice before other units, and submerge or retreat from battle even on defense, and if using ww2v3 rules not be hit by air unless the enemy has an isDestroyer
-			
-			canBeDamaged						values: sets if a unit can be attacked by strategic bombing raids or by rockets.  isFactory also allows these things
-			maxDamage							values: is the total damage the unit can take.  If a factory, and canProduceXUnits = -1 or is missing then maxDamage will be a multiple of the territory value (maxDamage defaults to 2 if canProduceXUnits = -1), otherwise it will be a set number 
-															So for example, if the unit isFactory Or canProduceUnits, And canProduceXUnits = -1, And maxDamage = 3, THEN you will be able to do 3x the territory value in damage to this unit. 
-															If However, canProduceXUnits = 2, and maxDamage = 3, then you can do up to 3 damage to this unit.
-			maxOperationalDamage				values: is used with certain features like isAirBase, repairsUnits, and givesMovement to determine if those features work or not based on the current damage of this unit. A disabled unit will not participate in combat too.  Does Not work with isFactory or canProduceUnits.
-			canDieFromReachingMaxDamage			values: means that if this unit reaches its maxDamage, then it will die.  maxDamage must be larger than zero
-			isInfrastructure					values: means a unit does not participate in combat, and they will be captured if the attacker is successful
-			destroyedWhenCapturedFrom			values: is a list of players who destroy a non-combat unit instead of letting it be captured.  destroyedWhenCapturedFrom just takes the value input then adds "FROM:" to the beginning, then calls destroyedWhenCapturedBy with the new value.
-			destroyedWhenCapturedBy				values: is a list of the players who destroy this non-combat unit instead of capturing it.  all non-combat units are normally captured by default. is a colon delimited list of player names.
-															You can prefix them with single instance of "BY:" or "FROM:" in order to determine if it is being captured by, or captured from, that determines if the unit is destroyed.
-															examples: <option name="destroyedWhenCapturedBy" value="BY:Chinese:Japanese"/> and <option name="destroyedWhenCapturedBy" value="FROM:Russians:Chinese"/>
-			whenCapturedChangesInto				values: allows a unit to change into a different unit when captured from a specific player to a specific player.  "fromPlayer:toPlayer:transferAttributes:unitType:numberOfUnits".  accepts "any" instead of a player name. allows multiple.
-															examples: <option name="whenCapturedChangesInto" value="any:any:true:Minor_Factory:1"/> and <option name="whenCapturedChangesInto" value="Russians:Germans:false:gold:3:lumber:1"/>
-			isAirBase							values: allows units with canScramble to scramble from a territory with this unit
-			maxScrambleCount					values: max number of units which can scramble from this air base. defaults to infinite.
-			givesMovement						values: allows a unit to give movement to other units.  must be an integer, followed by a colon ":", followed by the name of the unit
-			repairsUnits						values: is a colon delimited list of all the units this unit can repair. units to be repaired must be in the same territory as this unit. 
-															unless the unit being repaired is sea, and the unit repairing it is land, in which case the sea unit must be adjacent to the land unit 
-															example: option name="repairsUnits" value="battleship:super_carrier"
-			whenCombatDamaged					values: this property lets you set certain behaviors for when this unit is damaged. the value is the effect, while the count is the damage from where to where. (example: <option name="whenCombatDamaged" value="unitsMayNotLandOnCarrier" count="1:2"/>)
-															units start at zero combat damage, and usually die at 1 damage. some units have 2 hp, so you can use this with 1:1 to say that when a unit has 1 damage they have this effect.
-															currently only allows: unitsMayNotLandOnCarrier, unitsMayNotLeaveAlliedCarrier
-			canIntercept						values: allows this unit to participate in air battles, as a defending unit
-			canEscort							values: allows this unit to participate in air battles, as an attacking unit
-			airDefense							values: defense value of interceptor
-			airAttack							values: attack value of escort
-			fuelCost							values: fuelCost is a list of at least one resource that get used up for each point of movementCost a unit does.  (can have multiple). example: <option name="fuelCost" value="Fuel" count="5"/> and <option name="fuelCost" value="PUs" count="1"/>
-	
-	production related:
-			isFactory							values: allows a unit to produce other units, not participate in combat, be placed anywhere you owned at the beginning of the turn, be capturable, and be damaged by rockets and raids
-			canProduceXUnits					values: allows a factory-type unit to produce a set amount of units no matter where it is located.  if -1 then it will produce at the value of the territory where it is.  
-															if greater than -1, you must have "maxDamage" set to some number if the unit is also "canBeDamaged" or "isFactory".  defaults to -1 if missing
-			canProduceUnits						values: allows a unit to be a factory, without all the other things that come with being a factory (like capturable, land, non-combat, etc).  So if you want flying factories, go ahead. Just don't complain if you get errors.
-			createsUnitsList					values: is a list of units that this unit will create every turn at the end of the turn. can have multiple instances
-			createsResourcesList				values: is a list of resources that this unit will create every turn at the end of the turn. can have multiple instances
-	
-	placement related:
-			maxBuiltPerPlayer					values: is the number of this unit that can be BUILT by a player.  If they have fewer than this number they can build more, if they have more than this number they can not build more 
-															[this does not cause excess ones to disappear, and the player can still capture more and more of them if they are capturable]
-			canOnlyBePlacedInTerritoryValuedAtX	values: the minimum territory value to place the unit there. defaults to "-1" which means anywhere
-			unitPlacementRestrictions			values: a list of territories where this unit can not be built. list can contain any number of territories, including sea zones .
-															every unit may have a list, and the lists may be different for each unit. default is no list.  
-															the list may be turned on/off with "Unit Placement Restrictions" game property
-			unitPlacementOnlyAllowedIn			values: is the direct inverse of unitPlacementRestrictions
-			requiresUnits						values: is a list of units required to be present in the territory in order for you to build this unit there.  Can have multiple instances. Only one instance needs to be true in order to build.
-			consumesUnits						values: requires that a unit be present in a territory, then when this unit is placed the other units are destroyed / upgraded into this unit.  Can have multiple instances of this, which means it consumes multiple types of units.
-			isConstruction						values: allows the unit to be placed in territories that don't contain factories. only "constructionsPerTerrPerTypePerTurn" contructions of "constructionType" may be placed per territory per turn. 
-															may have only "maxConstructionsPerTypePerTerr" constructions Total per territory with/without a factory unless you enable "More Constructions with/without Factory", which will allow up a total number of up to the territory value
-															and "Unlimited Constructions" game property allows unlimited constructions total in a territory
-			constructionType					values: is just a unique string which identifies what kind of construction this. 
-															if two or more constructions have the exact same constructionType (and the same PerType rules), then they will follow the same rules for placement.
-															example: if you have little_bunker and big_bunker both as type "bunker", with constructionsPerTerrPerTypePerTurn=2, then you could place 2 littles, or 2 bigs, or 1 little and 1 big in a territory 
-															if you do not want this unit to be effected by the global properties "More Constructions with/without Factory" and "Unlimited Constructions", then make sure the type ends in "structure". example: "harbour_structure"
-			constructionsPerTerrPerTypePerTurn	values: is how many of this type you can place in a territory every turn
-			maxConstructionsPerTypePerTerr		values: is how many max of this type may be in a territory. this must be greater than constructionsPerTerrPerTypePerTurn
-															if "More Constructions with/without Factory" = true, then the minimum will be either maxConstructionsPerTypePerTerr or the PU value of the territory (whichever number is greater) in territories with/without factories
-															if "Unlimited Constructions" = true, then this number becomes 10000
-			special								values:	a colon delimited list of possible options for this unit.  Currently only supports: "canOnlyPlaceInOriginalTerritories"
-	
-	aa related:
-			isAA								values: allows a unit to shoot at air units before combat starts and not participate in the rest of combat, have certain movement restrictions, and be capturable
-			attackAA							values: the value that an isAA unit will attack at, for shooting at air units before battle
-			attackAAmaxDieSides					values: sets the dice sides for aa guns.  defaults to whatever you chose above in diceSides (or 6 if you didn't choose).  
-															Be Warned that all aa attack values (including with Radar and without Radar), MUST divide into attackAAmaxDieSides without remainders, or else there WILL be errors in LowLuck!
-			isAAforCombatOnly					values: allows this unit to be an AA gun for normal combat only.  it will not defend against strategic bombing raids
-			isAAforBombingThisUnitOnly			values: allows this unit to be an AA gun only when this unit is directly attacked by a strategic bombing raid (currently defends against all strategic bombing attacks in this territory, not just against this unit).  it will not defend against a normal attack
-			isRocket							values: allows this unit to become a rocket if the player has the rocket technology.  If the unit is named exactly "aaGun" then it will require an image called "rockets".  If the unit is named anything else, then it will require an image with "_rockets" appended to its original name
-			isAAmovement						values: forces this unit to follow the rules for movement of an AA gun, and for placement of AA guns (like no moving during combat phase, max of 1 of each unit per territory, etc.)
-			
-	-->
+    <!-- Certain units require extra graphical icons present, for when technology is researched or damage is done.  Here is a list, in order of what is needed:
+            Anything I list as "_something" means that you must have the units exact name in front of it, example: fighter_jp
+            if the unit is called "aaGun" then you need units called "rockets", "rockets_r", and "aaGun_r"
+            if the unit has "isAA", but is not exactly named "aaGun", then you need units called "_rockets" and "_r" and "_rockets_r"
+            if the unit has "isRocket", you need "_rockets"
+            if the unit has "isAAforCombatOnly" and/or "isAAforBombingThisUnitOnly", then you need "_r"
+            if the unit has "isAir", but not "isStrategicBomber", then you need "_lr", and "_jp", and "_lr_jp"
+            if the unit has "isAir", and is "isStrategicBomber", then you need "_lr", and "_hb", and "_lr_hb"
+            if the unit has "isSub", then you need "_ss"
+            if the unit has "isFactory", or is called "factory", then you need "_it", and "_it_hit"
+            if a unit can be damaged (by being a factory, or by having "canBeDamaged", then you will need "_hit"
+            if a unit can be disabled, then you will need "_disabled"
+    -->
+    <!-- the following options are allowed for "unitAttachment"
+            isAir                               values: if a unit is air or not, defaults to false
+            isSea                               values: if a unit is sea or not, defaults to false. any unit that is neither air or sea, is land
+            movement                            values: the allowed movement of a unit, defaults to zero
+            attack                              values: the attack value, where a rolled dice must be equal or less than to hit the enemy
+            defense                             values: the defense value, where a rolled dice must be equal or less than to hit the enemy
+            isTwoHit                            values: does the unit have 2 hitpoints. default is false, which means 1 hitpoint
+
+            artillerySupportable                values: with the 'artillery' and 'unitSupportCount' ability, these three create a set of support attachments at the start of the game,
+                                                            allows the unit to receive support from an "artillery" unit (land, sea, or air are allowed)
+            artillery                           values: with the 'artillerySupportable' and 'unitSupportCount' ability, these three create a set of support attachments at the start of the game,
+                                                            artillery gives support (+1 attack) to "artillerySupportable" units (land, sea, or air are allowed)
+            unitSupportCount                    values: with the 'artillerySupportable' and 'artillery' ability, these three create a set of support attachments at the start of the game,
+                                                            unitSupportCount is the number of units that will be supported by the artillery, defaults to 1 if missing
+            isMarine                            values: gives the unit +1 attack if it is attacking amphibiously
+            canBlitz                            values: allows the unit to move through multiple empty enemy territories in one turn
+            receivesAbilityWhenWith             values: gives a unit an ability when they are with, or on the same route as, another unit. currently only works with 'canBlitz'. example: value="canBlitz:armour"
+            canBeGivenByTerritoryTo             values: will allow a unit to be given from one player to another player, if it is in a territory with changeUnitOwners
+                                                            must be a list of Players who this unit can be given to.  example: value="Russians:Chinese"
+            canBeCapturedOnEnteringBy           values: will allow a unit to be captured from one player to another, if the specified player enters a territory with captureUnitOnEnteringBy
+                                                            must be a list of Players who this unit can be given to.  example: value="Russians:Chinese"
+            canInvadeOnlyFrom                   values: is a colon dilimited list of the transporting units which this unit can perform amphibious assaults from.
+                                                            A unit which can not perform amphibious assaults may instead disembark during non-combat
+                                                            can be set to "all", or "none", or a list of some transports. if this option is not present, it defaults to "all"
+            isInfantry                          values: allows the unit to be transported by 'isLandTransport' IF you have mechanizedInfantry technology
+            isLandTransport                     values: allows the unit to transport "isInfantry" on a one-to-one basis, if you have the mechanizedInfantry technology
+            isAirTransportable                  values: allows the unit to be transported by an "isAirTransport" unit, IF you have paratroopers technology
+            isAirTransport                      values: allows an air unit to carry land units when you have paratroopers tech
+            transportCost                       values: the space this unit takes up in a transport
+            transportCapacity                   values: the amount of space of land units this unit can carry. can be used with sea or air units, except that air units will also require isAirTransport.
+            isCombatTransport                   values: considers a unit to be a combat sea unit, even if it has transport capacity, for the purposes of convoys and restricted attack on transports
+            isAirTransportable                  values: does nothing
+            isInfantry                          values: does nothing
+
+            canScramble                         values: allows the aircraft to enter a surrounding sea zone if the enemy is doing an attack on or from the surrounding sea zone
+            maxScrambleDistance                 values: the distance out an aircraft can scramble. anything higher than 1 is not supported well at this point.
+            isSuicide                           values: makes a unit die before combat begins, however they do get to roll
+            isKamikaze                          values: allows an air unit to use up all of its movement to go to a battle
+            isStrategicBomber                   values: allows a unit to bombing factories and canBeDamaged units
+            bombingMaxDieSides                  values: is the max dice sides for a strategic bombing or rocket attack.  if you want to lower the luck involved, use bombing bonus and lower the max dice sides.  This property is optional, and only turns on when you have LL for bombing turned on.
+                                                            example: if you want to have either a 3 or 4 rolled, then set maxDieSides to 2, and the Bonus to 2.  this means you will roll a 2 sided die (results are either "1" or "2") and add "2" to the result (so you get "3" or "4")
+            bombingBonus                        values: is a number added to the die rolled, to give the total cost [displayed as a new die rolled], for strategic bombing and rockets only.  This property is optional, and only turns on when you have LL for bombing turned on.
+            carrierCost                         values: the space this unit takes up when sitting on a carrier
+            carrierCapacity                     values: the amount of space or air unit this unit can carry.
+
+            canBombard                          values: allows a sea unit to bombard the enemy during an amphibious assault
+            bombard                             values: the value this unit bombards at. defaults to the attack value of the unit if missing
+            blockade                            values: allows the unit to do damage up to the value of land territories surrounding a blockade zone, to the enemy's income
+            isDestroyer                         values: cancels out an isSub unit's first strike and submerge abilities, and allows it to be hit by air units if using ww2v3 rules
+            isSub                               values: allows the unit to roll dice before other units, and submerge or retreat from battle even on defense, and if using ww2v3 rules not be hit by air unless the enemy has an isDestroyer
+
+            canBeDamaged                        values: sets if a unit can be attacked by strategic bombing raids or by rockets.  isFactory also allows these things
+            maxDamage                           values: is the total damage the unit can take.  If a factory, and canProduceXUnits = -1 or is missing then maxDamage will be a multiple of the territory value (maxDamage defaults to 2 if canProduceXUnits = -1), otherwise it will be a set number
+                                                            So for example, if the unit isFactory Or canProduceUnits, And canProduceXUnits = -1, And maxDamage = 3, THEN you will be able to do 3x the territory value in damage to this unit.
+                                                            If However, canProduceXUnits = 2, and maxDamage = 3, then you can do up to 3 damage to this unit.
+            maxOperationalDamage                values: is used with certain features like isAirBase, repairsUnits, and givesMovement to determine if those features work or not based on the current damage of this unit. A disabled unit will not participate in combat too.  Does Not work with isFactory or canProduceUnits.
+            canDieFromReachingMaxDamage         values: means that if this unit reaches its maxDamage, then it will die.  maxDamage must be larger than zero
+            isInfrastructure                    values: means a unit does not participate in combat, and they will be captured if the attacker is successful
+            destroyedWhenCapturedFrom           values: is a list of players who destroy a non-combat unit instead of letting it be captured.  destroyedWhenCapturedFrom just takes the value input then adds "FROM:" to the beginning, then calls destroyedWhenCapturedBy with the new value.
+            destroyedWhenCapturedBy             values: is a list of the players who destroy this non-combat unit instead of capturing it.  all non-combat units are normally captured by default. is a colon delimited list of player names.
+                                                            You can prefix them with single instance of "BY:" or "FROM:" in order to determine if it is being captured by, or captured from, that determines if the unit is destroyed.
+                                                            examples: <option name="destroyedWhenCapturedBy" value="BY:Chinese:Japanese"/> and <option name="destroyedWhenCapturedBy" value="FROM:Russians:Chinese"/>
+            whenCapturedChangesInto             values: allows a unit to change into a different unit when captured from a specific player to a specific player.  "fromPlayer:toPlayer:transferAttributes:unitType:numberOfUnits".  accepts "any" instead of a player name. allows multiple.
+                                                            examples: <option name="whenCapturedChangesInto" value="any:any:true:Minor_Factory:1"/> and <option name="whenCapturedChangesInto" value="Russians:Germans:false:gold:3:lumber:1"/>
+            isAirBase                           values: allows units with canScramble to scramble from a territory with this unit
+            maxScrambleCount                    values: max number of units which can scramble from this air base. defaults to infinite.
+            givesMovement                       values: allows a unit to give movement to other units.  must be an integer, followed by a colon ":", followed by the name of the unit
+            repairsUnits                        values: is a colon delimited list of all the units this unit can repair. units to be repaired must be in the same territory as this unit.
+                                                            unless the unit being repaired is sea, and the unit repairing it is land, in which case the sea unit must be adjacent to the land unit
+                                                            example: option name="repairsUnits" value="battleship:super_carrier"
+            whenCombatDamaged                   values: this property lets you set certain behaviors for when this unit is damaged. the value is the effect, while the count is the damage from where to where. (example: <option name="whenCombatDamaged" value="unitsMayNotLandOnCarrier" count="1:2"/>)
+                                                            units start at zero combat damage, and usually die at 1 damage. some units have 2 hp, so you can use this with 1:1 to say that when a unit has 1 damage they have this effect.
+                                                            currently only allows: unitsMayNotLandOnCarrier, unitsMayNotLeaveAlliedCarrier
+            canIntercept                        values: allows this unit to participate in air battles, as a defending unit
+            canEscort                           values: allows this unit to participate in air battles, as an attacking unit
+            airDefense                          values: defense value of interceptor
+            airAttack                           values: attack value of escort
+            fuelCost                            values: fuelCost is a list of at least one resource that get used up for each point of movementCost a unit does.  (can have multiple). example: <option name="fuelCost" value="Fuel" count="5"/> and <option name="fuelCost" value="PUs" count="1"/>
+
+    production related:
+            isFactory                           values: allows a unit to produce other units, not participate in combat, be placed anywhere you owned at the beginning of the turn, be capturable, and be damaged by rockets and raids
+            canProduceXUnits                    values: allows a factory-type unit to produce a set amount of units no matter where it is located.  if -1 then it will produce at the value of the territory where it is.
+                                                            if greater than -1, you must have "maxDamage" set to some number if the unit is also "canBeDamaged" or "isFactory".  defaults to -1 if missing
+            canProduceUnits                     values: allows a unit to be a factory, without all the other things that come with being a factory (like capturable, land, non-combat, etc).  So if you want flying factories, go ahead. Just don't complain if you get errors.
+            createsUnitsList                    values: is a list of units that this unit will create every turn at the end of the turn. can have multiple instances
+            createsResourcesList                values: is a list of resources that this unit will create every turn at the end of the turn. can have multiple instances
+
+    placement related:
+            maxBuiltPerPlayer                   values: is the number of this unit that can be BUILT by a player.  If they have fewer than this number they can build more, if they have more than this number they can not build more
+                                                            [this does not cause excess ones to disappear, and the player can still capture more and more of them if they are capturable]
+            canOnlyBePlacedInTerritoryValuedAtX values: the minimum territory value to place the unit there. defaults to "-1" which means anywhere
+            unitPlacementRestrictions           values: a list of territories where this unit can not be built. list can contain any number of territories, including sea zones .
+                                                            every unit may have a list, and the lists may be different for each unit. default is no list.
+                                                            the list may be turned on/off with "Unit Placement Restrictions" game property
+            unitPlacementOnlyAllowedIn          values: is the direct inverse of unitPlacementRestrictions
+            requiresUnits                       values: is a list of units required to be present in the territory in order for you to build this unit there.  Can have multiple instances. Only one instance needs to be true in order to build.
+            consumesUnits                       values: requires that a unit be present in a territory, then when this unit is placed the other units are destroyed / upgraded into this unit.  Can have multiple instances of this, which means it consumes multiple types of units.
+            isConstruction                      values: allows the unit to be placed in territories that don't contain factories. only "constructionsPerTerrPerTypePerTurn" contructions of "constructionType" may be placed per territory per turn.
+                                                            may have only "maxConstructionsPerTypePerTerr" constructions Total per territory with/without a factory unless you enable "More Constructions with/without Factory", which will allow up a total number of up to the territory value
+                                                            and "Unlimited Constructions" game property allows unlimited constructions total in a territory
+            constructionType                    values: is just a unique string which identifies what kind of construction this.
+                                                            if two or more constructions have the exact same constructionType (and the same PerType rules), then they will follow the same rules for placement.
+                                                            example: if you have little_bunker and big_bunker both as type "bunker", with constructionsPerTerrPerTypePerTurn=2, then you could place 2 littles, or 2 bigs, or 1 little and 1 big in a territory
+                                                            if you do not want this unit to be effected by the global properties "More Constructions with/without Factory" and "Unlimited Constructions", then make sure the type ends in "structure". example: "harbour_structure"
+            constructionsPerTerrPerTypePerTurn  values: is how many of this type you can place in a territory every turn
+            maxConstructionsPerTypePerTerr      values: is how many max of this type may be in a territory. this must be greater than constructionsPerTerrPerTypePerTurn
+                                                            if "More Constructions with/without Factory" = true, then the minimum will be either maxConstructionsPerTypePerTerr or the PU value of the territory (whichever number is greater) in territories with/without factories
+                                                            if "Unlimited Constructions" = true, then this number becomes 10000
+            special                             values: a colon delimited list of possible options for this unit.  Currently only supports: "canOnlyPlaceInOriginalTerritories"
+
+    aa related:
+            isAA                                values: allows a unit to shoot at air units before combat starts and not participate in the rest of combat, have certain movement restrictions, and be capturable
+            attackAA                            values: the value that an isAA unit will attack at, for shooting at air units before battle
+            attackAAmaxDieSides                 values: sets the dice sides for aa guns.  defaults to whatever you chose above in diceSides (or 6 if you didn't choose).
+                                                            Be Warned that all aa attack values (including with Radar and without Radar), MUST divide into attackAAmaxDieSides without remainders, or else there WILL be errors in LowLuck!
+            isAAforCombatOnly                   values: allows this unit to be an AA gun for normal combat only.  it will not defend against strategic bombing raids
+            isAAforBombingThisUnitOnly          values: allows this unit to be an AA gun only when this unit is directly attacked by a strategic bombing raid (currently defends against all strategic bombing attacks in this territory, not just against this unit).  it will not defend against a normal attack
+            isRocket                            values: allows this unit to become a rocket if the player has the rocket technology.  If the unit is named exactly "aaGun" then it will require an image called "rockets".  If the unit is named anything else, then it will require an image with "_rockets" appended to its original name
+            isAAmovement                        values: forces this unit to follow the rules for movement of an AA gun, and for placement of AA guns (like no moving during combat phase, max of 1 of each unit per territory, etc.)
+
+    -->
 
                 <!-- Infantry -->
                 <attachment name="unitAttachment" attachTo="infantry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="1"/>
                          <option name="transportCost" value="2"/>
-						 <!-- isInfantry allows the unit to be transported by 'isLandTransport' IF you have mechanizedInfantry technology -->
+                         <!-- isInfantry allows the unit to be transported by 'isLandTransport' IF you have mechanizedInfantry technology -->
                          <option name="isInfantry" value="true"/>
-						 <!-- isMarine gives the unit +1 attack if it is attacking amphibiously -->
-						 <!-- <option name="isMarine" value="true"/> -->
+                         <!-- isMarine gives the unit +1 attack if it is attacking amphibiously -->
+                         <!-- <option name="isMarine" value="true"/> -->
                          <option name="attack" value="1"/>
                          <option name="defense" value="2"/>
-						 <!-- artillerySupportable allows the unit to receive support from an "artillery" unit (land, sea, or air are allowed) -->
+                         <!-- artillerySupportable allows the unit to receive support from an "artillery" unit (land, sea, or air are allowed) -->
                          <option name="artillerySupportable" value="true"/>
-						 <!-- isAirTransportable allows the unit to be transported by an "isAirTransport" unit, IF you have paratroopers technology -->
+                         <!-- isAirTransportable allows the unit to be transported by an "isAirTransport" unit, IF you have paratroopers technology -->
                          <option name="isAirTransportable" value="true"/>
-						 <!-- canBeGivenByTerritoryTo will allow a unit to be given from one player to another player, if it is in a territory with changeUnitOwners 
-								must be a list of Players who this unit can be given to.  example: value="Russians:Chinese" -->
-						 <option name="canBeGivenByTerritoryTo" value="Russians"/>
-						 <!-- canBeCapturedOnEnteringBy will allow a unit to be captured from one player to another, if the specified player enters a territory with captureUnitOnEnteringBy
-								must be a list of Players who this unit can be given to.  example: value="Russians:Chinese" 
-						 <option name="canBeCapturedOnEnteringBy" value="Americans:British"/>-->
-						 <!-- isAirTransportable and isInfantry currently do NOTHING, and are only kept for backwards compatibility
-						 <option name="isAirTransportable" value="false"/>
-						 <option name="isInfantry" value="false"/> -->
+                         <!-- canBeGivenByTerritoryTo will allow a unit to be given from one player to another player, if it is in a territory with changeUnitOwners
+                                must be a list of Players who this unit can be given to.  example: value="Russians:Chinese" -->
+                         <option name="canBeGivenByTerritoryTo" value="Russians"/>
+                         <!-- canBeCapturedOnEnteringBy will allow a unit to be captured from one player to another, if the specified player enters a territory with captureUnitOnEnteringBy
+                                must be a list of Players who this unit can be given to.  example: value="Russians:Chinese"
+                         <option name="canBeCapturedOnEnteringBy" value="Americans:British"/>-->
+                         <!-- isAirTransportable and isInfantry currently do NOTHING, and are only kept for backwards compatibility
+                         <option name="isAirTransportable" value="false"/>
+                         <option name="isInfantry" value="false"/> -->
                 </attachment>
-				
-				
+
+
                 <!-- Artillery -->
                 <attachment name="unitAttachment" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="1"/>
                          <option name="transportCost" value="3"/>
                          <option name="attack" value="2"/>
                          <option name="defense" value="2"/>
-						 <!-- artillery gives support (+1 attack) to "artillerySupportable" units (land, sea, or air are allowed) -->
+                         <!-- artillery gives support (+1 attack) to "artillerySupportable" units (land, sea, or air are allowed) -->
                          <option name="artillery" value="true"/>
-						 <!-- unitSupportCount is the number of units that will be supported by the artillery, defaults to 1 if missing -->
+                         <!-- unitSupportCount is the number of units that will be supported by the artillery, defaults to 1 if missing -->
                          <option name="unitSupportCount" value="1"/>
-						 <option name="canBeGivenByTerritoryTo" value="Russians"/>
+                         <option name="canBeGivenByTerritoryTo" value="Russians"/>
                          <option name="isAirTransportable" value="true"/>
-						 <!-- canInvadeOnlyFrom is a colon dilimited list of the transporting units which this unit can perform amphibious assaults from. 
-								A unit which can not perform amphibious assaults may instead disembark during non-combat
-								can be set to "all", or "none", or a list of some transports. if this option is not present, it defaults to "all" -->
-						 <option name="canInvadeOnlyFrom" value="transport:jp_transport:air_transport:super_carrier"/>
+                         <!-- canInvadeOnlyFrom is a colon dilimited list of the transporting units which this unit can perform amphibious assaults from.
+                                A unit which can not perform amphibious assaults may instead disembark during non-combat
+                                can be set to "all", or "none", or a list of some transports. if this option is not present, it defaults to "all" -->
+                         <option name="canInvadeOnlyFrom" value="transport:jp_transport:air_transport:super_carrier"/>
                 </attachment>
 
                 <!-- Armour -->
                 <attachment name="unitAttachment" attachTo="armour" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
                          <option name="transportCost" value="3"/>
-						 <!-- canBlitz allows the unit to move through multiple empty enemy territories in one turn -->
+                         <!-- canBlitz allows the unit to move through multiple empty enemy territories in one turn -->
                          <option name="canBlitz" value="true"/>
                          <option name="attack" value="3"/>
                          <option name="defense" value="3"/>
-						 <!-- isLandTransport allows the unit to transport "isInfantry" on a one-to-one basis, if you have the mechanizedInfantry technology -->
+                         <!-- isLandTransport allows the unit to transport "isInfantry" on a one-to-one basis, if you have the mechanizedInfantry technology -->
                          <option name="isLandTransport" value="true"/>
-						 <option name="canBeGivenByTerritoryTo" value="Russians"/>
-						 <!-- consumesUnits requires that a unit be present in a territory, then when this unit is placed the other units are destroyed / upgraded into this unit.  Can have multiple instances of this, which means it consumes multiple types of units.
-						 <option name="consumesUnits" value="2:infantry"/>
-						 <option name="consumesUnits" value="1:artillery"/>-->
+                         <option name="canBeGivenByTerritoryTo" value="Russians"/>
+                         <!-- consumesUnits requires that a unit be present in a territory, then when this unit is placed the other units are destroyed / upgraded into this unit.  Can have multiple instances of this, which means it consumes multiple types of units.
+                         <option name="consumesUnits" value="2:infantry"/>
+                         <option name="consumesUnits" value="1:artillery"/>-->
                          <option name="isAirTransportable" value="true"/>
-						 <!-- receivesAbilityWhenWith gives a unit an ability when they are with, or on the same route as, another unit 
-						 <option name="receivesAbilityWhenWith" value="canBlitz:armour"/>-->
+                         <!-- receivesAbilityWhenWith gives a unit an ability when they are with, or on the same route as, another unit
+                         <option name="receivesAbilityWhenWith" value="canBlitz:armour"/>-->
                 </attachment>
-                
+
                              <!-- Motorized -->
                 <attachment name="unitAttachment" attachTo="motorized" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
                          <option name="transportCost" value="3"/>
-						 <!-- canBlitz allows the unit to move through multiple empty enemy territories in one turn -->
+                         <!-- canBlitz allows the unit to move through multiple empty enemy territories in one turn -->
                          <option name="canBlitz" value="false"/>
                          <option name="attack" value="2"/>
                          <option name="defense" value="3"/>
                          <option name="fuelCost" value="Fuel" count="1"/>
                          <option name="fuelCost" value="PUs" count="1"/>
-                         
+
                 </attachment>
 
                 <!-- Fighter -->
@@ -1906,29 +1906,29 @@
                          <option name="isAir" value="true"/>
                          <option name="attack" value="3"/>
                          <option name="defense" value="4"/>
-						 <!-- canScramble and maxScrambleDistance are properties for scrambling. allows the aircraft to enter a surrounding sea zone if the enemy is doing an attack on or from the surrounding sea zone -->
+                         <!-- canScramble and maxScrambleDistance are properties for scrambling. allows the aircraft to enter a surrounding sea zone if the enemy is doing an attack on or from the surrounding sea zone -->
                          <option name="canScramble" value="true"/>
                          <option name="maxScrambleDistance" value="1"/>
-						 <option name="canIntercept" value="true"/>
-						 <option name="canEscort" value="true"/>
+                         <option name="canIntercept" value="true"/>
+                         <option name="canEscort" value="true"/>
                          <option name="airDefense" value="2"/>
                          <option name="airAttack" value="2"/>
                 </attachment>
-				
+
                 <attachment name="unitAttachment" attachTo="jp_fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="4"/>
                          <option name="carrierCost" value="1"/>
                          <option name="isAir" value="true"/>
                          <option name="attack" value="3"/>
                          <option name="defense" value="4"/>
-						 <option name="canScramble" value="true"/>
+                         <option name="canScramble" value="true"/>
                          <option name="maxScrambleDistance" value="1"/>
-						 <!-- isSuicide makes a unit die before combat begins, however they do get to roll -->
-						 <!--<option name="isSuicide" value="true"/>-->
-						 <!-- isKamikaze allows an air unit to use up all of its movement to go to a battle -->
-						 <!--<option name="isKamikaze" value="true"/>-->
-						 <option name="canIntercept" value="true"/>
-						 <option name="canEscort" value="true"/>
+                         <!-- isSuicide makes a unit die before combat begins, however they do get to roll -->
+                         <!--<option name="isSuicide" value="true"/>-->
+                         <!-- isKamikaze allows an air unit to use up all of its movement to go to a battle -->
+                         <!--<option name="isKamikaze" value="true"/>-->
+                         <option name="canIntercept" value="true"/>
+                         <option name="canEscort" value="true"/>
                          <option name="airDefense" value="2"/>
                          <option name="airAttack" value="2"/>
                 </attachment>
@@ -1939,15 +1939,15 @@
                          <option name="isAir" value="true"/>
                          <option name="attack" value="4"/>
                          <option name="defense" value="1"/>
-						 <!-- isStrategicBomber allows a unit to bombing factories and canBeDamaged units -->
+                         <!-- isStrategicBomber allows a unit to bombing factories and canBeDamaged units -->
                          <option name="isStrategicBomber" value="true"/>
-						 <!-- transportCapacity + isAirTransport can be used for transporting units IF you have the paratroopers technology -->
+                         <!-- transportCapacity + isAirTransport can be used for transporting units IF you have the paratroopers technology -->
                          <option name="transportCapacity" value="2"/>
                          <option name="isAirTransport" value="true"/>
-						 <!-- bombingMaxDieSides is the max dice sides for a strategic bombing or rocket attack.  if you want to lower the luck involved, use bombing bonus and lower the max dice sides.  This property is optional, and only turns on when you have LL for bombing turned on.
-								example: if you want to have either a 3 or 4 rolled, then set maxDieSides to 2, and the Bonus to 2.  this means you will roll a 2 sided die (results are either "1" or "2") and add "2" to the result (so you get "3" or "4") -->
+                         <!-- bombingMaxDieSides is the max dice sides for a strategic bombing or rocket attack.  if you want to lower the luck involved, use bombing bonus and lower the max dice sides.  This property is optional, and only turns on when you have LL for bombing turned on.
+                                example: if you want to have either a 3 or 4 rolled, then set maxDieSides to 2, and the Bonus to 2.  this means you will roll a 2 sided die (results are either "1" or "2") and add "2" to the result (so you get "3" or "4") -->
                          <option name="bombingMaxDieSides" value="2"/>
-						 <!-- bombingBonus is a number added to the die rolled, to give the total cost [displayed as a new die rolled], for strategic bombing and rockets only.  This property is optional, and only turns on when you have LL for bombing turned on. -->
+                         <!-- bombingBonus is a number added to the die rolled, to give the total cost [displayed as a new die rolled], for strategic bombing and rockets only.  This property is optional, and only turns on when you have LL for bombing turned on. -->
                          <option name="bombingBonus" value="2"/>
                          <option name="airAttack" value="1"/>
                 </attachment>
@@ -1958,7 +1958,7 @@
                          <option name="isAir" value="true"/>
                          <option name="attack" value="0"/>
                          <option name="defense" value="0"/>
-						 <!-- transportCapacity + isAirTransport can be used for transporting units IF you have the paratroopers technology -->
+                         <!-- transportCapacity + isAirTransport can be used for transporting units IF you have the paratroopers technology -->
                          <option name="transportCapacity" value="6"/>
                          <option name="isAirTransport" value="true"/>
                 </attachment>
@@ -1968,11 +1968,11 @@
                          <option name="movement" value="2"/>
                          <option name="isSea" value="true"/>
                          <option name="transportCapacity" value="5"/>
-						 <!-- attack and defense must be zero if you are using ww2v3 style transport rules (transports can not be used as fodder, etc.) -->
+                         <!-- attack and defense must be zero if you are using ww2v3 style transport rules (transports can not be used as fodder, etc.) -->
                          <option name="attack" value="0"/>
                          <option name="defense" value="0"/>
                 </attachment>
-				
+
                 <attachment name="unitAttachment" attachTo="jp_transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
                          <option name="isSea" value="true"/>
@@ -1989,13 +1989,13 @@
                          <option name="defense" value="4"/>
                          <option name="hitPoints" value="2"/>
                          <option name="canBombard" value="true"/>
-						 <!-- bombard defaults to the attack value of the unit if missing -->
+                         <!-- bombard defaults to the attack value of the unit if missing -->
                          <option name="bombard" value="4"/>
-						 <!-- blockade allows the unit to do damage up to the value of land territories surrounding a blockade zone, to the enemy's income -->
+                         <!-- blockade allows the unit to do damage up to the value of land territories surrounding a blockade zone, to the enemy's income -->
                          <option name="blockade" value="1"/>
                  </attachment>
-				
-				 <!-- Cruiser -->
+
+                 <!-- Cruiser -->
                 <attachment name="unitAttachment" attachTo="cruiser" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
                          <option name="isSea" value="true"/>
@@ -2013,11 +2013,11 @@
                          <option name="isSea" value="true"/>
                          <option name="attack" value="2"/>
                          <option name="defense" value="2"/>
-						 <!-- isDestroyer does a number of things, all of which target units that are isSub -->
+                         <!-- isDestroyer does a number of things, all of which target units that are isSub -->
                          <option name="isDestroyer" value="true"/>
                          <option name="blockade" value="1"/>
                 </attachment>
-				
+
                 <attachment name="unitAttachment" attachTo="jp_destroyer" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
                          <option name="isSea" value="true"/>
@@ -2025,7 +2025,7 @@
                          <option name="defense" value="2"/>
                          <option name="isDestroyer" value="true"/>
                          <option name="blockade" value="1"/>
-						 <!--<option name="transportCapacity" value="2"/>-->
+                         <!--<option name="transportCapacity" value="2"/>-->
                 </attachment>
 
                 <!-- Carrier -->
@@ -2046,18 +2046,18 @@
                          <option name="attack" value="1"/>
                          <option name="defense" value="3"/>
                          <option name="blockade" value="2"/>
-						 <option name="transportCapacity" value="5"/>
-						 <!-- isCombatTransport tells the engine that this sea unit can transport but can fight too. units will not be able to move through it like they would a transport, and it can be taken casualty during battle as normal -->
+                         <option name="transportCapacity" value="5"/>
+                         <!-- isCombatTransport tells the engine that this sea unit can transport but can fight too. units will not be able to move through it like they would a transport, and it can be taken casualty during battle as normal -->
                          <option name="isCombatTransport" value="true"/>
                          <!--<option name="hitPoints" value="2"/>-->
-						 <!-- whenCombatDamaged means that when this unit has x:y damage on it, it will have this effect
-						 <option name="whenCombatDamaged" value="unitsMayNotLandOnCarrier" count="1:2"/>
-						 <option name="whenCombatDamaged" value="unitsMayNotLeaveAlliedCarrier" count="1:2"/>-->
+                         <!-- whenCombatDamaged means that when this unit has x:y damage on it, it will have this effect
+                         <option name="whenCombatDamaged" value="unitsMayNotLandOnCarrier" count="1:2"/>
+                         <option name="whenCombatDamaged" value="unitsMayNotLeaveAlliedCarrier" count="1:2"/>-->
                 </attachment>
 
                 <!-- Submarine -->
                 <attachment name="unitAttachment" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						 <!-- isSub usually allows a unit to do first strikes and submerge and move under non-isDestroyer units, but all of these are subject to global game properties -->
+                         <!-- isSub usually allows a unit to do first strikes and submerge and move under non-isDestroyer units, but all of these are subject to global game properties -->
                          <option name="isSub" value="true"/>
                          <option name="movement" value="2"/>
                          <option name="isSea" value="true"/>
@@ -2065,144 +2065,144 @@
                          <option name="defense" value="1"/>
                          <option name="blockade" value="2"/>
                 </attachment>
-				
-				<!-- Midget Submarine -->
+
+                <!-- Midget Submarine -->
                 <attachment name="unitAttachment" attachTo="midget_submarine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						 <option name="isSub" value="true"/>
+                         <option name="isSub" value="true"/>
                          <option name="movement" value="2"/>
                          <option name="isSea" value="true"/>
                          <option name="attack" value="3"/>
                          <option name="defense" value="2"/>
                          <option name="blockade" value="1"/>
-						 <!-- isSuicide makes a unit die before combat begins, however they do get to roll -->
-						 <option name="isSuicide" value="true"/>
+                         <!-- isSuicide makes a unit die before combat begins, however they do get to roll -->
+                         <option name="isSuicide" value="true"/>
                 </attachment>
-				
+
                 <!-- Bunker -->
-				<attachment name="unitAttachment" attachTo="bunker" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+                <attachment name="unitAttachment" attachTo="bunker" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="0"/>
                          <option name="attack" value="0"/>
                          <option name="defense" value="4"/>
-						 <!-- canBeDamaged sets if a unit can be attacked by strategic bombing raids or by rockets.  isFactory also allows these things -->
-						 <option name="canBeDamaged" value="true"/>
-						 <!-- maxDamage is the total damage the unit can take.  If a factory, and canProduceXUnits = -1 or is missing then maxDamage will be a multiple of the territory value (maxDamage defaults to 2 if canProduceXUnits = -1), otherwise it will be a set number 
-								So for example, if the unit isFactory Or canProduceUnits, And canProduceXUnits = -1, And maxDamage = 3, THEN you will be able to do 3x the territory value in damage to this unit. If However, canProduceXUnits = 2, and maxDamage = 3, then you can do up to 3 damage to this unit. -->
-						 <option name="maxDamage" value="4"/>
-						 <!-- maxOperationalDamage is used with certain features like isAirBase, repairsUnits, and givesMovement to determine if those features work or not based on the current damage of this unit. A disabled unit will not participate in combat too.  Does Not work with isFactory or canProduceUnits. -->
-						 <option name="maxOperationalDamage" value="0"/>
-						 <!-- isConstruction allows the unit to be placed in territories that don't contain factories. only "constructionsPerTerrPerTypePerTurn" contructions of "constructionType" may be placed per territory per turn. 
-								may have only "maxConstructionsPerTypePerTerr" constructions Total per territory with/without a factory unless you enable "More Constructions with/without Factory", which will allow up a total number of up to the territory value
-								and "Unlimited Constructions" game property allows unlimited constructions total in a territory -->
-						 <option name="isConstruction" value="true"/>
-						 <!-- constructionType is just a unique string which identifies what kind of construction this. 
-								if two or more constructions have the exact same constructionType (and the same PerType rules), then they will follow the same rules for placement.
-								example: if you have little_bunker and big_bunker both as type "bunker", with constructionsPerTerrPerTypePerTurn=2, then you could place 2 littles, or 2 bigs, or 1 little and 1 big in a territory 
-								if you do not want this unit to be effected by the global properties "More Constructions with/without Factory" and "Unlimited Constructions", then make sure the type ends in "structure". example: "harbour_structure" -->
-						 <option name="constructionType" value="bunker"/>
-						 <!-- constructionsPerTerrPerTypePerTurn is how many of this type you can place in a territory every turn -->
-						 <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
-						 <!-- maxConstructionsPerTypePerTerr is how many max of this type may be in a territory. this must be greater than constructionsPerTerrPerTypePerTurn
-								if "More Constructions with/without Factory" = true, then the minimum will be either maxConstructionsPerTypePerTerr or the PU value of the territory (whichever number is greater) in territories with/without factories
-								if "Unlimited Constructions" = true, then this number becomes 10000 -->
-						 <option name="maxConstructionsPerTypePerTerr" value="1"/>
-						 <!--<option name="hitPoints" value="2"/>-->
-						 <!-- canDieFromReachingMaxDamage means that if this unit reaches its maxDamage, then it will die.  maxDamage must be larger than zero -->
-						 <option name="canDieFromReachingMaxDamage" value="true"/>
-						 <!-- requiresUnits is a list of units required to be present in the territory in order for you to build this unit there.  Can have multiple instances. Only one instance needs to be true in order to build. -->
-						 <option name="requiresUnits" value="fighter:bomber:air_transport"/>
-						 <option name="requiresUnits" value="factory"/>
-						 <option name="requiresUnits" value="airfield"/>
-						 <option name="requiresUnits" value="harbour"/>
-						 <option name="requiresUnits" value="infantry"/>
-						 <option name="requiresUnits" value="artillery"/>
-						 <option name="requiresUnits" value="armour"/>
-						 <option name="requiresUnits" value="aaGun"/>
+                         <!-- canBeDamaged sets if a unit can be attacked by strategic bombing raids or by rockets.  isFactory also allows these things -->
+                         <option name="canBeDamaged" value="true"/>
+                         <!-- maxDamage is the total damage the unit can take.  If a factory, and canProduceXUnits = -1 or is missing then maxDamage will be a multiple of the territory value (maxDamage defaults to 2 if canProduceXUnits = -1), otherwise it will be a set number
+                                So for example, if the unit isFactory Or canProduceUnits, And canProduceXUnits = -1, And maxDamage = 3, THEN you will be able to do 3x the territory value in damage to this unit. If However, canProduceXUnits = 2, and maxDamage = 3, then you can do up to 3 damage to this unit. -->
+                         <option name="maxDamage" value="4"/>
+                         <!-- maxOperationalDamage is used with certain features like isAirBase, repairsUnits, and givesMovement to determine if those features work or not based on the current damage of this unit. A disabled unit will not participate in combat too.  Does Not work with isFactory or canProduceUnits. -->
+                         <option name="maxOperationalDamage" value="0"/>
+                         <!-- isConstruction allows the unit to be placed in territories that don't contain factories. only "constructionsPerTerrPerTypePerTurn" contructions of "constructionType" may be placed per territory per turn.
+                                may have only "maxConstructionsPerTypePerTerr" constructions Total per territory with/without a factory unless you enable "More Constructions with/without Factory", which will allow up a total number of up to the territory value
+                                and "Unlimited Constructions" game property allows unlimited constructions total in a territory -->
+                         <option name="isConstruction" value="true"/>
+                         <!-- constructionType is just a unique string which identifies what kind of construction this.
+                                if two or more constructions have the exact same constructionType (and the same PerType rules), then they will follow the same rules for placement.
+                                example: if you have little_bunker and big_bunker both as type "bunker", with constructionsPerTerrPerTypePerTurn=2, then you could place 2 littles, or 2 bigs, or 1 little and 1 big in a territory
+                                if you do not want this unit to be effected by the global properties "More Constructions with/without Factory" and "Unlimited Constructions", then make sure the type ends in "structure". example: "harbour_structure" -->
+                         <option name="constructionType" value="bunker"/>
+                         <!-- constructionsPerTerrPerTypePerTurn is how many of this type you can place in a territory every turn -->
+                         <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+                         <!-- maxConstructionsPerTypePerTerr is how many max of this type may be in a territory. this must be greater than constructionsPerTerrPerTypePerTurn
+                                if "More Constructions with/without Factory" = true, then the minimum will be either maxConstructionsPerTypePerTerr or the PU value of the territory (whichever number is greater) in territories with/without factories
+                                if "Unlimited Constructions" = true, then this number becomes 10000 -->
+                         <option name="maxConstructionsPerTypePerTerr" value="1"/>
+                         <!--<option name="hitPoints" value="2"/>-->
+                         <!-- canDieFromReachingMaxDamage means that if this unit reaches its maxDamage, then it will die.  maxDamage must be larger than zero -->
+                         <option name="canDieFromReachingMaxDamage" value="true"/>
+                         <!-- requiresUnits is a list of units required to be present in the territory in order for you to build this unit there.  Can have multiple instances. Only one instance needs to be true in order to build. -->
+                         <option name="requiresUnits" value="fighter:bomber:air_transport"/>
+                         <option name="requiresUnits" value="factory"/>
+                         <option name="requiresUnits" value="airfield"/>
+                         <option name="requiresUnits" value="harbour"/>
+                         <option name="requiresUnits" value="infantry"/>
+                         <option name="requiresUnits" value="artillery"/>
+                         <option name="requiresUnits" value="armour"/>
+                         <option name="requiresUnits" value="aaGun"/>
                 </attachment>
-				
-				<!-- Airfield -->
+
+                <!-- Airfield -->
                 <attachment name="unitAttachment" attachTo="airfield" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						 <!-- isInfrastructure means a unit does not participate in combat, and they will be captured if the attacker is successful -->
+                         <!-- isInfrastructure means a unit does not participate in combat, and they will be captured if the attacker is successful -->
                          <option name="isInfrastructure" value="true"/>
-						 <option name="canBeDamaged" value="true"/>
-						 <option name="maxDamage" value="6"/>
-						 <option name="maxOperationalDamage" value="3"/>
-						 <!-- isAirBase allows units with canScramble to scramble from a territory with this unit -->
-						 <option name="isAirBase" value="true"/>
-						 <option name="isConstruction" value="true"/>
-						 <option name="constructionType" value="airfield_structure"/>
-						 <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
-						 <option name="maxConstructionsPerTypePerTerr" value="1"/>
-						 <!-- destroyedWhenCapturedBy is a list of the players who destroy this non-combat unit instead of capturing it.  all non-combat units are normally captured by default 
-								is a colon delimited list. example: value="Chinese:Russians" -->
-						 <option name="destroyedWhenCapturedBy" value="Chinese"/>
-						 <!-- givesMovement allows a unit to give movement to other units.  must be an integer, followed by a colon ":", followed by the name of the unit -->
-						 <option name="givesMovement" value="1:fighter"/>
-						 <option name="givesMovement" value="1:jp_fighter"/>
-						 <option name="givesMovement" value="1:bomber"/>
-						 <option name="givesMovement" value="1:air_transport"/>
-						 <!--<option name="isAAforBombingThisUnitOnly" value="true"/>-->
-						 <!--<option name="whenCapturedChangesInto" value="any:Italians:false:aaGun:2:infantry:1"/>
-						 <option name="whenCapturedChangesInto" value="Russians:any:true:factory:1"/>-->
+                         <option name="canBeDamaged" value="true"/>
+                         <option name="maxDamage" value="6"/>
+                         <option name="maxOperationalDamage" value="3"/>
+                         <!-- isAirBase allows units with canScramble to scramble from a territory with this unit -->
+                         <option name="isAirBase" value="true"/>
+                         <option name="isConstruction" value="true"/>
+                         <option name="constructionType" value="airfield_structure"/>
+                         <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+                         <option name="maxConstructionsPerTypePerTerr" value="1"/>
+                         <!-- destroyedWhenCapturedBy is a list of the players who destroy this non-combat unit instead of capturing it.  all non-combat units are normally captured by default
+                                is a colon delimited list. example: value="Chinese:Russians" -->
+                         <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                         <!-- givesMovement allows a unit to give movement to other units.  must be an integer, followed by a colon ":", followed by the name of the unit -->
+                         <option name="givesMovement" value="1:fighter"/>
+                         <option name="givesMovement" value="1:jp_fighter"/>
+                         <option name="givesMovement" value="1:bomber"/>
+                         <option name="givesMovement" value="1:air_transport"/>
+                         <!--<option name="isAAforBombingThisUnitOnly" value="true"/>-->
+                         <!--<option name="whenCapturedChangesInto" value="any:Italians:false:aaGun:2:infantry:1"/>
+                         <option name="whenCapturedChangesInto" value="Russians:any:true:factory:1"/>-->
                 </attachment>
-				
-				<!-- Harbour -->
+
+                <!-- Harbour -->
                 <attachment name="unitAttachment" attachTo="harbour" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="isInfrastructure" value="true"/>
-						 <option name="canBeDamaged" value="true"/>
-						 <option name="maxDamage" value="6"/>
-						 <option name="maxOperationalDamage" value="3"/>
-						 <!-- repairsUnits is a colon delimited list of all the units this unit can repair. units to be repaired must be in the same territory as this unit. 
-								unless the unit being repaired is sea, and the unit repairing it is land, in which case the sea unit must be adjacent to the land unit 
-								example: option name="repairsUnits" value="battleship:super_carrier" -->
-						 <option name="repairsUnits" value="battleship"/>
-						 <option name="isConstruction" value="true"/>
-						 <option name="constructionType" value="harbour_structure"/>
-						 <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
-						 <option name="maxConstructionsPerTypePerTerr" value="1"/>
-						 <option name="destroyedWhenCapturedBy" value="Chinese"/>
-						 <!--<option name="givesMovement" value="1:transport"/>
-						 <option name="givesMovement" value="1:jp_transport"/>-->
-						 <!--<option name="givesMovement" value="1:midget_submarine"/>-->
-						 <option name="givesMovement" value="1:submarine"/>
-						 <option name="givesMovement" value="1:destroyer"/>
-						 <option name="givesMovement" value="1:jp_destroyer"/>
-						 <option name="givesMovement" value="1:cruiser"/>
-						 <option name="givesMovement" value="1:carrier"/>
-						 <option name="givesMovement" value="1:battleship"/>
-						 <option name="givesMovement" value="1:super_carrier"/>
-						 <!--<option name="isAAforBombingThisUnitOnly" value="true"/>-->
+                         <option name="canBeDamaged" value="true"/>
+                         <option name="maxDamage" value="6"/>
+                         <option name="maxOperationalDamage" value="3"/>
+                         <!-- repairsUnits is a colon delimited list of all the units this unit can repair. units to be repaired must be in the same territory as this unit.
+                                unless the unit being repaired is sea, and the unit repairing it is land, in which case the sea unit must be adjacent to the land unit
+                                example: option name="repairsUnits" value="battleship:super_carrier" -->
+                         <option name="repairsUnits" value="battleship"/>
+                         <option name="isConstruction" value="true"/>
+                         <option name="constructionType" value="harbour_structure"/>
+                         <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+                         <option name="maxConstructionsPerTypePerTerr" value="1"/>
+                         <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                         <!--<option name="givesMovement" value="1:transport"/>
+                         <option name="givesMovement" value="1:jp_transport"/>-->
+                         <!--<option name="givesMovement" value="1:midget_submarine"/>-->
+                         <option name="givesMovement" value="1:submarine"/>
+                         <option name="givesMovement" value="1:destroyer"/>
+                         <option name="givesMovement" value="1:jp_destroyer"/>
+                         <option name="givesMovement" value="1:cruiser"/>
+                         <option name="givesMovement" value="1:carrier"/>
+                         <option name="givesMovement" value="1:battleship"/>
+                         <option name="givesMovement" value="1:super_carrier"/>
+                         <!--<option name="isAAforBombingThisUnitOnly" value="true"/>-->
                 </attachment>
-				
+
                 <!-- Factory -->
                 <attachment name="unitAttachment" attachTo="factory" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-						 <!-- isFactory units can have movement, but not much else -->
+                         <!-- isFactory units can have movement, but not much else -->
                          <option name="isFactory" value="true"/>
-						 <!--<option name="maxDamage" value="-1"/>-->
-						 <!-- unitPlacementRestrictions are a list of territories where this unit can not be built. list can contain any number of territories, including sea zones .
-								every unit may have a list, and the lists may be different for each unit. default is no list.  
-								the list may be turned on/off with "Unit Placement Restrictions" game property -->
-						 <option name="unitPlacementRestrictions" value="Midway:Greenland:Gibraltar:Solomon Islands:Wake Island:Caroline Islands"/>
-						 <!-- canOnlyBePlacedInTerritoryValuedAtX means the minimum territory value to place the unit there. defaults to "-1" which means anywhere -->
-						 <option name="canOnlyBePlacedInTerritoryValuedAtX" value="2"/>
-						 <!-- maxBuiltPerPlayer is the number of this unit that can be BUILT by a player.  If they have fewer than this number they can build more, 
-								if they have more than this number they can not build more [this does not cause excess ones to disappear, and the player can still capture more and more of them if they are capturable] -->
-						 <option name="maxBuiltPerPlayer" value="3"/>
-						 <option name="destroyedWhenCapturedBy" value="Chinese"/>
-						 <!-- unitPlacementOnlyAllowedIn is the direct inverse of unitPlacementRestrictions
-						 <option name="unitPlacementOnlyAllowedIn" value="Germany:East Balkans"/>-->
-						 <!-- canProduceXUnits allows a factory-type unit to produce a set amount of units no matter where it is located.  if -1 then it will produce at the value of the territory where it is.  
-								if greater than -1, you must have "maxDamage" set to some number if the unit is also "canBeDamaged" or "isFactory".  defaults to -1 if missing -->
-						 <option name="canProduceXUnits" value="-1"/>
-						 <!-- canProduceUnits allows a unit to be a factory, without all the other things that come with being a factory (like capturable, land, non-combat, etc).  So if you want flying factories, go ahead. Just don't complain if you get errors. 
-						 <option name="canProduceUnits" value="true"/>-->
-						 <!-- createsUnitsList is a list of units that this unit will create every turn at the end of the turn. can have multiple instances
-						 <option name="createsUnitsList" value="2:infantry"/>
-						 <option name="createsUnitsList" value="1:artillery"/>-->
-						 <!-- createsResourcesList is a list of resources that this unit will create every turn at the end of the turn. can have multiple instances 
-						 <option name="createsResourcesList" value="3:PUs"/>
-						 <option name="createsResourcesList" value="2:techTokens"/>-->
-						 <!-- special allows for some different options for the unit.
-						 <option name="special" value="canOnlyPlaceInOriginalTerritories"/>-->
+                         <!--<option name="maxDamage" value="-1"/>-->
+                         <!-- unitPlacementRestrictions are a list of territories where this unit can not be built. list can contain any number of territories, including sea zones .
+                                every unit may have a list, and the lists may be different for each unit. default is no list.
+                                the list may be turned on/off with "Unit Placement Restrictions" game property -->
+                         <option name="unitPlacementRestrictions" value="Midway:Greenland:Gibraltar:Solomon Islands:Wake Island:Caroline Islands"/>
+                         <!-- canOnlyBePlacedInTerritoryValuedAtX means the minimum territory value to place the unit there. defaults to "-1" which means anywhere -->
+                         <option name="canOnlyBePlacedInTerritoryValuedAtX" value="2"/>
+                         <!-- maxBuiltPerPlayer is the number of this unit that can be BUILT by a player.  If they have fewer than this number they can build more,
+                                if they have more than this number they can not build more [this does not cause excess ones to disappear, and the player can still capture more and more of them if they are capturable] -->
+                         <option name="maxBuiltPerPlayer" value="3"/>
+                         <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                         <!-- unitPlacementOnlyAllowedIn is the direct inverse of unitPlacementRestrictions
+                         <option name="unitPlacementOnlyAllowedIn" value="Germany:East Balkans"/>-->
+                         <!-- canProduceXUnits allows a factory-type unit to produce a set amount of units no matter where it is located.  if -1 then it will produce at the value of the territory where it is.
+                                if greater than -1, you must have "maxDamage" set to some number if the unit is also "canBeDamaged" or "isFactory".  defaults to -1 if missing -->
+                         <option name="canProduceXUnits" value="-1"/>
+                         <!-- canProduceUnits allows a unit to be a factory, without all the other things that come with being a factory (like capturable, land, non-combat, etc).  So if you want flying factories, go ahead. Just don't complain if you get errors.
+                         <option name="canProduceUnits" value="true"/>-->
+                         <!-- createsUnitsList is a list of units that this unit will create every turn at the end of the turn. can have multiple instances
+                         <option name="createsUnitsList" value="2:infantry"/>
+                         <option name="createsUnitsList" value="1:artillery"/>-->
+                         <!-- createsResourcesList is a list of resources that this unit will create every turn at the end of the turn. can have multiple instances
+                         <option name="createsResourcesList" value="3:PUs"/>
+                         <option name="createsResourcesList" value="2:techTokens"/>-->
+                         <!-- special allows for some different options for the unit.
+                         <option name="special" value="canOnlyPlaceInOriginalTerritories"/>-->
                 </attachment>
 
                 <!-- AA Gun -->
@@ -2210,81 +2210,81 @@
                          <option name="isAA" value="true"/>
                          <option name="transportCost" value="3"/>
                          <option name="movement" value="1"/>
-						 <option name="destroyedWhenCapturedBy" value="Chinese"/>
-						 <option name="destroyedWhenCapturedFrom" value="Russians"/>
-						 <!-- destroyedWhenCapturedBy and destroyedWhenCapturedFrom let a unit be destroyed instead of captured.  They can be a colon delimited list of players. 
-								You can prefix them with single instance of "BY:" or "FROM:" in order to determine if it is being captured by, or captured from, that determines if the unit is destroyed. 
-								destroyedWhenCapturedFrom just takes the value input then adds "FROM:" to the beginning, then calls destroyedWhenCapturedBy with the new value.
-						 <option name="destroyedWhenCapturedBy" value="BY:Chinese:Japanese"/>
-						 <option name="destroyedWhenCapturedBy" value="FROM:Russians:Chinese"/>-->
-						 <option name="bombingMaxDieSides" value="2"/>
-						 <option name="bombingBonus" value="2"/>
-						 <!-- attackAA sets the value the AA will attack at (radar adds 1 if this is not 0). Defaults to 1.  Can not be more than half the diceSides (even with radar)-->
-						 <option name="attackAA" value="1"/>
-						 <!-- attackAAmaxDieSides sets the dice sides for aa guns.  defaults to whatever you chose above in diceSides (or 6 if you didn't choose).  
-								Be Warned that all aa attack values (including with Radar and without Radar), MUST divide into attackAAmaxDieSides without remainders, or else there WILL be errors in LowLuck! -->
-						 <option name="attackAAmaxDieSides" value="6"/>
-						 <!-- isAAforCombatOnly allows this unit to be an AA gun for normal combat only.  it will not defend against strategic bombing raids 
-						 <option name="isAAforCombatOnly" value="true"/>-->
-						 <!-- isAAforBombingThisUnitOnly allows this unit to be an AA gun only when this unit is directly attacked by a strategic bombing raid (currently defends against all strategic bombing attacks in this territory, not just against this unit).  it will not defend against a normal attack 
-						 <option name="isAAforBombingThisUnitOnly" value="true"/>-->
-						 <!-- isRocket allows this unit to become a rocket if the player has the rocket technology.  If the unit is named exactly "aaGun" then it will require an image called "rockets".  If the unit is named anything else, then it will require an image with "_rockets" appended to its original name.
-						 <option name="isRocket" value="true"/>-->
-						 <!-- isAAmovement forces this unit to follow the rules for movement of an AA gun, and for placement of AA guns (like no moving during combat phase, max of 1 of each unit per territory, etc.)
-						 <option name="isAAmovement" value="true"/>-->
+                         <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                         <option name="destroyedWhenCapturedFrom" value="Russians"/>
+                         <!-- destroyedWhenCapturedBy and destroyedWhenCapturedFrom let a unit be destroyed instead of captured.  They can be a colon delimited list of players.
+                                You can prefix them with single instance of "BY:" or "FROM:" in order to determine if it is being captured by, or captured from, that determines if the unit is destroyed.
+                                destroyedWhenCapturedFrom just takes the value input then adds "FROM:" to the beginning, then calls destroyedWhenCapturedBy with the new value.
+                         <option name="destroyedWhenCapturedBy" value="BY:Chinese:Japanese"/>
+                         <option name="destroyedWhenCapturedBy" value="FROM:Russians:Chinese"/>-->
+                         <option name="bombingMaxDieSides" value="2"/>
+                         <option name="bombingBonus" value="2"/>
+                         <!-- attackAA sets the value the AA will attack at (radar adds 1 if this is not 0). Defaults to 1.  Can not be more than half the diceSides (even with radar)-->
+                         <option name="attackAA" value="1"/>
+                         <!-- attackAAmaxDieSides sets the dice sides for aa guns.  defaults to whatever you chose above in diceSides (or 6 if you didn't choose).
+                                Be Warned that all aa attack values (including with Radar and without Radar), MUST divide into attackAAmaxDieSides without remainders, or else there WILL be errors in LowLuck! -->
+                         <option name="attackAAmaxDieSides" value="6"/>
+                         <!-- isAAforCombatOnly allows this unit to be an AA gun for normal combat only.  it will not defend against strategic bombing raids
+                         <option name="isAAforCombatOnly" value="true"/>-->
+                         <!-- isAAforBombingThisUnitOnly allows this unit to be an AA gun only when this unit is directly attacked by a strategic bombing raid (currently defends against all strategic bombing attacks in this territory, not just against this unit).  it will not defend against a normal attack
+                         <option name="isAAforBombingThisUnitOnly" value="true"/>-->
+                         <!-- isRocket allows this unit to become a rocket if the player has the rocket technology.  If the unit is named exactly "aaGun" then it will require an image called "rockets".  If the unit is named anything else, then it will require an image with "_rockets" appended to its original name.
+                         <option name="isRocket" value="true"/>-->
+                         <!-- isAAmovement forces this unit to follow the rules for movement of an AA gun, and for placement of AA guns (like no moving during combat phase, max of 1 of each unit per territory, etc.)
+                         <option name="isAAmovement" value="true"/>-->
                 </attachment>
-				
-				
+
+
 <!-- Territory Attachments -->
-	<!-- <option name="unitProduction" value="x"/> must be placed under <option name="production" value="x"/> if it is being used. 
-			This is because a recent update to TripleA had the setting of 'production' automatically set 'unitProduction' to be equal to it. 
-			If you want to set "production" without also setting "unitProduction", then please use "productionOnly" -->
-	<!-- the following options are allowed for "territoryAttachment"
-			production								values: the PU production of the territory. also sets unitProduction to be equal.
-			productionOnly							values: please do not use this. it is only here for use with triggers. it sets "production" without setting "unitProduction"
-			unitProduction							values: unitProduction is complex and has 2 uses, depending on how you plan on dealing with damage. Defaults to whatever "production" is, so please set it after you set "production"
-																1. 	First use is used only with ww2v3 factory damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to a Territory, not to a Unit.
-																		This decides the damage the territory starts at.  If unitProduction is less than production, then the territory starts damaged.  If they are equal, then the territory is not damaged. 
-																2. 	Second use is used with newer maps which are using the new damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to an individual Unit instead of a Territory.
-																		When used with these rules, "unitProduction" lets you set the unit production potential of a territory, separate from the production. This means a territory with unitProduction = 2 will be able to produce 2 units there, regardless of if production is 0 or 20.
-																		(The damage potential of these units will normally be 2x the unitProduction, but this can be set individually by creative use of maxDamage and canProduceXUnits)
-			resources								values: the amount we will get, then the name of the resource. example: value="2:steel"
-			isImpassable							values: true or false, is this territory not passable?
-			capital									values: the capital of a player, and player's can have multiple capitals.  all players except for optional players require a capital. 
-																capital uses an image located in the "flags" folder of a map called "<nation>_large.png", and the location is determined in a file called "capitols.txt" in the map's root directory
-			victoryCity								values: a victory city is typically used for victory conditions
-																victoryCity uses an image located in the "misc" folder of a map called "vc.png", and the location is determined in a file called "vc.txt" in the map's root directory
-			originalFactory							values: means that the original controller of the territory may produce infinite units there, however if it is captured the opponent may only produce as normal, not infinite units
-			originalOwner							values: allows a territory to revert to this player's control if liberated by an ally
-			navalBase								values: works according to original pacific rules: it increases the non-combat movement of naval units by +1 IF they go from friendly naval base TO friendly naval base
-			airBase									values: works according to original pacific rules: it allows free movement between the land territory and any connecting water territories, 
-																which potentially gives an air units +2 movement if they move from airbase to airbase and both airbases have water connecting to them on the route (or are islands)
-			captureUnitOnEnteringBy					values: allows some players to have their units change to another player's control, if they are located in territories with this attachment, and the specified player captures this territory
-																it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans"
-			changeUnitOwners						values: allows some players to have their units change to another player's control, if they are located in territories with this attachment 
-																it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans"
-			convoyRoute								values: true or false. Is this territory part of a Convoy route. (meaning, if this territory Either REQUIRES other territories to be owned, or is REQUIRED BY other territories to be owned).
-			convoyAttached							values: a colon (":") delimited list of the territories this convoy is route is using (list of territories This territory REQUIRES). This can be empty if this territory does not require any other territories but is required by other territories.
-																At least one of the attached territories must be owned by a friendly to collect income from this territory.
-			blockadeZone							values: true or false, can this territory be blockaded by neighboring sea zones?
-			kamikazeZone							values: true or false, does nothing right now, but it will put a symbol on the map (the kamikazeZone symbol must be in the flags folder and be named "<owner_name>_fade"
-			territoryEffect							values: adds a territoryEffect to a territory, can have multiple
-			whenCapturedByGoesTo					values: the player that captures the territory, then the player that will get the territory, separated by a colon.  Can have multiple. For example: value="Americans:Russians"
-			
-	-->
-				
-				<attachment name="territoryAttachment" attachTo="West Balkans" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+    <!-- <option name="unitProduction" value="x"/> must be placed under <option name="production" value="x"/> if it is being used.
+            This is because a recent update to TripleA had the setting of 'production' automatically set 'unitProduction' to be equal to it.
+            If you want to set "production" without also setting "unitProduction", then please use "productionOnly" -->
+    <!-- the following options are allowed for "territoryAttachment"
+            production                              values: the PU production of the territory. also sets unitProduction to be equal.
+            productionOnly                          values: please do not use this. it is only here for use with triggers. it sets "production" without setting "unitProduction"
+            unitProduction                          values: unitProduction is complex and has 2 uses, depending on how you plan on dealing with damage. Defaults to whatever "production" is, so please set it after you set "production"
+                                                                1.  First use is used only with ww2v3 factory damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to a Territory, not to a Unit.
+                                                                        This decides the damage the territory starts at.  If unitProduction is less than production, then the territory starts damaged.  If they are equal, then the territory is not damaged.
+                                                                2.  Second use is used with newer maps which are using the new damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to an individual Unit instead of a Territory.
+                                                                        When used with these rules, "unitProduction" lets you set the unit production potential of a territory, separate from the production. This means a territory with unitProduction = 2 will be able to produce 2 units there, regardless of if production is 0 or 20.
+                                                                        (The damage potential of these units will normally be 2x the unitProduction, but this can be set individually by creative use of maxDamage and canProduceXUnits)
+            resources                               values: the amount we will get, then the name of the resource. example: value="2:steel"
+            isImpassable                            values: true or false, is this territory not passable?
+            capital                                 values: the capital of a player, and player's can have multiple capitals.  all players except for optional players require a capital.
+                                                                capital uses an image located in the "flags" folder of a map called "<nation>_large.png", and the location is determined in a file called "capitols.txt" in the map's root directory
+            victoryCity                             values: a victory city is typically used for victory conditions
+                                                                victoryCity uses an image located in the "misc" folder of a map called "vc.png", and the location is determined in a file called "vc.txt" in the map's root directory
+            originalFactory                         values: means that the original controller of the territory may produce infinite units there, however if it is captured the opponent may only produce as normal, not infinite units
+            originalOwner                           values: allows a territory to revert to this player's control if liberated by an ally
+            navalBase                               values: works according to original pacific rules: it increases the non-combat movement of naval units by +1 IF they go from friendly naval base TO friendly naval base
+            airBase                                 values: works according to original pacific rules: it allows free movement between the land territory and any connecting water territories,
+                                                                which potentially gives an air units +2 movement if they move from airbase to airbase and both airbases have water connecting to them on the route (or are islands)
+            captureUnitOnEnteringBy                 values: allows some players to have their units change to another player's control, if they are located in territories with this attachment, and the specified player captures this territory
+                                                                it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans"
+            changeUnitOwners                        values: allows some players to have their units change to another player's control, if they are located in territories with this attachment
+                                                                it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans"
+            convoyRoute                             values: true or false. Is this territory part of a Convoy route. (meaning, if this territory Either REQUIRES other territories to be owned, or is REQUIRED BY other territories to be owned).
+            convoyAttached                          values: a colon (":") delimited list of the territories this convoy is route is using (list of territories This territory REQUIRES). This can be empty if this territory does not require any other territories but is required by other territories.
+                                                                At least one of the attached territories must be owned by a friendly to collect income from this territory.
+            blockadeZone                            values: true or false, can this territory be blockaded by neighboring sea zones?
+            kamikazeZone                            values: true or false, does nothing right now, but it will put a symbol on the map (the kamikazeZone symbol must be in the flags folder and be named "<owner_name>_fade"
+            territoryEffect                         values: adds a territoryEffect to a territory, can have multiple
+            whenCapturedByGoesTo                    values: the player that captures the territory, then the player that will get the territory, separated by a colon.  Can have multiple. For example: value="Americans:Russians"
+
+    -->
+
+                <attachment name="territoryAttachment" attachTo="West Balkans" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
-						<!-- resources allow you to use custom resource production for a territory.
-						<option name="resources" value="1:Steel"/>
-						<option name="resources" value="1:Aluminium"/>-->
+                        <!-- resources allow you to use custom resource production for a territory.
+                        <option name="resources" value="1:Steel"/>
+                        <option name="resources" value="1:Aluminium"/>-->
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Greece" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
-						<!-- captureUnitOnEnteringBy allows some players to have their units change to another player's control, if they are located in territories with this attachment, and the specified player captures this territory
-								it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans" 
-						<option name="captureUnitOnEnteringBy" value="Americans:British"/>-->
+                        <!-- captureUnitOnEnteringBy allows some players to have their units change to another player's control, if they are located in territories with this attachment, and the specified player captures this territory
+                                it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans"
+                        <option name="captureUnitOnEnteringBy" value="Americans:British"/>-->
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Sicily" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2293,9 +2293,9 @@
 
                 <attachment name="territoryAttachment" attachTo="Sardinia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
-						<!-- convoyRoute and convoyAttached are for setting a territory to require another territory in order to collect income. at least one of the listed territories must be owned by a friendly to collect income from this territory.
-						<option name="convoyRoute" value="true"/>
-						<option name="convoyAttached" value="14 Sea Zone:13 Sea Zone"/> -->
+                        <!-- convoyRoute and convoyAttached are for setting a territory to require another territory in order to collect income. at least one of the listed territories must be owned by a friendly to collect income from this territory.
+                        <option name="convoyRoute" value="true"/>
+                        <option name="convoyAttached" value="14 Sea Zone:13 Sea Zone"/> -->
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Eastern Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2304,26 +2304,26 @@
 
                 <attachment name="territoryAttachment" attachTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment"  type="territory">
                         <option name="production" value="14"/>
-						<!-- capital uses an image located in the "flags" folder of a map called "<nation>_large.png", and the location is determined in a file called "capitols.txt" in the map's root directory -->
+                        <!-- capital uses an image located in the "flags" folder of a map called "<nation>_large.png", and the location is determined in a file called "capitols.txt" in the map's root directory -->
                         <option name="capital" value="Germans"/>
-						<!-- victoryCity uses an image located in the "misc" folder of a map called "vc.png", and the location is determined in a file called "vc.txt" in the map's root directory -->
-						<option name="victoryCity" value="1"/>
-						<!--- originalFactory means that the original controller of the territory may produce infinite units there, however if it is captured the opponent may only produce as normal, not infinite units 
-						<option name="originalFactory" value="true"/> -->
-						<!-- navalBase territory attachment works according to original pacific rules: it increases the non-combat movement of naval units by +1 IF they go from friendly naval base TO friendly naval base
-						<option name="navalBase" value="true"/> -->
-						<!-- airBase territory attachment works according to original pacific rules: it allows free movement between the land territory and any connecting water territories, 
-								which potentially gives an air units +2 movement if they move from airbase to airbase and both airbases have water connecting to them on the route (or are islands)
-						<option name="airBase" value="true"/> -->
-						<!-- unitProduction is complex and has 2 uses, depending on how you plan on dealing with damage. 
-									(setting "production" sets "unitProduction" at the same time to be equal, therefore unitProduction defaults to production if it is not set, or if it is set before production. 
-									If you want unitProduction to be different, please set it after you set production.)
-							1. 	First use is used only with ww2v3 factory damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to a Territory, not to a Unit.
-									This decides the damage the territory starts at.  If unitProduction is less than production, then the territory starts damaged.  If they are equal, then the territory is not damaged. 
-							2. 	Second use is used with newer maps which are using the new damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to an individual Unit instead of a Territory.
-									When used with these rules, "unitProduction" lets you set the unit production potential of a territory, separate from the production. This means a territory with unitProduction = 2 will be able to produce 2 units there, regardless of if production is 0 or 20.
-									The damage potential of these units will normally be 2x the unitProduction, but this can be set individually by creative use of maxDamage and canProduceXUnits.
-								Must be placed UNDER 'production' in the xml, because 'production' automatically sets 'unitProduction' to be equal otherwise.
+                        <!-- victoryCity uses an image located in the "misc" folder of a map called "vc.png", and the location is determined in a file called "vc.txt" in the map's root directory -->
+                        <option name="victoryCity" value="1"/>
+                        <!--- originalFactory means that the original controller of the territory may produce infinite units there, however if it is captured the opponent may only produce as normal, not infinite units
+                        <option name="originalFactory" value="true"/> -->
+                        <!-- navalBase territory attachment works according to original pacific rules: it increases the non-combat movement of naval units by +1 IF they go from friendly naval base TO friendly naval base
+                        <option name="navalBase" value="true"/> -->
+                        <!-- airBase territory attachment works according to original pacific rules: it allows free movement between the land territory and any connecting water territories,
+                                which potentially gives an air units +2 movement if they move from airbase to airbase and both airbases have water connecting to them on the route (or are islands)
+                        <option name="airBase" value="true"/> -->
+                        <!-- unitProduction is complex and has 2 uses, depending on how you plan on dealing with damage.
+                                    (setting "production" sets "unitProduction" at the same time to be equal, therefore unitProduction defaults to production if it is not set, or if it is set before production.
+                                    If you want unitProduction to be different, please set it after you set production.)
+                            1.  First use is used only with ww2v3 factory damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to a Territory, not to a Unit.
+                                    This decides the damage the territory starts at.  If unitProduction is less than production, then the territory starts damaged.  If they are equal, then the territory is not damaged.
+                            2.  Second use is used with newer maps which are using the new damage rules ("Damage From Bombing Done To Units Instead Of Territories"), which have damage done to an individual Unit instead of a Territory.
+                                    When used with these rules, "unitProduction" lets you set the unit production potential of a territory, separate from the production. This means a territory with unitProduction = 2 will be able to produce 2 units there, regardless of if production is 0 or 20.
+                                    The damage potential of these units will normally be 2x the unitProduction, but this can be set individually by creative use of maxDamage and canProduceXUnits.
+                                Must be placed UNDER 'production' in the xml, because 'production' automatically sets 'unitProduction' to be equal otherwise.
                         <option name="unitProduction" value="14"/>-->
                 </attachment>
 
@@ -2341,7 +2341,7 @@
 
                 <attachment name="territoryAttachment" attachTo="Australia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment"  type="territory">
                         <option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Kenya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2350,7 +2350,7 @@
 
                 <attachment name="territoryAttachment" attachTo="Manchuria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
-						<!-- originalOwner allows a territory to revert to that player's control if liberated by an ally -->
+                        <!-- originalOwner allows a territory to revert to that player's control if liberated by an ally -->
                         <option name="originalOwner" value="Chinese"/>
                 </attachment>
 
@@ -2377,7 +2377,7 @@
 
                 <attachment name="territoryAttachment" attachTo="India" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Soviet Far East" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2388,7 +2388,7 @@
                 <attachment name="territoryAttachment" attachTo="Italy" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="8"/>
                         <option name="capital" value="Italians"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                         <!--<option name="unitProduction" value="8"/>-->
                 </attachment>
 
@@ -2408,14 +2408,14 @@
 
                 <attachment name="territoryAttachment" attachTo="Philipine Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Archangel" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
-						<!-- changeUnitOwners allows some players to have their units change to another player's control, if they are located in territories with this attachment 
-								it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans" -->
-						<option name="changeUnitOwners" value="Russians"/>
+                        <!-- changeUnitOwners allows some players to have their units change to another player's control, if they are located in territories with this attachment
+                                it must be a list of the player's names in a ":" delimited list.  For example: value="Russians:Germans" -->
+                        <option name="changeUnitOwners" value="Russians"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Novisibirsk" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2442,19 +2442,19 @@
 
                 <attachment name="territoryAttachment" attachTo="Western United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="10"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                         <!--<option name="unitProduction" value="10"/>-->
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Karelia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Kwangtung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
- 			                       <option name="originalOwner" value="Chinese"/>
+                        <option name="victoryCity" value="1"/>
+                        <option name="originalOwner" value="Chinese"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Brazil" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2475,7 +2475,7 @@
 
                 <attachment name="territoryAttachment" attachTo="Hawaiian Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="East Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2494,8 +2494,8 @@
 
                 <attachment name="territoryAttachment" attachTo="Norway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
-						<option name="convoyRoute" value="true"/>
-						<option name="convoyAttached" value="5 Sea Zone:6 Sea Zone"/>
+                        <option name="convoyRoute" value="true"/>
+                        <option name="convoyAttached" value="5 Sea Zone:6 Sea Zone"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="French Indochina" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2523,13 +2523,13 @@
                 <attachment name="territoryAttachment" attachTo="United Kingdom" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="8"/>
                         <option name="capital" value="British"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                         <!--<option name="unitProduction" value="8"/>-->
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Western Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="6"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Rio De Oro" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2565,9 +2565,9 @@
 
                 <attachment name="territoryAttachment" attachTo="Caucus" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="4"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                         <!--<option name="unitProduction" value="4"/>-->
-						<!-- you can have multiple capitals per country, and can modify if they capture or destroy their PUs, and how many capitals are needed for that to happen -->
+                        <!-- you can have multiple capitals per country, and can modify if they capture or destroy their PUs, and how many capitals are needed for that to happen -->
                         <!--<option name="capital" value="Russians"/>-->
                 </attachment>
 
@@ -2591,7 +2591,7 @@
                 <attachment name="territoryAttachment" attachTo="Himilaya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                         <option name="isImpassable" value="true"/>
-						<option name="capital" value="Chinese"/>
+                        <option name="capital" value="Chinese"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Evanki National Okrug" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2619,9 +2619,9 @@
 
                 <attachment name="territoryAttachment" attachTo="West Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
-						<option name="whenCapturedByGoesTo" value="Americans:Russians"/>
-						<option name="whenCapturedByGoesTo" value="British:Russians"/>
-						<option name="whenCapturedByGoesTo" value="Chinese:Russians"/>
+                        <option name="whenCapturedByGoesTo" value="Americans:Russians"/>
+                        <option name="whenCapturedByGoesTo" value="British:Russians"/>
+                        <option name="whenCapturedByGoesTo" value="Chinese:Russians"/>
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Peru" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2633,7 +2633,7 @@
                 <attachment name="territoryAttachment" attachTo="Eastern United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="12"/>
                         <option name="capital" value="Americans"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                         <!--<option name="unitProduction" value="12"/>-->
                 </attachment>
 
@@ -2649,7 +2649,7 @@
                 <attachment name="territoryAttachment" attachTo="Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="8"/>
                         <option name="capital" value="Russians"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                         <!--<option name="unitProduction" value="8"/>-->
                 </attachment>
 
@@ -2676,7 +2676,7 @@
 
                 <attachment name="territoryAttachment" attachTo="Central United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="4"/>
-						<!--<option name="territoryEffect" value="mountain"/>-->
+                        <!--<option name="territoryEffect" value="mountain"/>-->
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Argentina" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -2696,1461 +2696,1461 @@
                 <attachment name="territoryAttachment" attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="8"/>
                         <option name="capital" value="Japanese"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                         <!--<option name="unitProduction" value="8"/>-->
                 </attachment>
 
                 <attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                 </attachment>
-				
-				<!-- Convoy Centers, Convoy Routes, Blockade Zones -->
-				<!-- Convoy Routes must be attached to both the Requiring territory and the Required territory. Sea convoys can have income too, and if they do then they operate just like Convoy Centers for the income
-				<attachment name="territoryAttachment" attachTo="13 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="convoyRoute" value="true"/>
-						<option name="convoyAttached" value=""/>
+
+                <!-- Convoy Centers, Convoy Routes, Blockade Zones -->
+                <!-- Convoy Routes must be attached to both the Requiring territory and the Required territory. Sea convoys can have income too, and if they do then they operate just like Convoy Centers for the income
+                <attachment name="territoryAttachment" attachTo="13 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="convoyRoute" value="true"/>
+                        <option name="convoyAttached" value=""/>
                 </attachment>
-				<attachment name="territoryAttachment" attachTo="14 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-						<option name="convoyRoute" value="true"/>
-						<option name="convoyAttached" value=""/>
+                <attachment name="territoryAttachment" attachTo="14 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="convoyRoute" value="true"/>
+                        <option name="convoyAttached" value=""/>
                 </attachment> -->
-				<attachment name="territoryAttachment" attachTo="5 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="2"/>
-						<!-- Sea zone 5 is part of the convoyRoute of Norway (Norway has it listed under convoyAttached), so Sea zone 5 must have convoyRoute = true -->
-						<option name="convoyRoute" value="true"/>
-						<!-- Sea zone 5 has an income of 2 for Germany, but it does not Require ownership of another territory in order to get the income, so "convoyAttached" is blank -->
-						<option name="convoyAttached" value=""/>
+                <attachment name="territoryAttachment" attachTo="5 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <!-- Sea zone 5 is part of the convoyRoute of Norway (Norway has it listed under convoyAttached), so Sea zone 5 must have convoyRoute = true -->
+                        <option name="convoyRoute" value="true"/>
+                        <!-- Sea zone 5 has an income of 2 for Germany, but it does not Require ownership of another territory in order to get the income, so "convoyAttached" is blank -->
+                        <option name="convoyAttached" value=""/>
                 </attachment>
-				<attachment name="territoryAttachment" attachTo="6 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="convoyRoute" value="true"/>
+                <attachment name="territoryAttachment" attachTo="6 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="convoyRoute" value="true"/>
                 </attachment>
-				
-				<!-- Convoy Centers are simply sea zones with income. if you control your convoy zone, you get the income from it, but if an enemy takes the zone they do not get any income, they just deny you the income. can only be entered during combat movement -->
+
+                <!-- Convoy Centers are simply sea zones with income. if you control your convoy zone, you get the income from it, but if an enemy takes the zone they do not get any income, they just deny you the income. can only be entered during combat movement -->
                 <attachment name="territoryAttachment" attachTo="3 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                 </attachment>
-				<attachment name="territoryAttachment" attachTo="4 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                <attachment name="territoryAttachment" attachTo="4 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                 </attachment>
-				
-				<!-- Blockade Zones are areas where if the enemy has ships there, they subtract money from each of the connecting land territories up to the value of the territory. 
-						if there are many enemy ships, you will collect no income from the connecting land territories. should be set to zero production otherwise they become convoy zones too -->
-				<attachment name="territoryAttachment" attachTo="37 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                <!-- Blockade Zones are areas where if the enemy has ships there, they subtract money from each of the connecting land territories up to the value of the territory.
+                        if there are many enemy ships, you will collect no income from the connecting land territories. should be set to zero production otherwise they become convoy zones too -->
+                <attachment name="territoryAttachment" attachTo="37 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
+                        <option name="blockadeZone" value="true"/>
                 </attachment>
-				<attachment name="territoryAttachment" attachTo="47 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                <attachment name="territoryAttachment" attachTo="47 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
+                        <option name="blockadeZone" value="true"/>
                 </attachment>
-				<attachment name="territoryAttachment" attachTo="48 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                <attachment name="territoryAttachment" attachTo="48 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
+                        <option name="blockadeZone" value="true"/>
                 </attachment>
-				<attachment name="territoryAttachment" attachTo="49 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                <attachment name="territoryAttachment" attachTo="49 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-						<!-- kamikazeZone does nothing right now, but it will put a symbol on the map (the kamikazeZone symbol must be in the flags folder and be named "<owner_name>_fade"
-						<option name="kamikazeZone" value="true"/>-->
+                        <option name="blockadeZone" value="true"/>
+                        <!-- kamikazeZone does nothing right now, but it will put a symbol on the map (the kamikazeZone symbol must be in the flags folder and be named "<owner_name>_fade"
+                        <option name="kamikazeZone" value="true"/>-->
                 </attachment>
-				<attachment name="territoryAttachment" attachTo="58 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                <attachment name="territoryAttachment" attachTo="58 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
+                        <option name="blockadeZone" value="true"/>
                 </attachment>
 
-				
-				
+
+
 <!-- Canals -->
-	<!-- the following options are allowed for "canalAttachmentXXX" (all canal attachments need X identical attachments attached to the X number of sea zones involved)
-			canalName							values: any string name for the canal. must match its counterpart attachment.
-			landTerritories						values: a colon (":") delimited list of the territories that make up this canal. must match its counterpart attachment.
-	-->
-			    <attachment name="canalAttachmentSuez" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Suez Canal"/>
-			    	<option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
-			    </attachment>
-			
-			    <attachment name="canalAttachmentSuez" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Suez Canal"/>
-			    	<option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
-			    </attachment>
-			
-		   	    <attachment name="canalAttachmentPanama" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Panama Canal"/>
-			    	<option name="landTerritories" value="Panama"/>
-			    </attachment>
-			
-			    <attachment name="canalAttachmentPanama" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Panama Canal"/>
-			    	<option name="landTerritories" value="Panama"/>
-			    </attachment>
-				
-				
-				
-				
+    <!-- the following options are allowed for "canalAttachmentXXX" (all canal attachments need X identical attachments attached to the X number of sea zones involved)
+            canalName                           values: any string name for the canal. must match its counterpart attachment.
+            landTerritories                     values: a colon (":") delimited list of the territories that make up this canal. must match its counterpart attachment.
+    -->
+                <attachment name="canalAttachmentSuez" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Suez Canal"/>
+                    <option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
+                </attachment>
+
+                <attachment name="canalAttachmentSuez" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Suez Canal"/>
+                    <option name="landTerritories" value="Anglo Egypt:Trans-Jordan"/>
+                </attachment>
+
+                <attachment name="canalAttachmentPanama" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Panama Canal"/>
+                    <option name="landTerritories" value="Panama"/>
+                </attachment>
+
+                <attachment name="canalAttachmentPanama" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Panama Canal"/>
+                    <option name="landTerritories" value="Panama"/>
+                </attachment>
+
+
+
+
 <!-- Territory Effects -->
-	<!-- the following options are allowed for "territoryEffectAttachment"
-			combatOffenseEffect					values: the name of the unit, and the count of how much offense you want to give this unit
-			combatDefenseEffect					values: the name of the unit, and the count of how much defense you want to give this unit
-	-->
-				<attachment name="territoryEffectAttachment" attachTo="mountain" javaClass="games.strategy.triplea.attachments.TerritoryEffectAttachment" type="territoryEffect">
-					<option name="combatOffenseEffect" value="infantry" count="1"/>
-					<option name="combatDefenseEffect" value="armour" count="-2"/>
-					<option name="noBlitz" value="armour"/>
-				</attachment>
-				
-				
-				
-				
+    <!-- the following options are allowed for "territoryEffectAttachment"
+            combatOffenseEffect                 values: the name of the unit, and the count of how much offense you want to give this unit
+            combatDefenseEffect                 values: the name of the unit, and the count of how much defense you want to give this unit
+    -->
+                <attachment name="territoryEffectAttachment" attachTo="mountain" javaClass="games.strategy.triplea.attachments.TerritoryEffectAttachment" type="territoryEffect">
+                    <option name="combatOffenseEffect" value="infantry" count="1"/>
+                    <option name="combatDefenseEffect" value="armour" count="-2"/>
+                    <option name="noBlitz" value="armour"/>
+                </attachment>
+
+
+
+
 <!-- Support Attachments -->
-	<!-- the following options are allowed for "supportAttachmentXXX" (must be unique names!)
-			unitType							values: the name of the unit (or units in a : delimited list) TO BE SUPPORTED BY THE ATTACHED UNIT (attached unit is "attachTO"). 
-														If you are changing the properties of a unit, then unitType should be the same as attachTo
-			faction								values: "allied" or "enemy" (enemy not yet coded, does nothing right now)
-			side								values: "offence" or "defence", support when attacking or defending, can be both (example: value="offence:defence")
-			dice								values: "strength" or "rolls", may be a list of both (rolls not yet coded, does nothing right now)
-			bonus								values: how much to add to strength or roll
-			number								values: how many units to be supported
-			bonusType							values: the name of the bonus, any string. any bonus with the same name will not stack, any bonus with a different name will stack
-														Please us the string "ArtyOld" if do not want your bonus to stack with normal artillery (ie: do not want the bonus to stack with any unit with the normal artillery attachment: <option name="artillery" value="true"/>)
-			players								values: names of players in a list, if missing defaults to no players, and if no players it means this support will not be active at start of game (can be activated later by a trigger) (example: value="Germans:Italians")
-			impArtTech							values: "true" or "false", does this support get doubled by the improvedArtillery technology?
-	-->
-	
-			    <!--<attachment name="supportAttachmentRussiansArtillery1" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-			    	<option name="unitType" value="infantry"/>
-					<option name="faction" value="allied"/>
-					<option name="side" value="offence"/>
-					<option name="dice" value="strength"/>
-					<option name="bonus" value="1"/>
-					<option name="number" value="1"/>
-					<option name="bonusType" value="ArtyOld"/>
-					<option name="impArtTech" value="true"/>
-			    </attachment>-->
-				
-			    <attachment name="supportAttachmentRussiansArtillery2" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-			    	<option name="unitType" value="infantry"/>
-					<option name="faction" value="allied"/>
-					<option name="side" value="offence"/>
-					<option name="dice" value="strength"/>
-					<option name="bonus" value="1"/>
-					<option name="number" value="2"/>
-					<option name="bonusType" value="ArtyNew"/>
-					<option name="impArtTech" value="true"/>
-					<!--<option name="players" value="Russians:British"/>-->
-			    </attachment>
-				
-			    <attachment name="supportAttachmentFighter" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-			    	<option name="unitType" value="infantry"/>
-					<option name="faction" value="allied"/>
-					<option name="side" value="offence"/>
-					<option name="dice" value="strength"/>
-					<option name="bonus" value="1"/>
-					<option name="number" value="1"/>
-					<option name="bonusType" value="combined_arms"/>
-					<option name="impArtTech" value="false"/>
-			    </attachment>
-				
-			    <attachment name="supportAttachmentSubmarineReinforcedHulls" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-			    	<option name="unitType" value="submarine"/>
-					<option name="faction" value="allied"/>
-					<option name="side" value="defence"/>
-					<option name="dice" value="strength"/>
-					<option name="bonus" value="2"/>
-					<option name="number" value="1"/>
-					<option name="bonusType" value="hulls"/>
-					<option name="impArtTech" value="false"/>
-			    </attachment>
-				
-			    <attachment name="supportAttachmentSubmarineWolfPackTacticsOffence" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-			    	<option name="unitType" value="submarine"/>
-					<option name="faction" value="allied"/>
-					<option name="side" value="offence"/>
-					<option name="dice" value="strength"/>
-					<option name="bonus" value="1"/>
-					<option name="number" value="1"/>
-					<option name="bonusType" value="tactics1"/>
-					<option name="impArtTech" value="false"/>
-			    </attachment>
-				
-			    <!--<attachment name="supportAttachmentSubmarineWolfPackTacticsDefence" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-			    	<option name="unitType" value="submarine"/>
-					<option name="faction" value="allied"/>
-					<option name="side" value="defence"/>
-					<option name="dice" value="strength"/>
-					<option name="bonus" value="1"/>
-					<option name="number" value="1"/>
-					<option name="bonusType" value="tactics2"/>
-					<option name="impArtTech" value="false"/>
-			    </attachment>-->
+    <!-- the following options are allowed for "supportAttachmentXXX" (must be unique names!)
+            unitType                            values: the name of the unit (or units in a : delimited list) TO BE SUPPORTED BY THE ATTACHED UNIT (attached unit is "attachTO").
+                                                        If you are changing the properties of a unit, then unitType should be the same as attachTo
+            faction                             values: "allied" or "enemy" (enemy not yet coded, does nothing right now)
+            side                                values: "offence" or "defence", support when attacking or defending, can be both (example: value="offence:defence")
+            dice                                values: "strength" or "rolls", may be a list of both (rolls not yet coded, does nothing right now)
+            bonus                               values: how much to add to strength or roll
+            number                              values: how many units to be supported
+            bonusType                           values: the name of the bonus, any string. any bonus with the same name will not stack, any bonus with a different name will stack
+                                                        Please us the string "ArtyOld" if do not want your bonus to stack with normal artillery (ie: do not want the bonus to stack with any unit with the normal artillery attachment: <option name="artillery" value="true"/>)
+            players                             values: names of players in a list, if missing defaults to no players, and if no players it means this support will not be active at start of game (can be activated later by a trigger) (example: value="Germans:Italians")
+            impArtTech                          values: "true" or "false", does this support get doubled by the improvedArtillery technology?
+    -->
+
+                <!--<attachment name="supportAttachmentRussiansArtillery1" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                    <option name="unitType" value="infantry"/>
+                    <option name="faction" value="allied"/>
+                    <option name="side" value="offence"/>
+                    <option name="dice" value="strength"/>
+                    <option name="bonus" value="1"/>
+                    <option name="number" value="1"/>
+                    <option name="bonusType" value="ArtyOld"/>
+                    <option name="impArtTech" value="true"/>
+                </attachment>-->
+
+                <attachment name="supportAttachmentRussiansArtillery2" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                    <option name="unitType" value="infantry"/>
+                    <option name="faction" value="allied"/>
+                    <option name="side" value="offence"/>
+                    <option name="dice" value="strength"/>
+                    <option name="bonus" value="1"/>
+                    <option name="number" value="2"/>
+                    <option name="bonusType" value="ArtyNew"/>
+                    <option name="impArtTech" value="true"/>
+                    <!--<option name="players" value="Russians:British"/>-->
+                </attachment>
+
+                <attachment name="supportAttachmentFighter" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                    <option name="unitType" value="infantry"/>
+                    <option name="faction" value="allied"/>
+                    <option name="side" value="offence"/>
+                    <option name="dice" value="strength"/>
+                    <option name="bonus" value="1"/>
+                    <option name="number" value="1"/>
+                    <option name="bonusType" value="combined_arms"/>
+                    <option name="impArtTech" value="false"/>
+                </attachment>
+
+                <attachment name="supportAttachmentSubmarineReinforcedHulls" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                    <option name="unitType" value="submarine"/>
+                    <option name="faction" value="allied"/>
+                    <option name="side" value="defence"/>
+                    <option name="dice" value="strength"/>
+                    <option name="bonus" value="2"/>
+                    <option name="number" value="1"/>
+                    <option name="bonusType" value="hulls"/>
+                    <option name="impArtTech" value="false"/>
+                </attachment>
+
+                <attachment name="supportAttachmentSubmarineWolfPackTacticsOffence" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                    <option name="unitType" value="submarine"/>
+                    <option name="faction" value="allied"/>
+                    <option name="side" value="offence"/>
+                    <option name="dice" value="strength"/>
+                    <option name="bonus" value="1"/>
+                    <option name="number" value="1"/>
+                    <option name="bonusType" value="tactics1"/>
+                    <option name="impArtTech" value="false"/>
+                </attachment>
+
+                <!--<attachment name="supportAttachmentSubmarineWolfPackTacticsDefence" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                    <option name="unitType" value="submarine"/>
+                    <option name="faction" value="allied"/>
+                    <option name="side" value="defence"/>
+                    <option name="dice" value="strength"/>
+                    <option name="bonus" value="1"/>
+                    <option name="number" value="1"/>
+                    <option name="bonusType" value="tactics2"/>
+                    <option name="impArtTech" value="false"/>
+                </attachment>-->
 
 <!--  National Objectives -->
-	<!-- all Objective Attachments, Conditions, Triggers, Rules, etc, must have a unique name (if you don't use unique names, you may get funny results with your trigger attachments, or even java errors) -->
-	<!-- the following options are allowed for "objectiveAttachmentXXX" (and also for "conditionAttachmentXXX").  all options below have an "AND" relationship with each other.
-			conditions							values: any objectiveAttachment or conditionAttachment, can be any player's attachment (must have unique names!), tested during attached player's turn
-															can be in a delimited list for an AND relationship (example: value="conditionAttachmentGermans3a:conditionAttachmentGermans3b")
-															any condition which includes other conditions, is considered a meta-condition, and it must come AFTER any conditions that it includes.
-			conditionType 						values: AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the "conditions" option.
-														AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
-														conditionType only affects the conditions listed under the option name="conditions", and does not affect any additional things also present.
-			invert								values: true or false. default if missing is false. if true, this attachment's condition will be reversed (does not reverse the effect). 
-														This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
-			objectiveValue						values: any integer number of PUs to be given (example: value="4")
-			uses								values: integer for the maximum number of times it should be awarded. if missing it defaults to infinity. Only applies to objectiveValue, and does NOT determine if the conditions is true or false.
-			turns								values: which turns this will be checked on (example: value="1:4:6-8:11-+" means turns 1,4,6,7,8,11,and all turns after 11)
-			relationship						values: a relationship that needs to be present in the game: "player1:player2:relationship" (will set #rounds to -1 by default) OR "player1:player2:relationship:numberOfRoundsThisRelationshipMustExistForMinimum"
-														for example: "Japan:China:War" or "Japan:China:War:-1" or "Japan:China:War:3".  It will accept "anyWar", "anyNeutral" and "anyAllied" as well.
-			
-			count								values: the number required to satisfy a rule. if missing, it defaults to ALL (unless specified). it can also be set to "each", which will act as "1" for the purposes of being a condition, but will multiply the bonus (do not use multiple options if you are using each).
-		the below options use count:
-			destroyedTUV						values: count=an amount of TUV that the attached player must destroy. value=currentRound/allRounds. This is not counting neutral (null) player, and is based on the cost for the defender to buy the units.
-														Be sure to check this condition only after the player's battle phase is completely over, since the data is only recorded after all battles are done. example: value="currentRound" count="20"
-			atWarPlayers						values: player names, in a : delimited list (example: value="Germans:Italians:Japanese" count="2" means that you must be at war with 2 of the 3 listed players). if count is zero, then you must be at war with none.
-			techs								values: any list of technologies, : delimited (if count = zero, then must have exactly zero technologies [if count is missing, defaults to zero])
-			directOwnershipTerritories			values: "original", "enemy", or a : delimited list of territories
-			alliedOwnershipTerritories			values: "original", "enemy", or a : delimited list of territories
-			directExclusionTerritories 			values: "original", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
-			alliedExclusionTerritories			values: "original", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
-			enemyExclusionTerritories			values: "original", "map" (map = all territories on map), or a : delimited list of territories
-			enemySurfaceExclusionTerritories	values: "original", "map" (map = all territories on map), or a : delimited list of territories
-			directPresenceTerritories 			values: "original", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
-			alliedPresenceTerritories 			values: "original", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
-			enemyPresenceTerritories 			values: "original", "map" (map = all territories on map), or a : delimited list of territories
-			unitPresence 						values: "ANY" or the exact name or names of the units, and the number of that unit.  (example: value="infantry" count="2", or: value="ANY" count="3", or: value="infantry:artillery:armour" count="3")
-														unitPresence can be put in multiple times. Its purpose is to specify the units for presence and excluded territories. If missing, then presence needs only 1 of any unit, and excluded needs to be completely devoid of units
-														For an "AND" relationship between the required units, put them in separately. For an "OR" relationship, put them in on one line with a colon separating them.
-														It can be used in conjunction with directPresenceTerritories, alliedPresenceTerritories, enemyPresenceTerritories, directExclusionTerritories, alliedExclusionTerritories, enemyExclusionTerritories, enemySurfaceExclusionTerritories
-														If used with an exclusion, then the number of units of that type must be less than or equal the count.  (Use count="0" if you want no units of that type in the territories) (can not use "each" for count here).
-			
-	-->
-	<!-- German Objectives -->
+    <!-- all Objective Attachments, Conditions, Triggers, Rules, etc, must have a unique name (if you don't use unique names, you may get funny results with your trigger attachments, or even java errors) -->
+    <!-- the following options are allowed for "objectiveAttachmentXXX" (and also for "conditionAttachmentXXX").  all options below have an "AND" relationship with each other.
+            conditions                          values: any objectiveAttachment or conditionAttachment, can be any player's attachment (must have unique names!), tested during attached player's turn
+                                                            can be in a delimited list for an AND relationship (example: value="conditionAttachmentGermans3a:conditionAttachmentGermans3b")
+                                                            any condition which includes other conditions, is considered a meta-condition, and it must come AFTER any conditions that it includes.
+            conditionType                       values: AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the "conditions" option.
+                                                        AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
+                                                        conditionType only affects the conditions listed under the option name="conditions", and does not affect any additional things also present.
+            invert                              values: true or false. default if missing is false. if true, this attachment's condition will be reversed (does not reverse the effect).
+                                                        This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
+            objectiveValue                      values: any integer number of PUs to be given (example: value="4")
+            uses                                values: integer for the maximum number of times it should be awarded. if missing it defaults to infinity. Only applies to objectiveValue, and does NOT determine if the conditions is true or false.
+            turns                               values: which turns this will be checked on (example: value="1:4:6-8:11-+" means turns 1,4,6,7,8,11,and all turns after 11)
+            relationship                        values: a relationship that needs to be present in the game: "player1:player2:relationship" (will set #rounds to -1 by default) OR "player1:player2:relationship:numberOfRoundsThisRelationshipMustExistForMinimum"
+                                                        for example: "Japan:China:War" or "Japan:China:War:-1" or "Japan:China:War:3".  It will accept "anyWar", "anyNeutral" and "anyAllied" as well.
+
+            count                               values: the number required to satisfy a rule. if missing, it defaults to ALL (unless specified). it can also be set to "each", which will act as "1" for the purposes of being a condition, but will multiply the bonus (do not use multiple options if you are using each).
+        the below options use count:
+            destroyedTUV                        values: count=an amount of TUV that the attached player must destroy. value=currentRound/allRounds. This is not counting neutral (null) player, and is based on the cost for the defender to buy the units.
+                                                        Be sure to check this condition only after the player's battle phase is completely over, since the data is only recorded after all battles are done. example: value="currentRound" count="20"
+            atWarPlayers                        values: player names, in a : delimited list (example: value="Germans:Italians:Japanese" count="2" means that you must be at war with 2 of the 3 listed players). if count is zero, then you must be at war with none.
+            techs                               values: any list of technologies, : delimited (if count = zero, then must have exactly zero technologies [if count is missing, defaults to zero])
+            directOwnershipTerritories          values: "original", "enemy", or a : delimited list of territories
+            alliedOwnershipTerritories          values: "original", "enemy", or a : delimited list of territories
+            directExclusionTerritories          values: "original", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
+            alliedExclusionTerritories          values: "original", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
+            enemyExclusionTerritories           values: "original", "map" (map = all territories on map), or a : delimited list of territories
+            enemySurfaceExclusionTerritories    values: "original", "map" (map = all territories on map), or a : delimited list of territories
+            directPresenceTerritories           values: "original", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
+            alliedPresenceTerritories           values: "original", "controlled", "controlledNoWater", "all" (all = original + controlled), "map" (map = all territories on map), or a : delimited list of territories
+            enemyPresenceTerritories            values: "original", "map" (map = all territories on map), or a : delimited list of territories
+            unitPresence                        values: "ANY" or the exact name or names of the units, and the number of that unit.  (example: value="infantry" count="2", or: value="ANY" count="3", or: value="infantry:artillery:armour" count="3")
+                                                        unitPresence can be put in multiple times. Its purpose is to specify the units for presence and excluded territories. If missing, then presence needs only 1 of any unit, and excluded needs to be completely devoid of units
+                                                        For an "AND" relationship between the required units, put them in separately. For an "OR" relationship, put them in on one line with a colon separating them.
+                                                        It can be used in conjunction with directPresenceTerritories, alliedPresenceTerritories, enemyPresenceTerritories, directExclusionTerritories, alliedExclusionTerritories, enemyExclusionTerritories, enemySurfaceExclusionTerritories
+                                                        If used with an exclusion, then the number of units of that type must be less than or equal the count.  (Use count="0" if you want no units of that type in the territories) (can not use "each" for count here).
+
+    -->
+    <!-- German Objectives -->
                 <attachment name="objectiveAttachmentGermans1_EasternEurope" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="alliedOwnershipTerritories" value="East Balkans:Eastern Europe:Ukraine S.S.R.:Belorussia:West Russia:Norway:Karelia S.S.R.:Archangel:Caucus" count="7"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="alliedOwnershipTerritories" value="East Balkans:Eastern Europe:Ukraine S.S.R.:Belorussia:West Russia:Norway:Karelia S.S.R.:Archangel:Caucus" count="7"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentGermans2_BalticSea" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="enemySurfaceExclusionTerritories" value="5 Sea Zone:6 Sea Zone:7 Sea Zone" count="3"/>
-					<option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="enemySurfaceExclusionTerritories" value="5 Sea Zone:6 Sea Zone:7 Sea Zone" count="3"/>
+                    <option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
                 </attachment>
 
-	<!-- Russian Objectives -->
+    <!-- Russian Objectives -->
                 <attachment name="objectiveAttachmentRussians1_EasternEurope" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="directOwnershipTerritories" value="Norway:Eastern Europe:East Balkans:Ukraine S.S.R.:Belorussia" count="3"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="directOwnershipTerritories" value="Norway:Eastern Europe:East Balkans:Ukraine S.S.R.:Belorussia" count="3"/>
                 </attachment>
-				
+
                 <attachment name="objectiveAttachmentRussians2_LendLease" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="alliedOwnershipTerritories" value="Archangel" count="1"/>
-                	<option name="alliedExclusionTerritories" value="controlledNoWater"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="alliedOwnershipTerritories" value="Archangel" count="1"/>
+                    <option name="alliedExclusionTerritories" value="controlledNoWater"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentRussians3_HardAdvance" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="2"/>
-                	<option name="directOwnershipTerritories" value="Norway:East Balkans" count="1"/>
-					<option name="uses" value="1"/>
-					<option name="atWarPlayers" value="Germans:Italians:Japanese" count="2"/>
+                    <option name="objectiveValue" value="2"/>
+                    <option name="directOwnershipTerritories" value="Norway:East Balkans" count="1"/>
+                    <option name="uses" value="1"/>
+                    <option name="atWarPlayers" value="Germans:Italians:Japanese" count="2"/>
                 </attachment>
 
-	<!-- Japanese Objectives -->
+    <!-- Japanese Objectives -->
                 <attachment name="objectiveAttachmentJapanese1_ControlOfAsia" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="alliedOwnershipTerritories" value="India:French Indochina:Kwangtung:Manchuria:China:Central China:Sinkiang" count="7"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="alliedOwnershipTerritories" value="India:French Indochina:Kwangtung:Manchuria:China:Central China:Sinkiang" count="7"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentJapanese2_ControlOfPacific" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="alliedOwnershipTerritories" value="Alaska:East Indies:Borneo:Philipine Islands:New Guinea:Solomon Islands:Caroline Islands:Australia:New Zealand:Okinawa:Wake Island:Hawaiian Islands:Midway" count="10"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="alliedOwnershipTerritories" value="Alaska:East Indies:Borneo:Philipine Islands:New Guinea:Solomon Islands:Caroline Islands:Australia:New Zealand:Okinawa:Wake Island:Hawaiian Islands:Midway" count="10"/>
                 </attachment>
 
-	<!-- British Objectives -->
+    <!-- British Objectives -->
                 <attachment name="objectiveAttachmentBritish1_PacificCounterAttack" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="directOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Okinawa" count="1"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="directOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Okinawa" count="1"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentBritish2_Africa" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="alliedOwnershipTerritories" value="Gibraltar:Algeria:Libya:Anglo Egypt:Trans-Jordan:Persia:French West Africa:French Equatorial Africa:Italian East Africa:Belgian Congo:Kenya" count="9"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="alliedOwnershipTerritories" value="Gibraltar:Algeria:Libya:Anglo Egypt:Trans-Jordan:Persia:French West Africa:French Equatorial Africa:Italian East Africa:Belgian Congo:Kenya" count="9"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentBritish3_SeatOfEmpire" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="alliedOwnershipTerritories" value="Union of South Africa:India:Australia" count="3"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="alliedOwnershipTerritories" value="Union of South Africa:India:Australia" count="3"/>
                 </attachment>
 
-	<!-- Italian Objectives -->
+    <!-- Italian Objectives -->
                 <attachment name="objectiveAttachmentItalians1_TheMed" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="alliedOwnershipTerritories" value="Western Europe:Sardinia:Sicily:West Balkans:Greece:Algeria:Libya:Anglo Egypt:Trans-Jordan:Italian East Africa:Gibraltar" count="8"/>
-                	<option name="enemySurfaceExclusionTerritories" value="13 Sea Zone:14 Sea Zone:15 Sea Zone:15B Sea Zone" count="4"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="alliedOwnershipTerritories" value="Western Europe:Sardinia:Sicily:West Balkans:Greece:Algeria:Libya:Anglo Egypt:Trans-Jordan:Italian East Africa:Gibraltar" count="8"/>
+                    <option name="enemySurfaceExclusionTerritories" value="13 Sea Zone:14 Sea Zone:15 Sea Zone:15B Sea Zone" count="4"/>
                 </attachment>
 
-	<!-- American Objectives -->
+    <!-- American Objectives -->
                 <attachment name="objectiveAttachmentAmericans2_TheAtlantic" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="alliedOwnershipTerritories" value="Western Europe:Sardinia:Sicily:Italy:Greece:West Balkans:Algeria:Libya" count="3"/>
-                	<option name="enemySurfaceExclusionTerritories" value="1 Sea Zone:2 Sea Zone:7 Sea Zone:8 Sea Zone:9 Sea Zone:10 Sea Zone:11 Sea Zone:12 Sea Zone:13 Sea Zone:14 Sea Zone" count="10"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="alliedOwnershipTerritories" value="Western Europe:Sardinia:Sicily:Italy:Greece:West Balkans:Algeria:Libya" count="3"/>
+                    <option name="enemySurfaceExclusionTerritories" value="1 Sea Zone:2 Sea Zone:7 Sea Zone:8 Sea Zone:9 Sea Zone:10 Sea Zone:11 Sea Zone:12 Sea Zone:13 Sea Zone:14 Sea Zone" count="10"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentAmericans3_ThePacific" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="alliedOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Australia:New Zealand:Okinawa:Wake Island:Philipine Islands:Alaska:Hawaiian Islands:Midway" count="6"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="alliedOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Australia:New Zealand:Okinawa:Wake Island:Philipine Islands:Alaska:Hawaiian Islands:Midway" count="6"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentAmericans1_WarPhase1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="2"/>
-                	<option name="rounds" value="2-3"/>
+                    <option name="objectiveValue" value="2"/>
+                    <option name="rounds" value="2-3"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentAmericans1_WarPhase2" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="rounds" value="4-5"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="rounds" value="4-5"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentAmericans1_WarPhase3" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="6"/>
-                	<option name="rounds" value="6-7"/>
+                    <option name="objectiveValue" value="6"/>
+                    <option name="rounds" value="6-7"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentAmericans1_WarPhase4" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="8"/>
-                	<option name="rounds" value="8-9"/>
+                    <option name="objectiveValue" value="8"/>
+                    <option name="rounds" value="8-9"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentAmericans1_WarPhase5" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="10"/>
-                	<option name="rounds" value="10-+"/>
+                    <option name="objectiveValue" value="10"/>
+                    <option name="rounds" value="10-+"/>
                 </attachment>
 
                 <!--<attachment name="objectiveAttachmentAmericans8" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="12"/>
-                	<option name="rounds" value="12-13"/>
+                    <option name="objectiveValue" value="12"/>
+                    <option name="rounds" value="12-13"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentAmericans9" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="14"/>
-                	<option name="rounds" value="14-15"/>
+                    <option name="objectiveValue" value="14"/>
+                    <option name="rounds" value="14-15"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentAmericans10" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="16"/>
-                	<option name="rounds" value="16-17"/>
+                    <option name="objectiveValue" value="16"/>
+                    <option name="rounds" value="16-17"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentAmericans11" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="18"/>
-                	<option name="rounds" value="18-19"/>
+                    <option name="objectiveValue" value="18"/>
+                    <option name="rounds" value="18-19"/>
                 </attachment>
 
                 <attachment name="objectiveAttachmentAmericans12" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="20"/>
-                	<option name="rounds" value="20-+"/>
+                    <option name="objectiveValue" value="20"/>
+                    <option name="rounds" value="20-+"/>
                 </attachment>-->
 
-	<!-- Chinese Objectives -->
+    <!-- Chinese Objectives -->
                 <attachment name="objectiveAttachmentChinese2_BurmaRoad" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="4"/>
-                	<option name="alliedOwnershipTerritories" value="Sinkiang:Central China:India" count="3"/>
+                    <option name="objectiveValue" value="4"/>
+                    <option name="alliedOwnershipTerritories" value="Sinkiang:Central China:India" count="3"/>
                 </attachment>
-				
+
 <!-- Conditions -->
-	<!-- Conditions follow the same rules as national objectives. both conditions and objectives must be BEFORE any triggers in the XML -->
-	<!-- Victory Conditions -->
+    <!-- Conditions follow the same rules as national objectives. both conditions and objectives must be BEFORE any triggers in the XML -->
+    <!-- Victory Conditions -->
                 <attachment name="conditionAttachmentAxisVictory1" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="United Kingdom:Russia:Germany:Japan" count="4"/>
+                    <option name="alliedOwnershipTerritories" value="United Kingdom:Russia:Germany:Japan" count="4"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentAlliesVictory1" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="Germany:Japan:United Kingdom:Eastern United States" count="4"/>
+                    <option name="alliedOwnershipTerritories" value="Germany:Japan:United Kingdom:Eastern United States" count="4"/>
                 </attachment>
-	
-	
-	<!-- Germans Conditions -->
+
+
+    <!-- Germans Conditions -->
                 <attachment name="conditionAttachmentGermans1" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="4:5"/>
-                	<option name="enemySurfaceExclusionTerritories" value="5 Sea Zone:6 Sea Zone:7 Sea Zone" count="3"/>
+                    <option name="rounds" value="4:5"/>
+                    <option name="enemySurfaceExclusionTerritories" value="5 Sea Zone:6 Sea Zone:7 Sea Zone" count="3"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermans2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="3:4"/>
-                	<option name="alliedOwnershipTerritories" value="East Balkans:Eastern Europe:Ukraine S.S.R.:Belorussia:Karelia S.S.R.:Archangel:Caucus" count="6"/>
+                    <option name="rounds" value="3:4"/>
+                    <option name="alliedOwnershipTerritories" value="East Balkans:Eastern Europe:Ukraine S.S.R.:Belorussia:Karelia S.S.R.:Archangel:Caucus" count="6"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermans3a" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="3:4"/>
-                	<option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
-                	<option name="invert" value="true"/>
+                    <option name="rounds" value="3:4"/>
+                    <option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermans3b" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="3:4"/>
-                	<option name="alliedOwnershipTerritories" value="Norway" count="1"/>
+                    <option name="rounds" value="3:4"/>
+                    <option name="alliedOwnershipTerritories" value="Norway" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermansParatroopers" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="paratroopers" count="1"/>
+                    <option name="techs" value="paratroopers" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermansSuperSubs" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="superSub" count="1"/>
+                    <option name="techs" value="superSub" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermansReinforcedHulls" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="reinforcedHulls" count="1"/>
+                    <option name="techs" value="reinforcedHulls" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermansWolfPackTactics" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="wolfPackTactics" count="1"/>
+                    <option name="techs" value="wolfPackTactics" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermansShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="shipyards" count="1"/>
+                    <option name="techs" value="shipyards" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermansShipyardsInvert" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="shipyards" count="1"/>
-					<option name="invert" value="true"/>
+                    <option name="techs" value="shipyards" count="1"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermansSubmarineTech2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansReinforcedHulls:conditionAttachmentGermansWolfPackTactics"/>
-                	<option name="conditionType" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermansReinforcedHulls:conditionAttachmentGermansWolfPackTactics"/>
+                    <option name="conditionType" value="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentGermansSubmarineTech3" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansReinforcedHulls:conditionAttachmentGermansWolfPackTactics"/>
-                	<option name="conditionType" value="2-3"/>
+                    <option name="conditions" value="conditionAttachmentGermansReinforcedHulls:conditionAttachmentGermansWolfPackTactics"/>
+                    <option name="conditionType" value="2-3"/>
                 </attachment>
-				
-	<!-- Japanese Conditions -->
+
+    <!-- Japanese Conditions -->
                 <attachment name="conditionAttachmentJapanese1a" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="Sinkiang:India:Burytia S.S.R." count="1"/>
-                	<option name="invert" value="true"/>
+                    <option name="alliedOwnershipTerritories" value="Sinkiang:India:Burytia S.S.R." count="1"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapanese1b" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="3:4"/>
+                    <option name="rounds" value="3:4"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapanese2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="3:4:5"/>
-                	<option name="alliedOwnershipTerritories" value="Australia:India:Sinkiang" count="3"/>
+                    <option name="rounds" value="3:4:5"/>
+                    <option name="alliedOwnershipTerritories" value="Australia:India:Sinkiang" count="3"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapanese3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="1-2:3:4-+"/>
-                	<option name="directOwnershipTerritories" value="original"/>
-                	<option name="invert" value="true"/>
+                    <option name="rounds" value="1-2:3:4-+"/>
+                    <option name="directOwnershipTerritories" value="original"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapanese4" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="directOwnershipTerritories" value="Burytia S.S.R.:Soviet Far East:Yakut S.S.R.:Evanki National Okrug:Novisibirsk:Kazakh S.S.R.:Caucus:Russia:Archangel:Karelia S.S.R." count="1"/>
+                    <option name="directOwnershipTerritories" value="Burytia S.S.R.:Soviet Far East:Yakut S.S.R.:Evanki National Okrug:Novisibirsk:Kazakh S.S.R.:Caucus:Russia:Archangel:Karelia S.S.R." count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapaneseParatroopers" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="paratroopers" count="1"/>
+                    <option name="techs" value="paratroopers" count="1"/>
                 </attachment>
-				
+
                 <!--<attachment name="conditionAttachmentJapaneseMidget1" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="Okinawa:Philipine Islands" count="2"/>
-                	<option name="invert" value="true"/>
+                    <option name="alliedOwnershipTerritories" value="Okinawa:Philipine Islands" count="2"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapaneseMidget2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="6"/>
-                	<option name="invert" value="true"/>
+                    <option name="alliedOwnershipTerritories" value="East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="6"/>
+                    <option name="invert" value="true"/>
                 </attachment>-->
-				
+
                 <attachment name="conditionAttachmentJapaneseMidget" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="Okinawa:Philipine Islands:East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="7"/>
-                	<option name="invert" value="true"/>
+                    <option name="alliedOwnershipTerritories" value="Okinawa:Philipine Islands:East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="7"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapaneseKamikaze1" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="Philipine Islands" count="1"/>
-                	<option name="invert" value="true"/>
+                    <option name="alliedOwnershipTerritories" value="Philipine Islands" count="1"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapaneseKamikaze2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="Okinawa:East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="7"/>
-                	<option name="invert" value="true"/>
+                    <option name="alliedOwnershipTerritories" value="Okinawa:East Indies:Borneo:New Guinea:Solomon Islands:Caroline Islands:Wake Island" count="7"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapaneseBattleships" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="directPresenceTerritories" value="map" count="1"/>
-					<option name="unitPresence" value="battleship" count="1"/>
+                        <option name="directPresenceTerritories" value="map" count="1"/>
+                    <option name="unitPresence" value="battleship" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapaneseCarriers" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="directPresenceTerritories" value="map" count="1"/>
-					<option name="unitPresence" value="carrier" count="1"/>
+                    <option name="directPresenceTerritories" value="map" count="1"/>
+                    <option name="unitPresence" value="carrier" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentJapaneseShipyards" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="shipyards" count="1"/>
+                    <option name="techs" value="shipyards" count="1"/>
                 </attachment>
-				
-	<!-- Italians Conditions -->
+
+    <!-- Italians Conditions -->
                 <attachment name="conditionAttachmentItalians1" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="3:4"/>
-                	<option name="alliedOwnershipTerritories" value="Algeria:Libya:Anglo Egypt:Trans-Jordan" count="4"/>
+                    <option name="rounds" value="3:4"/>
+                    <option name="alliedOwnershipTerritories" value="Algeria:Libya:Anglo Egypt:Trans-Jordan" count="4"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentItaliansParatroopers" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="paratroopers" count="1"/>
+                    <option name="techs" value="paratroopers" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentItaliansShipyards" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="shipyards" count="1"/>
+                    <option name="techs" value="shipyards" count="1"/>
                 </attachment>
-                
+
                 <attachment name="conditionAttachmentItalianTurn2" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="2"/>
+                    <option name="rounds" value="2"/>
                 </attachment>
                  <attachment name="conditionAttachmentItalianTurn1" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="1"/>
+                    <option name="rounds" value="1"/>
                 </attachment>
-                
-				
-	<!-- Americans Conditions -->
+
+
+    <!-- Americans Conditions -->
                 <attachment name="conditionAttachmentAmericans1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="3-5"/>
-                	<option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
+                    <option name="rounds" value="3-5"/>
+                    <option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentAmericans2" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="3-5"/>
-                	<option name="alliedOwnershipTerritories" value="Alaska:Wake Island:Hawaiian Islands:Midway" count="4"/>
+                    <option name="rounds" value="3-5"/>
+                    <option name="alliedOwnershipTerritories" value="Alaska:Wake Island:Hawaiian Islands:Midway" count="4"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentAmericans3a" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="1-8"/>
-                	<option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
+                    <option name="rounds" value="1-8"/>
+                    <option name="alliedOwnershipTerritories" value="Western Europe" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentAmericans3b" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="1:2:3-7:8"/>
-                	<option name="alliedOwnershipTerritories" value="Alaska:Wake Island:Hawaiian Islands:Midway" count="4"/>
+                    <option name="rounds" value="1:2:3-7:8"/>
+                    <option name="alliedOwnershipTerritories" value="Alaska:Wake Island:Hawaiian Islands:Midway" count="4"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentAmericans4" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="jetPower:warBonds" count="2"/>
+                    <option name="techs" value="jetPower:warBonds" count="2"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentAmericansParatroopers" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="paratroopers" count="1"/>
+                    <option name="techs" value="paratroopers" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentAmericansShipyards" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="shipyards" count="1"/>
+                    <option name="techs" value="shipyards" count="1"/>
                 </attachment>
-				
-	<!-- British Conditions -->
+
+    <!-- British Conditions -->
                 <attachment name="conditionAttachmentBritish2" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="3:4"/>
-                	<option name="alliedOwnershipTerritories" value="Union of South Africa:Gibraltar:Anglo Egypt:India:Australia" count="4"/>
+                    <option name="rounds" value="3:4"/>
+                    <option name="alliedOwnershipTerritories" value="Union of South Africa:Gibraltar:Anglo Egypt:India:Australia" count="4"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentBritishParatroopers" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="paratroopers" count="1"/>
+                    <option name="techs" value="paratroopers" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentBritishShipyards" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="shipyards" count="1"/>
+                    <option name="techs" value="shipyards" count="1"/>
                 </attachment>
-				
-	<!-- Russians Conditions -->
+
+    <!-- Russians Conditions -->
                 <attachment name="conditionAttachmentRussians2" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="rounds" value="3:4"/>
-                	<option name="alliedOwnershipTerritories" value="Karelia S.S.R.:Caucus" count="2"/>
+                    <option name="rounds" value="3:4"/>
+                    <option name="alliedOwnershipTerritories" value="Karelia S.S.R.:Caucus" count="2"/>
                 </attachment>
-                
-				<attachment name="conditionAttachmentRussiansNeutralAmericans" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-					<option name="relationship" value="Russians:Americans:anyNeutral"/>
+
+                <attachment name="conditionAttachmentRussiansNeutralAmericans" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                    <option name="relationship" value="Russians:Americans:anyNeutral"/>
                 </attachment>
-                
-				<attachment name="conditionAttachmentRussiansNeutralJapan" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-					<option name="relationship" value="Japanese:Russians:anyNeutral"/>
+
+                <attachment name="conditionAttachmentRussiansNeutralJapan" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                    <option name="relationship" value="Japanese:Russians:anyNeutral"/>
                 </attachment>
-                
-				<attachment name="conditionAttachmentRussiansNeutralJapanTurn5plus" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-					<option name="rounds" value="5-+"/>
-                	<option name="relationship" value="Japanese:Russians:anyNeutral"/>
+
+                <attachment name="conditionAttachmentRussiansNeutralJapanTurn5plus" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                    <option name="rounds" value="5-+"/>
+                    <option name="relationship" value="Japanese:Russians:anyNeutral"/>
                 </attachment>
-                
-				<attachment name="conditionAttachmentRussiansNeutralItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="relationship" value="Italians:Russians:anyNeutral:1"/>
+
+                <attachment name="conditionAttachmentRussiansNeutralItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                    <option name="relationship" value="Italians:Russians:anyNeutral:1"/>
                 </attachment>
-                
-				<attachment name="conditionAttachmentRussiansWarItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="relationship" value="Italians:Russians:anyWar:1"/>
+
+                <attachment name="conditionAttachmentRussiansWarItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                    <option name="relationship" value="Italians:Russians:anyWar:1"/>
                 </attachment>
-                
+
                 <attachment name="conditionAttachmentRussiansNeutralItaliansFor2Turns" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="relationship" value="Italians:Russians:anyNeutral:2"/>
+                    <option name="relationship" value="Italians:Russians:anyNeutral:2"/>
                 </attachment>
-                
+
                 <attachment name="conditionAttachmentChineseNeutralItalians" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="relationship" value="Italians:Chinese:anyNeutral"/>
+                    <option name="relationship" value="Italians:Chinese:anyNeutral"/>
                 </attachment>
-                
+
                 <attachment name="conditionAttachmentRussians3" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="Burytia S.S.R." count="1"/>
-                	<option name="invert" value="true"/>
+                    <option name="alliedOwnershipTerritories" value="Burytia S.S.R." count="1"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentRussiansParatroopers" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="paratroopers" count="1"/>
+                    <option name="techs" value="paratroopers" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentRussiansShipyards" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="shipyards" count="1"/>
+                    <option name="techs" value="shipyards" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentRussianCapitalLost" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="Russia" count="1"/>
-                	<option name="invert" value="true"/>
+                    <option name="alliedOwnershipTerritories" value="Russia" count="1"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
-	<!-- Chinese Conditions -->
+
+    <!-- Chinese Conditions -->
                 <attachment name="conditionAttachmentChinese3" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="enemyExclusionTerritories" value="Sinkiang:Central China:China:Manchuria:Kwangtung:French Indochina" count="3"/>
+                    <option name="enemyExclusionTerritories" value="Sinkiang:Central China:China:Manchuria:Kwangtung:French Indochina" count="3"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentChinese4" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="alliedOwnershipTerritories" value="Japan" count="1"/>
+                    <option name="alliedOwnershipTerritories" value="Japan" count="1"/>
                 </attachment>
-				
+
                 <!--<attachment name="conditionAttachmentChineseParatroopers" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="paratroopers" count="1"/>
+                    <option name="techs" value="paratroopers" count="1"/>
                 </attachment>
-				
+
                 <attachment name="conditionAttachmentChineseShipyards" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="techs" value="shipyards" count="1"/>
+                    <option name="techs" value="shipyards" count="1"/>
                 </attachment>-->
-				
-				
+
+
 <!-- Triggers -->
-	<!-- Triggers with "uses" will use up a single 'use' every round that they are used.  So a trigger that gives a player a tech, adds units to a territory, changes a relationship, and sends a notification to a player,
-				will use up a Single (1) use, assuming those four actions were done in a single round (as determined by the endRound phase [EndRoundDelegate])-->
-	<!-- the following options are allowed for "triggerAttachmentXXX"
-			conditions							values: any objectiveAttachment or conditionAttachment, can be any player's attachment (must have unique names!), tested during attached player's turn
-															can be in a delimited list for an AND relationship (example: value="conditionAttachmentGermans3a:conditionAttachmentGermans3b")
-			conditionType 						values: AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the trigger. 
-														AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
-			invert 								values: true or false. default if missing is false. if true, the condition will be reversed (does not reverse the effect)
-														This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
-			uses 								values: integer for the maximum number of times it should be awarded. if missing it defaults to infinity
-			when								values: this is a value of when the trigger should fire. it is optional, and if left out the trigger will fire at its default time. "before/after:name-of-step" (example: value="after:chineseEndTurn")
-			chance								values: "x:y", where x = to hit, and y = dice sides.  So "1:6" = 16.7% chance, while "3:10" = 30% chance
-			victory								values: the string message from notifications.properties to be displayed if the condition is true.
-			notification						values: this is a popup window containing a message that will be given to the current player. "name-of-entry-in-notifications.properties" or "message"
-															both "victory" and "notification" will look in the "notifications.properties" in your maps root folder for a string with the value's name, and then it will use whatever is to the right of the = sign.
-			resource							values: "PUs" or "techTokens", given at end of turn phase.  "resource" will be affected by "each" in a condition statement.
-			resourceCount						values: the number of specified resource to be given
-			placement							values: places units at beginning of combat movement phase. first in list is territory to be placed it, then list of units, then count.  "placement" will be affected by "each" in a condition statement.
-														(example: value="Moscow:artillery:infantry" count="2" [if count is missing, defaults to 1])
-			removeUnits							values: removes up to that number of the desired unit, at the beginning of the combat move phase. list is done the same way as placement.
-			purchase							values: adds listed units to user's purchase at beginning of purchase phase (example: value="infantry:destroyer" count="3").  "purchase" will be affected by "each" in a condition statement.
-			tech		 						values: the names of any technology to be given to the active or specified player. given at end of tech activation phase. (example: value="rocket:longRangeAir")
-			availableTech						values: the name of the category to be added to, followed by the names of the technologies to add to it. (example: value="airCategory:longRangeAir:jetPower:superHeavyBomber")
-														If prefixed with "-" then it will remove the tech from that category (if the player already has the tech, it will do nothing).
-			frontier							values: name of a production frontier, changes the player's production frontier to BE the one listed, at beginning of the purchase phase. (does not add the production to the current list, is a new list completely)
-			productionRule						values: the name of the frontier, and then the name of the production rule you want to add or remove from a frontier, at beginning of the purchase phase.
-														If prefixed with "-" then it will remove the production rule instead of adding it. (example: value="Germans_production:buySuper_Carrier" or value="Germans_production:-buyEarly_Fighter")
-			support								values: name of support attachment, adds specified player to the list of players a supportAttachment supports. Can be a list. (example: value="supportAttachmentGermans1AwesomeArtillery")
-														If prefixed with "-" then it will remove that player from the support attachment (example: value="-supportAttachmentArtyOldartillery")
-			relationshipChange					values: the change in relationship for these players, format: "player1:player2:oldRelation:newRelation" example: "Russians:Americans:coldWar:allOutWar"
-														oldRelation may be "any", "anyWar", "anyNeutral", "anyAllied", or an actual relationshipType used in this xml
-														You can enter multiple relationshipChanges in the trigger and it will perform every change in the trigger which is valid.
-			
-		For the following, you are actually changing raw data in the engine by calling the setters in the same way the engine does when it parses the xml.  The following are not validated at all, so if you don't use them correctly you will probably cause the engine to crash mid-game.
-		You may prefix the property count portion with "-clear-" if you wish to clear out the data in an array first (example: <option name="unitProperty" value="requiresUnits" count="-clear-factory:hangar"/> )
-			players								values: the names of the players to give these things to. if missing, defaults to attached player. (example: value="Germans:Italians"). Also used as list of players affected by a playerProperty change.
-			playerAttachmentName				values: the type of attachment (PlayerAttachment, TriggerAttachment, RulesAttachment, TechAttachment, PoliticalActionAttachment) and the exact full name of the attachment to be changed. 
-															(example: value="RulesAttachment" count="rulesAttachment"). Defaults to PlayerAttachment if missing.
-			playerProperty						values: the name of any actual attachment property, with a count equal to the property's values (examples: value="destroysPUs" count="true"). (requires players to be set, otherwise it uses the attached player)
-			unitType							values: the exact names of the unit to be affected by a unitProperty change (example: value="cruiser:super_cruiser")
-			unitAttachmentName					values: the type of attachment (UnitAttachment, UnitSupportAttachment) and the exact full name of the attachment to be changed. Defaults to UnitAttachment if missing.
-			unitProperty						values: the name of any actual attachment property, with a count equal to the property's values (examples: value="attack" count="4", or value="isAir" count="true"), requires unitType declared
-														Something to note is that <option name="artillery" value="true"/> AND <option name="artillerySupportable" value="true"/> AND <option name="unitSupportCount" value="1"/> are all converted into a support attachment when the game starts, 
-															so adding or removing them as unit properties will do nothing (the bonusType for them is "ArtyOld", and the supportAttachment name is "supportAttachmentArtyOld<nameofUnit>") unitProperty changes are done for ALL players who use that unitType, 
-															regardless of the player specified in the trigger. In order to have a unitType+unitProperty change only affect certain players and not others, you need to make a new unit type for those players (ie: rename the unit for those players only)
-			territories							values: the exact names of the territories to be affected by a territoryProperty change (example: value="Germany:Italy")
-			territoryAttachmentName				values: the type of attachment (TerritoryAttachment, CanalAttachment) and the exact full name of the attachment to be changed. Defaults to TerritoryAttachment if missing.
-			territoryProperty					values: the name of any actual attachment property, with a count equal to the property's values (examples: value="production" count="4", or value="victoryCity" count="true"), requires territories declared
-			relationshipTypes					values: the exact names of the relationshipType to be affected by a relationshipTypeProperty change
-			relationshipTypeAttachmentName		values: the type of attachment (RelationshipTypeAttachment) and the exact full name of the attachment to be changed. Defaults to RelationshipTypeAttachment if missing.
-			relationshipTypeProperty			values: the name of any actual attachment property, with a count equal to the property's values, requires relationshipTypes declared
-			territoryEffects					values: the exact names of the territoryEffects to be affected by a territoryEffectProperty change
-			territoryEffectAttachmentName		values: the type of attachment (TerritoryEffectAttachment) and the exact full name of the attachment to be changed. Defaults to TerritoryEffectAttachment if missing.
-			territoryEffectProperty				values: the name of any actual attachment property, with a count equal to the property's values, requires territoryEffects declared
-			
-	-->
-		<!-- Clarification on how "each" works.  (Each is just a way to simplify writing national objectives, conditions, and triggers. It does not do anything extra that you could not do before)
-				Lets say you have this objective:
-					<attachment name="objectiveAttachmentRussians1_EasternEuropeMegaIncome" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="4"/>
-						<option name="directOwnershipTerritories" value="Norway:Eastern Europe:East Balkans:Ukraine S.S.R.:Belorussia" count="each"/>
-					</attachment>
-				What would happen is that "Russians" would get 4 PUs for EACH territory in that list that satisfied directOwnershipTerritories.
-				If you used it as a condition statement, then it would act as 1 for the purposes of returning true/false (in other words, own at least 1 territory and the condition would be true).
-				Now lets say you have this trigger:
-					<attachment name="triggerAttachmentRussians5_FarEastReserves" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="objectiveAttachmentRussians1_EasternEuropeMegaIncome"/>
-						<option name="placement" value="Russia:infantry" count="2"/>
-					</attachment>
-				This trigger would add 2 infantry to russia for each territory inside the condition objectiveAttachmentRussians1_EasternEuropeMegaIncome that is true.
-				IF you have more than 1 condition with Each, then the trigger will use the largest Each.  If you have a meta-condition (a condition that contains other conditions), the trigger will NOT look inside the conditions inside the meta-condition.
-				Since it would be meaningless to, for example, change a relation to the same thing 10 times in a row, Each only works with the following kinds of triggers:
-				resource, placement, purchase
-		-->
-		<!-- Clarification on changing properties and clearing of properties. (Any property not in this list overwrites itself if you set it multiple times)
-				The following attachments may have MULTIPLE instances, meaning that they are adding to some variable, meaning that they may be cleared by triggers if you want to (by prefixing with "-clear-"):
-				Unit Attachments:
-					canBeGivenByTerritoryTo
-					canBeCapturedOnEnteringBy
-					destroyedWhenCapturedBy
-					requiresUnits
-					givesMovement
-					consumesUnits
-					createsUnitsList
-					createsResourcesList
-					receivesAbilityWhenWith
-					whenCapturedChangesInto
-					special
-					fuelCost
-					
-				Unit Support Attachments:
-					players
-					
-				Territory Attachments:
-					changeUnitOwners
-					captureUnitOnEnteringBy
-					territoryEffect
-					whenCapturedByGoesTo
-					convoyAttached
-					
-				Territory Effect Attachments:
-					combatDefenseEffect
-					combatOffenseEffect
-					
-				Player Attachments:
-					giveUnitControl
-					captureUnitOnEnteringBy
-					suicideAttackResources
-					
-				Objectives & Condition Attachments:
-					conditions
-					unitPresence
-					relationship
-				
-				Rules Attachments:
-					productionPerXTerritories
-					
-				Trigger Attachments:
-					conditions
-					productionRule
-					tech
-					availableTech
-					placement
-					purchase
-					support
-					relationshipChange
-					
-					players
-					playerProperty
-					unitType
-					unitProperty
-					territories
-					territoryProperty
-					relationshipTypes
-					relationshipTypeProperty
-					territoryEffects
-					territoryEffectProperty
-					
-				Political Action Attachments:
-					conditions
-					relationshipChange
-					actionAccept
-					
-		-->
-	<!-- Victory Triggers -->
-						<!-- Victory Triggers can be attached to anyone. Only 1 is needed per victory condition -->
+    <!-- Triggers with "uses" will use up a single 'use' every round that they are used.  So a trigger that gives a player a tech, adds units to a territory, changes a relationship, and sends a notification to a player,
+                will use up a Single (1) use, assuming those four actions were done in a single round (as determined by the endRound phase [EndRoundDelegate])-->
+    <!-- the following options are allowed for "triggerAttachmentXXX"
+            conditions                          values: any objectiveAttachment or conditionAttachment, can be any player's attachment (must have unique names!), tested during attached player's turn
+                                                            can be in a delimited list for an AND relationship (example: value="conditionAttachmentGermans3a:conditionAttachmentGermans3b")
+            conditionType                       values: AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the trigger.
+                                                        AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
+            invert                              values: true or false. default if missing is false. if true, the condition will be reversed (does not reverse the effect)
+                                                        This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
+            uses                                values: integer for the maximum number of times it should be awarded. if missing it defaults to infinity
+            when                                values: this is a value of when the trigger should fire. it is optional, and if left out the trigger will fire at its default time. "before/after:name-of-step" (example: value="after:chineseEndTurn")
+            chance                              values: "x:y", where x = to hit, and y = dice sides.  So "1:6" = 16.7% chance, while "3:10" = 30% chance
+            victory                             values: the string message from notifications.properties to be displayed if the condition is true.
+            notification                        values: this is a popup window containing a message that will be given to the current player. "name-of-entry-in-notifications.properties" or "message"
+                                                            both "victory" and "notification" will look in the "notifications.properties" in your maps root folder for a string with the value's name, and then it will use whatever is to the right of the = sign.
+            resource                            values: "PUs" or "techTokens", given at end of turn phase.  "resource" will be affected by "each" in a condition statement.
+            resourceCount                       values: the number of specified resource to be given
+            placement                           values: places units at beginning of combat movement phase. first in list is territory to be placed it, then list of units, then count.  "placement" will be affected by "each" in a condition statement.
+                                                        (example: value="Moscow:artillery:infantry" count="2" [if count is missing, defaults to 1])
+            removeUnits                         values: removes up to that number of the desired unit, at the beginning of the combat move phase. list is done the same way as placement.
+            purchase                            values: adds listed units to user's purchase at beginning of purchase phase (example: value="infantry:destroyer" count="3").  "purchase" will be affected by "each" in a condition statement.
+            tech                                values: the names of any technology to be given to the active or specified player. given at end of tech activation phase. (example: value="rocket:longRangeAir")
+            availableTech                       values: the name of the category to be added to, followed by the names of the technologies to add to it. (example: value="airCategory:longRangeAir:jetPower:superHeavyBomber")
+                                                        If prefixed with "-" then it will remove the tech from that category (if the player already has the tech, it will do nothing).
+            frontier                            values: name of a production frontier, changes the player's production frontier to BE the one listed, at beginning of the purchase phase. (does not add the production to the current list, is a new list completely)
+            productionRule                      values: the name of the frontier, and then the name of the production rule you want to add or remove from a frontier, at beginning of the purchase phase.
+                                                        If prefixed with "-" then it will remove the production rule instead of adding it. (example: value="Germans_production:buySuper_Carrier" or value="Germans_production:-buyEarly_Fighter")
+            support                             values: name of support attachment, adds specified player to the list of players a supportAttachment supports. Can be a list. (example: value="supportAttachmentGermans1AwesomeArtillery")
+                                                        If prefixed with "-" then it will remove that player from the support attachment (example: value="-supportAttachmentArtyOldartillery")
+            relationshipChange                  values: the change in relationship for these players, format: "player1:player2:oldRelation:newRelation" example: "Russians:Americans:coldWar:allOutWar"
+                                                        oldRelation may be "any", "anyWar", "anyNeutral", "anyAllied", or an actual relationshipType used in this xml
+                                                        You can enter multiple relationshipChanges in the trigger and it will perform every change in the trigger which is valid.
+
+        For the following, you are actually changing raw data in the engine by calling the setters in the same way the engine does when it parses the xml.  The following are not validated at all, so if you don't use them correctly you will probably cause the engine to crash mid-game.
+        You may prefix the property count portion with "-clear-" if you wish to clear out the data in an array first (example: <option name="unitProperty" value="requiresUnits" count="-clear-factory:hangar"/> )
+            players                             values: the names of the players to give these things to. if missing, defaults to attached player. (example: value="Germans:Italians"). Also used as list of players affected by a playerProperty change.
+            playerAttachmentName                values: the type of attachment (PlayerAttachment, TriggerAttachment, RulesAttachment, TechAttachment, PoliticalActionAttachment) and the exact full name of the attachment to be changed.
+                                                            (example: value="RulesAttachment" count="rulesAttachment"). Defaults to PlayerAttachment if missing.
+            playerProperty                      values: the name of any actual attachment property, with a count equal to the property's values (examples: value="destroysPUs" count="true"). (requires players to be set, otherwise it uses the attached player)
+            unitType                            values: the exact names of the unit to be affected by a unitProperty change (example: value="cruiser:super_cruiser")
+            unitAttachmentName                  values: the type of attachment (UnitAttachment, UnitSupportAttachment) and the exact full name of the attachment to be changed. Defaults to UnitAttachment if missing.
+            unitProperty                        values: the name of any actual attachment property, with a count equal to the property's values (examples: value="attack" count="4", or value="isAir" count="true"), requires unitType declared
+                                                        Something to note is that <option name="artillery" value="true"/> AND <option name="artillerySupportable" value="true"/> AND <option name="unitSupportCount" value="1"/> are all converted into a support attachment when the game starts,
+                                                            so adding or removing them as unit properties will do nothing (the bonusType for them is "ArtyOld", and the supportAttachment name is "supportAttachmentArtyOld<nameofUnit>") unitProperty changes are done for ALL players who use that unitType,
+                                                            regardless of the player specified in the trigger. In order to have a unitType+unitProperty change only affect certain players and not others, you need to make a new unit type for those players (ie: rename the unit for those players only)
+            territories                         values: the exact names of the territories to be affected by a territoryProperty change (example: value="Germany:Italy")
+            territoryAttachmentName             values: the type of attachment (TerritoryAttachment, CanalAttachment) and the exact full name of the attachment to be changed. Defaults to TerritoryAttachment if missing.
+            territoryProperty                   values: the name of any actual attachment property, with a count equal to the property's values (examples: value="production" count="4", or value="victoryCity" count="true"), requires territories declared
+            relationshipTypes                   values: the exact names of the relationshipType to be affected by a relationshipTypeProperty change
+            relationshipTypeAttachmentName      values: the type of attachment (RelationshipTypeAttachment) and the exact full name of the attachment to be changed. Defaults to RelationshipTypeAttachment if missing.
+            relationshipTypeProperty            values: the name of any actual attachment property, with a count equal to the property's values, requires relationshipTypes declared
+            territoryEffects                    values: the exact names of the territoryEffects to be affected by a territoryEffectProperty change
+            territoryEffectAttachmentName       values: the type of attachment (TerritoryEffectAttachment) and the exact full name of the attachment to be changed. Defaults to TerritoryEffectAttachment if missing.
+            territoryEffectProperty             values: the name of any actual attachment property, with a count equal to the property's values, requires territoryEffects declared
+
+    -->
+        <!-- Clarification on how "each" works.  (Each is just a way to simplify writing national objectives, conditions, and triggers. It does not do anything extra that you could not do before)
+                Lets say you have this objective:
+                    <attachment name="objectiveAttachmentRussians1_EasternEuropeMegaIncome" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="4"/>
+                        <option name="directOwnershipTerritories" value="Norway:Eastern Europe:East Balkans:Ukraine S.S.R.:Belorussia" count="each"/>
+                    </attachment>
+                What would happen is that "Russians" would get 4 PUs for EACH territory in that list that satisfied directOwnershipTerritories.
+                If you used it as a condition statement, then it would act as 1 for the purposes of returning true/false (in other words, own at least 1 territory and the condition would be true).
+                Now lets say you have this trigger:
+                    <attachment name="triggerAttachmentRussians5_FarEastReserves" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="objectiveAttachmentRussians1_EasternEuropeMegaIncome"/>
+                        <option name="placement" value="Russia:infantry" count="2"/>
+                    </attachment>
+                This trigger would add 2 infantry to russia for each territory inside the condition objectiveAttachmentRussians1_EasternEuropeMegaIncome that is true.
+                IF you have more than 1 condition with Each, then the trigger will use the largest Each.  If you have a meta-condition (a condition that contains other conditions), the trigger will NOT look inside the conditions inside the meta-condition.
+                Since it would be meaningless to, for example, change a relation to the same thing 10 times in a row, Each only works with the following kinds of triggers:
+                resource, placement, purchase
+        -->
+        <!-- Clarification on changing properties and clearing of properties. (Any property not in this list overwrites itself if you set it multiple times)
+                The following attachments may have MULTIPLE instances, meaning that they are adding to some variable, meaning that they may be cleared by triggers if you want to (by prefixing with "-clear-"):
+                Unit Attachments:
+                    canBeGivenByTerritoryTo
+                    canBeCapturedOnEnteringBy
+                    destroyedWhenCapturedBy
+                    requiresUnits
+                    givesMovement
+                    consumesUnits
+                    createsUnitsList
+                    createsResourcesList
+                    receivesAbilityWhenWith
+                    whenCapturedChangesInto
+                    special
+                    fuelCost
+
+                Unit Support Attachments:
+                    players
+
+                Territory Attachments:
+                    changeUnitOwners
+                    captureUnitOnEnteringBy
+                    territoryEffect
+                    whenCapturedByGoesTo
+                    convoyAttached
+
+                Territory Effect Attachments:
+                    combatDefenseEffect
+                    combatOffenseEffect
+
+                Player Attachments:
+                    giveUnitControl
+                    captureUnitOnEnteringBy
+                    suicideAttackResources
+
+                Objectives & Condition Attachments:
+                    conditions
+                    unitPresence
+                    relationship
+
+                Rules Attachments:
+                    productionPerXTerritories
+
+                Trigger Attachments:
+                    conditions
+                    productionRule
+                    tech
+                    availableTech
+                    placement
+                    purchase
+                    support
+                    relationshipChange
+
+                    players
+                    playerProperty
+                    unitType
+                    unitProperty
+                    territories
+                    territoryProperty
+                    relationshipTypes
+                    relationshipTypeProperty
+                    territoryEffects
+                    territoryEffectProperty
+
+                Political Action Attachments:
+                    conditions
+                    relationshipChange
+                    actionAccept
+
+        -->
+    <!-- Victory Triggers -->
+                        <!-- Victory Triggers can be attached to anyone. Only 1 is needed per victory condition -->
                 <attachment name="triggerAttachmentAxisVictory1_CapitalControl" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentAxisVictory1"/>
-					<!--<option name="when" value="after:chineseEndTurn"/>-->
-					<!-- both "victory" and "notification" will look in the "notifications.properties" in your maps root folder for a string with the value's name, and then it will use whatever is to the right of the = sign.-->
-                	<option name="victory" value="AXIS_VICTORY"/>
-					<!-- "players" when used with "victory" set which players are the winner. this is important for stats generation and for future use -->
-                	<option name="players" value="Germans:Italians:Japanese"/>
+                    <option name="conditions" value="conditionAttachmentAxisVictory1"/>
+                    <!--<option name="when" value="after:chineseEndTurn"/>-->
+                    <!-- both "victory" and "notification" will look in the "notifications.properties" in your maps root folder for a string with the value's name, and then it will use whatever is to the right of the = sign.-->
+                    <option name="victory" value="AXIS_VICTORY"/>
+                    <!-- "players" when used with "victory" set which players are the winner. this is important for stats generation and for future use -->
+                    <option name="players" value="Germans:Italians:Japanese"/>
                 </attachment>
-				
+
                 <attachment name="triggerAttachmentAlliesVictory1_CapitalControl" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentAlliesVictory1"/>
-					<option name="when" value="after:chineseEndTurn"/>
-                	<option name="victory" value="ALLIES_VICTORY"/>
-                	<option name="players" value="Russians:British:Americans:Chinese"/>
+                    <option name="conditions" value="conditionAttachmentAlliesVictory1"/>
+                    <option name="when" value="after:chineseEndTurn"/>
+                    <option name="victory" value="ALLIES_VICTORY"/>
+                    <option name="players" value="Russians:British:Americans:Chinese"/>
                 </attachment>
-	
-	<!-- Germans Triggers -->
+
+    <!-- Germans Triggers -->
                 <attachment name="triggerAttachmentGermans3_SuperSubs" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermans1"/>
-                	<option name="tech" value="superSub"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermans1"/>
+                    <option name="tech" value="superSub"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermans4_MechanizedInfantry" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermans2"/>
-                	<option name="tech" value="mechanizedInfantry"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermans2"/>
+                    <option name="tech" value="mechanizedInfantry"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermans5_Rockets" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermans3a:conditionAttachmentGermans3b"/>
-                	<option name="conditionType" value="AND"/>
-                	<option name="tech" value="rocket"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermans3a:conditionAttachmentGermans3b"/>
+                    <option name="conditionType" value="AND"/>
+                    <option name="tech" value="rocket"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentAmericans5_British4_Paratroopers" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentAmericans1"/>
-                	<option name="tech" value="paratroopers"/>
-                	<option name="players" value="Americans:British"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentAmericans1"/>
+                    <option name="tech" value="paratroopers"/>
+                    <option name="players" value="Americans:British"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentAmericans7_WarBonds" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentAmericans3a:conditionAttachmentAmericans3b"/>
-                	<option name="tech" value="warBonds"/>
-                	<option name="players" value="Americans"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentAmericans3a:conditionAttachmentAmericans3b"/>
+                    <option name="tech" value="warBonds"/>
+                    <option name="players" value="Americans"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermansParatroopersCanProduce" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansParatroopers"/>
-					<option name="productionRule" value="Germans_production:buyAir_Transport"/>
+                    <option name="conditions" value="conditionAttachmentGermansParatroopers"/>
+                    <option name="productionRule" value="Germans_production:buyAir_Transport"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermansSuperSubs1_NewSubmarineTech" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansSuperSubs"/>
-					<option name="availableTech" value="Submarine Technology:reinforcedHulls:wolfPackTactics"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermansSuperSubs"/>
+                    <option name="availableTech" value="Submarine Technology:reinforcedHulls:wolfPackTactics"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermansSuperSubs2_NewItalianTechAvailable" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansSuperSubs"/>
-					<option name="availableTech" value="Italian Technology:reinforcedHulls:-shipyards"/>
-                	<option name="uses" value="1"/>
-                	<option name="players" value="Italians"/>
+                    <option name="conditions" value="conditionAttachmentGermansSuperSubs"/>
+                    <option name="availableTech" value="Italian Technology:reinforcedHulls:-shipyards"/>
+                    <option name="uses" value="1"/>
+                    <option name="players" value="Italians"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermansReinforcedHulls" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansReinforcedHulls"/>
-                	<option name="support" value="supportAttachmentSubmarineReinforcedHulls"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermansReinforcedHulls"/>
+                    <option name="support" value="supportAttachmentSubmarineReinforcedHulls"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermansWolfPackTactics" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansWolfPackTactics"/>
-                	<option name="support" value="supportAttachmentSubmarineWolfPackTacticsOffence"/>
-                	<!--<option name="support" value="supportAttachmentSubmarineWolfPackTacticsDefence"/>-->
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermansWolfPackTactics"/>
+                    <option name="support" value="supportAttachmentSubmarineWolfPackTacticsOffence"/>
+                    <!--<option name="support" value="supportAttachmentSubmarineWolfPackTacticsDefence"/>-->
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermansShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansShipyards"/>
-					<option name="productionRule" value="Germans_production:-buyTransport"/>
-					<option name="productionRule" value="Germans_production:-buySubmarine"/>
-					<option name="productionRule" value="Germans_production:-buyDestroyer"/>
-					<option name="productionRule" value="Germans_production:-buyCruiser"/>
-					<option name="productionRule" value="Germans_production:-buyCarrier"/>
-					<option name="productionRule" value="Germans_production:-buyBattleship"/>
-					<option name="productionRule" value="Germans_production:-buySuper_Carrier"/>
-					<option name="productionRule" value="Germans_production:buyTransportShipyards"/>
-					<option name="productionRule" value="Germans_production:buySubmarineShipyards"/>
-					<option name="productionRule" value="Germans_production:buyDestroyerShipyards"/>
-					<option name="productionRule" value="Germans_production:buyCruiserShipyards"/>
-					<option name="productionRule" value="Germans_production:buyCarrierShipyards"/>
-					<option name="productionRule" value="Germans_production:buyBattleshipShipyards"/>
-					<option name="productionRule" value="Germans_production:buySuper_CarrierShipyards"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermansShipyards"/>
+                    <option name="productionRule" value="Germans_production:-buyTransport"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarine"/>
+                    <option name="productionRule" value="Germans_production:-buyDestroyer"/>
+                    <option name="productionRule" value="Germans_production:-buyCruiser"/>
+                    <option name="productionRule" value="Germans_production:-buyCarrier"/>
+                    <option name="productionRule" value="Germans_production:-buyBattleship"/>
+                    <option name="productionRule" value="Germans_production:-buySuper_Carrier"/>
+                    <option name="productionRule" value="Germans_production:buyTransportShipyards"/>
+                    <option name="productionRule" value="Germans_production:buySubmarineShipyards"/>
+                    <option name="productionRule" value="Germans_production:buyDestroyerShipyards"/>
+                    <option name="productionRule" value="Germans_production:buyCruiserShipyards"/>
+                    <option name="productionRule" value="Germans_production:buyCarrierShipyards"/>
+                    <option name="productionRule" value="Germans_production:buyBattleshipShipyards"/>
+                    <option name="productionRule" value="Germans_production:buySuper_CarrierShipyards"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermansSubmarineTech2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansSubmarineTech2:conditionAttachmentGermansShipyardsInvert"/>
-					<option name="productionRule" value="Germans_production:-buySubmarine"/>
-					<option name="productionRule" value="Germans_production:buySubmarineTech2"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermansSubmarineTech2:conditionAttachmentGermansShipyardsInvert"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarine"/>
+                    <option name="productionRule" value="Germans_production:buySubmarineTech2"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermansSubmarineTech3" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansSubmarineTech3:conditionAttachmentGermansShipyardsInvert"/>
-					<option name="productionRule" value="Germans_production:-buySubmarine"/>
-					<option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
-					<option name="productionRule" value="Germans_production:buySubmarineTech3"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermansSubmarineTech3:conditionAttachmentGermansShipyardsInvert"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarine"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
+                    <option name="productionRule" value="Germans_production:buySubmarineTech3"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermansSubmarineTech2AndShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansSubmarineTech2:conditionAttachmentGermansShipyards"/>
-					<option name="productionRule" value="Germans_production:-buySubmarine"/>
-					<option name="productionRule" value="Germans_production:-buySubmarineShipyards"/>
-					<option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
-					<option name="productionRule" value="Germans_production:buySubmarineTech2Shipyards"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermansSubmarineTech2:conditionAttachmentGermansShipyards"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarine"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarineShipyards"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
+                    <option name="productionRule" value="Germans_production:buySubmarineTech2Shipyards"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentGermansSubmarineTech3AndShipyards" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansSubmarineTech3:conditionAttachmentGermansShipyards"/>
-					<option name="productionRule" value="Germans_production:-buySubmarine"/>
-					<option name="productionRule" value="Germans_production:-buySubmarineShipyards"/>
-					<option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
-					<option name="productionRule" value="Germans_production:-buySubmarineTech3"/>
-					<option name="productionRule" value="Germans_production:-buySubmarineTech2Shipyards"/>
-					<option name="productionRule" value="Germans_production:buySubmarineTech3Shipyards"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermansSubmarineTech3:conditionAttachmentGermansShipyards"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarine"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarineShipyards"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarineTech2"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarineTech3"/>
+                    <option name="productionRule" value="Germans_production:-buySubmarineTech2Shipyards"/>
+                    <option name="productionRule" value="Germans_production:buySubmarineTech3Shipyards"/>
+                    <option name="uses" value="1"/>
                 </attachment>
-				
-	<!-- Japanese Triggers -->
+
+    <!-- Japanese Triggers -->
                 <attachment name="triggerAttachmentJapanese3_TokyoExpress" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentJapanese1a:conditionAttachmentJapanese1b"/>
-			    	<option name="unitType" value="jp_destroyer"/>
-					<option name="unitProperty" value="transportCapacity" count="2"/>
-					<option name="unitProperty" value="isCombatTransport" count="true"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentJapanese1a:conditionAttachmentJapanese1b"/>
+                    <option name="unitType" value="jp_destroyer"/>
+                    <option name="unitProperty" value="transportCapacity" count="2"/>
+                    <option name="unitProperty" value="isCombatTransport" count="true"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentJapanese4_ArmyControlOfNavy" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentJapanese2"/>
-			    	<option name="unitType" value="jp_transport"/>
-					<option name="unitProperty" value="transportCapacity" count="6"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentJapanese2"/>
+                    <option name="unitType" value="jp_transport"/>
+                    <option name="unitProperty" value="transportCapacity" count="6"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentJapanese5_ForTheEmperor" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentJapanese3"/>
-                	<option name="placement" value="61 Sea Zone:midget_submarine"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentJapanese3"/>
+                    <option name="placement" value="61 Sea Zone:midget_submarine"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentJapaneseParatroopersCanProduce" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentJapaneseParatroopers"/>
-					<option name="productionRule" value="Japanese_production:buyAir_Transport"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentJapaneseParatroopers"/>
+                    <option name="productionRule" value="Japanese_production:buyAir_Transport"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentJapanese6_MidgetSubCanProduce" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentJapaneseMidget"/>
-					<option name="productionRule" value="Japanese_production:buyMidget_Submarine"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentJapaneseMidget"/>
+                    <option name="productionRule" value="Japanese_production:buyMidget_Submarine"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentJapanese7_KamikazeRecruits" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentJapaneseKamikaze1:conditionAttachmentJapaneseKamikaze2"/>
-					<option name="productionRule" value="Japanese_production:-buyJP_Fighter"/>
-                	<option name="productionRule" value="Japanese_production:buyJP_FighterKamikaze"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentJapaneseKamikaze1:conditionAttachmentJapaneseKamikaze2"/>
+                    <option name="productionRule" value="Japanese_production:-buyJP_Fighter"/>
+                    <option name="productionRule" value="Japanese_production:buyJP_FighterKamikaze"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
-					<!-- since unit property changes occur at end of turn, we have this trigger as attached to British so that it happens at the end of their turn (British go right before Japan does) -->
+                    <!-- since unit property changes occur at end of turn, we have this trigger as attached to British so that it happens at the end of their turn (British go right before Japan does) -->
                 <attachment name="triggerAttachmentJapanese7_KamikazeAttack" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentJapaneseKamikaze1:conditionAttachmentJapaneseKamikaze2"/>
-			    	<option name="unitType" value="jp_fighter"/>
-					<option name="unitProperty" value="attack" count="5"/>
-					<option name="unitProperty" value="defense" count="3"/>
-					<option name="unitProperty" value="movement" count="3"/>
-					<option name="unitProperty" value="isSuicide" count="true"/>
-					<option name="unitProperty" value="isKamikaze" count="true"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentJapaneseKamikaze1:conditionAttachmentJapaneseKamikaze2"/>
+                    <option name="unitType" value="jp_fighter"/>
+                    <option name="unitProperty" value="attack" count="5"/>
+                    <option name="unitProperty" value="defense" count="3"/>
+                    <option name="unitProperty" value="movement" count="3"/>
+                    <option name="unitProperty" value="isSuicide" count="true"/>
+                    <option name="unitProperty" value="isKamikaze" count="true"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentJapaneseShipyards" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentJapaneseShipyards"/>
-					<option name="productionRule" value="Japanese_production:-buyTransport"/>
-					<option name="productionRule" value="Japanese_production:-buySubmarine"/>
-					<option name="productionRule" value="Japanese_production:-buyDestroyer"/>
-					<option name="productionRule" value="Japanese_production:-buyCruiser"/>
-					<option name="productionRule" value="Japanese_production:-buyCarrier"/>
-					<option name="productionRule" value="Japanese_production:-buyBattleship"/>
-					<option name="productionRule" value="Japanese_production:-buySuper_Carrier"/>
-					<option name="productionRule" value="Japanese_production:buyTransportShipyards"/>
-					<option name="productionRule" value="Japanese_production:buySubmarineShipyards"/>
-					<option name="productionRule" value="Japanese_production:buyDestroyerShipyards"/>
-					<option name="productionRule" value="Japanese_production:buyCruiserShipyards"/>
-					<option name="productionRule" value="Japanese_production:buyCarrierShipyards"/>
-					<option name="productionRule" value="Japanese_production:buyBattleshipShipyards"/>
-					<option name="productionRule" value="Japanese_production:buySuper_CarrierShipyards"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentJapaneseShipyards"/>
+                    <option name="productionRule" value="Japanese_production:-buyTransport"/>
+                    <option name="productionRule" value="Japanese_production:-buySubmarine"/>
+                    <option name="productionRule" value="Japanese_production:-buyDestroyer"/>
+                    <option name="productionRule" value="Japanese_production:-buyCruiser"/>
+                    <option name="productionRule" value="Japanese_production:-buyCarrier"/>
+                    <option name="productionRule" value="Japanese_production:-buyBattleship"/>
+                    <option name="productionRule" value="Japanese_production:-buySuper_Carrier"/>
+                    <option name="productionRule" value="Japanese_production:buyTransportShipyards"/>
+                    <option name="productionRule" value="Japanese_production:buySubmarineShipyards"/>
+                    <option name="productionRule" value="Japanese_production:buyDestroyerShipyards"/>
+                    <option name="productionRule" value="Japanese_production:buyCruiserShipyards"/>
+                    <option name="productionRule" value="Japanese_production:buyCarrierShipyards"/>
+                    <option name="productionRule" value="Japanese_production:buyBattleshipShipyards"/>
+                    <option name="productionRule" value="Japanese_production:buySuper_CarrierShipyards"/>
+                    <option name="uses" value="1"/>
                 </attachment>
-				
-	<!-- Italians Triggers -->
-				<!-- on turn 2 italy will go automatically to war with Russia 
+
+    <!-- Italians Triggers -->
+                <!-- on turn 2 italy will go automatically to war with Russia
                 <attachment name="triggerAttachmentItaliansWarRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentItalianTurn2"/>
-					<option name="relationshipChange" value="Italians:Russians:any:War"/>					
+                    <option name="conditions" value="conditionAttachmentItalianTurn2"/>
+                    <option name="relationshipChange" value="Italians:Russians:any:War"/>
                 </attachment>-->
-				
-				
+
+
                 <attachment name="triggerAttachmentItalians2_NorthAfrica" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentItalians1"/>
-					<option name="purchase" value="cruiser" count="1"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentItalians1"/>
+                    <option name="purchase" value="cruiser" count="1"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentItaliansParatroopersCanProduce" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentItaliansParatroopers"/>
-					<option name="productionRule" value="Italians_production:buyAir_Transport"/>
+                    <option name="conditions" value="conditionAttachmentItaliansParatroopers"/>
+                    <option name="productionRule" value="Italians_production:buyAir_Transport"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentItaliansReinforcedHulls" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermansReinforcedHulls"/>
-                	<option name="support" value="supportAttachmentSubmarineReinforcedHulls"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermansReinforcedHulls"/>
+                    <option name="support" value="supportAttachmentSubmarineReinforcedHulls"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentItaliansShipyards" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentItaliansShipyards"/>
-					<option name="productionRule" value="Italians_production:-buyTransport"/>
-					<option name="productionRule" value="Italians_production:-buySubmarine"/>
-					<option name="productionRule" value="Italians_production:-buyDestroyer"/>
-					<option name="productionRule" value="Italians_production:-buyCruiser"/>
-					<option name="productionRule" value="Italians_production:-buyCarrier"/>
-					<option name="productionRule" value="Italians_production:-buyBattleship"/>
-					<option name="productionRule" value="Italians_production:-buySuper_Carrier"/>
-					<option name="productionRule" value="Italians_production:buyTransportShipyards"/>
-					<option name="productionRule" value="Italians_production:buySubmarineShipyards"/>
-					<option name="productionRule" value="Italians_production:buyDestroyerShipyards"/>
-					<option name="productionRule" value="Italians_production:buyCruiserShipyards"/>
-					<option name="productionRule" value="Italians_production:buyCarrierShipyards"/>
-					<option name="productionRule" value="Italians_production:buyBattleshipShipyards"/>
-					<option name="productionRule" value="Italians_production:buySuper_CarrierShipyards"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentItaliansShipyards"/>
+                    <option name="productionRule" value="Italians_production:-buyTransport"/>
+                    <option name="productionRule" value="Italians_production:-buySubmarine"/>
+                    <option name="productionRule" value="Italians_production:-buyDestroyer"/>
+                    <option name="productionRule" value="Italians_production:-buyCruiser"/>
+                    <option name="productionRule" value="Italians_production:-buyCarrier"/>
+                    <option name="productionRule" value="Italians_production:-buyBattleship"/>
+                    <option name="productionRule" value="Italians_production:-buySuper_Carrier"/>
+                    <option name="productionRule" value="Italians_production:buyTransportShipyards"/>
+                    <option name="productionRule" value="Italians_production:buySubmarineShipyards"/>
+                    <option name="productionRule" value="Italians_production:buyDestroyerShipyards"/>
+                    <option name="productionRule" value="Italians_production:buyCruiserShipyards"/>
+                    <option name="productionRule" value="Italians_production:buyCarrierShipyards"/>
+                    <option name="productionRule" value="Italians_production:buyBattleshipShipyards"/>
+                    <option name="productionRule" value="Italians_production:buySuper_CarrierShipyards"/>
+                    <option name="uses" value="1"/>
                 </attachment>
-                
-				<!--  these triggers are notificationtriggers 
+
+                <!--  these triggers are notificationtriggers
                 <attachment name="triggerItalyTurn1CombatMoveNotification" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentItalianTurn1"/>
-					<option name="when" value="before:italianCombatMove"/>
-					<option name="notification" value="ITALY_TURN1_BEFORE_CM"/>
+                    <option name="conditions" value="conditionAttachmentItalianTurn1"/>
+                    <option name="when" value="before:italianCombatMove"/>
+                    <option name="notification" value="ITALY_TURN1_BEFORE_CM"/>
                 </attachment>
-                
+
                  <attachment name="triggerItalyTurn1AfterBattleNotification" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentItalianTurn1"/>
-					<option name="when" value="after:italianBattle"/>
-					<option name="notification" value="ITALY_TURN1_AFTER_BATTLE"/>
+                    <option name="conditions" value="conditionAttachmentItalianTurn1"/>
+                    <option name="when" value="after:italianBattle"/>
+                    <option name="notification" value="ITALY_TURN1_AFTER_BATTLE"/>
                 </attachment>-->
-                
-				
-	<!-- Americans Triggers -->
+
+
+    <!-- Americans Triggers -->
                 <!--<attachment name="triggerAttachmentAmericans1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentGermans3a:conditionAttachmentAmericans1"/>
-                	<option name="tech" value="paratroopers"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentGermans3a:conditionAttachmentAmericans1"/>
+                    <option name="tech" value="paratroopers"/>
+                    <option name="uses" value="1"/>
                 </attachment>-->
 
                 <attachment name="triggerAttachmentAmericans6_TheTurningPointInThePacific" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentAmericans2"/>
-                	<option name="tech" value="shipyards"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentAmericans2"/>
+                    <option name="tech" value="shipyards"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentAmericans8_TacticalAirUse" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentAmericans4"/>
-                	<option name="support" value="supportAttachmentFighter"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentAmericans4"/>
+                    <option name="support" value="supportAttachmentFighter"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
-						<!-- Here we want to see if Japan has Either Zero Battleships or Zero Carriers. So we set the relationship to AND, and then invert it.  So !X = (A && B)  becomes  X = !(A && B)  becomes  X = (!A || !B) -->
+                        <!-- Here we want to see if Japan has Either Zero Battleships or Zero Carriers. So we set the relationship to AND, and then invert it.  So !X = (A && B)  becomes  X = !(A && B)  becomes  X = (!A || !B) -->
                 <attachment name="triggerAttachmentAmericans4_JapaneseCapitalShipsSunk" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentJapaneseCarriers:conditionAttachmentJapaneseBattleships"/>
-					<option name="conditionType" value="AND"/>
-					<option name="invert" value="true"/>
-					<option name="resource" value="PUs"/>
-					<option name="resourceCount" value="4"/>
+                    <option name="conditions" value="conditionAttachmentJapaneseCarriers:conditionAttachmentJapaneseBattleships"/>
+                    <option name="conditionType" value="AND"/>
+                    <option name="invert" value="true"/>
+                    <option name="resource" value="PUs"/>
+                    <option name="resourceCount" value="4"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentAmericansParatroopersCanProduce" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentAmericansParatroopers"/>
-					<option name="productionRule" value="Americans_production:buyAir_Transport"/>
+                    <option name="conditions" value="conditionAttachmentAmericansParatroopers"/>
+                    <option name="productionRule" value="Americans_production:buyAir_Transport"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentAmericansShipyards" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentAmericansShipyards"/>
-					<option name="productionRule" value="Americans_production:-buyTransport"/>
-					<option name="productionRule" value="Americans_production:-buySubmarine"/>
-					<option name="productionRule" value="Americans_production:-buyDestroyer"/>
-					<option name="productionRule" value="Americans_production:-buyCruiser"/>
-					<option name="productionRule" value="Americans_production:-buyCarrier"/>
-					<option name="productionRule" value="Americans_production:-buyBattleship"/>
-					<option name="productionRule" value="Americans_production:-buySuper_Carrier"/>
-					<option name="productionRule" value="Americans_production:buyTransportShipyards"/>
-					<option name="productionRule" value="Americans_production:buySubmarineShipyards"/>
-					<option name="productionRule" value="Americans_production:buyDestroyerShipyards"/>
-					<option name="productionRule" value="Americans_production:buyCruiserShipyards"/>
-					<option name="productionRule" value="Americans_production:buyCarrierShipyards"/>
-					<option name="productionRule" value="Americans_production:buyBattleshipShipyards"/>
-					<option name="productionRule" value="Americans_production:buySuper_CarrierShipyards"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentAmericansShipyards"/>
+                    <option name="productionRule" value="Americans_production:-buyTransport"/>
+                    <option name="productionRule" value="Americans_production:-buySubmarine"/>
+                    <option name="productionRule" value="Americans_production:-buyDestroyer"/>
+                    <option name="productionRule" value="Americans_production:-buyCruiser"/>
+                    <option name="productionRule" value="Americans_production:-buyCarrier"/>
+                    <option name="productionRule" value="Americans_production:-buyBattleship"/>
+                    <option name="productionRule" value="Americans_production:-buySuper_Carrier"/>
+                    <option name="productionRule" value="Americans_production:buyTransportShipyards"/>
+                    <option name="productionRule" value="Americans_production:buySubmarineShipyards"/>
+                    <option name="productionRule" value="Americans_production:buyDestroyerShipyards"/>
+                    <option name="productionRule" value="Americans_production:buyCruiserShipyards"/>
+                    <option name="productionRule" value="Americans_production:buyCarrierShipyards"/>
+                    <option name="productionRule" value="Americans_production:buyBattleshipShipyards"/>
+                    <option name="productionRule" value="Americans_production:buySuper_CarrierShipyards"/>
+                    <option name="uses" value="1"/>
                 </attachment>
-				
-	<!-- British Triggers -->
+
+    <!-- British Triggers -->
                 <attachment name="triggerAttachmentBritish5_CentersOfPower" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentBritish2"/>
-                	<option name="tech" value="aARadar"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentBritish2"/>
+                    <option name="tech" value="aARadar"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentBritishParatroopersCanProduce" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentBritishParatroopers"/>
-					<option name="productionRule" value="British_production:buyAir_Transport"/>
+                    <option name="conditions" value="conditionAttachmentBritishParatroopers"/>
+                    <option name="productionRule" value="British_production:buyAir_Transport"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentBritishShipyards" attachTo="British" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentBritishShipyards"/>
-					<option name="productionRule" value="British_production:-buyTransport"/>
-					<option name="productionRule" value="British_production:-buySubmarine"/>
-					<option name="productionRule" value="British_production:-buyDestroyer"/>
-					<option name="productionRule" value="British_production:-buyCruiser"/>
-					<option name="productionRule" value="British_production:-buyCarrier"/>
-					<option name="productionRule" value="British_production:-buyBattleship"/>
-					<option name="productionRule" value="British_production:-buySuper_Carrier"/>
-					<option name="productionRule" value="British_production:buyTransportShipyards"/>
-					<option name="productionRule" value="British_production:buySubmarineShipyards"/>
-					<option name="productionRule" value="British_production:buyDestroyerShipyards"/>
-					<option name="productionRule" value="British_production:buyCruiserShipyards"/>
-					<option name="productionRule" value="British_production:buyCarrierShipyards"/>
-					<option name="productionRule" value="British_production:buyBattleshipShipyards"/>
-					<option name="productionRule" value="British_production:buySuper_CarrierShipyards"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentBritishShipyards"/>
+                    <option name="productionRule" value="British_production:-buyTransport"/>
+                    <option name="productionRule" value="British_production:-buySubmarine"/>
+                    <option name="productionRule" value="British_production:-buyDestroyer"/>
+                    <option name="productionRule" value="British_production:-buyCruiser"/>
+                    <option name="productionRule" value="British_production:-buyCarrier"/>
+                    <option name="productionRule" value="British_production:-buyBattleship"/>
+                    <option name="productionRule" value="British_production:-buySuper_Carrier"/>
+                    <option name="productionRule" value="British_production:buyTransportShipyards"/>
+                    <option name="productionRule" value="British_production:buySubmarineShipyards"/>
+                    <option name="productionRule" value="British_production:buyDestroyerShipyards"/>
+                    <option name="productionRule" value="British_production:buyCruiserShipyards"/>
+                    <option name="productionRule" value="British_production:buyCarrierShipyards"/>
+                    <option name="productionRule" value="British_production:buyBattleshipShipyards"/>
+                    <option name="productionRule" value="British_production:buySuper_CarrierShipyards"/>
+                    <option name="uses" value="1"/>
                 </attachment>
-				
-	<!-- Russians Triggers and Conditions -->
-                
-				<attachment name="triggerRussiansCapitalLost" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentRussianCapitalLost"/>
-					<option name="when" value="before:russianPurchase"/>
-					<option name="notification" value="RUSSIAN_CAPITAL_LOST"/>
-					<option name="uses" value="1"/>
-				</attachment>
-				
-                <!-- when Italy is at War with Russia, Russia will automatically go to war with Japan from any Neutral stance 
-	            <attachment name="triggerAttachmentRussiansWarJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentRussiansNeutralItalians"/>
-					<option name="relationshipChange" value="Russians:Japanese:anyNeutral:War"/>
+
+    <!-- Russians Triggers and Conditions -->
+
+                <attachment name="triggerRussiansCapitalLost" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussianCapitalLost"/>
+                    <option name="when" value="before:russianPurchase"/>
+                    <option name="notification" value="RUSSIAN_CAPITAL_LOST"/>
+                    <option name="uses" value="1"/>
+                </attachment>
+
+                <!-- when Italy is at War with Russia, Russia will automatically go to war with Japan from any Neutral stance
+                <attachment name="triggerAttachmentRussiansWarJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussiansNeutralItalians"/>
+                    <option name="relationshipChange" value="Russians:Japanese:anyNeutral:War"/>
                 </attachment>-->
-                
+
                 <!-- when Italy is at War with Russia, Russia will automatically go to war with Germany from exactly Neutral state
                 <attachment name="triggerAttachmentRussiansWarGermans" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentRussiansNeutralItalians"/>
-					<option name="relationshipChange" value="Russians:Germans:Neutrality:War"/>
+                    <option name="conditions" value="conditionAttachmentRussiansNeutralItalians"/>
+                    <option name="relationshipChange" value="Russians:Germans:Neutrality:War"/>
                 </attachment>-->
-                
+
                 <attachment name="triggerAttachmentRussians3_RecoveredGermanTech" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="objectiveAttachmentRussians3_HardAdvance"/>
-					<option name="resource" value="techTokens"/>
-					<option name="resourceCount" value="2"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="objectiveAttachmentRussians3_HardAdvance"/>
+                    <option name="resource" value="techTokens"/>
+                    <option name="resourceCount" value="2"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentRussians4a_LeningradAndStalingrad" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentRussians2"/>
-                	<option name="support" value="supportAttachmentRussiansArtillery2"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentRussians2"/>
+                    <option name="support" value="supportAttachmentRussiansArtillery2"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentRussians4b_LeningradAndStalingrad" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentRussians2"/>
-					<option name="players" value="Russians"/>
-                	<option name="support" value="-supportAttachmentArtyOldartillery"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentRussians2"/>
+                    <option name="players" value="Russians"/>
+                    <option name="support" value="-supportAttachmentArtyOldartillery"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentRussians5_FarEastReserves" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentJapanese4"/>
-                	<option name="placement" value="Yakut S.S.R.:infantry" count="3"/>
-                	<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentJapanese4"/>
+                    <option name="placement" value="Yakut S.S.R.:infantry" count="3"/>
+                    <option name="uses" value="1"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentRussiansParatroopersCanProduce" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentRussiansParatroopers"/>
-					<option name="productionRule" value="Russians_production:buyAir_Transport"/>
+                    <option name="conditions" value="conditionAttachmentRussiansParatroopers"/>
+                    <option name="productionRule" value="Russians_production:buyAir_Transport"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentRussiansShipyards" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentRussiansShipyards"/>
-					<option name="productionRule" value="Russians_production:-buyTransport"/>
-					<option name="productionRule" value="Russians_production:-buySubmarine"/>
-					<option name="productionRule" value="Russians_production:-buyDestroyer"/>
-					<option name="productionRule" value="Russians_production:-buyCruiser"/>
-					<option name="productionRule" value="Russians_production:-buyCarrier"/>
-					<option name="productionRule" value="Russians_production:-buyBattleship"/>
-					<option name="productionRule" value="Russians_production:-buySuper_Carrier"/>
-					<option name="productionRule" value="Russians_production:buyTransportShipyards"/>
-					<option name="productionRule" value="Russians_production:buySubmarineShipyards"/>
-					<option name="productionRule" value="Russians_production:buyDestroyerShipyards"/>
-					<option name="productionRule" value="Russians_production:buyCruiserShipyards"/>
-					<option name="productionRule" value="Russians_production:buyCarrierShipyards"/>
-					<option name="productionRule" value="Russians_production:buyBattleshipShipyards"/>
-					<option name="productionRule" value="Russians_production:buySuper_CarrierShipyards"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentRussiansShipyards"/>
+                    <option name="productionRule" value="Russians_production:-buyTransport"/>
+                    <option name="productionRule" value="Russians_production:-buySubmarine"/>
+                    <option name="productionRule" value="Russians_production:-buyDestroyer"/>
+                    <option name="productionRule" value="Russians_production:-buyCruiser"/>
+                    <option name="productionRule" value="Russians_production:-buyCarrier"/>
+                    <option name="productionRule" value="Russians_production:-buyBattleship"/>
+                    <option name="productionRule" value="Russians_production:-buySuper_Carrier"/>
+                    <option name="productionRule" value="Russians_production:buyTransportShipyards"/>
+                    <option name="productionRule" value="Russians_production:buySubmarineShipyards"/>
+                    <option name="productionRule" value="Russians_production:buyDestroyerShipyards"/>
+                    <option name="productionRule" value="Russians_production:buyCruiserShipyards"/>
+                    <option name="productionRule" value="Russians_production:buyCarrierShipyards"/>
+                    <option name="productionRule" value="Russians_production:buyBattleshipShipyards"/>
+                    <option name="productionRule" value="Russians_production:buySuper_CarrierShipyards"/>
+                    <option name="uses" value="1"/>
                 </attachment>
-				
-				<attachment name="triggerAttachmentRussiansWarJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentRussiansNeutralJapanTurn5plus"/>
-					<option name="relationshipChange" value="Russians:Japanese:anyNeutral:War"/>
-					<option name="notification" value="RUSSIANS_AT_WAR_WITH_JAPAN"/>
-					<option name="when" value="before:russianPolitics"/>
+
+                <attachment name="triggerAttachmentRussiansWarJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussiansNeutralJapanTurn5plus"/>
+                    <option name="relationshipChange" value="Russians:Japanese:anyNeutral:War"/>
+                    <option name="notification" value="RUSSIANS_AT_WAR_WITH_JAPAN"/>
+                    <option name="when" value="before:russianPolitics"/>
                 </attachment>
-				
-	<!-- Chinese Triggers and Conditions -->
+
+    <!-- Chinese Triggers and Conditions -->
                 <attachment name="triggerAttachmentChinese2a_BurmaRoadOpen" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="objectiveAttachmentChinese2_BurmaRoad"/>
-					<option name="frontier" value="Chinese_BurmaRoad_production"/>
+                    <option name="conditions" value="objectiveAttachmentChinese2_BurmaRoad"/>
+                    <option name="frontier" value="Chinese_BurmaRoad_production"/>
                 </attachment>
-				
+
                 <attachment name="triggerAttachmentChinese2b_BurmaRoadClosed" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="objectiveAttachmentChinese2_BurmaRoad"/>
-					<option name="frontier" value="Chinese_CutOff_production"/>
-					<option name="invert" value="true"/>
+                    <option name="conditions" value="objectiveAttachmentChinese2_BurmaRoad"/>
+                    <option name="frontier" value="Chinese_CutOff_production"/>
+                    <option name="invert" value="true"/>
                 </attachment>
-				
+
                 <attachment name="triggerAttachmentChinese3_MilitiaRisingUp" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentChinese3"/>
-                	<option name="placement" value="Sinkiang:infantry"/>
+                    <option name="conditions" value="conditionAttachmentChinese3"/>
+                    <option name="placement" value="Sinkiang:infantry"/>
                 </attachment>
-				
+
                 <attachment name="triggerAttachmentChinese4_ChineseOverrunTheirBorders" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentChinese4"/>
-					<option name="uses" value="1"/>
-                	<option name="players" value="Chinese"/>
-                	<option name="playerAttachmentName" value="RulesAttachment" count="rulesAttachment"/>
-                	<option name="playerProperty" value="movementRestrictionTerritories" count=""/>
-                	<option name="playerProperty" value="movementRestrictionType" count="disallowed"/>
-                	<option name="playerProperty" value="productionPerXTerritories" count="-clear-3:infantry"/>
-                	<option name="playerProperty" value="productionPerXTerritories" count="10:transport"/>
-                	<option name="playerProperty" value="placementAnySeaZone" count="true"/>
+                    <option name="conditions" value="conditionAttachmentChinese4"/>
+                    <option name="uses" value="1"/>
+                    <option name="players" value="Chinese"/>
+                    <option name="playerAttachmentName" value="RulesAttachment" count="rulesAttachment"/>
+                    <option name="playerProperty" value="movementRestrictionTerritories" count=""/>
+                    <option name="playerProperty" value="movementRestrictionType" count="disallowed"/>
+                    <option name="playerProperty" value="productionPerXTerritories" count="-clear-3:infantry"/>
+                    <option name="playerProperty" value="productionPerXTerritories" count="10:transport"/>
+                    <option name="playerProperty" value="placementAnySeaZone" count="true"/>
                 </attachment>
 
                 <!--<attachment name="triggerAttachmentChineseParatroopersCanProduce" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentChineseParatroopers"/>
-					<option name="productionRule" value="Germans_production:buyAir_Transport"/>
+                    <option name="conditions" value="conditionAttachmentChineseParatroopers"/>
+                    <option name="productionRule" value="Germans_production:buyAir_Transport"/>
                 </attachment>
 
                 <attachment name="triggerAttachmentChineseShipyards" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-                	<option name="conditions" value="conditionAttachmentChineseShipyards"/>
-					<option name="productionRule" value="Chinese_production:-buyTransport"/>
-					<option name="productionRule" value="Chinese_production:-buySubmarine"/>
-					<option name="productionRule" value="Chinese_production:-buyDestroyer"/>
-					<option name="productionRule" value="Chinese_production:-buyCruiser"/>
-					<option name="productionRule" value="Chinese_production:-buyCarrier"/>
-					<option name="productionRule" value="Chinese_production:-buyBattleship"/>
-					<option name="productionRule" value="Chinese_production:-buySuper_Carrier"/>
-					<option name="productionRule" value="Chinese_production:buyTransportShipyards"/>
-					<option name="productionRule" value="Chinese_production:buySubmarineShipyards"/>
-					<option name="productionRule" value="Chinese_production:buyDestroyerShipyards"/>
-					<option name="productionRule" value="Chinese_production:buyCruiserShipyards"/>
-					<option name="productionRule" value="Chinese_production:buyCarrierShipyards"/>
-					<option name="productionRule" value="Chinese_production:buyBattleshipShipyards"/>
-					<option name="productionRule" value="Chinese_production:buySuper_CarrierShipyards"/>
-					<option name="uses" value="1"/>
+                    <option name="conditions" value="conditionAttachmentChineseShipyards"/>
+                    <option name="productionRule" value="Chinese_production:-buyTransport"/>
+                    <option name="productionRule" value="Chinese_production:-buySubmarine"/>
+                    <option name="productionRule" value="Chinese_production:-buyDestroyer"/>
+                    <option name="productionRule" value="Chinese_production:-buyCruiser"/>
+                    <option name="productionRule" value="Chinese_production:-buyCarrier"/>
+                    <option name="productionRule" value="Chinese_production:-buyBattleship"/>
+                    <option name="productionRule" value="Chinese_production:-buySuper_Carrier"/>
+                    <option name="productionRule" value="Chinese_production:buyTransportShipyards"/>
+                    <option name="productionRule" value="Chinese_production:buySubmarineShipyards"/>
+                    <option name="productionRule" value="Chinese_production:buyDestroyerShipyards"/>
+                    <option name="productionRule" value="Chinese_production:buyCruiserShipyards"/>
+                    <option name="productionRule" value="Chinese_production:buyCarrierShipyards"/>
+                    <option name="productionRule" value="Chinese_production:buyBattleshipShipyards"/>
+                    <option name="productionRule" value="Chinese_production:buySuper_CarrierShipyards"/>
+                    <option name="uses" value="1"/>
                 </attachment>-->
-				
+
 <!--  Rules Restrictions (must have the exact name of "rulesAttachment"-->
-	<!-- the following options are allowed for "playerAttachment"
-			movementRestrictionType						values: "allowed" or "disallowed", affects the list movementRestrictionTerritories. defaults to null
-			movementRestrictionTerritories				values: a colon (":") delimited list of territories that the player either can not move into, or can not move outside of
-			productionPerXTerritories					values: gives units to a player as part of NoPuPurchase delegate.  You can have multiple instances of productionPerXTerritories.
-																	value = the name of the unit, and count = the number of territories you need to get 1 of that unit.  if the name of the unit is missing, it defaults to "infantry"
-			placementAnyTerritory						values: "true" or "false", can you place in any LAND territory you owned at the beginning of the turn?
-			placementAnySeaZone							values: "true" or "false", can you place in any SEA territory beside a LAND territory you owned at the beginning of the turn?
-			placementCapturedTerritory					values: "true" or "false", can you place in territory you captured this turn?
-			placementPerTerritory						values: governs if you can or can not place in that territory, based on the number of owned units in that territory.  You may place in any territory with LESS units than the given value
-																	A value greater than Zero is required to be able to produce infinite units (or infinite up to maxPlacePerTerritory, which you can set too)
-			maxPlacePerTerritory						values: governs the max you may place per turn per territory (can override factory rules and infinite placement rules)
-			unlimitedProduction							values: will turn off warnings about purchasing more units than you can place. does not actually do anything to the game.
-			dominatingFirstRoundAttack					values: means that the very first round of the game, all enemies defend on a "1" instead of their normal defense.
-			negateDominatingFirstRoundAttack			values: means that this player is not affected by the dominatingFirstRoundAttack
-			placementInCapitalRestricted				values: means that the player may only place units in their capitol
-	-->
-	<!-- Chinese Rules -->
-				<attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="movementRestrictionTerritories" value="Sinkiang:Central China:China:Manchuria:Kwangtung:French Indochina"/>
-                	<option name="movementRestrictionType" value="allowed"/>
-					<!-- productionPerXTerritories gives units to a player as part of NoPuPurchase delegate.  You can have multiple instances of productionPerXTerritories.
-							value = the name of the unit, and count = the number of territories you need to get 1 of that unit.  if the name of the unit is missing, it defaults to "infantry" -->
-                	<option name="productionPerXTerritories" value="infantry" count="2"/>
-                	<!--<option name="productionPerXTerritories" value="fighter" count="6"/>-->
-					<!-- if you are using productionPerXTerritories, you can have only territories worth at least 1 pu count towards the X by setting the game property "Production Per Valued Territory Restricted". 
-							the amount produced will be increased by 1 infantry if you are using PacificTheater and you control territories called "India", "Burma", "Yunnan", "Szechwan" -->
-                	<option name="placementAnyTerritory" value="true"/>
-                	<option name="placementCapturedTerritory" value="true"/>
-					<!-- placementPerTerritory governs if you can or can not place in that territory, based on the number of owned units in that territory.  You may place in any territory with LESS units than the given value
-							A value greater than Zero is required to be able to produce infinite units (or infinite up to maxPlacePerTerritory, which you can set too) -->
-                	<option name="placementPerTerritory" value="4"/>
-					<!-- maxPlacePerTerritory governs the max you may place per turn per territory (can override factory rules and infinite placement rules) -->
-                	<option name="maxPlacePerTerritory" value="2"/>
-					<option name="unlimitedProduction" value="true"/>
-					<!-- dominatingFirstRoundAttack means that the very first round of the game, all enemies defend on a "1" instead of their normal defense. negateDominatingFirstRoundAttack means that this player is not affected by the dominatingFirstRoundAttack
-					<option name="dominatingFirstRoundAttack" value="true"/>
-					<option name="negateDominatingFirstRoundAttack" value="true"/> -->
-					<!-- placementInCapitalRestricted means that the player may only place units in their capitol
-					<option name="placementInCapitalRestricted" value="true"/> -->
+    <!-- the following options are allowed for "playerAttachment"
+            movementRestrictionType                     values: "allowed" or "disallowed", affects the list movementRestrictionTerritories. defaults to null
+            movementRestrictionTerritories              values: a colon (":") delimited list of territories that the player either can not move into, or can not move outside of
+            productionPerXTerritories                   values: gives units to a player as part of NoPuPurchase delegate.  You can have multiple instances of productionPerXTerritories.
+                                                                    value = the name of the unit, and count = the number of territories you need to get 1 of that unit.  if the name of the unit is missing, it defaults to "infantry"
+            placementAnyTerritory                       values: "true" or "false", can you place in any LAND territory you owned at the beginning of the turn?
+            placementAnySeaZone                         values: "true" or "false", can you place in any SEA territory beside a LAND territory you owned at the beginning of the turn?
+            placementCapturedTerritory                  values: "true" or "false", can you place in territory you captured this turn?
+            placementPerTerritory                       values: governs if you can or can not place in that territory, based on the number of owned units in that territory.  You may place in any territory with LESS units than the given value
+                                                                    A value greater than Zero is required to be able to produce infinite units (or infinite up to maxPlacePerTerritory, which you can set too)
+            maxPlacePerTerritory                        values: governs the max you may place per turn per territory (can override factory rules and infinite placement rules)
+            unlimitedProduction                         values: will turn off warnings about purchasing more units than you can place. does not actually do anything to the game.
+            dominatingFirstRoundAttack                  values: means that the very first round of the game, all enemies defend on a "1" instead of their normal defense.
+            negateDominatingFirstRoundAttack            values: means that this player is not affected by the dominatingFirstRoundAttack
+            placementInCapitalRestricted                values: means that the player may only place units in their capitol
+    -->
+    <!-- Chinese Rules -->
+                <attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                    <option name="movementRestrictionTerritories" value="Sinkiang:Central China:China:Manchuria:Kwangtung:French Indochina"/>
+                    <option name="movementRestrictionType" value="allowed"/>
+                    <!-- productionPerXTerritories gives units to a player as part of NoPuPurchase delegate.  You can have multiple instances of productionPerXTerritories.
+                            value = the name of the unit, and count = the number of territories you need to get 1 of that unit.  if the name of the unit is missing, it defaults to "infantry" -->
+                    <option name="productionPerXTerritories" value="infantry" count="2"/>
+                    <!--<option name="productionPerXTerritories" value="fighter" count="6"/>-->
+                    <!-- if you are using productionPerXTerritories, you can have only territories worth at least 1 pu count towards the X by setting the game property "Production Per Valued Territory Restricted".
+                            the amount produced will be increased by 1 infantry if you are using PacificTheater and you control territories called "India", "Burma", "Yunnan", "Szechwan" -->
+                    <option name="placementAnyTerritory" value="true"/>
+                    <option name="placementCapturedTerritory" value="true"/>
+                    <!-- placementPerTerritory governs if you can or can not place in that territory, based on the number of owned units in that territory.  You may place in any territory with LESS units than the given value
+                            A value greater than Zero is required to be able to produce infinite units (or infinite up to maxPlacePerTerritory, which you can set too) -->
+                    <option name="placementPerTerritory" value="4"/>
+                    <!-- maxPlacePerTerritory governs the max you may place per turn per territory (can override factory rules and infinite placement rules) -->
+                    <option name="maxPlacePerTerritory" value="2"/>
+                    <option name="unlimitedProduction" value="true"/>
+                    <!-- dominatingFirstRoundAttack means that the very first round of the game, all enemies defend on a "1" instead of their normal defense. negateDominatingFirstRoundAttack means that this player is not affected by the dominatingFirstRoundAttack
+                    <option name="dominatingFirstRoundAttack" value="true"/>
+                    <option name="negateDominatingFirstRoundAttack" value="true"/> -->
+                    <!-- placementInCapitalRestricted means that the player may only place units in their capitol
+                    <option name="placementInCapitalRestricted" value="true"/> -->
                 </attachment>
-				
+
 <!-- Player Attachments -->
-	<!-- the following options are allowed for "playerAttachment"
-			giveUnitControl						values: allow multiple players to give units to multiple other players, if those units are in a designated territory 
-															must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
-			captureUnitOnEnteringBy				values: allows multiple players to let their units be captured by multiple other players, if those units are in a designated territory and a designated player captures that territory
-															must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
-			destroysPUs							values: means that when this player loses their capital, their PUs are destroyed instead of captured (defaults to false = capture the PUs)
-			retainCapitalNumber					values: means that we do not lose our money if we still control at least this many of our capitals (defaults to 1). 
-															If a player has no playerAttachment, then it defaults to X, where X = total number of capitals (ie: you lose your money if a single capital is captured)
-			retainCapitalProduceNumber			values: is similar to above, but only affect gaining income and producing units (probably should be less than or equal to retainCapitalNumber) 
-															If a player has no playerAttachment, then it defaults to 1 (ie: you keep collecting and producing units so long as you control at least 1 capital)
-			suicideAttackResources				values: the first value is the resource we wish to use for the suicide attacks, and the count is the attack value each of that resource has when used in Kamikaze Suicide Attacks
-															The attacks happen during an opponents turn at the beginning of the battle step, so for example Japan may launch these attacks after the American combat move. The attacks target specific warships for destruction.
-															These attacks only occur in territories that are designated as kamikazeZone, and the attacks will be done by the original owner of that territory (owner when the game started, make sure to set it in the ownerInitialize)
-															Currently the attacks only target units owned by the current player, and must be surface warships (not subs, not transports) [I plan to let you specify which units later, and let you target land units too].
-															examples: <option name="suicideAttackResources" value="SuicideAttackTokens" count="2"/> (
-			vps									values: not sure if it works
-			captureVps							values: not sure if it works
-	-->
-				<!-- Currently "vps" and "captureVps" do not work. if they work in the future they will follow original pacific rules
-				<attachment name="playerAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
-					<option name="vps" value="0"/>
-					<option name="captureVps" value="0"/>
-				</attachment> -->
-				
-				<attachment name="playerAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
-					<!-- destroysPUs means that when this player loses their capital, their PUs are destroyed instead of captured (defaults to false = capture the PUs) -->
-					<option name="destroysPUs" value="true"/>
-					<!-- retainCapitalNumber means that we do not lose our money if we still control at least this many of our capitals (defaults to 1). 
-						If a player has no playerAttachment, then it defaults to X, where X = total number of capitals (ie: you lose your money if a single capital is captured) -->
-					<!-- <option name="retainCapitalNumber" value="2"/> -->
-					<!-- retainCapitalProduceNumber is similar to above, but only affect gaining income and producing units (probably should be less than or equal to retainCapitalNumber) 
-						If a player has no playerAttachment, then it defaults to 1 (ie: you keep collecting and producing units so long as you control at least 1 capital) -->
-					<!-- <option name="retainCapitalProduceNumber" value="1"/> -->
-				</attachment>
-				
-				<attachment name="playerAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
-					<!-- giveUnitControl allow multiple players to give units to multiple other players, if those units are in a designated territory 
-							must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"-->
-					<option name="giveUnitControl" value="Russians"/>
-				</attachment>
-				
-				<!--<attachment name="playerAttachment" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
-					   <- captureUnitOnEnteringBy allows multiple players to let their units be captured by multiple other players, if those units are in a designated territory and a designated player captures that territory
-							must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
-					<option name="captureUnitOnEnteringBy" value="Americans:British"/>
-				</attachment>-->
-				
+    <!-- the following options are allowed for "playerAttachment"
+            giveUnitControl                     values: allow multiple players to give units to multiple other players, if those units are in a designated territory
+                                                            must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
+            captureUnitOnEnteringBy             values: allows multiple players to let their units be captured by multiple other players, if those units are in a designated territory and a designated player captures that territory
+                                                            must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
+            destroysPUs                         values: means that when this player loses their capital, their PUs are destroyed instead of captured (defaults to false = capture the PUs)
+            retainCapitalNumber                 values: means that we do not lose our money if we still control at least this many of our capitals (defaults to 1).
+                                                            If a player has no playerAttachment, then it defaults to X, where X = total number of capitals (ie: you lose your money if a single capital is captured)
+            retainCapitalProduceNumber          values: is similar to above, but only affect gaining income and producing units (probably should be less than or equal to retainCapitalNumber)
+                                                            If a player has no playerAttachment, then it defaults to 1 (ie: you keep collecting and producing units so long as you control at least 1 capital)
+            suicideAttackResources              values: the first value is the resource we wish to use for the suicide attacks, and the count is the attack value each of that resource has when used in Kamikaze Suicide Attacks
+                                                            The attacks happen during an opponents turn at the beginning of the battle step, so for example Japan may launch these attacks after the American combat move. The attacks target specific warships for destruction.
+                                                            These attacks only occur in territories that are designated as kamikazeZone, and the attacks will be done by the original owner of that territory (owner when the game started, make sure to set it in the ownerInitialize)
+                                                            Currently the attacks only target units owned by the current player, and must be surface warships (not subs, not transports) [I plan to let you specify which units later, and let you target land units too].
+                                                            examples: <option name="suicideAttackResources" value="SuicideAttackTokens" count="2"/> (
+            vps                                 values: not sure if it works
+            captureVps                          values: not sure if it works
+    -->
+                <!-- Currently "vps" and "captureVps" do not work. if they work in the future they will follow original pacific rules
+                <attachment name="playerAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
+                    <option name="vps" value="0"/>
+                    <option name="captureVps" value="0"/>
+                </attachment> -->
+
+                <attachment name="playerAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
+                    <!-- destroysPUs means that when this player loses their capital, their PUs are destroyed instead of captured (defaults to false = capture the PUs) -->
+                    <option name="destroysPUs" value="true"/>
+                    <!-- retainCapitalNumber means that we do not lose our money if we still control at least this many of our capitals (defaults to 1).
+                        If a player has no playerAttachment, then it defaults to X, where X = total number of capitals (ie: you lose your money if a single capital is captured) -->
+                    <!-- <option name="retainCapitalNumber" value="2"/> -->
+                    <!-- retainCapitalProduceNumber is similar to above, but only affect gaining income and producing units (probably should be less than or equal to retainCapitalNumber)
+                        If a player has no playerAttachment, then it defaults to 1 (ie: you keep collecting and producing units so long as you control at least 1 capital) -->
+                    <!-- <option name="retainCapitalProduceNumber" value="1"/> -->
+                </attachment>
+
+                <attachment name="playerAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
+                    <!-- giveUnitControl allow multiple players to give units to multiple other players, if those units are in a designated territory
+                            must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"-->
+                    <option name="giveUnitControl" value="Russians"/>
+                </attachment>
+
+                <!--<attachment name="playerAttachment" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
+                       <- captureUnitOnEnteringBy allows multiple players to let their units be captured by multiple other players, if those units are in a designated territory and a designated player captures that territory
+                            must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"
+                    <option name="captureUnitOnEnteringBy" value="Americans:British"/>
+                </attachment>-->
+
 <!-- Political Action Attachments -->
-	<!-- the following options are allowed for "politicalActionAttachmentXXX"
-			conditions							value: 	this is a colon delimited list of conditions, and this politicalActionAttachment is only active (thus can be performed) if this returns true
-			conditionType 						value: 	AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the trigger. 
-														AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
-			invert 								value: 	true or false. default if missing is false. if true, the condition will be reversed (does not reverse the effect)
-														This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
-			relationshipChange					value: 	the relationshipType that will exist after the action is succesful between the player and the otherPlayer format: "player1:player2:relationship"
-														You can add multiple relationshipchanges per attachment
-			chance								value: 	diceroll:dicesides to hit for this action to succeed for example "1:6" for the action to succeed 1 out of 6 times
-			costPU								value: 	ammount of PU you will be charged to attempt this action
-			text								value: 	a KEY referring to politicstext.properties to indicate the texts used for regarding this action
-			actionAccept						value: 	a list of players that must accept this action before it takes effect (handy for peacetreaties)
-			attemptsPerTurn						value: 	the number of times this action can be attempted per round (default: 1)
-	-->
-	     		<attachment name="politicalActionAttachmentItaliansDeclareWarOnRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-	     			<option name="conditions" value="conditionAttachmentRussiansNeutralItaliansFor2Turns"/>
-	     			<option name="relationshipChange" value="Italians:Russians:War"/>
-	     			<option name="text" value="ITALY_DECLAREWAR_RUSSIA"/>
-	     			<option name="chance" value="6:6"/>
-	     			<option name="costPU" value="0"/>
-					<option name="attemptsPerTurn" value="1"/>
-	     		</attachment>
-	     		<attachment name="politicalActionAttachmentItaliansProposeCeasefireRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-	     			<option name="conditions" value="conditionAttachmentRussiansWarItalians"/>
-	     			<option name="relationshipChange" value="Italians:Russians:Neutrality"/>
-	     			<option name="text" value="ITALY_PROPOSEPEACE_RUSSIA"/>
-	     			<option name="chance" value="6:6"/>
-	     			<option name="costPU" value="0"/>
-	     			<option name="actionAccept" value="Russians"/>
-	     			<option name="attemptsPerTurn" value="1"/>
-	     		</attachment>
-	     		<attachment name="politicalActionAttachmentItaliansDeclareWarOnChineseAndAmericans" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-	     			<option name="conditions" value="conditionAttachmentChineseNeutralItalians"/>
-	     			<option name="relationshipChange" value="Italians:Chinese:War"/>
-	     			<option name="relationshipChange" value="Italians:Americans:War"/>
-	     			<option name="text" value="ITALY_DECLAREWAR_CHINA_USA"/>
-	     			<option name="chance" value="2:6"/>
-	     			<option name="costPU" value="0"/>
-					<option name="attemptsPerTurn" value="1"/>
-	     		</attachment>
-	     		<attachment name="politicalActionAttachmentJapaneseDeclareWarOnRussians" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-	     			<option name="conditions" value="conditionAttachmentRussiansNeutralJapan"/>
-	     			<option name="relationshipChange" value="Japanese:Russians:War"/>
-	     			<option name="text" value="JAPANESE_DECLAREWAR_RUSSIANS"/>
-	     			<option name="chance" value="6:6"/>
-	     			<option name="costPU" value="0"/>
-					<option name="attemptsPerTurn" value="1"/>
-	     		</attachment>
-	     		<attachment name="politicalActionAttachmentRussiansDeclareWarOnItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-	     			<option name="conditions" value="conditionAttachmentRussiansNeutralItaliansFor2Turns"/>
-	     			<option name="relationshipChange" value="Italians:Russians:War"/>
-	     			<option name="text" value="RUSSIANS_DECLAREWAR_ITALIANS"/>
-	     			<option name="chance" value="6:6"/>
-	     			<option name="costPU" value="0"/>
-					<option name="attemptsPerTurn" value="1"/>
-	     		</attachment>
-	     		<attachment name="politicalActionAttachmentRussiansDeclareWarOnJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-	     			<option name="conditions" value="conditionAttachmentRussiansNeutralJapan"/>
-	     			<option name="relationshipChange" value="Japanese:Russians:War"/>
-	     			<option name="text" value="RUSSIANS_DECLAREWAR_JAPANESE"/>
-	     			<option name="chance" value="6:6"/>
-	     			<option name="costPU" value="0"/>
-					<option name="attemptsPerTurn" value="1"/>
-	     		</attachment>
-	     		<attachment name="politicalActionAttachmentRussiansAllyWithAmericansAndBritish" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-	     			<option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
-	     			<option name="relationshipChange" value="Americans:Russians:Allied"/>
-	     			<option name="relationshipChange" value="British:Russians:Allied"/>
-	     			<option name="text" value="RUSSIANS_ALLY_AMERICANS_BRITISH"/>
-	     			<option name="chance" value="6:6"/>
-	     			<option name="costPU" value="1"/>
-					<option name="attemptsPerTurn" value="1"/>
-	     			<option name="actionAccept" value="Americans:British"/>
-	     		</attachment>
-	     		<attachment name="politicalActionAttachmentBritishAndAmericansAllyWithRussians" attachTo="British" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-	     			<option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
-	     			<option name="relationshipChange" value="Americans:Russians:Allied"/>
-	     			<option name="relationshipChange" value="British:Russians:Allied"/>
-	     			<option name="text" value="AMERICANS_BRITISH_ALLY_RUSSIANS"/>
-	     			<option name="chance" value="6:6"/>
-	     			<option name="costPU" value="2"/>
-					<option name="attemptsPerTurn" value="1"/>
-	     			<option name="actionAccept" value="Russians"/>
-	     		</attachment>
-	     		<attachment name="politicalActionAttachmentAmericansAndBritishAllyWithRussians" attachTo="Americans" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-	     			<option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
-	     			<option name="relationshipChange" value="Americans:Russians:Allied"/>
-	     			<option name="relationshipChange" value="British:Russians:Allied"/>
-	     			<option name="text" value="AMERICANS_BRITISH_ALLY_RUSSIANS"/>
-	     			<option name="chance" value="6:6"/>
-	     			<option name="costPU" value="3"/>
-					<option name="attemptsPerTurn" value="1"/>
-	     			<option name="actionAccept" value="Russians"/>
-	     		</attachment>
+    <!-- the following options are allowed for "politicalActionAttachmentXXX"
+            conditions                          value:  this is a colon delimited list of conditions, and this politicalActionAttachment is only active (thus can be performed) if this returns true
+            conditionType                       value:  AND, OR, XOR, y, y-z.  Defaults to AND if missing. Defines the relationship the conditions must have if there are more than one condition or rules attachment in the trigger.
+                                                        AND means all conditions must be true, OR means just one condition must be true, XOR means that only one condition must be true while all others must be false. 'y' is an exact number of conditions, and 'y-z' is a range of numbers.
+            invert                              value:  true or false. default if missing is false. if true, the condition will be reversed (does not reverse the effect)
+                                                        This reverses the result of boolean result of this entire objectiveAttachment/conditionAttachment, and is considered a logical negation.
+            relationshipChange                  value:  the relationshipType that will exist after the action is succesful between the player and the otherPlayer format: "player1:player2:relationship"
+                                                        You can add multiple relationshipchanges per attachment
+            chance                              value:  diceroll:dicesides to hit for this action to succeed for example "1:6" for the action to succeed 1 out of 6 times
+            costPU                              value:  ammount of PU you will be charged to attempt this action
+            text                                value:  a KEY referring to politicstext.properties to indicate the texts used for regarding this action
+            actionAccept                        value:  a list of players that must accept this action before it takes effect (handy for peacetreaties)
+            attemptsPerTurn                     value:  the number of times this action can be attempted per round (default: 1)
+    -->
+                <attachment name="politicalActionAttachmentItaliansDeclareWarOnRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussiansNeutralItaliansFor2Turns"/>
+                    <option name="relationshipChange" value="Italians:Russians:War"/>
+                    <option name="text" value="ITALY_DECLAREWAR_RUSSIA"/>
+                    <option name="chance" value="6:6"/>
+                    <option name="costPU" value="0"/>
+                    <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentItaliansProposeCeasefireRussians" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussiansWarItalians"/>
+                    <option name="relationshipChange" value="Italians:Russians:Neutrality"/>
+                    <option name="text" value="ITALY_PROPOSEPEACE_RUSSIA"/>
+                    <option name="chance" value="6:6"/>
+                    <option name="costPU" value="0"/>
+                    <option name="actionAccept" value="Russians"/>
+                    <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentItaliansDeclareWarOnChineseAndAmericans" attachTo="Italians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentChineseNeutralItalians"/>
+                    <option name="relationshipChange" value="Italians:Chinese:War"/>
+                    <option name="relationshipChange" value="Italians:Americans:War"/>
+                    <option name="text" value="ITALY_DECLAREWAR_CHINA_USA"/>
+                    <option name="chance" value="2:6"/>
+                    <option name="costPU" value="0"/>
+                    <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentJapaneseDeclareWarOnRussians" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussiansNeutralJapan"/>
+                    <option name="relationshipChange" value="Japanese:Russians:War"/>
+                    <option name="text" value="JAPANESE_DECLAREWAR_RUSSIANS"/>
+                    <option name="chance" value="6:6"/>
+                    <option name="costPU" value="0"/>
+                    <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentRussiansDeclareWarOnItalians" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussiansNeutralItaliansFor2Turns"/>
+                    <option name="relationshipChange" value="Italians:Russians:War"/>
+                    <option name="text" value="RUSSIANS_DECLAREWAR_ITALIANS"/>
+                    <option name="chance" value="6:6"/>
+                    <option name="costPU" value="0"/>
+                    <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentRussiansDeclareWarOnJapanese" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussiansNeutralJapan"/>
+                    <option name="relationshipChange" value="Japanese:Russians:War"/>
+                    <option name="text" value="RUSSIANS_DECLAREWAR_JAPANESE"/>
+                    <option name="chance" value="6:6"/>
+                    <option name="costPU" value="0"/>
+                    <option name="attemptsPerTurn" value="1"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentRussiansAllyWithAmericansAndBritish" attachTo="Russians" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
+                    <option name="relationshipChange" value="Americans:Russians:Allied"/>
+                    <option name="relationshipChange" value="British:Russians:Allied"/>
+                    <option name="text" value="RUSSIANS_ALLY_AMERICANS_BRITISH"/>
+                    <option name="chance" value="6:6"/>
+                    <option name="costPU" value="1"/>
+                    <option name="attemptsPerTurn" value="1"/>
+                    <option name="actionAccept" value="Americans:British"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentBritishAndAmericansAllyWithRussians" attachTo="British" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
+                    <option name="relationshipChange" value="Americans:Russians:Allied"/>
+                    <option name="relationshipChange" value="British:Russians:Allied"/>
+                    <option name="text" value="AMERICANS_BRITISH_ALLY_RUSSIANS"/>
+                    <option name="chance" value="6:6"/>
+                    <option name="costPU" value="2"/>
+                    <option name="attemptsPerTurn" value="1"/>
+                    <option name="actionAccept" value="Russians"/>
+                </attachment>
+                <attachment name="politicalActionAttachmentAmericansAndBritishAllyWithRussians" attachTo="Americans" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentRussiansNeutralAmericans"/>
+                    <option name="relationshipChange" value="Americans:Russians:Allied"/>
+                    <option name="relationshipChange" value="British:Russians:Allied"/>
+                    <option name="text" value="AMERICANS_BRITISH_ALLY_RUSSIANS"/>
+                    <option name="chance" value="6:6"/>
+                    <option name="costPU" value="3"/>
+                    <option name="attemptsPerTurn" value="1"/>
+                    <option name="actionAccept" value="Russians"/>
+                </attachment>
 
         </attachmentList>
 
-		
+
         <initialize>
                 <ownerInitialize>
                         <!-- Italian Owned Territories -->
@@ -4171,7 +4171,7 @@
                         <territoryOwner territory="Eastern Europe" owner="Germans"/>
                         <territoryOwner territory="Belorussia" owner="Germans"/>
                         <territoryOwner territory="West Russia" owner="Germans"/>
-					
+
                         <territoryOwner territory="5 Sea Zone" owner="Germans"/>
                         <territoryOwner territory="6 Sea Zone" owner="Germans"/>
 
@@ -4186,7 +4186,7 @@
                         <territoryOwner territory="Yakut S.S.R." owner="Russians"/>
                         <territoryOwner territory="Soviet Far East" owner="Russians"/>
                         <territoryOwner territory="Burytia S.S.R." owner="Russians"/>
-					
+
                         <territoryOwner territory="3 Sea Zone" owner="Germans"/>
                         <territoryOwner territory="4 Sea Zone" owner="Russians"/>
 
@@ -4222,7 +4222,7 @@
                         <territoryOwner territory="Solomon Islands" owner="Japanese"/>
                         <territoryOwner territory="Okinawa" owner="Japanese"/>
                         <territoryOwner territory="Wake Island" owner="Japanese"/>
-					
+
                         <!--<territoryOwner territory="37 Sea Zone" owner="Japanese"/>
                         <territoryOwner territory="47 Sea Zone" owner="Japanese"/>
                         <territoryOwner territory="48 Sea Zone" owner="Japanese"/>
@@ -4241,7 +4241,7 @@
                         <territoryOwner territory="West Indies" owner="Americans"/>
                         <territoryOwner territory="Panama" owner="Americans"/>
                         <territoryOwner territory="Greenland" owner="Americans"/>
-						
+
                         <!-- Chinese Owned Territories -->
                         <territoryOwner territory="China" owner="Chinese"/>
                         <territoryOwner territory="Central China" owner="Chinese"/>
@@ -4289,7 +4289,7 @@
                         <unitPlacement unitType="infantry" territory="West Balkans" quantity="1" owner="Italians"/>
                         <unitPlacement unitType="infantry" territory="Sicily" quantity="1" owner="Italians"/>
                         <unitPlacement unitType="infantry" territory="Sardinia" quantity="1" owner="Italians"/>
-                        
+
 
                         <!-- German Unit Placements -->
                         <unitPlacement unitType="aaGun" territory="Western Europe" quantity="1" owner="Germans"/>
@@ -4349,7 +4349,7 @@
                         <unitPlacement unitType="infantry" territory="Australia" quantity="3" owner="British"/>
                         <unitPlacement unitType="infantry" territory="New Zealand" quantity="1" owner="British"/>
                         <unitPlacement unitType="infantry" territory="Western Canada" quantity="1" owner="British"/>
-                    	<unitPlacement unitType="infantry" territory="French Madagascar" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="French Madagascar" quantity="1" owner="British"/>
                         <unitPlacement unitType="transport" territory="1 Sea Zone" quantity="1" owner="British"/>
                         <unitPlacement unitType="destroyer" territory="1 Sea Zone" quantity="1" owner="British"/>
                         <unitPlacement unitType="destroyer" territory="1 Sea Zone" quantity="1" owner="British"/>
@@ -4409,13 +4409,13 @@
                         <unitPlacement unitType="infantry" territory="Midway" quantity="1" owner="Americans"/>
                         <unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="2" owner="Americans"/>
                         <unitPlacement unitType="aaGun" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Alaska" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Alaska" quantity="1" owner="Americans"/>
                         <unitPlacement unitType="aaGun" territory="Western United States" quantity="1" owner="Americans"/>
                         <unitPlacement unitType="factory" territory="Western United States" quantity="1" owner="Americans"/>
                         <unitPlacement unitType="infantry" territory="Western United States" quantity="3" owner="Americans"/>
                         <unitPlacement unitType="fighter" territory="Western United States" quantity="1" owner="Americans"/>
                         <unitPlacement unitType="infantry" territory="Central United States" quantity="3" owner="Americans"/>
-						<unitPlacement unitType="armour" territory="Central United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="armour" territory="Central United States" quantity="1" owner="Americans"/>
                         <unitPlacement unitType="transport" territory="10 Sea Zone" quantity="2" owner="Americans"/>
                         <unitPlacement unitType="destroyer" territory="55 Sea Zone" quantity="1" owner="Americans"/>
                         <unitPlacement unitType="destroyer" territory="10 Sea Zone" quantity="1" owner="Americans"/>
@@ -4424,7 +4424,7 @@
                         <unitPlacement unitType="fighter" territory="56 Sea Zone" quantity="2" owner="Americans"/>
                         <unitPlacement unitType="carrier" territory="56 Sea Zone" quantity="1" owner="Americans"/>
                         <unitPlacement unitType="submarine" territory="56 Sea Zone" quantity="1" owner="Americans"/>
-						
+
                         <!-- Chinese Unit Placements -->
                         <unitPlacement unitType="infantry" territory="China" quantity="2" owner="Chinese"/>
                         <unitPlacement unitType="fighter" territory="China" quantity="1" owner="Chinese"/>
@@ -4434,7 +4434,7 @@
                 </unitInitialize>
 
                 <resourceInitialize>
-						<!-- these do not have to match the production of the game starting out, they can be any number -->
+                        <!-- these do not have to match the production of the game starting out, they can be any number -->
                         <resourceGiven player="Japanese" resource="PUs" quantity="30"/>
                         <resourceGiven player="British" resource="PUs" quantity="33"/>
                         <resourceGiven player="Americans" resource="PUs" quantity="37"/>
@@ -4443,831 +4443,831 @@
                         <resourceGiven player="Italians" resource="PUs" quantity="16"/>
                         <resourceGiven player="Chinese" resource="PUs" quantity="0"/>
 
-						<resourceGiven player="Italians" resource="Fuel" quantity="20"/>
-						<resourceGiven player="Italians" resource="Ore" quantity="20"/>
-						
+                        <resourceGiven player="Italians" resource="Fuel" quantity="20"/>
+                        <resourceGiven player="Italians" resource="Ore" quantity="20"/>
+
                 </resourceInitialize>
 
-				<relationshipInitialize>
-						<!-- the order of player1 and player2 does not matter. roundValue is only used for conditions and can be positive or negative (use "1" if you don't know what you are doing).
-								having them listed twice in different orders will just have the later one overwrite the earlier one.
-								Make sure you cover all possibilities! (the number of possibilities is equal to the triangular number sequence: 1,3,6,10,15,21,28,36,45,55,66,78,91,105,120)
-						-->
-						
-						<relationship type="Allied" player1="Italians" player2="Germans" roundValue="1"/>
-						<relationship type="Allied" player1="Italians" player2="Japanese" roundValue="1"/>
-						<relationship type="Allied" player1="Germans" player2="Japanese" roundValue="1"/>
+                <relationshipInitialize>
+                        <!-- the order of player1 and player2 does not matter. roundValue is only used for conditions and can be positive or negative (use "1" if you don't know what you are doing).
+                                having them listed twice in different orders will just have the later one overwrite the earlier one.
+                                Make sure you cover all possibilities! (the number of possibilities is equal to the triangular number sequence: 1,3,6,10,15,21,28,36,45,55,66,78,91,105,120)
+                        -->
 
-						<relationship type="Neutrality" player1="Russians" player2="British" roundValue="1"/>
-						<relationship type="Neutrality" player1="Russians" player2="Americans" roundValue="1"/>
-						<relationship type="Allied" player1="Russians" player2="Chinese" roundValue="1"/>
-						<relationship type="Allied" player1="Americans" player2="British" roundValue="1"/>
-						<relationship type="Allied" player1="Americans" player2="Chinese" roundValue="1"/>
-						<relationship type="Allied" player1="British" player2="Chinese" roundValue="1"/>
+                        <relationship type="Allied" player1="Italians" player2="Germans" roundValue="1"/>
+                        <relationship type="Allied" player1="Italians" player2="Japanese" roundValue="1"/>
+                        <relationship type="Allied" player1="Germans" player2="Japanese" roundValue="1"/>
 
-						<relationship type="War" player1="British" player2="Germans" roundValue="1"/>
-						<relationship type="War" player1="British" player2="Italians" roundValue="1"/>
-						<relationship type="War" player1="British" player2="Japanese" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Russians" player2="British" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Russians" player2="Americans" roundValue="1"/>
+                        <relationship type="Allied" player1="Russians" player2="Chinese" roundValue="1"/>
+                        <relationship type="Allied" player1="Americans" player2="British" roundValue="1"/>
+                        <relationship type="Allied" player1="Americans" player2="Chinese" roundValue="1"/>
+                        <relationship type="Allied" player1="British" player2="Chinese" roundValue="1"/>
 
-						<relationship type="War" player1="Americans" player2="Germans" roundValue="1"/>
-						<relationship type="War" player1="Americans" player2="Italians" roundValue="1"/>
-						<relationship type="War" player1="Americans" player2="Japanese" roundValue="1"/>
+                        <relationship type="War" player1="British" player2="Germans" roundValue="1"/>
+                        <relationship type="War" player1="British" player2="Italians" roundValue="1"/>
+                        <relationship type="War" player1="British" player2="Japanese" roundValue="1"/>
 
-						<relationship type="War" player1="Russians" player2="Germans" roundValue="1"/>
-						<relationship type="War" player1="Russians" player2="Italians" roundValue="-1"/>
-						<relationship type="Neutrality" player1="Russians" player2="Japanese" roundValue="1"/>
-						<!--<relationship type="Neutrality" player1="Russians" player2="Germans" roundValue="1"/>
-						<relationship type="Allied" player1="Russians" player2="Italians" roundValue="1"/>
-						<relationship type="Neutrality" player1="Russians" player2="Japanese" roundValue="1"/>-->
+                        <relationship type="War" player1="Americans" player2="Germans" roundValue="1"/>
+                        <relationship type="War" player1="Americans" player2="Italians" roundValue="1"/>
+                        <relationship type="War" player1="Americans" player2="Japanese" roundValue="1"/>
 
-						<relationship type="War" player1="Chinese" player2="Germans" roundValue="1"/>
-						<relationship type="War" player1="Chinese" player2="Italians" roundValue="1"/>
-						<relationship type="War" player1="Chinese" player2="Japanese" roundValue="1"/>
-				</relationshipInitialize>
+                        <relationship type="War" player1="Russians" player2="Germans" roundValue="1"/>
+                        <relationship type="War" player1="Russians" player2="Italians" roundValue="-1"/>
+                        <relationship type="Neutrality" player1="Russians" player2="Japanese" roundValue="1"/>
+                        <!--<relationship type="Neutrality" player1="Russians" player2="Germans" roundValue="1"/>
+                        <relationship type="Allied" player1="Russians" player2="Italians" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Russians" player2="Japanese" roundValue="1"/>-->
+
+                        <relationship type="War" player1="Chinese" player2="Germans" roundValue="1"/>
+                        <relationship type="War" player1="Chinese" player2="Italians" roundValue="1"/>
+                        <relationship type="War" player1="Chinese" player2="Japanese" roundValue="1"/>
+                </relationshipInitialize>
 
         </initialize>
 
-		<propertyList>
-				<!-- PLEASE KEEP YOUR PROPERTIES IN THIS ORDER!!! -->
-				<!-- TYPICAL OPTIONAL PROPERTIES -->
-				<!-- Bidding -->
-				<property name="Italians bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Russians bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Germans bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="British bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Japanese bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Americans bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Chinese bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-				
-				<!-- victory options -->
-				<property name="Projection of Power" value="true" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- format of "<alliance> <Name of Victory Condition>" -->
-				<property name="Axis Projection of Power VCs" value="11" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Allies Projection of Power VCs" value="11" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Honorable Surrender" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Axis Honorable Victory VCs" value="12" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Allies Honorable Victory VCs" value="12" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Total Victory" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Axis Total Victory VCs" value="15" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Allies Total Victory VCs" value="15" editable="false">
-						<number min="10" max="15"/>
-				</property>
-
-				<property name="Economic Victory" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Axis Economic Victory" value="120" editable="false">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Allies Economic Victory" value="120" editable="false">
-						<number min="0" max="1000"/>
-				</property>
-
-						<!-- Triggered Victory is a victory condition set by a trigger, using a condition or national objective -->
-				<property name="Triggered Victory" value="true" editable="true">
-						<boolean/>
-				</property>
-				<!-- End of Victory Conditions, rest of typical changed properties below -->
-
-				<property name="Low Luck" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for AntiAircraft" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Technology" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Use Politics" value="true" editable="true">
-						<boolean/>
-				</property>
-				
-						<!-- If this is set, it adds or subtracks from any conditions that require a relationship to last for X rounds -->
-				<property name="Relationships Last Extra Rounds" value="0" editable="true">
-						<number min="-1" max="2"/>
-				</property>
-
-				<property name="Alliances Can Chain Together" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="National Objectives" value="true" editable="true">
-						<boolean/>
-				</property>
-				
-				<property name="Use Triggers" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Tech Development" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Super Sub Defence Bonus" value="0" editable="true">
-						<number min="0" max="1"/>
-				</property>
-
-						<!-- Heavy Bombers will choose best of 2 dice, and if Strat Bombing will add 1 to result -->
-				<property name="LHTR Heavy Bombers" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Heavy Bomber Dice Rolls" value="2" editable="false">
-						<number min="2" max="3"/>
-				</property>
-
-				<property name="Paratroopers Can Move During Non Combat" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Always on AA" value="false" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- Kamikaze Airplanes will allow all air units on the map to use all their movement to get to a battle -->
-				<property name="Kamikaze Airplanes" value="false" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- Use Kamikaze Suicide Attacks allows a player to use resources designated in player attachments to make special attacks -->
-				<property name="Use Kamikaze Suicide Attacks" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Units Repair Hits End Turn" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Units Repair Hits Start Turn" value="false" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- in order to repair, a unit must in the presence of a unit with "repairsUnits" unit attachment -->
-				<property name="Two HitPoint Units Require Repair Facilities" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<!-- Display Options -->
-						<!-- Multiply PUs will multiply all PUs gained or lost during a turn. It will not yet multiply costs of units or any other costs, or starting PUs -->
-				<property name="Multiply PUs" value="1" editable="false">
-						<number min="1" max="10"/>
-				</property>
-
-				<property name="Display Units as Counters" value="0" editable="true">
-						<number min="0" max="10"/>
-				</property>
-
-				<property name="Display Sea Names" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Selectable Zero Movement Units" value="false" editable="false">
-						<boolean/>
-				</property>
-				<!-- END OF TYPICAL OPTIONAL PROPERTIES -->
-
-				<!-- rules and tech -->
-						<!-- ww2v2 rules override many individual rules to create revised rules
-				<property name="WW2V2" value="false" editable="false">
-						<boolean/>
-				</property> -->
-
-				<property name="WW2V3" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="WW2V3 Tech Model" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Selectable Tech Roll" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Use Shipyards turns on the shipyards tech's old way of doing things, which requires that all nations use the same production frontiers. A new way of doing shipywards will require triggers and is currently being coded -->
-				<property name="Use Shipyards" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Scramble Rules In Effect" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scrambled Units Return To Base" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scramble To Sea Only" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scramble From Island Only" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scramble To Any Amphibious Assault" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="All Rockets Attack" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- will only allow a max of 1 rocket to attack each factory -->
-				<property name="Rocket Attack Per Factory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Rockets Can Fly Over Impassables" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Pacific Theater does 4 things: allows nations to gain VictoryPoints by capturing PUs, allows Strategic Bombing to destroy VPs,
-								allows NoPU purchases (ww2v3 does also), and allows an additional purchase in NOPU purchases if you control the Burma Road
-				<property name="Pacific Theater" value="false" editable="false">
-						<boolean/>
-				</property>-->
-
-				<property name="Use Fuel Cost" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<!-- These require an associated value in the attachments section above-->
-				<property name="Movement By Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Production Per X Territories Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- only territories with a production value of 1 or more may count towards the production per x territories -->
-				<property name="Production Per Valued Territory Restricted" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement Per Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Place in Any Territory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unplaced units live when not placed" value ="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Occupied Territories" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- allows a player to give units to another player if true. units must have canBeGivenByTerritory and territories must have changeUnitOwners and the players must have the player attachment giveUnitControl -->
-				<property name="Give Units By Territory" value ="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- allows a player to let its units be captured by another player if true, when the territory is captured. units must have canBeCapturedOnEnteringBy and territories must have captureUnitOnEnteringBy and the players must have the player attachment captureUnitOnEnteringBy -->
-				<property name="Capture Units On Entering Territory" value ="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- if "Capture Units On Entering Territory" is true, then the units can either be captured (default) or destroyed (only if this property below is true: "On Entering Units Destroyed Instead Of Captured") -->
-				<property name="On Entering Units Destroyed Instead Of Captured" value ="false" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- specific rules -->
-				<!-- land related -->
-						<!-- if true, units with destroyedWhenCapturedBy will be destroyed instead of captured. only applies to non-combat units, since combat units die in combat -->
-				<property name="Units Can Be Destroyed Instead Of Captured" value ="true" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- allows units to change into other units using the whenCapturedChangesInto ability -->
-				<property name="Units Can Be Changed On Capture" value ="true" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- if true you may have a number of constructions up to the value of the territory, in territories with factories -->
-				<property name="More Constructions with Factory" value="false" editable="true">
-						<boolean/>
-				</property>
-				
-						<!-- if true you may have a number of constructions up to the value of the territory, in territories without factories -->
-				<property name="More Constructions without Factory" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Unlimited Constructions" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Blitz Through Factories And AA Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- will roll dice for each type of aircraft separately -->
-				<property name="Roll AA Individually" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- random aa casualties lets the engine choose casualties randomly, and allows you to lose 2 bombers if you attack with 2 bombers and some fighters. I do not recommend using this property
-				<property name="Random AA Casualties" value="false" editable="false">
-						<boolean/>
-				</property>-->
-
-				<property name="Choose AA Casualties" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- will only roll aa if aaGun is in the territory getting attacked or bombed -->
-				<property name="AA Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Multiple AA Per Territory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- if false, (all property default to false), then units killed by suicide units can return fire.  if true, they can not return fire -->
-				<property name="Suicide and Munition Casualties Restricted" value="false" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- if suicide units act like normal units on defense, except that they can not die to attacks by other suicide units -->
-				<property name="Defending Suicide and Munition Units Do Not Fire" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Units May Give Bonus Movement allows units with givesMovement to give other units bonus movement-->
-				<property name="Units May Give Bonus Movement" value="true" editable="true">
-						<boolean/>
-				</property>
-				
-				<!-- sea related -->
-				<property name="Partial Amphibious Retreat" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- a subset of partial amphibious retreat, allows attacker to withdraw planes -->
-				<property name="Attacker Retreat Planes" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Shore Bombard Per Ground Unit Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Naval Bombard Casualties Return Fire" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- allows transport units to die under ww2v3 type rules -->
-				<property name="Hari-Kari Units" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- required for all maps, ensures allied aircraft on carriers that are attacking don't attack also -->
-				<property name="Allied Air Dependents" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Surviving Air Move To Land" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Air Attack Sub Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- transports may not unload to multiple territories -->
-				<property name="Transport Restricted Unload" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Ignore Transport In Movement" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Transport Casualties Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unescorted Transport Dies" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- if enabled, transports can capture convoy zones, etc. -->
-				<property name="Transport Control Sea Zone" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Ignore Sub In Movement" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Defending Subs Sneak Attack" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Sub Retreat Before Battle" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Submersible Subs" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Sub Control Sea Zone Restricted should be FALSE if there are any convoy zones! Only true if you want subs to move into owned sea zones during non-combat -->
-				<property name="Sub Control Sea Zone Restricted" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-						<!-- if true, naval units may not move into convoy zones or controlled sea zones during non-combat moves -->
-				<property name="Naval Units May Not NonCombat Move Into Controlled Sea Zones" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- allows sea zones containing mixed allied+enemy units to attack each other without having to move out then back in again -->
-				<property name="Previous Units Fight" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Only affects units exactly called "battleship" -->
-				<property name="Two hit battleship" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- production related -->
-				<property name="Produce fighters on carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Produce new fighters on old carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Move existing fighters to new carriers" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Land existing fighters on new carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- LHTR Carrier rules enable 'Produce fighters on carriers', and 'Produce new fighters on old carriers', and 'Land existing fighters on new carriers', AND it will disable 'Move existing fighters to new carriers' -->
-				<property name="LHTR Carrier production rules" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement In Enemy Seas" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- used to add destroyers and artillery to the ww2v1 map
-				<property name="Use Destroyers and Artillery" value="false" editable="false">
-						<boolean/>
-				</property>-->
-
-						<!-- may only bomb or rocket a factory to a max of its territory value per turn (the individual two parts are below) -->
-				<property name="Territory Turn Limit" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Limit SBR Damage Per Turn" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Limit Rocket Damage Per Turn" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="maxFactoriesPerTerritory" value="1" editable="false">
-						<number min="1" max="100"/>
-				</property>
-
-						<!-- Placement Restricted By Factory warns the player whenever they try to produce more units than their factories can handle (can be turned off for individual players using rules attachments for unlimitedProduction -->
-				<property name="Placement Restricted By Factory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Unit Placement Restrictions are restrictions on the placement of units: unitPlacementRestrictions, unitPlacementOnlyAllowedIn, canOnlyBePlacedInTerritoryValuedAtX, requiresUnits, -->
-				<property name="Unit Placement Restrictions" value="true" editable="false">
-						<boolean/>
-				</property>
-						<!-- Allows Strategic Bombing Raids to have Escort aircraft and also be Intercepted by the defender -->
-				<property name="Raids May Be Preceeded By Air Battles" value="true" editable="true">
-						<boolean/>
-				</property>
-
-						<!-- Damage From Bombing Done To Units Instead Of Territories has Strategic Bombing and Rockets do damage to a territory rather than directly to the player's PUs (the bank) -->
-				<property name="Damage From Bombing Done To Units Instead Of Territories" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- Damage From Bombing Done To Units Instead Of Territories has Strategic Bombing and Rockets do damage to a specific unit rather than directly to the player's PUs or to a territory.  You must have "Damage From Bombing Done To Units Instead Of Territories" false for this to work -->
-				<property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- similar to TTL, except that it is per rocket/aircraft instead of per turn -->
-				<property name="Limit SBR Damage To Factory Production" value="false" editable="false">
-						<boolean/>
-				</property>
-
-						<!-- allows the loss of a victory point for every 10 sbr damage per turn
-				<property name="SBR Victory Points" value="false" editable="false">
-						<boolean/>
-				</property>-->
-
-				<!-- Neutrals related -->
-						<!-- amount of money subtracted to attack a neutral territory, (set neutrals charge to zero if you plan on attacking neutrals) -->
-				<property name="neutralCharge" value="9999999" editable="false">
-						<number min="0" max="9999999"/>
-				</property>
-
-				<property name="Neutrals Are Impassable" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Neutrals Are Blitzable" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Neutral Flyover Allowed" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-				<!-- AI related -->
-				<property name="AI Bonus Income Flat Rate" value="0" editable="true">
-						<number min="-10" max="30"/>
-				</property>
-				
-				<property name="AI Bonus Income Percentage" value="20" editable="true">
-						<number min="-30" max="120"/>
-				</property>
-				
-				<property name="AI Bonus Attack" value="0" editable="true">
-						<number min="0" max="2"/>
-				</property>
-				
-				<property name="AI Bonus Defense" value="0" editable="true">
-						<number min="0" max="2"/>
-				</property>
-
-				<!-- Map Name: also used for map utils when asked (MUST exactly match the folder or zip name of your map (do not include the .zip of course). May point to another map folder if you are making a mod of that map) -->
-				<property name="mapName" value="victory_test" editable="false"/>
-
-				<!-- notes appear in the notes menu in the main screen, format as html -->
-				<property name="notes">
-					<value>
-					<![CDATA[
-						
-						<h2>Pact of Steel 2</h2>
-						<br>A mod of POS by Veqryn
-						<br>
-						<br>The purpose of this map is to provide a fun map that shows off all the newest features TripleA has to offer.
-						<br>
-						<br>This map uses the ww2v3 + LHTR rules as a base, expanding it with various upgrades like triggered bonuses, air scrambling, etc.
-						<br>
-						<br>
-						<br><b>New things:</b>
-						<br>1. Sea Zones 3 and 4, are Russian Convoy Centers. If Russia controls it, they get the income from it. If someone else controls it, that player gets no income from it, but they deny the income to Russia. It can not be captured during non-combat phase.
-        				<br>2. Sea Zones 5 and 6, are Convoy Routes. They are linked to the land territory of Norway. At least one Convoy Zone must be controlled by the same power that controls the land territory for that power to gain the income from the land territory. 
-								They can not be captured during non-combat phase. If more than 1 route is linked to a single land territory, only 1 route needs to be controlled to get the income from land territory. Routes can have PU values just like convoy centers.
-        				<br>3. Sea Zones 37, 47, 48, 49, 58, are Blockade Zones. Each enemy warship in these zones reduces the income of touching land territories by 1 per warship, 2 per normal submarine.
-        				<br>4. Air_Transport is an air unit that specializes in dropping off units, has 4 movement, and can carry into battle or drop off in a friendly territory any 2-3 units. Enabled when you get "paratroopers" tech.
-						<br>5. Super_Carrier is a beefed up carrier that can also transport 1 infantry and 1 other land unit like a tank or artillery. It has only 1 hitpoint, just like normal carriers and cruisers.
-						<br>6. Midget_Submarine is a Japanese only unit with 3 attack, 2 defence, and 2 movement (costs 4). If it attacks or defends it will die after shooting (it is a suicide unit). Japan can purchase them after certain conditions are met, and they don't receive bonus movement from harbours.
-						<br>7. Kamikaze Fighters are what Japanese fighters turn into if certain conditions are met.  They have 5 attack, 3 defense, and 3 movement (cost 8), and they are allowed to use up all their movement to go to a battle, 
-									do not require a landing zone for movement, and they will die after rolling their dice.
-						<br>8. Airfield gives +1 movement to air units, and allows fighters to scramble to defend surrounding sea zones if you turn on "Scramble Rules In Effect".
-						<br>9. Harbour gives +1 movement to warships, and are needed to repair Battleships if you turn on "Two HitPoint Units Require Repair Facilities".
-						<br>10. Bunkers are defensive units that can also be bombed/rocketted, will not participate in battle if damaged, and will die if they reach 4 damage.  
-									They may be placed in any territory you owned at the beginning of the turn (just like Factories, Airfields, and Harbours) where you also have a land unit, but there is a limit of 1 per territory.
-						<br>11. New Technologies: reinforcedHulls (gives +2 defense to subs), and wolfPackTactics (gives +1 att). Available to Germans after they get superSubs.
-						<br>12. Each nation may only purchase factories up to 3 total, if a nation controls more than 3 they can not purchase new factories (they can keep capturing new ones though).
-        				<br>13. Politics phase: alliances and states of war are now dynamic and can be changed in game.  Japan and Russia start out in a state of Neutrality towards each other, while Russia, America and the UK also start out as neutral towards each other.  
-									Japan and Russia will go to war on the 5th turn if they are still neutral by then.  Italy and Russia have the option of declaring a 2 round ceasefire.
-        				<br>14. Strategic Bombing Raids can now have an Air battle preceeding the raid. Fighters escorting the bombers, and any defending interceptors fire at 2, while the bombers fire at 1.  The battle only lasts 1 round.
-        				<br>
-        				<br>
-        				<br>
-						<b>National Objectives</b><br>
-        				<i>Germany: Lebensraum-</i><br>
-        				+4 PUs if Axis control 7 out of 9 of
-							East Balkans, Eastern Europe, Ukraine S.S.R., Belorussia, West Russia, Norway, Karelia S.S.R., Archangel, Caucus<br>
-        				+4 PUs if Axis control Western Europe, AND there are NO enemy surface ships in 3 out of 3 of sea zones 5, 6, and 7<br>
-						* Germany gains Super Subs if at the end of their 4th or 5th turn, there are NO enemy surface ships in 3 out of 3 of
-							sea zones 5, 6, and 7<br>
-        				* Germany gains Mechanized Infantry if at the end of their 3rd or 4th turn, the Axis control 6 out of 7 of
-							East Balkans, Eastern Europe, Ukraine S.S.R., Belorussia, Karelia S.S.R., Archangel, Caucus<br>
-						* Germany gains Rockets if at the end of their 3rd or 4th turn, the Axis do NOT control Western Europe, but DO control Norway<br>
-						* Germany has access to additional submarine technology if they get superSubs, and getting superSubs also gives access to reinforcedHulls to Italians (in place of Shipyards)<br>
-						<br>
-        				<i>Japan: The Greater East Asia Co-Prosperity Sphere-</i><br>
-        				+4 PUs if Axis control 7 out of 7 of India, French Indochina, Kwangtung, Manchuria, China, Central China, Sinkiang<br>
-        				+4 PUs if Axis control 10 out of 13 of Alaska, East Indies, Borneo, Philipine Islands, New Guinea, Solomon Islands,
-							Caroline Islands, Australia, New Zealand, Okinawa, Wake Island, Hawaiian Islands, Midway<br>
-						* Japan's destroyers gain the ability to transport a single infantry If on the 3rd or 4th turn, the Axis do NOT control ANY of
-							Sinkiang, India, Burytia S.S.R.<br>
-						* Japan's transports gain an additional capacity of 1 (allowing 3 infantry or 2 tanks/artillery per transport) If at the end of their 3rd, 4th, or 5th turns,
-							Japan controls 3 out of 3 of Australia, India, Sinkiang<br>
-						* Japan gains, only once, a single additional midget_submarine in sz61 If it loses control over any of its original territories<br>
-						* Japan gains the ability to produce midget_submarines If it loses control over 2 of its islands: Okinawa, Philipine Islands, East Indies, Borneo, New Guinea, Solomon Islands, Caroline Islands, Wake Island<br>
-						* Japan gains the ability to produce kamikaze fighters, and all their current fighters turn into kamikaze fighters 
-							If it loses control over 2 of its islands, one of which being Philipine Islands (note that this objective may or may not be wanted, depending on the situation)<br>
-        				<br>
-        				<i>Italy: Mare Nostrum-</i><br>
-        				+4 PUs if Axis control 8 out of 11 of
-							Western Europe, Sardinia, Sicily, West Balkans, Greece, Algeria, Libya, Anglo Egypt, Trans-Jordan, Italian East Africa, Gibraltar
-							AND no enemy surface ships in sea zones 13, 14, 15, and 15B<br>
-						* Italy gains, only once, a free purchase of a cruiser If at the beginning of their 3rd or 4th turn the Axis control 4 out of 4 of
-							Algeria, Libya, Anglo Egypt, Trans-Jordan<br>
-        				<br>
-        				<i>United States: The Arsenal of Democracy-</i><br>
-						+2-10 PUs, starting on turn 2 America will begin making +2 income as America's war-time economy ramps up. This will increase by +2 more every 2 turns, so that turn 4 will begin making +4, turn 6 will make +6, and so on until +10 is reached<br>
-        				+4 PUs if Allies control 3 out of 8 of Western Europe, Sardinia, Sicily, Italy, Greece, West Balkans, Algeria, Libya
-							AND no enemy surface ships in sea zones 1, 2, 7, 8, 9, 10, 11, 12, 13, and 14<br>
-        				+4 PUs if Allies controls 6 out of 13 of Alaska, East Indies, Borneo, Philipine Islands, New Guinea, Solomon Islands, Caroline Islands,
-							Australia, New Zealand, Okinawa, Wake Island, Hawaiian Islands, Midway<br>
-						+4 PUs if Japan has no Battleships OR no Carriers at the end of USA's turn<br>
-						* USA gains Paratroopers if at the end of Germany's 3rd, 4th or 5th turns, the Allies control Western Europe<br>
-						* USA gains Improved Shipyards if at the end of their 3rd, 4th or 5th turns, USA controls 4 out of 4 of
-							Alaska, Wake Island, Hawaiian Islands, Midway<br>
-						* USA gains War Bonds if at any time before the end of the 8th turn, the above 2 conditions are met at the end of Germany's turn<br>
-						* USA's fighter's gain the ability to support infantry, stackable with artillery, IF at any time the USA has 2 out of 2 of War Bonds and Jet Power technologies<br>
-						* USA can give land units to Russia by landing them in Archangel<br>
-        				<br>
-        				<i>United Kingdom: The British Empire-</i><br>
-        				+4 PUs if the UK controls 1 out of 6 of East Indies, Borneo, New Guinea, Solomon Islands, Caroline Islands, Okinawa<br>
-        				+4 PUs if Allies control 9 out of 11 of Gibraltar, Algeria, Libya, Anglo Egypt, Trans-Jordan, Persia, French West Africa,
-							French Equatorial Africa, Italian East Africa, Belgian Congo, Kenya<br>
-						+4 PUs if Allies control 3 out of 3 of Union of South Africa, India, Australia<br>
-						* UK gains Paratroopers if at the end of Germany's 3rd, 4th or 5th turns, the Allies control Western Europe<br>
-						* UK gains AA Radar if at the end their 3rd or 4th turn, the Allies control 4 out of 5 of
-							Union of South Africa, Gibraltar, Anglo Egypt, India, Australia<br>
-        				<br>
-        				<i>Soviet Union: The Great Patriotic War-</i><br>
-        				+4 PUs if Soviets control 3 out of 5 of Norway, Eastern Europe, East Balkans, Ukraine S.S.R., Belorussia<br>
-        				+4 PUs if Soviets control Archangel and no allied forces in Soviet controlled land territories<br>
-						+2 PUs AND +2 Tech Token, only once, if Soviets control Norway or East Balkans<br>
-        				* Soviet's artillery gain the ability to support 2 infantry on attack If at the end of their 3rd or 4th turn, the Soviets control
-							Karelia S.S.R. and Caucus (this effect can be doubled to 4 infantry supported if Russia gets Improved Artillery technology)<br>
-						* Soviets gain, only once, an additional 3 infantry in Yakut S.S.R. if at the beginning of their turn, Japan controls any original Russian territory<br>
-						* Soviets gain control of any American land units that are in Archangel at the end of America's turn<br>
-						* Soviets have double chance of getting Improved Artillery when rolling for tech<br>
-						* Soviets destroy their industrial production (PUs) instead of letting it be captured, when they lose their capital<br>
-						* Soviets destroy their AA Guns instead of letting them be captured<br>
-						<br>
-						<i>China: Chinese Resistance & The Flying Tigers </i><br>
-        				+1 infantry for every two territories controlled by China at the end of her turn, rounded up. May only place a max of 2 units per territory per turn. 
-							All units must be place in a territory with less than 4 Chinese units<br>
-        				+4 PUs and the ability to produce extra units, if Allies control Sinkiang, Central China, India.
-							May use this money to produce a limited selection of units. May purchase tanks and fighters if these territories are controlled.<br>
-						* China gains 1 infantry in Sinkiang if at the beginning of their turn, there are no enemy units in 3 out of 6 of
-							Sinkiang, Central China, China, Manchuria, Kwangtung, French Indochina. This unit is given at the beginning of combat move step, and can not be moved until next turn.<br>
-						* No Chinese Units, including the Chinese Fighter may leave Chinese territory: Sinkiang, Central China, China, Manchuria, Kwangtung, French Indochina
-							(this means no entering sea zones), unless the Japanese capital has fallen once<br>
-						* Chinese destroy any non-combat units they would otherwise capture (factories, aa guns, harbours, airfields)<br>
-						<br>
-						<br>
-						<b>Technology</b><br>
-         				*** Air/Naval Tech ***<br>
-        				SUPER SUBS- submarine units get +1 attack<br>
-        				JET POWER- fighters and air transports get +1 attack<br>
-        				IMPROVED SHIPYARDS- naval units are cheaper<br>
-        				AA RADAR- AA hit on 2 or less<br>
-        				LONG RANGE AIRCRAFT- aircraft range increased by 2<br>
-        				HEAVY BOMBER- roll 2 dice for each bomber attack (if LHTR enabled: rolls 2 dice and selects the best one, StratBombing adds one to result)<br>
-        				<br>
-         				*** Land/Production Tech ***<br>
-        				IMPROVED ARTILLERY SUPPORT- artillery support 2 infantry (double the support given)<br>
-        				ROCKETS- AA conduct rocket attacks for 1d6 damage to production (each factory may only be targetted once per turn by one rocket, and only 1 rocket in each territory may fire)<br>
-        				PARATROOPERS- each bomber may carry 1 infantry into combat (must stop in first enemy territory it reaches)<br>
-        				INCREASED FACTORY PRODUCTION- factories produce 2 additional units (if territory value is 3 or greater), repairs 1/2 price<br>
-        				WAR BONDS- collect an 1d6 extra PUs each turn<br>
-        				MECHANIZED INFANTRY- tanks may carry 1 infantry each for 2 spaces<br>
-						<br>
-						*** Submarine Technology ***<br>
-						REINFORCED HULLS- submarines get +2 defense (only shows up in battles)<br>
-						WOLF PACK TACTICS- submarines get +1 attack and +1 defense (only shows up in battles)<br>
-						<br>
-						<br>Each nation has at least one technology that they can not research. This is shown by a "-" in the research tab. 
-							The Germans can't research War Bonds, Japanese can't get Shipyards, Russians can't get Paratroopers, 
-							British can't get Mechanized Inf, Americans can't get Rockets, and Italians can't get about half of the techs.
-							Also, UK, Russia, and Italy get Destroyers Bombard instead of Super Subs.
-        				<br>
-        				<br>
-        				<b>Victory Conditions</b><br>
-        				Total Victory - 15 Victory Cities<br>
-        				Projection of Power - 11 Victory Cities<br>
-						Axis can achieve a Triggered Victory by controlling all 4 of Germany, Japan, United Kingdom, and Russia.<br>
-						Allies can achieve a Triggered Victory by controlling all 4 of United Kingdom, Eastern United States, Germany, and Japan.<br>
-						<br>
-        				<br>
-						<br>
-						<br><b>Major Differences Between ww2v2 revised and ww2v3</b>
-						<br>1.  In ww2v2 transport units are just like any other unit, and can be used as fodder by being taken casualty first in combat, however in ww2v3 style rules, transports have no defense power and may only be taken casualty after all other non-transport ships are dead.
-						<br>2.  In ww2v2, you can build fighters on carriers if you build both at the same time, and if you build a carrier you can move existing fighters to carriers when you build a carrier in the adjacent sea zone. In ww2v3, you can build new fighters onto existing
-								carriers as well as new carriers, but you may not move existing fighters onto new carriers, as instead you can non-combat move the fighters to where the carrier will be built, then place the carrier under it.
-						<br>3.  In ww2v2, when you strategic bomb or rocket a factory, you immediately reduce the enemy's PUs. In ww2v3, you do damage to the factory, up to twice the value of the territory. 
-								Each point of damage reduces the number of units that can be produced there by 1. The player may repair the damage during their purchase phase.
-						<br>4.  In ww2v2, when you fly over a territory with an AA Gun, the gun gets to fire at each aircraft. In ww2v3, the AA Gun only fires when you attack or bomb the territory it is in.
-						<br>5.  In ww2v2, submarines and transports block the movement of other sea units. In ww2v3, submarines and transports do not block the movement of other sea units, and may be bypassed or attacked.
-						<br>6.  In ww2v2, technology is rolled for, and if you miss nothing happens. In ww2v3, you buy tech tokens, and at the beginning of your turn you roll for each of your tokens. If you roll a 6, you discard all tokens and roll a second time to see which technology you get.
-						<br>7.  In ww2v2, no land units may retreat from an amphibious assault. In ww2v3, the non-amphibious units may retreat.
-						<br>8.  In ww2v2, bombardment immediately kills units, and you are allowed infinite bombardments. In ww2v3, a unit hit by bombard may return fire against the attacking units before dying, and the number of bombards is limited to the number of land units being dropped off from that sea zone.
-						<br>9.  In ww2v2, air units can hit submarines. In ww2v3, an owned destroyer must be present for air units to hit submarines.
-						<br>10. In ww2v2, submarines may choose to submerge at the end of each round of combat. In ww2v3, they may choose to submerge before each round of combat (and consequently, you can't kill them without a destroyer).
-						<br>11. In ww2v2, submarines fire at the beginning of combat, and if there is no enemy destroyer then any casualties are removed immediately. In ww2v3, submarines get their surprise strike both on offense and defense, and both can be nullified by the presence of an enemy destroyer
-								(so in ww2v3, if attacking an enemy sub, the attacker with a sub + destroyer, who's sub hits, would immediately kill the defending sub with no chance for it to return fire).
-						<br>
-						<br>
-						<br><b>Differences for LHTR rules</b>
-						<br>1. Technology is activated during the Place-Units phase (at the end of the turn rather then the beginning).
-						<br>2. Heavy Bombers roll 2 dice, selecting best one. If strategic bombing, select best of two dice, then add '1' to the result.
-						<br>3. Super Subs get a bonus of '1' to defense in addition to the bonus of '1' to attack.
-						<br>4. LHTR uses same fighter-carrier rules, and aaGun rules, as ww2v3.
-						<br>
-						<br>
-						<br><b>Generic How-To-Play</b>
-						<br>The game is made up of rounds, during a round each player gets to do a number of steps/phases.
-						<br>The phases are, in order: Research Technology, Repair Factories and Purchase Units, Combat Movement, Resolve Battles, Non-Combat Movement, Place Units.
-						<br>At the beginning of your turn, you purchase units. At the end of the turn, you get to place those units in territories you own that have a factory.
-						<br>During Combat Movment, you move any units to attack enemy units and territories. During Non-Combat Movement, you may move any units that have movement left (attacking an enemy remove any movement of land and sea units, but not air units).
-						<br>Battles happen by use of dice. A unit has a certain attack power, and you roll a dice for each unit. If your dice is equal or less than the attack power of the unit, you have scored a hit.
-							So for example, a tank attacks on 3. For it, you will roll a single die, and if you score 1-3 on the die you have hit the enemy, while if you score 4-6 you have missed the enemy. An infantry defends on 2, so a roll of 1-2 is a hit, while 3-6 are misses.
-						<br>After the attacker has rolled dice for each of his units, the defender tallies the total number of 'hits' and then selects which of his defending units will die later. After this, the defender rolls for his units and the attacker selects which of his units will die.
-							When both have finished rolling, the units selected to die are removed from the game. If there are no more attackers left, then the defender has won, and if there are no more defenders left, then the attacker has won and he moves his remaining attacking units into that territory.
-							If both players have units left still, the attack may choose to play another round of battle, or retreat all his remaining forces to a territory where at least one of his forces came from.
-						<br>Players must work with their allies to destroy the enemies, with the game ending when one side surrenders or certain conditions are met (like having captured a clear majority of the major cities).
-						<br>
-						<br>
-						<br>Credits for original POS:
-						<br>Triplelk, DMA02, Iron Cross, Aibrahim, SGB, KC1189, Zero Pilot, Tactics, Underdog
-						<br>A mod by Veqryn
-						<br>Many of the new properties and options were coded by Veqryn.
-						<br>A personal thank you to Squid Daddy and ComradeKev for coding some of the new features that this map shows off
-						<br>Relief Tiles by Conarymor.
-						<br>Only actual unit changes: some destroyers turned into cruisers, and a German destroyer added to sz5, German sub in sz8 moved to sz7.
-						<br>The AIs are meant to be bad at this map, please don't tell me the AIs are bad at this map.
-					]]>
-					</value>
-				</property>
+        <propertyList>
+                <!-- PLEASE KEEP YOUR PROPERTIES IN THIS ORDER!!! -->
+                <!-- TYPICAL OPTIONAL PROPERTIES -->
+                <!-- Bidding -->
+                <property name="Italians bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Russians bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Germans bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="British bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Japanese bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Americans bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Chinese bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <!-- victory options -->
+                <property name="Projection of Power" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- format of "<alliance> <Name of Victory Condition>" -->
+                <property name="Axis Projection of Power VCs" value="11" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Allies Projection of Power VCs" value="11" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Honorable Surrender" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Axis Honorable Victory VCs" value="12" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Allies Honorable Victory VCs" value="12" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Total Victory" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Axis Total Victory VCs" value="15" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Allies Total Victory VCs" value="15" editable="false">
+                        <number min="10" max="15"/>
+                </property>
+
+                <property name="Economic Victory" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Axis Economic Victory" value="120" editable="false">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Allies Economic Victory" value="120" editable="false">
+                        <number min="0" max="1000"/>
+                </property>
+
+                        <!-- Triggered Victory is a victory condition set by a trigger, using a condition or national objective -->
+                <property name="Triggered Victory" value="true" editable="true">
+                        <boolean/>
+                </property>
+                <!-- End of Victory Conditions, rest of typical changed properties below -->
+
+                <property name="Low Luck" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for AntiAircraft" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Technology" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Use Politics" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- If this is set, it adds or subtracks from any conditions that require a relationship to last for X rounds -->
+                <property name="Relationships Last Extra Rounds" value="0" editable="true">
+                        <number min="-1" max="2"/>
+                </property>
+
+                <property name="Alliances Can Chain Together" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="National Objectives" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Use Triggers" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Tech Development" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Super Sub Defence Bonus" value="0" editable="true">
+                        <number min="0" max="1"/>
+                </property>
+
+                        <!-- Heavy Bombers will choose best of 2 dice, and if Strat Bombing will add 1 to result -->
+                <property name="LHTR Heavy Bombers" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Heavy Bomber Dice Rolls" value="2" editable="false">
+                        <number min="2" max="3"/>
+                </property>
+
+                <property name="Paratroopers Can Move During Non Combat" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Always on AA" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- Kamikaze Airplanes will allow all air units on the map to use all their movement to get to a battle -->
+                <property name="Kamikaze Airplanes" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- Use Kamikaze Suicide Attacks allows a player to use resources designated in player attachments to make special attacks -->
+                <property name="Use Kamikaze Suicide Attacks" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Units Repair Hits End Turn" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Units Repair Hits Start Turn" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- in order to repair, a unit must in the presence of a unit with "repairsUnits" unit attachment -->
+                <property name="Two HitPoint Units Require Repair Facilities" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <!-- Display Options -->
+                        <!-- Multiply PUs will multiply all PUs gained or lost during a turn. It will not yet multiply costs of units or any other costs, or starting PUs -->
+                <property name="Multiply PUs" value="1" editable="false">
+                        <number min="1" max="10"/>
+                </property>
+
+                <property name="Display Units as Counters" value="0" editable="true">
+                        <number min="0" max="10"/>
+                </property>
+
+                <property name="Display Sea Names" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Selectable Zero Movement Units" value="false" editable="false">
+                        <boolean/>
+                </property>
+                <!-- END OF TYPICAL OPTIONAL PROPERTIES -->
+
+                <!-- rules and tech -->
+                        <!-- ww2v2 rules override many individual rules to create revised rules
+                <property name="WW2V2" value="false" editable="false">
+                        <boolean/>
+                </property> -->
+
+                <property name="WW2V3" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="WW2V3 Tech Model" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Selectable Tech Roll" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Use Shipyards turns on the shipyards tech's old way of doing things, which requires that all nations use the same production frontiers. A new way of doing shipywards will require triggers and is currently being coded -->
+                <property name="Use Shipyards" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble Rules In Effect" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scrambled Units Return To Base" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble To Sea Only" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble From Island Only" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble To Any Amphibious Assault" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="All Rockets Attack" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- will only allow a max of 1 rocket to attack each factory -->
+                <property name="Rocket Attack Per Factory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Rockets Can Fly Over Impassables" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Pacific Theater does 4 things: allows nations to gain VictoryPoints by capturing PUs, allows Strategic Bombing to destroy VPs,
+                                allows NoPU purchases (ww2v3 does also), and allows an additional purchase in NOPU purchases if you control the Burma Road
+                <property name="Pacific Theater" value="false" editable="false">
+                        <boolean/>
+                </property>-->
+
+                <property name="Use Fuel Cost" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <!-- These require an associated value in the attachments section above-->
+                <property name="Movement By Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Production Per X Territories Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- only territories with a production value of 1 or more may count towards the production per x territories -->
+                <property name="Production Per Valued Territory Restricted" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement Per Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Place in Any Territory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unplaced units live when not placed" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Occupied Territories" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- allows a player to give units to another player if true. units must have canBeGivenByTerritory and territories must have changeUnitOwners and the players must have the player attachment giveUnitControl -->
+                <property name="Give Units By Territory" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- allows a player to let its units be captured by another player if true, when the territory is captured. units must have canBeCapturedOnEnteringBy and territories must have captureUnitOnEnteringBy and the players must have the player attachment captureUnitOnEnteringBy -->
+                <property name="Capture Units On Entering Territory" value ="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if "Capture Units On Entering Territory" is true, then the units can either be captured (default) or destroyed (only if this property below is true: "On Entering Units Destroyed Instead Of Captured") -->
+                <property name="On Entering Units Destroyed Instead Of Captured" value ="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- specific rules -->
+                <!-- land related -->
+                        <!-- if true, units with destroyedWhenCapturedBy will be destroyed instead of captured. only applies to non-combat units, since combat units die in combat -->
+                <property name="Units Can Be Destroyed Instead Of Captured" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- allows units to change into other units using the whenCapturedChangesInto ability -->
+                <property name="Units Can Be Changed On Capture" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if true you may have a number of constructions up to the value of the territory, in territories with factories -->
+                <property name="More Constructions with Factory" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- if true you may have a number of constructions up to the value of the territory, in territories without factories -->
+                <property name="More Constructions without Factory" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Unlimited Constructions" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Blitz Through Factories And AA Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- will roll dice for each type of aircraft separately -->
+                <property name="Roll AA Individually" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- random aa casualties lets the engine choose casualties randomly, and allows you to lose 2 bombers if you attack with 2 bombers and some fighters. I do not recommend using this property
+                <property name="Random AA Casualties" value="false" editable="false">
+                        <boolean/>
+                </property>-->
+
+                <property name="Choose AA Casualties" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- will only roll aa if aaGun is in the territory getting attacked or bombed -->
+                <property name="AA Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Multiple AA Per Territory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if false, (all property default to false), then units killed by suicide units can return fire.  if true, they can not return fire -->
+                <property name="Suicide and Munition Casualties Restricted" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- if suicide units act like normal units on defense, except that they can not die to attacks by other suicide units -->
+                <property name="Defending Suicide and Munition Units Do Not Fire" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Units May Give Bonus Movement allows units with givesMovement to give other units bonus movement-->
+                <property name="Units May Give Bonus Movement" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <!-- sea related -->
+                <property name="Partial Amphibious Retreat" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- a subset of partial amphibious retreat, allows attacker to withdraw planes -->
+                <property name="Attacker Retreat Planes" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Shore Bombard Per Ground Unit Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Naval Bombard Casualties Return Fire" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- allows transport units to die under ww2v3 type rules -->
+                <property name="Hari-Kari Units" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- required for all maps, ensures allied aircraft on carriers that are attacking don't attack also -->
+                <property name="Allied Air Dependents" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Surviving Air Move To Land" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Air Attack Sub Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- transports may not unload to multiple territories -->
+                <property name="Transport Restricted Unload" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Ignore Transport In Movement" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Transport Casualties Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unescorted Transport Dies" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if enabled, transports can capture convoy zones, etc. -->
+                <property name="Transport Control Sea Zone" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Ignore Sub In Movement" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Defending Subs Sneak Attack" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Sub Retreat Before Battle" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Submersible Subs" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Sub Control Sea Zone Restricted should be FALSE if there are any convoy zones! Only true if you want subs to move into owned sea zones during non-combat -->
+                <property name="Sub Control Sea Zone Restricted" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- if true, naval units may not move into convoy zones or controlled sea zones during non-combat moves -->
+                <property name="Naval Units May Not NonCombat Move Into Controlled Sea Zones" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- allows sea zones containing mixed allied+enemy units to attack each other without having to move out then back in again -->
+                <property name="Previous Units Fight" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Only affects units exactly called "battleship" -->
+                <property name="Two hit battleship" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- production related -->
+                <property name="Produce fighters on carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Produce new fighters on old carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Move existing fighters to new carriers" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Land existing fighters on new carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- LHTR Carrier rules enable 'Produce fighters on carriers', and 'Produce new fighters on old carriers', and 'Land existing fighters on new carriers', AND it will disable 'Move existing fighters to new carriers' -->
+                <property name="LHTR Carrier production rules" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement In Enemy Seas" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- used to add destroyers and artillery to the ww2v1 map
+                <property name="Use Destroyers and Artillery" value="false" editable="false">
+                        <boolean/>
+                </property>-->
+
+                        <!-- may only bomb or rocket a factory to a max of its territory value per turn (the individual two parts are below) -->
+                <property name="Territory Turn Limit" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Limit SBR Damage Per Turn" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Limit Rocket Damage Per Turn" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="maxFactoriesPerTerritory" value="1" editable="false">
+                        <number min="1" max="100"/>
+                </property>
+
+                        <!-- Placement Restricted By Factory warns the player whenever they try to produce more units than their factories can handle (can be turned off for individual players using rules attachments for unlimitedProduction -->
+                <property name="Placement Restricted By Factory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Unit Placement Restrictions are restrictions on the placement of units: unitPlacementRestrictions, unitPlacementOnlyAllowedIn, canOnlyBePlacedInTerritoryValuedAtX, requiresUnits, -->
+                <property name="Unit Placement Restrictions" value="true" editable="false">
+                        <boolean/>
+                </property>
+                        <!-- Allows Strategic Bombing Raids to have Escort aircraft and also be Intercepted by the defender -->
+                <property name="Raids May Be Preceeded By Air Battles" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                        <!-- Damage From Bombing Done To Units Instead Of Territories has Strategic Bombing and Rockets do damage to a territory rather than directly to the player's PUs (the bank) -->
+                <property name="Damage From Bombing Done To Units Instead Of Territories" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- Damage From Bombing Done To Units Instead Of Territories has Strategic Bombing and Rockets do damage to a specific unit rather than directly to the player's PUs or to a territory.  You must have "Damage From Bombing Done To Units Instead Of Territories" false for this to work -->
+                <property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- similar to TTL, except that it is per rocket/aircraft instead of per turn -->
+                <property name="Limit SBR Damage To Factory Production" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                        <!-- allows the loss of a victory point for every 10 sbr damage per turn
+                <property name="SBR Victory Points" value="false" editable="false">
+                        <boolean/>
+                </property>-->
+
+                <!-- Neutrals related -->
+                        <!-- amount of money subtracted to attack a neutral territory, (set neutrals charge to zero if you plan on attacking neutrals) -->
+                <property name="neutralCharge" value="9999999" editable="false">
+                        <number min="0" max="9999999"/>
+                </property>
+
+                <property name="Neutrals Are Impassable" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Neutrals Are Blitzable" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Neutral Flyover Allowed" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- AI related -->
+                <property name="AI Bonus Income Flat Rate" value="0" editable="true">
+                        <number min="-10" max="30"/>
+                </property>
+
+                <property name="AI Bonus Income Percentage" value="20" editable="true">
+                        <number min="-30" max="120"/>
+                </property>
+
+                <property name="AI Bonus Attack" value="0" editable="true">
+                        <number min="0" max="2"/>
+                </property>
+
+                <property name="AI Bonus Defense" value="0" editable="true">
+                        <number min="0" max="2"/>
+                </property>
+
+                <!-- Map Name: also used for map utils when asked (MUST exactly match the folder or zip name of your map (do not include the .zip of course). May point to another map folder if you are making a mod of that map) -->
+                <property name="mapName" value="victory_test" editable="false"/>
+
+                <!-- notes appear in the notes menu in the main screen, format as html -->
+                <property name="notes">
+                    <value>
+                    <![CDATA[
+
+                        <h2>Pact of Steel 2</h2>
+                        <br>A mod of POS by Veqryn
+                        <br>
+                        <br>The purpose of this map is to provide a fun map that shows off all the newest features TripleA has to offer.
+                        <br>
+                        <br>This map uses the ww2v3 + LHTR rules as a base, expanding it with various upgrades like triggered bonuses, air scrambling, etc.
+                        <br>
+                        <br>
+                        <br><b>New things:</b>
+                        <br>1. Sea Zones 3 and 4, are Russian Convoy Centers. If Russia controls it, they get the income from it. If someone else controls it, that player gets no income from it, but they deny the income to Russia. It can not be captured during non-combat phase.
+                        <br>2. Sea Zones 5 and 6, are Convoy Routes. They are linked to the land territory of Norway. At least one Convoy Zone must be controlled by the same power that controls the land territory for that power to gain the income from the land territory.
+                                They can not be captured during non-combat phase. If more than 1 route is linked to a single land territory, only 1 route needs to be controlled to get the income from land territory. Routes can have PU values just like convoy centers.
+                        <br>3. Sea Zones 37, 47, 48, 49, 58, are Blockade Zones. Each enemy warship in these zones reduces the income of touching land territories by 1 per warship, 2 per normal submarine.
+                        <br>4. Air_Transport is an air unit that specializes in dropping off units, has 4 movement, and can carry into battle or drop off in a friendly territory any 2-3 units. Enabled when you get "paratroopers" tech.
+                        <br>5. Super_Carrier is a beefed up carrier that can also transport 1 infantry and 1 other land unit like a tank or artillery. It has only 1 hitpoint, just like normal carriers and cruisers.
+                        <br>6. Midget_Submarine is a Japanese only unit with 3 attack, 2 defence, and 2 movement (costs 4). If it attacks or defends it will die after shooting (it is a suicide unit). Japan can purchase them after certain conditions are met, and they don't receive bonus movement from harbours.
+                        <br>7. Kamikaze Fighters are what Japanese fighters turn into if certain conditions are met.  They have 5 attack, 3 defense, and 3 movement (cost 8), and they are allowed to use up all their movement to go to a battle,
+                                    do not require a landing zone for movement, and they will die after rolling their dice.
+                        <br>8. Airfield gives +1 movement to air units, and allows fighters to scramble to defend surrounding sea zones if you turn on "Scramble Rules In Effect".
+                        <br>9. Harbour gives +1 movement to warships, and are needed to repair Battleships if you turn on "Two HitPoint Units Require Repair Facilities".
+                        <br>10. Bunkers are defensive units that can also be bombed/rocketted, will not participate in battle if damaged, and will die if they reach 4 damage.
+                                    They may be placed in any territory you owned at the beginning of the turn (just like Factories, Airfields, and Harbours) where you also have a land unit, but there is a limit of 1 per territory.
+                        <br>11. New Technologies: reinforcedHulls (gives +2 defense to subs), and wolfPackTactics (gives +1 att). Available to Germans after they get superSubs.
+                        <br>12. Each nation may only purchase factories up to 3 total, if a nation controls more than 3 they can not purchase new factories (they can keep capturing new ones though).
+                        <br>13. Politics phase: alliances and states of war are now dynamic and can be changed in game.  Japan and Russia start out in a state of Neutrality towards each other, while Russia, America and the UK also start out as neutral towards each other.
+                                    Japan and Russia will go to war on the 5th turn if they are still neutral by then.  Italy and Russia have the option of declaring a 2 round ceasefire.
+                        <br>14. Strategic Bombing Raids can now have an Air battle preceeding the raid. Fighters escorting the bombers, and any defending interceptors fire at 2, while the bombers fire at 1.  The battle only lasts 1 round.
+                        <br>
+                        <br>
+                        <br>
+                        <b>National Objectives</b><br>
+                        <i>Germany: Lebensraum-</i><br>
+                        +4 PUs if Axis control 7 out of 9 of
+                            East Balkans, Eastern Europe, Ukraine S.S.R., Belorussia, West Russia, Norway, Karelia S.S.R., Archangel, Caucus<br>
+                        +4 PUs if Axis control Western Europe, AND there are NO enemy surface ships in 3 out of 3 of sea zones 5, 6, and 7<br>
+                        * Germany gains Super Subs if at the end of their 4th or 5th turn, there are NO enemy surface ships in 3 out of 3 of
+                            sea zones 5, 6, and 7<br>
+                        * Germany gains Mechanized Infantry if at the end of their 3rd or 4th turn, the Axis control 6 out of 7 of
+                            East Balkans, Eastern Europe, Ukraine S.S.R., Belorussia, Karelia S.S.R., Archangel, Caucus<br>
+                        * Germany gains Rockets if at the end of their 3rd or 4th turn, the Axis do NOT control Western Europe, but DO control Norway<br>
+                        * Germany has access to additional submarine technology if they get superSubs, and getting superSubs also gives access to reinforcedHulls to Italians (in place of Shipyards)<br>
+                        <br>
+                        <i>Japan: The Greater East Asia Co-Prosperity Sphere-</i><br>
+                        +4 PUs if Axis control 7 out of 7 of India, French Indochina, Kwangtung, Manchuria, China, Central China, Sinkiang<br>
+                        +4 PUs if Axis control 10 out of 13 of Alaska, East Indies, Borneo, Philipine Islands, New Guinea, Solomon Islands,
+                            Caroline Islands, Australia, New Zealand, Okinawa, Wake Island, Hawaiian Islands, Midway<br>
+                        * Japan's destroyers gain the ability to transport a single infantry If on the 3rd or 4th turn, the Axis do NOT control ANY of
+                            Sinkiang, India, Burytia S.S.R.<br>
+                        * Japan's transports gain an additional capacity of 1 (allowing 3 infantry or 2 tanks/artillery per transport) If at the end of their 3rd, 4th, or 5th turns,
+                            Japan controls 3 out of 3 of Australia, India, Sinkiang<br>
+                        * Japan gains, only once, a single additional midget_submarine in sz61 If it loses control over any of its original territories<br>
+                        * Japan gains the ability to produce midget_submarines If it loses control over 2 of its islands: Okinawa, Philipine Islands, East Indies, Borneo, New Guinea, Solomon Islands, Caroline Islands, Wake Island<br>
+                        * Japan gains the ability to produce kamikaze fighters, and all their current fighters turn into kamikaze fighters
+                            If it loses control over 2 of its islands, one of which being Philipine Islands (note that this objective may or may not be wanted, depending on the situation)<br>
+                        <br>
+                        <i>Italy: Mare Nostrum-</i><br>
+                        +4 PUs if Axis control 8 out of 11 of
+                            Western Europe, Sardinia, Sicily, West Balkans, Greece, Algeria, Libya, Anglo Egypt, Trans-Jordan, Italian East Africa, Gibraltar
+                            AND no enemy surface ships in sea zones 13, 14, 15, and 15B<br>
+                        * Italy gains, only once, a free purchase of a cruiser If at the beginning of their 3rd or 4th turn the Axis control 4 out of 4 of
+                            Algeria, Libya, Anglo Egypt, Trans-Jordan<br>
+                        <br>
+                        <i>United States: The Arsenal of Democracy-</i><br>
+                        +2-10 PUs, starting on turn 2 America will begin making +2 income as America's war-time economy ramps up. This will increase by +2 more every 2 turns, so that turn 4 will begin making +4, turn 6 will make +6, and so on until +10 is reached<br>
+                        +4 PUs if Allies control 3 out of 8 of Western Europe, Sardinia, Sicily, Italy, Greece, West Balkans, Algeria, Libya
+                            AND no enemy surface ships in sea zones 1, 2, 7, 8, 9, 10, 11, 12, 13, and 14<br>
+                        +4 PUs if Allies controls 6 out of 13 of Alaska, East Indies, Borneo, Philipine Islands, New Guinea, Solomon Islands, Caroline Islands,
+                            Australia, New Zealand, Okinawa, Wake Island, Hawaiian Islands, Midway<br>
+                        +4 PUs if Japan has no Battleships OR no Carriers at the end of USA's turn<br>
+                        * USA gains Paratroopers if at the end of Germany's 3rd, 4th or 5th turns, the Allies control Western Europe<br>
+                        * USA gains Improved Shipyards if at the end of their 3rd, 4th or 5th turns, USA controls 4 out of 4 of
+                            Alaska, Wake Island, Hawaiian Islands, Midway<br>
+                        * USA gains War Bonds if at any time before the end of the 8th turn, the above 2 conditions are met at the end of Germany's turn<br>
+                        * USA's fighter's gain the ability to support infantry, stackable with artillery, IF at any time the USA has 2 out of 2 of War Bonds and Jet Power technologies<br>
+                        * USA can give land units to Russia by landing them in Archangel<br>
+                        <br>
+                        <i>United Kingdom: The British Empire-</i><br>
+                        +4 PUs if the UK controls 1 out of 6 of East Indies, Borneo, New Guinea, Solomon Islands, Caroline Islands, Okinawa<br>
+                        +4 PUs if Allies control 9 out of 11 of Gibraltar, Algeria, Libya, Anglo Egypt, Trans-Jordan, Persia, French West Africa,
+                            French Equatorial Africa, Italian East Africa, Belgian Congo, Kenya<br>
+                        +4 PUs if Allies control 3 out of 3 of Union of South Africa, India, Australia<br>
+                        * UK gains Paratroopers if at the end of Germany's 3rd, 4th or 5th turns, the Allies control Western Europe<br>
+                        * UK gains AA Radar if at the end their 3rd or 4th turn, the Allies control 4 out of 5 of
+                            Union of South Africa, Gibraltar, Anglo Egypt, India, Australia<br>
+                        <br>
+                        <i>Soviet Union: The Great Patriotic War-</i><br>
+                        +4 PUs if Soviets control 3 out of 5 of Norway, Eastern Europe, East Balkans, Ukraine S.S.R., Belorussia<br>
+                        +4 PUs if Soviets control Archangel and no allied forces in Soviet controlled land territories<br>
+                        +2 PUs AND +2 Tech Token, only once, if Soviets control Norway or East Balkans<br>
+                        * Soviet's artillery gain the ability to support 2 infantry on attack If at the end of their 3rd or 4th turn, the Soviets control
+                            Karelia S.S.R. and Caucus (this effect can be doubled to 4 infantry supported if Russia gets Improved Artillery technology)<br>
+                        * Soviets gain, only once, an additional 3 infantry in Yakut S.S.R. if at the beginning of their turn, Japan controls any original Russian territory<br>
+                        * Soviets gain control of any American land units that are in Archangel at the end of America's turn<br>
+                        * Soviets have double chance of getting Improved Artillery when rolling for tech<br>
+                        * Soviets destroy their industrial production (PUs) instead of letting it be captured, when they lose their capital<br>
+                        * Soviets destroy their AA Guns instead of letting them be captured<br>
+                        <br>
+                        <i>China: Chinese Resistance & The Flying Tigers </i><br>
+                        +1 infantry for every two territories controlled by China at the end of her turn, rounded up. May only place a max of 2 units per territory per turn.
+                            All units must be place in a territory with less than 4 Chinese units<br>
+                        +4 PUs and the ability to produce extra units, if Allies control Sinkiang, Central China, India.
+                            May use this money to produce a limited selection of units. May purchase tanks and fighters if these territories are controlled.<br>
+                        * China gains 1 infantry in Sinkiang if at the beginning of their turn, there are no enemy units in 3 out of 6 of
+                            Sinkiang, Central China, China, Manchuria, Kwangtung, French Indochina. This unit is given at the beginning of combat move step, and can not be moved until next turn.<br>
+                        * No Chinese Units, including the Chinese Fighter may leave Chinese territory: Sinkiang, Central China, China, Manchuria, Kwangtung, French Indochina
+                            (this means no entering sea zones), unless the Japanese capital has fallen once<br>
+                        * Chinese destroy any non-combat units they would otherwise capture (factories, aa guns, harbours, airfields)<br>
+                        <br>
+                        <br>
+                        <b>Technology</b><br>
+                         *** Air/Naval Tech ***<br>
+                        SUPER SUBS- submarine units get +1 attack<br>
+                        JET POWER- fighters and air transports get +1 attack<br>
+                        IMPROVED SHIPYARDS- naval units are cheaper<br>
+                        AA RADAR- AA hit on 2 or less<br>
+                        LONG RANGE AIRCRAFT- aircraft range increased by 2<br>
+                        HEAVY BOMBER- roll 2 dice for each bomber attack (if LHTR enabled: rolls 2 dice and selects the best one, StratBombing adds one to result)<br>
+                        <br>
+                         *** Land/Production Tech ***<br>
+                        IMPROVED ARTILLERY SUPPORT- artillery support 2 infantry (double the support given)<br>
+                        ROCKETS- AA conduct rocket attacks for 1d6 damage to production (each factory may only be targetted once per turn by one rocket, and only 1 rocket in each territory may fire)<br>
+                        PARATROOPERS- each bomber may carry 1 infantry into combat (must stop in first enemy territory it reaches)<br>
+                        INCREASED FACTORY PRODUCTION- factories produce 2 additional units (if territory value is 3 or greater), repairs 1/2 price<br>
+                        WAR BONDS- collect an 1d6 extra PUs each turn<br>
+                        MECHANIZED INFANTRY- tanks may carry 1 infantry each for 2 spaces<br>
+                        <br>
+                        *** Submarine Technology ***<br>
+                        REINFORCED HULLS- submarines get +2 defense (only shows up in battles)<br>
+                        WOLF PACK TACTICS- submarines get +1 attack and +1 defense (only shows up in battles)<br>
+                        <br>
+                        <br>Each nation has at least one technology that they can not research. This is shown by a "-" in the research tab.
+                            The Germans can't research War Bonds, Japanese can't get Shipyards, Russians can't get Paratroopers,
+                            British can't get Mechanized Inf, Americans can't get Rockets, and Italians can't get about half of the techs.
+                            Also, UK, Russia, and Italy get Destroyers Bombard instead of Super Subs.
+                        <br>
+                        <br>
+                        <b>Victory Conditions</b><br>
+                        Total Victory - 15 Victory Cities<br>
+                        Projection of Power - 11 Victory Cities<br>
+                        Axis can achieve a Triggered Victory by controlling all 4 of Germany, Japan, United Kingdom, and Russia.<br>
+                        Allies can achieve a Triggered Victory by controlling all 4 of United Kingdom, Eastern United States, Germany, and Japan.<br>
+                        <br>
+                        <br>
+                        <br>
+                        <br><b>Major Differences Between ww2v2 revised and ww2v3</b>
+                        <br>1.  In ww2v2 transport units are just like any other unit, and can be used as fodder by being taken casualty first in combat, however in ww2v3 style rules, transports have no defense power and may only be taken casualty after all other non-transport ships are dead.
+                        <br>2.  In ww2v2, you can build fighters on carriers if you build both at the same time, and if you build a carrier you can move existing fighters to carriers when you build a carrier in the adjacent sea zone. In ww2v3, you can build new fighters onto existing
+                                carriers as well as new carriers, but you may not move existing fighters onto new carriers, as instead you can non-combat move the fighters to where the carrier will be built, then place the carrier under it.
+                        <br>3.  In ww2v2, when you strategic bomb or rocket a factory, you immediately reduce the enemy's PUs. In ww2v3, you do damage to the factory, up to twice the value of the territory.
+                                Each point of damage reduces the number of units that can be produced there by 1. The player may repair the damage during their purchase phase.
+                        <br>4.  In ww2v2, when you fly over a territory with an AA Gun, the gun gets to fire at each aircraft. In ww2v3, the AA Gun only fires when you attack or bomb the territory it is in.
+                        <br>5.  In ww2v2, submarines and transports block the movement of other sea units. In ww2v3, submarines and transports do not block the movement of other sea units, and may be bypassed or attacked.
+                        <br>6.  In ww2v2, technology is rolled for, and if you miss nothing happens. In ww2v3, you buy tech tokens, and at the beginning of your turn you roll for each of your tokens. If you roll a 6, you discard all tokens and roll a second time to see which technology you get.
+                        <br>7.  In ww2v2, no land units may retreat from an amphibious assault. In ww2v3, the non-amphibious units may retreat.
+                        <br>8.  In ww2v2, bombardment immediately kills units, and you are allowed infinite bombardments. In ww2v3, a unit hit by bombard may return fire against the attacking units before dying, and the number of bombards is limited to the number of land units being dropped off from that sea zone.
+                        <br>9.  In ww2v2, air units can hit submarines. In ww2v3, an owned destroyer must be present for air units to hit submarines.
+                        <br>10. In ww2v2, submarines may choose to submerge at the end of each round of combat. In ww2v3, they may choose to submerge before each round of combat (and consequently, you can't kill them without a destroyer).
+                        <br>11. In ww2v2, submarines fire at the beginning of combat, and if there is no enemy destroyer then any casualties are removed immediately. In ww2v3, submarines get their surprise strike both on offense and defense, and both can be nullified by the presence of an enemy destroyer
+                                (so in ww2v3, if attacking an enemy sub, the attacker with a sub + destroyer, who's sub hits, would immediately kill the defending sub with no chance for it to return fire).
+                        <br>
+                        <br>
+                        <br><b>Differences for LHTR rules</b>
+                        <br>1. Technology is activated during the Place-Units phase (at the end of the turn rather then the beginning).
+                        <br>2. Heavy Bombers roll 2 dice, selecting best one. If strategic bombing, select best of two dice, then add '1' to the result.
+                        <br>3. Super Subs get a bonus of '1' to defense in addition to the bonus of '1' to attack.
+                        <br>4. LHTR uses same fighter-carrier rules, and aaGun rules, as ww2v3.
+                        <br>
+                        <br>
+                        <br><b>Generic How-To-Play</b>
+                        <br>The game is made up of rounds, during a round each player gets to do a number of steps/phases.
+                        <br>The phases are, in order: Research Technology, Repair Factories and Purchase Units, Combat Movement, Resolve Battles, Non-Combat Movement, Place Units.
+                        <br>At the beginning of your turn, you purchase units. At the end of the turn, you get to place those units in territories you own that have a factory.
+                        <br>During Combat Movment, you move any units to attack enemy units and territories. During Non-Combat Movement, you may move any units that have movement left (attacking an enemy remove any movement of land and sea units, but not air units).
+                        <br>Battles happen by use of dice. A unit has a certain attack power, and you roll a dice for each unit. If your dice is equal or less than the attack power of the unit, you have scored a hit.
+                            So for example, a tank attacks on 3. For it, you will roll a single die, and if you score 1-3 on the die you have hit the enemy, while if you score 4-6 you have missed the enemy. An infantry defends on 2, so a roll of 1-2 is a hit, while 3-6 are misses.
+                        <br>After the attacker has rolled dice for each of his units, the defender tallies the total number of 'hits' and then selects which of his defending units will die later. After this, the defender rolls for his units and the attacker selects which of his units will die.
+                            When both have finished rolling, the units selected to die are removed from the game. If there are no more attackers left, then the defender has won, and if there are no more defenders left, then the attacker has won and he moves his remaining attacking units into that territory.
+                            If both players have units left still, the attack may choose to play another round of battle, or retreat all his remaining forces to a territory where at least one of his forces came from.
+                        <br>Players must work with their allies to destroy the enemies, with the game ending when one side surrenders or certain conditions are met (like having captured a clear majority of the major cities).
+                        <br>
+                        <br>
+                        <br>Credits for original POS:
+                        <br>Triplelk, DMA02, Iron Cross, Aibrahim, SGB, KC1189, Zero Pilot, Tactics, Underdog
+                        <br>A mod by Veqryn
+                        <br>Many of the new properties and options were coded by Veqryn.
+                        <br>A personal thank you to Squid Daddy and ComradeKev for coding some of the new features that this map shows off
+                        <br>Relief Tiles by Conarymor.
+                        <br>Only actual unit changes: some destroyers turned into cruisers, and a German destroyer added to sz5, German sub in sz8 moved to sz7.
+                        <br>The AIs are meant to be bad at this map, please don't tell me the AIs are bad at this map.
+                    ]]>
+                    </value>
+                </property>
         </propertyList>
 </game>

--- a/src/test/resources/ww2_g40_balanced.xml
+++ b/src/test/resources/ww2_g40_balanced.xml
@@ -7,17 +7,17 @@
   <diceSides value="6"/>
   <map>
     <!-- Full europe list:
-				West Indies:Central United States:Central America:Greenland:Southeast Mexico:Eastern United States:West India:Belgian Congo:Iceland:Quebec:Alberta Saskatchewan Manitoba:Trans-Jordan:British Somaliland:Alexandria:Gibraltar:New Brunswick Nova Scotia:Egypt:Union of South Africa:Cyprus:British Guiana:Gold Coast:Rio de Oro:Ontario:Scotland:South West Africa:Nigeria:Kenya:Malta:United Kingdom:Anglo Egyptian Sudan:Rhodesia:Tanganyika Territory:Newfoundland Labrador:Morocco:French Equatorial Africa:Normandy Bordeaux:French Central Africa:French Madagascar:French Guiana:Algeria:Southern France:Syria:French West Africa:France:Tunisia:Greater Southern Germany:Slovakia Hungary:Western Germany:Romania:Poland:Germany:Norway:Denmark:Holland Belgium:Tobruk:Albania:Northern Italy:Libya:Sicily:Italian Somaliland:Southern Italy:Ethiopia:Sardinia:Belarus:Karelia:Baltic States:Bryansk:Rostov:Nenetsia:Vyborg:Archangel:Eastern Poland:Bessarabia:Russia:Tambov:Ukraine:Western Ukraine:Vologda:Volgograd:Turkmenistan:Novgorod:Caucasus:Smolensk:Samara:Portugal:Portuguese Guinea:Ecuador:Chile:Afghanistan:Sierra Leone:Turkey:Mozambique:Saudi Arabia:Paraguay:Switzerland:Pripet Marshes:Eire:Crete:Argentina:Bulgaria:Angola:Greece:Iraq:Eastern Persia:Uruguay:Brazil:Venezuela:Northwest Persia:Persia:Sweden:Yugoslavia:Spain:Colombia:Bolivia:Liberia:Peru:Finland:Suriname
-				-->
+                West Indies:Central United States:Central America:Greenland:Southeast Mexico:Eastern United States:West India:Belgian Congo:Iceland:Quebec:Alberta Saskatchewan Manitoba:Trans-Jordan:British Somaliland:Alexandria:Gibraltar:New Brunswick Nova Scotia:Egypt:Union of South Africa:Cyprus:British Guiana:Gold Coast:Rio de Oro:Ontario:Scotland:South West Africa:Nigeria:Kenya:Malta:United Kingdom:Anglo Egyptian Sudan:Rhodesia:Tanganyika Territory:Newfoundland Labrador:Morocco:French Equatorial Africa:Normandy Bordeaux:French Central Africa:French Madagascar:French Guiana:Algeria:Southern France:Syria:French West Africa:France:Tunisia:Greater Southern Germany:Slovakia Hungary:Western Germany:Romania:Poland:Germany:Norway:Denmark:Holland Belgium:Tobruk:Albania:Northern Italy:Libya:Sicily:Italian Somaliland:Southern Italy:Ethiopia:Sardinia:Belarus:Karelia:Baltic States:Bryansk:Rostov:Nenetsia:Vyborg:Archangel:Eastern Poland:Bessarabia:Russia:Tambov:Ukraine:Western Ukraine:Vologda:Volgograd:Turkmenistan:Novgorod:Caucasus:Smolensk:Samara:Portugal:Portuguese Guinea:Ecuador:Chile:Afghanistan:Sierra Leone:Turkey:Mozambique:Saudi Arabia:Paraguay:Switzerland:Pripet Marshes:Eire:Crete:Argentina:Bulgaria:Angola:Greece:Iraq:Eastern Persia:Uruguay:Brazil:Venezuela:Northwest Persia:Persia:Sweden:Yugoslavia:Spain:Colombia:Bolivia:Liberia:Peru:Finland:Suriname
+                -->
     <!-- Border territories:
-				Evenkiyskiy:Urals:Novosibirsk:Himalayas:Kazakhstan:Timguska:India:Sikang:Tsinghai:Kansu
-				-->
+                Evenkiyskiy:Urals:Novosibirsk:Himalayas:Kazakhstan:Timguska:India:Sikang:Tsinghai:Kansu
+                -->
     <!-- Full pacific list:
-				Caroline Islands:Iwo Jima:Paulau Island:Marshall Islands:Shantung:Formosa:Kwangsi:Korea:Kiangsu:Kiangsi:Japan:Jehol:Okinawa:Marianas:Siam:Manchuria:Hainan:Shensi:Yunnan:Suiyuyan:Kweichow:Hunan:Hopei:Szechwan:Chahar:Anhwe:Gilbert Islands:Fiji:Ceylon:Samoa:Shan State:Burma:British Columbia:Malaya:Borneo:Yukon Territory:Kwangtung:Queensland:Victoria:New Britain:Northern Territory:New Zealand:New South Wales:South Australia:Western Australia:Solomon Islands:New Guinea:Philippines:Line Islands:Mexico:Guam:Wake Island:Western United States:Alaska:Aleutian Islands:Johnston Island:Hawaiian Islands:Midway:Sakha:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Siberia:Buryatia:French Indo China:New Hebrides:Celebes:Java:Dutch New Guinea:Sumatra:Olgiy:Dzavhan:Central Mongolia:Buyant-Uhaa:Ulaanbaatar:Tsagaan Olom
-				-->
+                Caroline Islands:Iwo Jima:Paulau Island:Marshall Islands:Shantung:Formosa:Kwangsi:Korea:Kiangsu:Kiangsi:Japan:Jehol:Okinawa:Marianas:Siam:Manchuria:Hainan:Shensi:Yunnan:Suiyuyan:Kweichow:Hunan:Hopei:Szechwan:Chahar:Anhwe:Gilbert Islands:Fiji:Ceylon:Samoa:Shan State:Burma:British Columbia:Malaya:Borneo:Yukon Territory:Kwangtung:Queensland:Victoria:New Britain:Northern Territory:New Zealand:New South Wales:South Australia:Western Australia:Solomon Islands:New Guinea:Philippines:Line Islands:Mexico:Guam:Wake Island:Western United States:Alaska:Aleutian Islands:Johnston Island:Hawaiian Islands:Midway:Sakha:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Siberia:Buryatia:French Indo China:New Hebrides:Celebes:Java:Dutch New Guinea:Sumatra:Olgiy:Dzavhan:Central Mongolia:Buyant-Uhaa:Ulaanbaatar:Tsagaan Olom
+                -->
     <!-- Full sea zone list:
-				1 Sea Zone:2 Sea Zone:3 Sea Zone:4 Sea Zone:5 Sea Zone:6 Sea Zone:7 Sea Zone:8 Sea Zone:9 Sea Zone:10 Sea Zone:11 Sea Zone:12 Sea Zone:13 Sea Zone:14 Sea Zone:15 Sea Zone:16 Sea Zone:17 Sea Zone:18 Sea Zone:19 Sea Zone:20 Sea Zone:21 Sea Zone:22 Sea Zone:23 Sea Zone:24 Sea Zone:25 Sea Zone:26 Sea Zone:27 Sea Zone:28 Sea Zone:29 Sea Zone:30 Sea Zone:31 Sea Zone:32 Sea Zone:33 Sea Zone:34 Sea Zone:35 Sea Zone:36 Sea Zone:37 Sea Zone:38 Sea Zone:39 Sea Zone:40 Sea Zone:41 Sea Zone:42 Sea Zone:43 Sea Zone:44 Sea Zone:45 Sea Zone:46 Sea Zone:47 Sea Zone:48 Sea Zone:49 Sea Zone:50 Sea Zone:51 Sea Zone:52 Sea Zone:53 Sea Zone:54 Sea Zone:55 Sea Zone:56 Sea Zone:57 Sea Zone:58 Sea Zone:59 Sea Zone:60 Sea Zone:61 Sea Zone:62 Sea Zone:63 Sea Zone:64 Sea Zone:65 Sea Zone:66 Sea Zone:67 Sea Zone:68 Sea Zone:69 Sea Zone:70 Sea Zone:71 Sea Zone:72 Sea Zone:73 Sea Zone:74 Sea Zone:75 Sea Zone:76 Sea Zone:77 Sea Zone:78 Sea Zone:79 Sea Zone:80 Sea Zone:81 Sea Zone:82 Sea Zone:83 Sea Zone:84 Sea Zone:85 Sea Zone:86 Sea Zone:87 Sea Zone:88 Sea Zone:89 Sea Zone:90 Sea Zone:91 Sea Zone:92 Sea Zone:93 Sea Zone:94 Sea Zone:95 Sea Zone:96 Sea Zone:97 Sea Zone:98 Sea Zone:99 Sea Zone:100 Sea Zone:101 Sea Zone:102 Sea Zone:103 Sea Zone:104 Sea Zone:105 Sea Zone:106 Sea Zone:107 Sea Zone:108 Sea Zone:109 Sea Zone:110 Sea Zone:111 Sea Zone:112 Sea Zone:113 Sea Zone:114 Sea Zone:115 Sea Zone:116 Sea Zone:117 Sea Zone:118 Sea Zone:119 Sea Zone:120 Sea Zone:121 Sea Zone:122 Sea Zone:123 Sea Zone:124 Sea Zone:125 Sea Zone:126 Sea Zone:127 Sea Zone:128 Sea Zone
-				-->
+                1 Sea Zone:2 Sea Zone:3 Sea Zone:4 Sea Zone:5 Sea Zone:6 Sea Zone:7 Sea Zone:8 Sea Zone:9 Sea Zone:10 Sea Zone:11 Sea Zone:12 Sea Zone:13 Sea Zone:14 Sea Zone:15 Sea Zone:16 Sea Zone:17 Sea Zone:18 Sea Zone:19 Sea Zone:20 Sea Zone:21 Sea Zone:22 Sea Zone:23 Sea Zone:24 Sea Zone:25 Sea Zone:26 Sea Zone:27 Sea Zone:28 Sea Zone:29 Sea Zone:30 Sea Zone:31 Sea Zone:32 Sea Zone:33 Sea Zone:34 Sea Zone:35 Sea Zone:36 Sea Zone:37 Sea Zone:38 Sea Zone:39 Sea Zone:40 Sea Zone:41 Sea Zone:42 Sea Zone:43 Sea Zone:44 Sea Zone:45 Sea Zone:46 Sea Zone:47 Sea Zone:48 Sea Zone:49 Sea Zone:50 Sea Zone:51 Sea Zone:52 Sea Zone:53 Sea Zone:54 Sea Zone:55 Sea Zone:56 Sea Zone:57 Sea Zone:58 Sea Zone:59 Sea Zone:60 Sea Zone:61 Sea Zone:62 Sea Zone:63 Sea Zone:64 Sea Zone:65 Sea Zone:66 Sea Zone:67 Sea Zone:68 Sea Zone:69 Sea Zone:70 Sea Zone:71 Sea Zone:72 Sea Zone:73 Sea Zone:74 Sea Zone:75 Sea Zone:76 Sea Zone:77 Sea Zone:78 Sea Zone:79 Sea Zone:80 Sea Zone:81 Sea Zone:82 Sea Zone:83 Sea Zone:84 Sea Zone:85 Sea Zone:86 Sea Zone:87 Sea Zone:88 Sea Zone:89 Sea Zone:90 Sea Zone:91 Sea Zone:92 Sea Zone:93 Sea Zone:94 Sea Zone:95 Sea Zone:96 Sea Zone:97 Sea Zone:98 Sea Zone:99 Sea Zone:100 Sea Zone:101 Sea Zone:102 Sea Zone:103 Sea Zone:104 Sea Zone:105 Sea Zone:106 Sea Zone:107 Sea Zone:108 Sea Zone:109 Sea Zone:110 Sea Zone:111 Sea Zone:112 Sea Zone:113 Sea Zone:114 Sea Zone:115 Sea Zone:116 Sea Zone:117 Sea Zone:118 Sea Zone:119 Sea Zone:120 Sea Zone:121 Sea Zone:122 Sea Zone:123 Sea Zone:124 Sea Zone:125 Sea Zone:126 Sea Zone:127 Sea Zone:128 Sea Zone
+                -->
     <!-- Territory Definitions -->
     <!-- P40 -->
     <territory name="Caroline Islands"/>
@@ -1504,78 +1504,78 @@
                         <cost resource="PUs" quantity="3" />
                         <result resourceOrUnit="infantry" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyMech_InfantryIndustrialTechnology">
                         <cost resource="PUs" quantity="4" />
                         <result resourceOrUnit="mech_infantry" quantity="1"/>
                 </productionRule>
-                
-				<productionRule name="buyArtilleryIndustrialTechnology">
+
+                <productionRule name="buyArtilleryIndustrialTechnology">
                         <cost resource="PUs" quantity="4" />
                         <result resourceOrUnit="artillery" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArmourIndustrialTechnology">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="armour" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFighterIndustrialTechnology">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="fighter" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyTactical_BomberIndustrialTechnology">
                         <cost resource="PUs" quantity="11" />
                         <result resourceOrUnit="tactical_bomber" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBomberIndustrialTechnology">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="bomber" quantity="1"/>
                 </productionRule>
-                
-				<productionRule name="buyTransportIndustrialTechnology">
+
+                <productionRule name="buyTransportIndustrialTechnology">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="transport" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyCarrierIndustrialTechnology">
                         <cost resource="PUs" quantity="13" />
                         <result resourceOrUnit="carrier" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyDestroyerIndustrialTechnology">
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiserIndustrialTechnology">
+
+                <productionRule name="buyCruiserIndustrialTechnology">
                         <cost resource="PUs" quantity="9" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBattleshipIndustrialTechnology">
                         <cost resource="PUs" quantity="17" />
                         <result resourceOrUnit="battleship" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buySubmarineIndustrialTechnology">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="submarine" quantity="1"/>
                 </productionRule>
-                
-                
-				<productionRule name="buyFactory_MinorIndustrialTechnology">
+
+
+                <productionRule name="buyFactory_MinorIndustrialTechnology">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="factory_minor" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFactory_MajorIndustrialTechnology">
                         <cost resource="PUs" quantity="30" />
                         <result resourceOrUnit="factory_major" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyAirfieldIndustrialTechnology">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="airfield" quantity="1"/>
@@ -1585,7 +1585,7 @@
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="harbour" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyAAGunIndustrialTechnology">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="aaGun" quantity="1"/>
@@ -1702,20 +1702,20 @@
     <!--<productionFrontier name="productionIndustrialTechnology">
                         <frontierRules name="buyInfantryIndustrialTechnology"/>
                         <frontierRules name="buyMech_InfantryIndustrialTechnology"/>
-						<frontierRules name="buyArtilleryIndustrialTechnology"/>
+                        <frontierRules name="buyArtilleryIndustrialTechnology"/>
                         <frontierRules name="buyArmourIndustrialTechnology"/>
                         <frontierRules name="buyFighterIndustrialTechnology"/>
-						<frontierRules name="buyTactical_BomberIndustrialTechnology"/>
+                        <frontierRules name="buyTactical_BomberIndustrialTechnology"/>
                         <frontierRules name="buyBomberIndustrialTechnology"/>
                         <frontierRules name="buyTransportIndustrialTechnology"/>
                         <frontierRules name="buySubmarineIndustrialTechnology"/>
                         <frontierRules name="buyCarrierIndustrialTechnology"/>
                         <frontierRules name="buyDestroyerIndustrialTechnology"/>
-						<frontierRules name="buyCruiserIndustrialTechnology"/>
+                        <frontierRules name="buyCruiserIndustrialTechnology"/>
                         <frontierRules name="buyBattleshipIndustrialTechnology"/>
                         <frontierRules name="buyAAGunIndustrialTechnology"/>
-						<frontierRules name="buyFactory_MinorIndustrialTechnology"/>
-						<frontierRules name="buyFactory_MajorIndustrialTechnology"/>
+                        <frontierRules name="buyFactory_MinorIndustrialTechnology"/>
+                        <frontierRules name="buyFactory_MajorIndustrialTechnology"/>
                         <frontierRules name="buyAirfieldIndustrialTechnology"/>
                         <frontierRules name="buyHarbourIndustrialTechnology"/>
                 </productionFrontier>-->
@@ -1739,7 +1739,7 @@
     <playerProduction player="ANZAC" frontier="production"/>
     <playerRepair player="Americans" frontier="repair"/>
     <!-- Chinese are not allowed to repair
-				<playerRepair player="Chinese" frontier="repair"/> -->
+                <playerRepair player="Chinese" frontier="repair"/> -->
     <playerRepair player="British" frontier="repair"/>
     <playerRepair player="UK_Pacific" frontier="repair"/>
     <playerRepair player="ANZAC" frontier="repair"/>
@@ -1970,14 +1970,14 @@
     </attachment>
     <attachment name="relationshipTypeAttachment" attachTo="Friendly" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
       <!--<option name="archeType" value="neutral"/>
-						<option name="canMoveLandUnitsOverOwnedLand" value="true"/>
-						<option name="canMoveAirUnitsOverOwnedLand" value="true"/>
-						<option name="canLandAirUnitsOnOwnedLand" value="true"/>-->
+                        <option name="canMoveLandUnitsOverOwnedLand" value="true"/>
+                        <option name="canMoveAirUnitsOverOwnedLand" value="true"/>
+                        <option name="canLandAirUnitsOnOwnedLand" value="true"/>-->
       <option name="archeType" value="allied"/>
     </attachment>
     <attachment name="relationshipTypeAttachment" attachTo="Custodianship" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
       <!--<option name="archeType" value="war"/>
-						<option name="canLandAirUnitsOnOwnedLand" value="true"/>-->
+                        <option name="canLandAirUnitsOnOwnedLand" value="true"/>-->
       <option name="archeType" value="allied"/>
       <option name="canTakeOverOwnedTerritory" value="true"/>
     </attachment>
@@ -1994,12 +1994,12 @@
       <option name="canMoveIntoDuringCombatMove" value="false"/>
       <option name="rocketsCanFlyOver" value="false"/>
       <!-- How Friendly Neutrals work:
-								They may not be attacked. (IE: can not move into during combat move phase) (DONE)
-								They can not be flown over. (Done)
-								They can not be moved through, or blitzed. (TODO)
-								During non-combat move, you may move land units into them to capture them and all their units. (Done)
-								May only capture with units that have attack power (no aa guns). (TODO)
-						-->
+                                They may not be attacked. (IE: can not move into during combat move phase) (DONE)
+                                They can not be flown over. (Done)
+                                They can not be moved through, or blitzed. (TODO)
+                                During non-combat move, you may move land units into them to capture them and all their units. (Done)
+                                May only capture with units that have attack power (no aa guns). (TODO)
+                        -->
     </attachment>
     <attachment name="relationshipTypeAttachment" attachTo="Unfriendly_Neutral" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
       <option name="archeType" value="war"/>
@@ -2360,14 +2360,14 @@
       <option name="defense" value="1"/>
       <option name="blockade" value="2"/>
       <!-- stuff for targeting unescorted transports (we are using the new-fangled aa-gun code)
-						 <option name="isAAforFlyOverOnly" value="true"/>
-						 <option name="targetsAA" value="transport"/>
-						 <option name="willNotFireIfPresent" value="destroyer:cruiser:battleship:carrier"/>
-						 <option name="mayOverStackAA" value="true"/>
-						 <option name="maxAAattacks" value="1"/>
-						 <option name="attackAA" value="2"/>
-						 <option name="attackAAmaxDieSides" value="6"/>
-						 <option name="typeAA" value="Submarine Strike on Unescorted Transports"/>-->
+                         <option name="isAAforFlyOverOnly" value="true"/>
+                         <option name="targetsAA" value="transport"/>
+                         <option name="willNotFireIfPresent" value="destroyer:cruiser:battleship:carrier"/>
+                         <option name="mayOverStackAA" value="true"/>
+                         <option name="maxAAattacks" value="1"/>
+                         <option name="attackAA" value="2"/>
+                         <option name="attackAAmaxDieSides" value="6"/>
+                         <option name="typeAA" value="Submarine Strike on Unescorted Transports"/>-->
       <option name="canBeGivenByTerritoryTo" value="British"/>
       <!-- TODO: submarines now prevent amphibious assaults unless there is an owned warship present -->
     </attachment>
@@ -2459,7 +2459,7 @@
       <!--<option name="isRocket" value="true"/>-->
       <option name="canNotMoveDuringCombatMove" value="true"/>
       <!--<option name="isInfrastructure" value="true"/>
-						 <option name="canBeDamaged" value="false"/>-->
+                         <option name="canBeDamaged" value="false"/>-->
       <option name="movement" value="1"/>
       <option name="transportCost" value="6"/>
       <option name="canBeGivenByTerritoryTo" value="British"/>
@@ -2675,7 +2675,7 @@
                     <attachment name="territoryAttachment" attachTo="Yukon Territory" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                    </attachment>
-				   -->
+                   -->
     <attachment name="territoryAttachment" attachTo="Kwangtung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
       <option name="production" value="3"/>
       <option name="victoryCity" value="1"/>
@@ -4502,18 +4502,18 @@
       <option name="relationship" value="British:Japanese:anyNeutral"/>
     </attachment>
     <!-- Russian Territories next to Mongolian Territories:
-						Timguska:Yenisey:Yakut S.S.R.:Buryatia:Amur
-						
-					 Mongolian Territories:
-						Olgiy:Dzavhan:Tsagaan Olom:Central Mongolia:Buyant-Uhaa:Ulaanbaatar
-						
-					 Japanese Territories next to Mongolian Territories:
-						Manchuria:Jehol
-						and Korea
-						
-					 Chinese Territories next to Mongolian Territories (could possibly be controlled by Japan):
-						Chahar:Suiyuyan:Kansu
-				-->
+                        Timguska:Yenisey:Yakut S.S.R.:Buryatia:Amur
+
+                     Mongolian Territories:
+                        Olgiy:Dzavhan:Tsagaan Olom:Central Mongolia:Buyant-Uhaa:Ulaanbaatar
+
+                     Japanese Territories next to Mongolian Territories:
+                        Manchuria:Jehol
+                        and Korea
+
+                     Chinese Territories next to Mongolian Territories (could possibly be controlled by Japan):
+                        Chahar:Suiyuyan:Kansu
+                -->
     <attachment name="conditionAttachment_Mongolia_Not_At_War_With_Allies" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
       <option name="relationship" value="British:Mongolians:anyWar"/>
       <option name="invert" value="true"/>
@@ -4601,86 +4601,86 @@
     </attachment>
     <!-- Japanese Triggers -->
     <!-- OLD Kamikaze trigger:
-				<attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
-					<option name="conditionType" value="OR"/>
-					<option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
-					<option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
-					<option name="territoryProperty" value="kamikazeZone" count="true"/>
-					<option name="uses" value="1"/>
-					<option name="when" value="after:britishEndTurn"/>
-				</attachment>
-				<attachment name="triggerAttachment_Japanese_Takes_the_Philippines" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
-					<option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots"/>
-					<option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
-					<option name="uses" value="1"/>
-					<option name="when" value="after:japaneseEndTurn"/>
-				</attachment>
-				<attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
-					<option name="conditionType" value="OR"/>
-					<option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
-					<option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
-					<option name="territoryProperty" value="kamikazeZone" count="true"/>
-					<option name="uses" value="1"/>
-					<option name="when" value="after:americansEndTurn"/>
-				</attachment>
-				<attachment name="triggerAttachment_Japanese_Takes_the_Philippines2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
-					<option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots2"/>
-					<option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
-					<option name="uses" value="1"/>
-					<option name="when" value="after:japaneseEndTurn"/>
-				</attachment>
-				<attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
-					<option name="conditionType" value="OR"/>
-					<option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
-					<option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
-					<option name="territoryProperty" value="kamikazeZone" count="true"/>
-					<option name="uses" value="1"/>
-					<option name="when" value="after:anzacEndTurn"/>
-				</attachment>
-				<attachment name="triggerAttachment_Japanese_Takes_the_Philippines3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
-					<option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3"/>
-					<option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
-					<option name="uses" value="1"/>
-					<option name="when" value="after:japaneseEndTurn"/>
-				</attachment>
-				<attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots4" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
-					<option name="conditionType" value="OR"/>
-					<option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
-					<option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
-					<option name="territoryProperty" value="kamikazeZone" count="true"/>
-					<option name="uses" value="1"/>
-					<option name="when" value="after:frenchEndTurn"/>
-				</attachment>
-				<attachment name="triggerAttachment_Japanese_Takes_the_Philippines4" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
-					<option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3"/>
-					<option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
-					<option name="uses" value="1"/>
-					<option name="when" value="after:japaneseEndTurn"/>
-				</attachment>
-				<attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots5" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
-					<option name="conditionType" value="OR"/>
-					<option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
-					<option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
-					<option name="territoryProperty" value="kamikazeZone" count="true"/>
-					<option name="uses" value="1"/>
-					<option name="when" value="after:russiansEndTurn"/>
-				</attachment>
-				<attachment name="triggerAttachment_Japanese_Takes_the_Philippines5" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-					<option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
-					<option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3"/>
-					<option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
-					<option name="uses" value="1"/>
-					<option name="when" value="after:japaneseEndTurn"/>
-				</attachment>-->
+                <attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
+                    <option name="conditionType" value="OR"/>
+                    <option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
+                    <option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
+                    <option name="territoryProperty" value="kamikazeZone" count="true"/>
+                    <option name="uses" value="1"/>
+                    <option name="when" value="after:britishEndTurn"/>
+                </attachment>
+                <attachment name="triggerAttachment_Japanese_Takes_the_Philippines" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
+                    <option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots"/>
+                    <option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
+                    <option name="uses" value="1"/>
+                    <option name="when" value="after:japaneseEndTurn"/>
+                </attachment>
+                <attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
+                    <option name="conditionType" value="OR"/>
+                    <option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
+                    <option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
+                    <option name="territoryProperty" value="kamikazeZone" count="true"/>
+                    <option name="uses" value="1"/>
+                    <option name="when" value="after:americansEndTurn"/>
+                </attachment>
+                <attachment name="triggerAttachment_Japanese_Takes_the_Philippines2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
+                    <option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots2"/>
+                    <option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
+                    <option name="uses" value="1"/>
+                    <option name="when" value="after:japaneseEndTurn"/>
+                </attachment>
+                <attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
+                    <option name="conditionType" value="OR"/>
+                    <option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
+                    <option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
+                    <option name="territoryProperty" value="kamikazeZone" count="true"/>
+                    <option name="uses" value="1"/>
+                    <option name="when" value="after:anzacEndTurn"/>
+                </attachment>
+                <attachment name="triggerAttachment_Japanese_Takes_the_Philippines3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
+                    <option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3"/>
+                    <option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
+                    <option name="uses" value="1"/>
+                    <option name="when" value="after:japaneseEndTurn"/>
+                </attachment>
+                <attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots4" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
+                    <option name="conditionType" value="OR"/>
+                    <option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
+                    <option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
+                    <option name="territoryProperty" value="kamikazeZone" count="true"/>
+                    <option name="uses" value="1"/>
+                    <option name="when" value="after:frenchEndTurn"/>
+                </attachment>
+                <attachment name="triggerAttachment_Japanese_Takes_the_Philippines4" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
+                    <option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3"/>
+                    <option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
+                    <option name="uses" value="1"/>
+                    <option name="when" value="after:japaneseEndTurn"/>
+                </attachment>
+                <attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots5" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
+                    <option name="conditionType" value="OR"/>
+                    <option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
+                    <option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
+                    <option name="territoryProperty" value="kamikazeZone" count="true"/>
+                    <option name="uses" value="1"/>
+                    <option name="when" value="after:russiansEndTurn"/>
+                </attachment>
+                <attachment name="triggerAttachment_Japanese_Takes_the_Philippines5" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                    <option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
+                    <option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3"/>
+                    <option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
+                    <option name="uses" value="1"/>
+                    <option name="when" value="after:japaneseEndTurn"/>
+                </attachment>-->
     <!-- New Kamikaze Trigger: -->
     <attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots_alpha" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
       <option name="conditions" value="conditionAttachmentAxisVictory3"/>
@@ -13381,13 +13381,13 @@
       <option name="relationshipChange" value="Americans:Neutral_Allies:anyNeutral:Friendly_Neutral"/>
       <option name="relationshipChange" value="Americans:Neutral_Axis:anyNeutral:Unfriendly_Neutral"/>
       <!--<option name="relationshipChange" value="Japanese:British:anyNeutral:War"/>
-					<option name="relationshipChange" value="Japanese:UK_Pacific:anyNeutral:War"/>
-					<option name="relationshipChange" value="Japanese:ANZAC:anyNeutral:War"/>
-					<option name="relationshipChange" value="Japanese:Dutch:anyNeutral:War"/>
-					<option name="relationshipChange" value="Chinese:British:anyNeutral:Allied"/>
-					<option name="relationshipChange" value="Chinese:UK_Pacific:anyNeutral:Allied"/>
-					<option name="relationshipChange" value="Chinese:ANZAC:anyNeutral:Allied"/>
-					<option name="relationshipChange" value="Chinese:Dutch:anyNeutral:Friendly"/>-->
+                    <option name="relationshipChange" value="Japanese:UK_Pacific:anyNeutral:War"/>
+                    <option name="relationshipChange" value="Japanese:ANZAC:anyNeutral:War"/>
+                    <option name="relationshipChange" value="Japanese:Dutch:anyNeutral:War"/>
+                    <option name="relationshipChange" value="Chinese:British:anyNeutral:Allied"/>
+                    <option name="relationshipChange" value="Chinese:UK_Pacific:anyNeutral:Allied"/>
+                    <option name="relationshipChange" value="Chinese:ANZAC:anyNeutral:Allied"/>
+                    <option name="relationshipChange" value="Chinese:Dutch:anyNeutral:Friendly"/>-->
       <option name="notification" value="Americans_War_Axis"/>
       <option name="when" value="after:americansPlace"/>
       <option name="uses" value="1"/>
@@ -13541,8 +13541,8 @@
       <!--<option name="suicideAttackTargets" value="battleship:carrier:cruiser:destroyer"/>-->
     </attachment>
     <attachment name="playerAttachment" attachTo="UK_Pacific" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
-      <!-- giveUnitControl allow multiple players to give units to multiple other players, if those units are in a designated territory 
-							must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"-->
+      <!-- giveUnitControl allow multiple players to give units to multiple other players, if those units are in a designated territory
+                            must be a list of the player's names, in a ":" delimited list.  Example: value="Russians:Chinese"-->
       <option name="giveUnitControl" value="British"/>
     </attachment>
     <attachment name="playerAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
@@ -13584,27 +13584,27 @@
       <option name="unlimitedProduction" value="true"/>
     </attachment>
     <!-- Americans in OOB are not allowed to move to or through these sea zones:
-						125 Sea Zone:111 Sea Zone:119 Sea Zone:109 Sea Zone:104 Sea Zone:91 Sea Zone:87 Sea Zone:83 Sea Zone:70 Sea Zone:71 Sea Zone:72 Sea Zone:76 Sea Zone:80 Sea Zone:79 Sea Zone
-					
-					 Americans in Alpha +3 are not allowed to end their movement in:
-						Europe board: any sea zone not touching an American territory, plus 102 sz
-						TODO: We need to disallow a movement ending in a territory
-						TODO: Currently we disallow any movement into, instead of just disallowing the ending of movement in.  So, for example, SZ 106 and 116 could be moved into on the way to 121.
-							65 Sea Zone:66 Sea Zone:85 Sea Zone:86 Sea Zone:88 Sea Zone:90 Sea Zone:103 Sea Zone:106 Sea Zone:107 Sea Zone:116 Sea Zone:117 Sea Zone:120 Sea Zone:122 Sea Zone
-						Pacific board: any sea zone touching a Japanese controlled territory
-						TODO: Currently we disallow any movement into, instead of just disallowing the ending of movement in.  So, for example, SZ 17, 22, 32, 33, 34, and 37 could all be moved through on the way to another territory.
-						TODO: Currently we have a "set list" of territories. Obviously if Japan conquers more territories, then this list should expand, but it doesn't yet.
-							6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:32 Sea Zone:34 Sea Zone:33 Sea Zone:36 Sea Zone:37 Sea Zone
-				-->
+                        125 Sea Zone:111 Sea Zone:119 Sea Zone:109 Sea Zone:104 Sea Zone:91 Sea Zone:87 Sea Zone:83 Sea Zone:70 Sea Zone:71 Sea Zone:72 Sea Zone:76 Sea Zone:80 Sea Zone:79 Sea Zone
+
+                     Americans in Alpha +3 are not allowed to end their movement in:
+                        Europe board: any sea zone not touching an American territory, plus 102 sz
+                        TODO: We need to disallow a movement ending in a territory
+                        TODO: Currently we disallow any movement into, instead of just disallowing the ending of movement in.  So, for example, SZ 106 and 116 could be moved into on the way to 121.
+                            65 Sea Zone:66 Sea Zone:85 Sea Zone:86 Sea Zone:88 Sea Zone:90 Sea Zone:103 Sea Zone:106 Sea Zone:107 Sea Zone:116 Sea Zone:117 Sea Zone:120 Sea Zone:122 Sea Zone
+                        Pacific board: any sea zone touching a Japanese controlled territory
+                        TODO: Currently we disallow any movement into, instead of just disallowing the ending of movement in.  So, for example, SZ 17, 22, 32, 33, 34, and 37 could all be moved through on the way to another territory.
+                        TODO: Currently we have a "set list" of territories. Obviously if Japan conquers more territories, then this list should expand, but it doesn't yet.
+                            6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:32 Sea Zone:34 Sea Zone:33 Sea Zone:36 Sea Zone:37 Sea Zone
+                -->
     <attachment name="rulesAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
       <option name="movementRestrictionTerritories" value="65 Sea Zone:66 Sea Zone:85 Sea Zone:86 Sea Zone:88 Sea Zone:90 Sea Zone:103 Sea Zone:106 Sea Zone:107 Sea Zone:116 Sea Zone:117 Sea Zone:120 Sea Zone:122 Sea Zone:19 Sea Zone:20 Sea Zone:36 Sea Zone"/>
       <!-- :6 Sea Zone:17 Sea Zone:22 Sea Zone:32 Sea Zone:33 Sea Zone:34 Sea Zone:37 Sea Zone -->
       <option name="movementRestrictionType" value="disallowed"/>
     </attachment>
     <!-- Japanese in Alpha +3 are not allowed to end their movement in:
-						Any Sea zone within 2 spaces of Alaska or Western United States
-							1 Sea Zone:2 Sea Zone:3 Sea Zone:8 Sea Zone:9 Sea Zone:10 Sea Zone:11 Sea Zone:12 Sea Zone
-				-->
+                        Any Sea zone within 2 spaces of Alaska or Western United States
+                            1 Sea Zone:2 Sea Zone:3 Sea Zone:8 Sea Zone:9 Sea Zone:10 Sea Zone:11 Sea Zone:12 Sea Zone
+                -->
     <attachment name="rulesAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
       <option name="movementRestrictionTerritories" value="1 Sea Zone:2 Sea Zone:3 Sea Zone:8 Sea Zone:9 Sea Zone:10 Sea Zone:11 Sea Zone:12 Sea Zone"/>
       <option name="movementRestrictionType" value="disallowed"/>
@@ -15168,7 +15168,7 @@
     </property>
     <property name="mapName" value="world_war_ii_g40_balanced" editable="false"/>
     <property name="notes">
-      <value><![CDATA[  
+      <value><![CDATA[
 <div style="padding:10px;font-size:14px;background-color:white;text-align:justify;">
 <b>G40 Balanced - Balance Mod 2.0</b><br>
 <br>
@@ -15185,7 +15185,7 @@
 
 <b>Revised Capital Capture Rules:</b> The capture of a player's capital results in the plunder of that player's PUs only the <b>first</b> time the capital is taken. Subsequent recapture of the same capital results in the player's PUs being destroyed.<br><br>
 
-<b>Revised Victory Conditions:</b> If Germany is Allied controlled, an Axis victory in the Pacific requires 7 (rather than 6) Pacific VCs. If Japan is Allied controlled, an Axis victory in Europe requires 9 (rather than 8) Europe VCs. 
+<b>Revised Victory Conditions:</b> If Germany is Allied controlled, an Axis victory in the Pacific requires 7 (rather than 6) Pacific VCs. If Japan is Allied controlled, an Axis victory in Europe requires 9 (rather than 8) Europe VCs.
 
 <br><br>
 
@@ -15207,9 +15207,9 @@
 <li>3 PUs if Russia is at war with European Axis, and there are no non-Russian Allied units in any originally Russian territory.</li>
 <li>3 PUs for each originally German, Italian, or Pro-Axis neutral territory that Russia controls <b>in mainland Europe.</b> (This modifies Russia's "Spread of Communism" objective). </li>
 <li>2 PUs for each of the following Lend-Lease lanes that is "open" (i.e., the specified Sea Zone has no enemy warships and the specified territory is Allied controlled) when Russia is at war with European Axis: (1) sz 125, Archangel ; (2) sz 80, Persia; (3) sz 5, Amur (This modifies Russia's "Lend Lease" objective).</li>
-<li>An additional 2 PUs per each "open" Lend-Lease lane, when Russia is at war with European Axis, if Japan has also declared war on Russia.</li> 
+<li>An additional 2 PUs per each "open" Lend-Lease lane, when Russia is at war with European Axis, if Japan has also declared war on Russia.</li>
 <br>
-<b>Note:</b> An Axis power may not move its units into originally Russian territory unless that Axis power is at war with Russia. Also, when not at war with Japan, Russia may not move its units into any non-Russian Allied territory in Asia, other than Syria, Trans-Jordan, Iraq, Persia, NorthWest Persia, and East Persia. 
+<b>Note:</b> An Axis power may not move its units into originally Russian territory unless that Axis power is at war with Russia. Also, when not at war with Japan, Russia may not move its units into any non-Russian Allied territory in Asia, other than Syria, Trans-Jordan, Iraq, Persia, NorthWest Persia, and East Persia.
 </ul>
 
 <b>Japan</b>
@@ -15262,7 +15262,7 @@
 <br><br>
 The following rule-set simulates the circumstances and strategic consequences of the Franco-German Armistice, and is intended for play with the G40 Balance Mod.
 <br><br>
-<b>Game Conditions for Franco-German Armistice</b> 
+<b>Game Conditions for Franco-German Armistice</b>
 <br><br>
 At the beginning of France's turn, if the following conditions are met, the Franco-German Armistice will occur:
 <br><br>
@@ -15280,13 +15280,13 @@ With the exception of Southern France (see discussion of "Zone Libere" below), V
 <br><br>
 Fly-over restrictions applicable to other Neutral territories do not apply to Vichy French territory.
 <br><br>
-<b>Fleet at Toulon:</b> In addition to the change in French territorial control, the Armistice changes control of the the French fleet in sz 93, from French to Pro-Axis neutral. The Vichy French fleet maintains a strictly defensive posture. It may not be moved. It may not be captured by the Axis. The fleet is immediately destroyed if any power, other than the Free French, occupies Southern France 
+<b>Fleet at Toulon:</b> In addition to the change in French territorial control, the Armistice changes control of the the French fleet in sz 93, from French to Pro-Axis neutral. The Vichy French fleet maintains a strictly defensive posture. It may not be moved. It may not be captured by the Axis. The fleet is immediately destroyed if any power, other than the Free French, occupies Southern France
 <br><br>
 <b>"Zone Libre":</b> Any Axis occupation of Southern France following the Armistice results in the scuttling of the Vichy French Fleet at Toulon and the disbandment of all remaining Vichy French forces. These forces are removed at the end of the Axis player's turn in which the occupation of Southern France takes place. Any formerly Vichy French forces that were previously commandeered by the Axis are unaffected by this change.
 <br><br>
-<b>Armistice's Effect on National Objectives:</b> Following the armistice, Southern France is considered Axis-controlled for purposes of Italy's "Roman Empire" objective. Otherwise, the Vichy France arrangement has no impact on National Objectives. Tunisia, Algeria and Morocco must still be directly occupied by Germany or Italy to achieve Italy's "North Africa" objective. Japanese occupation of French Indo China still negates Japan's "Trade With America" objective. 
+<b>Armistice's Effect on National Objectives:</b> Following the armistice, Southern France is considered Axis-controlled for purposes of Italy's "Roman Empire" objective. Otherwise, the Vichy France arrangement has no impact on National Objectives. Tunisia, Algeria and Morocco must still be directly occupied by Germany or Italy to achieve Italy's "North Africa" objective. Japanese occupation of French Indo China still negates Japan's "Trade With America" objective.
 <br><br>
-<b>Liberation of France:</b> The Allied liberation of France effectively terminates the Armistice. Any territory and forces still under Vichy French control (including any surviving fleet in sz 93) revert back to Free French control. The Vichy French forces in the Southern France and sz 93 will also revert back if Southern France is liberated by the Free French. 
+<b>Liberation of France:</b> The Allied liberation of France effectively terminates the Armistice. Any territory and forces still under Vichy French control (including any surviving fleet in sz 93) revert back to Free French control. The Vichy French forces in the Southern France and sz 93 will also revert back if Southern France is liberated by the Free French.
 
 
 <br><br>
@@ -15304,8 +15304,8 @@ Paratroopers tech enables a second combat movement phase which happens right aft
 <br>
 
 <b>Disclaimer</b><br>
-The game is not meant to take over your responsibility in knowing the rules. For example, the game engine is not always going to restrict or allow certain attacks. 
-It is your responsibility to know the rules and abide by them. Most of the game notes that follow can be thought of as differences compared to WWIIv3 or WWIIv4 rules but obviously are not a complete manual for the game. 
+The game is not meant to take over your responsibility in knowing the rules. For example, the game engine is not always going to restrict or allow certain attacks.
+It is your responsibility to know the rules and abide by them. Most of the game notes that follow can be thought of as differences compared to WWIIv3 or WWIIv4 rules but obviously are not a complete manual for the game.
 Beginners to these games are suggested to ask for help in the lobby or on the forums at http://www.tripleawarclub.org<br>
 You must always validate your own movement, especially air movement at sea.  The engine is not perfect.<br>
 <br>
@@ -15436,7 +15436,7 @@ At the start of the game Germany and Italy are at war with the UK and ANZAC and 
 <li>Once at war, the Minor Factories in continental USA upgrade to Major Factories automatically for free, and may be used immediately.</li>
 </ul>
 <br><b>Neutrals</b><br>
-There are three types of neutrals: 
+There are three types of neutrals:
 <ul>
 <li>pro-Axis: When an Axis unit moves into one of these zones for the first time, that country gets a one-time bonus number of infantry, specified on the map, and control of the territory. The new infantry cannot be moved until the next turn.</li>
 <li>pro-Allies: When an Allied unit moves into one of these zones for the first time, that country gets a one-time bonus number of infantry, specified on the map, and control of the territory. The new infantry cannot be moved until the next turn.</li>
@@ -15457,7 +15457,7 @@ For each attack, a die is rolled, and a 2 or less is considered a hit. Casualtie
 <br><br><hr><br>
 
 <b>Submarines Prevent Unescorted Transports From Making Amphibious Assaults</b><br>
-In any Sea Zone containing an enemy submarine, but not containing an owned warship, the submarine will prevent the offloading of troops for an amphibious assault. 
+In any Sea Zone containing an enemy submarine, but not containing an owned warship, the submarine will prevent the offloading of troops for an amphibious assault.
 <br><br><hr><br>
 
 
@@ -15640,8 +15640,8 @@ These changes to units are things other than price/movement which you can see in
 <br>
 <br><br><hr><br>
 </div>
-						
-						]]></value>
+
+                        ]]></value>
     </property>
   </propertyList>
 </game>

--- a/src/test/resources/ww2pac40_test.xml
+++ b/src/test/resources/ww2pac40_test.xml
@@ -3,7 +3,7 @@
 <game>
         <info name="World War II Pacific Test" version="2.7"/>
         <loader javaClass="games.strategy.triplea.TripleA"/>
-		<triplea minimumVersion="1.5.2"/>
+        <triplea minimumVersion="1.5.2"/>
         <map>
                 <!-- Territory Definitions -->
                 <territory name="Caroline Islands"/>
@@ -155,9 +155,9 @@
                 <territory name="62 Sea Zone" water="true"/>
                 <territory name="61 Sea Zone" water="true"/>
                 <territory name="60 Sea Zone" water="true"/>
-				<!--<territory name="Box1"/>-->
-				<!--<territory name="Box2"/>
-				<territory name="Box3"/>-->
+                <!--<territory name="Box1"/>-->
+                <!--<territory name="Box2"/>
+                <territory name="Box3"/>-->
 
                 <!-- Territory Connections -->
                 <connection t1="Caroline Islands" t2="33 Sea Zone"/>
@@ -350,7 +350,7 @@
                 <connection t1="31 Sea Zone" t2="23 Sea Zone"/>
                 <connection t1="31 Sea Zone" t2="26 Sea Zone"/>
                 <connection t1="31 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="30 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="30 Sea Zone"/>
                 <connection t1="30 Sea Zone" t2="26 Sea Zone"/>
                 <connection t1="30 Sea Zone" t2="27 Sea Zone"/>
                 <connection t1="30 Sea Zone" t2="29 Sea Zone"/>
@@ -494,44 +494,44 @@
                 <connection t1="61 Sea Zone" t2="South Australia"/>
                 <connection t1="60 Sea Zone" t2="59 Sea Zone"/>
                 <connection t1="60 Sea Zone" t2="56 Sea Zone"/>
-				<!--<connection t1="Box2" t2="Box3"/>-->
+                <!--<connection t1="Box2" t2="Box3"/>-->
         </map>
-        
-		
-		<resourceList>
+
+
+        <resourceList>
                 <resource name="PUs"/>
                 <resource name="techTokens"/>
                 <resource name="SuicideAttackTokens"/>
         </resourceList>
-		
-		
+
+
         <playerList>
                 <!-- In turn order -->
                 <player name="Japanese" optional="false"/>
                 <player name="Americans" optional="false"/>
-				<player name="Chinese" optional="false"/>
+                <player name="Chinese" optional="false"/>
                 <player name="British" optional="false"/>
                 <player name="ANZAC" optional="false"/>
-                
+
                 <player name="Russians" optional="true"/>
                 <player name="French" optional="true"/>
                 <player name="Dutch" optional="true"/>
 
-				
-				
+
+
                 <alliance player="Japanese" alliance="Axis"/>
-				
+
                 <alliance player="Americans" alliance="Allies"/>
                 <alliance player="Chinese" alliance="Allies"/>
                 <alliance player="British" alliance="Allies"/>
                 <alliance player="ANZAC" alliance="Allies"/>
-				
+
                 <alliance player="Russians" alliance="Russians"/>
                 <alliance player="French" alliance="French"/>
                 <alliance player="Dutch" alliance="Dutch"/>
         </playerList>
-		
-		
+
+
         <unitList>
                 <unit name="infantry"/>
                 <unit name="armour"/>
@@ -544,29 +544,29 @@
                 <unit name="aaGun"/>
                 <unit name="artillery"/>
                 <unit name="destroyer"/>
-				<unit name="cruiser"/>
-				<unit name="mech_infantry"/>
-				<unit name="tactical_bomber"/>
-				
-				<unit name="airfield"/>
-				<unit name="harbour"/>
-				<unit name="factory_major"/>
-				<unit name="factory_minor"/>
-				<unit name="factory_upgrade"/>
+                <unit name="cruiser"/>
+                <unit name="mech_infantry"/>
+                <unit name="tactical_bomber"/>
+
+                <unit name="airfield"/>
+                <unit name="harbour"/>
+                <unit name="factory_major"/>
+                <unit name="factory_minor"/>
+                <unit name="factory_upgrade"/>
         </unitList>
-		
+
         <!--  this is the list of relationshipTypes you can create between players -->
-        <!--  each relationshipType you define here MUST have a RelationshipTypeAttachment to define this relationship 
+        <!--  each relationshipType you define here MUST have a RelationshipTypeAttachment to define this relationship
               also each RelationshipTypeAttachment MUST have an archetype set to either: "allied", "neutral" or "war"
         -->
-		<relationshipTypes>
-				<relationshipType name="Allied"/>
-				<relationshipType name="War"/>
-				<relationshipType name="Neutrality"/>
-				<relationshipType name="Custodianship"/>
-				<relationshipType name="Friendly"/>
-		</relationshipTypes>
-		
+        <relationshipTypes>
+                <relationshipType name="Allied"/>
+                <relationshipType name="War"/>
+                <relationshipType name="Neutrality"/>
+                <relationshipType name="Custodianship"/>
+                <relationshipType name="Friendly"/>
+        </relationshipTypes>
+
         <gamePlay>
                 <delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate" display="Initializing Delegates"/>
                 <delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate" display="Research Technology"/>
@@ -575,37 +575,37 @@
                 <delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Combat Move"/>
                 <delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Units"/>
                 <delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
-				<!--<delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>-->
+                <!--<delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>-->
                 <delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate" display="Turn Complete"/>
-				<!--<delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>-->
+                <!--<delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>-->
                 <delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
                 <delegate name="placeBid" javaClass="games.strategy.triplea.delegate.BidPlaceDelegate" display="Bid Placement"/>
                 <delegate name="bid" javaClass="games.strategy.triplea.delegate.BidPurchaseDelegate" display="Bid Purchase"/>
                 <delegate name="politics" javaClass="games.strategy.triplea.delegate.PoliticsDelegate" display="Politics"/>
-                
-				<sequence>
+
+                <sequence>
                         <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
-						
+
                         <step name="japaneseBid" delegate="bid" player="Japanese" maxRunCount="1"/>
                         <step name="japaneseBidPlace" delegate="placeBid" player="Japanese" maxRunCount="1"/>
-						<step name="americanBid" delegate="bid" player="Americans" maxRunCount="1"/>
+                        <step name="americanBid" delegate="bid" player="Americans" maxRunCount="1"/>
                         <step name="americanBidPlace" delegate="placeBid" player="Americans" maxRunCount="1"/>
                         <step name="chineseBid" delegate="bid" player="Chinese" maxRunCount="1"/>
-						<step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
+                        <step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
                         <step name="britishBid" delegate="bid" player="British" maxRunCount="1"/>
                         <step name="britishBidPlace" delegate="placeBid" player="British" maxRunCount="1"/>
-						<step name="anzacBid" delegate="bid" player="ANZAC" maxRunCount="1"/>
+                        <step name="anzacBid" delegate="bid" player="ANZAC" maxRunCount="1"/>
                         <step name="anzacBidPlace" delegate="placeBid" player="ANZAC" maxRunCount="1"/>
-                        <!-- these are not needed: 
-						<step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
+                        <!-- these are not needed:
+                        <step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
                         <step name="russianBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
-						<step name="frenchBid" delegate="bid" player="French" maxRunCount="1"/>
+                        <step name="frenchBid" delegate="bid" player="French" maxRunCount="1"/>
                         <step name="frenchBidPlace" delegate="placeBid" player="French" maxRunCount="1"/>
                         <step name="dutchBid" delegate="bid" player="Dutch" maxRunCount="1"/>
                         <step name="dutchBidPlace" delegate="placeBid" player="Dutch" maxRunCount="1"/> -->
-                        
+
                         <step name="japanesePolitics" delegate="politics" player="Japanese"/>
-						<step name="japaneseTech" delegate="tech" player="Japanese"/>
+                        <step name="japaneseTech" delegate="tech" player="Japanese"/>
                         <step name="japanesePurchase" delegate="purchase" player="Japanese"/>
                         <step name="japaneseCombatMove" delegate="move" player="Japanese"/>
                         <step name="japaneseBattle" delegate="battle" player="Japanese"/>
@@ -613,19 +613,19 @@
                         <step name="japanesePlace" delegate="place" player="Japanese"/>
                         <step name="japaneseTechActivation" delegate="tech_activation" player="Japanese"/>
                         <step name="japaneseEndTurn" delegate="endTurn" player="Japanese"/>
-                        
+
                         <step name="americansPolitics" delegate="politics" player="Americans"/>
-						<step name="americansTech" delegate="tech" player="Americans"/>
+                        <step name="americansTech" delegate="tech" player="Americans"/>
                         <step name="americansPurchase" delegate="purchase" player="Americans"/>
-						<step name="americansCombatMove" delegate="move" player="Americans"/>
+                        <step name="americansCombatMove" delegate="move" player="Americans"/>
                         <step name="americansBattle" delegate="battle" player="Americans"/>
                         <step name="americansNonCombatMove" delegate="move" player="Americans" display="Non Combat Move"/>
-						<step name="americansPlace" delegate="place" player="Americans"/>
-						<step name="americansTechActivation" delegate="tech_activation" player="Americans"/>
+                        <step name="americansPlace" delegate="place" player="Americans"/>
+                        <step name="americansTechActivation" delegate="tech_activation" player="Americans"/>
                         <step name="americansEndTurn" delegate="endTurn" player="Americans"/>
-                        
+
                         <step name="chinesePolitics" delegate="politics" player="Chinese"/>
-						<!--<step name="chineseTech" delegate="tech" player="Chinese"/>-->
+                        <!--<step name="chineseTech" delegate="tech" player="Chinese"/>-->
                         <step name="chinesePurchase" delegate="purchase" player="Chinese"/>
                         <step name="chineseCombatMove" delegate="move" player="Chinese"/>
                         <step name="chineseBattle" delegate="battle" player="Chinese"/>
@@ -633,9 +633,9 @@
                         <step name="chinesePlace" delegate="place" player="Chinese"/>
                         <!--<step name="chineseTechActivation" delegate="tech_activation" player="Chinese"/>-->
                         <step name="chineseEndTurn" delegate="endTurn" player="Chinese"/>
-                        
+
                         <step name="britishPolitics" delegate="politics" player="British"/>
-						<step name="britishTech" delegate="tech" player="British"/>
+                        <step name="britishTech" delegate="tech" player="British"/>
                         <step name="britishPurchase" delegate="purchase" player="British"/>
                         <step name="britishCombatMove" delegate="move" player="British"/>
                         <step name="britishBattle" delegate="battle" player="British"/>
@@ -643,9 +643,9 @@
                         <step name="britishPlace" delegate="place" player="British"/>
                         <step name="britishTechActivation" delegate="tech_activation" player="British"/>
                         <step name="britishEndTurn" delegate="endTurn" player="British"/>
-						
+
                         <step name="anzacPolitics" delegate="politics" player="ANZAC"/>
-						<step name="anzacTech" delegate="tech" player="ANZAC"/>
+                        <step name="anzacTech" delegate="tech" player="ANZAC"/>
                         <step name="anzacPurchase" delegate="purchase" player="ANZAC"/>
                         <step name="anzacCombatMove" delegate="move" player="ANZAC"/>
                         <step name="anzacBattle" delegate="battle" player="ANZAC"/>
@@ -653,9 +653,9 @@
                         <step name="anzacPlace" delegate="place" player="ANZAC"/>
                         <step name="anzacTechActivation" delegate="tech_activation" player="ANZAC"/>
                         <step name="anzacEndTurn" delegate="endTurn" player="ANZAC"/>
-                        
-						<!-- not needed: 
-						<step name="russiansTech" delegate="tech" player="Russians"/>
+
+                        <!-- not needed:
+                        <step name="russiansTech" delegate="tech" player="Russians"/>
                         <step name="russiansPurchase" delegate="purchase" player="Russians"/>
                         <step name="russiansCombatMove" delegate="move" player="Russians"/>
                         <step name="russiansBattle" delegate="battle" player="Russians"/>
@@ -663,8 +663,8 @@
                         <step name="russiansPlace" delegate="place" player="Russians"/>
                         <step name="russiansTechActivation" delegate="tech_activation" player="Russians"/>
                         <step name="russiansEndTurn" delegate="endTurnNoPU" player="Russians"/>
-                        
-						<step name="frenchTech" delegate="tech" player="French"/>
+
+                        <step name="frenchTech" delegate="tech" player="French"/>
                         <step name="frenchPurchase" delegate="purchase" player="French"/>
                         <step name="frenchCombatMove" delegate="move" player="French"/>
                         <step name="frenchBattle" delegate="battle" player="French"/>
@@ -672,8 +672,8 @@
                         <step name="frenchPlace" delegate="place" player="French"/>
                         <step name="frenchTechActivation" delegate="tech_activation" player="French"/>
                         <step name="frenchEndTurn" delegate="endTurnNoPU" player="French"/>
-                        
-						<step name="dutchTech" delegate="tech" player="Dutch"/>
+
+                        <step name="dutchTech" delegate="tech" player="Dutch"/>
                         <step name="dutchPurchase" delegate="purchase" player="Dutch"/>
                         <step name="dutchCombatMove" delegate="move" player="Dutch"/>
                         <step name="dutchBattle" delegate="battle" player="Dutch"/>
@@ -681,7 +681,7 @@
                         <step name="dutchPlace" delegate="place" player="Dutch"/>
                         <step name="dutchTechActivation" delegate="tech_activation" player="Dutch"/>
                         <step name="dutchEndTurn" delegate="endTurnNoPU" player="Dutch"/> -->
-						
+
                         <step name="endRoundStep" delegate="endRound"/>
                 </sequence>
         </gamePlay>
@@ -691,17 +691,17 @@
                         <cost resource="PUs" quantity="3" />
                         <result resourceOrUnit="infantry" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyMech_Infantry">
+
+                <productionRule name="buyMech_Infantry">
                         <cost resource="PUs" quantity="4" />
                         <result resourceOrUnit="mech_infantry" quantity="1"/>
                 </productionRule>
-				
+
                 <productionRule name="buyArtillery">
                         <cost resource="PUs" quantity="4" />
                         <result resourceOrUnit="artillery" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArmour">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="armour" quantity="1"/>
@@ -711,18 +711,18 @@
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="fighter" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyTactical_Bomber">
                         <cost resource="PUs" quantity="11" />
                         <result resourceOrUnit="tactical_bomber" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBomber">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="bomber" quantity="1"/>
                 </productionRule>
-                
-				<productionRule name="buyTransport">
+
+                <productionRule name="buyTransport">
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="transport" quantity="1"/>
                 </productionRule>
@@ -731,17 +731,17 @@
                         <cost resource="PUs" quantity="16" />
                         <result resourceOrUnit="carrier" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyDestroyer">
                         <cost resource="PUs" quantity="8" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiser">
+
+                <productionRule name="buyCruiser">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBattleship">
                         <cost resource="PUs" quantity="20" />
                         <result resourceOrUnit="battleship" quantity="1"/>
@@ -751,341 +751,341 @@
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="submarine" quantity="1"/>
                 </productionRule>
-                
-                
-				<productionRule name="buyFactory_Minor">
+
+
+                <productionRule name="buyFactory_Minor">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="factory_minor" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFactory_Major">
                         <cost resource="PUs" quantity="30" />
                         <result resourceOrUnit="factory_major" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFactory_Upgrade">
                         <cost resource="PUs" quantity="20" />
                         <result resourceOrUnit="factory_upgrade" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyAirfield">
                         <cost resource="PUs" quantity="15" />
                         <result resourceOrUnit="airfield" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyHarbour">
                         <cost resource="PUs" quantity="15" />
                         <result resourceOrUnit="harbour" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyAAGun">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="aaGun" quantity="1"/>
                 </productionRule>
-				
+
 
                 <!-- Advanced Industrial Production -->
-                
+
                 <!--<productionRule name="buyInfantryIndustrialTechnology">
                         <cost resource="PUs" quantity="3" />
                         <result resourceOrUnit="infantry" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyMech_InfantryIndustrialTechnology">
                         <cost resource="PUs" quantity="4" />
                         <result resourceOrUnit="mech_infantry" quantity="1"/>
                 </productionRule>
-                
-				<productionRule name="buyArtilleryIndustrialTechnology">
+
+                <productionRule name="buyArtilleryIndustrialTechnology">
                         <cost resource="PUs" quantity="4" />
                         <result resourceOrUnit="artillery" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArmourIndustrialTechnology">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="armour" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFighterIndustrialTechnology">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="fighter" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyTactical_BomberIndustrialTechnology">
                         <cost resource="PUs" quantity="11" />
                         <result resourceOrUnit="tactical_bomber" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBomberIndustrialTechnology">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="bomber" quantity="1"/>
                 </productionRule>
-                
-				<productionRule name="buyTransportIndustrialTechnology">
+
+                <productionRule name="buyTransportIndustrialTechnology">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="transport" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyCarrierIndustrialTechnology">
                         <cost resource="PUs" quantity="13" />
                         <result resourceOrUnit="carrier" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyDestroyerIndustrialTechnology">
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiserIndustrialTechnology">
+
+                <productionRule name="buyCruiserIndustrialTechnology">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBattleshipIndustrialTechnology">
                         <cost resource="PUs" quantity="17" />
                         <result resourceOrUnit="battleship" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buySubmarineIndustrialTechnology">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="submarine" quantity="1"/>
                 </productionRule>
-                
-				<productionRule name="buyFactory_MinorIndustrialTechnology">
+
+                <productionRule name="buyFactory_MinorIndustrialTechnology">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="factory_minor" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFactory_MajorIndustrialTechnology">
                         <cost resource="PUs" quantity="30" />
                         <result resourceOrUnit="factory_major" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyAirfieldIndustrialTechnology">
                         <cost resource="PUs" quantity="15" />
                         <result resourceOrUnit="airfield" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyHarbourIndustrialTechnology">
                         <cost resource="PUs" quantity="15" />
                         <result resourceOrUnit="harbour" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyAAGunIndustrialTechnology">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="aaGun" quantity="1"/>
                 </productionRule>-->
-                
-                
+
+
                 <!-- SHIPYARD PRICES -->
-                
+
                 <productionRule name="buyTransportShipyards">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="transport" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyCarrierShipyards">
                         <cost resource="PUs" quantity="13" />
                         <result resourceOrUnit="carrier" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyDestroyerShipyards">
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiserShipyards">
+
+                <productionRule name="buyCruiserShipyards">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBattleshipShipyards">
                         <cost resource="PUs" quantity="17" />
                         <result resourceOrUnit="battleship" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buySubmarineShipyards">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="submarine" quantity="1"/>
                 </productionRule>
-                
+
                <!-- Repair rules -->
-				<repairRule name="repairFactory_Minor">
+                <repairRule name="repairFactory_Minor">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory_minor" quantity="1"/>
                 </repairRule>
-                
+
                 <repairRule name="repairFactory_MinorIndustrialTechnology">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory_minor" quantity="2"/>
                 </repairRule>
-                
+
                 <repairRule name="repairFactory_Major">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory_major" quantity="1"/>
                 </repairRule>
-                
+
                 <repairRule name="repairFactory_MajorIndustrialTechnology">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory_major" quantity="2"/>
                 </repairRule>
-                
+
                 <repairRule name="repairFactory_Upgrade">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory_upgrade" quantity="1"/>
                 </repairRule>
-                
+
                 <repairRule name="repairFactory_UpgradeIndustrialTechnology">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory_upgrade" quantity="2"/>
                 </repairRule>
-                
-				<repairRule name="repairAirfield">
+
+                <repairRule name="repairAirfield">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="airfield" quantity="1"/>
                 </repairRule>
-                
+
                 <repairRule name="repairAirfieldIndustrialTechnology">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="airfield" quantity="2"/>
                 </repairRule>
-                
+
                 <repairRule name="repairHarbour">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="harbour" quantity="1"/>
                 </repairRule>
-                
+
                 <repairRule name="repairHarbourIndustrialTechnology">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="harbour" quantity="2"/>
                 </repairRule>
-                
-				
-				
-				<repairFrontier name="repair">
-                	<repairRules name="repairFactory_Minor"/>
-					<repairRules name="repairFactory_Major"/>
-					<repairRules name="repairFactory_Upgrade"/>
-					<repairRules name="repairAirfield"/>
-					<repairRules name="repairHarbour"/>
+
+
+
+                <repairFrontier name="repair">
+                    <repairRules name="repairFactory_Minor"/>
+                    <repairRules name="repairFactory_Major"/>
+                    <repairRules name="repairFactory_Upgrade"/>
+                    <repairRules name="repairAirfield"/>
+                    <repairRules name="repairHarbour"/>
                 </repairFrontier>
-				
-                
+
+
                 <repairFrontier name="repairIndustrialTechnology">
-                	<repairRules name="repairFactory_MinorIndustrialTechnology"/>
-					<repairRules name="repairFactory_MajorIndustrialTechnology"/>
-					<repairRules name="repairFactory_UpgradeIndustrialTechnology"/>
-					<repairRules name="repairAirfieldIndustrialTechnology"/>
-					<repairRules name="repairHarbourIndustrialTechnology"/>
+                    <repairRules name="repairFactory_MinorIndustrialTechnology"/>
+                    <repairRules name="repairFactory_MajorIndustrialTechnology"/>
+                    <repairRules name="repairFactory_UpgradeIndustrialTechnology"/>
+                    <repairRules name="repairAirfieldIndustrialTechnology"/>
+                    <repairRules name="repairHarbourIndustrialTechnology"/>
                 </repairFrontier>
 
                 <productionFrontier name="production">
                         <frontierRules name="buyInfantry"/>
-						<frontierRules name="buyMech_Infantry"/>
+                        <frontierRules name="buyMech_Infantry"/>
                         <frontierRules name="buyArtillery"/>
                         <frontierRules name="buyArmour"/>
                         <frontierRules name="buyFighter"/>
-						<frontierRules name="buyTactical_Bomber"/>
+                        <frontierRules name="buyTactical_Bomber"/>
                         <frontierRules name="buyBomber"/>
                         <frontierRules name="buyTransport"/>
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buyAAGun"/>
-						<frontierRules name="buyFactory_Minor"/>
-						<frontierRules name="buyFactory_Upgrade"/>
-						<frontierRules name="buyFactory_Major"/>
-						<frontierRules name="buyAirfield"/>
-						<frontierRules name="buyHarbour"/>
+                        <frontierRules name="buyFactory_Minor"/>
+                        <frontierRules name="buyFactory_Upgrade"/>
+                        <frontierRules name="buyFactory_Major"/>
+                        <frontierRules name="buyAirfield"/>
+                        <frontierRules name="buyHarbour"/>
                 </productionFrontier>
-				
-				<productionFrontier name="productionChinese_Burma_Road_Open">
+
+                <productionFrontier name="productionChinese_Burma_Road_Open">
                         <frontierRules name="buyInfantry"/>
-                        <frontierRules name="buyArtillery"/>        
+                        <frontierRules name="buyArtillery"/>
                 </productionFrontier>
-				<productionFrontier name="productionChinese_Burma_Road_Closed">
+                <productionFrontier name="productionChinese_Burma_Road_Closed">
                         <frontierRules name="buyInfantry"/>
                 </productionFrontier>
-                
+
                 <!--<productionFrontier name="productionIndustrialTechnology">
                         <frontierRules name="buyInfantryIndustrialTechnology"/>
                         <frontierRules name="buyMech_InfantryIndustrialTechnology"/>
-						<frontierRules name="buyArtilleryIndustrialTechnology"/>
+                        <frontierRules name="buyArtilleryIndustrialTechnology"/>
                         <frontierRules name="buyArmourIndustrialTechnology"/>
                         <frontierRules name="buyFighterIndustrialTechnology"/>
-						<frontierRules name="buyTactical_BomberIndustrialTechnology"/>
+                        <frontierRules name="buyTactical_BomberIndustrialTechnology"/>
                         <frontierRules name="buyBomberIndustrialTechnology"/>
                         <frontierRules name="buyTransportIndustrialTechnology"/>
                         <frontierRules name="buySubmarineIndustrialTechnology"/>
                         <frontierRules name="buyCarrierIndustrialTechnology"/>
                         <frontierRules name="buyDestroyerIndustrialTechnology"/>
-						<frontierRules name="buyCruiserIndustrialTechnology"/>
+                        <frontierRules name="buyCruiserIndustrialTechnology"/>
                         <frontierRules name="buyBattleshipIndustrialTechnology"/>
                         <frontierRules name="buyAAGunIndustrialTechnology"/>
-						<frontierRules name="buyFactory_MinorIndustrialTechnology"/>
-						<frontierRules name="buyFactory_MajorIndustrialTechnology"/>
-						<frontierRules name="buyAirfieldIndustrialTechnology"/>
-						<frontierRules name="buyHarbourIndustrialTechnology"/>
+                        <frontierRules name="buyFactory_MinorIndustrialTechnology"/>
+                        <frontierRules name="buyFactory_MajorIndustrialTechnology"/>
+                        <frontierRules name="buyAirfieldIndustrialTechnology"/>
+                        <frontierRules name="buyHarbourIndustrialTechnology"/>
                 </productionFrontier>-->
-                
+
                 <productionFrontier name="productionShipyards">
                         <frontierRules name="buyTransportShipyards"/>
                         <frontierRules name="buySubmarineShipyards"/>
                         <frontierRules name="buyCarrierShipyards"/>
                         <frontierRules name="buyDestroyerShipyards"/>
-						<frontierRules name="buyCruiserShipyards"/>
-                        <frontierRules name="buyBattleshipShipyards"/>   
+                        <frontierRules name="buyCruiserShipyards"/>
+                        <frontierRules name="buyBattleshipShipyards"/>
                 </productionFrontier>
-                
+
                 <playerProduction player="Japanese" frontier="production"/>
-				<playerProduction player="Americans" frontier="production"/>
+                <playerProduction player="Americans" frontier="production"/>
                 <playerProduction player="Chinese" frontier="productionChinese_Burma_Road_Open"/>
                 <playerProduction player="British" frontier="production"/>
                 <playerProduction player="ANZAC" frontier="production"/>
-				<playerProduction player="Russians" frontier="production"/>
-				<playerProduction player="French" frontier="production"/>
-				<playerProduction player="Dutch" frontier="production"/>
-				
+                <playerProduction player="Russians" frontier="production"/>
+                <playerProduction player="French" frontier="production"/>
+                <playerProduction player="Dutch" frontier="production"/>
+
                 <playerRepair player="Japanese" frontier="repair"/>
-				<playerRepair player="Americans" frontier="repair"/>
-				<playerRepair player="Chinese" frontier="repair"/>
-				<playerRepair player="British" frontier="repair"/>
-				<playerRepair player="ANZAC" frontier="repair"/>
+                <playerRepair player="Americans" frontier="repair"/>
+                <playerRepair player="Chinese" frontier="repair"/>
+                <playerRepair player="British" frontier="repair"/>
+                <playerRepair player="ANZAC" frontier="repair"/>
                 <playerRepair player="Russians" frontier="repair"/>
-				<playerRepair player="French" frontier="repair"/>
+                <playerRepair player="French" frontier="repair"/>
                 <playerRepair player="Dutch" frontier="repair"/>
-				
+
         </production>
         <attachmentList>
-					<attachment name="relationshipTypeAttachment" attachTo="War" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="war"/>
-					</attachment>
+                    <attachment name="relationshipTypeAttachment" attachTo="War" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="war"/>
+                    </attachment>
 
-					<attachment name="relationshipTypeAttachment" attachTo="Allied" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="allied"/>
-					</attachment>
+                    <attachment name="relationshipTypeAttachment" attachTo="Allied" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="allied"/>
+                    </attachment>
 
-					<attachment name="relationshipTypeAttachment" attachTo="Neutrality" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<option name="archeType" value="neutral"/>
-					</attachment>
+                    <attachment name="relationshipTypeAttachment" attachTo="Neutrality" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <option name="archeType" value="neutral"/>
+                    </attachment>
 
-					<attachment name="relationshipTypeAttachment" attachTo="Friendly" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<!--<option name="archeType" value="neutral"/>
-						<option name="canMoveLandUnitsOverOwnedLand" value="true"/>
-						<option name="canMoveAirUnitsOverOwnedLand" value="true"/>
-						<option name="canLandAirUnitsOnOwnedLand" value="true"/>-->
-						<option name="archeType" value="allied"/>
-					</attachment>
-					
-					<attachment name="relationshipTypeAttachment" attachTo="Custodianship" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
-						<!--<option name="archeType" value="war"/>
-						<option name="canLandAirUnitsOnOwnedLand" value="true"/>-->
-						<option name="archeType" value="allied"/>
-						<option name="canTakeOverOwnedTerritory" value="true"/>
-					</attachment>
-				
+                    <attachment name="relationshipTypeAttachment" attachTo="Friendly" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <!--<option name="archeType" value="neutral"/>
+                        <option name="canMoveLandUnitsOverOwnedLand" value="true"/>
+                        <option name="canMoveAirUnitsOverOwnedLand" value="true"/>
+                        <option name="canLandAirUnitsOnOwnedLand" value="true"/>-->
+                        <option name="archeType" value="allied"/>
+                    </attachment>
+
+                    <attachment name="relationshipTypeAttachment" attachTo="Custodianship" javaClass="games.strategy.triplea.attachments.RelationshipTypeAttachment" type="relationship">
+                        <!--<option name="archeType" value="war"/>
+                        <option name="canLandAirUnitsOnOwnedLand" value="true"/>-->
+                        <option name="archeType" value="allied"/>
+                        <option name="canTakeOverOwnedTerritory" value="true"/>
+                    </attachment>
+
                     <attachment name="techAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
@@ -1198,8 +1198,8 @@
                         <option name="warBonds" value="false"/>
                         <option name="mechanizedInfantry" value="false"/>
                     </attachment>-->
-					
-					
+
+
                     <!-- Infantry -->
                 <attachment name="unitAttachment" attachTo="infantry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="1"/>
@@ -1208,10 +1208,10 @@
                          <option name="attack" value="1"/>
                          <option name="defense" value="2"/>
                          <option name="artillerySupportable" value="true"/>
-						 <option name="isAirTransportable" value="true"/>
+                         <option name="isAirTransportable" value="true"/>
                 </attachment>
-				
-				
+
+
                 <!-- Mech Infantry -->
                 <attachment name="unitAttachment" attachTo="mech_infantry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
@@ -1219,9 +1219,9 @@
                          <option name="attack" value="1"/>
                          <option name="defense" value="2"/>
                          <option name="artillerySupportable" value="true"/>
-						 <!-- only supposed to get blitz when paired with a tank -->
+                         <!-- only supposed to get blitz when paired with a tank -->
                          <!--<option name="canBlitz" value="true"/>-->
-						 <option name="receivesAbilityWhenWith" value="canBlitz:armour"/>
+                         <option name="receivesAbilityWhenWith" value="canBlitz:armour"/>
                 </attachment>
 
                 <!-- Artillery -->
@@ -1240,9 +1240,9 @@
                          <option name="canBlitz" value="true"/>
                          <option name="attack" value="3"/>
                          <option name="defense" value="3"/>
-						 <option name="isLandTransport" value="true"/>
+                         <option name="isLandTransport" value="true"/>
                 </attachment>
-            
+
                 <!-- Fighter -->
                 <attachment name="unitAttachment" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="4"/>
@@ -1250,14 +1250,14 @@
                          <option name="isAir" value="true"/>
                          <option name="attack" value="3"/>
                          <option name="defense" value="4"/>
-						 <option name="canScramble" value="true"/>
+                         <option name="canScramble" value="true"/>
                          <option name="maxScrambleDistance" value="1"/>
-						 <option name="canIntercept" value="true"/>
-						 <option name="canEscort" value="true"/>
+                         <option name="canIntercept" value="true"/>
+                         <option name="canEscort" value="true"/>
                          <option name="airDefense" value="2"/>
                          <option name="airAttack" value="1"/>
                 </attachment>
-            
+
                 <!-- Bomber -->
                 <attachment name="unitAttachment" attachTo="bomber" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="6"/>
@@ -1265,31 +1265,31 @@
                          <option name="attack" value="4"/>
                          <option name="defense" value="1"/>
                          <option name="isStrategicBomber" value="true"/>
-						 <option name="isAirTransport" value="true"/>
+                         <option name="isAirTransport" value="true"/>
                          <option name="transportCapacity" value="2"/>
-						 <!-- new rules have scrambling for fighters to defend against a strat bombing raid against anything that can be strat bombed (factories, bases)-->
+                         <!-- new rules have scrambling for fighters to defend against a strat bombing raid against anything that can be strat bombed (factories, bases)-->
                 </attachment>
 
                 <!-- Tactical Bomber -->
                 <attachment name="unitAttachment" attachTo="tactical_bomber" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="4"/>
                          <option name="carrierCost" value="1"/>
-                         <option name="isAir" value="true"/>   
+                         <option name="isAir" value="true"/>
                          <option name="attack" value="3"/>
                          <option name="defense" value="3"/>
-						 <option name="canScramble" value="true"/>
+                         <option name="canScramble" value="true"/>
                          <option name="maxScrambleDistance" value="1"/>
                 </attachment>
-            
+
                 <!-- Transport -->
                 <attachment name="unitAttachment" attachTo="transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
-                         <option name="transportCapacity" value="5"/>   
+                         <option name="isSea" value="true"/>
+                         <option name="transportCapacity" value="5"/>
                          <option name="attack" value="0"/>
                          <option name="defense" value="0"/>
                 </attachment>
-            
+
                 <!-- Battle Ship -->
                 <attachment name="unitAttachment" attachTo="battleship" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
@@ -1298,10 +1298,10 @@
                          <option name="defense" value="4"/>
                          <option name="canBombard" value="true"/>
                          <option name="hitPoints" value="2"/>
-						 <option name="blockade" value="1"/>
+                         <option name="blockade" value="1"/>
                  </attachment>
-				 
-				 <!-- Cruiser -->
+
+                 <!-- Cruiser -->
                 <attachment name="unitAttachment" attachTo="cruiser" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
                          <option name="isSea" value="true"/>
@@ -1309,149 +1309,149 @@
                          <option name="defense" value="3"/>
                          <option name="canBombard" value="true"/>
                          <option name="hitPoints" value="1"/>
-						 <option name="blockade" value="1"/>
+                         <option name="blockade" value="1"/>
                  </attachment>
-                 
+
                 <!-- Destroyer -->
                 <attachment name="unitAttachment" attachTo="destroyer" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
+                         <option name="isSea" value="true"/>
                          <option name="attack" value="2"/>
                          <option name="defense" value="2"/>
                          <option name="isDestroyer" value="true"/>
-						 <option name="blockade" value="1"/>
+                         <option name="blockade" value="1"/>
                 </attachment>
-                
+
                 <!-- Carrier -->
                 <attachment name="unitAttachment" attachTo="carrier" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
+                         <option name="isSea" value="true"/>
                          <option name="attack" value="0"/>
                          <option name="defense" value="2"/>
-						 <option name="carrierCapacity" value="2"/>
+                         <option name="carrierCapacity" value="2"/>
                          <option name="hitPoints" value="2"/>
-						 <option name="blockade" value="1"/>
-						 <!-- whenCombatDamaged means that when this unit has x:y damage on it, it will have this effect -->
-						 <option name="whenCombatDamaged" value="unitsMayNotLandOnCarrier" count="1:2"/>
-						 <option name="whenCombatDamaged" value="unitsMayNotLeaveAlliedCarrier" count="1:2"/>
+                         <option name="blockade" value="1"/>
+                         <!-- whenCombatDamaged means that when this unit has x:y damage on it, it will have this effect -->
+                         <option name="whenCombatDamaged" value="unitsMayNotLandOnCarrier" count="1:2"/>
+                         <option name="whenCombatDamaged" value="unitsMayNotLeaveAlliedCarrier" count="1:2"/>
                 </attachment>
 
                 <!-- Submarine -->
                 <attachment name="unitAttachment" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
+                         <option name="isSea" value="true"/>
                          <option name="isSub" value="true"/>
                          <option name="attack" value="2"/>
                          <option name="defense" value="1"/>
-						 <option name="blockade" value="2"/>
-							<!-- stuff for targeting unescorted transports (we are using the new-fangled aa-gun code) -->
-						 <!--<option name="isAAforCombatOnly" value="true"/>-->
-						 <option name="isAAforFlyOverOnly" value="true"/>
-						 <option name="targetsAA" value="transport"/>
-						 <option name="willNotFireIfPresent" value="destroyer:cruiser:battleship:carrier"/>
-						 <option name="mayOverStackAA" value="true"/>
-						 <option name="maxAAattacks" value="1"/>
-						 <option name="attackAA" value="2"/>
-						 <option name="attackAAmaxDieSides" value="6"/>
-						 <option name="typeAA" value="Submarine Strike on Unescorted Transports"/>
+                         <option name="blockade" value="2"/>
+                            <!-- stuff for targeting unescorted transports (we are using the new-fangled aa-gun code) -->
+                         <!--<option name="isAAforCombatOnly" value="true"/>-->
+                         <option name="isAAforFlyOverOnly" value="true"/>
+                         <option name="targetsAA" value="transport"/>
+                         <option name="willNotFireIfPresent" value="destroyer:cruiser:battleship:carrier"/>
+                         <option name="mayOverStackAA" value="true"/>
+                         <option name="maxAAattacks" value="1"/>
+                         <option name="attackAA" value="2"/>
+                         <option name="attackAAmaxDieSides" value="6"/>
+                         <option name="typeAA" value="Submarine Strike on Unescorted Transports"/>
                 </attachment>
-				
-				
-				
+
+
+
                 <!-- Factory Minor -->
                 <attachment name="unitAttachment" attachTo="factory_minor" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-                         <option name="isFactory" value="true"/>   
-						 <!-- costs 20 ipcs to upgrade to a major -->
-						 <option name="unitPlacementRestrictions" value="Ceylon:Sumatra:Java:Borneo:Hainan:Philippines:Celebes:Dutch New Guinea:Paulau Island:New Guinea:New Britain:Solomon Islands:New Hebrides:New Zealand:Fiji:Samoa:Line Islands:Johnston Island:Hawaiian Islands:Midway:Iwo Jima:Aleutian Islands:Gilbert Islands:Marshall Islands:Caroline Islands:Wake Island:Marianas:Guam:Formosa:Okinawa"/>
-						 <option name="canOnlyBePlacedInTerritoryValuedAtX" value="2"/>
-						 <option name="destroyedWhenCapturedBy" value="Chinese"/>
-						 <option name="isAAforBombingThisUnitOnly" value="true"/>
-						 <option name="canProduceXUnits" value="3"/>
-						 <option name="maxDamage" value="6"/>
+                         <option name="isFactory" value="true"/>
+                         <!-- costs 20 ipcs to upgrade to a major -->
+                         <option name="unitPlacementRestrictions" value="Ceylon:Sumatra:Java:Borneo:Hainan:Philippines:Celebes:Dutch New Guinea:Paulau Island:New Guinea:New Britain:Solomon Islands:New Hebrides:New Zealand:Fiji:Samoa:Line Islands:Johnston Island:Hawaiian Islands:Midway:Iwo Jima:Aleutian Islands:Gilbert Islands:Marshall Islands:Caroline Islands:Wake Island:Marianas:Guam:Formosa:Okinawa"/>
+                         <option name="canOnlyBePlacedInTerritoryValuedAtX" value="2"/>
+                         <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                         <option name="isAAforBombingThisUnitOnly" value="true"/>
+                         <option name="canProduceXUnits" value="3"/>
+                         <option name="maxDamage" value="6"/>
                 </attachment>
-            
+
                 <!-- Factory Major -->
                 <attachment name="unitAttachment" attachTo="factory_major" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="isFactory" value="true"/>
-						 <option name="unitPlacementRestrictions" value="Ceylon:Sumatra:Java:Borneo:Hainan:Philippines:Celebes:Dutch New Guinea:Paulau Island:New Guinea:New Britain:Solomon Islands:New Hebrides:New Zealand:Fiji:Samoa:Line Islands:Johnston Island:Hawaiian Islands:Midway:Iwo Jima:Aleutian Islands:Gilbert Islands:Marshall Islands:Caroline Islands:Wake Island:Marianas:Guam:Formosa:Okinawa"/>
-						 <option name="canOnlyBePlacedInTerritoryValuedAtX" value="3"/>
-						 <option name="destroyedWhenCapturedBy" value="Chinese"/>
-						 <option name="isAAforBombingThisUnitOnly" value="true"/>
-						 <option name="canProduceXUnits" value="10"/>
-						 <option name="maxDamage" value="20"/>
-						 <option name="whenCapturedChangesInto" value="any:any:true:factory_minor:1"/>
-						 <!--<option name="special" value="canOnlyPlaceInOriginalTerritories"/>-->
+                         <option name="unitPlacementRestrictions" value="Ceylon:Sumatra:Java:Borneo:Hainan:Philippines:Celebes:Dutch New Guinea:Paulau Island:New Guinea:New Britain:Solomon Islands:New Hebrides:New Zealand:Fiji:Samoa:Line Islands:Johnston Island:Hawaiian Islands:Midway:Iwo Jima:Aleutian Islands:Gilbert Islands:Marshall Islands:Caroline Islands:Wake Island:Marianas:Guam:Formosa:Okinawa"/>
+                         <option name="canOnlyBePlacedInTerritoryValuedAtX" value="3"/>
+                         <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                         <option name="isAAforBombingThisUnitOnly" value="true"/>
+                         <option name="canProduceXUnits" value="10"/>
+                         <option name="maxDamage" value="20"/>
+                         <option name="whenCapturedChangesInto" value="any:any:true:factory_minor:1"/>
+                         <!--<option name="special" value="canOnlyPlaceInOriginalTerritories"/>-->
                 </attachment>
-            
+
                 <!-- Factory Upgrade -->
                 <attachment name="unitAttachment" attachTo="factory_upgrade" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="isFactory" value="true"/>
-						 <option name="unitPlacementRestrictions" value="Ceylon:Sumatra:Java:Borneo:Hainan:Philippines:Celebes:Dutch New Guinea:Paulau Island:New Guinea:New Britain:Solomon Islands:New Hebrides:New Zealand:Fiji:Samoa:Line Islands:Johnston Island:Hawaiian Islands:Midway:Iwo Jima:Aleutian Islands:Gilbert Islands:Marshall Islands:Caroline Islands:Wake Island:Marianas:Guam:Formosa:Okinawa"/>
-						 <option name="canOnlyBePlacedInTerritoryValuedAtX" value="3"/>
-						 <option name="destroyedWhenCapturedBy" value="Chinese"/>
-						 <option name="isAAforBombingThisUnitOnly" value="true"/>
-						 <option name="canProduceXUnits" value="10"/>
-						 <option name="maxDamage" value="20"/>
-						 <option name="consumesUnits" value="1:factory_minor"/>
-						 <option name="whenCapturedChangesInto" value="any:any:true:factory_minor:1"/>
-						 <!--<option name="special" value="canOnlyPlaceInOriginalTerritories"/>-->
+                         <option name="unitPlacementRestrictions" value="Ceylon:Sumatra:Java:Borneo:Hainan:Philippines:Celebes:Dutch New Guinea:Paulau Island:New Guinea:New Britain:Solomon Islands:New Hebrides:New Zealand:Fiji:Samoa:Line Islands:Johnston Island:Hawaiian Islands:Midway:Iwo Jima:Aleutian Islands:Gilbert Islands:Marshall Islands:Caroline Islands:Wake Island:Marianas:Guam:Formosa:Okinawa"/>
+                         <option name="canOnlyBePlacedInTerritoryValuedAtX" value="3"/>
+                         <option name="destroyedWhenCapturedBy" value="Chinese"/>
+                         <option name="isAAforBombingThisUnitOnly" value="true"/>
+                         <option name="canProduceXUnits" value="10"/>
+                         <option name="maxDamage" value="20"/>
+                         <option name="consumesUnits" value="1:factory_minor"/>
+                         <option name="whenCapturedChangesInto" value="any:any:true:factory_minor:1"/>
+                         <!--<option name="special" value="canOnlyPlaceInOriginalTerritories"/>-->
                 </attachment>
-            
-				<!-- Air Base -->
+
+                <!-- Air Base -->
                 <attachment name="unitAttachment" attachTo="airfield" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="isInfrastructure" value="true"/>
-						 <option name="canBeDamaged" value="true"/>
-						 <option name="maxDamage" value="6"/>
-						 <option name="maxOperationalDamage" value="2"/>
-						 <option name="isAirBase" value="true"/>
-						 <option name="isConstruction" value="true"/>
-						 <option name="constructionType" value="airfield_structure"/>
-						 <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
-						 <option name="maxConstructionsPerTypePerTerr" value="1"/>
+                         <option name="canBeDamaged" value="true"/>
+                         <option name="maxDamage" value="6"/>
+                         <option name="maxOperationalDamage" value="2"/>
+                         <option name="isAirBase" value="true"/>
+                         <option name="isConstruction" value="true"/>
+                         <option name="constructionType" value="airfield_structure"/>
+                         <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+                         <option name="maxConstructionsPerTypePerTerr" value="1"/>
                          <option name="movement" value="0"/>
-						 <!--option name="unitPlacementRestrictions" value="Box2:Box3"/>-->
-						 <option name="givesMovement" value="1:fighter"/>
-						 <option name="givesMovement" value="1:bomber"/>
-						 <option name="givesMovement" value="1:tactical_bomber"/>
-						 <option name="isAAforBombingThisUnitOnly" value="true"/>
+                         <!--option name="unitPlacementRestrictions" value="Box2:Box3"/>-->
+                         <option name="givesMovement" value="1:fighter"/>
+                         <option name="givesMovement" value="1:bomber"/>
+                         <option name="givesMovement" value="1:tactical_bomber"/>
+                         <option name="isAAforBombingThisUnitOnly" value="true"/>
                 </attachment>
-            
-				<!-- Naval Base -->
+
+                <!-- Naval Base -->
                 <attachment name="unitAttachment" attachTo="harbour" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="isInfrastructure" value="true"/>
-						 <option name="canBeDamaged" value="true"/>
-						 <option name="maxDamage" value="6"/>
-						 <option name="maxOperationalDamage" value="2"/>
-						 <option name="repairsUnits" value="battleship:carrier"/>
-						 <option name="isConstruction" value="true"/>
-						 <option name="constructionType" value="harbour_structure"/>
-						 <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
-						 <option name="maxConstructionsPerTypePerTerr" value="1"/>
+                         <option name="canBeDamaged" value="true"/>
+                         <option name="maxDamage" value="6"/>
+                         <option name="maxOperationalDamage" value="2"/>
+                         <option name="repairsUnits" value="battleship:carrier"/>
+                         <option name="isConstruction" value="true"/>
+                         <option name="constructionType" value="harbour_structure"/>
+                         <option name="constructionsPerTerrPerTypePerTurn" value="1"/>
+                         <option name="maxConstructionsPerTypePerTerr" value="1"/>
                          <option name="movement" value="0"/>
-						 <!--<option name="unitPlacementRestrictions" value="Box2:Box3"/>-->
-						 <option name="givesMovement" value="1:transport"/>
-						 <option name="givesMovement" value="1:submarine"/>
-						 <option name="givesMovement" value="1:destroyer"/>
-						 <option name="givesMovement" value="1:cruiser"/>
-						 <option name="givesMovement" value="1:carrier"/>
-						 <option name="givesMovement" value="1:battleship"/>
-						 <option name="isAAforBombingThisUnitOnly" value="true"/>
+                         <!--<option name="unitPlacementRestrictions" value="Box2:Box3"/>-->
+                         <option name="givesMovement" value="1:transport"/>
+                         <option name="givesMovement" value="1:submarine"/>
+                         <option name="givesMovement" value="1:destroyer"/>
+                         <option name="givesMovement" value="1:cruiser"/>
+                         <option name="givesMovement" value="1:carrier"/>
+                         <option name="givesMovement" value="1:battleship"/>
+                         <option name="isAAforBombingThisUnitOnly" value="true"/>
                 </attachment>
-            
+
                 <!-- AA Gun -->
                 <attachment name="unitAttachment" attachTo="aaGun" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="isAAforCombatOnly" value="true"/>
-						 <option name="isRocket" value="true"/>
-						 <option name="canNotMoveDuringCombatMove" value="true"/>
-						 <option name="isInfrastructure" value="true"/>
-						 <option name="canBeDamaged" value="false"/>
+                         <option name="isRocket" value="true"/>
+                         <option name="canNotMoveDuringCombatMove" value="true"/>
+                         <option name="isInfrastructure" value="true"/>
+                         <option name="canBeDamaged" value="false"/>
                          <option name="movement" value="1"/>
-						 <option name="transportCost" value="3"/>
+                         <option name="transportCost" value="3"/>
                 </attachment>
-				
-		
-				<!-- Territory Attachments -->
-					<attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+
+                <!-- Territory Attachments -->
+                    <attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Iwo Jima" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
@@ -1465,14 +1465,14 @@
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Shantung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
-						<option name="originalOwner" value="Chinese"/>
+                        <option name="originalOwner" value="Chinese"/>
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Formosa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Kwangsi" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
-						<option name="originalOwner" value="Chinese"/>
+                        <option name="originalOwner" value="Chinese"/>
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Korea" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
@@ -1483,7 +1483,7 @@
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Kiangsi" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
-						<option name="originalOwner" value="Chinese"/>
+                        <option name="originalOwner" value="Chinese"/>
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="8"/>
@@ -1492,7 +1492,7 @@
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Jehol" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
-						<option name="originalOwner" value="Chinese"/>
+                        <option name="originalOwner" value="Chinese"/>
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Okinawa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
@@ -1505,7 +1505,7 @@
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Manchuria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
-						<option name="originalOwner" value="Chinese"/>
+                        <option name="originalOwner" value="Chinese"/>
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Hainan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
@@ -1533,7 +1533,7 @@
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Tsinghai" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
-						
+
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Szechwan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
@@ -1543,7 +1543,7 @@
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Sikang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
-						
+
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Anhwe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
@@ -1572,7 +1572,7 @@
                     <attachment name="territoryAttachment" attachTo="India" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
                         <option name="victoryCity" value="1"/>
-						<option name="capital" value="British"/>
+                        <option name="capital" value="British"/>
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Malaya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
@@ -1638,7 +1638,7 @@
                     <attachment name="territoryAttachment" attachTo="Western United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="10"/>
                         <option name="victoryCity" value="1"/>
-						<option name="capital" value="Americans"/>
+                        <option name="capital" value="Americans"/>
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Alaska" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
@@ -1661,7 +1661,7 @@
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Moscow" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<!--<option name="capital" value="Russians"/>-->
+                        <!--<option name="capital" value="Russians"/>-->
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Evenkiyskiy" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
@@ -1692,11 +1692,11 @@
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="French Indo China" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
-						<!--<option name="capital" value="French"/>-->
+                        <!--<option name="capital" value="French"/>-->
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="New Hebrides" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						
+
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Celebes" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
@@ -1706,7 +1706,7 @@
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Dutch New Guinea" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<!--<option name="capital" value="Dutch"/>-->
+                        <!--<option name="capital" value="Dutch"/>-->
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Sumatra" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="4"/>
@@ -1723,8 +1723,8 @@
                     <attachment name="territoryAttachment" attachTo="Himalayas" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                         <option name="isImpassable" value="true"/>
-						<option name="capital" value="Chinese"/>
-						<!-- used for chinese capitol until the engine supports capitols not in the map -->
+                        <option name="capital" value="Chinese"/>
+                        <!-- used for chinese capitol until the engine supports capitols not in the map -->
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Buyant-Uhaa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
@@ -1738,407 +1738,407 @@
                     <!--<attachment name="territoryAttachment" attachTo="Box1" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                    </attachment>-->
-                    
-					<!--<attachment name="territoryAttachment" attachTo="Box2" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <!--<attachment name="territoryAttachment" attachTo="Box2" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                    </attachment>
                     <attachment name="territoryAttachment" attachTo="Box3" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                    </attachment>-->
-					
-					<attachment name="territoryAttachment" attachTo="1 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="6 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="10 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="17 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="22 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="26 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="35 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="36 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="37 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="39 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="41 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="42 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="43 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="44 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="54 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="62 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-					<attachment name="territoryAttachment" attachTo="63 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="0"/>
-						<option name="blockadeZone" value="true"/>
-					</attachment>
-				   
-				   <!-- No Canals -->
-				   
-				   <!-- Support Attachments -->
-					<attachment name="supportAttachmentFighter" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-						<option name="unitType" value="tactical_bomber"/>
-						<option name="faction" value="allied"/>
-						<option name="side" value="offence"/>
-						<option name="dice" value="strength"/>
-						<option name="bonus" value="1"/>
-						<option name="number" value="1"/>
-						<option name="bonusType" value="combined_arms"/>
-						<option name="impArtTech" value="false"/>
-						<option name="players" value="Japanese:Americans:Chinese:British:ANZAC:Russians:French:Dutch"/>
-					</attachment>
-					<attachment name="supportAttachmentFighter" attachTo="armour" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
-						<option name="unitType" value="tactical_bomber"/>
-						<option name="faction" value="allied"/>
-						<option name="side" value="offence"/>
-						<option name="dice" value="strength"/>
-						<option name="bonus" value="1"/>
-						<option name="number" value="1"/>
-						<option name="bonusType" value="combined_arms"/>
-						<option name="impArtTech" value="false"/>
-						<option name="players" value="Japanese:Americans:Chinese:British:ANZAC:Russians:French:Dutch"/>
-					</attachment>
-				   
-				   <!--  National Objectives -->
-					<attachment name="objectiveAttachment_Japanese1_Control_Dutch_East_Indies" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="5"/>
-						<option name="alliedOwnershipTerritories" value="Java:Sumatra:Borneo:Celebes" count="4"/>
-					</attachment>
-					<attachment name="objectiveAttachment_Japanese_2_Control_Honolulu_Sydney_Calcutta" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="5"/>
-						<option name="alliedOwnershipTerritories" value="Hawaiian Islands:New South Wales:India" count="each"/>
-					</attachment>
-					<attachment name="objectiveAttachment_Japanese3_Control_Strategic_Islands" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="5"/>
-						<option name="alliedOwnershipTerritories" value="Solomon Islands:Dutch New Guinea:New Guinea:New Britain" count="4"/>
-					</attachment>
-					
-					<attachment name="objectiveAttachment_Americans1_Wartime_Economy" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="40"/>
-						<option name="relationship" value="Americans:Japanese:anyWar"/>
-					</attachment>
-					<attachment name="objectiveAttachment_Americans2_Control_Philippines" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="5"/>
-						<option name="directOwnershipTerritories" value="Philippines" count="1"/>
-					</attachment>
-					<attachment name="objectiveAttachment_Americans3_Control_Japanese_Islands" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="5"/>
-						<option name="directOwnershipTerritories" value="Okinawa:Iwo Jima" count="2"/>
-					</attachment>
-					
-					<attachment name="conditionAttachmentJapaneseDoNotControlBurmaRoad" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="India:Burma:Yunnan:Szechwan" count="1"/>
-						<option name="invert" value="true"/>
-					</attachment>
-					
-					<attachment name="objectiveAttachment_Chinese1_Burma_Road" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="6"/>
-						<option name="conditions" value="conditionAttachmentJapaneseDoNotControlBurmaRoad"/>
-					</attachment>
-					
-					<attachment name="objectiveAttachment_British1_Control_Dutch_East_Indies" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="5"/>
-						<option name="directOwnershipTerritories" value="Java:Sumatra:Borneo:Celebes" count="4"/>
-							<!-- we do not want dutch control of the east indies to count towards this goal -->
-						<option name="players" value="British:Americans:ANZAC"/>
-					</attachment>
-					<attachment name="objectiveAttachment_British2_Retaining_Empire" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="5"/>
-						<option name="directOwnershipTerritories" value="Kwangtung:Malaya" count="2"/>
-					</attachment>
-					
-					<attachment name="objectiveAttachment_ANZAC1_Control_Strategic_Islands" attachTo="ANZAC" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="5"/>
-						<option name="directOwnershipTerritories" value="Solomon Islands:Dutch New Guinea:New Guinea:New Britain" count="4"/>
-							<!-- we do not want dutch control of new guinea to count towards this goal -->
-						<option name="players" value="British:Americans:ANZAC"/>
-					</attachment>
-					
-					<attachment name="objectiveAttachment_ANZAC2_High_Morale" attachTo="ANZAC" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="objectiveValue" value="5"/>
-						<option name="uses" value="1"/>
-						<!-- occupy means any unit <option name="directOwnershipTerritories" value="Japan:Siam:Hainan:Formosa:Caroline Islands:Marshall Islands:Marianas:Paulau Island:Okinawa:Iwo Jima:Korea" count="1"/>-->
-						<option name="directPresenceTerritories" value="Japan:Siam:Hainan:Formosa:Caroline Islands:Marshall Islands:Marianas:Paulau Island:Okinawa:Iwo Jima:Korea" count="1"/>
-						<!--<option name="unitPresence" value="ANY" count="1"/>-->
-					</attachment>
-					
-					
-					<!-- Victory Conditions -->
-					<attachment name="conditionAttachmentAxisVictory1" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Japan" count="1"/>
-					</attachment>
-					<attachment name="conditionAttachmentAxisVictory2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Kiangsu:India:Kwangtung:New South Wales:Philippines:Western United States:Hawaiian Islands" count="5"/>
-					</attachment>
-					
-					<attachment name="conditionAttachmentAlliesVictory1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="India:New South Wales:Western United States" count="1"/>
-					</attachment>
-					<attachment name="conditionAttachmentAlliesVictory2" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedOwnershipTerritories" value="Japan" count="1"/>
-					</attachment>
-					
-					
-					<!-- Conditions -->
-					<attachment name="conditionAttachmentAmericansNotYetAtWar" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="rounds" value="3"/>
-						<option name="relationship" value="Americans:Japanese:anyNeutral"/>
-					</attachment>
-					
-					<attachment name="conditionAttachmentBritishNotYetAtWar" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="relationship" value="British:Japanese:anyNeutral"/>
-					</attachment>
-					
-					<attachment name="conditionAttachmentJapaneseNotYetAtWar" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="relationship" value="Americans:Japanese:anyNeutral"/>
-					</attachment>
-					
-					<attachment name="conditionAttachmentAllies_Conquer_Japanese_Islands" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedPresenceTerritories" value="Iwo Jima:Marianas:Okinawa" count="1"/>
-						<option name="unitPresence" value="ANY" count="1"/>
-					</attachment>
-					
-					<attachment name="conditionAttachmentAllies_Retake_the_Philippines" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedPresenceTerritories" value="Philippines" count="1"/>
-						<option name="unitPresence" value="ANY" count="1"/>
-					</attachment>
-					
-					<attachment name="conditionAttachmentJapan_Takes_the_Philippines" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="alliedPresenceTerritories" value="Philippines" count="1"/>
-						<option name="unitPresence" value="ANY" count="1"/>
-					</attachment>
-					
-					
-					
-					<!-- Triggers -->
-					<attachment name="triggerAttachment_Axis_Victory" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAxisVictory1:conditionAttachmentAxisVictory2"/>
-						<option name="victory" value="The Japan (Axis) achieve a Triggered Victory, by controlling Japan plus 5 victory cities!"/>
-						<option name="players" value="Japanese"/>
-					</attachment>
-					
-					<attachment name="triggerAttachment_Allies_Victory" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAlliesVictory1:conditionAttachmentAlliesVictory2"/>
-						<option name="victory" value="The Allies achieve a Triggered Victory, by controlling 1 Allied Capital plus Japan!"/>
-						<option name="when" value="after:japaneseEndTurn"/>
-						<option name="players" value="British:ANZAC:Americans:Chinese:French:Dutch"/>
-					</attachment>
-				
-				
-					<attachment name="triggerAttachment_Chinese_Artillery_Supplies" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="objectiveAttachment_Chinese1_Burma_Road"/>
-						<option name="frontier" value="productionChinese_Burma_Road_Open"/>
-					</attachment>
-				
-					<attachment name="triggerAttachment_Chinese_Loses_Burma_Road" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="objectiveAttachment_Chinese1_Burma_Road"/>
-						<option name="frontier" value="productionChinese_Burma_Road_Closed"/>
-						<option name="invert" value="true"/>
-					</attachment>
-					
-					<attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
-						<option name="conditionType" value="OR"/>
-						<option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
-						<option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
-						<option name="territoryProperty" value="kamikazeZone" count="true"/>
-						<option name="uses" value="1"/>
-						<option name="when" value="after:britishEndTurn"/>
-					</attachment>
-					
-					<attachment name="triggerAttachment_Japanese_Takes_the_Philippines" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
-						<option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots"/>
-						<option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
-						<option name="uses" value="1"/>
-						<option name="when" value="after:japaneseEndTurn"/>
-					</attachment>
-					
-					<attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
-						<option name="conditionType" value="OR"/>
-						<option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
-						<option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
-						<option name="territoryProperty" value="kamikazeZone" count="true"/>
-						<option name="uses" value="1"/>
-						<option name="when" value="after:americansEndTurn"/>
-					</attachment>
-					
-					<attachment name="triggerAttachment_Japanese_Takes_the_Philippines2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
-						<option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots2"/>
-						<option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
-						<option name="uses" value="1"/>
-						<option name="when" value="after:japaneseEndTurn"/>
-					</attachment>
-					
-					<attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
-						<option name="conditionType" value="OR"/>
-						<option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
-						<option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
-						<option name="territoryProperty" value="kamikazeZone" count="true"/>
-						<option name="uses" value="1"/>
-						<option name="when" value="after:anzacEndTurn"/>
-					</attachment>
-					
-					<attachment name="triggerAttachment_Japanese_Takes_the_Philippines3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
-						<option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3"/>
-						<option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
-						<option name="uses" value="1"/>
-						<option name="when" value="after:japaneseEndTurn"/>
-					</attachment>
-				
-					<attachment name="triggerAttachment_Americans_War_Japanese" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentAmericansNotYetAtWar"/>
-						<option name="relationshipChange" value="Japanese:Americans:anyNeutral:War"/>
-						<option name="relationshipChange" value="Japanese:British:anyNeutral:War"/>
-						<option name="relationshipChange" value="Japanese:ANZAC:anyNeutral:War"/>
-						<option name="relationshipChange" value="Japanese:Dutch:anyNeutral:War"/>
-						<option name="relationshipChange" value="Chinese:Americans:anyNeutral:Allied"/>
-						<option name="relationshipChange" value="Chinese:British:anyNeutral:Allied"/>
-						<option name="relationshipChange" value="Chinese:ANZAC:anyNeutral:Allied"/>
-						<option name="relationshipChange" value="British:Americans:anyNeutral:Allied"/>
-						<option name="relationshipChange" value="ANZAC:Americans:anyNeutral:Allied"/>
-						<option name="relationshipChange" value="Americans:French:anyNeutral:Friendly"/>
-						<option name="relationshipChange" value="Americans:Dutch:anyNeutral:Friendly"/>
-						<option name="notification" value="Americans_War_Japanese"/>
-						<option name="when" value="after:americansPlace"/>
-						<option name="uses" value="1"/>
-					</attachment>
-				    
-					
-					<!--  Rules Restrictions -->
-					<attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="movementRestrictionTerritories" value="Shantung:Kwangsi:Kiangsi:Kiangsu:Jehol:Manchuria:Shensi:Yunnan:Suiyuan:Kweichow:Hunan:Kansu:Hopei:Tsinghai:Szechwan:Chahar:Sikang:Anhwe:Kwangtung:Burma"/>
-						<option name="movementRestrictionType" value="allowed"/>
-						<!--<option name="productionPerXTerritories" value="1"/>-->
-						<option name="placementAnyTerritory" value="true"/>
-						<option name="placementCapturedTerritory" value="true"/>
-						<option name="placementPerTerritory" value="255"/>
-						<option name="unlimitedProduction" value="true"/>
-					</attachment>
-					
-					<attachment name="rulesAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
-						<option name="movementRestrictionType" value="allowed"/>
-					</attachment>
-					<attachment name="rulesAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
-						<option name="movementRestrictionType" value="disallowed"/>
-					</attachment>
-					<attachment name="rulesAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
-						<option name="movementRestrictionType" value="disallowed"/>
-					</attachment>
-					<attachment name="rulesAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
-						<option name="movementRestrictionType" value="disallowed"/>
-					</attachment>
-					<attachment name="rulesAttachment" attachTo="ANZAC" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
-						<option name="movementRestrictionType" value="disallowed"/>
-					</attachment>
-					<attachment name="rulesAttachment" attachTo="French" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
-						<option name="movementRestrictionType" value="disallowed"/>
-					</attachment>
-					<attachment name="rulesAttachment" attachTo="Dutch" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-						<option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
-						<option name="movementRestrictionType" value="disallowed"/>
-					</attachment>
-					
-					<!-- Player attachments -->
-					<attachment name="playerAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
-						<option name="suicideAttackResources" value="SuicideAttackTokens" count="2"/>
-						<!--<option name="suicideAttackTargets" value="battleship:carrier:cruiser:destroyer"/>-->
-					</attachment>
-					
-					<!-- Political Action Attachments -->
-					<attachment name="politicalActionAttachment_Japanese_To_War" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentJapaneseNotYetAtWar"/>
-						<option name="relationshipChange" value="Japanese:Americans:War"/>
-						<option name="relationshipChange" value="Japanese:British:War"/>
-						<option name="relationshipChange" value="Japanese:ANZAC:War"/>
-						<option name="relationshipChange" value="Japanese:Dutch:War"/>
-						<option name="relationshipChange" value="Chinese:Americans:Allied"/>
-						<option name="relationshipChange" value="Chinese:British:Allied"/>
-						<option name="relationshipChange" value="Chinese:ANZAC:Allied"/>
-						<option name="relationshipChange" value="British:Americans:Allied"/>
-						<option name="relationshipChange" value="ANZAC:Americans:Allied"/>
-						<option name="relationshipChange" value="Americans:French:Friendly"/>
-						<option name="relationshipChange" value="Americans:Dutch:Friendly"/>
-						<option name="text" value="Japanese_War_Americans"/>
-					</attachment>
-					<attachment name="politicalActionAttachment_British_To_War" attachTo="British" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentBritishNotYetAtWar"/>
-						<option name="relationshipChange" value="Japanese:British:War"/>
-						<option name="relationshipChange" value="Japanese:ANZAC:War"/>
-						<option name="relationshipChange" value="Japanese:Dutch:War"/>
-						<option name="relationshipChange" value="Chinese:British:Allied"/>
-						<option name="relationshipChange" value="Chinese:ANZAC:Allied"/>
-						<option name="text" value="British_War_Japanese"/>
-					</attachment>
-					<attachment name="politicalActionAttachment_ANZAC_To_War" attachTo="ANZAC" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
-						<option name="conditions" value="conditionAttachmentBritishNotYetAtWar"/>
-						<option name="relationshipChange" value="Japanese:British:War"/>
-						<option name="relationshipChange" value="Japanese:ANZAC:War"/>
-						<option name="relationshipChange" value="Japanese:Dutch:War"/>
-						<option name="relationshipChange" value="Chinese:British:Allied"/>
-						<option name="relationshipChange" value="Chinese:ANZAC:Allied"/>
-						<option name="text" value="British_War_Japanese"/>
-					</attachment>
-					
-					
+
+                    <attachment name="territoryAttachment" attachTo="1 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="6 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="10 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="17 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="22 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="26 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="35 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="36 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="37 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="39 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="41 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="42 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="43 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="44 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="54 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="62 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+                    <attachment name="territoryAttachment" attachTo="63 Sea Zone" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="blockadeZone" value="true"/>
+                    </attachment>
+
+                   <!-- No Canals -->
+
+                   <!-- Support Attachments -->
+                    <attachment name="supportAttachmentFighter" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                        <option name="unitType" value="tactical_bomber"/>
+                        <option name="faction" value="allied"/>
+                        <option name="side" value="offence"/>
+                        <option name="dice" value="strength"/>
+                        <option name="bonus" value="1"/>
+                        <option name="number" value="1"/>
+                        <option name="bonusType" value="combined_arms"/>
+                        <option name="impArtTech" value="false"/>
+                        <option name="players" value="Japanese:Americans:Chinese:British:ANZAC:Russians:French:Dutch"/>
+                    </attachment>
+                    <attachment name="supportAttachmentFighter" attachTo="armour" javaClass="games.strategy.triplea.attachments.UnitSupportAttachment" type="unitType">
+                        <option name="unitType" value="tactical_bomber"/>
+                        <option name="faction" value="allied"/>
+                        <option name="side" value="offence"/>
+                        <option name="dice" value="strength"/>
+                        <option name="bonus" value="1"/>
+                        <option name="number" value="1"/>
+                        <option name="bonusType" value="combined_arms"/>
+                        <option name="impArtTech" value="false"/>
+                        <option name="players" value="Japanese:Americans:Chinese:British:ANZAC:Russians:French:Dutch"/>
+                    </attachment>
+
+                   <!--  National Objectives -->
+                    <attachment name="objectiveAttachment_Japanese1_Control_Dutch_East_Indies" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="5"/>
+                        <option name="alliedOwnershipTerritories" value="Java:Sumatra:Borneo:Celebes" count="4"/>
+                    </attachment>
+                    <attachment name="objectiveAttachment_Japanese_2_Control_Honolulu_Sydney_Calcutta" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="5"/>
+                        <option name="alliedOwnershipTerritories" value="Hawaiian Islands:New South Wales:India" count="each"/>
+                    </attachment>
+                    <attachment name="objectiveAttachment_Japanese3_Control_Strategic_Islands" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="5"/>
+                        <option name="alliedOwnershipTerritories" value="Solomon Islands:Dutch New Guinea:New Guinea:New Britain" count="4"/>
+                    </attachment>
+
+                    <attachment name="objectiveAttachment_Americans1_Wartime_Economy" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="40"/>
+                        <option name="relationship" value="Americans:Japanese:anyWar"/>
+                    </attachment>
+                    <attachment name="objectiveAttachment_Americans2_Control_Philippines" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="5"/>
+                        <option name="directOwnershipTerritories" value="Philippines" count="1"/>
+                    </attachment>
+                    <attachment name="objectiveAttachment_Americans3_Control_Japanese_Islands" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="5"/>
+                        <option name="directOwnershipTerritories" value="Okinawa:Iwo Jima" count="2"/>
+                    </attachment>
+
+                    <attachment name="conditionAttachmentJapaneseDoNotControlBurmaRoad" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="India:Burma:Yunnan:Szechwan" count="1"/>
+                        <option name="invert" value="true"/>
+                    </attachment>
+
+                    <attachment name="objectiveAttachment_Chinese1_Burma_Road" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="6"/>
+                        <option name="conditions" value="conditionAttachmentJapaneseDoNotControlBurmaRoad"/>
+                    </attachment>
+
+                    <attachment name="objectiveAttachment_British1_Control_Dutch_East_Indies" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="5"/>
+                        <option name="directOwnershipTerritories" value="Java:Sumatra:Borneo:Celebes" count="4"/>
+                            <!-- we do not want dutch control of the east indies to count towards this goal -->
+                        <option name="players" value="British:Americans:ANZAC"/>
+                    </attachment>
+                    <attachment name="objectiveAttachment_British2_Retaining_Empire" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="5"/>
+                        <option name="directOwnershipTerritories" value="Kwangtung:Malaya" count="2"/>
+                    </attachment>
+
+                    <attachment name="objectiveAttachment_ANZAC1_Control_Strategic_Islands" attachTo="ANZAC" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="5"/>
+                        <option name="directOwnershipTerritories" value="Solomon Islands:Dutch New Guinea:New Guinea:New Britain" count="4"/>
+                            <!-- we do not want dutch control of new guinea to count towards this goal -->
+                        <option name="players" value="British:Americans:ANZAC"/>
+                    </attachment>
+
+                    <attachment name="objectiveAttachment_ANZAC2_High_Morale" attachTo="ANZAC" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="objectiveValue" value="5"/>
+                        <option name="uses" value="1"/>
+                        <!-- occupy means any unit <option name="directOwnershipTerritories" value="Japan:Siam:Hainan:Formosa:Caroline Islands:Marshall Islands:Marianas:Paulau Island:Okinawa:Iwo Jima:Korea" count="1"/>-->
+                        <option name="directPresenceTerritories" value="Japan:Siam:Hainan:Formosa:Caroline Islands:Marshall Islands:Marianas:Paulau Island:Okinawa:Iwo Jima:Korea" count="1"/>
+                        <!--<option name="unitPresence" value="ANY" count="1"/>-->
+                    </attachment>
+
+
+                    <!-- Victory Conditions -->
+                    <attachment name="conditionAttachmentAxisVictory1" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Japan" count="1"/>
+                    </attachment>
+                    <attachment name="conditionAttachmentAxisVictory2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Kiangsu:India:Kwangtung:New South Wales:Philippines:Western United States:Hawaiian Islands" count="5"/>
+                    </attachment>
+
+                    <attachment name="conditionAttachmentAlliesVictory1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="India:New South Wales:Western United States" count="1"/>
+                    </attachment>
+                    <attachment name="conditionAttachmentAlliesVictory2" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedOwnershipTerritories" value="Japan" count="1"/>
+                    </attachment>
+
+
+                    <!-- Conditions -->
+                    <attachment name="conditionAttachmentAmericansNotYetAtWar" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="rounds" value="3"/>
+                        <option name="relationship" value="Americans:Japanese:anyNeutral"/>
+                    </attachment>
+
+                    <attachment name="conditionAttachmentBritishNotYetAtWar" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="relationship" value="British:Japanese:anyNeutral"/>
+                    </attachment>
+
+                    <attachment name="conditionAttachmentJapaneseNotYetAtWar" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="relationship" value="Americans:Japanese:anyNeutral"/>
+                    </attachment>
+
+                    <attachment name="conditionAttachmentAllies_Conquer_Japanese_Islands" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedPresenceTerritories" value="Iwo Jima:Marianas:Okinawa" count="1"/>
+                        <option name="unitPresence" value="ANY" count="1"/>
+                    </attachment>
+
+                    <attachment name="conditionAttachmentAllies_Retake_the_Philippines" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedPresenceTerritories" value="Philippines" count="1"/>
+                        <option name="unitPresence" value="ANY" count="1"/>
+                    </attachment>
+
+                    <attachment name="conditionAttachmentJapan_Takes_the_Philippines" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="alliedPresenceTerritories" value="Philippines" count="1"/>
+                        <option name="unitPresence" value="ANY" count="1"/>
+                    </attachment>
+
+
+
+                    <!-- Triggers -->
+                    <attachment name="triggerAttachment_Axis_Victory" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAxisVictory1:conditionAttachmentAxisVictory2"/>
+                        <option name="victory" value="The Japan (Axis) achieve a Triggered Victory, by controlling Japan plus 5 victory cities!"/>
+                        <option name="players" value="Japanese"/>
+                    </attachment>
+
+                    <attachment name="triggerAttachment_Allies_Victory" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAlliesVictory1:conditionAttachmentAlliesVictory2"/>
+                        <option name="victory" value="The Allies achieve a Triggered Victory, by controlling 1 Allied Capital plus Japan!"/>
+                        <option name="when" value="after:japaneseEndTurn"/>
+                        <option name="players" value="British:ANZAC:Americans:Chinese:French:Dutch"/>
+                    </attachment>
+
+
+                    <attachment name="triggerAttachment_Chinese_Artillery_Supplies" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="objectiveAttachment_Chinese1_Burma_Road"/>
+                        <option name="frontier" value="productionChinese_Burma_Road_Open"/>
+                    </attachment>
+
+                    <attachment name="triggerAttachment_Chinese_Loses_Burma_Road" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="objectiveAttachment_Chinese1_Burma_Road"/>
+                        <option name="frontier" value="productionChinese_Burma_Road_Closed"/>
+                        <option name="invert" value="true"/>
+                    </attachment>
+
+                    <attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
+                        <option name="conditionType" value="OR"/>
+                        <option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
+                        <option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
+                        <option name="territoryProperty" value="kamikazeZone" count="true"/>
+                        <option name="uses" value="1"/>
+                        <option name="when" value="after:britishEndTurn"/>
+                    </attachment>
+
+                    <attachment name="triggerAttachment_Japanese_Takes_the_Philippines" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
+                        <option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots"/>
+                        <option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
+                        <option name="uses" value="1"/>
+                        <option name="when" value="after:japaneseEndTurn"/>
+                    </attachment>
+
+                    <attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
+                        <option name="conditionType" value="OR"/>
+                        <option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
+                        <option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
+                        <option name="territoryProperty" value="kamikazeZone" count="true"/>
+                        <option name="uses" value="1"/>
+                        <option name="when" value="after:americansEndTurn"/>
+                    </attachment>
+
+                    <attachment name="triggerAttachment_Japanese_Takes_the_Philippines2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
+                        <option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots2"/>
+                        <option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
+                        <option name="uses" value="1"/>
+                        <option name="when" value="after:japaneseEndTurn"/>
+                    </attachment>
+
+                    <attachment name="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAllies_Conquer_Japanese_Islands"/>
+                        <option name="conditionType" value="OR"/>
+                        <option name="territories" value="6 Sea Zone:17 Sea Zone:19 Sea Zone:20 Sea Zone:22 Sea Zone:35 Sea Zone"/>
+                        <option name="territoryAttachmentName" value="TerritoryAttachment" count="territoryAttachment"/>
+                        <option name="territoryProperty" value="kamikazeZone" count="true"/>
+                        <option name="uses" value="1"/>
+                        <option name="when" value="after:anzacEndTurn"/>
+                    </attachment>
+
+                    <attachment name="triggerAttachment_Japanese_Takes_the_Philippines3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapan_Takes_the_Philippines"/>
+                        <option name="playerAttachmentName" value="TriggerAttachment" count="triggerAttachment_Japanese_Recruit_Kamikaze_Pilots3"/>
+                        <option name="playerProperty" value="conditions" count="conditionAttachmentAllies_Retake_the_Philippines"/>
+                        <option name="uses" value="1"/>
+                        <option name="when" value="after:japaneseEndTurn"/>
+                    </attachment>
+
+                    <attachment name="triggerAttachment_Americans_War_Japanese" attachTo="Americans" javaClass="games.strategy.triplea.attachments.TriggerAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentAmericansNotYetAtWar"/>
+                        <option name="relationshipChange" value="Japanese:Americans:anyNeutral:War"/>
+                        <option name="relationshipChange" value="Japanese:British:anyNeutral:War"/>
+                        <option name="relationshipChange" value="Japanese:ANZAC:anyNeutral:War"/>
+                        <option name="relationshipChange" value="Japanese:Dutch:anyNeutral:War"/>
+                        <option name="relationshipChange" value="Chinese:Americans:anyNeutral:Allied"/>
+                        <option name="relationshipChange" value="Chinese:British:anyNeutral:Allied"/>
+                        <option name="relationshipChange" value="Chinese:ANZAC:anyNeutral:Allied"/>
+                        <option name="relationshipChange" value="British:Americans:anyNeutral:Allied"/>
+                        <option name="relationshipChange" value="ANZAC:Americans:anyNeutral:Allied"/>
+                        <option name="relationshipChange" value="Americans:French:anyNeutral:Friendly"/>
+                        <option name="relationshipChange" value="Americans:Dutch:anyNeutral:Friendly"/>
+                        <option name="notification" value="Americans_War_Japanese"/>
+                        <option name="when" value="after:americansPlace"/>
+                        <option name="uses" value="1"/>
+                    </attachment>
+
+
+                    <!--  Rules Restrictions -->
+                    <attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="movementRestrictionTerritories" value="Shantung:Kwangsi:Kiangsi:Kiangsu:Jehol:Manchuria:Shensi:Yunnan:Suiyuan:Kweichow:Hunan:Kansu:Hopei:Tsinghai:Szechwan:Chahar:Sikang:Anhwe:Kwangtung:Burma"/>
+                        <option name="movementRestrictionType" value="allowed"/>
+                        <!--<option name="productionPerXTerritories" value="1"/>-->
+                        <option name="placementAnyTerritory" value="true"/>
+                        <option name="placementCapturedTerritory" value="true"/>
+                        <option name="placementPerTerritory" value="255"/>
+                        <option name="unlimitedProduction" value="true"/>
+                    </attachment>
+
+                    <attachment name="rulesAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
+                        <option name="movementRestrictionType" value="allowed"/>
+                    </attachment>
+                    <attachment name="rulesAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
+                        <option name="movementRestrictionType" value="disallowed"/>
+                    </attachment>
+                    <attachment name="rulesAttachment" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
+                        <option name="movementRestrictionType" value="disallowed"/>
+                    </attachment>
+                    <attachment name="rulesAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
+                        <option name="movementRestrictionType" value="disallowed"/>
+                    </attachment>
+                    <attachment name="rulesAttachment" attachTo="ANZAC" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
+                        <option name="movementRestrictionType" value="disallowed"/>
+                    </attachment>
+                    <attachment name="rulesAttachment" attachTo="French" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
+                        <option name="movementRestrictionType" value="disallowed"/>
+                    </attachment>
+                    <attachment name="rulesAttachment" attachTo="Dutch" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                        <option name="movementRestrictionTerritories" value="Sakha:Moscow:Evenkiyskiy:Yenisey:Soviet Far East:Amur:Yakut S.S.R.:Tunguska:Siberia:Kazakhstan:Buryatia"/>
+                        <option name="movementRestrictionType" value="disallowed"/>
+                    </attachment>
+
+                    <!-- Player attachments -->
+                    <attachment name="playerAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PlayerAttachment" type="player">
+                        <option name="suicideAttackResources" value="SuicideAttackTokens" count="2"/>
+                        <!--<option name="suicideAttackTargets" value="battleship:carrier:cruiser:destroyer"/>-->
+                    </attachment>
+
+                    <!-- Political Action Attachments -->
+                    <attachment name="politicalActionAttachment_Japanese_To_War" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentJapaneseNotYetAtWar"/>
+                        <option name="relationshipChange" value="Japanese:Americans:War"/>
+                        <option name="relationshipChange" value="Japanese:British:War"/>
+                        <option name="relationshipChange" value="Japanese:ANZAC:War"/>
+                        <option name="relationshipChange" value="Japanese:Dutch:War"/>
+                        <option name="relationshipChange" value="Chinese:Americans:Allied"/>
+                        <option name="relationshipChange" value="Chinese:British:Allied"/>
+                        <option name="relationshipChange" value="Chinese:ANZAC:Allied"/>
+                        <option name="relationshipChange" value="British:Americans:Allied"/>
+                        <option name="relationshipChange" value="ANZAC:Americans:Allied"/>
+                        <option name="relationshipChange" value="Americans:French:Friendly"/>
+                        <option name="relationshipChange" value="Americans:Dutch:Friendly"/>
+                        <option name="text" value="Japanese_War_Americans"/>
+                    </attachment>
+                    <attachment name="politicalActionAttachment_British_To_War" attachTo="British" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentBritishNotYetAtWar"/>
+                        <option name="relationshipChange" value="Japanese:British:War"/>
+                        <option name="relationshipChange" value="Japanese:ANZAC:War"/>
+                        <option name="relationshipChange" value="Japanese:Dutch:War"/>
+                        <option name="relationshipChange" value="Chinese:British:Allied"/>
+                        <option name="relationshipChange" value="Chinese:ANZAC:Allied"/>
+                        <option name="text" value="British_War_Japanese"/>
+                    </attachment>
+                    <attachment name="politicalActionAttachment_ANZAC_To_War" attachTo="ANZAC" javaClass="games.strategy.triplea.attachments.PoliticalActionAttachment" type="player">
+                        <option name="conditions" value="conditionAttachmentBritishNotYetAtWar"/>
+                        <option name="relationshipChange" value="Japanese:British:War"/>
+                        <option name="relationshipChange" value="Japanese:ANZAC:War"/>
+                        <option name="relationshipChange" value="Japanese:Dutch:War"/>
+                        <option name="relationshipChange" value="Chinese:British:Allied"/>
+                        <option name="relationshipChange" value="Chinese:ANZAC:Allied"/>
+                        <option name="text" value="British_War_Japanese"/>
+                    </attachment>
+
+
         </attachmentList>
         <initialize>
                 <ownerInitialize>
@@ -2172,7 +2172,7 @@
                         <territoryOwner territory="Sikang" owner="Chinese"/>
                         <territoryOwner territory="Anhwe" owner="Chinese"/>
                         <!-- himalayas contain chinese capitol, so must be owned by china or they do not collect ipcs -->
-						<territoryOwner territory="Himalayas" owner="Chinese"/>
+                        <territoryOwner territory="Himalayas" owner="Chinese"/>
                         <territoryOwner territory="Gilbert Islands" owner="British"/>
                         <territoryOwner territory="Fiji" owner="British"/>
                         <territoryOwner territory="Ceylon" owner="British"/>
@@ -2206,7 +2206,7 @@
                         <territoryOwner territory="Johnston Island" owner="Americans"/>
                         <territoryOwner territory="Hawaiian Islands" owner="Americans"/>
                         <territoryOwner territory="Midway" owner="Americans"/>
-						<!--<territoryOwner territory="Box2" owner="Americans"/>-->
+                        <!--<territoryOwner territory="Box2" owner="Americans"/>-->
                         <territoryOwner territory="Sakha" owner="Russians"/>
                         <territoryOwner territory="Moscow" owner="Russians"/>
                         <territoryOwner territory="Evenkiyskiy" owner="Russians"/>
@@ -2224,8 +2224,8 @@
                         <territoryOwner territory="Java" owner="Dutch"/>
                         <territoryOwner territory="Dutch New Guinea" owner="Dutch"/>
                         <territoryOwner territory="Sumatra" owner="Dutch"/>
-						
-						<!-- original owner of kamikaze zones -->
+
+                        <!-- original owner of kamikaze zones -->
                         <territoryOwner territory="6 Sea Zone" owner="Japanese"/>
                         <territoryOwner territory="17 Sea Zone" owner="Japanese"/>
                         <territoryOwner territory="19 Sea Zone" owner="Japanese"/>
@@ -2234,151 +2234,151 @@
                         <territoryOwner territory="35 Sea Zone" owner="Japanese"/>
                 </ownerInitialize>
                 <unitInitialize>
-				
-						<unitPlacement unitType="infantry" territory="Korea" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Manchuria" quantity="4" owner="Japanese"/>
-						<unitPlacement unitType="artillery" territory="Manchuria" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="mech_infantry" territory="Manchuria" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="bomber" territory="Manchuria" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Manchuria" quantity="3" owner="Japanese"/>
-						<unitPlacement unitType="tactical_bomber" territory="Manchuria" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="aaGun" territory="Manchuria" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Jehol" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="artillery" territory="Jehol" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Shantung" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Kiangsu" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Kiangsu" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="tactical_bomber" territory="Kiangsu" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="bomber" territory="Kiangsu" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Kiangsi" quantity="3" owner="Japanese"/>
-						<unitPlacement unitType="artillery" territory="Kiangsi" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Kwangsi" quantity="3" owner="Japanese"/>
-						<unitPlacement unitType="artillery" territory="Kwangsi" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Siam" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Caroline Islands" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="aaGun" territory="Caroline Islands" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="airfield" territory="Caroline Islands" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="harbour" territory="Caroline Islands" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Paulau Island" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Formosa" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Okinawa" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Okinawa" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Iwo Jima" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Japan" quantity="8" owner="Japanese"/>
-						<unitPlacement unitType="artillery" territory="Japan" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="armour" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="bomber" territory="Japan" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Japan" quantity="5" owner="Japanese"/>
-						<unitPlacement unitType="tactical_bomber" territory="Japan" quantity="4" owner="Japanese"/>
-						<unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="airfield" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="harbour" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="factory_major" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="destroyer" territory="19 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="submarine" territory="19 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="cruiser" territory="19 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="transport" territory="6 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="destroyer" territory="6 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="carrier" territory="6 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="6 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="tactical_bomber" territory="6 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="submarine" territory="6 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="cruiser" territory="6 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="battleship" territory="6 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="transport" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="destroyer" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="battleship" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="carrier" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="tactical_bomber" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
-						
-						<unitPlacement unitType="infantry" territory="Philippines" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Philippines" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="bomber" territory="Philippines" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="airfield" territory="Philippines" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="harbour" territory="Philippines" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="airfield" territory="Guam" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="airfield" territory="Wake Island" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="bomber" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="tactical_bomber" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="airfield" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="harbour" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="airfield" territory="Midway" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Western United States" quantity="3" owner="Americans"/>
-						<unitPlacement unitType="artillery" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="mech_infantry" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="armour" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="bomber" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="tactical_bomber" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="aaGun" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="airfield" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="harbour" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="factory_major" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="35 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="transport" territory="35 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="transport" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="submarine" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="cruiser" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="carrier" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="tactical_bomber" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="battleship" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="transport" territory="26 Sea Zone" quantity="1" owner="Americans"/>
-						<!--<unitPlacement unitType="infantry" territory="Box2" quantity="1" owner="Americans"/>-->
-						
-						<unitPlacement unitType="infantry" territory="Suiyuan" quantity="2" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Shensi" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Szechwan" quantity="4" owner="Chinese"/>
-						<unitPlacement unitType="fighter" territory="Szechwan" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Kweichow" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Hunan" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Yunnan" quantity="3" owner="Chinese"/>
-						
-						<unitPlacement unitType="infantry" territory="Kwangtung" quantity="2" owner="British"/>
-						<unitPlacement unitType="harbour" territory="Kwangtung" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Malaya" quantity="4" owner="British"/>
-						<unitPlacement unitType="harbour" territory="Malaya" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Burma" quantity="1" owner="British"/>
-						<unitPlacement unitType="fighter" territory="Burma" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="India" quantity="4" owner="British"/>
-						<unitPlacement unitType="artillery" territory="India" quantity="1" owner="British"/>
-						<unitPlacement unitType="fighter" territory="India" quantity="3" owner="British"/>
-						<unitPlacement unitType="tactical_bomber" territory="India" quantity="1" owner="British"/>
-						<unitPlacement unitType="aaGun" territory="India" quantity="1" owner="British"/>
-						<unitPlacement unitType="airfield" territory="India" quantity="1" owner="British"/>
-						<unitPlacement unitType="harbour" territory="India" quantity="1" owner="British"/>
-						<unitPlacement unitType="factory_major" territory="India" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="39 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="cruiser" territory="39 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="37 Sea Zone" quantity="2" owner="British"/>
-						<unitPlacement unitType="battleship" territory="37 Sea Zone" quantity="1" owner="British"/>
-						
-						<unitPlacement unitType="infantry" territory="Malaya" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="infantry" territory="New South Wales" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="factory_minor" territory="New South Wales" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="infantry" territory="Queensland" quantity="2" owner="ANZAC"/>
-						<unitPlacement unitType="artillery" territory="Queensland" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="fighter" territory="Queensland" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="airfield" territory="Queensland" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="harbour" territory="Queensland" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="infantry" territory="New Zealand" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="fighter" territory="New Zealand" quantity="3" owner="ANZAC"/>
-						<unitPlacement unitType="airfield" territory="New Zealand" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="harbour" territory="New Zealand" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="submarine" territory="47 Sea Zone" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="destroyer" territory="62 Sea Zone" quantity="1" owner="ANZAC"/>
-						<unitPlacement unitType="transport" territory="62 Sea Zone" quantity="1" owner="ANZAC"/>
-						
-						<unitPlacement unitType="infantry" territory="Ulaanbaatar" quantity="1"/>
-						<unitPlacement unitType="infantry" territory="Buyant-Uhaa" quantity="2"/>
-						<unitPlacement unitType="infantry" territory="Olgiy" quantity="2"/>
-						<unitPlacement unitType="infantry" territory="Dzavhan" quantity="1"/>
-						
-						
+
+                        <unitPlacement unitType="infantry" territory="Korea" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Manchuria" quantity="4" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="Manchuria" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="mech_infantry" territory="Manchuria" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="bomber" territory="Manchuria" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Manchuria" quantity="3" owner="Japanese"/>
+                        <unitPlacement unitType="tactical_bomber" territory="Manchuria" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="aaGun" territory="Manchuria" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Jehol" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="Jehol" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Shantung" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Kiangsu" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Kiangsu" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="tactical_bomber" territory="Kiangsu" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="bomber" territory="Kiangsu" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Kiangsi" quantity="3" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="Kiangsi" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Kwangsi" quantity="3" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="Kwangsi" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Siam" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Caroline Islands" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="aaGun" territory="Caroline Islands" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="airfield" territory="Caroline Islands" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="harbour" territory="Caroline Islands" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Paulau Island" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Formosa" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Okinawa" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Okinawa" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Iwo Jima" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Japan" quantity="8" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="Japan" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="armour" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="bomber" territory="Japan" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Japan" quantity="5" owner="Japanese"/>
+                        <unitPlacement unitType="tactical_bomber" territory="Japan" quantity="4" owner="Japanese"/>
+                        <unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="airfield" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="harbour" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="factory_major" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="destroyer" territory="19 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="submarine" territory="19 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="cruiser" territory="19 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="transport" territory="6 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="destroyer" territory="6 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="6 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="6 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="tactical_bomber" territory="6 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="submarine" territory="6 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="cruiser" territory="6 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="battleship" territory="6 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="transport" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="destroyer" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="battleship" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="tactical_bomber" territory="33 Sea Zone" quantity="1" owner="Japanese"/>
+
+                        <unitPlacement unitType="infantry" territory="Philippines" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Philippines" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="bomber" territory="Philippines" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="airfield" territory="Philippines" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="harbour" territory="Philippines" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="airfield" territory="Guam" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="airfield" territory="Wake Island" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="bomber" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="tactical_bomber" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="airfield" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="harbour" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="airfield" territory="Midway" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Western United States" quantity="3" owner="Americans"/>
+                        <unitPlacement unitType="artillery" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="mech_infantry" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="armour" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="bomber" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="tactical_bomber" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="aaGun" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="airfield" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="harbour" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="factory_major" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="35 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="35 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="submarine" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="cruiser" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="carrier" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="tactical_bomber" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="battleship" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="26 Sea Zone" quantity="1" owner="Americans"/>
+                        <!--<unitPlacement unitType="infantry" territory="Box2" quantity="1" owner="Americans"/>-->
+
+                        <unitPlacement unitType="infantry" territory="Suiyuan" quantity="2" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Shensi" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Szechwan" quantity="4" owner="Chinese"/>
+                        <unitPlacement unitType="fighter" territory="Szechwan" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Kweichow" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Hunan" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Yunnan" quantity="3" owner="Chinese"/>
+
+                        <unitPlacement unitType="infantry" territory="Kwangtung" quantity="2" owner="British"/>
+                        <unitPlacement unitType="harbour" territory="Kwangtung" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Malaya" quantity="4" owner="British"/>
+                        <unitPlacement unitType="harbour" territory="Malaya" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Burma" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="Burma" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="India" quantity="4" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="India" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="India" quantity="3" owner="British"/>
+                        <unitPlacement unitType="tactical_bomber" territory="India" quantity="1" owner="British"/>
+                        <unitPlacement unitType="aaGun" territory="India" quantity="1" owner="British"/>
+                        <unitPlacement unitType="airfield" territory="India" quantity="1" owner="British"/>
+                        <unitPlacement unitType="harbour" territory="India" quantity="1" owner="British"/>
+                        <unitPlacement unitType="factory_major" territory="India" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="39 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="cruiser" territory="39 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="37 Sea Zone" quantity="2" owner="British"/>
+                        <unitPlacement unitType="battleship" territory="37 Sea Zone" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Malaya" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="infantry" territory="New South Wales" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="factory_minor" territory="New South Wales" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="infantry" territory="Queensland" quantity="2" owner="ANZAC"/>
+                        <unitPlacement unitType="artillery" territory="Queensland" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="fighter" territory="Queensland" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="airfield" territory="Queensland" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="harbour" territory="Queensland" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="infantry" territory="New Zealand" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="fighter" territory="New Zealand" quantity="3" owner="ANZAC"/>
+                        <unitPlacement unitType="airfield" territory="New Zealand" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="harbour" territory="New Zealand" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="submarine" territory="47 Sea Zone" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="destroyer" territory="62 Sea Zone" quantity="1" owner="ANZAC"/>
+                        <unitPlacement unitType="transport" territory="62 Sea Zone" quantity="1" owner="ANZAC"/>
+
+                        <unitPlacement unitType="infantry" territory="Ulaanbaatar" quantity="1"/>
+                        <unitPlacement unitType="infantry" territory="Buyant-Uhaa" quantity="2"/>
+                        <unitPlacement unitType="infantry" territory="Olgiy" quantity="2"/>
+                        <unitPlacement unitType="infantry" territory="Dzavhan" quantity="1"/>
+
+
                 </unitInitialize>
                 <resourceInitialize>
                         <resourceGiven player="Japanese" resource="PUs" quantity="26"/>
@@ -2389,58 +2389,58 @@
                         <resourceGiven player="Russians" resource="PUs" quantity="0"/>
                         <resourceGiven player="French" resource="PUs" quantity="0"/>
                         <resourceGiven player="Dutch" resource="PUs" quantity="0"/>
-						
+
                         <resourceGiven player="Japanese" resource="SuicideAttackTokens" quantity="6"/>
                 </resourceInitialize>
-				
-				<relationshipInitialize>
-						<!-- the order of player1 and player2 does not matter. 
-						having them listed twice in different orders will just have the later one overwrite the earlier one -->
-						<relationship type="Allied" player1="British" player2="ANZAC" roundValue="1"/>
-						<relationship type="War" player1="Japanese" player2="Chinese" roundValue="1"/>
-						<relationship type="War" player1="Japanese" player2="French" roundValue="1"/>
-						<relationship type="Neutrality" player1="Chinese" player2="French" roundValue="1"/>
-						<relationship type="Friendly" player1="British" player2="French" roundValue="1"/>
-						<relationship type="Custodianship" player1="British" player2="Dutch" roundValue="1"/>
-						<relationship type="Friendly" player1="ANZAC" player2="French" roundValue="1"/>
-						<relationship type="Custodianship" player1="ANZAC" player2="Dutch" roundValue="1"/>
-						<relationship type="Neutrality" player1="Japanese" player2="British" roundValue="1"/>
-						<relationship type="Neutrality" player1="Japanese" player2="ANZAC" roundValue="1"/>
-						<relationship type="Neutrality" player1="Japanese" player2="Americans" roundValue="1"/>
-						<relationship type="Neutrality" player1="Japanese" player2="Russians" roundValue="1"/>
-						<relationship type="Neutrality" player1="Japanese" player2="Dutch" roundValue="1"/>
-						<relationship type="Neutrality" player1="Chinese" player2="British" roundValue="1"/>
-						<relationship type="Neutrality" player1="Chinese" player2="ANZAC" roundValue="1"/>
-						<relationship type="Neutrality" player1="Chinese" player2="Americans" roundValue="1"/>
-						<relationship type="Neutrality" player1="Chinese" player2="Russians" roundValue="1"/>
-						<relationship type="Neutrality" player1="Chinese" player2="Dutch" roundValue="1"/>
-						<relationship type="Neutrality" player1="British" player2="Americans" roundValue="1"/>
-						<relationship type="Neutrality" player1="British" player2="Russians" roundValue="1"/>
-						<relationship type="Neutrality" player1="ANZAC" player2="Americans" roundValue="1"/>
-						<relationship type="Neutrality" player1="ANZAC" player2="Russians" roundValue="1"/>
-						<relationship type="Neutrality" player1="Americans" player2="Russians" roundValue="1"/>
-						<relationship type="Neutrality" player1="Americans" player2="French" roundValue="1"/>
-						<relationship type="Neutrality" player1="Americans" player2="Dutch" roundValue="1"/>
-						<relationship type="Neutrality" player1="Russians" player2="French" roundValue="1"/>
-						<relationship type="Neutrality" player1="Russians" player2="Dutch" roundValue="1"/>
-						<relationship type="Neutrality" player1="French" player2="Dutch" roundValue="1"/>
-				</relationshipInitialize>
-				
+
+                <relationshipInitialize>
+                        <!-- the order of player1 and player2 does not matter.
+                        having them listed twice in different orders will just have the later one overwrite the earlier one -->
+                        <relationship type="Allied" player1="British" player2="ANZAC" roundValue="1"/>
+                        <relationship type="War" player1="Japanese" player2="Chinese" roundValue="1"/>
+                        <relationship type="War" player1="Japanese" player2="French" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Chinese" player2="French" roundValue="1"/>
+                        <relationship type="Friendly" player1="British" player2="French" roundValue="1"/>
+                        <relationship type="Custodianship" player1="British" player2="Dutch" roundValue="1"/>
+                        <relationship type="Friendly" player1="ANZAC" player2="French" roundValue="1"/>
+                        <relationship type="Custodianship" player1="ANZAC" player2="Dutch" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Japanese" player2="British" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Japanese" player2="ANZAC" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Japanese" player2="Americans" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Japanese" player2="Russians" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Japanese" player2="Dutch" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Chinese" player2="British" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Chinese" player2="ANZAC" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Chinese" player2="Americans" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Chinese" player2="Russians" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Chinese" player2="Dutch" roundValue="1"/>
+                        <relationship type="Neutrality" player1="British" player2="Americans" roundValue="1"/>
+                        <relationship type="Neutrality" player1="British" player2="Russians" roundValue="1"/>
+                        <relationship type="Neutrality" player1="ANZAC" player2="Americans" roundValue="1"/>
+                        <relationship type="Neutrality" player1="ANZAC" player2="Russians" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Americans" player2="Russians" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Americans" player2="French" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Americans" player2="Dutch" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Russians" player2="French" roundValue="1"/>
+                        <relationship type="Neutrality" player1="Russians" player2="Dutch" roundValue="1"/>
+                        <relationship type="Neutrality" player1="French" player2="Dutch" roundValue="1"/>
+                </relationshipInitialize>
+
         </initialize>
         <propertyList>
-				<!-- PLEASE KEEP YOUR PROPERTIES IN THIS ORDER!!! -->
-				<!-- TYPICAL OPTIONAL PROPERTIES -->
-				<!-- Bidding -->
-				<!--<property name="Dutch bid" value="0" editable="true">
+                <!-- PLEASE KEEP YOUR PROPERTIES IN THIS ORDER!!! -->
+                <!-- TYPICAL OPTIONAL PROPERTIES -->
+                <!-- Bidding -->
+                <!--<property name="Dutch bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
-				<property name="Russians bid" value="0" editable="true">
+                <property name="Russians bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
                 <property name="French bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>-->
-				<property name="British bid" value="0" editable="true">
+                <property name="British bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
                 <property name="Japanese bid" value="0" editable="true">
@@ -2449,450 +2449,450 @@
                 <property name="Americans bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
-				<property name="ANZAC bid" value="0" editable="true">
+                <property name="ANZAC bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
-				<property name="Chinese bid" value="0" editable="true">
+                <property name="Chinese bid" value="0" editable="true">
                         <number min="0" max="1000"/>
                 </property>
-				
-				<!-- victory options -->
-				<property name="Triggered Victory" value="true" editable="true">
-						<boolean/>
-				</property>
-				
-				<property name="Honorable Surrender" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Axis Honorable Victory VCs" value="6" editable="true">
-						<number min="5" max="8"/>
-				</property>
-
-				<property name="Allies Honorable Victory VCs" value="7" editable="true">
-						<number min="6" max="8"/>
-				</property>
-				<!-- End of Victory Conditions, rest of typical changed properties below -->
-
-				<property name="Low Luck" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for AntiAircraft" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Technology" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Use Politics" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="National Objectives" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Use Triggers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Tech Development" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Super Sub Defence Bonus" value="0" editable="true">
-						<number min="0" max="1"/>
-				</property>
-
-				<property name="LHTR Heavy Bombers" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Heavy Bomber Dice Rolls" value="2" editable="false">
-						<number min="2" max="3"/>
-				</property>
-
-				<property name="Paratroopers Can Move During Non Combat" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Paratroopers Can Attack Deep Into Enemy Territory" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Always on AA" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Kamikaze Airplanes" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Use Kamikaze Suicide Attacks" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Kamikaze Suicide Attacks Done By Current Territory Owner" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Units Repair Hits End Turn" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Units Repair Hits Start Turn" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Two HitPoint Units Require Repair Facilities" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<!-- Display Options -->
-				<property name="Multiply PUs" value="1" editable="false">
-						<number min="1" max="10"/>
-				</property>
-
-				<property name="Display Units as Counters" value="0" editable="false">
-						<number min="0" max="10"/>
-				</property>
-
-				<property name="Display Sea Names" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Selectable Zero Movement Units" value="false" editable="false">
-						<boolean/>
-				</property>
-				<!-- END OF TYPICAL OPTIONAL PROPERTIES -->
-
-				<!-- rules and tech -->
-				<property name="WW2V3" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="WW2V3 Tech Model" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Selectable Tech Roll" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Use Shipyards" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Scramble Rules In Effect" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scrambled Units Return To Base" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scramble To Sea Only" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scramble From Island Only" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Scramble To Any Amphibious Assault" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="All Rockets Attack" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Rocket Attack Per Factory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Rockets Can Fly Over Impassables" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- These require an associated value in the attachments section above-->
-				<property name="Movement By Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Production Per X Territories Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Production Per Valued Territory Restricted" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement Per Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Place in Any Territory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unplaced units live when not placed" value ="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Occupied Territories" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Give Units By Territory" value ="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Capture Units On Entering Territory" value ="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="On Entering Units Destroyed Instead Of Captured" value ="false" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- specific rules -->
-				<!-- land related -->
-				<property name="Units Can Be Destroyed Instead Of Captured" value ="true" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="Units Can Be Changed On Capture" value ="false" editable="true">
-						<boolean/>
-				</property>
-				
-				<property name="More Constructions with Factory" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="More Constructions without Factory" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unlimited Constructions" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Blitz Through Factories And AA Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Roll AA Individually" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Choose AA Casualties" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="AA Territory Restricted" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Force AA Attacks For Last Step Of Fly Over" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Multiple AA Per Territory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Suicide and Munition Casualties Restricted" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Defending Suicide and Munition Units Do Not Fire" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="Units May Give Bonus Movement" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<!-- sea related -->
-				<property name="Partial Amphibious Retreat" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Attacker Retreat Planes" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Shore Bombard Per Ground Unit Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Naval Bombard Casualties Return Fire" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Hari-Kari Units" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Allied Air Dependents" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Surviving Air Move To Land" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Air Attack Sub Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Transport Restricted Unload" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Ignore Transport In Movement" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Transport Casualties Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unescorted Transport Dies" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Transport Control Sea Zone" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Ignore Sub In Movement" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Defending Subs Sneak Attack" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Sub Retreat Before Battle" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Submersible Subs" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Sub Control Sea Zone Restricted" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="Naval Units May Not NonCombat Move Into Controlled Sea Zones" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Previous Units Fight" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Two hit battleship" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- production related -->
-				<property name="Produce fighters on carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Produce new fighters on old carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Move existing fighters to new carriers" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Land existing fighters on new carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="LHTR Carrier production rules" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement In Enemy Seas" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Territory Turn Limit" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Limit SBR Damage Per Turn" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Limit Rocket Damage Per Turn" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="maxFactoriesPerTerritory" value="2" editable="false">
-						<number min="1" max="100"/>
-				</property>
-
-				<property name="Placement Restricted By Factory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement Restrictions" value="true" editable="true">
-						<boolean/>
-				</property>
-				
-				<property name="Raids May Be Preceeded By Air Battles" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Damage From Bombing Done To Units Instead Of Territories" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Limit SBR Damage To Factory Production" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- Neutrals related -->
-				<property name="neutralCharge" value="0" editable="false">
-						<number min="0" max="9999999"/>
-				</property>
-
-				<property name="Neutrals Are Impassable" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Neutrals Are Blitzable" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Neutral Flyover Allowed" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				
+
+                <!-- victory options -->
+                <property name="Triggered Victory" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Honorable Surrender" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Axis Honorable Victory VCs" value="6" editable="true">
+                        <number min="5" max="8"/>
+                </property>
+
+                <property name="Allies Honorable Victory VCs" value="7" editable="true">
+                        <number min="6" max="8"/>
+                </property>
+                <!-- End of Victory Conditions, rest of typical changed properties below -->
+
+                <property name="Low Luck" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for AntiAircraft" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Technology" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Use Politics" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="National Objectives" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Use Triggers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Tech Development" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Super Sub Defence Bonus" value="0" editable="true">
+                        <number min="0" max="1"/>
+                </property>
+
+                <property name="LHTR Heavy Bombers" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Heavy Bomber Dice Rolls" value="2" editable="false">
+                        <number min="2" max="3"/>
+                </property>
+
+                <property name="Paratroopers Can Move During Non Combat" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Paratroopers Can Attack Deep Into Enemy Territory" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Always on AA" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Kamikaze Airplanes" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Use Kamikaze Suicide Attacks" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Kamikaze Suicide Attacks Done By Current Territory Owner" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Units Repair Hits End Turn" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Units Repair Hits Start Turn" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Two HitPoint Units Require Repair Facilities" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <!-- Display Options -->
+                <property name="Multiply PUs" value="1" editable="false">
+                        <number min="1" max="10"/>
+                </property>
+
+                <property name="Display Units as Counters" value="0" editable="false">
+                        <number min="0" max="10"/>
+                </property>
+
+                <property name="Display Sea Names" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Selectable Zero Movement Units" value="false" editable="false">
+                        <boolean/>
+                </property>
+                <!-- END OF TYPICAL OPTIONAL PROPERTIES -->
+
+                <!-- rules and tech -->
+                <property name="WW2V3" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="WW2V3 Tech Model" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Selectable Tech Roll" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Use Shipyards" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble Rules In Effect" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scrambled Units Return To Base" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble To Sea Only" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble From Island Only" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Scramble To Any Amphibious Assault" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="All Rockets Attack" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Rocket Attack Per Factory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Rockets Can Fly Over Impassables" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- These require an associated value in the attachments section above-->
+                <property name="Movement By Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Production Per X Territories Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Production Per Valued Territory Restricted" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement Per Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Place in Any Territory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unplaced units live when not placed" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Occupied Territories" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Give Units By Territory" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Capture Units On Entering Territory" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="On Entering Units Destroyed Instead Of Captured" value ="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- specific rules -->
+                <!-- land related -->
+                <property name="Units Can Be Destroyed Instead Of Captured" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Units Can Be Changed On Capture" value ="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="More Constructions with Factory" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="More Constructions without Factory" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unlimited Constructions" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Blitz Through Factories And AA Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Roll AA Individually" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Choose AA Casualties" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="AA Territory Restricted" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Force AA Attacks For Last Step Of Fly Over" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Multiple AA Per Territory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Suicide and Munition Casualties Restricted" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Defending Suicide and Munition Units Do Not Fire" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Units May Give Bonus Movement" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <!-- sea related -->
+                <property name="Partial Amphibious Retreat" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Attacker Retreat Planes" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Shore Bombard Per Ground Unit Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Naval Bombard Casualties Return Fire" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Hari-Kari Units" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Allied Air Dependents" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Surviving Air Move To Land" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Air Attack Sub Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Transport Restricted Unload" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Ignore Transport In Movement" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Transport Casualties Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unescorted Transport Dies" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Transport Control Sea Zone" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Ignore Sub In Movement" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Defending Subs Sneak Attack" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Sub Retreat Before Battle" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Submersible Subs" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Sub Control Sea Zone Restricted" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Naval Units May Not NonCombat Move Into Controlled Sea Zones" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Previous Units Fight" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Two hit battleship" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- production related -->
+                <property name="Produce fighters on carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Produce new fighters on old carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Move existing fighters to new carriers" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Land existing fighters on new carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="LHTR Carrier production rules" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement In Enemy Seas" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Territory Turn Limit" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Limit SBR Damage Per Turn" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Limit Rocket Damage Per Turn" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="maxFactoriesPerTerritory" value="2" editable="false">
+                        <number min="1" max="100"/>
+                </property>
+
+                <property name="Placement Restricted By Factory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement Restrictions" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Raids May Be Preceeded By Air Battles" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Damage From Bombing Done To Units Instead Of Territories" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Limit SBR Damage To Factory Production" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- Neutrals related -->
+                <property name="neutralCharge" value="0" editable="false">
+                        <number min="0" max="9999999"/>
+                </property>
+
+                <property name="Neutrals Are Impassable" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Neutrals Are Blitzable" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Neutral Flyover Allowed" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+
                 <property name="mapName" value="World War II Pacific Test" editable="false"/>
-				
+
                 <property name="notes">
-						<value>
-					<![CDATA[  
+                        <value>
+                    <![CDATA[
 <div style="padding:10px;font-size:14px;background-color:white;text-align:justify;">
 <b>Pacific 1940 Original</b><br>
 <br>
@@ -2945,7 +2945,7 @@ At the start of the game Japan is at war with China and France only. Any countri
 </ul>
 <br><b>China</b>
 <ul>
-<li>China may not move units outside of its historical range, which includes: Burma, Kwangtung, and its original territories 
+<li>China may not move units outside of its historical range, which includes: Burma, Kwangtung, and its original territories
 (the ones it starts with, plus Kwangsi, Kiangsi, Kiangsu, Shantung, Jehol, and Manchuria).</li>
 <li>China has no capital and will keep its money even if all its territories are lost.</li>
 </ul>
@@ -3077,8 +3077,8 @@ These changes to units are things other than price/movement which you can see in
 <br>
 <br><br><hr><br>
 </div>
-						
-						]]>
+
+                        ]]>
                         </value>
                 </property>
         </propertyList>

--- a/src/test/resources/ww2v3_1941_test.xml
+++ b/src/test/resources/ww2v3_1941_test.xml
@@ -4,117 +4,117 @@
 
 <game>
         <info name="World War II v3 1941 Test" version="1.7"/>
-        
+
         <loader javaClass="games.strategy.triplea.TripleA"/>
-		
-		<triplea minimumVersion="1.7"/>
+
+        <triplea minimumVersion="1.7"/>
 
         <map>
                 <!-- Territory Name Definitions -->
                 <territory name="Afghanistan"/>
-				<territory name="Alaska"/>
-				<territory name="Anglo-Egypt Sudan"/>
-				<territory name="Angola"/>
-				<territory name="Argentina Chile"/>
-				<territory name="Archangel"/>
-				<territory name="Australia"/>
-				<territory name="Balkans"/>
-				<territory name="Baltic States"/>
-				<territory name="Belgian Congo"/>
-				<territory name="Belorussia"/>
-				<territory name="Borneo"/>
-				<territory name="Brazil"/>
-				<territory name="Burma"/>
-				<territory name="Buryatia S.S.R."/>
-				<territory name="Caroline Islands"/>
-				<territory name="Caucasus"/>
-				<territory name="Central United States"/>
-				<territory name="Chinghai"/>
-				<territory name="Czechoslovakia Hungary"/>
-				<territory name="East Indies"/>
-				<territory name="Eastern Canada"/>
-				<territory name="East Poland"/>
-				<territory name="Eastern United States"/>
-				<territory name="Egypt"/>
-				<territory name="Eire"/>
-				<territory name="Evenki National Okrug"/>
-				<territory name="France"/>
-				<territory name="French Equatorial Africa"/>
-				<territory name="French Indo-China Thailand"/>
-				<territory name="French Madagascar"/>
-				<territory name="French West Africa"/>
-				<territory name="Finland"/>
-				<territory name="Formosa"/>
-				<territory name="Fukien"/>
-				<territory name="Germany"/>
-				<territory name="Gibraltar"/>
-				<territory name="Greenland"/>
-				<territory name="Hawaiian Islands"/>
-				<territory name="Himalaya"/>
-				<territory name="Hupeh"/>
-				<territory name="Iceland"/>
-				<territory name="India"/>
-				<territory name="Italian Africa"/>
-				<territory name="Italy"/>
-				<territory name="Iwo Jima"/>
-				<territory name="Japan"/>
-				<territory name="Karelia S.S.R."/>
-				<territory name="Kazakh S.S.R."/>
-				<territory name="Kiangsu"/>
-				<territory name="Kwangtung"/>
-				<territory name="Libya"/>
-				<territory name="Manchuria"/>
-				<territory name="Mexico"/>
-				<territory name="Midway"/>
-				<territory name="Mongolia"/>
-				<territory name="Morocco Algeria"/>
-				<territory name="Mozambique"/>
-				<territory name="New Guinea"/>
-				<territory name="New Zealand"/>
-				<territory name="Ningxia"/>
-				<territory name="Eastern Ukraine"/>
-				<territory name="Northwestern Europe"/>
-				<territory name="Norway"/>
-				<territory name="Novosibirsk"/>
-				<territory name="Okinawa"/>
-				<territory name="Panama"/>
-				<territory name="Persia"/>
-				<territory name="Peruvian Central"/>
-				<territory name="Philippine Islands"/>
-				<territory name="Poland"/>
-				<territory name="Rhodesia"/>
-				<territory name="Bulgaria Romania"/>
-				<territory name="Russia"/>
-				<territory name="Sahara"/>
-				<territory name="Saudi Arabia"/>
-				<territory name="Sikang"/>
-				<territory name="Solomon Islands"/>
-				<territory name="Soviet Far East"/>
-				<territory name="Spain"/>
-				<territory name="Stanovoj Chrebet"/>
-				<territory name="Suiyuan"/>
-				<territory name="Sweden"/>
-				<territory name="Switzerland"/>
-				<territory name="Trans-Jordan"/>
-				<territory name="Turkey"/>
-				<territory name="Ukraine"/>
-				<territory name="Union of South Africa"/>
-				<territory name="United Kingdom"/>
-				<territory name="Urals"/>
-				<territory name="Northern South America"/>
-				<territory name="Wake Island"/>
-				<territory name="West Indies"/>
-				<territory name="Western Canada"/>
-				<territory name="Western United States"/>
-				<territory name="Yakut S.S.R."/>
-				<territory name="Yunnan"/>
-				
-				<!-- Seazone Name Definitions -->
-				<territory name="1 Sea Zone" water="true"/>
+                <territory name="Alaska"/>
+                <territory name="Anglo-Egypt Sudan"/>
+                <territory name="Angola"/>
+                <territory name="Argentina Chile"/>
+                <territory name="Archangel"/>
+                <territory name="Australia"/>
+                <territory name="Balkans"/>
+                <territory name="Baltic States"/>
+                <territory name="Belgian Congo"/>
+                <territory name="Belorussia"/>
+                <territory name="Borneo"/>
+                <territory name="Brazil"/>
+                <territory name="Burma"/>
+                <territory name="Buryatia S.S.R."/>
+                <territory name="Caroline Islands"/>
+                <territory name="Caucasus"/>
+                <territory name="Central United States"/>
+                <territory name="Chinghai"/>
+                <territory name="Czechoslovakia Hungary"/>
+                <territory name="East Indies"/>
+                <territory name="Eastern Canada"/>
+                <territory name="East Poland"/>
+                <territory name="Eastern United States"/>
+                <territory name="Egypt"/>
+                <territory name="Eire"/>
+                <territory name="Evenki National Okrug"/>
+                <territory name="France"/>
+                <territory name="French Equatorial Africa"/>
+                <territory name="French Indo-China Thailand"/>
+                <territory name="French Madagascar"/>
+                <territory name="French West Africa"/>
+                <territory name="Finland"/>
+                <territory name="Formosa"/>
+                <territory name="Fukien"/>
+                <territory name="Germany"/>
+                <territory name="Gibraltar"/>
+                <territory name="Greenland"/>
+                <territory name="Hawaiian Islands"/>
+                <territory name="Himalaya"/>
+                <territory name="Hupeh"/>
+                <territory name="Iceland"/>
+                <territory name="India"/>
+                <territory name="Italian Africa"/>
+                <territory name="Italy"/>
+                <territory name="Iwo Jima"/>
+                <territory name="Japan"/>
+                <territory name="Karelia S.S.R."/>
+                <territory name="Kazakh S.S.R."/>
+                <territory name="Kiangsu"/>
+                <territory name="Kwangtung"/>
+                <territory name="Libya"/>
+                <territory name="Manchuria"/>
+                <territory name="Mexico"/>
+                <territory name="Midway"/>
+                <territory name="Mongolia"/>
+                <territory name="Morocco Algeria"/>
+                <territory name="Mozambique"/>
+                <territory name="New Guinea"/>
+                <territory name="New Zealand"/>
+                <territory name="Ningxia"/>
+                <territory name="Eastern Ukraine"/>
+                <territory name="Northwestern Europe"/>
+                <territory name="Norway"/>
+                <territory name="Novosibirsk"/>
+                <territory name="Okinawa"/>
+                <territory name="Panama"/>
+                <territory name="Persia"/>
+                <territory name="Peruvian Central"/>
+                <territory name="Philippine Islands"/>
+                <territory name="Poland"/>
+                <territory name="Rhodesia"/>
+                <territory name="Bulgaria Romania"/>
+                <territory name="Russia"/>
+                <territory name="Sahara"/>
+                <territory name="Saudi Arabia"/>
+                <territory name="Sikang"/>
+                <territory name="Solomon Islands"/>
+                <territory name="Soviet Far East"/>
+                <territory name="Spain"/>
+                <territory name="Stanovoj Chrebet"/>
+                <territory name="Suiyuan"/>
+                <territory name="Sweden"/>
+                <territory name="Switzerland"/>
+                <territory name="Trans-Jordan"/>
+                <territory name="Turkey"/>
+                <territory name="Ukraine"/>
+                <territory name="Union of South Africa"/>
+                <territory name="United Kingdom"/>
+                <territory name="Urals"/>
+                <territory name="Northern South America"/>
+                <territory name="Wake Island"/>
+                <territory name="West Indies"/>
+                <territory name="Western Canada"/>
+                <territory name="Western United States"/>
+                <territory name="Yakut S.S.R."/>
+                <territory name="Yunnan"/>
+
+                <!-- Seazone Name Definitions -->
+                <territory name="1 Sea Zone" water="true"/>
                 <territory name="2 Sea Zone" water="true"/>
                 <territory name="3 Sea Zone" water="true"/>
                 <territory name="4 Sea Zone" water="true"/>
-				<territory name="5 Sea Zone" water="true"/>
+                <territory name="5 Sea Zone" water="true"/>
                 <territory name="6 Sea Zone" water="true"/>
                 <territory name="7 Sea Zone" water="true"/>
                 <territory name="8 Sea Zone" water="true"/>
@@ -126,7 +126,7 @@
                 <territory name="14 Sea Zone" water="true"/>
                 <territory name="15 Sea Zone" water="true"/>
                 <territory name="16 Sea Zone" water="true"/>
-				<territory name="17 Sea Zone" water="true"/>
+                <territory name="17 Sea Zone" water="true"/>
                 <territory name="18 Sea Zone" water="true"/>
                 <territory name="19 Sea Zone" water="true"/>
                 <territory name="20 Sea Zone" water="true"/>
@@ -138,7 +138,7 @@
                 <territory name="26 Sea Zone" water="true"/>
                 <territory name="27 Sea Zone" water="true"/>
                 <territory name="28 Sea Zone" water="true"/>
-				<territory name="29 Sea Zone" water="true"/>
+                <territory name="29 Sea Zone" water="true"/>
                 <territory name="30 Sea Zone" water="true"/>
                 <territory name="31 Sea Zone" water="true"/>
                 <territory name="32 Sea Zone" water="true"/>
@@ -149,7 +149,7 @@
                 <territory name="37 Sea Zone" water="true"/>
                 <territory name="38 Sea Zone" water="true"/>
                 <territory name="39 Sea Zone" water="true"/>
-				<territory name="40 Sea Zone" water="true"/>
+                <territory name="40 Sea Zone" water="true"/>
                 <territory name="41 Sea Zone" water="true"/>
                 <territory name="42 Sea Zone" water="true"/>
                 <territory name="43 Sea Zone" water="true"/>
@@ -161,7 +161,7 @@
                 <territory name="49 Sea Zone" water="true"/>
                 <territory name="50 Sea Zone" water="true"/>
                 <territory name="51 Sea Zone" water="true"/>
-				<territory name="52 Sea Zone" water="true"/>
+                <territory name="52 Sea Zone" water="true"/>
                 <territory name="53 Sea Zone" water="true"/>
                 <territory name="54 Sea Zone" water="true"/>
                 <territory name="55 Sea Zone" water="true"/>
@@ -173,448 +173,448 @@
                 <territory name="61 Sea Zone" water="true"/>
                 <territory name="62 Sea Zone" water="true"/>
                 <territory name="63 Sea Zone" water="true"/>
-				<territory name="64 Sea Zone" water="true"/>
+                <territory name="64 Sea Zone" water="true"/>
                 <territory name="65 Sea Zone" water="true"/>
 
                 <!-- Territory and Seazone Connections -->
                 <connection t1="1 Sea Zone" t2="2 Sea Zone"/>
-				<connection t1="1 Sea Zone" t2="8 Sea Zone"/>
-				<connection t1="1 Sea Zone" t2="9 Sea Zone"/>
-				<connection t1="1 Sea Zone" t2="Eastern Canada"/>
-				<connection t1="2 Sea Zone" t2="3 Sea Zone"/>
-				<connection t1="2 Sea Zone" t2="8 Sea Zone"/>
-				<connection t1="2 Sea Zone" t2="Eire"/>
-				<connection t1="2 Sea Zone" t2="Greenland"/>
-				<connection t1="2 Sea Zone" t2="Iceland"/>
-				<connection t1="2 Sea Zone" t2="United Kingdom"/>
-				<connection t1="3 Sea Zone" t2="4 Sea Zone"/>
-				<connection t1="3 Sea Zone" t2="6 Sea Zone"/>
-				<connection t1="3 Sea Zone" t2="Norway"/>
-				<connection t1="3 Sea Zone" t2="United Kingdom"/>
-				<connection t1="4 Sea Zone" t2="Archangel"/>
-				<connection t1="4 Sea Zone" t2="Finland"/>
-				<connection t1="4 Sea Zone" t2="Karelia S.S.R."/>
-				<connection t1="5 Sea Zone" t2="6 Sea Zone"/>
-				<connection t1="5 Sea Zone" t2="Baltic States"/>
-				<connection t1="5 Sea Zone" t2="Finland"/>
-				<connection t1="5 Sea Zone" t2="Germany"/>
-				<connection t1="5 Sea Zone" t2="Karelia S.S.R."/>
-				<connection t1="5 Sea Zone" t2="Northwestern Europe"/>
-				<connection t1="5 Sea Zone" t2="Norway"/>
-				<connection t1="5 Sea Zone" t2="Sweden"/>
-				<connection t1="5 Sea Zone" t2="Poland"/>
-				<connection t1="6 Sea Zone" t2="7 Sea Zone"/>
-				<connection t1="6 Sea Zone" t2="Northwestern Europe"/>
-				<connection t1="6 Sea Zone" t2="Norway"/>
-				<connection t1="6 Sea Zone" t2="United Kingdom"/>
-				<connection t1="7 Sea Zone" t2="8 Sea Zone"/>
-				<connection t1="7 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="7 Sea Zone" t2="France"/>
-				<connection t1="7 Sea Zone" t2="Northwestern Europe"/>
-				<connection t1="7 Sea Zone" t2="United Kingdom"/>
-				<connection t1="8 Sea Zone" t2="9 Sea Zone"/> 
-				<connection t1="8 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="8 Sea Zone" t2="Eire"/>
-				<connection t1="8 Sea Zone" t2="United Kingdom"/>
-				<connection t1="9 Sea Zone" t2="10 Sea Zone"/>
-				<connection t1="9 Sea Zone" t2="11 Sea Zone"/>
-				<connection t1="9 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="9 Sea Zone" t2="Eastern Canada"/>
-				<connection t1="10 Sea Zone" t2="11 Sea Zone"/>
-				<connection t1="10 Sea Zone" t2="19 Sea Zone"/>
-				<connection t1="10 Sea Zone" t2="Eastern United States"/>
-				<connection t1="10 Sea Zone" t2="Panama"/>
-				<connection t1="11 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="11 Sea Zone" t2="18 Sea Zone"/>
-				<connection t1="11 Sea Zone" t2="19 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="13 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="17 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="18 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="Gibraltar"/>
-				<connection t1="12 Sea Zone" t2="Morocco Algeria"/>
-				<connection t1="12 Sea Zone" t2="Spain"/>
-				<connection t1="13 Sea Zone" t2="14 Sea Zone"/> 
-				<connection t1="13 Sea Zone" t2="France"/>
-				<connection t1="13 Sea Zone" t2="Gibraltar"/>
-				<connection t1="13 Sea Zone" t2="Morocco Algeria"/>
-				<connection t1="13 Sea Zone" t2="Spain"/>
-				<connection t1="14 Sea Zone" t2="15 Sea Zone"/>
-				<connection t1="14 Sea Zone" t2="16 Sea Zone"/>
-				<connection t1="14 Sea Zone" t2="Italy"/>
-				<connection t1="14 Sea Zone" t2="Libya"/>
-				<connection t1="14 Sea Zone" t2="Balkans"/>
-				<connection t1="15 Sea Zone" t2="16 Sea Zone"/>
-				<connection t1="15 Sea Zone" t2="Egypt"/>
-				<connection t1="15 Sea Zone" t2="Trans-Jordan"/>
-				<connection t1="15 Sea Zone" t2="Turkey"/>
-				<connection t1="15 Sea Zone" t2="34 Sea Zone"/>
-				<connection t1="16 Sea Zone" t2="Caucasus"/>
-				<connection t1="16 Sea Zone" t2="Bulgaria Romania"/>
-				<connection t1="16 Sea Zone" t2="Turkey"/>
-				<connection t1="16 Sea Zone" t2="Ukraine"/> 
-				<connection t1="17 Sea Zone" t2="18 Sea Zone"/>
-				<connection t1="17 Sea Zone" t2="22 Sea Zone"/>
-				<connection t1="17 Sea Zone" t2="23 Sea Zone"/>
-				<connection t1="17 Sea Zone" t2="French West Africa"/>
-				<connection t1="17 Sea Zone" t2="Sahara"/>
-				<connection t1="18 Sea Zone" t2="19 Sea Zone"/>
-				<connection t1="18 Sea Zone" t2="22 Sea Zone"/>
-				<connection t1="18 Sea Zone" t2="Brazil"/>
-				<connection t1="19 Sea Zone" t2="20 Sea Zone"/>
-				<connection t1="19 Sea Zone" t2="Northern South America"/>
-				<connection t1="19 Sea Zone" t2="Panama"/>
-				<connection t1="19 Sea Zone" t2="West Indies"/>
-				<connection t1="20 Sea Zone" t2="21 Sea Zone"/>
-				<connection t1="20 Sea Zone" t2="55 Sea Zone"/>
-				<connection t1="20 Sea Zone" t2="Northern South America"/>
-				<connection t1="20 Sea Zone" t2="Panama"/>
-				<connection t1="20 Sea Zone" t2="Peruvian Central"/>
-				<connection t1="21 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="21 Sea Zone" t2="44 Sea Zone"/>
-				<connection t1="21 Sea Zone" t2="Argentina Chile"/>
-				<connection t1="21 Sea Zone" t2="Peruvian Central"/>
-				<connection t1="22 Sea Zone" t2="23 Sea Zone"/>
-				<connection t1="22 Sea Zone" t2="24 Sea Zone"/>
-				<connection t1="22 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="22 Sea Zone" t2="Brazil"/>
-				<connection t1="23 Sea Zone" t2="24 Sea Zone"/> 
-				<connection t1="23 Sea Zone" t2="27 Sea Zone"/>
-				<connection t1="23 Sea Zone" t2="Angola"/>
-				<connection t1="23 Sea Zone" t2="Belgian Congo"/>
-				<connection t1="23 Sea Zone" t2="French Equatorial Africa"/>
-				<connection t1="24 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="24 Sea Zone" t2="26 Sea Zone"/>
-				<connection t1="24 Sea Zone" t2="27 Sea Zone"/>
-				<connection t1="25 Sea Zone" t2="26 Sea Zone"/>
-				<connection t1="25 Sea Zone" t2="43 Sea Zone"/>
-				<connection t1="25 Sea Zone" t2="Argentina Chile"/>
-				<connection t1="26 Sea Zone" t2="27 Sea Zone"/>
-				<connection t1="27 Sea Zone" t2="28 Sea Zone"/>
-				<connection t1="27 Sea Zone" t2="Angola"/>
-				<connection t1="27 Sea Zone" t2="Union of South Africa"/>
-				<connection t1="28 Sea Zone" t2="29 Sea Zone"/>
-				<connection t1="28 Sea Zone" t2="33 Sea Zone"/>
-				<connection t1="28 Sea Zone" t2="French Madagascar"/>
-				<connection t1="28 Sea Zone" t2="Union of South Africa"/>
-				<connection t1="29 Sea Zone" t2="30 Sea Zone"/>
-				<connection t1="29 Sea Zone" t2="32 Sea Zone"/>
-				<connection t1="29 Sea Zone" t2="French Madagascar"/>
-				<connection t1="30 Sea Zone" t2="31 Sea Zone"/>
-				<connection t1="30 Sea Zone" t2="39 Sea Zone"/>
-				<connection t1="30 Sea Zone" t2="40 Sea Zone"/>
-				<connection t1="30 Sea Zone" t2="32 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="32 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="35 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="38 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="39 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="33 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="34 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="35 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="French Madagascar"/>
-				<connection t1="33 Sea Zone" t2="34 Sea Zone"/>
-				<connection t1="33 Sea Zone" t2="French Madagascar"/>
-				<connection t1="33 Sea Zone" t2="Mozambique"/>
-				<connection t1="33 Sea Zone" t2="Rhodesia"/>
-				<connection t1="34 Sea Zone" t2="35 Sea Zone"/>
-				<connection t1="34 Sea Zone" t2="Anglo-Egypt Sudan"/>
-				<connection t1="34 Sea Zone" t2="Egypt"/>
-				<connection t1="34 Sea Zone" t2="Italian Africa"/>
-				<connection t1="34 Sea Zone" t2="Saudi Arabia"/>
-				<connection t1="34 Sea Zone" t2="Trans-Jordan"/>
-				<connection t1="34 Sea Zone" t2="Persia"/>
-				<connection t1="35 Sea Zone" t2="37 Sea Zone"/>
-				<connection t1="35 Sea Zone" t2="38 Sea Zone"/>
-				<connection t1="35 Sea Zone" t2="India"/>
-				<connection t1="36 Sea Zone" t2="37 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="49 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="50 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="61 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="French Indo-China Thailand"/>
-				<connection t1="37 Sea Zone" t2="38 Sea Zone"/>
-				<connection t1="37 Sea Zone" t2="49 Sea Zone"/>
-				<connection t1="37 Sea Zone" t2="Burma"/>
-				<connection t1="37 Sea Zone" t2="French Indo-China Thailand"/>
-				<connection t1="38 Sea Zone" t2="39 Sea Zone"/>
-				<connection t1="38 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="38 Sea Zone" t2="49 Sea Zone"/>
-				<connection t1="38 Sea Zone" t2="East Indies"/>
-				<connection t1="39 Sea Zone" t2="40 Sea Zone"/>      
-				<connection t1="39 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="39 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="39 Sea Zone" t2="Australia"/>
-				<connection t1="40 Sea Zone" t2="41 Sea Zone"/>
-				<connection t1="40 Sea Zone" t2="Australia"/>
-				<connection t1="41 Sea Zone" t2="42 Sea Zone"/>
-				<connection t1="41 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="41 Sea Zone" t2="Australia"/>
-				<connection t1="42 Sea Zone" t2="43 Sea Zone"/>
-				<connection t1="42 Sea Zone" t2="45 Sea Zone"/>
-				<connection t1="42 Sea Zone" t2="46 Sea Zone"/>
-				<connection t1="42 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="42 Sea Zone" t2="New Zealand"/>
-				<connection t1="43 Sea Zone" t2="44 Sea Zone"/>
-				<connection t1="43 Sea Zone" t2="45 Sea Zone"/>
-				<connection t1="44 Sea Zone" t2="45 Sea Zone"/>
-				<connection t1="44 Sea Zone" t2="54 Sea Zone"/>
-				<connection t1="44 Sea Zone" t2="55 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="46 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="53 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="54 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="51 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="53 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="Solomon Islands"/>
-				<connection t1="47 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="47 Sea Zone" t2="Australia"/>
-				<connection t1="48 Sea Zone" t2="49 Sea Zone"/>
-				<connection t1="48 Sea Zone" t2="50 Sea Zone"/>
-				<connection t1="48 Sea Zone" t2="51 Sea Zone"/>
-				<connection t1="48 Sea Zone" t2="New Guinea"/>
-				<connection t1="49 Sea Zone" t2="50 Sea Zone"/> 
-				<connection t1="49 Sea Zone" t2="Borneo"/>
-				<connection t1="50 Sea Zone" t2="51 Sea Zone"/>
-				<connection t1="50 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="50 Sea Zone" t2="61 Sea Zone"/>
-				<connection t1="50 Sea Zone" t2="Philippine Islands"/>
-				<connection t1="51 Sea Zone" t2="52 Sea Zone"/> 
-				<connection t1="51 Sea Zone" t2="53 Sea Zone"/>
-				<connection t1="51 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="51 Sea Zone" t2="Caroline Islands"/>
-				<connection t1="52 Sea Zone" t2="53 Sea Zone"/> 
-				<connection t1="52 Sea Zone" t2="57 Sea Zone"/>
-				<connection t1="52 Sea Zone" t2="59 Sea Zone"/>
-				<connection t1="52 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="52 Sea Zone" t2="Wake Island"/>
-				<connection t1="53 Sea Zone" t2="54 Sea Zone"/>
-				<connection t1="53 Sea Zone" t2="56 Sea Zone"/>
-				<connection t1="53 Sea Zone" t2="57 Sea Zone"/>
-				<connection t1="53 Sea Zone" t2="Hawaiian Islands"/>
-				<connection t1="54 Sea Zone" t2="55 Sea Zone"/>
-				<connection t1="54 Sea Zone" t2="56 Sea Zone"/>
-				<connection t1="55 Sea Zone" t2="56 Sea Zone"/>
-				<connection t1="55 Sea Zone" t2="Mexico"/>
-				<connection t1="56 Sea Zone" t2="57 Sea Zone"/>  
-				<connection t1="56 Sea Zone" t2="65 Sea Zone"/>
-				<connection t1="56 Sea Zone" t2="Western Canada"/>
-				<connection t1="56 Sea Zone" t2="Western United States"/>
-				<connection t1="57 Sea Zone" t2="58 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="59 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="64 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="65 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="Midway"/>
-				<connection t1="58 Sea Zone" t2="59 Sea Zone"/>
-				<connection t1="58 Sea Zone" t2="62 Sea Zone"/>
-				<connection t1="58 Sea Zone" t2="63 Sea Zone"/>
-				<connection t1="58 Sea Zone" t2="64 Sea Zone"/>
-				<connection t1="59 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="59 Sea Zone" t2="62 Sea Zone"/>
-				<connection t1="59 Sea Zone" t2="Iwo Jima"/>
-				<connection t1="60 Sea Zone" t2="61 Sea Zone"/>
-				<connection t1="60 Sea Zone" t2="62 Sea Zone"/>
-				<connection t1="60 Sea Zone" t2="Okinawa"/>
-				<connection t1="61 Sea Zone" t2="62 Sea Zone"/> 
-				<connection t1="61 Sea Zone" t2="Formosa"/>
-				<connection t1="61 Sea Zone" t2="Fukien"/>
-				<connection t1="61 Sea Zone" t2="Kiangsu"/>
-				<connection t1="61 Sea Zone" t2="Kwangtung"/>
-				<connection t1="62 Sea Zone" t2="63 Sea Zone"/> 
-				<connection t1="62 Sea Zone" t2="Buryatia S.S.R."/>
-				<connection t1="62 Sea Zone" t2="Japan"/>
-				<connection t1="62 Sea Zone" t2="Manchuria"/>
-				<connection t1="63 Sea Zone" t2="64 Sea Zone"/>
-				<connection t1="63 Sea Zone" t2="Buryatia S.S.R."/>
-				<connection t1="63 Sea Zone" t2="Soviet Far East"/>
-				<connection t1="64 Sea Zone" t2="65 Sea Zone"/>           
-				<connection t1="64 Sea Zone" t2="Alaska"/>
-				<connection t1="65 Sea Zone" t2="Alaska"/>
-				<connection t1="65 Sea Zone" t2="Western Canada"/>
-				<connection t1="Afghanistan" t2="Chinghai"/>
-				<connection t1="Afghanistan" t2="Himalaya"/>
-				<connection t1="Afghanistan" t2="India"/>
-				<connection t1="Afghanistan" t2="Kazakh S.S.R."/>
-				<connection t1="Afghanistan" t2="Persia"/>
-				<connection t1="Alaska" t2="Western Canada"/>
-				<connection t1="Anglo-Egypt Sudan" t2="Belgian Congo"/>
-				<connection t1="Anglo-Egypt Sudan" t2="Egypt"/>
-				<connection t1="Anglo-Egypt Sudan" t2="French Equatorial Africa"/>
-				<connection t1="Anglo-Egypt Sudan" t2="Italian Africa"/>
-				<connection t1="Anglo-Egypt Sudan" t2="Sahara"/>
-				<connection t1="Angola" t2="Belgian Congo"/> 
-				<connection t1="Angola" t2="Rhodesia"/>
-				<connection t1="Angola" t2="Union of South Africa"/>
-				<connection t1="Argentina Chile" t2="Brazil"/> 
-				<connection t1="Argentina Chile" t2="Peruvian Central"/>
-				<connection t1="Archangel" t2="Belorussia"/> 
-				<connection t1="Archangel" t2="Karelia S.S.R."/>
-				<connection t1="Archangel" t2="Russia"/>
-				<connection t1="Archangel" t2="Urals"/>
-				<connection t1="Baltic States" t2="Belorussia"/> 
-				<connection t1="Baltic States" t2="East Poland"/>
-				<connection t1="Baltic States" t2="Karelia S.S.R."/>
-				<connection t1="Baltic States" t2="Poland"/>
-				<connection t1="Belgian Congo" t2="French Equatorial Africa"/>
-				<connection t1="Belgian Congo" t2="Rhodesia"/>
-				<connection t1="Belgian Congo" t2="Italian Africa"/>
-				<connection t1="Belorussia" t2="East Poland"/>
-				<connection t1="Belorussia" t2="Karelia S.S.R."/>
-				<connection t1="Belorussia" t2="Eastern Ukraine"/>
-				<connection t1="Belorussia" t2="Russia"/>
-				<connection t1="Brazil" t2="Northern South America"/>
-				<connection t1="Brazil" t2="Peruvian Central"/>
-				<connection t1="Burma" t2="French Indo-China Thailand"/> 
-				<connection t1="Burma" t2="Himalaya"/>
-				<connection t1="Burma" t2="India"/>
-				<connection t1="Burma" t2="Yunnan"/>
-				<connection t1="Buryatia S.S.R." t2="Manchuria"/>
-				<connection t1="Buryatia S.S.R." t2="Mongolia"/>
-				<connection t1="Buryatia S.S.R." t2="Soviet Far East"/>
-				<connection t1="Buryatia S.S.R." t2="Stanovoj Chrebet"/>
-				<connection t1="Caucasus" t2="Kazakh S.S.R."/>
-				<connection t1="Caucasus" t2="Eastern Ukraine"/>
-				<connection t1="Caucasus" t2="Persia"/>
-				<connection t1="Caucasus" t2="Russia"/>
-				<connection t1="Caucasus" t2="Turkey"/>
-				<connection t1="Caucasus" t2="Ukraine"/>
-				<connection t1="Central United States" t2="Eastern United States"/>
-				<connection t1="Central United States" t2="Mexico"/>
-				<connection t1="Central United States" t2="Western Canada"/>
-				<connection t1="Central United States" t2="Western United States"/>
-				<connection t1="Chinghai" t2="Himalaya"/>
-				<connection t1="Chinghai" t2="Kazakh S.S.R."/>
-				<connection t1="Chinghai" t2="Mongolia"/>
-				<connection t1="Chinghai" t2="Ningxia"/>
-				<connection t1="Chinghai" t2="Novosibirsk"/>
-				<connection t1="Chinghai" t2="Sikang"/>
-				<connection t1="Czechoslovakia Hungary" t2="Germany"/>
-				<connection t1="Czechoslovakia Hungary" t2="Bulgaria Romania"/>
-				<connection t1="Czechoslovakia Hungary" t2="Balkans"/>
-				<connection t1="Czechoslovakia Hungary" t2="Poland"/>
-				<connection t1="Eastern Canada" t2="Eastern United States"/>
-				<connection t1="Eastern Canada" t2="Western Canada"/>
-				<connection t1="East Poland" t2="Eastern Ukraine"/> 
-				<connection t1="East Poland" t2="Bulgaria Romania"/>
-				<connection t1="East Poland" t2="Ukraine"/>
-				<connection t1="East Poland" t2="Poland"/>
-				<connection t1="Eastern United States" t2="Panama"/>
-				<connection t1="Egypt" t2="Libya"/> 
-				<connection t1="Egypt" t2="Sahara"/>
-				<connection t1="Egypt" t2="Trans-Jordan"/>
-				<connection t1="Eire" t2="United Kingdom"/> 
-				<connection t1="Evenki National Okrug" t2="Mongolia"/>
-				<connection t1="Evenki National Okrug" t2="Novosibirsk"/>
-				<connection t1="Evenki National Okrug" t2="Urals"/>
-				<connection t1="Evenki National Okrug" t2="Yakut S.S.R."/>
-				<connection t1="France" t2="Germany"/>
-				<connection t1="France" t2="Italy"/>
-				<connection t1="France" t2="Northwestern Europe"/>
-				<connection t1="France" t2="Spain"/>
-				<connection t1="France" t2="Switzerland"/>
-				<connection t1="French Equatorial Africa" t2="French West Africa"/>
-				<connection t1="French Equatorial Africa" t2="Sahara"/>
-				<connection t1="French Indo-China Thailand" t2="Fukien"/>
-				<connection t1="French Indo-China Thailand" t2="Kwangtung"/>
-				<connection t1="French Indo-China Thailand" t2="Yunnan"/>
-				<connection t1="French West Africa" t2="Sahara"/>
-				<connection t1="Finland" t2="Karelia S.S.R."/> 
-				<connection t1="Finland" t2="Norway"/>
-				<connection t1="Finland" t2="Sweden"/>
-				<connection t1="Fukien" t2="Hupeh"/> 
-				<connection t1="Fukien" t2="Kiangsu"/>
-				<connection t1="Fukien" t2="Kwangtung"/>
-				<connection t1="Fukien" t2="Yunnan"/>
-				<connection t1="Germany" t2="Northwestern Europe"/>
-				<connection t1="Germany" t2="Switzerland"/>
-				<connection t1="Germany" t2="Balkans"/>
-				<connection t1="Germany" t2="Poland"/>
-				<connection t1="Gibraltar" t2="Spain"/>
-				<connection t1="Himalaya" t2="India"/>
-				<connection t1="Himalaya" t2="Sikang"/>
-				<connection t1="Himalaya" t2="Yunnan"/>
-				<connection t1="Hupeh" t2="Kiangsu"/>
-				<connection t1="Hupeh" t2="Ningxia"/>
-				<connection t1="Hupeh" t2="Sikang"/>
-				<connection t1="Hupeh" t2="Suiyuan"/>
-				<connection t1="Hupeh" t2="Yunnan"/>
-				<connection t1="India" t2="Persia"/>
-				<connection t1="Italian Africa" t2="Rhodesia"/>
-				<connection t1="Italy" t2="Switzerland"/>
-				<connection t1="Italy" t2="Balkans"/>
-				<connection t1="Kazakh S.S.R." t2="Russia"/>
-				<connection t1="Kazakh S.S.R." t2="Novosibirsk"/>
-				<connection t1="Kiangsu" t2="Manchuria"/> 
-				<connection t1="Kiangsu" t2="Suiyuan"/>
-				<connection t1="Libya" t2="Morocco Algeria"/>
-				<connection t1="Libya" t2="Sahara"/>
-				<connection t1="Mexico" t2="Western United States"/>
-				<connection t1="Mexico" t2="Panama"/>
-				<connection t1="Manchuria" t2="Mongolia"/>
-				<connection t1="Manchuria" t2="Suiyuan"/>
-				<connection t1="Mongolia" t2="Novosibirsk"/>
-				<connection t1="Mongolia" t2="Ningxia"/>
-				<connection t1="Mongolia" t2="Stanovoj Chrebet"/>
-				<connection t1="Mongolia" t2="Suiyuan"/>
-				<connection t1="Mongolia" t2="Yakut S.S.R."/>
-				<connection t1="Morocco Algeria" t2="Sahara"/>
-				<connection t1="Mozambique" t2="Rhodesia"/>
-				<connection t1="Mozambique" t2="Union of South Africa"/>
-				<connection t1="Ningxia" t2="Sikang"/>
-				<connection t1="Ningxia" t2="Suiyuan"/>
-				<connection t1="Northern South America" t2="Peruvian Central"/>
-				<connection t1="Northern South America" t2="Panama"/>
-				<connection t1="Eastern Ukraine" t2="Ukraine"/>
-				<connection t1="Norway" t2="Sweden"/>
-				<connection t1="Novosibirsk" t2="Russia"/>
-				<connection t1="Novosibirsk" t2="Urals"/>
-				<connection t1="Persia" t2="Kazakh S.S.R."/>
-				<connection t1="Persia" t2="Trans-Jordan"/>
-				<connection t1="Persia" t2="Turkey"/>
-				<connection t1="Rhodesia" t2="Union of South Africa"/>
-				<connection t1="Bulgaria Romania" t2="Turkey"/> 
-				<connection t1="Bulgaria Romania" t2="Ukraine"/>
-				<connection t1="Bulgaria Romania" t2="Balkans"/>
-				<connection t1="Bulgaria Romania" t2="Poland"/>
-				<connection t1="Russia" t2="Eastern Ukraine"/>
-				<connection t1="Russia" t2="Urals"/>
-				<connection t1="Saudi Arabia" t2="Trans-Jordan"/>
-				<connection t1="Sikang" t2="Yunnan"/>
-				<connection t1="Soviet Far East" t2="Stanovoj Chrebet"/>
-				<connection t1="Soviet Far East" t2="Yakut S.S.R."/>
-				<connection t1="Stanovoj Chrebet" t2="Yakut S.S.R."/> 
-				<connection t1="Switzerland" t2="Balkans"/>
-				<connection t1="Trans-Jordan" t2="Turkey"/>
-				<connection t1="Western Canada" t2="Western United States"/>
+                <connection t1="1 Sea Zone" t2="8 Sea Zone"/>
+                <connection t1="1 Sea Zone" t2="9 Sea Zone"/>
+                <connection t1="1 Sea Zone" t2="Eastern Canada"/>
+                <connection t1="2 Sea Zone" t2="3 Sea Zone"/>
+                <connection t1="2 Sea Zone" t2="8 Sea Zone"/>
+                <connection t1="2 Sea Zone" t2="Eire"/>
+                <connection t1="2 Sea Zone" t2="Greenland"/>
+                <connection t1="2 Sea Zone" t2="Iceland"/>
+                <connection t1="2 Sea Zone" t2="United Kingdom"/>
+                <connection t1="3 Sea Zone" t2="4 Sea Zone"/>
+                <connection t1="3 Sea Zone" t2="6 Sea Zone"/>
+                <connection t1="3 Sea Zone" t2="Norway"/>
+                <connection t1="3 Sea Zone" t2="United Kingdom"/>
+                <connection t1="4 Sea Zone" t2="Archangel"/>
+                <connection t1="4 Sea Zone" t2="Finland"/>
+                <connection t1="4 Sea Zone" t2="Karelia S.S.R."/>
+                <connection t1="5 Sea Zone" t2="6 Sea Zone"/>
+                <connection t1="5 Sea Zone" t2="Baltic States"/>
+                <connection t1="5 Sea Zone" t2="Finland"/>
+                <connection t1="5 Sea Zone" t2="Germany"/>
+                <connection t1="5 Sea Zone" t2="Karelia S.S.R."/>
+                <connection t1="5 Sea Zone" t2="Northwestern Europe"/>
+                <connection t1="5 Sea Zone" t2="Norway"/>
+                <connection t1="5 Sea Zone" t2="Sweden"/>
+                <connection t1="5 Sea Zone" t2="Poland"/>
+                <connection t1="6 Sea Zone" t2="7 Sea Zone"/>
+                <connection t1="6 Sea Zone" t2="Northwestern Europe"/>
+                <connection t1="6 Sea Zone" t2="Norway"/>
+                <connection t1="6 Sea Zone" t2="United Kingdom"/>
+                <connection t1="7 Sea Zone" t2="8 Sea Zone"/>
+                <connection t1="7 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="7 Sea Zone" t2="France"/>
+                <connection t1="7 Sea Zone" t2="Northwestern Europe"/>
+                <connection t1="7 Sea Zone" t2="United Kingdom"/>
+                <connection t1="8 Sea Zone" t2="9 Sea Zone"/>
+                <connection t1="8 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="8 Sea Zone" t2="Eire"/>
+                <connection t1="8 Sea Zone" t2="United Kingdom"/>
+                <connection t1="9 Sea Zone" t2="10 Sea Zone"/>
+                <connection t1="9 Sea Zone" t2="11 Sea Zone"/>
+                <connection t1="9 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="9 Sea Zone" t2="Eastern Canada"/>
+                <connection t1="10 Sea Zone" t2="11 Sea Zone"/>
+                <connection t1="10 Sea Zone" t2="19 Sea Zone"/>
+                <connection t1="10 Sea Zone" t2="Eastern United States"/>
+                <connection t1="10 Sea Zone" t2="Panama"/>
+                <connection t1="11 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="11 Sea Zone" t2="18 Sea Zone"/>
+                <connection t1="11 Sea Zone" t2="19 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="13 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="17 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="18 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="Gibraltar"/>
+                <connection t1="12 Sea Zone" t2="Morocco Algeria"/>
+                <connection t1="12 Sea Zone" t2="Spain"/>
+                <connection t1="13 Sea Zone" t2="14 Sea Zone"/>
+                <connection t1="13 Sea Zone" t2="France"/>
+                <connection t1="13 Sea Zone" t2="Gibraltar"/>
+                <connection t1="13 Sea Zone" t2="Morocco Algeria"/>
+                <connection t1="13 Sea Zone" t2="Spain"/>
+                <connection t1="14 Sea Zone" t2="15 Sea Zone"/>
+                <connection t1="14 Sea Zone" t2="16 Sea Zone"/>
+                <connection t1="14 Sea Zone" t2="Italy"/>
+                <connection t1="14 Sea Zone" t2="Libya"/>
+                <connection t1="14 Sea Zone" t2="Balkans"/>
+                <connection t1="15 Sea Zone" t2="16 Sea Zone"/>
+                <connection t1="15 Sea Zone" t2="Egypt"/>
+                <connection t1="15 Sea Zone" t2="Trans-Jordan"/>
+                <connection t1="15 Sea Zone" t2="Turkey"/>
+                <connection t1="15 Sea Zone" t2="34 Sea Zone"/>
+                <connection t1="16 Sea Zone" t2="Caucasus"/>
+                <connection t1="16 Sea Zone" t2="Bulgaria Romania"/>
+                <connection t1="16 Sea Zone" t2="Turkey"/>
+                <connection t1="16 Sea Zone" t2="Ukraine"/>
+                <connection t1="17 Sea Zone" t2="18 Sea Zone"/>
+                <connection t1="17 Sea Zone" t2="22 Sea Zone"/>
+                <connection t1="17 Sea Zone" t2="23 Sea Zone"/>
+                <connection t1="17 Sea Zone" t2="French West Africa"/>
+                <connection t1="17 Sea Zone" t2="Sahara"/>
+                <connection t1="18 Sea Zone" t2="19 Sea Zone"/>
+                <connection t1="18 Sea Zone" t2="22 Sea Zone"/>
+                <connection t1="18 Sea Zone" t2="Brazil"/>
+                <connection t1="19 Sea Zone" t2="20 Sea Zone"/>
+                <connection t1="19 Sea Zone" t2="Northern South America"/>
+                <connection t1="19 Sea Zone" t2="Panama"/>
+                <connection t1="19 Sea Zone" t2="West Indies"/>
+                <connection t1="20 Sea Zone" t2="21 Sea Zone"/>
+                <connection t1="20 Sea Zone" t2="55 Sea Zone"/>
+                <connection t1="20 Sea Zone" t2="Northern South America"/>
+                <connection t1="20 Sea Zone" t2="Panama"/>
+                <connection t1="20 Sea Zone" t2="Peruvian Central"/>
+                <connection t1="21 Sea Zone" t2="25 Sea Zone"/>
+                <connection t1="21 Sea Zone" t2="44 Sea Zone"/>
+                <connection t1="21 Sea Zone" t2="Argentina Chile"/>
+                <connection t1="21 Sea Zone" t2="Peruvian Central"/>
+                <connection t1="22 Sea Zone" t2="23 Sea Zone"/>
+                <connection t1="22 Sea Zone" t2="24 Sea Zone"/>
+                <connection t1="22 Sea Zone" t2="25 Sea Zone"/>
+                <connection t1="22 Sea Zone" t2="Brazil"/>
+                <connection t1="23 Sea Zone" t2="24 Sea Zone"/>
+                <connection t1="23 Sea Zone" t2="27 Sea Zone"/>
+                <connection t1="23 Sea Zone" t2="Angola"/>
+                <connection t1="23 Sea Zone" t2="Belgian Congo"/>
+                <connection t1="23 Sea Zone" t2="French Equatorial Africa"/>
+                <connection t1="24 Sea Zone" t2="25 Sea Zone"/>
+                <connection t1="24 Sea Zone" t2="26 Sea Zone"/>
+                <connection t1="24 Sea Zone" t2="27 Sea Zone"/>
+                <connection t1="25 Sea Zone" t2="26 Sea Zone"/>
+                <connection t1="25 Sea Zone" t2="43 Sea Zone"/>
+                <connection t1="25 Sea Zone" t2="Argentina Chile"/>
+                <connection t1="26 Sea Zone" t2="27 Sea Zone"/>
+                <connection t1="27 Sea Zone" t2="28 Sea Zone"/>
+                <connection t1="27 Sea Zone" t2="Angola"/>
+                <connection t1="27 Sea Zone" t2="Union of South Africa"/>
+                <connection t1="28 Sea Zone" t2="29 Sea Zone"/>
+                <connection t1="28 Sea Zone" t2="33 Sea Zone"/>
+                <connection t1="28 Sea Zone" t2="French Madagascar"/>
+                <connection t1="28 Sea Zone" t2="Union of South Africa"/>
+                <connection t1="29 Sea Zone" t2="30 Sea Zone"/>
+                <connection t1="29 Sea Zone" t2="32 Sea Zone"/>
+                <connection t1="29 Sea Zone" t2="French Madagascar"/>
+                <connection t1="30 Sea Zone" t2="31 Sea Zone"/>
+                <connection t1="30 Sea Zone" t2="39 Sea Zone"/>
+                <connection t1="30 Sea Zone" t2="40 Sea Zone"/>
+                <connection t1="30 Sea Zone" t2="32 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="32 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="35 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="38 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="39 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="33 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="34 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="35 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="French Madagascar"/>
+                <connection t1="33 Sea Zone" t2="34 Sea Zone"/>
+                <connection t1="33 Sea Zone" t2="French Madagascar"/>
+                <connection t1="33 Sea Zone" t2="Mozambique"/>
+                <connection t1="33 Sea Zone" t2="Rhodesia"/>
+                <connection t1="34 Sea Zone" t2="35 Sea Zone"/>
+                <connection t1="34 Sea Zone" t2="Anglo-Egypt Sudan"/>
+                <connection t1="34 Sea Zone" t2="Egypt"/>
+                <connection t1="34 Sea Zone" t2="Italian Africa"/>
+                <connection t1="34 Sea Zone" t2="Saudi Arabia"/>
+                <connection t1="34 Sea Zone" t2="Trans-Jordan"/>
+                <connection t1="34 Sea Zone" t2="Persia"/>
+                <connection t1="35 Sea Zone" t2="37 Sea Zone"/>
+                <connection t1="35 Sea Zone" t2="38 Sea Zone"/>
+                <connection t1="35 Sea Zone" t2="India"/>
+                <connection t1="36 Sea Zone" t2="37 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="49 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="50 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="61 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="French Indo-China Thailand"/>
+                <connection t1="37 Sea Zone" t2="38 Sea Zone"/>
+                <connection t1="37 Sea Zone" t2="49 Sea Zone"/>
+                <connection t1="37 Sea Zone" t2="Burma"/>
+                <connection t1="37 Sea Zone" t2="French Indo-China Thailand"/>
+                <connection t1="38 Sea Zone" t2="39 Sea Zone"/>
+                <connection t1="38 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="38 Sea Zone" t2="49 Sea Zone"/>
+                <connection t1="38 Sea Zone" t2="East Indies"/>
+                <connection t1="39 Sea Zone" t2="40 Sea Zone"/>
+                <connection t1="39 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="39 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="39 Sea Zone" t2="Australia"/>
+                <connection t1="40 Sea Zone" t2="41 Sea Zone"/>
+                <connection t1="40 Sea Zone" t2="Australia"/>
+                <connection t1="41 Sea Zone" t2="42 Sea Zone"/>
+                <connection t1="41 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="41 Sea Zone" t2="Australia"/>
+                <connection t1="42 Sea Zone" t2="43 Sea Zone"/>
+                <connection t1="42 Sea Zone" t2="45 Sea Zone"/>
+                <connection t1="42 Sea Zone" t2="46 Sea Zone"/>
+                <connection t1="42 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="42 Sea Zone" t2="New Zealand"/>
+                <connection t1="43 Sea Zone" t2="44 Sea Zone"/>
+                <connection t1="43 Sea Zone" t2="45 Sea Zone"/>
+                <connection t1="44 Sea Zone" t2="45 Sea Zone"/>
+                <connection t1="44 Sea Zone" t2="54 Sea Zone"/>
+                <connection t1="44 Sea Zone" t2="55 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="46 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="54 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="51 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="Solomon Islands"/>
+                <connection t1="47 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="47 Sea Zone" t2="Australia"/>
+                <connection t1="48 Sea Zone" t2="49 Sea Zone"/>
+                <connection t1="48 Sea Zone" t2="50 Sea Zone"/>
+                <connection t1="48 Sea Zone" t2="51 Sea Zone"/>
+                <connection t1="48 Sea Zone" t2="New Guinea"/>
+                <connection t1="49 Sea Zone" t2="50 Sea Zone"/>
+                <connection t1="49 Sea Zone" t2="Borneo"/>
+                <connection t1="50 Sea Zone" t2="51 Sea Zone"/>
+                <connection t1="50 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="50 Sea Zone" t2="61 Sea Zone"/>
+                <connection t1="50 Sea Zone" t2="Philippine Islands"/>
+                <connection t1="51 Sea Zone" t2="52 Sea Zone"/>
+                <connection t1="51 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="51 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="51 Sea Zone" t2="Caroline Islands"/>
+                <connection t1="52 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="57 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="59 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="Wake Island"/>
+                <connection t1="53 Sea Zone" t2="54 Sea Zone"/>
+                <connection t1="53 Sea Zone" t2="56 Sea Zone"/>
+                <connection t1="53 Sea Zone" t2="57 Sea Zone"/>
+                <connection t1="53 Sea Zone" t2="Hawaiian Islands"/>
+                <connection t1="54 Sea Zone" t2="55 Sea Zone"/>
+                <connection t1="54 Sea Zone" t2="56 Sea Zone"/>
+                <connection t1="55 Sea Zone" t2="56 Sea Zone"/>
+                <connection t1="55 Sea Zone" t2="Mexico"/>
+                <connection t1="56 Sea Zone" t2="57 Sea Zone"/>
+                <connection t1="56 Sea Zone" t2="65 Sea Zone"/>
+                <connection t1="56 Sea Zone" t2="Western Canada"/>
+                <connection t1="56 Sea Zone" t2="Western United States"/>
+                <connection t1="57 Sea Zone" t2="58 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="59 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="64 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="65 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="Midway"/>
+                <connection t1="58 Sea Zone" t2="59 Sea Zone"/>
+                <connection t1="58 Sea Zone" t2="62 Sea Zone"/>
+                <connection t1="58 Sea Zone" t2="63 Sea Zone"/>
+                <connection t1="58 Sea Zone" t2="64 Sea Zone"/>
+                <connection t1="59 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="59 Sea Zone" t2="62 Sea Zone"/>
+                <connection t1="59 Sea Zone" t2="Iwo Jima"/>
+                <connection t1="60 Sea Zone" t2="61 Sea Zone"/>
+                <connection t1="60 Sea Zone" t2="62 Sea Zone"/>
+                <connection t1="60 Sea Zone" t2="Okinawa"/>
+                <connection t1="61 Sea Zone" t2="62 Sea Zone"/>
+                <connection t1="61 Sea Zone" t2="Formosa"/>
+                <connection t1="61 Sea Zone" t2="Fukien"/>
+                <connection t1="61 Sea Zone" t2="Kiangsu"/>
+                <connection t1="61 Sea Zone" t2="Kwangtung"/>
+                <connection t1="62 Sea Zone" t2="63 Sea Zone"/>
+                <connection t1="62 Sea Zone" t2="Buryatia S.S.R."/>
+                <connection t1="62 Sea Zone" t2="Japan"/>
+                <connection t1="62 Sea Zone" t2="Manchuria"/>
+                <connection t1="63 Sea Zone" t2="64 Sea Zone"/>
+                <connection t1="63 Sea Zone" t2="Buryatia S.S.R."/>
+                <connection t1="63 Sea Zone" t2="Soviet Far East"/>
+                <connection t1="64 Sea Zone" t2="65 Sea Zone"/>
+                <connection t1="64 Sea Zone" t2="Alaska"/>
+                <connection t1="65 Sea Zone" t2="Alaska"/>
+                <connection t1="65 Sea Zone" t2="Western Canada"/>
+                <connection t1="Afghanistan" t2="Chinghai"/>
+                <connection t1="Afghanistan" t2="Himalaya"/>
+                <connection t1="Afghanistan" t2="India"/>
+                <connection t1="Afghanistan" t2="Kazakh S.S.R."/>
+                <connection t1="Afghanistan" t2="Persia"/>
+                <connection t1="Alaska" t2="Western Canada"/>
+                <connection t1="Anglo-Egypt Sudan" t2="Belgian Congo"/>
+                <connection t1="Anglo-Egypt Sudan" t2="Egypt"/>
+                <connection t1="Anglo-Egypt Sudan" t2="French Equatorial Africa"/>
+                <connection t1="Anglo-Egypt Sudan" t2="Italian Africa"/>
+                <connection t1="Anglo-Egypt Sudan" t2="Sahara"/>
+                <connection t1="Angola" t2="Belgian Congo"/>
+                <connection t1="Angola" t2="Rhodesia"/>
+                <connection t1="Angola" t2="Union of South Africa"/>
+                <connection t1="Argentina Chile" t2="Brazil"/>
+                <connection t1="Argentina Chile" t2="Peruvian Central"/>
+                <connection t1="Archangel" t2="Belorussia"/>
+                <connection t1="Archangel" t2="Karelia S.S.R."/>
+                <connection t1="Archangel" t2="Russia"/>
+                <connection t1="Archangel" t2="Urals"/>
+                <connection t1="Baltic States" t2="Belorussia"/>
+                <connection t1="Baltic States" t2="East Poland"/>
+                <connection t1="Baltic States" t2="Karelia S.S.R."/>
+                <connection t1="Baltic States" t2="Poland"/>
+                <connection t1="Belgian Congo" t2="French Equatorial Africa"/>
+                <connection t1="Belgian Congo" t2="Rhodesia"/>
+                <connection t1="Belgian Congo" t2="Italian Africa"/>
+                <connection t1="Belorussia" t2="East Poland"/>
+                <connection t1="Belorussia" t2="Karelia S.S.R."/>
+                <connection t1="Belorussia" t2="Eastern Ukraine"/>
+                <connection t1="Belorussia" t2="Russia"/>
+                <connection t1="Brazil" t2="Northern South America"/>
+                <connection t1="Brazil" t2="Peruvian Central"/>
+                <connection t1="Burma" t2="French Indo-China Thailand"/>
+                <connection t1="Burma" t2="Himalaya"/>
+                <connection t1="Burma" t2="India"/>
+                <connection t1="Burma" t2="Yunnan"/>
+                <connection t1="Buryatia S.S.R." t2="Manchuria"/>
+                <connection t1="Buryatia S.S.R." t2="Mongolia"/>
+                <connection t1="Buryatia S.S.R." t2="Soviet Far East"/>
+                <connection t1="Buryatia S.S.R." t2="Stanovoj Chrebet"/>
+                <connection t1="Caucasus" t2="Kazakh S.S.R."/>
+                <connection t1="Caucasus" t2="Eastern Ukraine"/>
+                <connection t1="Caucasus" t2="Persia"/>
+                <connection t1="Caucasus" t2="Russia"/>
+                <connection t1="Caucasus" t2="Turkey"/>
+                <connection t1="Caucasus" t2="Ukraine"/>
+                <connection t1="Central United States" t2="Eastern United States"/>
+                <connection t1="Central United States" t2="Mexico"/>
+                <connection t1="Central United States" t2="Western Canada"/>
+                <connection t1="Central United States" t2="Western United States"/>
+                <connection t1="Chinghai" t2="Himalaya"/>
+                <connection t1="Chinghai" t2="Kazakh S.S.R."/>
+                <connection t1="Chinghai" t2="Mongolia"/>
+                <connection t1="Chinghai" t2="Ningxia"/>
+                <connection t1="Chinghai" t2="Novosibirsk"/>
+                <connection t1="Chinghai" t2="Sikang"/>
+                <connection t1="Czechoslovakia Hungary" t2="Germany"/>
+                <connection t1="Czechoslovakia Hungary" t2="Bulgaria Romania"/>
+                <connection t1="Czechoslovakia Hungary" t2="Balkans"/>
+                <connection t1="Czechoslovakia Hungary" t2="Poland"/>
+                <connection t1="Eastern Canada" t2="Eastern United States"/>
+                <connection t1="Eastern Canada" t2="Western Canada"/>
+                <connection t1="East Poland" t2="Eastern Ukraine"/>
+                <connection t1="East Poland" t2="Bulgaria Romania"/>
+                <connection t1="East Poland" t2="Ukraine"/>
+                <connection t1="East Poland" t2="Poland"/>
+                <connection t1="Eastern United States" t2="Panama"/>
+                <connection t1="Egypt" t2="Libya"/>
+                <connection t1="Egypt" t2="Sahara"/>
+                <connection t1="Egypt" t2="Trans-Jordan"/>
+                <connection t1="Eire" t2="United Kingdom"/>
+                <connection t1="Evenki National Okrug" t2="Mongolia"/>
+                <connection t1="Evenki National Okrug" t2="Novosibirsk"/>
+                <connection t1="Evenki National Okrug" t2="Urals"/>
+                <connection t1="Evenki National Okrug" t2="Yakut S.S.R."/>
+                <connection t1="France" t2="Germany"/>
+                <connection t1="France" t2="Italy"/>
+                <connection t1="France" t2="Northwestern Europe"/>
+                <connection t1="France" t2="Spain"/>
+                <connection t1="France" t2="Switzerland"/>
+                <connection t1="French Equatorial Africa" t2="French West Africa"/>
+                <connection t1="French Equatorial Africa" t2="Sahara"/>
+                <connection t1="French Indo-China Thailand" t2="Fukien"/>
+                <connection t1="French Indo-China Thailand" t2="Kwangtung"/>
+                <connection t1="French Indo-China Thailand" t2="Yunnan"/>
+                <connection t1="French West Africa" t2="Sahara"/>
+                <connection t1="Finland" t2="Karelia S.S.R."/>
+                <connection t1="Finland" t2="Norway"/>
+                <connection t1="Finland" t2="Sweden"/>
+                <connection t1="Fukien" t2="Hupeh"/>
+                <connection t1="Fukien" t2="Kiangsu"/>
+                <connection t1="Fukien" t2="Kwangtung"/>
+                <connection t1="Fukien" t2="Yunnan"/>
+                <connection t1="Germany" t2="Northwestern Europe"/>
+                <connection t1="Germany" t2="Switzerland"/>
+                <connection t1="Germany" t2="Balkans"/>
+                <connection t1="Germany" t2="Poland"/>
+                <connection t1="Gibraltar" t2="Spain"/>
+                <connection t1="Himalaya" t2="India"/>
+                <connection t1="Himalaya" t2="Sikang"/>
+                <connection t1="Himalaya" t2="Yunnan"/>
+                <connection t1="Hupeh" t2="Kiangsu"/>
+                <connection t1="Hupeh" t2="Ningxia"/>
+                <connection t1="Hupeh" t2="Sikang"/>
+                <connection t1="Hupeh" t2="Suiyuan"/>
+                <connection t1="Hupeh" t2="Yunnan"/>
+                <connection t1="India" t2="Persia"/>
+                <connection t1="Italian Africa" t2="Rhodesia"/>
+                <connection t1="Italy" t2="Switzerland"/>
+                <connection t1="Italy" t2="Balkans"/>
+                <connection t1="Kazakh S.S.R." t2="Russia"/>
+                <connection t1="Kazakh S.S.R." t2="Novosibirsk"/>
+                <connection t1="Kiangsu" t2="Manchuria"/>
+                <connection t1="Kiangsu" t2="Suiyuan"/>
+                <connection t1="Libya" t2="Morocco Algeria"/>
+                <connection t1="Libya" t2="Sahara"/>
+                <connection t1="Mexico" t2="Western United States"/>
+                <connection t1="Mexico" t2="Panama"/>
+                <connection t1="Manchuria" t2="Mongolia"/>
+                <connection t1="Manchuria" t2="Suiyuan"/>
+                <connection t1="Mongolia" t2="Novosibirsk"/>
+                <connection t1="Mongolia" t2="Ningxia"/>
+                <connection t1="Mongolia" t2="Stanovoj Chrebet"/>
+                <connection t1="Mongolia" t2="Suiyuan"/>
+                <connection t1="Mongolia" t2="Yakut S.S.R."/>
+                <connection t1="Morocco Algeria" t2="Sahara"/>
+                <connection t1="Mozambique" t2="Rhodesia"/>
+                <connection t1="Mozambique" t2="Union of South Africa"/>
+                <connection t1="Ningxia" t2="Sikang"/>
+                <connection t1="Ningxia" t2="Suiyuan"/>
+                <connection t1="Northern South America" t2="Peruvian Central"/>
+                <connection t1="Northern South America" t2="Panama"/>
+                <connection t1="Eastern Ukraine" t2="Ukraine"/>
+                <connection t1="Norway" t2="Sweden"/>
+                <connection t1="Novosibirsk" t2="Russia"/>
+                <connection t1="Novosibirsk" t2="Urals"/>
+                <connection t1="Persia" t2="Kazakh S.S.R."/>
+                <connection t1="Persia" t2="Trans-Jordan"/>
+                <connection t1="Persia" t2="Turkey"/>
+                <connection t1="Rhodesia" t2="Union of South Africa"/>
+                <connection t1="Bulgaria Romania" t2="Turkey"/>
+                <connection t1="Bulgaria Romania" t2="Ukraine"/>
+                <connection t1="Bulgaria Romania" t2="Balkans"/>
+                <connection t1="Bulgaria Romania" t2="Poland"/>
+                <connection t1="Russia" t2="Eastern Ukraine"/>
+                <connection t1="Russia" t2="Urals"/>
+                <connection t1="Saudi Arabia" t2="Trans-Jordan"/>
+                <connection t1="Sikang" t2="Yunnan"/>
+                <connection t1="Soviet Far East" t2="Stanovoj Chrebet"/>
+                <connection t1="Soviet Far East" t2="Yakut S.S.R."/>
+                <connection t1="Stanovoj Chrebet" t2="Yakut S.S.R."/>
+                <connection t1="Switzerland" t2="Balkans"/>
+                <connection t1="Trans-Jordan" t2="Turkey"/>
+                <connection t1="Western Canada" t2="Western United States"/>
         </map>
-        
+
         <resourceList>
                 <resource name="PUs"/>
-                <resource name="techTokens"/>                
+                <resource name="techTokens"/>
         </resourceList>
 
-        
+
         <playerList>
                 <!-- Player Turn Order -->
-                
+
                 <player name="Germans" optional="false"/>
-				<player name="Russians" optional="false"/>
-				<player name="Japanese" optional="false"/>
+                <player name="Russians" optional="false"/>
+                <player name="Japanese" optional="false"/>
                 <player name="British" optional="false"/>
                 <player name="Italians" optional="false"/>
-				<player name="Chinese" optional="false"/>
+                <player name="Chinese" optional="false"/>
                 <player name="Americans" optional="false"/>
 
                 <!-- Axis Alliance -->
                 <alliance player="Italians" alliance="Axis"/>
-				<alliance player="Germans" alliance="Axis"/>
+                <alliance player="Germans" alliance="Axis"/>
                 <alliance player="Japanese" alliance="Axis"/>
-                
+
                 <!-- Allied Alliance -->
                 <alliance player="Russians" alliance="Allies"/>
                 <alliance player="British" alliance="Allies"/>
-				<alliance player="Chinese" alliance="Allies"/>
+                <alliance player="Chinese" alliance="Allies"/>
                 <alliance player="Americans" alliance="Allies"/>
         </playerList>
-  
+
         <unitList>
                 <unit name="infantry"/>
                 <unit name="artillery"/>
@@ -624,7 +624,7 @@
                 <unit name="transport"/>
                 <unit name="submarine"/>
                 <unit name="destroyer"/>
-				<unit name="cruiser"/>
+                <unit name="cruiser"/>
                 <unit name="carrier"/>
                 <unit name="battleship"/>
                 <unit name="aaGun"/>
@@ -639,40 +639,40 @@
                 <delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Combat Move"/>
                 <delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Units"/>
                 <delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
-				<delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>
+                <delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>
                 <delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate" display="Turn Complete"/>
-				<delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
+                <delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
                 <delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
                 <delegate name="placeBid" javaClass="games.strategy.triplea.delegate.BidPlaceDelegate" display="Bid Placement"/>
                 <delegate name="bid" javaClass="games.strategy.triplea.delegate.BidPurchaseDelegate" display="Bid Purchase"/>
-                
-                
+
+
                 <sequence>
                         <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
-                     
+
                         <!-- Bidding Phase -->
-                        
+
                         <step name="germanBid" delegate="bid" player="Germans" maxRunCount="1"/>
                         <step name="germanBidPlace" delegate="placeBid" player="Germans" maxRunCount="1"/>
-						
-						<step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
+
+                        <step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
                         <step name="russianBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
-						
-						<step name="japaneseBid" delegate="bid" player="Japanese" maxRunCount="1"/>
+
+                        <step name="japaneseBid" delegate="bid" player="Japanese" maxRunCount="1"/>
                         <step name="japaneseBidPlace" delegate="placeBid" player="Japanese" maxRunCount="1"/>
-						
-						<step name="britishBid" delegate="bid" player="British" maxRunCount="1"/>
+
+                        <step name="britishBid" delegate="bid" player="British" maxRunCount="1"/>
                         <step name="britishBidPlace" delegate="placeBid" player="British" maxRunCount="1"/>
-						
-						<step name="italiansBid" delegate="bid" player="Italians" maxRunCount="1"/>
+
+                        <step name="italiansBid" delegate="bid" player="Italians" maxRunCount="1"/>
                         <step name="italiansBidPlace" delegate="placeBid" player="Italians" maxRunCount="1"/>
-						
-						<step name="chineseBid" delegate="bid" player="Chinese" maxRunCount="1"/>
-						<step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
-						
-						<step name="americanBid" delegate="bid" player="Americans" maxRunCount="1"/>
+
+                        <step name="chineseBid" delegate="bid" player="Chinese" maxRunCount="1"/>
+                        <step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
+
+                        <step name="americanBid" delegate="bid" player="Americans" maxRunCount="1"/>
                         <step name="americanBidPlace" delegate="placeBid" player="Americans" maxRunCount="1"/>
-                        
+
                         <!-- Germans Game Sequence -->
                         <step name="germanTech" delegate="tech" player="Germans"/>
                         <step name="germanTechActivation" delegate="tech_activation" player="Germans"/>
@@ -682,8 +682,8 @@
                         <step name="germanNonCombatMove" delegate="move" player="Germans" display="Non Combat Move"/>
                         <step name="germanPlace" delegate="place" player="Germans"/>
                         <step name="germanEndTurn" delegate="endTurn" player="Germans"/>
-						
-						<!-- Russians Game Sequence -->
+
+                        <!-- Russians Game Sequence -->
                         <step name="russianTech" delegate="tech" player="Russians"/>
                         <step name="russianTechActivation" delegate="tech_activation" player="Russians"/>
                         <step name="russianPurchase" delegate="purchase" player="Russians"/>
@@ -692,8 +692,8 @@
                         <step name="russianNonCombatMove" delegate="move" player="Russians" display="Non Combat Move"/>
                         <step name="russianPlace" delegate="place" player="Russians"/>
                         <step name="russianEndTurn" delegate="endTurn" player="Russians"/>
-						
-						<!-- Japanese Game Sequence -->
+
+                        <!-- Japanese Game Sequence -->
                         <step name="japaneseTech" delegate="tech" player="Japanese"/>
                         <step name="japaneseTechActivation" delegate="tech_activation" player="Japanese"/>
                         <step name="japanesePurchase" delegate="purchase" player="Japanese"/>
@@ -702,8 +702,8 @@
                         <step name="japaneseNonCombatMove" delegate="move" player="Japanese" display="Non Combat Move"/>
                         <step name="japanesePlace" delegate="place" player="Japanese"/>
                         <step name="japaneseEndTurn" delegate="endTurn" player="Japanese"/>
-						
-						<!-- British Game Sequence -->
+
+                        <!-- British Game Sequence -->
                         <step name="britishTech" delegate="tech" player="British"/>
                         <step name="britishTechActivation" delegate="tech_activation" player="British"/>
                         <step name="britishPurchase" delegate="purchase" player="British"/>
@@ -712,8 +712,8 @@
                         <step name="britishNonCombatMove" delegate="move" player="British" display="Non Combat Move"/>
                         <step name="britishPlace" delegate="place" player="British"/>
                         <step name="britishEndTurn" delegate="endTurn" player="British"/>
-						
-						<!-- Italians Game Sequence -->
+
+                        <!-- Italians Game Sequence -->
                         <step name="italianTech" delegate="tech" player="Italians"/>
                         <step name="italianTechActivation" delegate="tech_activation" player="Italians"/>
                         <step name="italianPurchase" delegate="purchase" player="Italians"/>
@@ -722,28 +722,28 @@
                         <step name="italianNonCombatMove" delegate="move" player="Italians" display="Non Combat Move"/>
                         <step name="italianPlace" delegate="place" player="Italians"/>
                         <step name="italianEndTurn" delegate="endTurn" player="Italians"/>
-						
+
                         <!-- Chinese/Americans Game Sequence -->
                         <step name="americanTech" delegate="tech" player="Americans"/>
                         <step name="americanTechActivation" delegate="tech_activation" player="Americans"/>
                         <step name="americanPurchase" delegate="purchase" player="Americans"/>
-						<step name="chinesePurchase" delegate="purchaseNoPU" player="Chinese"/>
+                        <step name="chinesePurchase" delegate="purchaseNoPU" player="Chinese"/>
                         <step name="americanCombatMove" delegate="move" player="Americans"/>
                         <step name="americanBattle" delegate="battle" player="Americans"/>
                         <step name="americanNonCombatMove" delegate="move" player="Americans" display="Non Combat Move"/>
-						<step name="chineseCombatMove" delegate="move" player="Chinese"/>
-						<step name="chineseBattle" delegate="battle" player="Chinese"/>
-						<step name="chineseNonCombatMove" delegate="move" player="Chinese" display="Non Combat Move"/>
+                        <step name="chineseCombatMove" delegate="move" player="Chinese"/>
+                        <step name="chineseBattle" delegate="battle" player="Chinese"/>
+                        <step name="chineseNonCombatMove" delegate="move" player="Chinese" display="Non Combat Move"/>
                         <step name="americanPlace" delegate="place" player="Americans"/>
-						<step name="chinesePlace" delegate="place" player="Chinese"/>
-						<step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese">
-								<stepProperty name="skipPosting" value="true"/>
-						</step>
+                        <step name="chinesePlace" delegate="place" player="Chinese"/>
+                        <step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese">
+                                <stepProperty name="skipPosting" value="true"/>
+                        </step>
                         <step name="americanEndTurn" delegate="endTurn" player="Americans">
-								<stepProperty name="turnSummaryPlayers" value="Americans:Chinese"/>
-						</step>
-                              
-						<!-- End Round -->
+                                <stepProperty name="turnSummaryPlayers" value="Americans:Chinese"/>
+                        </step>
+
+                        <!-- End Round -->
                         <step name="endRoundStep" delegate="endRound"/>
                 </sequence>
         </gamePlay>
@@ -754,12 +754,12 @@
                         <cost resource="PUs" quantity="3" />
                         <result resourceOrUnit="infantry" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArtillery">
                         <cost resource="PUs" quantity="4" />
                         <result resourceOrUnit="artillery" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArmour">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="armour" quantity="1"/>
@@ -769,12 +769,12 @@
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="fighter" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBomber">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="bomber" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyTransport">
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="transport" quantity="1"/>
@@ -784,17 +784,17 @@
                         <cost resource="PUs" quantity="14" />
                         <result resourceOrUnit="carrier" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyDestroyer">
                         <cost resource="PUs" quantity="8" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiser">
+
+                <productionRule name="buyCruiser">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBattleship">
                         <cost resource="PUs" quantity="20" />
                         <result resourceOrUnit="battleship" quantity="1"/>
@@ -804,12 +804,12 @@
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="submarine" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFactory">
                         <cost resource="PUs" quantity="15" />
                         <result resourceOrUnit="factory" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyAAGun">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="aaGun" quantity="1"/>
@@ -817,124 +817,124 @@
 
 
 
-                <!-- Advanced Industrial Production 
-                
+                <!-- Advanced Industrial Production
+
                 <productionRule name="buyInfantryIndustrialTechnology">
                         <cost resource="PUs" quantity="3" />
                         <result resourceOrUnit="infantry" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArtilleryIndustrialTechnology">
                         <cost resource="PUs" quantity="4" />
                         <result resourceOrUnit="artillery" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArmourIndustrialTechnology">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="armour" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFighterIndustrialTechnology">
                         <cost resource="PUs" quantity="9" />
                         <result resourceOrUnit="fighter" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBomberIndustrialTechnology">
                         <cost resource="PUs" quantity="11" />
                         <result resourceOrUnit="bomber" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyTransportIndustrialTechnology">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="transport" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyCarrierIndustrialTechnology">
                         <cost resource="PUs" quantity="11" />
                         <result resourceOrUnit="carrier" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyDestroyerIndustrialTechnology">
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiserIndustrialTechnology">
+
+                <productionRule name="buyCruiserIndustrialTechnology">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBattleshipIndustrialTechnology">
                         <cost resource="PUs" quantity="17" />
                         <result resourceOrUnit="battleship" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buySubmarineIndustrialTechnology">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="submarine" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFactoryIndustrialTechnology">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="factory" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyAAGunIndustrialTechnology">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="aaGun" quantity="1"/>
                 </productionRule>
                 -->
-                
-                
+
+
                 <!-- SHIPYARD PRICES -->
-                
+
                 <productionRule name="buyTransportShipyards">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="transport" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyCarrierShipyards">
                         <cost resource="PUs" quantity="11" />
                         <result resourceOrUnit="carrier" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyDestroyerShipyards">
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiserShipyards">
+
+                <productionRule name="buyCruiserShipyards">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBattleshipShipyards">
                         <cost resource="PUs" quantity="17" />
                         <result resourceOrUnit="battleship" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buySubmarineShipyards">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="submarine" quantity="1"/>
                 </productionRule>
-                
-               <!-- Repair rules -->                
+
+               <!-- Repair rules -->
                 <repairRule name="repairFactory">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory" quantity="1"/>
                 </repairRule>
-                
+
                 <repairRule name="repairFactoryIndustrialTechnology">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory" quantity="2"/>
                 </repairRule>
-                
+
                 <repairFrontier name="repair">
-                	<repairRules name="repairFactory"/>
+                    <repairRules name="repairFactory"/>
                 </repairFrontier>
-                
+
                 <repairFrontier name="repairIndustrialTechnology">
-                	<repairRules name="repairFactoryIndustrialTechnology"/>
+                    <repairRules name="repairFactoryIndustrialTechnology"/>
                 </repairFrontier>
 
                 <productionFrontier name="production">
@@ -946,14 +946,14 @@
                         <frontierRules name="buyTransport"/>
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buyAAGun"/>
-                        <frontierRules name="buyFactory"/>        
+                        <frontierRules name="buyFactory"/>
                 </productionFrontier>
-                
-				<!--
+
+                <!--
                 <productionFrontier name="productionIndustrialTechnology">
                         <frontierRules name="buyInfantryIndustrialTechnology"/>
                         <frontierRules name="buyArtilleryIndustrialTechnology"/>
@@ -963,44 +963,44 @@
                         <frontierRules name="buyTransportIndustrialTechnology"/>
                         <frontierRules name="buySubmarineIndustrialTechnology"/>
                         <frontierRules name="buyDestroyerIndustrialTechnology"/>
-						<frontierRules name="buyCruiserIndustrialTechnology"/>
+                        <frontierRules name="buyCruiserIndustrialTechnology"/>
                         <frontierRules name="buyCarrierIndustrialTechnology"/>
                         <frontierRules name="buyBattleshipIndustrialTechnology"/>
                         <frontierRules name="buyAAGunIndustrialTechnology"/>
-                        <frontierRules name="buyFactoryIndustrialTechnology"/>        
+                        <frontierRules name="buyFactoryIndustrialTechnology"/>
                 </productionFrontier>
-				-->
-                
+                -->
+
                 <productionFrontier name="productionShipyards">
                         <frontierRules name="buyTransportShipyards"/>
                         <frontierRules name="buySubmarineShipyards"/>
                         <frontierRules name="buyDestroyerShipyards"/>
-						<frontierRules name="buyCruiserShipyards"/>
+                        <frontierRules name="buyCruiserShipyards"/>
                         <frontierRules name="buyCarrierShipyards"/>
-                        <frontierRules name="buyBattleshipShipyards"/>   
+                        <frontierRules name="buyBattleshipShipyards"/>
                 </productionFrontier>
-                
+
                 <playerProduction player="Germans" frontier="production"/>
-				<playerProduction player="Russians" frontier="production"/>
-				<playerProduction player="Japanese" frontier="production"/>
-				<playerProduction player="British" frontier="production"/>
+                <playerProduction player="Russians" frontier="production"/>
+                <playerProduction player="Japanese" frontier="production"/>
+                <playerProduction player="British" frontier="production"/>
                 <playerProduction player="Italians" frontier="production"/>
-				<playerProduction player="Chinese" frontier="production"/>
+                <playerProduction player="Chinese" frontier="production"/>
                 <playerProduction player="Americans" frontier="production"/>
-                
+
                 <playerRepair player="Germans" frontier="repair"/>
-				<playerRepair player="Russians" frontier="repair"/>
-				<playerRepair player="Japanese" frontier="repair"/>
-				<playerRepair player="British" frontier="repair"/>
+                <playerRepair player="Russians" frontier="repair"/>
+                <playerRepair player="Japanese" frontier="repair"/>
+                <playerRepair player="British" frontier="repair"/>
                 <playerRepair player="Italians" frontier="repair"/>
-				<playerRepair player="Chinese" frontier="repair"/>
+                <playerRepair player="Chinese" frontier="repair"/>
                 <playerRepair player="Americans" frontier="repair"/>
-                
-                
-        </production> 
-        
+
+
+        </production>
+
         <attachmentList>
-        		<!-- Germans -->
+                <!-- Germans -->
                 <attachment name="techAttachment" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
@@ -1015,8 +1015,8 @@
                         <option name="warBonds" value="false"/>
                         <option name="mechanizedInfantry" value="false"/>
                 </attachment>
-				
-				<!-- Russians -->
+
+                <!-- Russians -->
                 <attachment name="techAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
@@ -1031,7 +1031,7 @@
                         <option name="warBonds" value="false"/>
                         <option name="mechanizedInfantry" value="false"/>
                 </attachment>
-                
+
                 <!-- Japanese -->
                 <attachment name="techAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="superSub" value="false"/>
@@ -1063,8 +1063,8 @@
                         <option name="warBonds" value="false"/>
                         <option name="mechanizedInfantry" value="false"/>
                 </attachment>
-				
-				<!-- Italians -->
+
+                <!-- Italians -->
                 <attachment name="techAttachment" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
@@ -1106,8 +1106,8 @@
                          <option name="defense" value="2"/>
                          <option name="artillerySupportable" value="true"/>
                 </attachment>
-				
-				
+
+
                 <!-- Artillery -->
                 <attachment name="unitAttachment" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="1"/>
@@ -1126,20 +1126,20 @@
                          <option name="attack" value="3"/>
                          <option name="defense" value="3"/>
                 </attachment>
-            
+
                 <!-- Fighter -->
                 <attachment name="unitAttachment" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="4"/>
                          <option name="carrierCost" value="1"/>
-                         <option name="isAir" value="true"/>   
+                         <option name="isAir" value="true"/>
                          <option name="attack" value="3"/>
                          <option name="defense" value="4"/>
-						 <option name="canIntercept" value="true"/>
-						 <option name="canEscort" value="true"/>
+                         <option name="canIntercept" value="true"/>
+                         <option name="canEscort" value="true"/>
                          <option name="airDefense" value="1"/>
                          <option name="airAttack" value="1"/>
                 </attachment>
-            
+
                 <!-- Bomber -->
                 <attachment name="unitAttachment" attachTo="bomber" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="6"/>
@@ -1155,12 +1155,12 @@
                 <!-- Transport -->
                 <attachment name="unitAttachment" attachTo="transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
-                         <option name="transportCapacity" value="5"/>   
+                         <option name="isSea" value="true"/>
+                         <option name="transportCapacity" value="5"/>
                          <option name="attack" value="0"/>
                          <option name="defense" value="0"/>
                 </attachment>
-            
+
                 <!-- Battle Ship -->
                 <attachment name="unitAttachment" attachTo="battleship" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
@@ -1170,8 +1170,8 @@
                          <option name="canBombard" value="true"/>
                          <option name="hitPoints" value="2"/>
                  </attachment>
-				 
-				 <!-- Cruiser -->
+
+                 <!-- Cruiser -->
                 <attachment name="unitAttachment" attachTo="cruiser" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
                          <option name="isSea" value="true"/>
@@ -1180,21 +1180,21 @@
                          <option name="canBombard" value="true"/>
                          <option name="hitPoints" value="1"/>
                  </attachment>
-                 
+
                 <!-- Destroyer -->
                 <attachment name="unitAttachment" attachTo="destroyer" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
+                         <option name="isSea" value="true"/>
                          <option name="attack" value="2"/>
                          <option name="defense" value="2"/>
                          <option name="isDestroyer" value="true"/>
                 </attachment>
-                
+
                 <!-- Carrier -->
                 <attachment name="unitAttachment" attachTo="carrier" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="carrierCapacity" value="2"/>
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
+                         <option name="isSea" value="true"/>
                          <option name="attack" value="1"/>
                          <option name="defense" value="2"/>
                 </attachment>
@@ -1203,594 +1203,594 @@
                 <attachment name="unitAttachment" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="isSub" value="true"/>
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
+                         <option name="isSea" value="true"/>
                          <option name="attack" value="2"/>
                          <option name="defense" value="1"/>
                 </attachment>
 
                 <!-- Factory -->
                 <attachment name="unitAttachment" attachTo="factory" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-                         <option name="isFactory" value="true"/>   
+                         <option name="isFactory" value="true"/>
                 </attachment>
-            
+
                 <!-- AA Gun -->
                 <attachment name="unitAttachment" attachTo="aaGun" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-                         <option name="isAA" value="true"/>   
+                         <option name="isAA" value="true"/>
                          <option name="transportCost" value="3"/>
                          <option name="movement" value="1"/>
                 </attachment>
-		
-				<!-- Territory Attachments -->
-					<attachment name="territoryAttachment" attachTo="Afghanistan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                <!-- Territory Attachments -->
+                    <attachment name="territoryAttachment" attachTo="Afghanistan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
+                        <option name="isImpassable" value="true"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Alaska" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Alaska" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Anglo-Egypt Sudan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Anglo-Egypt Sudan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Angola" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Angola" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
+                        <option name="isImpassable" value="true"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Argentina Chile" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Argentina Chile" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
+                        <option name="isImpassable" value="true"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Archangel" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Archangel" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Australia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Australia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Baltic States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Baltic States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Belgian Congo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Belgian Congo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Belorussia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Belorussia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Borneo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Borneo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="4"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Brazil" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Brazil" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Burma" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Burma" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                         <option name="originalOwner" value="British"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Buryatia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Buryatia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Caucasus" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Caucasus" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="4"/>
                         <option name="unitProduction" value="4"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Central United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Central United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="6"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Chinghai" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Chinghai" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Czechoslovakia Hungary" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Czechoslovakia Hungary" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="East Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="East Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="4"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Eastern Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Eastern Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="East Poland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="East Poland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<!--US Capitol-->
-					<attachment name="territoryAttachment" attachTo="Eastern United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <!--US Capitol-->
+                    <attachment name="territoryAttachment" attachTo="Eastern United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="12"/>
                         <option name="unitProduction" value="12"/>
-						<option name="capital" value="Americans"/> 
+                        <option name="capital" value="Americans"/>
                         <option name="victoryCity" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Egypt" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Egypt" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Eire" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Evenki National Okrug" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="France" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="6"/>
-						<option name="victoryCity" value="1"/>
-					</attachment>
-					
-					<attachment name="territoryAttachment" attachTo="French Equatorial Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="French Indo-China Thailand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="French Madagascar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="French West Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Finland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Formosa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Fukien" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<!--German Capitol-->
-					<attachment name="territoryAttachment" attachTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="10"/>
-                        <option name="unitProduction" value="10"/>
-						<option name="capital" value="Germans"/> 
-                        <option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Gibraltar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Greenland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Hawaiian Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Himalaya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Hupeh" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Iceland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="India" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Italian Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Italy" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="6"/>
-                        <option name="unitProduction" value="6"/>
-						<option name="capital" value="Italians"/> 
-                        <option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Iwo Jima" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="8"/>
-                        <option name="unitProduction" value="8"/>
-						<option name="capital" value="Japanese"/> 
-                        <option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Karelia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                        <option name="unitProduction" value="2"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Kazakh S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Kiangsu" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-						<option name="victoryCity" value="1"/>
-                        <option name="originalOwner" value="Chinese"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Kwangtung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Libya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Manchuria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="3"/>
-                        <option name="originalOwner" value="Chinese"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Mexico" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Midway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Mongolia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Eire" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                         <option name="isImpassable" value="true"/>
-						<option name="capital" value="Chinese"/>
-                  </attachment>
-				  
-					<attachment name="territoryAttachment" attachTo="Morocco Algeria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Evenki National Okrug" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Mozambique" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="New Guinea" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="New Zealand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Ningxia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Northern South America" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Eastern Ukraine" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Northwestern Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Norway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="3"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Novosibirsk" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Okinawa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Panama" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Persia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Peruvian Central" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Philippine Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Rhodesia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Bulgaria Romania" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="France" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="6"/>
-                        <option name="unitProduction" value="6"/>
-						<option name="capital" value="Russians"/> 
                         <option name="victoryCity" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Sahara" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Saudi Arabia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Sikang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="French Equatorial Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Solomon Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Soviet Far East" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Spain" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Stanovoj Chrebet" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Suiyuan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Sweden" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Switzerland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Trans-Jordan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Turkey" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Ukraine" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="French Indo-China Thailand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Union of South Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="French Madagascar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="French West Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Finland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                     </attachment>
-					
-					<!--British Capitol-->
-					<attachment name="territoryAttachment" attachTo="United Kingdom" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="8"/>
-                        <option name="unitProduction" value="8"/>
-						<option name="capital" value="British"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Urals" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Formosa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Wake Island" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="West Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Fukien" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Balkans" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="3"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Western Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Poland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Western United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <!--German Capitol-->
+                    <attachment name="territoryAttachment" attachTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="10"/>
                         <option name="unitProduction" value="10"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="capital" value="Germans"/>
+                        <option name="victoryCity" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Yakut S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Gibraltar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Greenland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Hawaiian Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Himalaya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Hupeh" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Yunnan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-					</attachment>
-                
+
+                    <attachment name="territoryAttachment" attachTo="Iceland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="India" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Italian Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Italy" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                        <option name="unitProduction" value="6"/>
+                        <option name="capital" value="Italians"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Iwo Jima" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="8"/>
+                        <option name="unitProduction" value="8"/>
+                        <option name="capital" value="Japanese"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Karelia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="unitProduction" value="2"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Kazakh S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Kiangsu" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="1"/>
+                        <option name="originalOwner" value="Chinese"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Kwangtung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Libya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Manchuria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="originalOwner" value="Chinese"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Mexico" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Midway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Mongolia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                        <option name="capital" value="Chinese"/>
+                  </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Morocco Algeria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Mozambique" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="New Guinea" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="New Zealand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Ningxia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Northern South America" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Eastern Ukraine" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Northwestern Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Norway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Novosibirsk" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Okinawa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Panama" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Persia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Peruvian Central" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Philippine Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Rhodesia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Bulgaria Romania" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                        <option name="unitProduction" value="6"/>
+                        <option name="capital" value="Russians"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Sahara" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Saudi Arabia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Sikang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Solomon Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Soviet Far East" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Spain" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Stanovoj Chrebet" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Suiyuan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Sweden" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Switzerland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Trans-Jordan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Turkey" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Ukraine" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Union of South Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <!--British Capitol-->
+                    <attachment name="territoryAttachment" attachTo="United Kingdom" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="8"/>
+                        <option name="unitProduction" value="8"/>
+                        <option name="capital" value="British"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Urals" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Wake Island" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="West Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Balkans" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Western Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Poland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Western United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="10"/>
+                        <option name="unitProduction" value="10"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Yakut S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Yunnan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
                 <!-- Canals -->
 
-			    <attachment name="canalAttachment" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Suez Canal"/>
-			    	<option name="landTerritories" value="Egypt:Trans-Jordan"/>
-			    </attachment>
-			    
-			    <attachment name="canalAttachment" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Suez Canal"/>
-			    	<option name="landTerritories" value="Egypt:Trans-Jordan"/>
-			    </attachment>
-			    
-		   	    <attachment name="canalAttachment" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Panama Canal"/>
-			    	<option name="landTerritories" value="Panama"/>
-			    </attachment>
-			    
-			    <attachment name="canalAttachment" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Panama Canal"/>
-			    	<option name="landTerritories" value="Panama"/>
-			    </attachment>
-                
+                <attachment name="canalAttachment" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Suez Canal"/>
+                    <option name="landTerritories" value="Egypt:Trans-Jordan"/>
+                </attachment>
+
+                <attachment name="canalAttachment" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Suez Canal"/>
+                    <option name="landTerritories" value="Egypt:Trans-Jordan"/>
+                </attachment>
+
+                   <attachment name="canalAttachment" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Panama Canal"/>
+                    <option name="landTerritories" value="Panama"/>
+                </attachment>
+
+                <attachment name="canalAttachment" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Panama Canal"/>
+                    <option name="landTerritories" value="Panama"/>
+                </attachment>
+
 <!--  National Objectives -->
-	<!-- German Objectives -->
+    <!-- German Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>   
-                	<option name="alliedOwnershipTerritories" value="France:Northwestern Europe:Germany:Poland:Czechoslovakia Hungary:Bulgaria Romania" count="6"/> 
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="France:Northwestern Europe:Germany:Poland:Czechoslovakia Hungary:Bulgaria Romania" count="6"/>
                 </attachment>
-         
+
                 <attachment name="objectiveAttachment2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Baltic States:East Poland:Belorussia:Eastern Ukraine:Ukraine" count="3"/>
-                </attachment>         
-                
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Baltic States:East Poland:Belorussia:Eastern Ukraine:Ukraine" count="3"/>
+                </attachment>
+
                 <attachment name="objectiveAttachment3" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Karelia S.S.R.:Caucasus" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Karelia S.S.R.:Caucasus" count="1"/>
                 </attachment>
-                
-	<!-- Russian Objectives -->
+
+    <!-- Russian Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Archangel" count="1"/>
-                	<option name="alliedExclusionTerritories" value="controlled"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Archangel" count="1"/>
+                    <option name="alliedExclusionTerritories" value="controlled"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment2" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="10"/>
-                	<option name="alliedOwnershipTerritories" value="Norway:Finland:Poland:Bulgaria Romania:Czechoslovakia Hungary:Balkans" count="3"/>
+                    <option name="objectiveValue" value="10"/>
+                    <option name="alliedOwnershipTerritories" value="Norway:Finland:Poland:Bulgaria Romania:Czechoslovakia Hungary:Balkans" count="3"/>
                 </attachment>
-                
-	<!-- Japanese Objectives -->         
+
+    <!-- Japanese Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Manchuria:Kiangsu:French Indo-China Thailand" count="3"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Manchuria:Kiangsu:French Indo-China Thailand" count="3"/>
                 </attachment>
-                                
+
                 <attachment name="objectiveAttachment2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Kwangtung:East Indies:Borneo:Philippine Islands:New Guinea:Solomon Islands" count="4"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Kwangtung:East Indies:Borneo:Philippine Islands:New Guinea:Solomon Islands" count="4"/>
                 </attachment>
-                                
+
                 <attachment name="objectiveAttachment3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Hawaiian Islands:Australia:India" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Hawaiian Islands:Australia:India" count="1"/>
                 </attachment>
-                
-	<!-- British Objectives -->
+
+    <!-- British Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Caroline Islands:French Indo-China Thailand:Formosa:Iwo Jima:Japan:Okinawa" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Caroline Islands:French Indo-China Thailand:Formosa:Iwo Jima:Japan:Okinawa" count="1"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment2" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Eastern Canada:Western Canada:Gibraltar:Egypt:Australia:Union of South Africa" count="6"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Eastern Canada:Western Canada:Gibraltar:Egypt:Australia:Union of South Africa" count="6"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment3" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="France:Balkans" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="France:Balkans" count="1"/>
                 </attachment>
-                
-	<!-- Italian Objectives -->
+
+    <!-- Italian Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Egypt:Trans-Jordan:France:Gibraltar" count="3"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Egypt:Trans-Jordan:France:Gibraltar" count="3"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment2" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Italy:Balkans:Morocco Algeria:Libya" count="4"/>
-                	<option name="enemySurfaceExclusionTerritories" value="13 Sea Zone:14 Sea Zone:15 Sea Zone" count="3"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Italy:Balkans:Morocco Algeria:Libya" count="4"/>
+                    <option name="enemySurfaceExclusionTerritories" value="13 Sea Zone:14 Sea Zone:15 Sea Zone" count="3"/>
                 </attachment>
-                
-	<!-- American Objectives -->
+
+    <!-- American Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="France" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="France" count="1"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment2" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Philippine Islands" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Philippine Islands" count="1"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment3" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Western United States:Eastern United States:Central United States" count="3"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Western United States:Eastern United States:Central United States" count="3"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment4" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Midway:Wake Island:Hawaiian Islands:Solomon Islands" count="3"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Midway:Wake Island:Hawaiian Islands:Solomon Islands" count="3"/>
                 </attachment>
-                
+
 <!--  Rules Restrictions -->
-	<!-- Chinese Rules -->
-				<attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="movementRestrictionTerritories" value="Chinghai:Ningxia:Sikang:Yunnan:Hupeh:Fukien:Suiyuan:Manchuria:Kiangsu:Kwangtung"/>
-                	<option name="movementRestrictionType" value="allowed"/>
-                	<option name="productionPerXTerritories" value="2"/>
-                	<option name="placementAnyTerritory" value="true"/>
-                	<option name="placementCapturedTerritory" value="true"/>
-                	<option name="placementPerTerritory" value="3"/>
+    <!-- Chinese Rules -->
+                <attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                    <option name="movementRestrictionTerritories" value="Chinghai:Ningxia:Sikang:Yunnan:Hupeh:Fukien:Suiyuan:Manchuria:Kiangsu:Kwangtung"/>
+                    <option name="movementRestrictionType" value="allowed"/>
+                    <option name="productionPerXTerritories" value="2"/>
+                    <option name="placementAnyTerritory" value="true"/>
+                    <option name="placementCapturedTerritory" value="true"/>
+                    <option name="placementPerTerritory" value="3"/>
                 </attachment>
-                
+
         </attachmentList>
 
         <initialize>
@@ -1805,43 +1805,43 @@
                         <territoryOwner territory="Norway" owner="Germans"/>
                         <territoryOwner territory="Bulgaria Romania" owner="Germans"/>
                         <territoryOwner territory="Poland" owner="Germans"/>
-						
-						<!-- Russian Owned Territories -->
+
+                        <!-- Russian Owned Territories -->
                         <territoryOwner territory="Archangel" owner="Russians"/>
-						<territoryOwner territory="Baltic States" owner="Russians"/>
+                        <territoryOwner territory="Baltic States" owner="Russians"/>
                         <territoryOwner territory="Belorussia" owner="Russians"/>
                         <territoryOwner territory="Buryatia S.S.R." owner="Russians"/>
                         <territoryOwner territory="Caucasus" owner="Russians"/>
-						<territoryOwner territory="East Poland" owner="Russians"/>
+                        <territoryOwner territory="East Poland" owner="Russians"/>
                         <territoryOwner territory="Evenki National Okrug" owner="Russians"/>
                         <territoryOwner territory="Karelia S.S.R." owner="Russians"/>
                         <territoryOwner territory="Kazakh S.S.R." owner="Russians"/>
-						<territoryOwner territory="Eastern Ukraine" owner="Russians"/>
+                        <territoryOwner territory="Eastern Ukraine" owner="Russians"/>
                         <territoryOwner territory="Novosibirsk" owner="Russians"/>
                         <territoryOwner territory="Russia" owner="Russians"/>
                         <territoryOwner territory="Soviet Far East" owner="Russians"/>
                         <territoryOwner territory="Stanovoj Chrebet" owner="Russians"/>
-						<territoryOwner territory="Ukraine" owner="Russians"/>
+                        <territoryOwner territory="Ukraine" owner="Russians"/>
                         <territoryOwner territory="Urals" owner="Russians"/>
                         <territoryOwner territory="Yakut S.S.R." owner="Russians"/>
-						
-						<!-- Japanese Owned Territories -->
+
+                        <!-- Japanese Owned Territories -->
                         <territoryOwner territory="Caroline Islands" owner="Japanese"/>
-						<territoryOwner territory="French Indo-China Thailand" owner="Japanese"/>
+                        <territoryOwner territory="French Indo-China Thailand" owner="Japanese"/>
                         <territoryOwner territory="Formosa" owner="Japanese"/>
                         <territoryOwner territory="Iwo Jima" owner="Japanese"/>
                         <territoryOwner territory="Japan" owner="Japanese"/>
                         <territoryOwner territory="Kiangsu" owner="Japanese"/>
                         <territoryOwner territory="Manchuria" owner="Japanese"/>
                         <territoryOwner territory="Okinawa" owner="Japanese"/>
-						
-						<!-- British Owned Territories -->
+
+                        <!-- British Owned Territories -->
                         <territoryOwner territory="Anglo-Egypt Sudan" owner="British"/>
                         <territoryOwner territory="Australia" owner="British"/>
                         <territoryOwner territory="Belgian Congo" owner="British"/>
-						<territoryOwner territory="Borneo" owner="British"/>
-						<territoryOwner territory="Burma" owner="British"/>
-						<territoryOwner territory="East Indies" owner="British"/>
+                        <territoryOwner territory="Borneo" owner="British"/>
+                        <territoryOwner territory="Burma" owner="British"/>
+                        <territoryOwner territory="East Indies" owner="British"/>
                         <territoryOwner territory="Eastern Canada" owner="British"/>
                         <territoryOwner territory="Egypt" owner="British"/>
                         <territoryOwner territory="French Equatorial Africa" owner="British"/>
@@ -1851,622 +1851,622 @@
                         <territoryOwner territory="Iceland" owner="British"/>
                         <territoryOwner territory="India" owner="British"/>
                         <territoryOwner territory="Italian Africa" owner="British"/>
-						<territoryOwner territory="Kwangtung" owner="British"/>
-						<territoryOwner territory="New Guinea" owner="British"/>
+                        <territoryOwner territory="Kwangtung" owner="British"/>
+                        <territoryOwner territory="New Guinea" owner="British"/>
                         <territoryOwner territory="New Zealand" owner="British"/>
                         <territoryOwner territory="Persia" owner="British"/>
                         <territoryOwner territory="Rhodesia" owner="British"/>
                         <territoryOwner territory="Saudi Arabia" owner="British"/>
-						<territoryOwner territory="Solomon Islands" owner="British"/>
+                        <territoryOwner territory="Solomon Islands" owner="British"/>
                         <territoryOwner territory="Trans-Jordan" owner="British"/>
                         <territoryOwner territory="Union of South Africa" owner="British"/>
                         <territoryOwner territory="United Kingdom" owner="British"/>
                         <territoryOwner territory="Western Canada" owner="British"/>
-						
-						<!-- Italian Owned Territories -->
+
+                        <!-- Italian Owned Territories -->
                         <territoryOwner territory="Italy" owner="Italians"/>
                         <territoryOwner territory="Libya" owner="Italians"/>
                         <territoryOwner territory="Balkans" owner="Italians"/>
-						
-						<!-- US Chinese Owned Territories -->
-						<territoryOwner territory="Chinghai" owner="Chinese"/>
-						<territoryOwner territory="Fukien" owner="Chinese"/>
-						<territoryOwner territory="Hupeh" owner="Chinese"/>
-						<territoryOwner territory="Ningxia" owner="Chinese"/>
-						<territoryOwner territory="Sikang" owner="Chinese"/>
-						<territoryOwner territory="Suiyuan" owner="Chinese"/>
-						<territoryOwner territory="Yunnan" owner="Chinese"/>
-                        
+
+                        <!-- US Chinese Owned Territories -->
+                        <territoryOwner territory="Chinghai" owner="Chinese"/>
+                        <territoryOwner territory="Fukien" owner="Chinese"/>
+                        <territoryOwner territory="Hupeh" owner="Chinese"/>
+                        <territoryOwner territory="Ningxia" owner="Chinese"/>
+                        <territoryOwner territory="Sikang" owner="Chinese"/>
+                        <territoryOwner territory="Suiyuan" owner="Chinese"/>
+                        <territoryOwner territory="Yunnan" owner="Chinese"/>
+
                         <!-- American Owned Territories -->
                         <territoryOwner territory="Alaska" owner="Americans"/>
-						<territoryOwner territory="Brazil" owner="Americans"/>
-						<territoryOwner territory="Central United States" owner="Americans"/>
-						<territoryOwner territory="Eastern United States" owner="Americans"/>
-						<territoryOwner territory="Greenland" owner="Americans"/>
-						<territoryOwner territory="Hawaiian Islands" owner="Americans"/>
-						<territoryOwner territory="Mexico" owner="Americans"/>
-						<territoryOwner territory="Midway" owner="Americans"/>
-						<territoryOwner territory="Panama" owner="Americans"/>
-						<territoryOwner territory="Philippine Islands" owner="Americans"/>
-						<territoryOwner territory="Wake Island" owner="Americans"/>
-						<territoryOwner territory="West Indies" owner="Americans"/>
-						<territoryOwner territory="Western United States" owner="Americans"/>
-						
+                        <territoryOwner territory="Brazil" owner="Americans"/>
+                        <territoryOwner territory="Central United States" owner="Americans"/>
+                        <territoryOwner territory="Eastern United States" owner="Americans"/>
+                        <territoryOwner territory="Greenland" owner="Americans"/>
+                        <territoryOwner territory="Hawaiian Islands" owner="Americans"/>
+                        <territoryOwner territory="Mexico" owner="Americans"/>
+                        <territoryOwner territory="Midway" owner="Americans"/>
+                        <territoryOwner territory="Panama" owner="Americans"/>
+                        <territoryOwner territory="Philippine Islands" owner="Americans"/>
+                        <territoryOwner territory="Wake Island" owner="Americans"/>
+                        <territoryOwner territory="West Indies" owner="Americans"/>
+                        <territoryOwner territory="Western United States" owner="Americans"/>
+
                 </ownerInitialize>
 
                 <unitInitialize>
                         <!-- German Unit Placements -->
-						<unitPlacement unitType="armour" territory="Czechoslovakia Hungary" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="France" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="France" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Finland" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="factory" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="aaGun" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Germany" quantity="3" owner="Germans"/>
-						<unitPlacement unitType="artillery" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="bomber" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Libya" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="artillery" territory="Libya" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Libya" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Morocco Algeria" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Northwestern Europe" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Northwestern Europe" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Norway" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Norway" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Bulgaria Romania" quantity="3" owner="Germans"/>
-						<unitPlacement unitType="artillery" territory="Bulgaria Romania" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Bulgaria Romania" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Poland" quantity="4" owner="Germans"/>
-						<unitPlacement unitType="artillery" territory="Poland" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Poland" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Poland" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="submarine" territory="7 Sea Zone" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="cruiser" territory="5 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="submarine" territory="5 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="transport" territory="5 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="transport" territory="13 Sea Zone" quantity="1" owner="Germans"/>
-						
-						<!-- Russian Unit Placements -->
-						<unitPlacement unitType="infantry" territory="Archangel" quantity="2" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Baltic States" quantity="3" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Belorussia" quantity="2" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Buryatia S.S.R." quantity="3" owner="Russians"/>
-						<unitPlacement unitType="factory" territory="Caucasus" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="aaGun" territory="Caucasus" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Caucasus" quantity="4" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="East Poland" quantity="2" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Evenki National Okrug" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="factory" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
-						<unitPlacement unitType="aaGun" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Karelia S.S.R." quantity="5" owner="Russians"/>
-						<unitPlacement unitType="artillery" territory="Karelia S.S.R." quantity="1" owner="Russians"/>						  
-						<unitPlacement unitType="infantry" territory="Kazakh S.S.R." quantity="2" owner="Russians"/>						  
-						<unitPlacement unitType="infantry" territory="Eastern Ukraine" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Novosibirsk" quantity="2" owner="Russians"/>						  
-						<unitPlacement unitType="factory" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="aaGun" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Russia" quantity="3" owner="Russians"/>
-						<unitPlacement unitType="artillery" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="armour" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Soviet Far East" quantity="2" owner="Russians"/>						  
-						<unitPlacement unitType="infantry" territory="Stanovoj Chrebet" quantity="2" owner="Russians"/>						 
-						<unitPlacement unitType="infantry" territory="Ukraine" quantity="2" owner="Russians"/>						   
-						<unitPlacement unitType="infantry" territory="Yakut S.S.R." quantity="1" owner="Russians"/>
-						<unitPlacement unitType="submarine" territory="4 Sea Zone" quantity="1" owner="Russians"/>
-						
-						<!-- Japanese Unit Placements -->
-						<unitPlacement unitType="infantry" territory="Caroline Islands" quantity="3" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Formosa" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="French Indo-China Thailand" quantity="3" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Iwo Jima" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Japan" quantity="4" owner="Japanese"/>
-						<unitPlacement unitType="artillery" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="armour" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Kiangsu" quantity="3" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Manchuria" quantity="3" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Manchuria" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Okinawa" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="transport" territory="51 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="destroyer" territory="51 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="carrier" territory="57 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="57 Sea Zone" quantity="4" owner="Japanese"/>
-						<unitPlacement unitType="transport" territory="61 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="61 Sea Zone" quantity="3" owner="Japanese"/>
-						<unitPlacement unitType="artillery" territory="61 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="cruiser" territory="61 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="carrier" territory="61 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="61 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="battleship" territory="61 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="transport" territory="62 Sea Zone" quantity="1" owner="Japanese"/>
-						
-						<!-- British Unit Placements -->
-						<unitPlacement unitType="aaGun" territory="Australia" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Australia" quantity="3" owner="British"/>
-						<unitPlacement unitType="artillery" territory="Australia" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Burma" quantity="1" owner="British"/>
-						<unitPlacement unitType="armour" territory="Eastern Canada" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Egypt" quantity="2" owner="British"/>
-						<unitPlacement unitType="artillery" territory="Egypt" quantity="1" owner="British"/>
-						<unitPlacement unitType="armour" territory="Egypt" quantity="1" owner="British"/>
-						<unitPlacement unitType="fighter" territory="Egypt" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="India" quantity="3" owner="British"/>
-						<unitPlacement unitType="artillery" territory="India" quantity="1" owner="British"/>
-						<unitPlacement unitType="aaGun" territory="India" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Kwangtung" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Trans-Jordan" quantity="2" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Union of South Africa" quantity="2" owner="British"/>
-						<unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="United Kingdom" quantity="2" owner="British"/>
-						<unitPlacement unitType="artillery" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="armour" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="fighter" territory="United Kingdom" quantity="2" owner="British"/>
-						<unitPlacement unitType="bomber" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Western Canada" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="2 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="battleship" territory="2 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="6 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="9 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="9 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="cruiser" territory="12 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="12 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="35 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="35 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="41 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="41 Sea Zone" quantity="1" owner="British"/>
-						
-						<!-- Italian Unit Placements -->
-						<unitPlacement unitType="factory" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="aaGun" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="armour" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="fighter" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="artillery" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="Libya" quantity="2" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="Balkans" quantity="2" owner="Italians"/>
-						<unitPlacement unitType="armour" territory="Balkans" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="transport" territory="14 Sea Zone" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="cruiser" territory="14 Sea Zone" quantity="2" owner="Italians"/>
-						<unitPlacement unitType="battleship" territory="14 Sea Zone" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="armour" territory="Czechoslovakia Hungary" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="France" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="France" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Finland" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="factory" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="aaGun" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Germany" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="bomber" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Libya" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Libya" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Libya" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Morocco Algeria" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Northwestern Europe" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Northwestern Europe" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Norway" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Norway" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Bulgaria Romania" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Bulgaria Romania" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Bulgaria Romania" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Poland" quantity="4" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Poland" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Poland" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Poland" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="submarine" territory="7 Sea Zone" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="cruiser" territory="5 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="submarine" territory="5 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="transport" territory="5 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="transport" territory="13 Sea Zone" quantity="1" owner="Germans"/>
 
-						<!-- US Chinese Placements -->
-						<unitPlacement unitType="infantry" territory="Fukien" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Hupeh" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Suiyuan" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Yunnan" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="fighter" territory="Yunnan" quantity="1" owner="Chinese"/>
-						
+                        <!-- Russian Unit Placements -->
+                        <unitPlacement unitType="infantry" territory="Archangel" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Baltic States" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Belorussia" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Buryatia S.S.R." quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="factory" territory="Caucasus" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Caucasus" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Caucasus" quantity="4" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="East Poland" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Evenki National Okrug" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="factory" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Karelia S.S.R." quantity="5" owner="Russians"/>
+                        <unitPlacement unitType="artillery" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Kazakh S.S.R." quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Eastern Ukraine" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Novosibirsk" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="factory" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Russia" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="artillery" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="armour" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Soviet Far East" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Stanovoj Chrebet" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Ukraine" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Yakut S.S.R." quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="submarine" territory="4 Sea Zone" quantity="1" owner="Russians"/>
+
+                        <!-- Japanese Unit Placements -->
+                        <unitPlacement unitType="infantry" territory="Caroline Islands" quantity="3" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Formosa" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="French Indo-China Thailand" quantity="3" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Iwo Jima" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Japan" quantity="4" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="armour" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Kiangsu" quantity="3" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Manchuria" quantity="3" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Manchuria" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Okinawa" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="transport" territory="51 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="destroyer" territory="51 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="57 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="57 Sea Zone" quantity="4" owner="Japanese"/>
+                        <unitPlacement unitType="transport" territory="61 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="61 Sea Zone" quantity="3" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="61 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="cruiser" territory="61 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="61 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="61 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="battleship" territory="61 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="transport" territory="62 Sea Zone" quantity="1" owner="Japanese"/>
+
+                        <!-- British Unit Placements -->
+                        <unitPlacement unitType="aaGun" territory="Australia" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Australia" quantity="3" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="Australia" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Burma" quantity="1" owner="British"/>
+                        <unitPlacement unitType="armour" territory="Eastern Canada" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Egypt" quantity="2" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="Egypt" quantity="1" owner="British"/>
+                        <unitPlacement unitType="armour" territory="Egypt" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="Egypt" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="India" quantity="3" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="India" quantity="1" owner="British"/>
+                        <unitPlacement unitType="aaGun" territory="India" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Kwangtung" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Trans-Jordan" quantity="2" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Union of South Africa" quantity="2" owner="British"/>
+                        <unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="United Kingdom" quantity="2" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="armour" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="United Kingdom" quantity="2" owner="British"/>
+                        <unitPlacement unitType="bomber" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Western Canada" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="2 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="battleship" territory="2 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="6 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="9 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="9 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="cruiser" territory="12 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="12 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="35 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="35 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="41 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="41 Sea Zone" quantity="1" owner="British"/>
+
+                        <!-- Italian Unit Placements -->
+                        <unitPlacement unitType="factory" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="aaGun" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="armour" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="fighter" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="artillery" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="Libya" quantity="2" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="Balkans" quantity="2" owner="Italians"/>
+                        <unitPlacement unitType="armour" territory="Balkans" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="transport" territory="14 Sea Zone" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="cruiser" territory="14 Sea Zone" quantity="2" owner="Italians"/>
+                        <unitPlacement unitType="battleship" territory="14 Sea Zone" quantity="1" owner="Italians"/>
+
+                        <!-- US Chinese Placements -->
+                        <unitPlacement unitType="infantry" territory="Fukien" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Hupeh" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Suiyuan" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Yunnan" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="fighter" territory="Yunnan" quantity="1" owner="Chinese"/>
+
                         <!-- American Unit Placements -->
                         <unitPlacement unitType="infantry" territory="Alaska" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Central United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="factory" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="aaGun" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="artillery" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="bomber" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Midway" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Philippine Islands" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Wake Island" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="factory" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="aaGun" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="bomber" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="transport" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="44 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="44 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="carrier" territory="44 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="transport" territory="50 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="50 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="battleship" territory="53 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="transport" territory="56 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="56 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Central United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="factory" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="aaGun" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="artillery" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="bomber" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Midway" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Philippine Islands" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Wake Island" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="factory" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="aaGun" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="bomber" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="44 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="44 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="carrier" territory="44 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="50 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="50 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="battleship" territory="53 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="56 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="56 Sea Zone" quantity="1" owner="Americans"/>
                 </unitInitialize>
-        
-                <resourceInitialize>                      
+
+                <resourceInitialize>
                         <resourceGiven player="Germans" resource="PUs" quantity="31"/>
                         <resourceGiven player="Russians" resource="PUs" quantity="30"/>
-						<resourceGiven player="Japanese" resource="PUs" quantity="17"/>
-						<resourceGiven player="British" resource="PUs" quantity="43"/>
-						<resourceGiven player="Italians" resource="PUs" quantity="10"/>
-						<resourceGiven player="Chinese" resource="PUs" quantity="0"/>
-						<resourceGiven player="Americans" resource="PUs" quantity="40"/>
-						
+                        <resourceGiven player="Japanese" resource="PUs" quantity="17"/>
+                        <resourceGiven player="British" resource="PUs" quantity="43"/>
+                        <resourceGiven player="Italians" resource="PUs" quantity="10"/>
+                        <resourceGiven player="Chinese" resource="PUs" quantity="0"/>
+                        <resourceGiven player="Americans" resource="PUs" quantity="40"/>
+
                         <resourceGiven player="Germans" resource="techTokens" quantity="0"/>
                         <resourceGiven player="Russians" resource="techTokens" quantity="0"/>
-						<resourceGiven player="Japanese" resource="techTokens" quantity="0"/>
-						<resourceGiven player="British" resource="techTokens" quantity="0"/>
-						<resourceGiven player="Italians" resource="techTokens" quantity="0"/>
-						<resourceGiven player="Chinese" resource="techTokens" quantity="0"/>
-						<resourceGiven player="Americans" resource="techTokens" quantity="0"/>
+                        <resourceGiven player="Japanese" resource="techTokens" quantity="0"/>
+                        <resourceGiven player="British" resource="techTokens" quantity="0"/>
+                        <resourceGiven player="Italians" resource="techTokens" quantity="0"/>
+                        <resourceGiven player="Chinese" resource="techTokens" quantity="0"/>
+                        <resourceGiven player="Americans" resource="techTokens" quantity="0"/>
                 </resourceInitialize>
         </initialize>
 
-		<propertyList>
-				<!-- PLEASE KEEP YOUR PROPERTIES IN THIS ORDER!!! -->
-				<!-- TYPICAL OPTIONAL PROPERTIES -->
-				<!-- Bidding -->
-				<property name="Italians bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Russians bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Germans bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="British bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Japanese bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Americans bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-				
-				<!-- victory options -->
-				<property name="Projection of Power" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Honorable Surrender" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Total Victory" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for AntiAircraft" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Technology" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="National Objectives" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Tech Development" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="LHTR Heavy Bombers" value="true" editable="true">
-				  		<boolean/>
-				</property>
-
-				<property name="Heavy Bomber Dice Rolls" value="2" editable="false">
-						<number min="2" max="3"/>
-				</property>
-
-				<property name="Always on AA" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Kamikaze Airplanes" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Super Sub Defence Bonus" value="0" editable="true">
-						<number min="0" max="1"/>
-				</property>
-
-				<property name="Units Repair Hits End Turn" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Units Repair Hits Start Turn" value="false" editable="true">
-						<boolean/>
-				</property>
-				<!-- END OF TYPICAL OPTIONAL PROPERTIES -->
-
-				<!-- rules and tech -->
-				<property name="WW2V3" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="WW2V3 Tech Model" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Use Shipyards" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="All Rockets Attack" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Rockets Can Fly Over Impassables" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- These require an associated value in the attachments section above-->
-				<property name="Movement By Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Production Per X Territories Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement Per Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Place in Any Territory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unplaced units live when not placed" value ="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Occupied Territories" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- specific rules -->
-				<!-- land related -->
-				<property name="Blitz Through Factories And AA Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Roll AA Individually" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Choose AA Casualties" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="AA Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- sea related -->
-				<property name="Partial Amphibious Retreat" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Shore Bombard Per Ground Unit Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Naval Bombard Casualties Return Fire" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Hari-Kari Units" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Allied Air Dependents" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Surviving Air Move To Land" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Air Attack Sub Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Ignore Transport In Movement" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Transport Casualties Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unescorted Transport Dies" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Ignore Sub In Movement" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Defending Subs Sneak Attack" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Sub Retreat Before Battle" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Submersible Subs" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- Sub Control Sea Zone Restricted should be FALSE if there are any convoy zones! -->
-				<property name="Sub Control Sea Zone Restricted" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="Subs Can End NonCombat Move With Enemies" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Previous Units Fight" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Two hit battleship" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- production related -->
-				<property name="Produce fighters on carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Produce new fighters on old carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Move existing fighters to new carriers" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Land existing fighters on new carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="LHTR Carrier production rules" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement In Enemy Seas" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Territory Turn Limit" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="maxFactoriesPerTerritory" value="1"/>
-
-				<property name="Placement Restricted By Factory" value="true" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="Raids May Be Preceeded By Air Battles" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- to do with neutrals, (set neutrals charge to zero if you plan on attacking neutrals) -->
-				<property name="neutralCharge" value="9999999"/>
-
-				<property name="Neutrals Are Impassable" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Neutrals Are Blitzable" value="false" editable="false">
-						<boolean/>
-				</property>
-
-
-				<!-- Map Name: also used for map utils when asked -->
-				<property name="mapName" value="World War II v3 1941 Test" editable="false"/>
-
-				<!-- notes appear in the notes menu in the main screen, format as html -->
-
-				<property name="notes">
-					<value>
-					<![CDATA[  
-						
-						1941 Starting Set-Up <br>
-						Credits:
-						<br>
-						Triplelk Jason Clark - baseline <br>
-						Zero Pilot Mike McCaughey - integration <br>
-						ComradeKev - custom code and rules<br>
-						Seidelin - playtesting<br>
-						<br>
-						<br>
-						<b>Technology</b><br>
-         				*** Air/Naval Tech ***<br>
-        				SUPER SUBS- subs attack at 3<br>
-        				JET POWER- fighters attack at 4<br>
-        				IMPROVED SHIPYARDS- naval units are cheaper<br>
-        				AA RADAR- AA hit on 2 or less<br>
-        				LONG RANGE AIRCRAFT- aircraft range increased by 2<br>
-        				HEAVY BOMBER- roll 2 dice for each bomber attack<br>
-        				<br>
-         				*** Land/Production Tech ***<br>
-        				IMPROVED ARTILLERY SUPPORT- artillery support 2 infantry<br>
-        				ROCKETS- AA conduct rocket attacks for 1d6 damage to production (each factory may only be targetted once per turn by one rocket, and only 1 rocket in each territory may fire)<br>
-        				PARATROOPERS- each bomber may carry 1 infantry into combat (must stop in first enemy territory it reaches)<br>
-        				INCREASED FACTORY PRODUCTION- factories produce 2 additional units (if territory value is 3 or greater), repairs 1/2 price<br>
-        				WAR BONDS- collect an 1d6 extra PUs each turn<br>
-        				MECHANIZED INFANTRY- tanks may carry 1 infantry each for 2 spaces<br>
-        				<br>
-        				<br>
-        				<b>Victory Conditions</b><br>
-        				Total Victory - 18 Victory Cities<br>
-        				Honorable Surrender - 15 Victory Cities<br>
-        				Projection of Power - 13 Victory Cities<br>
-        				<br>
-        				<br>
-        				<b>National Objectives</b><br>
-        				<i>Germany: Lebensraum-</i><br>
-        				+5 PUs if Axis control France, NW Europe, Germany, Czechoslovakia, Bulgaria, and Poland.<br>
-        				+5 PUs if Axis control 3 of Baltic States, East Poland, Ukraine, East Ukrain, and Belorussia.<br>
-        				+5 PUs if Axis control Karelia or Caucasus <br>
-        				<br>
-        				<i>Japan: The Greater East Asia Coprosperity Sphere-</i><br>
-        				+5 PUs if Axis control Manchuria, Kiangsu, and French Indo China.<br>
-        				+5 PUs if Axis control 4 of Kwangtung, East Indies, Borneo, Philippine Islands, New Guinea and Solomon Islands.<br>
-        				+5 PUs if Axis control 1 of Hawaiian Islands, Australia, or India<br>
-        				<br>
-        				<i>Italy: Mare Nostrum-</i><br>
-        				+5 PUs if Axis control 3 of Egypt, Trans Jordan, France, and Gibraltar<br>
-        				+5 PUs if Axis control Italy, Balkans, Morocco and Libya AND no enemy surface ships in sea zones 13, 14, or 15.<br>
-        				<br>
-        				<i>United States: The Arsenal of Democracy-</i><br>
-        				+5 PUs if Allies control France.<br>
-        				+5 PUs if Allies control Philippine Islands.<br>
-        				+5 PUs Allies control W U.S., Central U.S., and E U.S.<br>
-        				+5 PUs if Allies control 3 of Midway, Wake Island, Hawaiian Islands, and Solomon Islands.<br>
-        				<br>
-        				<i>United Kingdom: The British Empire-</i><br>
-        				+5 PUs if Allies control any territory originally controlled by Japan.<br>
-        				+5 PUs if Allies control E Canada, W Canada, Gibraltar, Egypt, Australia and South Africa.<br>
-        				+5 PUs if Allies control France or the Balkans.<br>
-        				<br>
-        				<i>Soviet Union: The Great Patriotic War-</i><br>
-        				+5 PUs if Soviets control Archangel and no allied forces in Soviet controlled territories.<br>
-        				+10 PUs if Allies control 3 of Norway, Finland, Poland, Bulgaria, Czechoslovakia, and Balkans.<br>
-        				
-        				<br>
-						<i>China: Chinese Resistance & The Flying Tigers </i><br>
-        				+1 infantry for every two territories controlled by China at the beginning of her turn.  These infantry must be place in a territory with less than three Chinese pieces.  <br>
-        				No Chinese Units, including the Chinese Fighter may leave Chinese territory (except for Kwangtung) (this means no entering sea zones). <br>  
-        				
-        				
-        
-					]]>	
-					</value>
-				</property>
+        <propertyList>
+                <!-- PLEASE KEEP YOUR PROPERTIES IN THIS ORDER!!! -->
+                <!-- TYPICAL OPTIONAL PROPERTIES -->
+                <!-- Bidding -->
+                <property name="Italians bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Russians bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Germans bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="British bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Japanese bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Americans bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <!-- victory options -->
+                <property name="Projection of Power" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Honorable Surrender" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Total Victory" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for AntiAircraft" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Technology" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="National Objectives" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Tech Development" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="LHTR Heavy Bombers" value="true" editable="true">
+                          <boolean/>
+                </property>
+
+                <property name="Heavy Bomber Dice Rolls" value="2" editable="false">
+                        <number min="2" max="3"/>
+                </property>
+
+                <property name="Always on AA" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Kamikaze Airplanes" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Super Sub Defence Bonus" value="0" editable="true">
+                        <number min="0" max="1"/>
+                </property>
+
+                <property name="Units Repair Hits End Turn" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Units Repair Hits Start Turn" value="false" editable="true">
+                        <boolean/>
+                </property>
+                <!-- END OF TYPICAL OPTIONAL PROPERTIES -->
+
+                <!-- rules and tech -->
+                <property name="WW2V3" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="WW2V3 Tech Model" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Use Shipyards" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="All Rockets Attack" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Rockets Can Fly Over Impassables" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- These require an associated value in the attachments section above-->
+                <property name="Movement By Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Production Per X Territories Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement Per Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Place in Any Territory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unplaced units live when not placed" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Occupied Territories" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- specific rules -->
+                <!-- land related -->
+                <property name="Blitz Through Factories And AA Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Roll AA Individually" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Choose AA Casualties" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="AA Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- sea related -->
+                <property name="Partial Amphibious Retreat" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Shore Bombard Per Ground Unit Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Naval Bombard Casualties Return Fire" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Hari-Kari Units" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Allied Air Dependents" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Surviving Air Move To Land" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Air Attack Sub Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Ignore Transport In Movement" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Transport Casualties Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unescorted Transport Dies" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Ignore Sub In Movement" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Defending Subs Sneak Attack" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Sub Retreat Before Battle" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Submersible Subs" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- Sub Control Sea Zone Restricted should be FALSE if there are any convoy zones! -->
+                <property name="Sub Control Sea Zone Restricted" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Subs Can End NonCombat Move With Enemies" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Previous Units Fight" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Two hit battleship" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- production related -->
+                <property name="Produce fighters on carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Produce new fighters on old carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Move existing fighters to new carriers" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Land existing fighters on new carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="LHTR Carrier production rules" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement In Enemy Seas" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Territory Turn Limit" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="maxFactoriesPerTerritory" value="1"/>
+
+                <property name="Placement Restricted By Factory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Raids May Be Preceeded By Air Battles" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- to do with neutrals, (set neutrals charge to zero if you plan on attacking neutrals) -->
+                <property name="neutralCharge" value="9999999"/>
+
+                <property name="Neutrals Are Impassable" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Neutrals Are Blitzable" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+
+                <!-- Map Name: also used for map utils when asked -->
+                <property name="mapName" value="World War II v3 1941 Test" editable="false"/>
+
+                <!-- notes appear in the notes menu in the main screen, format as html -->
+
+                <property name="notes">
+                    <value>
+                    <![CDATA[
+
+                        1941 Starting Set-Up <br>
+                        Credits:
+                        <br>
+                        Triplelk Jason Clark - baseline <br>
+                        Zero Pilot Mike McCaughey - integration <br>
+                        ComradeKev - custom code and rules<br>
+                        Seidelin - playtesting<br>
+                        <br>
+                        <br>
+                        <b>Technology</b><br>
+                         *** Air/Naval Tech ***<br>
+                        SUPER SUBS- subs attack at 3<br>
+                        JET POWER- fighters attack at 4<br>
+                        IMPROVED SHIPYARDS- naval units are cheaper<br>
+                        AA RADAR- AA hit on 2 or less<br>
+                        LONG RANGE AIRCRAFT- aircraft range increased by 2<br>
+                        HEAVY BOMBER- roll 2 dice for each bomber attack<br>
+                        <br>
+                         *** Land/Production Tech ***<br>
+                        IMPROVED ARTILLERY SUPPORT- artillery support 2 infantry<br>
+                        ROCKETS- AA conduct rocket attacks for 1d6 damage to production (each factory may only be targetted once per turn by one rocket, and only 1 rocket in each territory may fire)<br>
+                        PARATROOPERS- each bomber may carry 1 infantry into combat (must stop in first enemy territory it reaches)<br>
+                        INCREASED FACTORY PRODUCTION- factories produce 2 additional units (if territory value is 3 or greater), repairs 1/2 price<br>
+                        WAR BONDS- collect an 1d6 extra PUs each turn<br>
+                        MECHANIZED INFANTRY- tanks may carry 1 infantry each for 2 spaces<br>
+                        <br>
+                        <br>
+                        <b>Victory Conditions</b><br>
+                        Total Victory - 18 Victory Cities<br>
+                        Honorable Surrender - 15 Victory Cities<br>
+                        Projection of Power - 13 Victory Cities<br>
+                        <br>
+                        <br>
+                        <b>National Objectives</b><br>
+                        <i>Germany: Lebensraum-</i><br>
+                        +5 PUs if Axis control France, NW Europe, Germany, Czechoslovakia, Bulgaria, and Poland.<br>
+                        +5 PUs if Axis control 3 of Baltic States, East Poland, Ukraine, East Ukrain, and Belorussia.<br>
+                        +5 PUs if Axis control Karelia or Caucasus <br>
+                        <br>
+                        <i>Japan: The Greater East Asia Coprosperity Sphere-</i><br>
+                        +5 PUs if Axis control Manchuria, Kiangsu, and French Indo China.<br>
+                        +5 PUs if Axis control 4 of Kwangtung, East Indies, Borneo, Philippine Islands, New Guinea and Solomon Islands.<br>
+                        +5 PUs if Axis control 1 of Hawaiian Islands, Australia, or India<br>
+                        <br>
+                        <i>Italy: Mare Nostrum-</i><br>
+                        +5 PUs if Axis control 3 of Egypt, Trans Jordan, France, and Gibraltar<br>
+                        +5 PUs if Axis control Italy, Balkans, Morocco and Libya AND no enemy surface ships in sea zones 13, 14, or 15.<br>
+                        <br>
+                        <i>United States: The Arsenal of Democracy-</i><br>
+                        +5 PUs if Allies control France.<br>
+                        +5 PUs if Allies control Philippine Islands.<br>
+                        +5 PUs Allies control W U.S., Central U.S., and E U.S.<br>
+                        +5 PUs if Allies control 3 of Midway, Wake Island, Hawaiian Islands, and Solomon Islands.<br>
+                        <br>
+                        <i>United Kingdom: The British Empire-</i><br>
+                        +5 PUs if Allies control any territory originally controlled by Japan.<br>
+                        +5 PUs if Allies control E Canada, W Canada, Gibraltar, Egypt, Australia and South Africa.<br>
+                        +5 PUs if Allies control France or the Balkans.<br>
+                        <br>
+                        <i>Soviet Union: The Great Patriotic War-</i><br>
+                        +5 PUs if Soviets control Archangel and no allied forces in Soviet controlled territories.<br>
+                        +10 PUs if Allies control 3 of Norway, Finland, Poland, Bulgaria, Czechoslovakia, and Balkans.<br>
+
+                        <br>
+                        <i>China: Chinese Resistance & The Flying Tigers </i><br>
+                        +1 infantry for every two territories controlled by China at the beginning of her turn.  These infantry must be place in a territory with less than three Chinese pieces.  <br>
+                        No Chinese Units, including the Chinese Fighter may leave Chinese territory (except for Kwangtung) (this means no entering sea zones). <br>
+
+
+
+                    ]]>
+                    </value>
+                </property>
 
         </propertyList>
 </game>
-						<!-- 
-						WW2V2 XML by Zero Pilot 9.08
-						Triplelk Jason Clark - baseline
-						Zero Pilot Mike McCaughey - integration
-						ComradeKev - custom code and rules
-						Seidelin - playtesting
-						Veqryn - Minor updates for engine 1.2.5.x, and again for engine 1.3.x.x
-						-->
+                        <!--
+                        WW2V2 XML by Zero Pilot 9.08
+                        Triplelk Jason Clark - baseline
+                        Zero Pilot Mike McCaughey - integration
+                        ComradeKev - custom code and rules
+                        Seidelin - playtesting
+                        Veqryn - Minor updates for engine 1.2.5.x, and again for engine 1.3.x.x
+                        -->

--- a/src/test/resources/ww2v3_1942_test.xml
+++ b/src/test/resources/ww2v3_1942_test.xml
@@ -4,120 +4,120 @@
 
 <game>
         <info name="World War II v3 1942 Test" version="1.7"/>
-        
+
         <loader javaClass="games.strategy.triplea.TripleA"/>
-		
-		<triplea minimumVersion="1.7"/>
+
+        <triplea minimumVersion="1.7"/>
 
         <map>
                 <!-- Territory Name Definitions -->
                 <territory name="Afghanistan"/>
-				<territory name="Alaska"/>
-				<territory name="Anglo-Egypt Sudan"/>
-				<territory name="Angola"/>
-				<territory name="Argentina Chile"/>
-				<territory name="Archangel"/>
-				<territory name="Australia"/>
-				<territory name="Balkans"/>
-				<territory name="Baltic States"/>
-				<territory name="Belgian Congo"/>
-				<territory name="Belorussia"/>
-				<territory name="Borneo"/>
-				<territory name="Brazil"/>
-				<territory name="Burma"/>
-				<territory name="Buryatia S.S.R."/>
-				<territory name="Caroline Islands"/>
-				<territory name="Caucasus"/>
-				<territory name="Central United States"/>
-				<territory name="Chinghai"/>
-				<territory name="Czechoslovakia Hungary"/>
-				<territory name="East Indies"/>
-				<territory name="Eastern Canada"/>
-				<territory name="East Poland"/>
-				<territory name="Eastern Ukraine"/>
-				<territory name="Eastern United States"/>
-				<territory name="Egypt"/>
-				<territory name="Eire"/>
-				<territory name="Evenki National Okrug"/>
-				<territory name="France"/>
-				<territory name="French Equatorial Africa"/>
+                <territory name="Alaska"/>
+                <territory name="Anglo-Egypt Sudan"/>
+                <territory name="Angola"/>
+                <territory name="Argentina Chile"/>
+                <territory name="Archangel"/>
+                <territory name="Australia"/>
+                <territory name="Balkans"/>
+                <territory name="Baltic States"/>
+                <territory name="Belgian Congo"/>
+                <territory name="Belorussia"/>
+                <territory name="Borneo"/>
+                <territory name="Brazil"/>
+                <territory name="Burma"/>
+                <territory name="Buryatia S.S.R."/>
+                <territory name="Caroline Islands"/>
+                <territory name="Caucasus"/>
+                <territory name="Central United States"/>
+                <territory name="Chinghai"/>
+                <territory name="Czechoslovakia Hungary"/>
+                <territory name="East Indies"/>
+                <territory name="Eastern Canada"/>
+                <territory name="East Poland"/>
+                <territory name="Eastern Ukraine"/>
+                <territory name="Eastern United States"/>
+                <territory name="Egypt"/>
+                <territory name="Eire"/>
+                <territory name="Evenki National Okrug"/>
+                <territory name="France"/>
+                <territory name="French Equatorial Africa"/>
 
-				<territory name="French Madagascar"/>
-				<territory name="French West Africa"/>
-				<territory name="Finland"/>
-				<territory name="Formosa"/>
-				<territory name="Fukien"/>
-				<territory name="Germany"/>
-				<territory name="Gibraltar"/>
-				<territory name="Greenland"/>
-				<territory name="Hawaiian Islands"/>
-				<territory name="Himalaya"/>
-				<territory name="Hupeh"/>
-				<territory name="Iceland"/>
-				<territory name="India"/>
-				<territory name="French Indo-China Thailand"/>
-				<territory name="Italian Africa"/>
-				<territory name="Italy"/>
-				<territory name="Iwo Jima"/>
-				<territory name="Japan"/>
-				<territory name="Karelia S.S.R."/>
-				<territory name="Kazakh S.S.R."/>
-				<territory name="Kiangsu"/>
-				<territory name="Kwangtung"/>
-				<territory name="Libya"/>
-				<territory name="Manchuria"/>
-				<territory name="Mexico"/>
-				<territory name="Midway"/>
-				<territory name="Mongolia"/>
-				<territory name="Morocco Algeria"/>
-				<territory name="Mozambique"/>
-				<territory name="New Guinea"/>
-				<territory name="New Zealand"/>
-				<territory name="Ningxia"/>
+                <territory name="French Madagascar"/>
+                <territory name="French West Africa"/>
+                <territory name="Finland"/>
+                <territory name="Formosa"/>
+                <territory name="Fukien"/>
+                <territory name="Germany"/>
+                <territory name="Gibraltar"/>
+                <territory name="Greenland"/>
+                <territory name="Hawaiian Islands"/>
+                <territory name="Himalaya"/>
+                <territory name="Hupeh"/>
+                <territory name="Iceland"/>
+                <territory name="India"/>
+                <territory name="French Indo-China Thailand"/>
+                <territory name="Italian Africa"/>
+                <territory name="Italy"/>
+                <territory name="Iwo Jima"/>
+                <territory name="Japan"/>
+                <territory name="Karelia S.S.R."/>
+                <territory name="Kazakh S.S.R."/>
+                <territory name="Kiangsu"/>
+                <territory name="Kwangtung"/>
+                <territory name="Libya"/>
+                <territory name="Manchuria"/>
+                <territory name="Mexico"/>
+                <territory name="Midway"/>
+                <territory name="Mongolia"/>
+                <territory name="Morocco Algeria"/>
+                <territory name="Mozambique"/>
+                <territory name="New Guinea"/>
+                <territory name="New Zealand"/>
+                <territory name="Ningxia"/>
 
-				<territory name="Northwestern Europe"/>
-				<territory name="Norway"/>
-				<territory name="Novosibirsk"/>
-				<territory name="Okinawa"/>
-				<territory name="Panama"/>
-				<territory name="Persia"/>
-				<territory name="Peruvian Central"/>
-				<territory name="Philippine Islands"/>
-				<territory name="Rhodesia"/>
-				<territory name="Poland"/>
+                <territory name="Northwestern Europe"/>
+                <territory name="Norway"/>
+                <territory name="Novosibirsk"/>
+                <territory name="Okinawa"/>
+                <territory name="Panama"/>
+                <territory name="Persia"/>
+                <territory name="Peruvian Central"/>
+                <territory name="Philippine Islands"/>
+                <territory name="Rhodesia"/>
+                <territory name="Poland"/>
 
-				<territory name="Bulgaria Romania"/>
-				<territory name="Russia"/>
-				<territory name="Sahara"/>
-				<territory name="Saudi Arabia"/>
-				<territory name="Sikang"/>
-				<territory name="Solomon Islands"/>
-				<territory name="Soviet Far East"/>
-				<territory name="Spain"/>
-				<territory name="Stanovoj Chrebet"/>
-				<territory name="Suiyuan"/>
-				<territory name="Sweden"/>
-				<territory name="Switzerland"/>
-				<territory name="Trans-Jordan"/>
-				<territory name="Turkey"/>
-				<territory name="Ukraine"/>
-				<territory name="Union of South Africa"/>
-				<territory name="United Kingdom"/>
-				<territory name="Urals"/>
-				<territory name="Northern South America"/>
-				<territory name="Wake Island"/>
-				<territory name="West Indies"/>
-				<territory name="Western Canada"/>
-				<territory name="Western United States"/>
-				<territory name="Yakut S.S.R."/>
-				<territory name="Yunnan"/>
-				
-				<!-- Seazone Name Definitions -->
-				<territory name="1 Sea Zone" water="true"/>
+                <territory name="Bulgaria Romania"/>
+                <territory name="Russia"/>
+                <territory name="Sahara"/>
+                <territory name="Saudi Arabia"/>
+                <territory name="Sikang"/>
+                <territory name="Solomon Islands"/>
+                <territory name="Soviet Far East"/>
+                <territory name="Spain"/>
+                <territory name="Stanovoj Chrebet"/>
+                <territory name="Suiyuan"/>
+                <territory name="Sweden"/>
+                <territory name="Switzerland"/>
+                <territory name="Trans-Jordan"/>
+                <territory name="Turkey"/>
+                <territory name="Ukraine"/>
+                <territory name="Union of South Africa"/>
+                <territory name="United Kingdom"/>
+                <territory name="Urals"/>
+                <territory name="Northern South America"/>
+                <territory name="Wake Island"/>
+                <territory name="West Indies"/>
+                <territory name="Western Canada"/>
+                <territory name="Western United States"/>
+                <territory name="Yakut S.S.R."/>
+                <territory name="Yunnan"/>
+
+                <!-- Seazone Name Definitions -->
+                <territory name="1 Sea Zone" water="true"/>
                 <territory name="2 Sea Zone" water="true"/>
                 <territory name="3 Sea Zone" water="true"/>
                 <territory name="4 Sea Zone" water="true"/>
-				<territory name="5 Sea Zone" water="true"/>
+                <territory name="5 Sea Zone" water="true"/>
                 <territory name="6 Sea Zone" water="true"/>
                 <territory name="7 Sea Zone" water="true"/>
                 <territory name="8 Sea Zone" water="true"/>
@@ -129,7 +129,7 @@
                 <territory name="14 Sea Zone" water="true"/>
                 <territory name="15 Sea Zone" water="true"/>
                 <territory name="16 Sea Zone" water="true"/>
-				<territory name="17 Sea Zone" water="true"/>
+                <territory name="17 Sea Zone" water="true"/>
                 <territory name="18 Sea Zone" water="true"/>
                 <territory name="19 Sea Zone" water="true"/>
                 <territory name="20 Sea Zone" water="true"/>
@@ -141,7 +141,7 @@
                 <territory name="26 Sea Zone" water="true"/>
                 <territory name="27 Sea Zone" water="true"/>
                 <territory name="28 Sea Zone" water="true"/>
-				<territory name="29 Sea Zone" water="true"/>
+                <territory name="29 Sea Zone" water="true"/>
                 <territory name="30 Sea Zone" water="true"/>
                 <territory name="31 Sea Zone" water="true"/>
                 <territory name="32 Sea Zone" water="true"/>
@@ -152,7 +152,7 @@
                 <territory name="37 Sea Zone" water="true"/>
                 <territory name="38 Sea Zone" water="true"/>
                 <territory name="39 Sea Zone" water="true"/>
-				<territory name="40 Sea Zone" water="true"/>
+                <territory name="40 Sea Zone" water="true"/>
                 <territory name="41 Sea Zone" water="true"/>
                 <territory name="42 Sea Zone" water="true"/>
                 <territory name="43 Sea Zone" water="true"/>
@@ -164,7 +164,7 @@
                 <territory name="49 Sea Zone" water="true"/>
                 <territory name="50 Sea Zone" water="true"/>
                 <territory name="51 Sea Zone" water="true"/>
-				<territory name="52 Sea Zone" water="true"/>
+                <territory name="52 Sea Zone" water="true"/>
                 <territory name="53 Sea Zone" water="true"/>
                 <territory name="54 Sea Zone" water="true"/>
                 <territory name="55 Sea Zone" water="true"/>
@@ -176,448 +176,448 @@
                 <territory name="61 Sea Zone" water="true"/>
                 <territory name="62 Sea Zone" water="true"/>
                 <territory name="63 Sea Zone" water="true"/>
-				<territory name="64 Sea Zone" water="true"/>
+                <territory name="64 Sea Zone" water="true"/>
                 <territory name="65 Sea Zone" water="true"/>
 
                 <!-- Territory and Seazone Connections -->
                 <connection t1="1 Sea Zone" t2="2 Sea Zone"/>
-				<connection t1="1 Sea Zone" t2="8 Sea Zone"/>
-				<connection t1="1 Sea Zone" t2="9 Sea Zone"/>
-				<connection t1="1 Sea Zone" t2="Eastern Canada"/>
-				<connection t1="2 Sea Zone" t2="3 Sea Zone"/>
-				<connection t1="2 Sea Zone" t2="8 Sea Zone"/>
-				<connection t1="2 Sea Zone" t2="Eire"/>
-				<connection t1="2 Sea Zone" t2="Greenland"/>
-				<connection t1="2 Sea Zone" t2="Iceland"/>
-				<connection t1="2 Sea Zone" t2="United Kingdom"/>
-				<connection t1="3 Sea Zone" t2="4 Sea Zone"/>
-				<connection t1="3 Sea Zone" t2="6 Sea Zone"/>
-				<connection t1="3 Sea Zone" t2="Norway"/>
-				<connection t1="3 Sea Zone" t2="United Kingdom"/>
-				<connection t1="4 Sea Zone" t2="Archangel"/>
-				<connection t1="4 Sea Zone" t2="Finland"/>
-				<connection t1="4 Sea Zone" t2="Karelia S.S.R."/>
-				<connection t1="5 Sea Zone" t2="6 Sea Zone"/>
-				<connection t1="5 Sea Zone" t2="Baltic States"/>
-				<connection t1="5 Sea Zone" t2="Finland"/>
-				<connection t1="5 Sea Zone" t2="Germany"/>
-				<connection t1="5 Sea Zone" t2="Karelia S.S.R."/>
-				<connection t1="5 Sea Zone" t2="Northwestern Europe"/>
-				<connection t1="5 Sea Zone" t2="Norway"/>
-				<connection t1="5 Sea Zone" t2="Sweden"/>
-				<connection t1="5 Sea Zone" t2="Poland"/>
-				<connection t1="6 Sea Zone" t2="7 Sea Zone"/>
-				<connection t1="6 Sea Zone" t2="Northwestern Europe"/>
-				<connection t1="6 Sea Zone" t2="Norway"/>
-				<connection t1="6 Sea Zone" t2="United Kingdom"/>
-				<connection t1="7 Sea Zone" t2="8 Sea Zone"/>
-				<connection t1="7 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="7 Sea Zone" t2="France"/>
-				<connection t1="7 Sea Zone" t2="Northwestern Europe"/>
-				<connection t1="7 Sea Zone" t2="United Kingdom"/>
-				<connection t1="8 Sea Zone" t2="9 Sea Zone"/> 
-				<connection t1="8 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="8 Sea Zone" t2="Eire"/>
-				<connection t1="8 Sea Zone" t2="United Kingdom"/>
-				<connection t1="9 Sea Zone" t2="10 Sea Zone"/>
-				<connection t1="9 Sea Zone" t2="11 Sea Zone"/>
-				<connection t1="9 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="9 Sea Zone" t2="Eastern Canada"/>
-				<connection t1="10 Sea Zone" t2="11 Sea Zone"/>
-				<connection t1="10 Sea Zone" t2="19 Sea Zone"/>
-				<connection t1="10 Sea Zone" t2="Eastern United States"/>
-				<connection t1="10 Sea Zone" t2="Panama"/>
-				<connection t1="11 Sea Zone" t2="12 Sea Zone"/>
-				<connection t1="11 Sea Zone" t2="18 Sea Zone"/>
-				<connection t1="11 Sea Zone" t2="19 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="13 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="17 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="18 Sea Zone"/>
-				<connection t1="12 Sea Zone" t2="Gibraltar"/>
-				<connection t1="12 Sea Zone" t2="Morocco Algeria"/>
-				<connection t1="12 Sea Zone" t2="Spain"/>
-				<connection t1="13 Sea Zone" t2="14 Sea Zone"/> 
-				<connection t1="13 Sea Zone" t2="France"/>
-				<connection t1="13 Sea Zone" t2="Gibraltar"/>
-				<connection t1="13 Sea Zone" t2="Morocco Algeria"/>
-				<connection t1="13 Sea Zone" t2="Spain"/>
-				<connection t1="14 Sea Zone" t2="15 Sea Zone"/>
-				<connection t1="14 Sea Zone" t2="16 Sea Zone"/>
-				<connection t1="14 Sea Zone" t2="Italy"/>
-				<connection t1="14 Sea Zone" t2="Libya"/>
-				<connection t1="14 Sea Zone" t2="Balkans"/>
-				<connection t1="15 Sea Zone" t2="16 Sea Zone"/>
-				<connection t1="15 Sea Zone" t2="Egypt"/>
-				<connection t1="15 Sea Zone" t2="Trans-Jordan"/>
-				<connection t1="15 Sea Zone" t2="Turkey"/>
-				<connection t1="15 Sea Zone" t2="34 Sea Zone"/>
-				<connection t1="16 Sea Zone" t2="Caucasus"/>
-				<connection t1="16 Sea Zone" t2="Bulgaria Romania"/>
-				<connection t1="16 Sea Zone" t2="Turkey"/>
-				<connection t1="16 Sea Zone" t2="Ukraine"/> 
-				<connection t1="17 Sea Zone" t2="18 Sea Zone"/>
-				<connection t1="17 Sea Zone" t2="22 Sea Zone"/>
-				<connection t1="17 Sea Zone" t2="23 Sea Zone"/>
-				<connection t1="17 Sea Zone" t2="French West Africa"/>
-				<connection t1="17 Sea Zone" t2="Sahara"/>
-				<connection t1="18 Sea Zone" t2="19 Sea Zone"/>
-				<connection t1="18 Sea Zone" t2="22 Sea Zone"/>
-				<connection t1="18 Sea Zone" t2="Brazil"/>
-				<connection t1="19 Sea Zone" t2="20 Sea Zone"/>
-				<connection t1="19 Sea Zone" t2="Northern South America"/>
-				<connection t1="19 Sea Zone" t2="Panama"/>
-				<connection t1="19 Sea Zone" t2="West Indies"/>
-				<connection t1="20 Sea Zone" t2="21 Sea Zone"/>
-				<connection t1="20 Sea Zone" t2="55 Sea Zone"/>
-				<connection t1="20 Sea Zone" t2="Northern South America"/>
-				<connection t1="20 Sea Zone" t2="Panama"/>
-				<connection t1="20 Sea Zone" t2="Peruvian Central"/>
-				<connection t1="21 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="21 Sea Zone" t2="44 Sea Zone"/>
-				<connection t1="21 Sea Zone" t2="Argentina Chile"/>
-				<connection t1="21 Sea Zone" t2="Peruvian Central"/>
-				<connection t1="22 Sea Zone" t2="23 Sea Zone"/>
-				<connection t1="22 Sea Zone" t2="24 Sea Zone"/>
-				<connection t1="22 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="22 Sea Zone" t2="Brazil"/>
-				<connection t1="23 Sea Zone" t2="24 Sea Zone"/> 
-				<connection t1="23 Sea Zone" t2="27 Sea Zone"/>
-				<connection t1="23 Sea Zone" t2="Angola"/>
-				<connection t1="23 Sea Zone" t2="Belgian Congo"/>
-				<connection t1="23 Sea Zone" t2="French Equatorial Africa"/>
-				<connection t1="24 Sea Zone" t2="25 Sea Zone"/>
-				<connection t1="24 Sea Zone" t2="26 Sea Zone"/>
-				<connection t1="24 Sea Zone" t2="27 Sea Zone"/>
-				<connection t1="25 Sea Zone" t2="26 Sea Zone"/>
-				<connection t1="25 Sea Zone" t2="43 Sea Zone"/>
-				<connection t1="25 Sea Zone" t2="Argentina Chile"/>
-				<connection t1="26 Sea Zone" t2="27 Sea Zone"/>
-				<connection t1="27 Sea Zone" t2="28 Sea Zone"/>
-				<connection t1="27 Sea Zone" t2="Angola"/>
-				<connection t1="27 Sea Zone" t2="Union of South Africa"/>
-				<connection t1="28 Sea Zone" t2="29 Sea Zone"/>
-				<connection t1="28 Sea Zone" t2="33 Sea Zone"/>
-				<connection t1="28 Sea Zone" t2="French Madagascar"/>
-				<connection t1="28 Sea Zone" t2="Union of South Africa"/>
-				<connection t1="29 Sea Zone" t2="30 Sea Zone"/>
-				<connection t1="29 Sea Zone" t2="32 Sea Zone"/>
-				<connection t1="29 Sea Zone" t2="French Madagascar"/>
-				<connection t1="30 Sea Zone" t2="31 Sea Zone"/>
-				<connection t1="30 Sea Zone" t2="39 Sea Zone"/>
-				<connection t1="30 Sea Zone" t2="40 Sea Zone"/>
-				<connection t1="30 Sea Zone" t2="32 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="32 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="35 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="38 Sea Zone"/>
-				<connection t1="31 Sea Zone" t2="39 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="33 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="34 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="35 Sea Zone"/>
-				<connection t1="32 Sea Zone" t2="French Madagascar"/>
-				<connection t1="33 Sea Zone" t2="34 Sea Zone"/>
-				<connection t1="33 Sea Zone" t2="French Madagascar"/>
-				<connection t1="33 Sea Zone" t2="Mozambique"/>
-				<connection t1="33 Sea Zone" t2="Rhodesia"/>
-				<connection t1="34 Sea Zone" t2="35 Sea Zone"/>
-				<connection t1="34 Sea Zone" t2="Anglo-Egypt Sudan"/>
-				<connection t1="34 Sea Zone" t2="Egypt"/>
-				<connection t1="34 Sea Zone" t2="Italian Africa"/>
-				<connection t1="34 Sea Zone" t2="Saudi Arabia"/>
-				<connection t1="34 Sea Zone" t2="Trans-Jordan"/>
-				<connection t1="34 Sea Zone" t2="Persia"/>
-				<connection t1="35 Sea Zone" t2="37 Sea Zone"/>
-				<connection t1="35 Sea Zone" t2="38 Sea Zone"/>
-				<connection t1="35 Sea Zone" t2="India"/>
-				<connection t1="36 Sea Zone" t2="37 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="49 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="50 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="61 Sea Zone"/>
-				<connection t1="36 Sea Zone" t2="French Indo-China Thailand"/>
-				<connection t1="37 Sea Zone" t2="38 Sea Zone"/>
-				<connection t1="37 Sea Zone" t2="49 Sea Zone"/>
-				<connection t1="37 Sea Zone" t2="Burma"/>
-				<connection t1="37 Sea Zone" t2="French Indo-China Thailand"/>
-				<connection t1="38 Sea Zone" t2="39 Sea Zone"/>
-				<connection t1="38 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="38 Sea Zone" t2="49 Sea Zone"/>
-				<connection t1="38 Sea Zone" t2="East Indies"/>
-				<connection t1="39 Sea Zone" t2="40 Sea Zone"/>      
-				<connection t1="39 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="39 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="39 Sea Zone" t2="Australia"/>
-				<connection t1="40 Sea Zone" t2="41 Sea Zone"/>
-				<connection t1="40 Sea Zone" t2="Australia"/>
-				<connection t1="41 Sea Zone" t2="42 Sea Zone"/>
-				<connection t1="41 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="41 Sea Zone" t2="Australia"/>
-				<connection t1="42 Sea Zone" t2="43 Sea Zone"/>
-				<connection t1="42 Sea Zone" t2="45 Sea Zone"/>
-				<connection t1="42 Sea Zone" t2="46 Sea Zone"/>
-				<connection t1="42 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="42 Sea Zone" t2="New Zealand"/>
-				<connection t1="43 Sea Zone" t2="44 Sea Zone"/>
-				<connection t1="43 Sea Zone" t2="45 Sea Zone"/>
-				<connection t1="44 Sea Zone" t2="45 Sea Zone"/>
-				<connection t1="44 Sea Zone" t2="54 Sea Zone"/>
-				<connection t1="44 Sea Zone" t2="55 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="46 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="53 Sea Zone"/>
-				<connection t1="45 Sea Zone" t2="54 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="47 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="51 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="53 Sea Zone"/>
-				<connection t1="46 Sea Zone" t2="Solomon Islands"/>
-				<connection t1="47 Sea Zone" t2="48 Sea Zone"/>
-				<connection t1="47 Sea Zone" t2="Australia"/>
-				<connection t1="48 Sea Zone" t2="49 Sea Zone"/>
-				<connection t1="48 Sea Zone" t2="50 Sea Zone"/>
-				<connection t1="48 Sea Zone" t2="51 Sea Zone"/>
-				<connection t1="48 Sea Zone" t2="New Guinea"/>
-				<connection t1="49 Sea Zone" t2="50 Sea Zone"/> 
-				<connection t1="49 Sea Zone" t2="Borneo"/>
-				<connection t1="50 Sea Zone" t2="51 Sea Zone"/>
-				<connection t1="50 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="50 Sea Zone" t2="61 Sea Zone"/>
-				<connection t1="50 Sea Zone" t2="Philippine Islands"/>
-				<connection t1="51 Sea Zone" t2="52 Sea Zone"/> 
-				<connection t1="51 Sea Zone" t2="53 Sea Zone"/>
-				<connection t1="51 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="51 Sea Zone" t2="Caroline Islands"/>
-				<connection t1="52 Sea Zone" t2="53 Sea Zone"/> 
-				<connection t1="52 Sea Zone" t2="57 Sea Zone"/>
-				<connection t1="52 Sea Zone" t2="59 Sea Zone"/>
-				<connection t1="52 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="52 Sea Zone" t2="Wake Island"/>
-				<connection t1="53 Sea Zone" t2="54 Sea Zone"/>
-				<connection t1="53 Sea Zone" t2="56 Sea Zone"/>
-				<connection t1="53 Sea Zone" t2="57 Sea Zone"/>
-				<connection t1="53 Sea Zone" t2="Hawaiian Islands"/>
-				<connection t1="54 Sea Zone" t2="55 Sea Zone"/>
-				<connection t1="54 Sea Zone" t2="56 Sea Zone"/>
-				<connection t1="55 Sea Zone" t2="56 Sea Zone"/>
-				<connection t1="55 Sea Zone" t2="Mexico"/>
-				<connection t1="56 Sea Zone" t2="57 Sea Zone"/>  
-				<connection t1="56 Sea Zone" t2="65 Sea Zone"/>
-				<connection t1="56 Sea Zone" t2="Western Canada"/>
-				<connection t1="56 Sea Zone" t2="Western United States"/>
-				<connection t1="57 Sea Zone" t2="58 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="59 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="64 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="65 Sea Zone"/>
-				<connection t1="57 Sea Zone" t2="Midway"/>
-				<connection t1="58 Sea Zone" t2="59 Sea Zone"/>
-				<connection t1="58 Sea Zone" t2="62 Sea Zone"/>
-				<connection t1="58 Sea Zone" t2="63 Sea Zone"/>
-				<connection t1="58 Sea Zone" t2="64 Sea Zone"/>
-				<connection t1="59 Sea Zone" t2="60 Sea Zone"/>
-				<connection t1="59 Sea Zone" t2="62 Sea Zone"/>
-				<connection t1="59 Sea Zone" t2="Iwo Jima"/>
-				<connection t1="60 Sea Zone" t2="61 Sea Zone"/>
-				<connection t1="60 Sea Zone" t2="62 Sea Zone"/>
-				<connection t1="60 Sea Zone" t2="Okinawa"/>
-				<connection t1="61 Sea Zone" t2="62 Sea Zone"/> 
-				<connection t1="61 Sea Zone" t2="Formosa"/>
-				<connection t1="61 Sea Zone" t2="Fukien"/>
-				<connection t1="61 Sea Zone" t2="Kiangsu"/>
-				<connection t1="61 Sea Zone" t2="Kwangtung"/>
-				<connection t1="62 Sea Zone" t2="63 Sea Zone"/> 
-				<connection t1="62 Sea Zone" t2="Buryatia S.S.R."/>
-				<connection t1="62 Sea Zone" t2="Japan"/>
-				<connection t1="62 Sea Zone" t2="Manchuria"/>
-				<connection t1="63 Sea Zone" t2="64 Sea Zone"/>
-				<connection t1="63 Sea Zone" t2="Buryatia S.S.R."/>
-				<connection t1="63 Sea Zone" t2="Soviet Far East"/>
-				<connection t1="64 Sea Zone" t2="65 Sea Zone"/>           
-				<connection t1="64 Sea Zone" t2="Alaska"/>
-				<connection t1="65 Sea Zone" t2="Alaska"/>
-				<connection t1="65 Sea Zone" t2="Western Canada"/>
-				<connection t1="Afghanistan" t2="Chinghai"/>
-				<connection t1="Afghanistan" t2="Himalaya"/>
-				<connection t1="Afghanistan" t2="India"/>
-				<connection t1="Afghanistan" t2="Kazakh S.S.R."/>
-				<connection t1="Afghanistan" t2="Persia"/>
-				<connection t1="Alaska" t2="Western Canada"/>
-				<connection t1="Anglo-Egypt Sudan" t2="Belgian Congo"/>
-				<connection t1="Anglo-Egypt Sudan" t2="Egypt"/>
-				<connection t1="Anglo-Egypt Sudan" t2="French Equatorial Africa"/>
-				<connection t1="Anglo-Egypt Sudan" t2="Italian Africa"/>
-				<connection t1="Anglo-Egypt Sudan" t2="Sahara"/>
-				<connection t1="Angola" t2="Belgian Congo"/> 
-				<connection t1="Angola" t2="Rhodesia"/>
-				<connection t1="Angola" t2="Union of South Africa"/>
-				<connection t1="Argentina Chile" t2="Brazil"/> 
-				<connection t1="Argentina Chile" t2="Peruvian Central"/>
-				<connection t1="Archangel" t2="Belorussia"/> 
-				<connection t1="Archangel" t2="Karelia S.S.R."/>
-				<connection t1="Archangel" t2="Russia"/>
-				<connection t1="Archangel" t2="Urals"/>
-				<connection t1="Baltic States" t2="Belorussia"/> 
-				<connection t1="Baltic States" t2="East Poland"/>
-				<connection t1="Baltic States" t2="Karelia S.S.R."/>
-				<connection t1="Baltic States" t2="Poland"/>
-				<connection t1="Belgian Congo" t2="French Equatorial Africa"/>
-				<connection t1="Belgian Congo" t2="Rhodesia"/>
-				<connection t1="Belgian Congo" t2="Italian Africa"/>
-				<connection t1="Belorussia" t2="East Poland"/>
-				<connection t1="Belorussia" t2="Karelia S.S.R."/>
-				<connection t1="Belorussia" t2="Eastern Ukraine"/>
-				<connection t1="Belorussia" t2="Russia"/>
-				<connection t1="Brazil" t2="Northern South America"/>
-				<connection t1="Brazil" t2="Peruvian Central"/>
-				<connection t1="Burma" t2="French Indo-China Thailand"/> 
-				<connection t1="Burma" t2="Himalaya"/>
-				<connection t1="Burma" t2="India"/>
-				<connection t1="Burma" t2="Yunnan"/>
-				<connection t1="Buryatia S.S.R." t2="Manchuria"/>
-				<connection t1="Buryatia S.S.R." t2="Mongolia"/>
-				<connection t1="Buryatia S.S.R." t2="Soviet Far East"/>
-				<connection t1="Buryatia S.S.R." t2="Stanovoj Chrebet"/>
-				<connection t1="Caucasus" t2="Kazakh S.S.R."/>
-				<connection t1="Caucasus" t2="Eastern Ukraine"/>
-				<connection t1="Caucasus" t2="Persia"/>
-				<connection t1="Caucasus" t2="Russia"/>
-				<connection t1="Caucasus" t2="Turkey"/>
-				<connection t1="Caucasus" t2="Ukraine"/>
-				<connection t1="Central United States" t2="Eastern United States"/>
-				<connection t1="Central United States" t2="Mexico"/>
-				<connection t1="Central United States" t2="Western Canada"/>
-				<connection t1="Central United States" t2="Western United States"/>
-				<connection t1="Chinghai" t2="Himalaya"/>
-				<connection t1="Chinghai" t2="Kazakh S.S.R."/>
-				<connection t1="Chinghai" t2="Mongolia"/>
-				<connection t1="Chinghai" t2="Ningxia"/>
-				<connection t1="Chinghai" t2="Novosibirsk"/>
-				<connection t1="Chinghai" t2="Sikang"/>
-				<connection t1="Czechoslovakia Hungary" t2="Germany"/>
-				<connection t1="Czechoslovakia Hungary" t2="Bulgaria Romania"/>
-				<connection t1="Czechoslovakia Hungary" t2="Balkans"/>
-				<connection t1="Czechoslovakia Hungary" t2="Poland"/>
-				<connection t1="Eastern Canada" t2="Eastern United States"/>
-				<connection t1="Eastern Canada" t2="Western Canada"/>
-				<connection t1="East Poland" t2="Eastern Ukraine"/> 
-				<connection t1="East Poland" t2="Bulgaria Romania"/>
-				<connection t1="East Poland" t2="Ukraine"/>
-				<connection t1="East Poland" t2="Poland"/>
-				<connection t1="Eastern United States" t2="Panama"/>
-				<connection t1="Egypt" t2="Libya"/> 
-				<connection t1="Egypt" t2="Sahara"/>
-				<connection t1="Egypt" t2="Trans-Jordan"/>
-				<connection t1="Eire" t2="United Kingdom"/> 
-				<connection t1="Evenki National Okrug" t2="Mongolia"/>
-				<connection t1="Evenki National Okrug" t2="Novosibirsk"/>
-				<connection t1="Evenki National Okrug" t2="Urals"/>
-				<connection t1="Evenki National Okrug" t2="Yakut S.S.R."/>
-				<connection t1="France" t2="Germany"/>
-				<connection t1="France" t2="Italy"/>
-				<connection t1="France" t2="Northwestern Europe"/>
-				<connection t1="France" t2="Spain"/>
-				<connection t1="France" t2="Switzerland"/>
-				<connection t1="French Equatorial Africa" t2="French West Africa"/>
-				<connection t1="French Equatorial Africa" t2="Sahara"/>
-				<connection t1="French Indo-China Thailand" t2="Fukien"/>
-				<connection t1="French Indo-China Thailand" t2="Kwangtung"/>
-				<connection t1="French Indo-China Thailand" t2="Yunnan"/>
-				<connection t1="French West Africa" t2="Sahara"/>
-				<connection t1="Finland" t2="Karelia S.S.R."/> 
-				<connection t1="Finland" t2="Norway"/>
-				<connection t1="Finland" t2="Sweden"/>
-				<connection t1="Fukien" t2="Hupeh"/> 
-				<connection t1="Fukien" t2="Kiangsu"/>
-				<connection t1="Fukien" t2="Kwangtung"/>
-				<connection t1="Fukien" t2="Yunnan"/>
-				<connection t1="Germany" t2="Northwestern Europe"/>
-				<connection t1="Germany" t2="Switzerland"/>
-				<connection t1="Germany" t2="Balkans"/>
-				<connection t1="Germany" t2="Poland"/>
-				<connection t1="Gibraltar" t2="Spain"/>
-				<connection t1="Himalaya" t2="India"/>
-				<connection t1="Himalaya" t2="Sikang"/>
-				<connection t1="Himalaya" t2="Yunnan"/>
-				<connection t1="Hupeh" t2="Kiangsu"/>
-				<connection t1="Hupeh" t2="Ningxia"/>
-				<connection t1="Hupeh" t2="Sikang"/>
-				<connection t1="Hupeh" t2="Suiyuan"/>
-				<connection t1="Hupeh" t2="Yunnan"/>
-				<connection t1="India" t2="Persia"/>
-				<connection t1="Italian Africa" t2="Rhodesia"/>
-				<connection t1="Italy" t2="Switzerland"/>
-				<connection t1="Italy" t2="Balkans"/>
-				<connection t1="Kazakh S.S.R." t2="Russia"/>
-				<connection t1="Kazakh S.S.R." t2="Novosibirsk"/>
-				<connection t1="Kiangsu" t2="Manchuria"/> 
-				<connection t1="Kiangsu" t2="Suiyuan"/>
-				<connection t1="Libya" t2="Morocco Algeria"/>
-				<connection t1="Libya" t2="Sahara"/>
-				<connection t1="Mexico" t2="Western United States"/>
-				<connection t1="Mexico" t2="Panama"/>
-				<connection t1="Manchuria" t2="Mongolia"/>
-				<connection t1="Manchuria" t2="Suiyuan"/>
-				<connection t1="Mongolia" t2="Novosibirsk"/>
-				<connection t1="Mongolia" t2="Ningxia"/>
-				<connection t1="Mongolia" t2="Stanovoj Chrebet"/>
-				<connection t1="Mongolia" t2="Suiyuan"/>
-				<connection t1="Mongolia" t2="Yakut S.S.R."/>
-				<connection t1="Morocco Algeria" t2="Sahara"/>
-				<connection t1="Mozambique" t2="Rhodesia"/>
-				<connection t1="Mozambique" t2="Union of South Africa"/>
-				<connection t1="Ningxia" t2="Sikang"/>
-				<connection t1="Ningxia" t2="Suiyuan"/>
-				<connection t1="Northern South America" t2="Peruvian Central"/>
-				<connection t1="Northern South America" t2="Panama"/>
-				<connection t1="Eastern Ukraine" t2="Ukraine"/>
-				<connection t1="Norway" t2="Sweden"/>
-				<connection t1="Novosibirsk" t2="Russia"/>
-				<connection t1="Novosibirsk" t2="Urals"/>
-				<connection t1="Persia" t2="Kazakh S.S.R."/>
-				<connection t1="Persia" t2="Trans-Jordan"/>
-				<connection t1="Persia" t2="Turkey"/>
-				<connection t1="Rhodesia" t2="Union of South Africa"/>
-				<connection t1="Bulgaria Romania" t2="Turkey"/> 
-				<connection t1="Bulgaria Romania" t2="Ukraine"/>
-				<connection t1="Bulgaria Romania" t2="Balkans"/>
-				<connection t1="Bulgaria Romania" t2="Poland"/>
-				<connection t1="Russia" t2="Eastern Ukraine"/>
-				<connection t1="Russia" t2="Urals"/>
-				<connection t1="Saudi Arabia" t2="Trans-Jordan"/>
-				<connection t1="Sikang" t2="Yunnan"/>
-				<connection t1="Soviet Far East" t2="Stanovoj Chrebet"/>
-				<connection t1="Soviet Far East" t2="Yakut S.S.R."/>
-				<connection t1="Stanovoj Chrebet" t2="Yakut S.S.R."/> 
-				<connection t1="Switzerland" t2="Balkans"/>
-				<connection t1="Trans-Jordan" t2="Turkey"/>
-				<connection t1="Western Canada" t2="Western United States"/>
+                <connection t1="1 Sea Zone" t2="8 Sea Zone"/>
+                <connection t1="1 Sea Zone" t2="9 Sea Zone"/>
+                <connection t1="1 Sea Zone" t2="Eastern Canada"/>
+                <connection t1="2 Sea Zone" t2="3 Sea Zone"/>
+                <connection t1="2 Sea Zone" t2="8 Sea Zone"/>
+                <connection t1="2 Sea Zone" t2="Eire"/>
+                <connection t1="2 Sea Zone" t2="Greenland"/>
+                <connection t1="2 Sea Zone" t2="Iceland"/>
+                <connection t1="2 Sea Zone" t2="United Kingdom"/>
+                <connection t1="3 Sea Zone" t2="4 Sea Zone"/>
+                <connection t1="3 Sea Zone" t2="6 Sea Zone"/>
+                <connection t1="3 Sea Zone" t2="Norway"/>
+                <connection t1="3 Sea Zone" t2="United Kingdom"/>
+                <connection t1="4 Sea Zone" t2="Archangel"/>
+                <connection t1="4 Sea Zone" t2="Finland"/>
+                <connection t1="4 Sea Zone" t2="Karelia S.S.R."/>
+                <connection t1="5 Sea Zone" t2="6 Sea Zone"/>
+                <connection t1="5 Sea Zone" t2="Baltic States"/>
+                <connection t1="5 Sea Zone" t2="Finland"/>
+                <connection t1="5 Sea Zone" t2="Germany"/>
+                <connection t1="5 Sea Zone" t2="Karelia S.S.R."/>
+                <connection t1="5 Sea Zone" t2="Northwestern Europe"/>
+                <connection t1="5 Sea Zone" t2="Norway"/>
+                <connection t1="5 Sea Zone" t2="Sweden"/>
+                <connection t1="5 Sea Zone" t2="Poland"/>
+                <connection t1="6 Sea Zone" t2="7 Sea Zone"/>
+                <connection t1="6 Sea Zone" t2="Northwestern Europe"/>
+                <connection t1="6 Sea Zone" t2="Norway"/>
+                <connection t1="6 Sea Zone" t2="United Kingdom"/>
+                <connection t1="7 Sea Zone" t2="8 Sea Zone"/>
+                <connection t1="7 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="7 Sea Zone" t2="France"/>
+                <connection t1="7 Sea Zone" t2="Northwestern Europe"/>
+                <connection t1="7 Sea Zone" t2="United Kingdom"/>
+                <connection t1="8 Sea Zone" t2="9 Sea Zone"/>
+                <connection t1="8 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="8 Sea Zone" t2="Eire"/>
+                <connection t1="8 Sea Zone" t2="United Kingdom"/>
+                <connection t1="9 Sea Zone" t2="10 Sea Zone"/>
+                <connection t1="9 Sea Zone" t2="11 Sea Zone"/>
+                <connection t1="9 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="9 Sea Zone" t2="Eastern Canada"/>
+                <connection t1="10 Sea Zone" t2="11 Sea Zone"/>
+                <connection t1="10 Sea Zone" t2="19 Sea Zone"/>
+                <connection t1="10 Sea Zone" t2="Eastern United States"/>
+                <connection t1="10 Sea Zone" t2="Panama"/>
+                <connection t1="11 Sea Zone" t2="12 Sea Zone"/>
+                <connection t1="11 Sea Zone" t2="18 Sea Zone"/>
+                <connection t1="11 Sea Zone" t2="19 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="13 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="17 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="18 Sea Zone"/>
+                <connection t1="12 Sea Zone" t2="Gibraltar"/>
+                <connection t1="12 Sea Zone" t2="Morocco Algeria"/>
+                <connection t1="12 Sea Zone" t2="Spain"/>
+                <connection t1="13 Sea Zone" t2="14 Sea Zone"/>
+                <connection t1="13 Sea Zone" t2="France"/>
+                <connection t1="13 Sea Zone" t2="Gibraltar"/>
+                <connection t1="13 Sea Zone" t2="Morocco Algeria"/>
+                <connection t1="13 Sea Zone" t2="Spain"/>
+                <connection t1="14 Sea Zone" t2="15 Sea Zone"/>
+                <connection t1="14 Sea Zone" t2="16 Sea Zone"/>
+                <connection t1="14 Sea Zone" t2="Italy"/>
+                <connection t1="14 Sea Zone" t2="Libya"/>
+                <connection t1="14 Sea Zone" t2="Balkans"/>
+                <connection t1="15 Sea Zone" t2="16 Sea Zone"/>
+                <connection t1="15 Sea Zone" t2="Egypt"/>
+                <connection t1="15 Sea Zone" t2="Trans-Jordan"/>
+                <connection t1="15 Sea Zone" t2="Turkey"/>
+                <connection t1="15 Sea Zone" t2="34 Sea Zone"/>
+                <connection t1="16 Sea Zone" t2="Caucasus"/>
+                <connection t1="16 Sea Zone" t2="Bulgaria Romania"/>
+                <connection t1="16 Sea Zone" t2="Turkey"/>
+                <connection t1="16 Sea Zone" t2="Ukraine"/>
+                <connection t1="17 Sea Zone" t2="18 Sea Zone"/>
+                <connection t1="17 Sea Zone" t2="22 Sea Zone"/>
+                <connection t1="17 Sea Zone" t2="23 Sea Zone"/>
+                <connection t1="17 Sea Zone" t2="French West Africa"/>
+                <connection t1="17 Sea Zone" t2="Sahara"/>
+                <connection t1="18 Sea Zone" t2="19 Sea Zone"/>
+                <connection t1="18 Sea Zone" t2="22 Sea Zone"/>
+                <connection t1="18 Sea Zone" t2="Brazil"/>
+                <connection t1="19 Sea Zone" t2="20 Sea Zone"/>
+                <connection t1="19 Sea Zone" t2="Northern South America"/>
+                <connection t1="19 Sea Zone" t2="Panama"/>
+                <connection t1="19 Sea Zone" t2="West Indies"/>
+                <connection t1="20 Sea Zone" t2="21 Sea Zone"/>
+                <connection t1="20 Sea Zone" t2="55 Sea Zone"/>
+                <connection t1="20 Sea Zone" t2="Northern South America"/>
+                <connection t1="20 Sea Zone" t2="Panama"/>
+                <connection t1="20 Sea Zone" t2="Peruvian Central"/>
+                <connection t1="21 Sea Zone" t2="25 Sea Zone"/>
+                <connection t1="21 Sea Zone" t2="44 Sea Zone"/>
+                <connection t1="21 Sea Zone" t2="Argentina Chile"/>
+                <connection t1="21 Sea Zone" t2="Peruvian Central"/>
+                <connection t1="22 Sea Zone" t2="23 Sea Zone"/>
+                <connection t1="22 Sea Zone" t2="24 Sea Zone"/>
+                <connection t1="22 Sea Zone" t2="25 Sea Zone"/>
+                <connection t1="22 Sea Zone" t2="Brazil"/>
+                <connection t1="23 Sea Zone" t2="24 Sea Zone"/>
+                <connection t1="23 Sea Zone" t2="27 Sea Zone"/>
+                <connection t1="23 Sea Zone" t2="Angola"/>
+                <connection t1="23 Sea Zone" t2="Belgian Congo"/>
+                <connection t1="23 Sea Zone" t2="French Equatorial Africa"/>
+                <connection t1="24 Sea Zone" t2="25 Sea Zone"/>
+                <connection t1="24 Sea Zone" t2="26 Sea Zone"/>
+                <connection t1="24 Sea Zone" t2="27 Sea Zone"/>
+                <connection t1="25 Sea Zone" t2="26 Sea Zone"/>
+                <connection t1="25 Sea Zone" t2="43 Sea Zone"/>
+                <connection t1="25 Sea Zone" t2="Argentina Chile"/>
+                <connection t1="26 Sea Zone" t2="27 Sea Zone"/>
+                <connection t1="27 Sea Zone" t2="28 Sea Zone"/>
+                <connection t1="27 Sea Zone" t2="Angola"/>
+                <connection t1="27 Sea Zone" t2="Union of South Africa"/>
+                <connection t1="28 Sea Zone" t2="29 Sea Zone"/>
+                <connection t1="28 Sea Zone" t2="33 Sea Zone"/>
+                <connection t1="28 Sea Zone" t2="French Madagascar"/>
+                <connection t1="28 Sea Zone" t2="Union of South Africa"/>
+                <connection t1="29 Sea Zone" t2="30 Sea Zone"/>
+                <connection t1="29 Sea Zone" t2="32 Sea Zone"/>
+                <connection t1="29 Sea Zone" t2="French Madagascar"/>
+                <connection t1="30 Sea Zone" t2="31 Sea Zone"/>
+                <connection t1="30 Sea Zone" t2="39 Sea Zone"/>
+                <connection t1="30 Sea Zone" t2="40 Sea Zone"/>
+                <connection t1="30 Sea Zone" t2="32 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="32 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="35 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="38 Sea Zone"/>
+                <connection t1="31 Sea Zone" t2="39 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="33 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="34 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="35 Sea Zone"/>
+                <connection t1="32 Sea Zone" t2="French Madagascar"/>
+                <connection t1="33 Sea Zone" t2="34 Sea Zone"/>
+                <connection t1="33 Sea Zone" t2="French Madagascar"/>
+                <connection t1="33 Sea Zone" t2="Mozambique"/>
+                <connection t1="33 Sea Zone" t2="Rhodesia"/>
+                <connection t1="34 Sea Zone" t2="35 Sea Zone"/>
+                <connection t1="34 Sea Zone" t2="Anglo-Egypt Sudan"/>
+                <connection t1="34 Sea Zone" t2="Egypt"/>
+                <connection t1="34 Sea Zone" t2="Italian Africa"/>
+                <connection t1="34 Sea Zone" t2="Saudi Arabia"/>
+                <connection t1="34 Sea Zone" t2="Trans-Jordan"/>
+                <connection t1="34 Sea Zone" t2="Persia"/>
+                <connection t1="35 Sea Zone" t2="37 Sea Zone"/>
+                <connection t1="35 Sea Zone" t2="38 Sea Zone"/>
+                <connection t1="35 Sea Zone" t2="India"/>
+                <connection t1="36 Sea Zone" t2="37 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="49 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="50 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="61 Sea Zone"/>
+                <connection t1="36 Sea Zone" t2="French Indo-China Thailand"/>
+                <connection t1="37 Sea Zone" t2="38 Sea Zone"/>
+                <connection t1="37 Sea Zone" t2="49 Sea Zone"/>
+                <connection t1="37 Sea Zone" t2="Burma"/>
+                <connection t1="37 Sea Zone" t2="French Indo-China Thailand"/>
+                <connection t1="38 Sea Zone" t2="39 Sea Zone"/>
+                <connection t1="38 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="38 Sea Zone" t2="49 Sea Zone"/>
+                <connection t1="38 Sea Zone" t2="East Indies"/>
+                <connection t1="39 Sea Zone" t2="40 Sea Zone"/>
+                <connection t1="39 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="39 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="39 Sea Zone" t2="Australia"/>
+                <connection t1="40 Sea Zone" t2="41 Sea Zone"/>
+                <connection t1="40 Sea Zone" t2="Australia"/>
+                <connection t1="41 Sea Zone" t2="42 Sea Zone"/>
+                <connection t1="41 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="41 Sea Zone" t2="Australia"/>
+                <connection t1="42 Sea Zone" t2="43 Sea Zone"/>
+                <connection t1="42 Sea Zone" t2="45 Sea Zone"/>
+                <connection t1="42 Sea Zone" t2="46 Sea Zone"/>
+                <connection t1="42 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="42 Sea Zone" t2="New Zealand"/>
+                <connection t1="43 Sea Zone" t2="44 Sea Zone"/>
+                <connection t1="43 Sea Zone" t2="45 Sea Zone"/>
+                <connection t1="44 Sea Zone" t2="45 Sea Zone"/>
+                <connection t1="44 Sea Zone" t2="54 Sea Zone"/>
+                <connection t1="44 Sea Zone" t2="55 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="46 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="45 Sea Zone" t2="54 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="47 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="51 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="46 Sea Zone" t2="Solomon Islands"/>
+                <connection t1="47 Sea Zone" t2="48 Sea Zone"/>
+                <connection t1="47 Sea Zone" t2="Australia"/>
+                <connection t1="48 Sea Zone" t2="49 Sea Zone"/>
+                <connection t1="48 Sea Zone" t2="50 Sea Zone"/>
+                <connection t1="48 Sea Zone" t2="51 Sea Zone"/>
+                <connection t1="48 Sea Zone" t2="New Guinea"/>
+                <connection t1="49 Sea Zone" t2="50 Sea Zone"/>
+                <connection t1="49 Sea Zone" t2="Borneo"/>
+                <connection t1="50 Sea Zone" t2="51 Sea Zone"/>
+                <connection t1="50 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="50 Sea Zone" t2="61 Sea Zone"/>
+                <connection t1="50 Sea Zone" t2="Philippine Islands"/>
+                <connection t1="51 Sea Zone" t2="52 Sea Zone"/>
+                <connection t1="51 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="51 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="51 Sea Zone" t2="Caroline Islands"/>
+                <connection t1="52 Sea Zone" t2="53 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="57 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="59 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="52 Sea Zone" t2="Wake Island"/>
+                <connection t1="53 Sea Zone" t2="54 Sea Zone"/>
+                <connection t1="53 Sea Zone" t2="56 Sea Zone"/>
+                <connection t1="53 Sea Zone" t2="57 Sea Zone"/>
+                <connection t1="53 Sea Zone" t2="Hawaiian Islands"/>
+                <connection t1="54 Sea Zone" t2="55 Sea Zone"/>
+                <connection t1="54 Sea Zone" t2="56 Sea Zone"/>
+                <connection t1="55 Sea Zone" t2="56 Sea Zone"/>
+                <connection t1="55 Sea Zone" t2="Mexico"/>
+                <connection t1="56 Sea Zone" t2="57 Sea Zone"/>
+                <connection t1="56 Sea Zone" t2="65 Sea Zone"/>
+                <connection t1="56 Sea Zone" t2="Western Canada"/>
+                <connection t1="56 Sea Zone" t2="Western United States"/>
+                <connection t1="57 Sea Zone" t2="58 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="59 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="64 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="65 Sea Zone"/>
+                <connection t1="57 Sea Zone" t2="Midway"/>
+                <connection t1="58 Sea Zone" t2="59 Sea Zone"/>
+                <connection t1="58 Sea Zone" t2="62 Sea Zone"/>
+                <connection t1="58 Sea Zone" t2="63 Sea Zone"/>
+                <connection t1="58 Sea Zone" t2="64 Sea Zone"/>
+                <connection t1="59 Sea Zone" t2="60 Sea Zone"/>
+                <connection t1="59 Sea Zone" t2="62 Sea Zone"/>
+                <connection t1="59 Sea Zone" t2="Iwo Jima"/>
+                <connection t1="60 Sea Zone" t2="61 Sea Zone"/>
+                <connection t1="60 Sea Zone" t2="62 Sea Zone"/>
+                <connection t1="60 Sea Zone" t2="Okinawa"/>
+                <connection t1="61 Sea Zone" t2="62 Sea Zone"/>
+                <connection t1="61 Sea Zone" t2="Formosa"/>
+                <connection t1="61 Sea Zone" t2="Fukien"/>
+                <connection t1="61 Sea Zone" t2="Kiangsu"/>
+                <connection t1="61 Sea Zone" t2="Kwangtung"/>
+                <connection t1="62 Sea Zone" t2="63 Sea Zone"/>
+                <connection t1="62 Sea Zone" t2="Buryatia S.S.R."/>
+                <connection t1="62 Sea Zone" t2="Japan"/>
+                <connection t1="62 Sea Zone" t2="Manchuria"/>
+                <connection t1="63 Sea Zone" t2="64 Sea Zone"/>
+                <connection t1="63 Sea Zone" t2="Buryatia S.S.R."/>
+                <connection t1="63 Sea Zone" t2="Soviet Far East"/>
+                <connection t1="64 Sea Zone" t2="65 Sea Zone"/>
+                <connection t1="64 Sea Zone" t2="Alaska"/>
+                <connection t1="65 Sea Zone" t2="Alaska"/>
+                <connection t1="65 Sea Zone" t2="Western Canada"/>
+                <connection t1="Afghanistan" t2="Chinghai"/>
+                <connection t1="Afghanistan" t2="Himalaya"/>
+                <connection t1="Afghanistan" t2="India"/>
+                <connection t1="Afghanistan" t2="Kazakh S.S.R."/>
+                <connection t1="Afghanistan" t2="Persia"/>
+                <connection t1="Alaska" t2="Western Canada"/>
+                <connection t1="Anglo-Egypt Sudan" t2="Belgian Congo"/>
+                <connection t1="Anglo-Egypt Sudan" t2="Egypt"/>
+                <connection t1="Anglo-Egypt Sudan" t2="French Equatorial Africa"/>
+                <connection t1="Anglo-Egypt Sudan" t2="Italian Africa"/>
+                <connection t1="Anglo-Egypt Sudan" t2="Sahara"/>
+                <connection t1="Angola" t2="Belgian Congo"/>
+                <connection t1="Angola" t2="Rhodesia"/>
+                <connection t1="Angola" t2="Union of South Africa"/>
+                <connection t1="Argentina Chile" t2="Brazil"/>
+                <connection t1="Argentina Chile" t2="Peruvian Central"/>
+                <connection t1="Archangel" t2="Belorussia"/>
+                <connection t1="Archangel" t2="Karelia S.S.R."/>
+                <connection t1="Archangel" t2="Russia"/>
+                <connection t1="Archangel" t2="Urals"/>
+                <connection t1="Baltic States" t2="Belorussia"/>
+                <connection t1="Baltic States" t2="East Poland"/>
+                <connection t1="Baltic States" t2="Karelia S.S.R."/>
+                <connection t1="Baltic States" t2="Poland"/>
+                <connection t1="Belgian Congo" t2="French Equatorial Africa"/>
+                <connection t1="Belgian Congo" t2="Rhodesia"/>
+                <connection t1="Belgian Congo" t2="Italian Africa"/>
+                <connection t1="Belorussia" t2="East Poland"/>
+                <connection t1="Belorussia" t2="Karelia S.S.R."/>
+                <connection t1="Belorussia" t2="Eastern Ukraine"/>
+                <connection t1="Belorussia" t2="Russia"/>
+                <connection t1="Brazil" t2="Northern South America"/>
+                <connection t1="Brazil" t2="Peruvian Central"/>
+                <connection t1="Burma" t2="French Indo-China Thailand"/>
+                <connection t1="Burma" t2="Himalaya"/>
+                <connection t1="Burma" t2="India"/>
+                <connection t1="Burma" t2="Yunnan"/>
+                <connection t1="Buryatia S.S.R." t2="Manchuria"/>
+                <connection t1="Buryatia S.S.R." t2="Mongolia"/>
+                <connection t1="Buryatia S.S.R." t2="Soviet Far East"/>
+                <connection t1="Buryatia S.S.R." t2="Stanovoj Chrebet"/>
+                <connection t1="Caucasus" t2="Kazakh S.S.R."/>
+                <connection t1="Caucasus" t2="Eastern Ukraine"/>
+                <connection t1="Caucasus" t2="Persia"/>
+                <connection t1="Caucasus" t2="Russia"/>
+                <connection t1="Caucasus" t2="Turkey"/>
+                <connection t1="Caucasus" t2="Ukraine"/>
+                <connection t1="Central United States" t2="Eastern United States"/>
+                <connection t1="Central United States" t2="Mexico"/>
+                <connection t1="Central United States" t2="Western Canada"/>
+                <connection t1="Central United States" t2="Western United States"/>
+                <connection t1="Chinghai" t2="Himalaya"/>
+                <connection t1="Chinghai" t2="Kazakh S.S.R."/>
+                <connection t1="Chinghai" t2="Mongolia"/>
+                <connection t1="Chinghai" t2="Ningxia"/>
+                <connection t1="Chinghai" t2="Novosibirsk"/>
+                <connection t1="Chinghai" t2="Sikang"/>
+                <connection t1="Czechoslovakia Hungary" t2="Germany"/>
+                <connection t1="Czechoslovakia Hungary" t2="Bulgaria Romania"/>
+                <connection t1="Czechoslovakia Hungary" t2="Balkans"/>
+                <connection t1="Czechoslovakia Hungary" t2="Poland"/>
+                <connection t1="Eastern Canada" t2="Eastern United States"/>
+                <connection t1="Eastern Canada" t2="Western Canada"/>
+                <connection t1="East Poland" t2="Eastern Ukraine"/>
+                <connection t1="East Poland" t2="Bulgaria Romania"/>
+                <connection t1="East Poland" t2="Ukraine"/>
+                <connection t1="East Poland" t2="Poland"/>
+                <connection t1="Eastern United States" t2="Panama"/>
+                <connection t1="Egypt" t2="Libya"/>
+                <connection t1="Egypt" t2="Sahara"/>
+                <connection t1="Egypt" t2="Trans-Jordan"/>
+                <connection t1="Eire" t2="United Kingdom"/>
+                <connection t1="Evenki National Okrug" t2="Mongolia"/>
+                <connection t1="Evenki National Okrug" t2="Novosibirsk"/>
+                <connection t1="Evenki National Okrug" t2="Urals"/>
+                <connection t1="Evenki National Okrug" t2="Yakut S.S.R."/>
+                <connection t1="France" t2="Germany"/>
+                <connection t1="France" t2="Italy"/>
+                <connection t1="France" t2="Northwestern Europe"/>
+                <connection t1="France" t2="Spain"/>
+                <connection t1="France" t2="Switzerland"/>
+                <connection t1="French Equatorial Africa" t2="French West Africa"/>
+                <connection t1="French Equatorial Africa" t2="Sahara"/>
+                <connection t1="French Indo-China Thailand" t2="Fukien"/>
+                <connection t1="French Indo-China Thailand" t2="Kwangtung"/>
+                <connection t1="French Indo-China Thailand" t2="Yunnan"/>
+                <connection t1="French West Africa" t2="Sahara"/>
+                <connection t1="Finland" t2="Karelia S.S.R."/>
+                <connection t1="Finland" t2="Norway"/>
+                <connection t1="Finland" t2="Sweden"/>
+                <connection t1="Fukien" t2="Hupeh"/>
+                <connection t1="Fukien" t2="Kiangsu"/>
+                <connection t1="Fukien" t2="Kwangtung"/>
+                <connection t1="Fukien" t2="Yunnan"/>
+                <connection t1="Germany" t2="Northwestern Europe"/>
+                <connection t1="Germany" t2="Switzerland"/>
+                <connection t1="Germany" t2="Balkans"/>
+                <connection t1="Germany" t2="Poland"/>
+                <connection t1="Gibraltar" t2="Spain"/>
+                <connection t1="Himalaya" t2="India"/>
+                <connection t1="Himalaya" t2="Sikang"/>
+                <connection t1="Himalaya" t2="Yunnan"/>
+                <connection t1="Hupeh" t2="Kiangsu"/>
+                <connection t1="Hupeh" t2="Ningxia"/>
+                <connection t1="Hupeh" t2="Sikang"/>
+                <connection t1="Hupeh" t2="Suiyuan"/>
+                <connection t1="Hupeh" t2="Yunnan"/>
+                <connection t1="India" t2="Persia"/>
+                <connection t1="Italian Africa" t2="Rhodesia"/>
+                <connection t1="Italy" t2="Switzerland"/>
+                <connection t1="Italy" t2="Balkans"/>
+                <connection t1="Kazakh S.S.R." t2="Russia"/>
+                <connection t1="Kazakh S.S.R." t2="Novosibirsk"/>
+                <connection t1="Kiangsu" t2="Manchuria"/>
+                <connection t1="Kiangsu" t2="Suiyuan"/>
+                <connection t1="Libya" t2="Morocco Algeria"/>
+                <connection t1="Libya" t2="Sahara"/>
+                <connection t1="Mexico" t2="Western United States"/>
+                <connection t1="Mexico" t2="Panama"/>
+                <connection t1="Manchuria" t2="Mongolia"/>
+                <connection t1="Manchuria" t2="Suiyuan"/>
+                <connection t1="Mongolia" t2="Novosibirsk"/>
+                <connection t1="Mongolia" t2="Ningxia"/>
+                <connection t1="Mongolia" t2="Stanovoj Chrebet"/>
+                <connection t1="Mongolia" t2="Suiyuan"/>
+                <connection t1="Mongolia" t2="Yakut S.S.R."/>
+                <connection t1="Morocco Algeria" t2="Sahara"/>
+                <connection t1="Mozambique" t2="Rhodesia"/>
+                <connection t1="Mozambique" t2="Union of South Africa"/>
+                <connection t1="Ningxia" t2="Sikang"/>
+                <connection t1="Ningxia" t2="Suiyuan"/>
+                <connection t1="Northern South America" t2="Peruvian Central"/>
+                <connection t1="Northern South America" t2="Panama"/>
+                <connection t1="Eastern Ukraine" t2="Ukraine"/>
+                <connection t1="Norway" t2="Sweden"/>
+                <connection t1="Novosibirsk" t2="Russia"/>
+                <connection t1="Novosibirsk" t2="Urals"/>
+                <connection t1="Persia" t2="Kazakh S.S.R."/>
+                <connection t1="Persia" t2="Trans-Jordan"/>
+                <connection t1="Persia" t2="Turkey"/>
+                <connection t1="Rhodesia" t2="Union of South Africa"/>
+                <connection t1="Bulgaria Romania" t2="Turkey"/>
+                <connection t1="Bulgaria Romania" t2="Ukraine"/>
+                <connection t1="Bulgaria Romania" t2="Balkans"/>
+                <connection t1="Bulgaria Romania" t2="Poland"/>
+                <connection t1="Russia" t2="Eastern Ukraine"/>
+                <connection t1="Russia" t2="Urals"/>
+                <connection t1="Saudi Arabia" t2="Trans-Jordan"/>
+                <connection t1="Sikang" t2="Yunnan"/>
+                <connection t1="Soviet Far East" t2="Stanovoj Chrebet"/>
+                <connection t1="Soviet Far East" t2="Yakut S.S.R."/>
+                <connection t1="Stanovoj Chrebet" t2="Yakut S.S.R."/>
+                <connection t1="Switzerland" t2="Balkans"/>
+                <connection t1="Trans-Jordan" t2="Turkey"/>
+                <connection t1="Western Canada" t2="Western United States"/>
         </map>
-        
+
         <resourceList>
                 <resource name="PUs"/>
                 <resource name="techTokens"/>
         </resourceList>
 
-        
+
         <playerList>
                 <!-- Player Turn Order -->
-                
-				<player name="Japanese" optional="false"/>
-				<player name="Russians" optional="false"/>
+
+                <player name="Japanese" optional="false"/>
+                <player name="Russians" optional="false"/>
                 <player name="Germans" optional="false"/>
                 <player name="British" optional="false"/>
                 <player name="Italians" optional="false"/>
-				<player name="Chinese" optional="false"/>
+                <player name="Chinese" optional="false"/>
                 <player name="Americans" optional="false"/>
 
                 <!-- Axis Alliance -->
                 <alliance player="Italians" alliance="Axis"/>
-				<alliance player="Germans" alliance="Axis"/>
+                <alliance player="Germans" alliance="Axis"/>
                 <alliance player="Japanese" alliance="Axis"/>
-                
+
                 <!-- Allied Alliance -->
                 <alliance player="Russians" alliance="Allies"/>
                 <alliance player="British" alliance="Allies"/>
-				<alliance player="Chinese" alliance="Allies"/>
+                <alliance player="Chinese" alliance="Allies"/>
                 <alliance player="Americans" alliance="Allies"/>
         </playerList>
-  
+
         <unitList>
                 <unit name="infantry"/>
                 <unit name="armour"/>
@@ -631,7 +631,7 @@
                 <unit name="aaGun"/>
                 <unit name="artillery"/>
                 <unit name="destroyer"/>
-				<unit name="cruiser"/>
+                <unit name="cruiser"/>
         </unitList>
 
         <gamePlay>
@@ -642,44 +642,44 @@
                 <delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Combat Move"/>
                 <delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Units"/>
                 <delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
-				<delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>
+                <delegate name="purchaseNoPU" javaClass="games.strategy.triplea.delegate.NoPUPurchaseDelegate" display="Purchase Units"/>
                 <delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate" display="Turn Complete"/>
-				<delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
+                <delegate name="endTurnNoPU" javaClass="games.strategy.triplea.delegate.NoPUEndTurnDelegate" display="Turn Complete"/>
                 <delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
                 <delegate name="placeBid" javaClass="games.strategy.triplea.delegate.BidPlaceDelegate" display="Bid Placement"/>
                 <delegate name="bid" javaClass="games.strategy.triplea.delegate.BidPurchaseDelegate" display="Bid Purchase"/>
-                
-                
+
+
                 <sequence>
                         <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
-                     
+
                         <!-- Bidding Phase -->
-                        
+
                         <step name="japaneseBid" delegate="bid" player="Japanese" maxRunCount="1"/>
                         <step name="japaneseBidPlace" delegate="placeBid" player="Japanese" maxRunCount="1"/>
 
 
-						
-						<step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
+
+                        <step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
                         <step name="russianBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
-						
-						<step name="germanBid" delegate="bid" player="Germans" maxRunCount="1"/>
+
+                        <step name="germanBid" delegate="bid" player="Germans" maxRunCount="1"/>
                         <step name="germanBidPlace" delegate="placeBid" player="Germans" maxRunCount="1"/>
 
 
-						
-						<step name="britishBid" delegate="bid" player="British" maxRunCount="1"/>
+
+                        <step name="britishBid" delegate="bid" player="British" maxRunCount="1"/>
                         <step name="britishBidPlace" delegate="placeBid" player="British" maxRunCount="1"/>
-						
-						<step name="italiansBid" delegate="bid" player="Italians" maxRunCount="1"/>
+
+                        <step name="italiansBid" delegate="bid" player="Italians" maxRunCount="1"/>
                         <step name="italiansBidPlace" delegate="placeBid" player="Italians" maxRunCount="1"/>
-						
-						<step name="chineseBid" delegate="bid" player="Chinese" maxRunCount="1"/>
-						<step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
-						
-						<step name="americanBid" delegate="bid" player="Americans" maxRunCount="1"/>
+
+                        <step name="chineseBid" delegate="bid" player="Chinese" maxRunCount="1"/>
+                        <step name="chineseBidPlace" delegate="placeBid" player="Chinese" maxRunCount="1"/>
+
+                        <step name="americanBid" delegate="bid" player="Americans" maxRunCount="1"/>
                         <step name="americanBidPlace" delegate="placeBid" player="Americans" maxRunCount="1"/>
-                        
+
                         <!-- Japanese Game Sequence -->
                         <step name="japaneseTech" delegate="tech" player="Japanese"/>
                         <step name="japaneseTechActivation" delegate="tech_activation" player="Japanese"/>
@@ -698,8 +698,8 @@
 
 
 
-						
-						<!-- Russians Game Sequence -->
+
+                        <!-- Russians Game Sequence -->
                         <step name="russianTech" delegate="tech" player="Russians"/>
                         <step name="russianTechActivation" delegate="tech_activation" player="Russians"/>
                         <step name="russianPurchase" delegate="purchase" player="Russians"/>
@@ -708,8 +708,8 @@
                         <step name="russianNonCombatMove" delegate="move" player="Russians" display="Non Combat Move"/>
                         <step name="russianPlace" delegate="place" player="Russians"/>
                         <step name="russianEndTurn" delegate="endTurn" player="Russians"/>
-						
-						<!-- Germans Game Sequence -->
+
+                        <!-- Germans Game Sequence -->
                         <step name="germanTech" delegate="tech" player="Germans"/>
                         <step name="germanTechActivation" delegate="tech_activation" player="Germans"/>
                         <step name="germanPurchase" delegate="purchase" player="Germans"/>
@@ -727,8 +727,8 @@
 
 
 
-						
-						<!-- British Game Sequence -->
+
+                        <!-- British Game Sequence -->
                         <step name="britishTech" delegate="tech" player="British"/>
                         <step name="britishTechActivation" delegate="tech_activation" player="British"/>
                         <step name="britishPurchase" delegate="purchase" player="British"/>
@@ -737,8 +737,8 @@
                         <step name="britishNonCombatMove" delegate="move" player="British" display="Non Combat Move"/>
                         <step name="britishPlace" delegate="place" player="British"/>
                         <step name="britishEndTurn" delegate="endTurn" player="British"/>
-						
-						<!-- Italians Game Sequence -->
+
+                        <!-- Italians Game Sequence -->
                         <step name="italianTech" delegate="tech" player="Italians"/>
                         <step name="italianTechActivation" delegate="tech_activation" player="Italians"/>
                         <step name="italianPurchase" delegate="purchase" player="Italians"/>
@@ -747,28 +747,28 @@
                         <step name="italianNonCombatMove" delegate="move" player="Italians" display="Non Combat Move"/>
                         <step name="italianPlace" delegate="place" player="Italians"/>
                         <step name="italianEndTurn" delegate="endTurn" player="Italians"/>
-						
-						<!-- Chinese/Americans Game Sequence -->
+
+                        <!-- Chinese/Americans Game Sequence -->
                         <step name="americanTech" delegate="tech" player="Americans"/>
                         <step name="americanTechActivation" delegate="tech_activation" player="Americans"/>
                         <step name="americanPurchase" delegate="purchase" player="Americans"/>
-						<step name="chinesePurchase" delegate="purchaseNoPU" player="Chinese"/>
+                        <step name="chinesePurchase" delegate="purchaseNoPU" player="Chinese"/>
                         <step name="americanCombatMove" delegate="move" player="Americans"/>
                         <step name="americanBattle" delegate="battle" player="Americans"/>
                         <step name="americanNonCombatMove" delegate="move" player="Americans" display="Non Combat Move"/>
                         <step name="americanPlace" delegate="place" player="Americans"/>
-						<step name="chineseCombatMove" delegate="move" player="Chinese"/>
-						<step name="chineseBattle" delegate="battle" player="Chinese"/>
-						<step name="chineseNonCombatMove" delegate="move" player="Chinese" display="Non Combat Move"/>
-						<step name="chinesePlace" delegate="place" player="Chinese"/>
-						<step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese">
-								<stepProperty name="skipPosting" value="true"/>
-						</step>
+                        <step name="chineseCombatMove" delegate="move" player="Chinese"/>
+                        <step name="chineseBattle" delegate="battle" player="Chinese"/>
+                        <step name="chineseNonCombatMove" delegate="move" player="Chinese" display="Non Combat Move"/>
+                        <step name="chinesePlace" delegate="place" player="Chinese"/>
+                        <step name="chineseEndTurn" delegate="endTurnNoPU" player="Chinese">
+                                <stepProperty name="skipPosting" value="true"/>
+                        </step>
                         <step name="americanEndTurn" delegate="endTurn" player="Americans">
-								<stepProperty name="turnSummaryPlayers" value="Americans:Chinese"/>
-						</step>
-                              
-						<!-- End Round -->
+                                <stepProperty name="turnSummaryPlayers" value="Americans:Chinese"/>
+                        </step>
+
+                        <!-- End Round -->
                         <step name="endRoundStep" delegate="endRound"/>
                 </sequence>
         </gamePlay>
@@ -779,12 +779,12 @@
                         <cost resource="PUs" quantity="3" />
                         <result resourceOrUnit="infantry" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArtillery">
                         <cost resource="PUs" quantity="4" />
                         <result resourceOrUnit="artillery" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArmour">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="armour" quantity="1"/>
@@ -794,12 +794,12 @@
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="fighter" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBomber">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="bomber" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyTransport">
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="transport" quantity="1"/>
@@ -809,17 +809,17 @@
                         <cost resource="PUs" quantity="14" />
                         <result resourceOrUnit="carrier" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyDestroyer">
                         <cost resource="PUs" quantity="8" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiser">
+
+                <productionRule name="buyCruiser">
                         <cost resource="PUs" quantity="12" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBattleship">
                         <cost resource="PUs" quantity="20" />
                         <result resourceOrUnit="battleship" quantity="1"/>
@@ -829,12 +829,12 @@
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="submarine" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFactory">
                         <cost resource="PUs" quantity="15" />
                         <result resourceOrUnit="factory" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyAAGun">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="aaGun" quantity="1"/>
@@ -842,126 +842,126 @@
 
 
 
-                <!-- Advanced Industrial Production 
-                
+                <!-- Advanced Industrial Production
+
                 <productionRule name="buyInfantryIndustrialTechnology">
                         <cost resource="PUs" quantity="3" />
 
                         <result resourceOrUnit="infantry" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArtilleryIndustrialTechnology">
                         <cost resource="PUs" quantity="4" />
 
                         <result resourceOrUnit="artillery" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyArmourIndustrialTechnology">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="armour" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFighterIndustrialTechnology">
                         <cost resource="PUs" quantity="9" />
                         <result resourceOrUnit="fighter" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBomberIndustrialTechnology">
                         <cost resource="PUs" quantity="11" />
                         <result resourceOrUnit="bomber" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyTransportIndustrialTechnology">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="transport" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyCarrierIndustrialTechnology">
                         <cost resource="PUs" quantity="11" />
                         <result resourceOrUnit="carrier" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyDestroyerIndustrialTechnology">
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiserIndustrialTechnology">
+
+                <productionRule name="buyCruiserIndustrialTechnology">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBattleshipIndustrialTechnology">
                         <cost resource="PUs" quantity="17" />
                         <result resourceOrUnit="battleship" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buySubmarineIndustrialTechnology">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="submarine" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyFactoryIndustrialTechnology">
                         <cost resource="PUs" quantity="14" />
                         <result resourceOrUnit="factory" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyAAGunIndustrialTechnology">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="aaGun" quantity="1"/>
                 </productionRule>
-				-->
+                -->
 
 
-				<!-- SHIPYARD PRICES -->
-                
+                <!-- SHIPYARD PRICES -->
+
                 <productionRule name="buyTransportShipyards">
                         <cost resource="PUs" quantity="6" />
                         <result resourceOrUnit="transport" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyCarrierShipyards">
                         <cost resource="PUs" quantity="11" />
                         <result resourceOrUnit="carrier" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyDestroyerShipyards">
                         <cost resource="PUs" quantity="7" />
                         <result resourceOrUnit="destroyer" quantity="1"/>
                 </productionRule>
-				
-				<productionRule name="buyCruiserShipyards">
+
+                <productionRule name="buyCruiserShipyards">
                         <cost resource="PUs" quantity="10" />
                         <result resourceOrUnit="cruiser" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buyBattleshipShipyards">
                         <cost resource="PUs" quantity="17" />
                         <result resourceOrUnit="battleship" quantity="1"/>
                 </productionRule>
-                
+
                 <productionRule name="buySubmarineShipyards">
                         <cost resource="PUs" quantity="5" />
                         <result resourceOrUnit="submarine" quantity="1"/>
                 </productionRule>
 
-				<!-- Repair rules -->                
+                <!-- Repair rules -->
                 <repairRule name="repairFactory">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory" quantity="1"/>
                 </repairRule>
-                
+
                 <repairRule name="repairFactoryIndustrialTechnology">
                         <cost resource="PUs" quantity="1" />
                         <result resourceOrUnit="factory" quantity="2"/>
                 </repairRule>
-                
+
                 <repairFrontier name="repair">
-                	<repairRules name="repairFactory"/>
+                    <repairRules name="repairFactory"/>
                 </repairFrontier>
-                
+
                 <repairFrontier name="repairIndustrialTechnology">
-                	<repairRules name="repairFactoryIndustrialTechnology"/>
+                    <repairRules name="repairFactoryIndustrialTechnology"/>
                 </repairFrontier>
 
                 <productionFrontier name="production">
@@ -974,13 +974,13 @@
                         <frontierRules name="buySubmarine"/>
                         <frontierRules name="buyCarrier"/>
                         <frontierRules name="buyDestroyer"/>
-						<frontierRules name="buyCruiser"/>
+                        <frontierRules name="buyCruiser"/>
                         <frontierRules name="buyBattleship"/>
                         <frontierRules name="buyAAGun"/>
-                        <frontierRules name="buyFactory"/>        
+                        <frontierRules name="buyFactory"/>
                 </productionFrontier>
-                
-				<!--
+
+                <!--
                 <productionFrontier name="productionIndustrialTechnology">
                         <frontierRules name="buyInfantryIndustrialTechnology"/>
                         <frontierRules name="buyArtilleryIndustrialTechnology"/>
@@ -991,42 +991,42 @@
                         <frontierRules name="buySubmarineIndustrialTechnology"/>
                         <frontierRules name="buyCarrierIndustrialTechnology"/>
                         <frontierRules name="buyDestroyerIndustrialTechnology"/>
-						<frontierRules name="buyCruiserIndustrialTechnology"/>
+                        <frontierRules name="buyCruiserIndustrialTechnology"/>
                         <frontierRules name="buyBattleshipIndustrialTechnology"/>
                         <frontierRules name="buyAAGunIndustrialTechnology"/>
-                        <frontierRules name="buyFactoryIndustrialTechnology"/>        
+                        <frontierRules name="buyFactoryIndustrialTechnology"/>
                 </productionFrontier>
-				-->
-                
+                -->
+
                 <productionFrontier name="productionShipyards">
                         <frontierRules name="buyTransportShipyards"/>
                         <frontierRules name="buySubmarineShipyards"/>
                         <frontierRules name="buyCarrierShipyards"/>
                         <frontierRules name="buyDestroyerShipyards"/>
-						<frontierRules name="buyCruiserShipyards"/>
-                        <frontierRules name="buyBattleshipShipyards"/>   
+                        <frontierRules name="buyCruiserShipyards"/>
+                        <frontierRules name="buyBattleshipShipyards"/>
                 </productionFrontier>
-                
+
 
                 <playerProduction player="Germans" frontier="production"/>
-				<playerProduction player="Russians" frontier="production"/>
-				<playerProduction player="Japanese" frontier="production"/>
-				<playerProduction player="British" frontier="production"/>
+                <playerProduction player="Russians" frontier="production"/>
+                <playerProduction player="Japanese" frontier="production"/>
+                <playerProduction player="British" frontier="production"/>
                 <playerProduction player="Italians" frontier="production"/>
-				<playerProduction player="Chinese" frontier="production"/>
+                <playerProduction player="Chinese" frontier="production"/>
                 <playerProduction player="Americans" frontier="production"/>
-                
+
                 <playerRepair player="Germans" frontier="repair"/>
-				<playerRepair player="Russians" frontier="repair"/>
-				<playerRepair player="Japanese" frontier="repair"/>
-				<playerRepair player="British" frontier="repair"/>
+                <playerRepair player="Russians" frontier="repair"/>
+                <playerRepair player="Japanese" frontier="repair"/>
+                <playerRepair player="British" frontier="repair"/>
                 <playerRepair player="Italians" frontier="repair"/>
-				<playerRepair player="Chinese" frontier="repair"/>
+                <playerRepair player="Chinese" frontier="repair"/>
                 <playerRepair player="Americans" frontier="repair"/>
-                                
-                
-        </production> 
-        
+
+
+        </production>
+
         <attachmentList>
                 <!-- Germans -->
                 <attachment name="techAttachment" attachTo="Germans" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
@@ -1043,8 +1043,8 @@
                         <option name="warBonds" value="false"/>
                         <option name="mechanizedInfantry" value="false"/>
                 </attachment>
-				
-				<!-- Russians -->
+
+                <!-- Russians -->
                 <attachment name="techAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
@@ -1059,7 +1059,7 @@
                         <option name="warBonds" value="false"/>
                         <option name="mechanizedInfantry" value="false"/>
                 </attachment>
-                
+
                 <!-- Japanese -->
                 <attachment name="techAttachment" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="superSub" value="false"/>
@@ -1091,8 +1091,8 @@
                         <option name="warBonds" value="false"/>
                         <option name="mechanizedInfantry" value="false"/>
                 </attachment>
-				
-				<!-- Italians -->
+
+                <!-- Italians -->
                 <attachment name="techAttachment" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
                         <option name="superSub" value="false"/>
                         <option name="jetPower" value="false"/>
@@ -1134,7 +1134,7 @@
                          <option name="defense" value="2"/>
                          <option name="artillerySupportable" value="true"/>
                 </attachment>
-			
+
 
                 <!-- Artillery -->
                 <attachment name="unitAttachment" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
@@ -1154,20 +1154,20 @@
                          <option name="attack" value="3"/>
                          <option name="defense" value="3"/>
                 </attachment>
-            
+
                 <!-- Fighter -->
                 <attachment name="unitAttachment" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="4"/>
                          <option name="carrierCost" value="1"/>
-                         <option name="isAir" value="true"/>   
+                         <option name="isAir" value="true"/>
                          <option name="attack" value="3"/>
                          <option name="defense" value="4"/>
-						 <option name="canIntercept" value="true"/>
-						 <option name="canEscort" value="true"/>
+                         <option name="canIntercept" value="true"/>
+                         <option name="canEscort" value="true"/>
                          <option name="airDefense" value="1"/>
                          <option name="airAttack" value="1"/>
                 </attachment>
-            
+
                 <!-- Bomber -->
                 <attachment name="unitAttachment" attachTo="bomber" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="6"/>
@@ -1183,12 +1183,12 @@
                 <!-- Transport -->
                 <attachment name="unitAttachment" attachTo="transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
-                         <option name="transportCapacity" value="5"/>   
+                         <option name="isSea" value="true"/>
+                         <option name="transportCapacity" value="5"/>
                          <option name="attack" value="0"/>
                          <option name="defense" value="0"/>
                 </attachment>
-            
+
                 <!-- Battle Ship -->
                 <attachment name="unitAttachment" attachTo="battleship" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
@@ -1198,8 +1198,8 @@
                          <option name="canBombard" value="true"/>
                          <option name="hitPoints" value="2"/>
                  </attachment>
-				 
-				 <!-- Cruiser -->
+
+                 <!-- Cruiser -->
                 <attachment name="unitAttachment" attachTo="cruiser" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
                          <option name="isSea" value="true"/>
@@ -1208,21 +1208,21 @@
                          <option name="canBombard" value="true"/>
                          <option name="hitPoints" value="1"/>
                  </attachment>
-                 
+
                 <!-- Destroyer -->
                 <attachment name="unitAttachment" attachTo="destroyer" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
+                         <option name="isSea" value="true"/>
                          <option name="attack" value="2"/>
                          <option name="defense" value="2"/>
                          <option name="isDestroyer" value="true"/>
                 </attachment>
-                
+
                 <!-- Carrier -->
                 <attachment name="unitAttachment" attachTo="carrier" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="carrierCapacity" value="2"/>
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
+                         <option name="isSea" value="true"/>
                          <option name="attack" value="1"/>
                          <option name="defense" value="2"/>
                 </attachment>
@@ -1231,616 +1231,616 @@
                 <attachment name="unitAttachment" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
                          <option name="isSub" value="true"/>
                          <option name="movement" value="2"/>
-                         <option name="isSea" value="true"/>   
+                         <option name="isSea" value="true"/>
                          <option name="attack" value="2"/>
                          <option name="defense" value="1"/>
                 </attachment>
 
                 <!-- Factory -->
                 <attachment name="unitAttachment" attachTo="factory" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-                         <option name="isFactory" value="true"/>   
+                         <option name="isFactory" value="true"/>
                 </attachment>
-            
+
                 <!-- AA Gun -->
                 <attachment name="unitAttachment" attachTo="aaGun" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
-                         <option name="isAA" value="true"/>   
+                         <option name="isAA" value="true"/>
                          <option name="transportCost" value="3"/>
                          <option name="movement" value="1"/>
                 </attachment>
-		
-				<!-- Territory Attachments -->
-					<attachment name="territoryAttachment" attachTo="Afghanistan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Alaska" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Anglo-Egypt Sudan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Angola" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Argentina Chile" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Archangel" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Australia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Baltic States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                        <option name="originalOwner" value="Russians"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Belgian Congo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Belorussia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                        <option name="originalOwner" value="Russians"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Borneo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="4"/>
-                        <option name="originalOwner" value="British"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Brazil" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="3"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Burma" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                        <option name="originalOwner" value="British"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Buryatia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Caucasus" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="4"/>
-                        <option name="unitProduction" value="4"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Central United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="6"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Chinghai" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Czechoslovakia Hungary" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="East Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="4"/>
-                        <option name="originalOwner" value="British"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Eastern Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="East Poland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                        <option name="originalOwner" value="Russians"/>
-                    </attachment>
-					
-					<!--US Capitol-->
-					<attachment name="territoryAttachment" attachTo="Eastern United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="12"/>
-                        <option name="unitProduction" value="12"/>
-						<option name="capital" value="Americans"/> 
-                        <option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Egypt" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Eire" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Evenki National Okrug" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="France" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="6"/>
-						<option name="victoryCity" value="1"/>
-					</attachment>
-					
-					<attachment name="territoryAttachment" attachTo="French Equatorial Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="French Indo-China Thailand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="French Madagascar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="French West Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Finland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Formosa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Fukien" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<!--German Capitol-->
-					<attachment name="territoryAttachment" attachTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="10"/>
-                        <option name="unitProduction" value="10"/>
-						<option name="capital" value="Germans"/> 
-                        <option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Gibraltar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Greenland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Hawaiian Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Himalaya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Hupeh" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Iceland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="India" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Italian Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Italy" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="6"/>
-                        <option name="unitProduction" value="6"/>
-						<option name="capital" value="Italians"/> 
-                        <option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Iwo Jima" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="8"/>
-                        <option name="unitProduction" value="8"/>
-						<option name="capital" value="Japanese"/> 
-                        <option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Karelia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                        <option name="unitProduction" value="2"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Kazakh S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Kiangsu" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-						<option name="victoryCity" value="1"/>						
-                        <option name="originalOwner" value="Chinese"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Kwangtung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                        <option name="originalOwner" value="British"/>
-						<option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Libya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Manchuria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="3"/>
-                        <option name="originalOwner" value="Chinese"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Mexico" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Midway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Mongolia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                <!-- Territory Attachments -->
+                    <attachment name="territoryAttachment" attachTo="Afghanistan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                         <option name="isImpassable" value="true"/>
-						<option name="capital" value="Chinese"/>
-                  </attachment>
-				  
-					<attachment name="territoryAttachment" attachTo="Morocco Algeria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Alaska" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Anglo-Egypt Sudan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Mozambique" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Angola" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
+                        <option name="isImpassable" value="true"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="New Guinea" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                        <option name="originalOwner" value="British"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="New Zealand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Ningxia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Northern South America" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Argentina Chile" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
+                        <option name="isImpassable" value="true"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Eastern Ukraine" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                        <option name="originalOwner" value="Russians"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Northwestern Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Archangel" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Norway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="3"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Novosibirsk" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Australia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Okinawa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Panama" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Persia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Peruvian Central" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Philippine Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                           <option name="originalOwner" value="Americans"/>
-			   <option name="victoryCity" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Rhodesia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="1"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Bulgaria Romania" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="2"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="6"/>
-                        <option name="unitProduction" value="6"/>
-						<option name="capital" value="Russians"/> 
                         <option name="victoryCity" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Sahara" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
+
+                    <attachment name="territoryAttachment" attachTo="Baltic States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <option name="originalOwner" value="Russians"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Saudi Arabia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-                        <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
-                    </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Sikang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Belgian Congo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Solomon Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Belorussia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <option name="originalOwner" value="Russians"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Borneo" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                        <option name="originalOwner" value="British"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Brazil" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Burma" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="originalOwner" value="British"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Buryatia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Caroline Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Caucasus" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                        <option name="unitProduction" value="4"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Central United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Chinghai" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Czechoslovakia Hungary" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="East Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="4"/>
+                        <option name="originalOwner" value="British"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Eastern Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="East Poland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <option name="originalOwner" value="Russians"/>
+                    </attachment>
+
+                    <!--US Capitol-->
+                    <attachment name="territoryAttachment" attachTo="Eastern United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="12"/>
+                        <option name="unitProduction" value="12"/>
+                        <option name="capital" value="Americans"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Egypt" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Eire" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Evenki National Okrug" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="France" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="French Equatorial Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="French Indo-China Thailand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="French Madagascar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="French West Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Finland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Formosa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Fukien" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <!--German Capitol-->
+                    <attachment name="territoryAttachment" attachTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="10"/>
+                        <option name="unitProduction" value="10"/>
+                        <option name="capital" value="Germans"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Gibraltar" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Greenland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Hawaiian Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Himalaya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Hupeh" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Iceland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="India" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Italian Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Italy" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                        <option name="unitProduction" value="6"/>
+                        <option name="capital" value="Italians"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Iwo Jima" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Japan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="8"/>
+                        <option name="unitProduction" value="8"/>
+                        <option name="capital" value="Japanese"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Karelia S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="unitProduction" value="2"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Kazakh S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Kiangsu" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                        <option name="victoryCity" value="1"/>
+                        <option name="originalOwner" value="Chinese"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Kwangtung" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <option name="originalOwner" value="British"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Libya" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Manchuria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                        <option name="originalOwner" value="Chinese"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Mexico" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Midway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Mongolia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                        <option name="capital" value="Chinese"/>
+                  </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Morocco Algeria" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Mozambique" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="New Guinea" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <option name="originalOwner" value="British"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="New Zealand" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Ningxia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Northern South America" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Eastern Ukraine" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                        <option name="originalOwner" value="Russians"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Northwestern Europe" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Norway" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="3"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Novosibirsk" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Okinawa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Panama" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Persia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Peruvian Central" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Philippine Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                           <option name="originalOwner" value="Americans"/>
+               <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Rhodesia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Bulgaria Romania" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="2"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Russia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="6"/>
+                        <option name="unitProduction" value="6"/>
+                        <option name="capital" value="Russians"/>
+                        <option name="victoryCity" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Sahara" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Saudi Arabia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="0"/>
+                        <option name="isImpassable" value="true"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Sikang" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
+                    <attachment name="territoryAttachment" attachTo="Solomon Islands" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                         <option name="originalOwner" value="British"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Soviet Far East" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Soviet Far East" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Spain" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Spain" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
+                        <option name="isImpassable" value="true"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Stanovoj Chrebet" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Stanovoj Chrebet" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Suiyuan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Suiyuan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Sweden" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Sweden" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
+                        <option name="isImpassable" value="true"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Switzerland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Switzerland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
+                        <option name="isImpassable" value="true"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Trans-Jordan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Trans-Jordan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Turkey" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Turkey" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
-						<option name="isImpassable" value="true"/>
+                        <option name="isImpassable" value="true"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Ukraine" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Ukraine" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                         <option name="originalOwner" value="Russians"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Union of South Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Union of South Africa" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="2"/>
                     </attachment>
-					
-					<!--British Capitol-->
-					<attachment name="territoryAttachment" attachTo="United Kingdom" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <!--British Capitol-->
+                    <attachment name="territoryAttachment" attachTo="United Kingdom" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="8"/>
                         <option name="unitProduction" value="8"/>
-						<option name="capital" value="British"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="capital" value="British"/>
+                        <option name="victoryCity" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Urals" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Urals" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Wake Island" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Wake Island" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="0"/>
                         <option name="originalOwner" value="Americans"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="West Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="West Indies" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Balkans" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Balkans" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Western Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Western Canada" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Poland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Poland" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="3"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Western United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Western United States" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="10"/>
                         <option name="unitProduction" value="10"/>
-						<option name="victoryCity" value="1"/>
+                        <option name="victoryCity" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Yakut S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+
+                    <attachment name="territoryAttachment" attachTo="Yakut S.S.R." javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
                         <option name="production" value="1"/>
                     </attachment>
-					
-					<attachment name="territoryAttachment" attachTo="Yunnan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
-						<option name="production" value="1"/>
-					</attachment>
-                
+
+                    <attachment name="territoryAttachment" attachTo="Yunnan" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+                        <option name="production" value="1"/>
+                    </attachment>
+
                 <!-- Canals -->
 
-			    <attachment name="canalAttachment" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Suez Canal"/>
-			    	<option name="landTerritories" value="Egypt:Trans-Jordan"/>
-			    </attachment>
-			    
-			    <attachment name="canalAttachment" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Suez Canal"/>
-			    	<option name="landTerritories" value="Egypt:Trans-Jordan"/>
-			    </attachment>
-			    
-		   	    <attachment name="canalAttachment" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Panama Canal"/>
-			    	<option name="landTerritories" value="Panama"/>
-			    </attachment>
-			    
-			    <attachment name="canalAttachment" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
-			    	<option name="canalName" value="Panama Canal"/>
-			    	<option name="landTerritories" value="Panama"/>
-			    </attachment>
-                  
+                <attachment name="canalAttachment" attachTo="15 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Suez Canal"/>
+                    <option name="landTerritories" value="Egypt:Trans-Jordan"/>
+                </attachment>
+
+                <attachment name="canalAttachment" attachTo="34 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Suez Canal"/>
+                    <option name="landTerritories" value="Egypt:Trans-Jordan"/>
+                </attachment>
+
+                   <attachment name="canalAttachment" attachTo="19 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Panama Canal"/>
+                    <option name="landTerritories" value="Panama"/>
+                </attachment>
+
+                <attachment name="canalAttachment" attachTo="20 Sea Zone" javaClass="games.strategy.triplea.attachments.CanalAttachment" type="territory">
+                    <option name="canalName" value="Panama Canal"/>
+                    <option name="landTerritories" value="Panama"/>
+                </attachment>
+
 <!--  National Objectives -->
-	<!-- German Objectives -->
+    <!-- German Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>   
-                	<option name="alliedOwnershipTerritories" value="France:Northwestern Europe:Germany:Poland:Czechoslovakia Hungary:Bulgaria Romania" count="6"/> 
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="France:Northwestern Europe:Germany:Poland:Czechoslovakia Hungary:Bulgaria Romania" count="6"/>
                 </attachment>
-         
+
                 <attachment name="objectiveAttachment2" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Baltic States:East Poland:Belorussia:Eastern Ukraine:Ukraine" count="3"/>
-                </attachment>         
-                
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Baltic States:East Poland:Belorussia:Eastern Ukraine:Ukraine" count="3"/>
+                </attachment>
+
                 <attachment name="objectiveAttachment3" attachTo="Germans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Karelia S.S.R.:Caucasus" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Karelia S.S.R.:Caucasus" count="1"/>
                 </attachment>
-                
-	<!-- Russian Objectives -->
+
+    <!-- Russian Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Archangel" count="1"/>
-                	<option name="alliedExclusionTerritories" value="controlled"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Archangel" count="1"/>
+                    <option name="alliedExclusionTerritories" value="controlled"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment2" attachTo="Russians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="10"/>
-                	<option name="alliedOwnershipTerritories" value="Norway:Finland:Poland:Bulgaria Romania:Czechoslovakia Hungary:Balkans" count="3"/>
+                    <option name="objectiveValue" value="10"/>
+                    <option name="alliedOwnershipTerritories" value="Norway:Finland:Poland:Bulgaria Romania:Czechoslovakia Hungary:Balkans" count="3"/>
                 </attachment>
-                
-	<!-- Japanese Objectives -->         
+
+    <!-- Japanese Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Manchuria:Kiangsu:French Indo-China Thailand" count="3"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Manchuria:Kiangsu:French Indo-China Thailand" count="3"/>
                 </attachment>
-                                
+
                 <attachment name="objectiveAttachment2" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Kwangtung:East Indies:Borneo:Philippine Islands:New Guinea:Solomon Islands" count="4"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Kwangtung:East Indies:Borneo:Philippine Islands:New Guinea:Solomon Islands" count="4"/>
                 </attachment>
-                                
+
                 <attachment name="objectiveAttachment3" attachTo="Japanese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Hawaiian Islands:Australia:India" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Hawaiian Islands:Australia:India" count="1"/>
                 </attachment>
-                
-	<!-- British Objectives -->
+
+    <!-- British Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Caroline Islands:French Indo-China Thailand:Formosa:Iwo Jima:Japan:Okinawa" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Caroline Islands:French Indo-China Thailand:Formosa:Iwo Jima:Japan:Okinawa" count="1"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment2" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Eastern Canada:Western Canada:Gibraltar:Egypt:Australia:Union of South Africa" count="6"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Eastern Canada:Western Canada:Gibraltar:Egypt:Australia:Union of South Africa" count="6"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment3" attachTo="British" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="France:Balkans" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="France:Balkans" count="1"/>
                 </attachment>
-                
-	<!-- Italian Objectives -->
+
+    <!-- Italian Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Egypt:Trans-Jordan:France:Gibraltar" count="3"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Egypt:Trans-Jordan:France:Gibraltar" count="3"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment2" attachTo="Italians" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Italy:Balkans:Morocco Algeria:Libya" count="4"/>
-                	<option name="enemySurfaceExclusionTerritories" value="13 Sea Zone:14 Sea Zone:15 Sea Zone" count="3"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Italy:Balkans:Morocco Algeria:Libya" count="4"/>
+                    <option name="enemySurfaceExclusionTerritories" value="13 Sea Zone:14 Sea Zone:15 Sea Zone" count="3"/>
                 </attachment>
-                
-	<!-- American Objectives -->
+
+    <!-- American Objectives -->
                 <attachment name="objectiveAttachment1" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="France" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="France" count="1"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment2" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Philippine Islands" count="1"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Philippine Islands" count="1"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment3" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Western United States:Eastern United States:Central United States" count="3"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Western United States:Eastern United States:Central United States" count="3"/>
                 </attachment>
-                
+
                 <attachment name="objectiveAttachment4" attachTo="Americans" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="objectiveValue" value="5"/>
-                	<option name="alliedOwnershipTerritories" value="Midway:Wake Island:Hawaiian Islands:Solomon Islands" count="3"/>
+                    <option name="objectiveValue" value="5"/>
+                    <option name="alliedOwnershipTerritories" value="Midway:Wake Island:Hawaiian Islands:Solomon Islands" count="3"/>
                 </attachment>
-                
+
 <!--  Rules Restrictions -->
-	<!-- Chinese Rules -->
-				<attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
-                	<option name="movementRestrictionTerritories" value="Chinghai:Ningxia:Sikang:Yunnan:Hupeh:Fukien:Suiyuan:Manchuria:Kiangsu:Kwangtung"/>
-                	<option name="movementRestrictionType" value="allowed"/>
-                	<option name="productionPerXTerritories" value="2"/>
-                	<option name="placementAnyTerritory" value="true"/>
-                	<option name="placementCapturedTerritory" value="true"/>
-                	<option name="placementPerTerritory" value="3"/>
+    <!-- Chinese Rules -->
+                <attachment name="rulesAttachment" attachTo="Chinese" javaClass="games.strategy.triplea.attachments.RulesAttachment" type="player">
+                    <option name="movementRestrictionTerritories" value="Chinghai:Ningxia:Sikang:Yunnan:Hupeh:Fukien:Suiyuan:Manchuria:Kiangsu:Kwangtung"/>
+                    <option name="movementRestrictionType" value="allowed"/>
+                    <option name="productionPerXTerritories" value="2"/>
+                    <option name="placementAnyTerritory" value="true"/>
+                    <option name="placementCapturedTerritory" value="true"/>
+                    <option name="placementPerTerritory" value="3"/>
                 </attachment>
-                                
+
         </attachmentList>
 
         <initialize>
                 <ownerInitialize>
                         <!-- German Owned Territories -->
-						<territoryOwner territory="Baltic States" owner="Germans"/>
-						<territoryOwner territory="Belorussia" owner="Germans"/>
+                        <territoryOwner territory="Baltic States" owner="Germans"/>
+                        <territoryOwner territory="Belorussia" owner="Germans"/>
                         <territoryOwner territory="Czechoslovakia Hungary" owner="Germans"/>
-						<territoryOwner territory="East Poland" owner="Germans"/>
-						<territoryOwner territory="Eastern Ukraine" owner="Germans"/>
+                        <territoryOwner territory="East Poland" owner="Germans"/>
+                        <territoryOwner territory="Eastern Ukraine" owner="Germans"/>
                         <territoryOwner territory="Finland" owner="Germans"/>
                         <territoryOwner territory="France" owner="Germans"/>
                         <territoryOwner territory="Germany" owner="Germans"/>
@@ -1849,53 +1849,53 @@
                         <territoryOwner territory="Norway" owner="Germans"/>
                         <territoryOwner territory="Bulgaria Romania" owner="Germans"/>
                         <territoryOwner territory="Poland" owner="Germans"/>
-						<territoryOwner territory="Ukraine" owner="Germans"/>
-						
-						<!-- Russian Owned Territories -->
+                        <territoryOwner territory="Ukraine" owner="Germans"/>
+
+                        <!-- Russian Owned Territories -->
                         <territoryOwner territory="Archangel" owner="Russians"/>
 
 
-						<territoryOwner territory="Buryatia S.S.R." owner="Russians"/>
+                        <territoryOwner territory="Buryatia S.S.R." owner="Russians"/>
                         <territoryOwner territory="Caucasus" owner="Russians"/>
 
-						<territoryOwner territory="Evenki National Okrug" owner="Russians"/>
+                        <territoryOwner territory="Evenki National Okrug" owner="Russians"/>
                         <territoryOwner territory="Karelia S.S.R." owner="Russians"/>
                         <territoryOwner territory="Kazakh S.S.R." owner="Russians"/>
 
-						<territoryOwner territory="Novosibirsk" owner="Russians"/>
+                        <territoryOwner territory="Novosibirsk" owner="Russians"/>
                         <territoryOwner territory="Russia" owner="Russians"/>
                         <territoryOwner territory="Soviet Far East" owner="Russians"/>
                         <territoryOwner territory="Stanovoj Chrebet" owner="Russians"/>
 
-						<territoryOwner territory="Urals" owner="Russians"/>
+                        <territoryOwner territory="Urals" owner="Russians"/>
                         <territoryOwner territory="Yakut S.S.R." owner="Russians"/>
-						
-						<!-- Japanese Owned Territories -->
+
+                        <!-- Japanese Owned Territories -->
                         <territoryOwner territory="Borneo" owner="Japanese"/>
-						<territoryOwner territory="Burma" owner="Japanese"/>
-						<territoryOwner territory="Caroline Islands" owner="Japanese"/>
-						<territoryOwner territory="East Indies" owner="Japanese"/>
+                        <territoryOwner territory="Burma" owner="Japanese"/>
+                        <territoryOwner territory="Caroline Islands" owner="Japanese"/>
+                        <territoryOwner territory="East Indies" owner="Japanese"/>
                         <territoryOwner territory="French Indo-China Thailand" owner="Japanese"/>
                         <territoryOwner territory="Formosa" owner="Japanese"/>
                         <territoryOwner territory="Iwo Jima" owner="Japanese"/>
                         <territoryOwner territory="Japan" owner="Japanese"/>
                         <territoryOwner territory="Kiangsu" owner="Japanese"/>
-						<territoryOwner territory="Kwangtung" owner="Japanese"/>
-						<territoryOwner territory="Manchuria" owner="Japanese"/>
-						<territoryOwner territory="New Guinea" owner="Japanese"/>
+                        <territoryOwner territory="Kwangtung" owner="Japanese"/>
+                        <territoryOwner territory="Manchuria" owner="Japanese"/>
+                        <territoryOwner territory="New Guinea" owner="Japanese"/>
                         <territoryOwner territory="Okinawa" owner="Japanese"/>
-						<territoryOwner territory="Philippine Islands" owner="Japanese"/>
-						<territoryOwner territory="Solomon Islands" owner="Japanese"/>
-						<territoryOwner territory="Wake Island" owner="Japanese"/>
-						
-						<!-- British Owned Territories -->
+                        <territoryOwner territory="Philippine Islands" owner="Japanese"/>
+                        <territoryOwner territory="Solomon Islands" owner="Japanese"/>
+                        <territoryOwner territory="Wake Island" owner="Japanese"/>
+
+                        <!-- British Owned Territories -->
                         <territoryOwner territory="Anglo-Egypt Sudan" owner="British"/>
                         <territoryOwner territory="Australia" owner="British"/>
                         <territoryOwner territory="Belgian Congo" owner="British"/>
 
 
 
-						<territoryOwner territory="Eastern Canada" owner="British"/>
+                        <territoryOwner territory="Eastern Canada" owner="British"/>
                         <territoryOwner territory="Egypt" owner="British"/>
                         <territoryOwner territory="French Equatorial Africa" owner="British"/>
                         <territoryOwner territory="French Madagascar" owner="British"/>
@@ -1906,284 +1906,284 @@
                         <territoryOwner territory="Italian Africa" owner="British"/>
 
 
-						<territoryOwner territory="New Zealand" owner="British"/>
+                        <territoryOwner territory="New Zealand" owner="British"/>
                         <territoryOwner territory="Persia" owner="British"/>
                         <territoryOwner territory="Rhodesia" owner="British"/>
                         <territoryOwner territory="Saudi Arabia" owner="British"/>
 
-						<territoryOwner territory="Trans-Jordan" owner="British"/>
+                        <territoryOwner territory="Trans-Jordan" owner="British"/>
                         <territoryOwner territory="Union of South Africa" owner="British"/>
                         <territoryOwner territory="United Kingdom" owner="British"/>
                         <territoryOwner territory="Western Canada" owner="British"/>
-						
-						<!-- Italian Owned Territories -->
+
+                        <!-- Italian Owned Territories -->
                         <territoryOwner territory="Italy" owner="Italians"/>
                         <territoryOwner territory="Libya" owner="Italians"/>
                         <territoryOwner territory="Balkans" owner="Italians"/>
-						
-						<!-- US Chinese Owned Territories -->
-						<territoryOwner territory="Chinghai" owner="Chinese"/>
-						<territoryOwner territory="Fukien" owner="Chinese"/>
-						<territoryOwner territory="Hupeh" owner="Chinese"/>
-						<territoryOwner territory="Ningxia" owner="Chinese"/>
-						<territoryOwner territory="Sikang" owner="Chinese"/>
-						<territoryOwner territory="Suiyuan" owner="Chinese"/>
-						<territoryOwner territory="Yunnan" owner="Chinese"/>
-                        
+
+                        <!-- US Chinese Owned Territories -->
+                        <territoryOwner territory="Chinghai" owner="Chinese"/>
+                        <territoryOwner territory="Fukien" owner="Chinese"/>
+                        <territoryOwner territory="Hupeh" owner="Chinese"/>
+                        <territoryOwner territory="Ningxia" owner="Chinese"/>
+                        <territoryOwner territory="Sikang" owner="Chinese"/>
+                        <territoryOwner territory="Suiyuan" owner="Chinese"/>
+                        <territoryOwner territory="Yunnan" owner="Chinese"/>
+
                         <!-- American Owned Territories -->
                         <territoryOwner territory="Alaska" owner="Americans"/>
-						<territoryOwner territory="Brazil" owner="Americans"/>
-						<territoryOwner territory="Central United States" owner="Americans"/>
-						<territoryOwner territory="Eastern United States" owner="Americans"/>
-						<territoryOwner territory="Greenland" owner="Americans"/>
-						<territoryOwner territory="Hawaiian Islands" owner="Americans"/>
-						<territoryOwner territory="Mexico" owner="Americans"/>
-						<territoryOwner territory="Midway" owner="Americans"/>
-						<territoryOwner territory="Panama" owner="Americans"/>
+                        <territoryOwner territory="Brazil" owner="Americans"/>
+                        <territoryOwner territory="Central United States" owner="Americans"/>
+                        <territoryOwner territory="Eastern United States" owner="Americans"/>
+                        <territoryOwner territory="Greenland" owner="Americans"/>
+                        <territoryOwner territory="Hawaiian Islands" owner="Americans"/>
+                        <territoryOwner territory="Mexico" owner="Americans"/>
+                        <territoryOwner territory="Midway" owner="Americans"/>
+                        <territoryOwner territory="Panama" owner="Americans"/>
 
 
-						<territoryOwner territory="West Indies" owner="Americans"/>
-						<territoryOwner territory="Western United States" owner="Americans"/>
-						
+                        <territoryOwner territory="West Indies" owner="Americans"/>
+                        <territoryOwner territory="Western United States" owner="Americans"/>
+
                 </ownerInitialize>
 
                 <unitInitialize>
                         <!-- German Unit Placements -->
-						<unitPlacement unitType="infantry" territory="Baltic States" quantity="3" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Belorussia" quantity="3" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Bulgaria Romania" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Bulgaria Romania" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Bulgaria Romania" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Czechoslovakia Hungary" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="East Poland" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="artillery" territory="East Poland" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="East Poland" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Eastern Ukraine" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Eastern Ukraine" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="artillery" territory="Eastern Ukraine" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="aaGun" territory="France" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Baltic States" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Belorussia" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Bulgaria Romania" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Bulgaria Romania" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Bulgaria Romania" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Czechoslovakia Hungary" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="East Poland" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="East Poland" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="East Poland" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Eastern Ukraine" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Eastern Ukraine" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Eastern Ukraine" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="aaGun" territory="France" quantity="1" owner="Germans"/>
 
-						<unitPlacement unitType="infantry" territory="France" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="France" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="France" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Finland" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="factory" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="aaGun" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Germany" quantity="4" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Germany" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="bomber" territory="Germany" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Libya" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="France" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="France" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="France" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Finland" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="factory" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="aaGun" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Germany" quantity="4" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Germany" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="bomber" territory="Germany" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Libya" quantity="1" owner="Germans"/>
 
-						<unitPlacement unitType="armour" territory="Libya" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Morocco Algeria" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="artillery" territory="Morocco Algeria" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Northwestern Europe" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Northwestern Europe" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Norway" quantity="3" owner="Germans"/>
-						<unitPlacement unitType="fighter" territory="Norway" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Poland" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Poland" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="infantry" territory="Ukraine" quantity="2" owner="Germans"/>
-						<unitPlacement unitType="armour" territory="Ukraine" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="submarine" territory="7 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="submarine" territory="8 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="submarine" territory="5 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Libya" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Morocco Algeria" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="artillery" territory="Morocco Algeria" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Northwestern Europe" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Northwestern Europe" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Norway" quantity="3" owner="Germans"/>
+                        <unitPlacement unitType="fighter" territory="Norway" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Poland" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Poland" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="infantry" territory="Ukraine" quantity="2" owner="Germans"/>
+                        <unitPlacement unitType="armour" territory="Ukraine" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="submarine" territory="7 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="submarine" territory="8 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="submarine" territory="5 Sea Zone" quantity="1" owner="Germans"/>
 
-						<unitPlacement unitType="destroyer" territory="5 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="cruiser" territory="5 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="destroyer" territory="5 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="cruiser" territory="5 Sea Zone" quantity="1" owner="Germans"/>
 
-						<unitPlacement unitType="transport" territory="5 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="transport" territory="13 Sea Zone" quantity="1" owner="Germans"/>
-						<unitPlacement unitType="destroyer" territory="13 Sea Zone" quantity="1" owner="Germans"/>
-						
-						<!-- Russian Unit Placements -->
-						<unitPlacement unitType="infantry" territory="Archangel" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="transport" territory="5 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="transport" territory="13 Sea Zone" quantity="1" owner="Germans"/>
+                        <unitPlacement unitType="destroyer" territory="13 Sea Zone" quantity="1" owner="Germans"/>
 
-						<unitPlacement unitType="armour" territory="Archangel" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Buryatia S.S.R." quantity="3" owner="Russians"/>
-						<unitPlacement unitType="factory" territory="Caucasus" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="aaGun" territory="Caucasus" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Caucasus" quantity="3" owner="Russians"/>
-						<unitPlacement unitType="artillery" territory="Caucasus" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="armour" territory="Caucasus" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Evenki National Okrug" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="factory" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
-						<unitPlacement unitType="aaGun" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Karelia S.S.R." quantity="3" owner="Russians"/>
-						<unitPlacement unitType="fighter" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Kazakh S.S.R." quantity="2" owner="Russians"/>	
+                        <!-- Russian Unit Placements -->
+                        <unitPlacement unitType="infantry" territory="Archangel" quantity="3" owner="Russians"/>
 
-						<unitPlacement unitType="infantry" territory="Novosibirsk" quantity="2" owner="Russians"/>	
-						<unitPlacement unitType="factory" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="aaGun" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Russia" quantity="3" owner="Russians"/>
-						<unitPlacement unitType="artillery" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="armour" territory="Russia" quantity="2" owner="Russians"/>
-						<unitPlacement unitType="bomber" territory="Russia" quantity="1" owner="Russians"/>
-						<unitPlacement unitType="infantry" territory="Soviet Far East" quantity="3" owner="Russians"/>	
-						<unitPlacement unitType="infantry" territory="Stanovoj Chrebet" quantity="1" owner="Russians"/>	
-						<unitPlacement unitType="infantry" territory="Urals" quantity="1" owner="Russians"/>								
-						<unitPlacement unitType="infantry" territory="Yakut S.S.R." quantity="1" owner="Russians"/>
-						<unitPlacement unitType="submarine" territory="4 Sea Zone" quantity="1" owner="Russians"/>
-						
-						<!-- Japanese Unit Placements -->
-						<unitPlacement unitType="infantry" territory="Borneo" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Burma" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Caroline Islands" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="East Indies" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Formosa" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="French Indo-China Thailand" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="French Indo-China Thailand" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Iwo Jima" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="armour" territory="Archangel" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Buryatia S.S.R." quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="factory" territory="Caucasus" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Caucasus" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Caucasus" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="artillery" territory="Caucasus" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="armour" territory="Caucasus" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Evenki National Okrug" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="factory" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Karelia S.S.R." quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="fighter" territory="Karelia S.S.R." quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Kazakh S.S.R." quantity="2" owner="Russians"/>
 
-						<unitPlacement unitType="infantry" territory="Japan" quantity="4" owner="Japanese"/>
-						<unitPlacement unitType="artillery" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="armour" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="bomber" territory="Japan" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Kiangsu" quantity="3" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Kwangtung" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Manchuria" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="Manchuria" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="New Guinea" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Okinawa" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Philippine Islands" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Wake Island" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="fighter" territory="38 Sea Zone" quantity="2" owner="Japanese"/>
-						<unitPlacement unitType="carrier" territory="38 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="battleship" territory="38 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="submarine" territory="46 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="cruiser" territory="50 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Novosibirsk" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="factory" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="aaGun" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Russia" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="artillery" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="armour" territory="Russia" quantity="2" owner="Russians"/>
+                        <unitPlacement unitType="bomber" territory="Russia" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Soviet Far East" quantity="3" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Stanovoj Chrebet" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Urals" quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="infantry" territory="Yakut S.S.R." quantity="1" owner="Russians"/>
+                        <unitPlacement unitType="submarine" territory="4 Sea Zone" quantity="1" owner="Russians"/>
 
-						<unitPlacement unitType="destroyer" territory="51 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="carrier" territory="51 Sea Zone" quantity="1" owner="Japanese"/>
+                        <!-- Japanese Unit Placements -->
+                        <unitPlacement unitType="infantry" territory="Borneo" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Burma" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Caroline Islands" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="East Indies" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Formosa" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="French Indo-China Thailand" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="French Indo-China Thailand" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Iwo Jima" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="aaGun" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="factory" territory="Japan" quantity="1" owner="Japanese"/>
 
+                        <unitPlacement unitType="infantry" territory="Japan" quantity="4" owner="Japanese"/>
+                        <unitPlacement unitType="artillery" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="armour" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="bomber" territory="Japan" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Kiangsu" quantity="3" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Kwangtung" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Manchuria" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="Manchuria" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="New Guinea" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Okinawa" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Philippine Islands" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Wake Island" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="fighter" territory="38 Sea Zone" quantity="2" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="38 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="battleship" territory="38 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="submarine" territory="46 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="cruiser" territory="50 Sea Zone" quantity="1" owner="Japanese"/>
 
+                        <unitPlacement unitType="destroyer" territory="51 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="carrier" territory="51 Sea Zone" quantity="1" owner="Japanese"/>
 
 
 
 
-						<unitPlacement unitType="fighter" territory="51 Sea Zone" quantity="1" owner="Japanese"/>
-
-						<unitPlacement unitType="transport" territory="62 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="battleship" territory="62 Sea Zone" quantity="1" owner="Japanese"/>
-						<unitPlacement unitType="infantry" territory="Solomon Islands" quantity="1" owner="Japanese"/>
-						
-						
-						<!-- British Unit Placements -->
-						<unitPlacement unitType="aaGun" territory="Australia" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Australia" quantity="3" owner="British"/>
-						<unitPlacement unitType="fighter" territory="Australia" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Eastern Canada" quantity="2" owner="British"/>
-						<unitPlacement unitType="armour" territory="Eastern Canada" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Egypt" quantity="3" owner="British"/>
-
-						<unitPlacement unitType="armour" territory="Egypt" quantity="1" owner="British"/>
-						<unitPlacement unitType="fighter" territory="Egypt" quantity="1" owner="British"/>
-						<unitPlacement unitType="aaGun" territory="India" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="India" quantity="3" owner="British"/>
-						<unitPlacement unitType="infantry" territory="New Zealand" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Persia" quantity="1" owner="British"/>
-
-						<unitPlacement unitType="infantry" territory="Trans-Jordan" quantity="1" owner="British"/>
-						<unitPlacement unitType="artillery" territory="Trans-Jordan" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Union of South Africa" quantity="1" owner="British"/>
-						<unitPlacement unitType="artillery" territory="Union of South Africa" quantity="1" owner="British"/>
-						<unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="United Kingdom" quantity="2" owner="British"/>
-						<unitPlacement unitType="artillery" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="armour" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="fighter" territory="United Kingdom" quantity="2" owner="British"/>
-						<unitPlacement unitType="bomber" territory="United Kingdom" quantity="1" owner="British"/>
-						<unitPlacement unitType="infantry" territory="Western Canada" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="1 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="cruiser" territory="1 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="2 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="2 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="battleship" territory="2 Sea Zone" quantity="1" owner="British"/>
 
 
+                        <unitPlacement unitType="fighter" territory="51 Sea Zone" quantity="1" owner="Japanese"/>
 
-						<unitPlacement unitType="cruiser" territory="12 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="12 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="15 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="27 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="transport" territory="35 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="destroyer" territory="35 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="fighter" territory="35 Sea Zone" quantity="1" owner="British"/>
-						<unitPlacement unitType="carrier" territory="35 Sea Zone" quantity="1" owner="British"/>
-						
-						<!-- Italian Unit Placements -->
-						<unitPlacement unitType="factory" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="aaGun" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="armour" territory="Italy" quantity="2" owner="Italians"/>
-						<unitPlacement unitType="fighter" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="Italy" quantity="2" owner="Italians"/>
-						<unitPlacement unitType="artillery" territory="Italy" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="Libya" quantity="2" owner="Italians"/>
-						<unitPlacement unitType="infantry" territory="Balkans" quantity="2" owner="Italians"/>
-						<unitPlacement unitType="armour" territory="Balkans" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="transport" territory="14 Sea Zone" quantity="1" owner="Italians"/>
-						<unitPlacement unitType="cruiser" territory="14 Sea Zone" quantity="2" owner="Italians"/>
-						<unitPlacement unitType="battleship" territory="14 Sea Zone" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="transport" territory="62 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="battleship" territory="62 Sea Zone" quantity="1" owner="Japanese"/>
+                        <unitPlacement unitType="infantry" territory="Solomon Islands" quantity="1" owner="Japanese"/>
 
-						<!-- US Chinese Placements -->
-						<unitPlacement unitType="infantry" territory="Chinghai" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Fukien" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Hupeh" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Ningxia" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Sikang" quantity="1" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Suiyuan" quantity="2" owner="Chinese"/>
-						<unitPlacement unitType="infantry" territory="Yunnan" quantity="2" owner="Chinese"/>
-						<unitPlacement unitType="fighter" territory="Yunnan" quantity="1" owner="Chinese"/>
-						
+
+                        <!-- British Unit Placements -->
+                        <unitPlacement unitType="aaGun" territory="Australia" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Australia" quantity="3" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="Australia" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Eastern Canada" quantity="2" owner="British"/>
+                        <unitPlacement unitType="armour" territory="Eastern Canada" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Egypt" quantity="3" owner="British"/>
+
+                        <unitPlacement unitType="armour" territory="Egypt" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="Egypt" quantity="1" owner="British"/>
+                        <unitPlacement unitType="aaGun" territory="India" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="India" quantity="3" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="New Zealand" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Persia" quantity="1" owner="British"/>
+
+                        <unitPlacement unitType="infantry" territory="Trans-Jordan" quantity="1" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="Trans-Jordan" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Union of South Africa" quantity="1" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="Union of South Africa" quantity="1" owner="British"/>
+                        <unitPlacement unitType="factory" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="aaGun" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="United Kingdom" quantity="2" owner="British"/>
+                        <unitPlacement unitType="artillery" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="armour" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="United Kingdom" quantity="2" owner="British"/>
+                        <unitPlacement unitType="bomber" territory="United Kingdom" quantity="1" owner="British"/>
+                        <unitPlacement unitType="infantry" territory="Western Canada" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="1 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="cruiser" territory="1 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="2 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="2 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="battleship" territory="2 Sea Zone" quantity="1" owner="British"/>
+
+
+
+                        <unitPlacement unitType="cruiser" territory="12 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="12 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="15 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="27 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="transport" territory="35 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="destroyer" territory="35 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="fighter" territory="35 Sea Zone" quantity="1" owner="British"/>
+                        <unitPlacement unitType="carrier" territory="35 Sea Zone" quantity="1" owner="British"/>
+
+                        <!-- Italian Unit Placements -->
+                        <unitPlacement unitType="factory" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="aaGun" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="armour" territory="Italy" quantity="2" owner="Italians"/>
+                        <unitPlacement unitType="fighter" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="Italy" quantity="2" owner="Italians"/>
+                        <unitPlacement unitType="artillery" territory="Italy" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="Libya" quantity="2" owner="Italians"/>
+                        <unitPlacement unitType="infantry" territory="Balkans" quantity="2" owner="Italians"/>
+                        <unitPlacement unitType="armour" territory="Balkans" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="transport" territory="14 Sea Zone" quantity="1" owner="Italians"/>
+                        <unitPlacement unitType="cruiser" territory="14 Sea Zone" quantity="2" owner="Italians"/>
+                        <unitPlacement unitType="battleship" territory="14 Sea Zone" quantity="1" owner="Italians"/>
+
+                        <!-- US Chinese Placements -->
+                        <unitPlacement unitType="infantry" territory="Chinghai" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Fukien" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Hupeh" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Ningxia" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Sikang" quantity="1" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Suiyuan" quantity="2" owner="Chinese"/>
+                        <unitPlacement unitType="infantry" territory="Yunnan" quantity="2" owner="Chinese"/>
+                        <unitPlacement unitType="fighter" territory="Yunnan" quantity="1" owner="Chinese"/>
+
                         <!-- American Unit Placements -->
                         <unitPlacement unitType="infantry" territory="Alaska" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Central United States" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="factory" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="aaGun" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Eastern United States" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="artillery" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="armour" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="bomber" territory="Eastern United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Midway" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Central United States" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="factory" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="aaGun" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Eastern United States" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="artillery" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="armour" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="bomber" territory="Eastern United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Hawaiian Islands" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Hawaiian Islands" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Midway" quantity="1" owner="Americans"/>
 
 
-						<unitPlacement unitType="factory" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="aaGun" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="infantry" territory="Western United States" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="bomber" territory="Western United States" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="bomber" territory="United Kingdom" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="transport" territory="10 Sea Zone" quantity="2" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="10 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="20 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="destroyer" territory="53 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="fighter" territory="53 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="factory" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="aaGun" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="infantry" territory="Western United States" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="bomber" territory="Western United States" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="bomber" territory="United Kingdom" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="10 Sea Zone" quantity="2" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="10 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="20 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="destroyer" territory="53 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="fighter" territory="53 Sea Zone" quantity="1" owner="Americans"/>
 
 
-						<unitPlacement unitType="carrier" territory="53 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="transport" territory="56 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="submarine" territory="56 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="cruiser" territory="56 Sea Zone" quantity="1" owner="Americans"/>
-						<unitPlacement unitType="battleship" territory="56 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="carrier" territory="53 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="transport" territory="56 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="submarine" territory="56 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="cruiser" territory="56 Sea Zone" quantity="1" owner="Americans"/>
+                        <unitPlacement unitType="battleship" territory="56 Sea Zone" quantity="1" owner="Americans"/>
                 </unitInitialize>
-        
-                <resourceInitialize>                      
+
+                <resourceInitialize>
                         <resourceGiven player="Germans" resource="PUs" quantity="37"/>
                         <resourceGiven player="Russians" resource="PUs" quantity="24"/>
-						<resourceGiven player="Japanese" resource="PUs" quantity="31"/>
-						<resourceGiven player="British" resource="PUs" quantity="31"/>
-						<resourceGiven player="Italians" resource="PUs" quantity="10"/>
-						<resourceGiven player="Chinese" resource="PUs" quantity="0"/>
-						<resourceGiven player="Americans" resource="PUs" quantity="38"/>
+                        <resourceGiven player="Japanese" resource="PUs" quantity="31"/>
+                        <resourceGiven player="British" resource="PUs" quantity="31"/>
+                        <resourceGiven player="Italians" resource="PUs" quantity="10"/>
+                        <resourceGiven player="Chinese" resource="PUs" quantity="0"/>
+                        <resourceGiven player="Americans" resource="PUs" quantity="38"/>
 
 
 
@@ -2195,386 +2195,386 @@
                 </resourceInitialize>
         </initialize>
 
-		<propertyList>
-
-				<!-- OPTIONAL PROPERTIES -->
-				<!-- Bidding -->
-				<property name="Italians bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Russians bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Germans bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="British bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Japanese bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-
-				<property name="Americans bid" value="0" editable="true">
-						<number min="0" max="1000"/>
-				</property>
-				
-				<!-- victory options -->
-				<property name="Projection of Power" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Honorable Surrender" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Total Victory" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for AntiAircraft" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Technology" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="National Objectives" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Tech Development" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="LHTR Heavy Bombers" value="true" editable="true">
-				  		<boolean/>
-				</property>
-
-				<property name="Heavy Bomber Dice Rolls" value="2" editable="false">
-						<number min="2" max="3"/>
-				</property>
-
-				<property name="Always on AA" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Kamikaze Airplanes" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Super Sub Defence Bonus" value="0" editable="true">
-						<number min="0" max="1"/>
-				</property>
-
-				<property name="Units Repair Hits End Turn" value="true" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Units Repair Hits Start Turn" value="false" editable="true">
-						<boolean/>
-				</property>
-				<!-- END OF OPTIONAL PROPERTIES -->
-
-				<!-- rules and tech -->
-				<property name="WW2V3" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="WW2V3 Tech Model" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Use Shipyards" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="All Rockets Attack" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Rockets Can Fly Over Impassables" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- These require an associated value in the attachments section above-->
-				<property name="Movement By Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Production Per X Territories Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement Per Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Place in Any Territory" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unplaced units live when not placed" value ="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Occupied Territories" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- specific rules -->
-				<!-- land related -->
-				<property name="Blitz Through Factories And AA Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Roll AA Individually" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Choose AA Casualties" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="AA Territory Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- sea related -->
-				<property name="Partial Amphibious Retreat" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Shore Bombard Per Ground Unit Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Naval Bombard Casualties Return Fire" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Hari-Kari Units" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Allied Air Dependents" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Surviving Air Move To Land" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Air Attack Sub Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Ignore Transport In Movement" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Transport Casualties Restricted" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unescorted Transport Dies" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Ignore Sub In Movement" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Defending Subs Sneak Attack" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Sub Retreat Before Battle" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Submersible Subs" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- Sub Control Sea Zone Restricted should be FALSE if there are any convoy zones! -->
-				<property name="Sub Control Sea Zone Restricted" value="false" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="Subs Can End NonCombat Move With Enemies" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Previous Units Fight" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Two hit battleship" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- production related -->
-				<property name="Produce fighters on carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Produce new fighters on old carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Move existing fighters to new carriers" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Land existing fighters on new carriers" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="LHTR Carrier production rules" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Unit Placement In Enemy Seas" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Territory Turn Limit" value="false" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="maxFactoriesPerTerritory" value="1"/>
-
-				<property name="Placement Restricted By Factory" value="true" editable="false">
-						<boolean/>
-				</property>
-				
-				<property name="Raids May Be Preceeded By Air Battles" value="false" editable="true">
-						<boolean/>
-				</property>
-
-				<property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<!-- to do with neutrals -->
-				<property name="neutralCharge" value="9999999"/>
-
-				<property name="Neutrals Are Impassable" value="true" editable="false">
-						<boolean/>
-				</property>
-
-				<property name="Neutrals Are Blitzable" value="false" editable="false">
-						<boolean/>
-				</property>
-
-
-				<!-- Map Name: also used for map utils when asked -->
-				<property name="mapName" value="World War II v3 1942 Test" editable="false"/>
-
-				<!-- notes appear in the notes menu in the main screen, format as html -->
-
-		
-				<property name="notes">
-					<value>
-					<![CDATA[  						
-						1942 Starting Set-Up <br> 
-						
-
-						Credits:
-						<br>
-						Triplelk Jason Clark - baseline <br>
-						Zero Pilot Mike McCaughey - integration<br>
-						ComradeKev - custom code and rules<br>
-						Seidelin - playtesting<br>
-						<br>
-						<br>
-						<b>Technology</b><br>
-         				*** Air/Naval Tech ***<br>
-        				SUPER SUBS- subs attack at 3<br>
-        				JET POWER- fighters attack at 4<br>
-        				IMPROVED SHIPYARDS- naval units are cheaper<br>
-        				AA RADAR- AA hit on 2 or less<br>
-        				LONG RANGE AIRCRAFT- aircraft range increased by 2<br>
-        				HEAVY BOMBER- roll 2 dice for each bomber attack<br>
-        				<br>
-         				*** Land/Production Tech ***<br>
-        				IMPROVED ARTILLERY SUPPORT- artillery support 2 infantry<br>
-        				ROCKETS- AA conduct rocket attacks for 1d6 damage to production<br>
-        				PARATROOPERS- each bomber may carry 1 infantry into combat<br>
-        				INCREASED FACTORY PRODUCTION- factories produce 2 additional units, repairs 1/2 price<br>
-        				WAR BONDS- collect an 1d6 extra PUs each turn<br>
-        				MECHANIZED INFANTRY- tanks may carry 1 infantry each for 2 spaces<br>
-        				<br>
-        				<br>
-        				<b>Victory Conditions</b><br>
-        				Total Victory - 18 Victory Cities<br>
-        				Honorable Surrender - 15 Victory Cities<br>
-        				Projection of Power - 13 Victory Cities<br>
-						<br>
-        				<br>
-        				<b>National Objectives</b><br>
-        				<i>Germany: Lebensraum-</i><br>
-        				+5 PUs if Axis control France, NW Europe, Germany, Czechoslovakia, Bulgaria, and Poland.<br>
-        				+5 PUs if Axis control 3 of Baltic States, East Poland, Ukraine, East Ukrain, and Belorussia.<br>
-        				+5 PUs if Axis control Karelia or Caucasus <br>
-        				<br>
-        				<i>Japan: The Greater East Asia Coprosperity Sphere-</i><br>
-        				+5 PUs if Axis control Manchuria, Kiangsu, and French Indo China.<br>
-        				+5 PUs if Axis control 4 of Kwangtung, East Indies, Borneo, Philippine Islands, New Guinea and Solomon Islands.<br>
-        				+5 PUs if Axis control 1 of Hawaiian Islands, Australia, or India<br>
-        				<br>
-        				<i>Italy: Mare Nostrum-</i><br>
-        				+5 PUs if Axis control 3 of Egypt, Trans Jordan, France, and Gibraltar<br>
-        				+5 PUs if Axis control Italy, Balkans, Morocco and Libya AND no enemy surface ships in sea zones 13, 14, or 15.<br>
-        				<br>
-        				<i>United States: The Arsenal of Democracy-</i><br>
-        				+5 PUs if Allies control France.<br>
-        				+5 PUs if Allies control Philippine Islands.<br>
-        				+5 PUs Allies control W U.S., Central U.S., and E U.S.<br>
-        				+5 PUs if Allies control 3 of Midway, Wake Island, Hawaiian Islands, and Solomon Islands.<br>
-        				<br>
-        				<i>United Kingdom: The British Empire-</i><br>
-        				+5 PUs if Allies control any territory originally controlled by Japan.<br>
-        				+5 PUs if Allies control E Canada, W Canada, Gibraltar, Egypt, Australia and South Africa.<br>
-        				+5 PUs if Allies control France or the Balkans.<br>
-        				<br>
-        				<i>Soviet Union: The Great Patriotic War-</i><br>
-        				+5 PUs if Soviets control Archangel and no allied forces in Soviet controlled territories.<br>
-        				+10 PUs if Allies control 3 of Norway, Finland, Poland, Bulgaria, Czechoslovakia, and Balkans.<br>
-        				
-        				<br>
-						<i>China: Chinese Resistance & The Flying Tigers </i><br>
-        				+1 infantry for every two territories controlled by China at the beginning of her turn.  These infantry must be place in a territory with less than three Chinese pieces.  <br>
-        				No Chinese Units, including the Chinese Fighter may leave Chinese territory (except for Kwangtung) (this means no entering sea zones). <br>  
-        				
-        				
-        
-					]]>	
-					</value>
-				</property>
-				
+        <propertyList>
+
+                <!-- OPTIONAL PROPERTIES -->
+                <!-- Bidding -->
+                <property name="Italians bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Russians bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Germans bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="British bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Japanese bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <property name="Americans bid" value="0" editable="true">
+                        <number min="0" max="1000"/>
+                </property>
+
+                <!-- victory options -->
+                <property name="Projection of Power" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Honorable Surrender" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Total Victory" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for AntiAircraft" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Technology" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="National Objectives" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Tech Development" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="LHTR Heavy Bombers" value="true" editable="true">
+                          <boolean/>
+                </property>
+
+                <property name="Heavy Bomber Dice Rolls" value="2" editable="false">
+                        <number min="2" max="3"/>
+                </property>
+
+                <property name="Always on AA" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Kamikaze Airplanes" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Super Sub Defence Bonus" value="0" editable="true">
+                        <number min="0" max="1"/>
+                </property>
+
+                <property name="Units Repair Hits End Turn" value="true" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Units Repair Hits Start Turn" value="false" editable="true">
+                        <boolean/>
+                </property>
+                <!-- END OF OPTIONAL PROPERTIES -->
+
+                <!-- rules and tech -->
+                <property name="WW2V3" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="WW2V3 Tech Model" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Use Shipyards" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="All Rockets Attack" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Rockets Can Fly Over Impassables" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- These require an associated value in the attachments section above-->
+                <property name="Movement By Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Production Per X Territories Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement Per Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Place in Any Territory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unplaced units live when not placed" value ="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Occupied Territories" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- specific rules -->
+                <!-- land related -->
+                <property name="Blitz Through Factories And AA Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Roll AA Individually" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Choose AA Casualties" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="AA Territory Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- sea related -->
+                <property name="Partial Amphibious Retreat" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Shore Bombard Per Ground Unit Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Naval Bombard Casualties Return Fire" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Hari-Kari Units" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Allied Air Dependents" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Surviving Air Move To Land" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Air Attack Sub Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Ignore Transport In Movement" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Transport Casualties Restricted" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unescorted Transport Dies" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Ignore Sub In Movement" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Defending Subs Sneak Attack" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Sub Retreat Before Battle" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Submersible Subs" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- Sub Control Sea Zone Restricted should be FALSE if there are any convoy zones! -->
+                <property name="Sub Control Sea Zone Restricted" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Subs Can End NonCombat Move With Enemies" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Previous Units Fight" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Two hit battleship" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- production related -->
+                <property name="Produce fighters on carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Produce new fighters on old carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Move existing fighters to new carriers" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Land existing fighters on new carriers" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="LHTR Carrier production rules" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Unit Placement In Enemy Seas" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Territory Turn Limit" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="maxFactoriesPerTerritory" value="1"/>
+
+                <property name="Placement Restricted By Factory" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Raids May Be Preceeded By Air Battles" value="false" editable="true">
+                        <boolean/>
+                </property>
+
+                <property name="Damage From Bombing Done To Units Instead Of Territories" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <!-- to do with neutrals -->
+                <property name="neutralCharge" value="9999999"/>
+
+                <property name="Neutrals Are Impassable" value="true" editable="false">
+                        <boolean/>
+                </property>
+
+                <property name="Neutrals Are Blitzable" value="false" editable="false">
+                        <boolean/>
+                </property>
+
+
+                <!-- Map Name: also used for map utils when asked -->
+                <property name="mapName" value="World War II v3 1942 Test" editable="false"/>
+
+                <!-- notes appear in the notes menu in the main screen, format as html -->
+
+
+                <property name="notes">
+                    <value>
+                    <![CDATA[
+                        1942 Starting Set-Up <br>
+
+
+                        Credits:
+                        <br>
+                        Triplelk Jason Clark - baseline <br>
+                        Zero Pilot Mike McCaughey - integration<br>
+                        ComradeKev - custom code and rules<br>
+                        Seidelin - playtesting<br>
+                        <br>
+                        <br>
+                        <b>Technology</b><br>
+                         *** Air/Naval Tech ***<br>
+                        SUPER SUBS- subs attack at 3<br>
+                        JET POWER- fighters attack at 4<br>
+                        IMPROVED SHIPYARDS- naval units are cheaper<br>
+                        AA RADAR- AA hit on 2 or less<br>
+                        LONG RANGE AIRCRAFT- aircraft range increased by 2<br>
+                        HEAVY BOMBER- roll 2 dice for each bomber attack<br>
+                        <br>
+                         *** Land/Production Tech ***<br>
+                        IMPROVED ARTILLERY SUPPORT- artillery support 2 infantry<br>
+                        ROCKETS- AA conduct rocket attacks for 1d6 damage to production<br>
+                        PARATROOPERS- each bomber may carry 1 infantry into combat<br>
+                        INCREASED FACTORY PRODUCTION- factories produce 2 additional units, repairs 1/2 price<br>
+                        WAR BONDS- collect an 1d6 extra PUs each turn<br>
+                        MECHANIZED INFANTRY- tanks may carry 1 infantry each for 2 spaces<br>
+                        <br>
+                        <br>
+                        <b>Victory Conditions</b><br>
+                        Total Victory - 18 Victory Cities<br>
+                        Honorable Surrender - 15 Victory Cities<br>
+                        Projection of Power - 13 Victory Cities<br>
+                        <br>
+                        <br>
+                        <b>National Objectives</b><br>
+                        <i>Germany: Lebensraum-</i><br>
+                        +5 PUs if Axis control France, NW Europe, Germany, Czechoslovakia, Bulgaria, and Poland.<br>
+                        +5 PUs if Axis control 3 of Baltic States, East Poland, Ukraine, East Ukrain, and Belorussia.<br>
+                        +5 PUs if Axis control Karelia or Caucasus <br>
+                        <br>
+                        <i>Japan: The Greater East Asia Coprosperity Sphere-</i><br>
+                        +5 PUs if Axis control Manchuria, Kiangsu, and French Indo China.<br>
+                        +5 PUs if Axis control 4 of Kwangtung, East Indies, Borneo, Philippine Islands, New Guinea and Solomon Islands.<br>
+                        +5 PUs if Axis control 1 of Hawaiian Islands, Australia, or India<br>
+                        <br>
+                        <i>Italy: Mare Nostrum-</i><br>
+                        +5 PUs if Axis control 3 of Egypt, Trans Jordan, France, and Gibraltar<br>
+                        +5 PUs if Axis control Italy, Balkans, Morocco and Libya AND no enemy surface ships in sea zones 13, 14, or 15.<br>
+                        <br>
+                        <i>United States: The Arsenal of Democracy-</i><br>
+                        +5 PUs if Allies control France.<br>
+                        +5 PUs if Allies control Philippine Islands.<br>
+                        +5 PUs Allies control W U.S., Central U.S., and E U.S.<br>
+                        +5 PUs if Allies control 3 of Midway, Wake Island, Hawaiian Islands, and Solomon Islands.<br>
+                        <br>
+                        <i>United Kingdom: The British Empire-</i><br>
+                        +5 PUs if Allies control any territory originally controlled by Japan.<br>
+                        +5 PUs if Allies control E Canada, W Canada, Gibraltar, Egypt, Australia and South Africa.<br>
+                        +5 PUs if Allies control France or the Balkans.<br>
+                        <br>
+                        <i>Soviet Union: The Great Patriotic War-</i><br>
+                        +5 PUs if Soviets control Archangel and no allied forces in Soviet controlled territories.<br>
+                        +10 PUs if Allies control 3 of Norway, Finland, Poland, Bulgaria, Czechoslovakia, and Balkans.<br>
+
+                        <br>
+                        <i>China: Chinese Resistance & The Flying Tigers </i><br>
+                        +1 infantry for every two territories controlled by China at the beginning of her turn.  These infantry must be place in a territory with less than three Chinese pieces.  <br>
+                        No Chinese Units, including the Chinese Fighter may leave Chinese territory (except for Kwangtung) (this means no entering sea zones). <br>
+
+
+
+                    ]]>
+                    </value>
+                </property>
+
 
         </propertyList>
 </game>
-						<!-- 
-						WW2V2 XML by Zero Pilot 9.08
-						Triplelk Jason Clark - baseline
-						Zero Pilot Mike McCaughey - integration
-						ComradeKev - custom code and rules
-						Seidelin - playtesting
-						Veqryn - Minor updates for engine 1.2.5.x, and again for engine 1.3.x.x
-						-->
+                        <!--
+                        WW2V2 XML by Zero Pilot 9.08
+                        Triplelk Jason Clark - baseline
+                        Zero Pilot Mike McCaughey - integration
+                        ComradeKev - custom code and rules
+                        Seidelin - playtesting
+                        Veqryn - Minor updates for engine 1.2.5.x, and again for engine 1.3.x.x
+                        -->


### PR DESCRIPTION
This PR fixes violations of the `FileTabCharacter` Checkstyle rule.  It was another class of low-hanging fruit that was easy to fix and knocked out about 50% (15,570 occurrences) of the remaining Checkstyle violations.

(Note that the total violation count I provided in #1579 is not quite correct.  When running Checkstyle from Gradle, it does not process applicable files in `src/main/resources` and `src/test/resources`; whereas running it from within Eclipse does process files in these folders.  Because our Checkstyle configuration specifies that `*.properties` and `*.xml` files should be processed, I believe the Eclipse behavior is correct.  It's a small change to `build.gradle` to get consistent results between Gradle and Eclipse; I plan on submitting that change in a separate PR.)

This PR consists of **whitespace-only changes**.  Please view the diff with `?w=1` (or `&w=1` if there's already a query string) to verify.

#### Functional changes
None.

#### Refactoring changes
None.