### PR TITLE
Remove references to legacy maps folder

### DIFF
--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/AvailableGames.java
@@ -25,7 +25,6 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
-import games.strategy.engine.framework.ui.NewGameChooserModel;
 import games.strategy.triplea.Constants;
 import games.strategy.util.UrlStreams;
 
@@ -58,12 +57,19 @@ public class AvailableGames {
     return getGameDataFromXML(m_availableGames.get(gameName));
   }
 
-  public URI getGameURI(final String gameName) {
-    return m_availableGames.get(gameName);
-  }
-
+  /**
+   * Returns the path to the file associated with the specified game.
+   *
+   * <p>
+   * The "path" is actually a URI in string form.
+   * </p>
+   *
+   * @param gameName The name of the game whose file path is to be retrieved; may be {@code null}.
+   *
+   * @return The path to the game file; or {@code null} if the game is not available.
+   */
   public String getGameFilePath(final String gameName) {
-    return getGameXMLLocation(m_availableGames.get(gameName));
+    return Optional.ofNullable(m_availableGames.get(gameName)).map(Object::toString).orElse(null);
   }
 
   private static void populateAvailableGames(final Map<String, URI> availableGames,
@@ -81,9 +87,7 @@ public class AvailableGames {
 
   private static List<File> allMapFiles() {
     final List<File> rVal = new ArrayList<>();
-    // prioritize user maps folder over root folder
     rVal.addAll(safeListFiles(ClientFileSystemHelper.getUserMapsFolder()));
-    rVal.addAll(safeListFiles(NewGameChooserModel.getDefaultMapsDir()));
     return rVal;
   }
 
@@ -169,21 +173,6 @@ public class AvailableGames {
       }
     }
     return false;
-  }
-
-  private static String getGameXMLLocation(final URI uri) {
-    if (uri == null) {
-      return null;
-    }
-    final String raw = uri.toString();
-    final String base = ClientFileSystemHelper.getRootFolder().toURI().toString() + "maps";
-    if (raw.startsWith(base)) {
-      return raw.substring(base.length());
-    }
-    if (raw.startsWith("jar:" + base)) {
-      return raw.substring("jar:".length() + base.length());
-    }
-    return raw;
   }
 
   private static GameData getGameDataFromXML(final URI uri) {

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -11,7 +11,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.triplea.settings.SystemPreferenceKey;
 import games.strategy.triplea.settings.SystemPreferences;
 import games.strategy.ui.SwingComponents;
@@ -76,10 +75,7 @@ public class MapDownloadController {
 
     for (final DownloadFileDescription d : gamesDownloadFileDescriptions) {
       if (d != null) {
-        File installed = new File(ClientFileSystemHelper.getUserMapsFolder(), d.getMapName() + ".zip");
-        if (!installed.exists()) {
-          installed = new File(GameSelectorModel.DEFAULT_MAP_DIRECTORY, d.getMapName() + ".zip");
-        }
+        final File installed = new File(ClientFileSystemHelper.getUserMapsFolder(), d.getMapName() + ".zip");
         if (installed.exists()) {
           if (d.getVersion() != null && d.getVersion().isGreaterThan(DownloadMapsWindow.getVersion(installed), true)) {
             listingToBeAddedTo.add(d.getMapName());

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -30,8 +30,6 @@ public class GameSelectorModel extends Observable {
    * Example: returns "games" which would be the games folder of "triplea/maps/someMapFooBar/games"
    */
   public static final String DEFAULT_GAME_XML_DIRECTORY_NAME = "games";
-  /** Returns the folder where maps are held, example: "/maps" */
-  public static final File DEFAULT_MAP_DIRECTORY = new File(ClientFileSystemHelper.getRootFolder(), "maps");
   private static final String DEFAULT_GAME_NAME_PREF = "DefaultGameName2";
   private static final String DEFAULT_GAME_NAME = "Big World : 1942";
   private static final String DEFAULT_GAME_URI_PREF = "DefaultGameURI";
@@ -290,9 +288,8 @@ public class GameSelectorModel extends Observable {
     // version of triplea
     // was using running a game within its root folder, we shouldn't open it)
     final String user = ClientFileSystemHelper.getUserRootFolder().toURI().toString();
-    final String root = ClientFileSystemHelper.getRootFolder().toURI().toString();
     if (!forceFactoryDefault && userPreferredDefaultGameURI != null && userPreferredDefaultGameURI.length() > 0
-        && (userPreferredDefaultGameURI.contains(root) || userPreferredDefaultGameURI.contains(user))) {
+        && userPreferredDefaultGameURI.contains(user)) {
       // if the user has a preferred URI, then we load it, and don't bother parsing or doing anything with the whole
       // game model list
       try {

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -11,7 +11,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import games.strategy.debug.ClientLogger;
-import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
@@ -150,16 +149,17 @@ public class NewGameChooserEntry {
     return url;
   }
 
+  /**
+   * Returns the location of the game file.
+   *
+   * <p>
+   * The "location" is actually a URI in string form.
+   * </p>
+   *
+   * @return The location of the game file; never {@code null}.
+   */
   public String getLocation() {
-    final String raw = url.toString();
-    final String base = ClientFileSystemHelper.getRootFolder().toURI().toString() + "maps";
-    if (raw.startsWith(base)) {
-      return raw.substring(base.length());
-    }
-    if (raw.startsWith("jar:" + base)) {
-      return raw.substring("jar:".length() + base.length());
-    }
-    return raw;
+    return url.toString();
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -56,15 +56,9 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
     return super.get(i);
   }
 
-  public static File getDefaultMapsDir() {
-    return ClientFileSystemHelper.getRootFolder();
-  }
-
   private static List<File> allMapFiles() {
     final List<File> rVal = new ArrayList<>();
-    // prioritize user maps folder over root folder
     rVal.addAll(safeListFiles(ClientFileSystemHelper.getUserMapsFolder()));
-    rVal.addAll(safeListFiles(getDefaultMapsDir()));
     return rVal;
   }
 

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -92,8 +92,6 @@ public class ResourceLoader implements Closeable {
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), dirName + File.separator + "map"));
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), dirName));
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), zipName));
-    candidates.add(new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps", dirName));
-    candidates.add(new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps", zipName));
 
     final String normalizedZipName = normalizeMapZipName(zipName);
 

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -81,13 +81,8 @@ public class AutoPlacementFinder {
       System.out.println("Shutting down");
       System.exit(0);
     }
-    File file = new File(
+    final File file = new File(
         ClientFileSystemHelper.getUserMapsFolder() + File.separator + mapDir + File.separator + "map.properties");
-    if (!file.exists()) {
-      file = new File(
-          ClientFileSystemHelper.getRootFolder() + File.separator + "maps" + File.separator + mapDir + File.separator
-              + "map.properties");
-    }
     if (file.exists() && s_mapFolderLocation == null) {
       s_mapFolderLocation = file.getParentFile();
     }

--- a/src/main/java/tools/map/xml/creator/MapXmlCreator.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlCreator.java
@@ -22,7 +22,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
@@ -63,6 +62,7 @@ import javax.xml.transform.stream.StreamResult;
 import org.xml.sax.SAXException;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameParser;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
@@ -355,12 +355,8 @@ public class MapXmlCreator extends JFrame {
         + File.separator + "games" + File.separator + "new_world_order.xml");
   }
 
-  /**
-   * @return
-   */
-  public File getDefaultMapFolderLocation() {
-    // return new File(ClientFileSystemHelper.getRootFolder() + File.separator + "maps");
-    return new File(Paths.get("." + File.separator + "maps").toAbsolutePath().normalize().toString());
+  private static File getDefaultMapFolderLocation() {
+    return ClientFileSystemHelper.getUserMapsFolder();
   }
 
   /**


### PR DESCRIPTION
This PR is a follow-up to #1492 and #1585.  As confirmed [here](https://github.com/triplea-game/triplea/issues/1567#issuecomment-287519293), the legacy maps folder (i.e. `<rootDir>/maps`) is now deprecated.  This PR removes all references to that folder from the code in preference of the user maps folder, which is now the single source for maps to the engine.

#### Functional changes
* Removed all references to the legacy maps folder.

#### Function issues for review
None.

#### Refactoring changes
None.

#### Testing
I manually performed the following tests, which were confirmed (via breakpoint) to pass through the code changed in this PR:
* Verified that I could select a local game and start it.
* Verified that I could start a headless server, connect to it, select a game, and start it.
* Verified that the outdated maps check uses the user maps folder.  (**NOTE:**  I think there is an existing bug here related to map zip file names; I will create a separate issue to discuss it.)
* Verified that `AutoPlacementFinder` uses the user maps folder.  (**NOTE:** There is an existing bug in this code related to the map folder structure; I will create a separate issue for it.)
* Verified that `XmlMapCreator` uses the user maps folder.