### PR TITLE
Fight auto kills vs defenseless transports and undefended non-depende…

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -101,6 +101,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       m_needToAddBombardmentSources = false;
     }
     m_battleTracker.fightAirRaidsAndStrategicBombing(m_bridge);
+    m_battleTracker.fightDefenselessBattles(m_bridge);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -32,6 +32,8 @@ import games.strategy.net.GUID;
 import games.strategy.sound.SoundPath;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
+import games.strategy.triplea.ai.proAI.ProData;
+import games.strategy.triplea.ai.proAI.util.ProBattleUtils;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -1111,9 +1113,6 @@ public class BattleTracker implements java.io.Serializable {
   void fightAirRaidsAndStrategicBombing(final IDelegateBridge delegateBridge,
       Supplier<Collection<Territory>> pendingBattleSiteSupplier,
       BiFunction<Territory, BattleType, IBattle> pendingBattleFunction) {
-
-
-
     // First we'll fight all of the air battles (air raids)
     // Then we will have a wave of battles for the SBR. AA guns will shoot, and we'll roll for damage.
     // CAUTION: air raid battles when completed will potentially spawn new bombing raids. Would be good to refactor
@@ -1133,6 +1132,43 @@ public class BattleTracker implements java.io.Serializable {
         bombingRaid.fight(delegateBridge);
       }
     }
+  }
+
+  /**
+   *  Kill undefended transports. Done first to remove potentially dependent sea battles
+   *  Which could block amphibious assaults later
+   */
+  public void fightDefenselessBattles(final IDelegateBridge bridge) {
+    final GameData gameData = bridge.getData();
+    // Here and below parameter "false" to getPendingBattleSites & getPendingBattle denote non-SBR battles
+    for (final Territory territory : getPendingBattleSites(false)) {
+      final IBattle battle = getPendingBattle(territory, false, BattleType.NORMAL);
+      final List<Unit> defenders = new ArrayList<>();
+      defenders.addAll(battle.getDefendingUnits());
+      final List<Unit> sortedUnitsList = getSortedDefendingUnits(gameData, territory, defenders);
+      if (DiceRoll.getTotalPower(
+          DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defenders, false, false, gameData,
+            territory, TerritoryEffectHelper.getEffects(territory), false, null), gameData) == 0) {
+        battle.fight(bridge);
+      }
+    }
+    getPendingBattleSites(false).stream()
+         .map(territory -> getPendingBattle(territory, false, BattleType.NORMAL))
+         .forEach( battle -> {
+           if (battle instanceof NonFightingBattle && getDependentOn(battle).isEmpty()) {
+             battle.fight( bridge );
+           }
+         });
+  }
+
+  private List<Unit> getSortedDefendingUnits(final GameData gameData, final Territory territory,
+      final List<Unit> defenders) {
+    final List<Unit> sortedUnitsList = new ArrayList<>(Match.getMatches(defenders,
+               Matches.UnitCanBeInBattle(true, !territory.isWater(), gameData, 1, false, true, true)));
+    Collections.sort(sortedUnitsList, new UnitBattleComparator(false, ProData.unitValueMap,
+        TerritoryEffectHelper.getEffects(territory), gameData, false, false));
+    Collections.reverse(sortedUnitsList);
+    return sortedUnitsList;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -1154,9 +1154,9 @@ public class BattleTracker implements java.io.Serializable {
     }
     getPendingBattleSites(false).stream()
          .map(territory -> getPendingBattle(territory, false, BattleType.NORMAL))
-         .forEach( battle -> {
+         .forEach(battle -> {
            if (battle instanceof NonFightingBattle && getDependentOn(battle).isEmpty()) {
-             battle.fight( bridge );
+             battle.fight(bridge);
            }
          });
   }

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3_42_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3_42_Test.java
@@ -29,6 +29,8 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.ai.proAI.ProAI;
+import games.strategy.triplea.ai.proAI.ProData;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.xml.TestMapGameData;
 
@@ -94,6 +96,7 @@ public class WW2V3_42_Test {
 
   @Test
   public void testLingeringSeaUnitsJoinBattle() throws Exception {
+    ProData.initializeSimulation(new ProAI("one","two"), m_data, germans(m_data));
     final Territory sz5 = territory("5 Sea Zone", m_data);
     final Territory sz6 = territory("6 Sea Zone", m_data);
     final Territory sz7 = territory("7 Sea Zone", m_data);


### PR DESCRIPTION
…nt amphibious assaults

Can we just auto fight the defenseless amphibious assaults and defenseless transports?

Whenever my custom build has to push out this feature it really annoys me to click on an amphibious assault only to have it say "ha ha, you haven't killed the transport yet". It's stupid. I just don't understand why you would want to have to click these battles.