### PR TITLE
Include resources in Checkstyle processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,14 @@ checkstyle{
 	showViolations = false
 }
 
+checkstyleMain {
+    source(sourceSets.main.output.resourcesDir)
+}
+
+checkstyleTest {
+    source(sourceSets.test.output.resourcesDir)
+}
+
 jar {
 	manifest {
 		attributes 'Main-Class': mainClassName, 'TripleA-Version': version


### PR DESCRIPTION
The Gradle Checkstyle plugin only processes sources in `<sourceSet>.allJava` by default.  Our Checkstyle configuration specifies that `*.properties` and `*.xml` files should be analyzed, in addition to `*.java` files.  Because these types of files are stored under `src/main/resources` and `src/test/resources`, these folders should be included when the appropriate Checkstyle task is run from Gradle.

(Note that the Eclipse Checkstyle plugin includes all source folders for analysis.  Thus, there is precedent for including resources in Checkstyle processing.)

#### Functional changes
None.

#### Refactoring changes
None.

#### Other changes
* The Gradle `checkstyleMain` and `checkstyleTest` tasks were updated to include the corresponding resource folder for the associated source set.  Note that the `Checkstyle#source()` method _adds_ additional sources; it does not overwrite existing sources, so that the original Java source folders are still processed.

#### Other issues for review
* I believe it's sufficient to only update the Checkstyle task configuration with respect to sources (via `source()`).  I don't think it's necessary to also update the `classpath` property, as its default value is `<sourceSet>.output`, which should include both `build/classes/<sourceSet>` and `build/resources/<sourceSet>`.  Gradle ninjas, please correct me if I'm wrong.

#### Testing
I verified that the Checkstyle reports for both the `main` and `test` source sets contain files from `src/main/resources` and `src/test/resources`, respectively.  `src/test/resources` already includes processable (`*.xml`) files.  However, `src/main/resources` includes neither `*.properties` nor `*.xml` files, so I had to temporarily add one locally in order to verify Checkstyle picked it up.