### PR TITLE
Allow invisible units

### DIFF
--- a/game_engine.properties
+++ b/game_engine.properties
@@ -1,4 +1,4 @@
-engine_version = 1.9.0.0
+engine_version = 1.9.0.2
 
 ## Map_List_File
 # URL if the value begins with http, otherwise assumed to be a file. This file lists which maps are available

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -856,7 +856,7 @@ public class UnitAttachment extends DefaultAttachment {
   public void setSpecial(final String value) throws GameParseException {
     final String[] s = value.split(":");
     for (final String option : s) {
-      if (!(option.equals("none") || option.equals("canOnlyPlaceInOriginalTerritories"))) {
+      if (!(option.equals("none") || option.equals("canOnlyPlaceInOriginalTerritories") || option.equals("invisible"))){
         throw new GameParseException("special does not allow: " + option + thisErrorMsg());
       }
       m_special.add(option);

--- a/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -167,9 +167,10 @@ public class GameStepPropertiesHelper {
         final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_repairUnits);
         if (prop != null) {
           isRepairUnits = Boolean.parseBoolean(prop);
-        } else
+        } else {
           isRepairUnits = (isCombatDelegate(data) && repairAtStartAndOnlyOwn)
             || (data.getSequence().getStep().getName().endsWith("EndTurn") && repairAtEndAndAll);
+        }
       }
     } finally {
       data.releaseReadLock();
@@ -211,8 +212,9 @@ public class GameStepPropertiesHelper {
       } else if (data.getSequence().getStep().getDelegate() != null
         && NoAirCheckPlaceDelegate.class.equals(data.getSequence().getStep().getDelegate().getClass())) {
         isRemoveAir = false;
-      } else
+      } else {
         isRemoveAir = isNonCombatDelegate(data) || data.getSequence().getStep().getName().endsWith("Place");
+      }
     } finally {
       data.releaseReadLock();
     }
@@ -298,8 +300,9 @@ public class GameStepPropertiesHelper {
       final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_bid);
       if (prop != null) {
         isBid = Boolean.parseBoolean(prop);
-      } else
+      } else {
         isBid = isBidPurchaseDelegate(data) || isBidPlaceDelegate(data);
+      }
     } finally {
       data.releaseReadLock();
     }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -840,6 +840,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         clearWaitingToDie(bridge);
       }
     });
+    /** Submerge subs if -vs air only & air restricted from attacking subs */
+    if (isAirAttackSubRestricted()) {
+      steps.add(new IExecutable() {
+        private static final long serialVersionUID = 99990L;
+
+        @Override
+        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+          submergeSubsVsOnlyAir(bridge);
+        }
+      });
+    }
     steps.add(new IExecutable() {
       // not compatible with 0.9.0.2 saved games. this is new for 1.2.6.0
       private static final long serialVersionUID = 6387198382888361848L;
@@ -1000,17 +1011,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private void addFightStepsNonEditMode(final List<IExecutable> steps) {
-    /** Submerge subs if -vs air only & air restricted from attacking subs */
-    if (isAirAttackSubRestricted()) {
-      steps.add(new IExecutable() {
-        private static final long serialVersionUID = 99990L;
-
-        @Override
-        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          submergeSubsVsOnlyAir(bridge);
-        }
-      });
-    }
     /** Ask to retreat defending subs before battle */
     if (isSubRetreatBeforeBattle()) {
       steps.add(new IExecutable() {

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -1824,13 +1824,13 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    */
   private void submergeSubsVsOnlyAir(final IDelegateBridge bridge) {
     // if All attackers are AIR submerge any defending subs ..m_defendingUnits.removeAll(m_killed);
-    if ( Match.allMatch(m_attackingUnits, Matches.UnitIsAir) && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
+    if (Match.allMatch(m_attackingUnits, Matches.UnitIsAir) && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
       // Get all defending subs (including allies) in the territory.
       final List<Unit> defendingSubs = Match.getMatches(m_defendingUnits, Matches.UnitIsSub);
       // submerge defending subs
       submergeUnits(defendingSubs, true, bridge);
       // checking defending air on attacking subs
-    } else if ( Match.allMatch(m_defendingUnits, Matches.UnitIsAir)
+    } else if (Match.allMatch(m_defendingUnits, Matches.UnitIsAir)
         && Match.someMatch(m_attackingUnits, Matches.UnitIsSub)) {
       // Get all attacking subs in the territory
       final List<Unit> attackingSubs = Match.getMatches(m_attackingUnits, Matches.UnitIsSub);

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -843,7 +843,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+          checkUndefendedTransports(bridge, m_attacker);
           checkUndefendedTransports(bridge, m_defender);
+          checkForUnitsThatCanRollLeft(bridge, true);
+          checkForUnitsThatCanRollLeft(bridge, false);
+          clearWaitingToDie(bridge);
         }
       });
     }
@@ -894,11 +898,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         // changed to only look at units that can be destroyed in combat, and therefore not include factories, aaguns,
         // and infrastructure.
         else if (Match.getMatches(m_defendingUnits, Matches.UnitIsNotInfrastructure).size() == 0) {
-          if (isTransportCasualtiesRestricted()) {
-            // If there are undefended attacking transports, determine if they automatically die
-            checkUndefendedTransports(bridge, m_defender);
-          }
-          checkForUnitsThatCanRollLeft(bridge, false);
           endBattle(bridge);
           attackerWins(bridge);
         } else if (shouldEndBattleDueToMaxRounds()
@@ -1836,14 +1835,13 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    */
   private void submergeSubsVsOnlyAir(final IDelegateBridge bridge) {
     // if All attackers are AIR submerge any defending subs ..m_defendingUnits.removeAll(m_killed);
-    if ( ( Match.allMatch(m_attackingUnits, Matches.UnitIsAir) || m_attackingUnits.isEmpty() )
-        && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
+    if ( Match.allMatch(m_attackingUnits, Matches.UnitIsAir) && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
       // Get all defending subs (including allies) in the territory.
       final List<Unit> defendingSubs = Match.getMatches(m_defendingUnits, Matches.UnitIsSub);
       // submerge defending subs
       submergeUnits(defendingSubs, true, bridge);
       // checking defending air on attacking subs
-    } else if ( ( Match.allMatch(m_defendingUnits, Matches.UnitIsAir) || m_defendingUnits.isEmpty() )
+    } else if ( Match.allMatch(m_defendingUnits, Matches.UnitIsAir)
         && Match.someMatch(m_attackingUnits, Matches.UnitIsSub)) {
       // Get all attacking subs in the territory
       final List<Unit> attackingSubs = Match.getMatches(m_attackingUnits, Matches.UnitIsSub);

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -833,24 +833,13 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        if( Match.someMatch( m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1) ) 
+            && Match.allMatch( m_defendingUnits, Matches.unitHasDefenseThatIsMoreThanOrEqualTo(1).invert() ) ) {
+          remove( m_defendingUnits, bridge, m_battleSite, true);
+        }
         clearWaitingToDie(bridge);
       }
     });
-    /** Remove undefended trns */
-    if (isTransportCasualtiesRestricted()) {
-      steps.add(new IExecutable() {
-        private static final long serialVersionUID = 99989L;
-
-        @Override
-        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          checkUndefendedTransports(bridge, m_attacker);
-          checkUndefendedTransports(bridge, m_defender);
-          checkForUnitsThatCanRollLeft(bridge, true);
-          checkForUnitsThatCanRollLeft(bridge, false);
-          clearWaitingToDie(bridge);
-        }
-      });
-    }
     steps.add(new IExecutable() {
       // not compatible with 0.9.0.2 saved games. this is new for 1.2.6.0
       private static final long serialVersionUID = 6387198382888361848L;

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -717,6 +717,22 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       });
     }
     if (firstRun) {
+      /** Remove undefended trns */
+      if (isTransportCasualtiesRestricted()) {
+        steps.add(new IExecutable() {
+          private static final long serialVersionUID = 99989L;
+
+          @Override
+          public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+            checkUndefendedTransports(bridge, m_defender);
+            checkUndefendedTransports(bridge, m_attacker);
+            checkForUnitsThatCanRollLeft(bridge, true);
+            checkForUnitsThatCanRollLeft(bridge, false);
+            clearWaitingToDie(bridge);
+            // ?? This appears to remove both sides undefended transports twice
+          }
+        });
+      }
       steps.add(new IExecutable() {
         private static final long serialVersionUID = -2255284529092427441L;
 
@@ -765,22 +781,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           markNoMovementLeft(bridge);
         }
       });
-      /** Remove undefended trns */
-      if (isTransportCasualtiesRestricted()) {
-        steps.add(new IExecutable() {
-          private static final long serialVersionUID = 99989L;
-
-          @Override
-          public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-            checkUndefendedTransports(bridge, m_defender);
-            checkUndefendedTransports(bridge, m_attacker);
-            checkForUnitsThatCanRollLeft(bridge, true);
-            checkForUnitsThatCanRollLeft(bridge, false);
-            clearWaitingToDie(bridge);
-            // ?? This appears to remove both sides undefended transports twice
-          }
-        });
-      }
     }
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -513,6 +513,21 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           }
         }
       }
+      // See if there any unescorted trns
+      if (m_battleSite.isWater() && isTransportCasualtiesRestricted()) {
+        if (Match.someMatch(m_attackingUnits, Matches.UnitIsTransport)
+            || Match.someMatch(m_defendingUnits, Matches.UnitIsTransport)) {
+          steps.add(REMOVE_UNESCORTED_TRANSPORTS);
+        }
+      }
+    }
+    // Air only Units can't attack subs without Destroyers present
+    if (isAirAttackSubRestricted()) {
+      final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
+      units.addAll(m_attackingUnits);
+      if (Match.someMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
+        steps.add(SUBMERGE_SUBS_VS_AIR_ONLY);
+      }
     }
     // Check if defending subs can submerge before battle
     if (isSubRetreatBeforeBattle()) {
@@ -523,13 +538,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       if (!Match.someMatch(m_attackingUnits, Matches.UnitIsDestroyer)
           && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
         steps.add(m_defender.getName() + SUBS_SUBMERGE);
-      }
-    }
-    // See if there any unescorted trns
-    if (m_battleSite.isWater() && isTransportCasualtiesRestricted()) {
-      if (Match.someMatch(m_attackingUnits, Matches.UnitIsTransport)
-          || Match.someMatch(m_defendingUnits, Matches.UnitIsTransport)) {
-        steps.add(REMOVE_UNESCORTED_TRANSPORTS);
       }
     }
     // if attacker has no sneak attack subs, then defendering sneak attack subs fire first and remove casualties
@@ -569,16 +577,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         && (returnFireAgainstDefendingSubs() != ReturnFire.ALL || returnFireAgainstAttackingSubs() != ReturnFire.ALL)) {
       steps.add(REMOVE_SNEAK_ATTACK_CASUALTIES);
     }
-    // Air only Units can't attack subs without Destroyers present
-    if (isAirAttackSubRestricted()) {
-      final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
-      units.addAll(m_attackingUnits);
-      // if(!Match.someMatch(m_attackingUnits, Matches.UnitIsDestroyer) && Match.allMatch(m_attackingUnits,
-      // Matches.UnitIsAir))
-      if (Match.someMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
-        steps.add(SUBMERGE_SUBS_VS_AIR_ONLY);
-      }
-    }
     // Air Units can't attack subs without Destroyers present
     if (m_battleSite.isWater() && isAirAttackSubRestricted()) {
       final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
@@ -611,9 +609,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final Collection<Unit> units = new ArrayList<>(m_defendingUnits.size() + m_defendingWaitingToDie.size());
       units.addAll(m_defendingUnits);
       units.addAll(m_defendingWaitingToDie);
-      // if(!Match.someMatch(m_defendingUnits, Matches.UnitIsDestroyer) && Match.someMatch(m_defendingUnits,
-      // Matches.UnitIsAir) &&
-      // Match.someMatch(m_attackingUnits, Matches.UnitIsSub))
       if (Match.someMatch(m_defendingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_attackingUnits, units)) {
         steps.add(AIR_DEFEND_NON_SUBS);
       }
@@ -646,6 +641,13 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
             steps.add(m_defender.getName() + SUBS_WITHDRAW);
           }
         }
+      }
+    }
+    // See if there any unescorted trns
+    if (m_battleSite.isWater() && isTransportCasualtiesRestricted()) {
+      if (Match.someMatch(m_attackingUnits, Matches.UnitIsTransport)
+          || Match.someMatch(m_defendingUnits, Matches.UnitIsTransport)) {
+        steps.add(REMOVE_UNESCORTED_TRANSPORTS);
       }
     }
     // if we are a sea zone, then we may not be able to retreat
@@ -763,6 +765,22 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           markNoMovementLeft(bridge);
         }
       });
+      /** Remove undefended trns */
+      if (isTransportCasualtiesRestricted()) {
+        steps.add(new IExecutable() {
+          private static final long serialVersionUID = 99989L;
+
+          @Override
+          public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+            checkUndefendedTransports(bridge, m_defender);
+            checkUndefendedTransports(bridge, m_attacker);
+            checkForUnitsThatCanRollLeft(bridge, true);
+            checkForUnitsThatCanRollLeft(bridge, false);
+            clearWaitingToDie(bridge);
+            // ?? This appears to remove both sides undefended transports twice
+          }
+        });
+      }
     }
   }
 
@@ -818,6 +836,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         clearWaitingToDie(bridge);
       }
     });
+    /** Remove undefended trns */
+    if (isTransportCasualtiesRestricted()) {
+      steps.add(new IExecutable() {
+        private static final long serialVersionUID = 99989L;
+
+        @Override
+        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+          checkUndefendedTransports(bridge, m_defender);
+        }
+      });
+    }
     steps.add(new IExecutable() {
       // not compatible with 0.9.0.2 saved games. this is new for 1.2.6.0
       private static final long serialVersionUID = 6387198382888361848L;
@@ -983,6 +1012,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private void addFightStepsNonEditMode(final List<IExecutable> steps) {
+    /** Submerge subs if -vs air only & air restricted from attacking subs */
+    if (isAirAttackSubRestricted()) {
+      steps.add(new IExecutable() {
+        private static final long serialVersionUID = 99990L;
+
+        @Override
+        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+          submergeSubsVsOnlyAir(bridge);
+        }
+      });
+    }
     /** Ask to retreat defending subs before battle */
     if (isSubRetreatBeforeBattle()) {
       steps.add(new IExecutable() {
@@ -1017,31 +1057,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         checkSuicideUnits(bridge);
       }
     });
-    /** Remove undefended trns */
-    if (isTransportCasualtiesRestricted()) {
-      steps.add(new IExecutable() {
-        private static final long serialVersionUID = 99989L;
-
-        @Override
-        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          checkUndefendedTransports(bridge, m_defender);
-          checkUndefendedTransports(bridge, m_attacker);
-          checkForUnitsThatCanRollLeft(bridge, true);
-          checkForUnitsThatCanRollLeft(bridge, false);
-        }
-      });
-    }
-    /** Submerge subs if -vs air only & air restricted from attacking subs */
-    if (isAirAttackSubRestricted()) {
-      steps.add(new IExecutable() {
-        private static final long serialVersionUID = 99990L;
-
-        @Override
-        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          submergeSubsVsOnlyAir(bridge);
-        }
-      });
-    }
     final ReturnFire returnFireAgainstAttackingSubs = returnFireAgainstAttackingSubs();
     final ReturnFire returnFireAgainstDefendingSubs = returnFireAgainstDefendingSubs();
     if (defenderSubsFireFirst()) {
@@ -1821,13 +1836,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    */
   private void submergeSubsVsOnlyAir(final IDelegateBridge bridge) {
     // if All attackers are AIR submerge any defending subs ..m_defendingUnits.removeAll(m_killed);
-    if (Match.allMatch(m_attackingUnits, Matches.UnitIsAir) && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
+    if ( ( Match.allMatch(m_attackingUnits, Matches.UnitIsAir) || m_attackingUnits.isEmpty() )
+        && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
       // Get all defending subs (including allies) in the territory.
       final List<Unit> defendingSubs = Match.getMatches(m_defendingUnits, Matches.UnitIsSub);
       // submerge defending subs
       submergeUnits(defendingSubs, true, bridge);
       // checking defending air on attacking subs
-    } else if (Match.allMatch(m_defendingUnits, Matches.UnitIsAir)
+    } else if ( ( Match.allMatch(m_defendingUnits, Matches.UnitIsAir) || m_defendingUnits.isEmpty() )
         && Match.someMatch(m_attackingUnits, Matches.UnitIsSub)) {
       // Get all attacking subs in the territory
       final List<Unit> attackingSubs = Match.getMatches(m_attackingUnits, Matches.UnitIsSub);

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -425,13 +425,18 @@ public class BattleDisplay extends JPanel {
       // if you have eliminated the impossible, whatever remains, no matter
       // how improbable, must be the truth
       // retreat
-      final RetreatComponent comp = new RetreatComponent(possible);
-      final int option = JOptionPane.showConfirmDialog(BattleDisplay.this, comp, message,
-          JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null);
-      if (option == JOptionPane.OK_OPTION) {
-        if (comp.getSelection() != null) {
-          retreatTo[0] = comp.getSelection();
-          latch.countDown();
+      if (possible.size() == 1) {
+        retreatTo[0] = possible.iterator().next();
+        latch.countDown();
+      } else {
+        final RetreatComponent comp = new RetreatComponent(possible);
+        final int option = JOptionPane.showConfirmDialog(BattleDisplay.this, comp, message,
+            JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null);
+        if (option == JOptionPane.OK_OPTION) {
+          if (comp.getSelection() != null) {
+            retreatTo[0] = comp.getSelection();
+            latch.countDown();
+          }
         }
       }
     });

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -18,6 +18,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.TripleAUnit;
+import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.image.MapImage;
@@ -78,6 +79,7 @@ public class UnitsDrawer implements IDrawable {
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
 
+    boolean invisible = false;
     // If there are too many Units at one point a black line is drawn to make clear which units belong to where
     if (overflow) {
       graphics.setColor(Color.BLACK);
@@ -90,6 +92,13 @@ public class UnitsDrawer implements IDrawable {
       throw new IllegalStateException("Type not found:" + unitType);
     }
     final PlayerID owner = data.getPlayerList().getPlayerID(playerName);
+    for (final String special : UnitAttachment.get(type).getSpecial()) {
+      invisible = special.equals("invisible");
+      if (invisible) {
+        return;
+      }
+    }
+
     final Optional<Image> img =
         uiContext.getUnitImageFactory().getImage(type, owner, data, damaged > 0 || bombingUnitDamage > 0, disabled);
 

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -1005,14 +1005,13 @@ public class WW2V3_41_Test {
     assertEquals(2, mfb.getBombardingUnits().size());
     // Show that bombard casualties can return fire
     // Note- the 3 & 2 hits below show default behavior of bombarding at attack strength
-    // 3= Battleship hitting a 4, 2=Cruiser hitting a 3, 5555=italian infantry missing on 6s, 00= british getting return
-    // fire on 1.
-    bridge.setRandomSource(new ScriptedRandomSource(2, 2, 5, 5, 5, 5, 0, 0));
+    // 2= Battleship hitting a 3, 2=Cruiser hitting a 3, 15=British infantry hitting once
+    bridge.setRandomSource(new ScriptedRandomSource(2, 2, 1, 5, 5, 5, 5, 5));
     battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
     battleDelegate(m_data).start();
     fight(battleDelegate(m_data), eg);
     // end result should be 2 italian infantry.
-    assertEquals(2, eg.getUnits().size());
+    assertEquals(3, eg.getUnits().size());
   }
 
   @Test

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -1007,7 +1007,7 @@ public class WW2V3_41_Test {
     // Note- the 3 & 2 hits below show default behavior of bombarding at attack strength
     // 3= Battleship hitting a 4, 2=Cruiser hitting a 3, 5555=italian infantry missing on 6s, 00= british getting return
     // fire on 1.
-    bridge.setRandomSource(new ScriptedRandomSource(3, 2, 5, 5, 5, 5, 0, 0));
+    bridge.setRandomSource(new ScriptedRandomSource(2, 2, 5, 5, 5, 5, 0, 0));
     battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
     battleDelegate(m_data).start();
     fight(battleDelegate(m_data), eg);


### PR DESCRIPTION
Builds on #1599 

The major reason for this is to allow a universal scramble relatively easily by putting an airstrip in every territory.