### PR TITLE
Fix AutoPlacementFinder map.properties path resolution

### DIFF
--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.LineNumberReader;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -81,8 +82,7 @@ public class AutoPlacementFinder {
       System.out.println("Shutting down");
       System.exit(0);
     }
-    final File file = new File(
-        ClientFileSystemHelper.getUserMapsFolder() + File.separator + mapDir + File.separator + "map.properties");
+    final File file = getMapPropertiesFile(mapDir);
     if (file.exists() && s_mapFolderLocation == null) {
       s_mapFolderLocation = file.getParentFile();
     }
@@ -247,6 +247,23 @@ public class AutoPlacementFinder {
     } else {
       return null;
     }
+  }
+
+  private static File getMapPropertiesFile(final String mapDir) {
+    final File file = getMapPropertiesFileForCurrentFolderStructure(mapDir);
+    if (file.exists()) {
+      return file;
+    }
+
+    return getMapPropertiesFileForLegacyFolderStructure(mapDir);
+  }
+
+  private static File getMapPropertiesFileForCurrentFolderStructure(final String mapDir) {
+    return new File(ClientFileSystemHelper.getUserMapsFolder(), Paths.get(mapDir, "map", "map.properties").toString());
+  }
+
+  private static File getMapPropertiesFileForLegacyFolderStructure(final String mapDir) {
+    return new File(ClientFileSystemHelper.getUserMapsFolder(), Paths.get(mapDir, "map.properties").toString());
   }
 
   private static String getUnitsScale() {


### PR DESCRIPTION
This PR fixes an issue with the `AutoPlacementFinder` tool, in which it cannot find an existing `map.properties` file for maps using the "new" (post-September 2016) folder structure.

The canonical location for map resources (including `map.properties`) was changed from `<mapRoot>` to `<mapRoot>/map` in 372f336.  This PR allows `AutoPlacementFinder` to work with either the current or legacy map folder structure.

#### Functional changes
* Modified `AutoPlacementFinder` to look for an existing `map.properties` file first in the new folder structure.  If the file does not exist, fall back to looking for it in the legacy folder structure.

#### Functional issues for review
* It may not be necessary to support both the old and new map folder structures; simply supporting the new folder structure may be sufficient.  `AutoPlacementFinder` seems to have a unique mechanism (compared to the other tools) for locating map resources based on `ClientFileSystemHelper#getUserMapsFolder()`.  In that respect, `AutoPlacementFinder` is vaguely similar to `ResourceLoader`.  And because `ResourceLoader` supports both folder structures, I chose to make `AutoPlacementFinder` do so, as well.  All other tools seem to allow the user to directly select (via a file chooser) the location of the map folder.
* The engine's knowledge about the old and new map folder structures is spread around the `ResourceLocationTracker`, `ResourceLoader`, and `NewGameChooserModel` classes.  In a misguided attempt to fix the problem described in this PR (and what turned out to be numerous other non-issues), I tried to expose this knowledge via a [public API](https://github.com/ssoloff/triplea/blob/fix-map-resource-paths/src/main/java/games/strategy/triplea/MapResources.java).  I did not submit those changes as part of this PR because it seemed like overkill to do that refactoring for what is effectively a single line change in one tool (it was much more attractive when I thought eight or nine tools required similar changes).  However, please advise if such a refactoring would be beneficial and should be included in this PR.

#### Refactoring changes
None.

#### Testing
I manually verified that `AutoPlacementFinder` can locate an existing `map.properties` file using maps with both the old and new folder structure.  I also manually verified that when such a file does not exist, `AutoPlacementFinder` continues to prompt the user to input that information via the UI.