### PR TITLE
Add missing curly braces around compound statements

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -167,9 +167,10 @@ public class GameStepPropertiesHelper {
         final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_repairUnits);
         if (prop != null) {
           isRepairUnits = Boolean.parseBoolean(prop);
-        } else
+        } else {
           isRepairUnits = (isCombatDelegate(data) && repairAtStartAndOnlyOwn)
             || (data.getSequence().getStep().getName().endsWith("EndTurn") && repairAtEndAndAll);
+        }
       }
     } finally {
       data.releaseReadLock();
@@ -211,8 +212,9 @@ public class GameStepPropertiesHelper {
       } else if (data.getSequence().getStep().getDelegate() != null
         && NoAirCheckPlaceDelegate.class.equals(data.getSequence().getStep().getDelegate().getClass())) {
         isRemoveAir = false;
-      } else
+      } else {
         isRemoveAir = isNonCombatDelegate(data) || data.getSequence().getStep().getName().endsWith("Place");
+      }
     } finally {
       data.releaseReadLock();
     }
@@ -298,8 +300,9 @@ public class GameStepPropertiesHelper {
       final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_bid);
       if (prop != null) {
         isBid = Boolean.parseBoolean(prop);
-      } else
+      } else {
         isBid = isBidPurchaseDelegate(data) || isBidPlaceDelegate(data);
+      }
     } finally {
       data.releaseReadLock();
     }


### PR DESCRIPTION
This PR simply adds curly braces that were missing around some compound statements.  It looks like they were unintentionally removed by an automated refactoring in ff3c95e after being manually added in the prior commit 6a782c9.