### PR TITLE
Fix headless game server Eclipse launcher

### DIFF
--- a/eclipse/launchers/HeadlessGameServer_local_test.launch
+++ b/eclipse/launchers/HeadlessGameServer_local_test.launch
@@ -8,6 +8,6 @@
 <listEntry value="1"/>
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.headlessGameServer.HeadlessGameServer"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="triplea.game.host.console=true &#13;&#10;triplea.game.host.ui=true&#13;&#10;triplea.game= triplea.server=true &#13;&#10;triplea.port=3300&#13;&#10;triplea.lobby.host=127.0.0.1&#13;&#10;triplea.lobby.port=3300&#13;&#10;triplea.name=Bot1_TestServer &#13;&#10;triplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;triplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;triplea.lobby.game.comments=automated_host"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="triplea.game.host.console=true &#13;&#10;triplea.game= triplea.server=true &#13;&#10;triplea.port=3300&#13;&#10;triplea.lobby.host=127.0.0.1&#13;&#10;triplea.lobby.port=3300&#13;&#10;triplea.name=Bot1_TestServer &#13;&#10;triplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;triplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;triplea.lobby.game.comments=automated_host"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="triplea"/>
 </launchConfiguration>


### PR DESCRIPTION
This PR fixes the broken `HeadlessGameServer_local_test` Eclipse launcher.

The headless game server will not start because the `triplea.game.host.ui` property is unrecognized by the command-line argument parser.  This property appears to have been removed in c8155b0.

The issue was fixed simply by removing `triplea.game.host.ui` from the launcher argument list.