### PR TITLE
Map Name wrong + add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ local.properties
 temp_eclipse/
 classes.jar
 
+# Vi tmp files
+*~
+
 # Eclipse Core
 .project
 

--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -1811,7 +1811,7 @@
     <br>
     <br>Created by Veqryn
     <br>
-- mapName: World War II Global Redesign Testing
+- mapName: Global 1940 Redesign HouseRules
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/Global_1940_Redesign_HouseRules/archive/master.zip
   version: 1


### PR DESCRIPTION
Mismatch in redesign global repo name. Didn't know this was required to match!

Also, add files ending in ~ to .gitignore. Vim appends this to backup versions.