### PR TITLE
Fix tutorial map not found error (#1567)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ before_deploy:
 - ENGINE_VERSION=$(grep "engine_version" $GAME_CONFIG | sed 's/.*= *//g')
 - export TAGGED_VERSION="$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER"
 - sed -i "s/engine_version.*/engine_version = $TAGGED_VERSION/" $GAME_CONFIG
-## Download tutorial map
-- wget https://github.com/triplea-maps/tutorial/releases/download/0.125/tutorial.zip
 ## Run the gradle release build process - creates the installers
 - ./gradlew --no-daemon release
 ### Debug, show the artifacts that have been built

--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ task generateInstallers(type: Install4jTask, dependsOn: [renameShadowJar, copyJR
 task setRunnableLinux(dependsOn: [generateInstallers]) {
 	doLast {
 		def linuxFile = "TripleA_${version}_unix.sh"
-		ant.chmod(dir: "$buildDir/releases", perm: "0755", includes: linuxFile)
+		ant.chmod(dir: "$buildDir/releases", perm: '+x', includes: linuxFile)
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import de.undercouch.gradle.tasks.download.Download
+
 buildscript {
 	repositories {
 		maven { url 'http://maven.ej-technologies.com/repository' }
@@ -14,12 +16,17 @@ plugins {
 	id 'com.github.ben-manes.versions' version '0.12.0'
 	id 'com.github.johnrengelman.shadow' version '1.2.3'
 	id "de.qaware.seu.as.code.git" version "2.2.0"
+	id 'de.undercouch.download' version '3.2.0'
 }
 
 version = System.getenv("TAGGED_VERSION") ?: ""
 group = 'triplea'
 description = 'TripleA is a free online turn based strategy game and board game engine, similar to such board games as Axis & Allies or Risk.'
 mainClassName = "games.strategy.engine.framework.GameRunner"
+
+ext {
+    mapsDir = file("$buildDir/maps")
+}
 
 compileJava {
     options.encoding = 'UTF-8'
@@ -106,7 +113,19 @@ task renameShadowJar(type: Copy, group: 'release', dependsOn: [shadowJar]) {
 task updateAssets(dependsOn: ['gitCloneAssets', 'gitPullAssets']) {
 }
 
-task allPlatform(type: Zip, group: 'release', dependsOn: [renameShadowJar, updateAssets]) {
+task downloadMaps(type: Download) {
+    src([
+        'https://github.com/triplea-maps/tutorial/releases/download/0.125/tutorial.zip'
+    ])
+    dest mapsDir
+    onlyIfNewer true
+
+    doFirst {
+        mapsDir.mkdirs()
+    }
+}
+
+task allPlatform(type: Zip, group: 'release', dependsOn: [renameShadowJar, updateAssets, downloadMaps]) {
 	classifier 'all_platforms'
 	['assets', 'dice_servers', 'maps', 'old'].each { folder ->
 		from(folder) {
@@ -162,7 +181,7 @@ task generateInstallers(type: Install4jTask, dependsOn: [renameShadowJar, copyJR
 
 task setRunnableLinux(dependsOn: [generateInstallers]) {
 	doLast {
-		def linuxFile = "triplea_unix_${project.version}.sh"
+		def linuxFile = "TripleA_${version}_unix.sh"
 		ant.chmod(dir: "$buildDir/releases", perm: "0755", includes: linuxFile)
 	}
 }

--- a/build.install4j
+++ b/build.install4j
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <install4j version="6.1.2" transformSequenceNumber="5">
-  <directoryPresets config="tutorial.zip" />
+  <directoryPresets config="./game_engine.properties" />
   <application name="TripleA_${compiler:sys.version}" distributionSourceDir="" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.shortName}_${compiler:sys.platform}" compression="6" lzmaCompression="false" pack200Compression="false" excludeSignedFromPacking="true" commonExternalFiles="false" createMd5Sums="true" shrinkRuntime="true" shortName="TripleA_${compiler:sys.version}" publisher="TripleA Developer Team" publisherWeb="triplea-game.github.io" version="${compiler:sys.version}" allPathsRelative="true" backupOnSave="false" autoSave="true" convertDotsToUnderscores="false" macSignature="????" macVolumeId="af9346379363d40e" javaMinVersion="1.8" javaMaxVersion="" allowBetaVM="true" jdkMode="jdk" jdkName="">
     <languages skipLanguageSelection="false" languageSelectionInPrincipalLanguage="false">
       <principalLanguage id="en" customLocalizationFile="" />
@@ -17,7 +17,9 @@
   </application>
   <files keepModificationTimes="false" missingFilesStrategy="warn" globalExcludeSuffixes="" defaultOverwriteMode="4" defaultUninstallMode="0" launcherOverwriteMode="3" defaultFileMode="644" defaultDirMode="755">
     <filesets />
-    <roots />
+    <roots>
+      <root id="171" fileset="" location="${installer:sys.userHome}" />
+    </roots>
     <mountPoints>
       <mountPoint id="28" root="" location="assets" mode="755" />
       <mountPoint id="23" root="" location="bin" mode="755" />
@@ -25,6 +27,8 @@
       <mountPoint id="26" root="" location="icons" mode="755" />
       <mountPoint id="25" root="" location="old" mode="755" />
       <mountPoint id="22" root="" location="" mode="755" />
+      <mountPoint id="172" root="171" location="triplea" mode="755" />
+      <mountPoint id="173" root="171" location="triplea/downloadedMaps" mode="755" />
     </mountPoints>
     <entries>
       <dirEntry mountPoint="28" file="assets" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="assets" excludeSuffixes="" dirMode="755" overrideDirMode="false">
@@ -41,7 +45,9 @@
         <exclude />
       </dirEntry>
       <fileEntry mountPoint="22" file="./game_engine.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
-      <fileEntry mountPoint="22" file="tutorial.zip" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
+      <dirEntry mountPoint="173" file="build/maps" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="" excludeSuffixes="" dirMode="755" overrideDirMode="false">
+        <exclude />
+      </dirEntry>
     </entries>
     <components />
   </files>

--- a/build.install4j
+++ b/build.install4j
@@ -18,7 +18,7 @@
   <files keepModificationTimes="false" missingFilesStrategy="warn" globalExcludeSuffixes="" defaultOverwriteMode="4" defaultUninstallMode="0" launcherOverwriteMode="3" defaultFileMode="644" defaultDirMode="755">
     <filesets />
     <roots>
-      <root id="171" fileset="" location="${installer:sys.userHome}" />
+      <root id="171" fileset="" location="${installer:userMapsDir}" />
     </roots>
     <mountPoints>
       <mountPoint id="28" root="" location="assets" mode="755" />
@@ -27,8 +27,7 @@
       <mountPoint id="26" root="" location="icons" mode="755" />
       <mountPoint id="25" root="" location="old" mode="755" />
       <mountPoint id="22" root="" location="" mode="755" />
-      <mountPoint id="172" root="171" location="triplea" mode="755" />
-      <mountPoint id="173" root="171" location="triplea/downloadedMaps" mode="755" />
+      <mountPoint id="232" root="171" location="" mode="755" />
     </mountPoints>
     <entries>
       <dirEntry mountPoint="28" file="assets" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="assets" excludeSuffixes="" dirMode="755" overrideDirMode="false">
@@ -45,7 +44,7 @@
         <exclude />
       </dirEntry>
       <fileEntry mountPoint="22" file="./game_engine.properties" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
-      <dirEntry mountPoint="173" file="build/maps" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="" excludeSuffixes="" dirMode="755" overrideDirMode="false">
+      <dirEntry mountPoint="232" file="build/maps" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
     </entries>
@@ -155,7 +154,9 @@
           </java>
         </serializedBean>
         <launcherIds />
-        <variables />
+        <variables>
+          <variable name="userMapsDir" value="" description="The directory in which user maps are stored." category="" valueClass="string" registerForResponseFile="false" responseFileComment="" hidden="false" />
+        </variables>
         <startup>
           <screen name="" id="1" customizedId="" beanClass="com.install4j.runtime.beans.screens.StartupScreen" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" backButton="2" finishScreen="false" wizardIndexChangeType="unchanged" wizardIndexKey="">
             <serializedBean>
@@ -303,7 +304,13 @@
             </serializedBean>
             <condition />
             <validation />
-            <preActivation />
+            <preActivation>import java.util.prefs.Preferences;
+
+final Preferences tripleaSettings = Preferences.userRoot().node("/games/strategy/triplea/settings");
+final String defaultUserMapsDir = "${installer:sys.userHome}/triplea/downloadedMaps";
+final String userMapsDir = tripleaSettings.get("USER_MAPS_FOLDER_PATH", defaultUserMapsDir);
+context.setVariable("userMapsDir", userMapsDir);
+</preActivation>
             <postActivation />
             <actions>
               <action name="" id="96" customizedId="" beanClass="com.install4j.runtime.beans.actions.UninstallPreviousAction" enabled="true" commentSet="false" comment="" actionElevationType="none" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">


### PR DESCRIPTION
This PR fixes the `MapNotFoundException` raised when attempting to select the Tutorial map.

The preferred solution discussed in #1567 was implemented: to place the tutorial in the user maps folder during installation.  If the user has explicitly defined a maps folder in their settings, the installer will use it.  Otherwise, it will use the default user maps folder (`~/triplea/downloadedMaps` on *NIX; `%USERPROFILE%\triplea\downloadedMaps` on Windows).  As with prior releases, the Tutorial map is only available through use of one of the platform installers.  If using a zipped release (e.g. `triplea-1.9.0.0.*-all_platforms.zip`), the Tutorial map must be downloaded and installed manually.

I plan on submitting a separate PR to remove all references to the deprecated `maps` folder, as confirmed [here](https://github.com/triplea-game/triplea/issues/1567#issuecomment-287519293).

#### Functional changes
None.

#### Refactoring changes
None.

#### Other changes
* The installer was changed to install the Tutorial map to the user maps folder.
* Downloading the Tutorial map during the build is now performed via a Gradle task rather than as a shell command in the Travis build script.  I did this to make running the `release` task as consistent as possible when building either locally or from Travis.
* I fixed the `setRunnableLinux` task, which was broken due to use of the wrong Unix installer name.  I tried to see if there was a way to get install4j to create the Unix installer with the executable bit already set so that the file name wouldn't have to be duplicated in the Gradle build script, but I was unable to find a way to do this.

#### Other issues for review
* I introduced a new Gradle plugin: `de.undercouch.download`.  Please advise if introducing such a dependency requires further discussion.
* I wasn't sure where the best place was to initialize the new installer variable `userMapsDir`.  I wanted to initialize it in the pre-activation script for `InstallationDirectoryScreen`, but that screen may not be displayed during a quiet upgrade.  The install4j docs weren't clear if the pre-activation script still gets run even if the screen isn't displayed (and I was too lazy to run through an upgrade scenario).  I ended up initializing it at the latest possible time: in the pre-activation script for `InstallationScreen`, which is always displayed.

#### Testing
I created a separate [branch](https://github.com/ssoloff/triplea/tree/issue-1567-deployment-branch) in order to run the deploy phase of the Travis build (slightly tweaked so it will work from my fork).  The artifacts from this branch are available [here](https://github.com/ssoloff/triplea/releases).  I tested [build 1.9.0.0.112](https://github.com/ssoloff/triplea/releases/tag/1.9.0.0.112) for the Unix, Windows x86, and Windows x64 platforms and verified:

* the Tutorial map was installed to the user maps folder (both with an explicit user maps folder set from a previous install via the engine settings and the default user maps folder when the setting is absent);
* I could start TripleA, select the Tutorial map, and start a new game;
* uninstalling TripleA removed the Tutorial map from the user maps folder (both with an explicit user maps folder and the default user maps folder).

:warning: **I am unable to test the [macOS release](https://github.com/ssoloff/triplea/releases/download/1.9.0.0.108/TripleA_1.9.0.0.108_macos.dmg).**  I would appreciate it if someone could test this platform before merging, if possible.