### PR TITLE
Checkstyle: Fail build when warning threshold exceeded (#747)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ script:
 - ruby -e "require 'yaml';puts YAML.load_file('./triplea_maps.yaml')" > /dev/null || exit 1
 - ruby -e "require 'yaml';puts YAML.load_file('./lobby_server.yaml')" > /dev/null || exit 1
 ## run the gradle build
-- ./gradlew --no-daemon test
-# Command with checkstyle run  - ./gradlew check --info
+- ./gradlew --no-daemon check
 before_deploy:
 ## Run the travis setup, will download install4j and configure it
 - chmod +x ./.travis/setup && ./.travis/setup

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ tasks.withType(JavaCompile) {
 }
 
 checkstyle {
-	toolVersion = "7.1"
+    toolVersion = "7.6.1"
 }
 
 checkstyleMain {

--- a/build.gradle
+++ b/build.gradle
@@ -36,17 +36,18 @@ tasks.withType(JavaCompile) {
 	options.incremental = true
 }
 
-checkstyle{
+checkstyle {
 	toolVersion = "7.1"
-	showViolations = false
 }
 
 checkstyleMain {
-    source(sourceSets.main.output.resourcesDir)
+    maxWarnings = checkstyleMainMaxWarnings.toInteger()
+    source sourceSets.main.output.resourcesDir
 }
 
 checkstyleTest {
-    source(sourceSets.test.output.resourcesDir)
+    maxWarnings = checkstyleTestMaxWarnings.toInteger()
+    source sourceSets.test.output.resourcesDir
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+checkstyleMainMaxWarnings=9122
+checkstyleTestMaxWarnings=416


### PR DESCRIPTION
This PR forces Checkstyle to fail the build when the number of Checkstyle violations exceeds the current count.  It is intended to prevent the overall number of Checkstyle violations from increasing.

I intend to follow-up with another PR which will automatically update the thresholds as part of the Travis build in the event they decrease.  In that respect, the thresholds introduced in this PR must be manually updated as Checkstyle violations are fixed.  I volunteer to keep track of this until the second PR is complete, which I hope is no more than a week or two away. :smiley:

#### Functional changes
None.

#### Refactoring changes
None.

#### Other changes
* I defined the [`maxWarnings`](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.CheckstyleExtension.html#org.gradle.api.plugins.quality.CheckstyleExtension:maxWarnings) property of the `checkstyleMain` and `checkstyleTest` Gradle tasks to force the build to fail if the actual violations detected when running these tasks exceeds the threshold.
* I enabled Checkstyle output during the build.  My intention here is to be able to log the warnings in the event someone submits a PR that increases the violation count so they can be compared to the previous build in order to isolate the new warnings (the Checkstyle reports written during the build are not available from Travis).
* Upgraded Checkstyle to the latest version (4.6.1).  The total violation count did not change as part of this upgrade.

#### Other issues for review
* Enabling Checkstyle output during the build may be questionable.  Now that the violation count is below 10,000, it no longer overflows the Travis log as previously [reported](https://github.com/triplea-game/triplea/pull/1100#issuecomment-241220907).  Realistically, I see the violation count dropping by another 2,000-4,000 in the near future, as that range represents violations that have a no-risk fix.  However, other devs may find this output annoying when running the Gradle build locally.  Please advise if this output should continue to be suppressed until the violation count is reduced further.

#### Testing
I created a [branch](https://github.com/ssoloff/triplea/tree/issue-747-test-checkstyle-build-failure) to verify that the Travis build fails if a new violation is added to code under either `src/main` or `src/test`.  The Travis build logs of interest for this branch can be reviewed using the below links:

* [Initial build](https://travis-ci.org/ssoloff/triplea/builds/219411210)
* [Introduce new warning under `src/main`](https://travis-ci.org/ssoloff/triplea/builds/219414843)
* [Revert previous change](https://travis-ci.org/ssoloff/triplea/builds/219417009)
* [Introduce new warning under `src/test`](https://travis-ci.org/ssoloff/triplea/builds/219426898)
* [Revert previous change](https://travis-ci.org/ssoloff/triplea/builds/219429218)