### PR TITLE
Checkstyle: Fix whitespace violations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=9096
+checkstyleMainMaxWarnings=8990
 checkstyleTestMaxWarnings=416

--- a/src/main/java/games/strategy/debug/ThreadReader.java
+++ b/src/main/java/games/strategy/debug/ThreadReader.java
@@ -26,7 +26,7 @@ class ThreadReader implements Runnable {
       if (m_displayConsoleOnWrite && !parentConsole.isVisible()) {
         parentConsole.setVisible(true);
       }
-      if(!ThreadUtil.sleep(CONSOLE_UPDATE_INTERVAL_MS)) {
+      if (!ThreadUtil.sleep(CONSOLE_UPDATE_INTERVAL_MS)) {
         break;
       }
     }

--- a/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -142,7 +142,7 @@ public class GameDataExporter {
   }
 
   @SuppressWarnings("unchecked")
-  private void propertyList(final GameData data) {// TODO: Unchecked Reflection
+  private void propertyList(final GameData data) { // TODO: Unchecked Reflection
     xmlfile.append("    <propertyList>\n");
     final GameProperties gameProperties = data.getProperties();
     try {

--- a/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
+++ b/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
@@ -160,7 +160,7 @@ public class XmlGameElementMapper {
    * Assumes a zero argument constructor.
    */
   public Optional<IDelegate> getDelegate(final String className) {
-    if(!delegateMap.containsKey(className)) {
+    if (!delegateMap.containsKey(className)) {
       handleMissingObjectError("delegate", className);
       return Optional.empty();
     }
@@ -177,7 +177,7 @@ public class XmlGameElementMapper {
   }
 
   public Optional<IAttachment> getAttachment(String javaClass, String name, Attachable attachable, GameData data) {
-    if(!attachmentMap.containsKey(javaClass)) {
+    if (!attachmentMap.containsKey(javaClass)) {
       handleMissingObjectError("attachment", javaClass);
       return Optional.empty();
     }

--- a/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -129,7 +129,7 @@ public class ClientGame extends AbstractGame {
           } finally {
             m_data.releaseReadLock();
           }
-          if(!ThreadUtil.sleep(100)) {
+          if (!ThreadUtil.sleep(100)) {
             break;
           }
           i++;

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -559,7 +559,7 @@ public class HeadlessGameServer {
 
     final Runnable r = () -> {
       while (!m_shutDown) {
-        if(!ThreadUtil.sleep(8000)) {
+        if (!ThreadUtil.sleep(8000)) {
           m_shutDown = true;
           break;
         }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -136,7 +136,7 @@ public class DownloadFileDescription {
 
   public String toHtmlString() {
     String text = "<h1>" + getMapName() + "</h1>\n";
-    if(!img.isEmpty()) {
+    if (!img.isEmpty()) {
       text += "<img src='" + img + "' />\n";
     }
     text += getDescription();

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -49,13 +49,13 @@ final class DownloadFileParser {
       }
 
       DownloadFileDescription.MapCategory mapCategory = DownloadFileDescription.MapCategory.EXPERIMENTAL;
-        String mapCategoryString = yaml.get(Tags.mapCategory.toString());
+      String mapCategoryString = yaml.get(Tags.mapCategory.toString());
       if (mapCategoryString != null) {
         mapCategory = DownloadFileDescription.MapCategory.valueOf(mapCategoryString);
       }
 
       String img = yaml.get(Tags.img.toString());
-      if(img == null ) {
+      if (img == null) {
         img = "";
       }
       final DownloadFileDescription dl =

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -123,11 +123,11 @@ public class DownloadMapsWindow extends JFrame {
 
     JTabbedPane mapTabs = SwingComponents.newJTabbedPane();
 
-    for(DownloadFileDescription.MapCategory mapCategory : Arrays.asList(DownloadFileDescription.MapCategory.values()) ) {
+    for (DownloadFileDescription.MapCategory mapCategory : Arrays.asList(DownloadFileDescription.MapCategory.values()) ) {
 
       List<DownloadFileDescription> mapsByCategory =
           maps.stream().filter(map -> map.getMapCategory() == mapCategory).collect(Collectors.toList());
-      if(!mapsByCategory.isEmpty()) {
+      if (!mapsByCategory.isEmpty()) {
         JTabbedPane subTab = createAvailableInstalledTabbedPanel(Optional.of(mapCategory.toString()), mapsByCategory);
         mapTabs.add(mapCategory.toString(), subTab);
       }
@@ -298,8 +298,8 @@ public class DownloadMapsWindow extends JFrame {
     String labelText = "<html>" + map.getMapName() + DOUBLE_SPACE + " v" + map.getVersion();
     
     if (action == MapAction.INSTALL) {
-      if(map.newURL() == null ) {
-       mapSize = 0L;
+      if (map.newURL() == null) {
+        mapSize = 0L;
       } else {
         mapSize = DownloadUtils.getDownloadLength(map.newURL()).orElse(-1);
       }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -20,9 +20,9 @@ public class DownloadUtils {
 
 
   static Optional<Integer> getDownloadLength(URL url) {
-    if(!downloadLengthCache.containsKey(url)) {
+    if (!downloadLengthCache.containsKey(url)) {
       Optional<Integer> length = getDownloadLengthWithoutCache(url);
-      if(length.isPresent()) {
+      if (length.isPresent()) {
         downloadLengthCache.put(url, length.get());
       } else {
         return Optional.empty();
@@ -38,7 +38,7 @@ public class DownloadUtils {
       // always check HTTP response code first
       if (responseCode == HttpURLConnection.HTTP_OK) {
         int length = httpConn.getContentLength();
-        if(length <= 0) {
+        if (length <= 0) {
           return Optional.empty();
         } else {
           return Optional.of(httpConn.getContentLength());

--- a/src/main/java/games/strategy/engine/framework/map/download/FileSizeWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FileSizeWatcher.java
@@ -30,7 +30,7 @@ public class FileSizeWatcher {
     return () -> {
       while (!stop) {
         progressListener.accept((int) fileToWatch.length());
-        if(!ThreadUtil.sleep(50)) {
+        if (!ThreadUtil.sleep(50)) {
           break;
         }
       }

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
@@ -14,7 +14,7 @@ public class MapDownloadList {
 
   public MapDownloadList(final List<DownloadFileDescription> downloads, final FileSystemAccessStrategy strategy) {
     for (final DownloadFileDescription download : downloads) {
-      if(download == null) {
+      if (download == null) {
         return;
       }
       final Optional<Version> mapVersion = strategy.getMapVersion(download.getInstallLocation().getAbsolutePath());

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -578,7 +578,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     if (removeConnectionsLatch != null) {
       try {
         removeConnectionsLatch.await(6, TimeUnit.SECONDS);
-      } catch (final InterruptedException e) {// no worries
+      } catch (final InterruptedException e) { // no worries
       }
     }
     // will be handled elsewhere

--- a/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -242,7 +242,7 @@ public class EnginePreferences extends JDialog {
       if (answer == JOptionPane.YES_OPTION) {
         GameRunner.setServerStartGameSyncWaitTime(clientWait.getValue());
         GameRunner.setServerObserverJoinWaitTime(observerWait.getValue());
-      } else if (answer == JOptionPane.NO_OPTION) {// reset
+      } else if (answer == JOptionPane.NO_OPTION) { // reset
         GameRunner.resetServerStartGameSyncWaitTime();
         GameRunner.resetServerObserverJoinWaitTime();
       }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -87,7 +87,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
     if (fileName != null && fileName.length() > 1) {
       try {
         fileName = URLDecoder.decode(fileName, "UTF-8");
-      } catch (final IllegalArgumentException | UnsupportedEncodingException e) {// ignore
+      } catch (final IllegalArgumentException | UnsupportedEncodingException e) { // ignore
       }
     }
     m_fileNameText.setText(getFormattedFileNameText(fileName,

--- a/src/main/java/games/strategy/engine/framework/startup/ui/MainFrame.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/MainFrame.java
@@ -46,9 +46,9 @@ public class MainFrame extends JFrame {
     }
     s_instance = this;
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-    addWindowListener(new WindowAdapter(){
+    addWindowListener(new WindowAdapter() {
       @Override
-      public void windowClosing(WindowEvent e){
+      public void windowClosing(WindowEvent e) {
         GameRunner.exitGameIfFinished();
       }
     });

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -42,10 +42,10 @@ public class LobbyFrame extends JFrame {
   private static final long serialVersionUID = -388371674076362572L;
 
   private static final List<String> banOrMuteOptions = ImmutableList.of(
-    "Mac Address Only",
-    "User Name only",
-    "Name and Mac",
-    "Cancel");
+      "Mac Address Only",
+      "User Name only",
+      "Name and Mac",
+      "Cancel");
 
   private final LobbyClient m_client;
   private final ChatMessagePanel m_chatMessagePanel;
@@ -57,7 +57,7 @@ public class LobbyFrame extends JFrame {
     m_client = client;
     setJMenuBar(new LobbyMenu(this));
     final Chat chat = new Chat(m_client.getMessenger(), LobbyServer.LOBBY_CHAT, m_client.getChannelMessenger(),
-      m_client.getRemoteMessenger(), Chat.CHAT_SOUND_PROFILE.LOBBY_CHATROOM);
+        m_client.getRemoteMessenger(), Chat.CHAT_SOUND_PROFILE.LOBBY_CHATROOM);
     m_chatMessagePanel = new ChatMessagePanel(chat);
     showServerMessage(props);
     m_chatMessagePanel.setShowTime(true);
@@ -119,9 +119,9 @@ public class LobbyFrame extends JFrame {
     }));
     rVal.add(SwingAction.of("Ban Player", e -> {
       final int resultBT = JOptionPane.showOptionDialog(LobbyFrame.this,
-        "<html>Select the type of ban: <br>Please consult other admins before banning longer than 1 day. <br>And please remember to report this ban.</html>",
-        "Select Ban Type", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, banOrMuteOptions.toArray(),
-        banOrMuteOptions.toArray()[banOrMuteOptions.size() - 1]);
+          "<html>Select the type of ban: <br>Please consult other admins before banning longer than 1 day. <br>And please remember to report this ban.</html>",
+          "Select Ban Type", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, banOrMuteOptions.toArray(),
+          banOrMuteOptions.toArray()[banOrMuteOptions.size() - 1]);
       if (resultBT < 0) {
         return;
       }

--- a/src/main/java/games/strategy/engine/lobby/server/IModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/IModeratorController.java
@@ -99,8 +99,8 @@ public interface IModeratorController extends IRemote {
    * <p>
    * You cannot change the password of an anonymous node, and you cannot change the password for an admin user.
    * <p>
-   *   @deprecated Remove usages of this. Does not make sense for moderators to be able to reset passwords of logged
-   *   in users.
+   * @deprecated Remove usages of this. Does not make sense for moderators to be able to reset passwords of logged
+   *             in users.
    */
   @Deprecated
   String setPassword(INode node, String hashedPassword);

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
@@ -182,7 +182,7 @@ public class Database {
     final Thread backupThread = new Thread(() -> {
       while (true) {
         // wait 7 days
-        if(!ThreadUtil.sleep(7 * 24 * 60 * 60 * 1000)) {
+        if (!ThreadUtil.sleep(7 * 24 * 60 * 60 * 1000)) {
           break;
         }
         backup();

--- a/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -145,7 +145,7 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
   public void waitForNodesToImplement(final String endPointName) {
     final long endTime = NODE_IMPLEMENTATION_TIMEOUT + System.currentTimeMillis();
     while (System.currentTimeMillis() < endTime && !hasImplementors(endPointName)) {
-      if(!ThreadUtil.sleep(50)) {
+      if (!ThreadUtil.sleep(50)) {
         return;
       }
     }

--- a/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/src/main/java/games/strategy/net/ClientMessenger.java
@@ -84,7 +84,7 @@ public class ClientMessenger implements IClientMessenger, NIOSocketListener {
         if (m_socketChannel.finishConnect()) {
           break;
         }
-        if(!ThreadUtil.sleep(50)) {
+        if (!ThreadUtil.sleep(50)) {
           shutDown();
           m_socket = null;
           return;
@@ -170,7 +170,7 @@ public class ClientMessenger implements IClientMessenger, NIOSocketListener {
   @Override
   public void shutDown() {
     m_shutDown = true;
-    if(m_socket != null) {
+    if (m_socket != null) {
       m_socket.shutDown();
     }
     try {

--- a/src/main/java/games/strategy/net/IPFinder.java
+++ b/src/main/java/games/strategy/net/IPFinder.java
@@ -79,7 +79,7 @@ public class IPFinder {
     }
     // all else fails, return localhost
     return InetAddress.getLocalHost();
-  }// end static findInetAddress()
+  } // end static findInetAddress()
 
   private static boolean isPrivateNetworkAddress(final InetAddress address) {
     // stupid java signed byte type

--- a/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
+++ b/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
@@ -30,7 +30,7 @@ class ResourceLocationTracker {
 
 
     // map skins will have the full path name as their map name.
-    if(mapName.endsWith("-master.zip")) {
+    if (mapName.endsWith("-master.zip")) {
       mapPrefix = mapName.substring(0, mapName.length() - "-master.zip".length()) + MASTER_ZIP_MAGIC_PREFIX;
     } else {
       mapPrefix = isUsingMasterZip ? mapName + MASTER_ZIP_MAGIC_PREFIX : "";

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
@@ -222,9 +222,9 @@ public class ProBidAI {
             PUsToSpend, buyLimit, data, player, 2);
       }
     } else if (Math.random() < 0.35) {
-      if (Math.random() > 0.55 && carrierRule != null && fighterRule != null) {// force a carrier purchase if enough
-                                                                               // available $$ for it and
-                                                                               // at least 1 fighter
+      if (Math.random() > 0.55 && carrierRule != null && fighterRule != null) { // force a carrier purchase if enough
+                                                                                // available $$ for it and
+                                                                                // at least 1 fighter
         final int cost = carrierRule.getCosts().getInt(pus);
         final int fighterCost = fighterRule.getCosts().getInt(pus);
         if ((cost + fighterCost) <= PUsToSpend) {

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -220,7 +220,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       // units may have special restrictions like RequiresUnits
 
       final List<Unit> unitsCanBePlacedByThisProducer;
-      if(bidMode == BidMode.BID) {
+      if (bidMode == BidMode.BID) {
         unitsCanBePlacedByThisProducer = new ArrayList<>(unitsLeftToPlace);
       } else {
         unitsCanBePlacedByThisProducer = (isUnitPlacementRestrictions()
@@ -233,7 +233,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       int maxPlaceable = maxPlaceableMap.getInt(producer);
       if (maxPlaceable == 0 && bidMode == BidMode.NOT_BID) {
         continue;
-      } else if(maxPlaceable == 0) {
+      } else if (maxPlaceable == 0) {
         maxPlaceable = 1;
       }
 

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -253,8 +253,8 @@ public class BattleTracker implements java.io.Serializable {
   }
 
   void addBombingBattle(final Route route, final Collection<Unit> units, final PlayerID id,
-    final IDelegateBridge bridge, final UndoableMove changeTracker,
-    final Collection<Unit> unitsNotUnloadedTilEndOfRoute) {
+      final IDelegateBridge bridge, final UndoableMove changeTracker,
+      final Collection<Unit> unitsNotUnloadedTilEndOfRoute) {
 
     this.addBattle(route, units, true, id, bridge, changeTracker, unitsNotUnloadedTilEndOfRoute, null, false);
   }
@@ -1105,7 +1105,7 @@ public class BattleTracker implements java.io.Serializable {
   void fightAirRaidsAndStrategicBombing(final IDelegateBridge delegateBridge) {
     boolean bombing = true;
     fightAirRaidsAndStrategicBombing(delegateBridge, () -> getPendingBattleSites(bombing),
-            (territory, battleType) -> getPendingBattle(territory, bombing, battleType));
+        (territory, battleType) -> getPendingBattle(territory, bombing, battleType));
   }
 
   @VisibleForTesting
@@ -1119,7 +1119,7 @@ public class BattleTracker implements java.io.Serializable {
     // CAUTION: air raid battles when completed will potentially spawn new bombing raids. Would be good to refactor
     // that out, in the meantime be aware there are mass side effects in these calls..
 
-    for( final Territory t : pendingBattleSiteSupplier.get()) {
+    for (final Territory t : pendingBattleSiteSupplier.get()) {
       final IBattle airRaid = pendingBattleFunction.apply(t, BattleType.AIR_RAID);
       if (airRaid != null) {
         airRaid.fight(delegateBridge);
@@ -1127,9 +1127,9 @@ public class BattleTracker implements java.io.Serializable {
     }
 
     // now that we've done all of the air battles, do all of the SBR's as a second wave.
-    for( final Territory t : pendingBattleSiteSupplier.get()) {
+    for (final Territory t : pendingBattleSiteSupplier.get()) {
       final IBattle bombingRaid = pendingBattleFunction.apply(t, BattleType.BOMBING_RAID);
-      if( bombingRaid != null ) {
+      if (bombingRaid != null) {
         bombingRaid.fight(delegateBridge);
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
@@ -36,8 +36,8 @@ public class FinishedBattle extends AbstractBattle {
   private final Map<Territory, Collection<Unit>> m_attackingFromMap = new HashMap<>();
 
   FinishedBattle(final Territory battleSite, final PlayerID attacker, final BattleTracker battleTracker,
-    final boolean isBombingRun, final BattleType battleType, final GameData data,
-    final BattleResultDescription battleResultDescription, final WhoWon whoWon) {
+      final boolean isBombingRun, final BattleType battleType, final GameData data,
+      final BattleResultDescription battleResultDescription, final WhoWon whoWon) {
     super(battleSite, attacker, battleTracker, isBombingRun, battleType, data);
     m_battleResultDescription = battleResultDescription;
     m_whoWon = whoWon;

--- a/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -210,7 +210,7 @@ public class GameStepPropertiesHelper {
       if (prop != null) {
         isRemoveAir = Boolean.parseBoolean(prop);
       } else if (data.getSequence().getStep().getDelegate() != null
-        && NoAirCheckPlaceDelegate.class.equals(data.getSequence().getStep().getDelegate().getClass())) {
+          && NoAirCheckPlaceDelegate.class.equals(data.getSequence().getStep().getDelegate().getClass())) {
         isRemoveAir = false;
       } else {
         isRemoveAir = isNonCombatDelegate(data) || data.getSequence().getStep().getName().endsWith("Place");
@@ -264,7 +264,7 @@ public class GameStepPropertiesHelper {
     data.acquireReadLock();
     try {
       final String prop =
-        data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_resetUnitStateAtStart);
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_resetUnitStateAtStart);
       isReset = (prop != null) && Boolean.parseBoolean(prop);
     } finally {
       data.releaseReadLock();

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -615,8 +615,8 @@ public class MoveValidator {
             + (route.numberOfSteps() > 1 ? "these territories" : "this territory"));
       }
     } // !isEditMode
-      // make sure that no non sea non transportable no carriable units
-      // end at sea
+    // make sure that no non sea non transportable no carriable units
+    // end at sea
     if (route.getEnd() != null && route.getEnd().isWater()) {
       for (final Unit unit : MoveValidator.getUnitsThatCantGoOnWater(units)) {
         result.addDisallowedUnit("Not all units can end at water", unit);

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -97,7 +97,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
       if (m_currentPickingPlayer == null || !playersCanPick.contains(m_currentPickingPlayer)) {
         m_currentPickingPlayer = playersCanPick.get(0);
       }
-      if(!ThreadUtil.sleep(250)) {
+      if (!ThreadUtil.sleep(250)) {
         return;
       }
       Territory picked;

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -107,7 +107,7 @@ public class RocketsFireHelper {
         attackingFromTerritories.put(target,territory);
       }
     }
-    for( final Territory target : attackedTerritories ) {
+    for (final Territory target : attackedTerritories) {
       // Roll dice for the rocket attack damage and apply it
       fireRocket(player, target, bridge, attackingFromTerritories.get(target));
     }

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -209,7 +209,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           .forEach(entry -> steps.add(new FireAA(entry.getValue())));
 
       // otherwise fire an AA shot at all the planes
-      if(steps.isEmpty()) {
+      if (steps.isEmpty()) {
         steps.add(new FireAA());
       }
     }
@@ -355,7 +355,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         final Collection<Unit> currentPossibleAA                = Match.getMatches(m_defendingAA, Matches.UnitIsAAofTypeAA(currentTypeAA));
         final Set<UnitType> targetUnitTypesForThisTypeAA        = UnitAttachment.get(currentPossibleAA.iterator().next().getType()).getTargetsAA(m_data);
         final Set<UnitType> airborneTypesTargettedToo           = TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAA);
-        if( determineAttackers ) {
+        if (determineAttackers) {
           validAttackingUnitsForThisRoll = Match.getMatches(m_attackingUnits, new CompositeMatchOr<>(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAA),
                     new CompositeMatchAnd<Unit>(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         }

--- a/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -228,7 +228,7 @@ public class TransportTracker {
       // then we must have been transported on our own transport
       final TripleAUnit taUnit = (TripleAUnit) u;
       if (taUnit.getWasLoadedThisTurn() && taUnit.getTransportedBy() != null &&
-      // an allied transport if the owner of the transport is not the owner of the unit
+          // an allied transport if the owner of the transport is not the owner of the unit
           !taUnit.getTransportedBy().getOwner().equals(taUnit.getOwner())) {
         rVal.add(u);
       }

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -170,8 +170,8 @@ public class UndoableMove extends AbstractUndoableMove {
         throw new IllegalStateException("other should not be null");
       }
       if ( // if the other move has moves that depend on this
-      !Util.intersection(other.getUnits(), this.getUnits()).isEmpty() ||
-      // if the other move has transports that we are loading
+          !Util.intersection(other.getUnits(), this.getUnits()).isEmpty() ||
+          // if the other move has transports that we are loading
           !Util.intersection(other.m_units, this.m_loaded).isEmpty() ||
           // or we are moving through a previously conqueured territory
           // we should be able to take this out later

--- a/src/main/java/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
+++ b/src/main/java/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
@@ -177,7 +177,7 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
               + m_topicId + ".0;num_replies=" + numReplies);
           httpPost.addHeader("Accept", "*/*");
           // the site has spam prevention which means you can't post until 15 seconds after login
-          if(!ThreadUtil.sleep(15 * 1000)) {
+          if (!ThreadUtil.sleep(15 * 1000)) {
             return false;
           }
           httpPost.setConfig(RequestConfig.custom().setRedirectsEnabled(false).build());

--- a/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
@@ -134,21 +134,21 @@ class BattleStepsPanel extends JPanel implements Active {
 
   private void waitThenWalk() {
     new Thread(() -> {
+      synchronized (m_mutex) {
+        if (m_hasWalkThread) {
+          return;
+        }
+        m_hasWalkThread = true;
+      }
+      try {
+        if (ThreadUtil.sleep(330)) {
+          SwingUtilities.invokeLater(this::walkStep);
+        }
+      } finally {
         synchronized (m_mutex) {
-          if (m_hasWalkThread) {
-            return;
-          }
-          m_hasWalkThread = true;
+          m_hasWalkThread = false;
         }
-        try {
-          if(ThreadUtil.sleep(330)) {
-            SwingUtilities.invokeLater(this::walkStep);
-          }
-        } finally {
-          synchronized (m_mutex) {
-            m_hasWalkThread = false;
-          }
-        }
+      }
     }).start();
   }
 

--- a/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
@@ -16,7 +16,7 @@ public class EndTurnPanel extends AbstractForumPosterPanel {
     if (m_forumPosterComponent.getHasPostedTurnSummary() || JOptionPane.YES_OPTION ==
         JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(EndTurnPanel.this),
         "Are you sure you don't want to post?", "Bypass post", JOptionPane.YES_NO_OPTION)) {
-        release();
+      release();
     }
   });
 

--- a/src/main/java/games/strategy/triplea/ui/MapRouteDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/MapRouteDrawer.java
@@ -73,7 +73,7 @@ public class MapRouteDrawer {
     final boolean tooFewPoints = points.length <= 2;
     final double scale = mapPanel.getScale();
     if (tooFewTerritories || tooFewPoints) {
-      if (routeDescription.getEnd() != null) {// AI has no End Point
+      if (routeDescription.getEnd() != null) { // AI has no End Point
         drawDirectPath(graphics, new Point(routeDescription.getStart()), new Point(routeDescription.getEnd()), xOffset,
             yOffset, scale);
       } else {

--- a/src/main/java/games/strategy/triplea/ui/MemoryLabel.java
+++ b/src/main/java/games/strategy/triplea/ui/MemoryLabel.java
@@ -71,7 +71,7 @@ class Updater implements Runnable {
   @Override
   public void run() {
     while (m_label.get() != null) {
-      if(!ThreadUtil.sleep(2000)) {
+      if (!ThreadUtil.sleep(2000)) {
         return;
       }
       update();

--- a/src/main/java/games/strategy/triplea/ui/logic/Point.java
+++ b/src/main/java/games/strategy/triplea/ui/logic/Point.java
@@ -8,7 +8,7 @@ public class Point {
   private double x;
   private double y;
   
-  public Point(){
+  public Point() {
     this(0, 0);
   }
 

--- a/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -48,8 +48,8 @@ public class ImageScrollerLargeView extends JComponent {
   private int m_drag_scrolling_lasty;
   private boolean wasLastActionDragging = false;
   
-  public boolean wasLastActionDraggingAndReset(){
-    if(wasLastActionDragging){
+  public boolean wasLastActionDraggingAndReset() {
+    if (wasLastActionDragging) {
       wasLastActionDragging = false;
       return true;
     }

--- a/src/main/java/games/strategy/util/CompositeMatchOr.java
+++ b/src/main/java/games/strategy/util/CompositeMatchOr.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class CompositeMatchOr<T> extends CompositeMatch<T> {
   /** Creates new CompositeMatchOr */
   @SuppressWarnings("unchecked")
-  public CompositeMatchOr(final Match<?>... matches) {// TODO rewrite in order to remove Suppressed Warning
+  public CompositeMatchOr(final Match<?>... matches) { // TODO rewrite in order to remove Suppressed Warning
     super();
     for (final Match<?> m : matches) {
       add((Match<T>) m);

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -204,7 +204,7 @@ public class PointFileReaderWriter {
       System.exit(0);
     } finally {
       try {
-        if(stream != null) {
+        if (stream != null) {
           stream.close();
         }
       } catch (final IOException e) {

--- a/src/main/java/games/strategy/util/Util.java
+++ b/src/main/java/games/strategy/util/Util.java
@@ -158,10 +158,10 @@ public class Util {
     });
   }
   
-  public static String getStringFromInputStream(InputStream in){
+  public static String getStringFromInputStream(InputStream in) {
     StringBuilder builder = new StringBuilder();
-    try(Scanner scanner = new Scanner(in)){
-      while(scanner.hasNextLine()){
+    try (Scanner scanner = new Scanner(in)) {
+      while (scanner.hasNextLine()) {
         builder.append(scanner.nextLine()).append("\n");
       }
     }

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -393,7 +393,7 @@ public class AutoPlacementFinder {
       final List<Point> placementPoints, final Rectangle2D place, final int x, final int y) {
     place.setFrame(x, y, PLACEWIDTH, PLACEHEIGHT);
     if (containedIn(place, countryPolygons) && !intersectsOneOf(place, placementRects) &&
-    // make sure it is not in or intersects the contained country
+        // make sure it is not in or intersects the contained country
         (!containedIn(place, containedCountryPolygons) && !intersectsOneOf(place, containedCountryPolygons))) {
       placementPoints.add(new Point((int) place.getX(), (int) place.getY()));
       final Rectangle2D newRect = new Rectangle2D.Double();

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -91,7 +91,7 @@ public class CenterPicker extends JFrame {
       System.out.println("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
-  }// end main
+  } // end main
 
   /**
    * Constructor CenterPicker(java.lang.String)
@@ -183,7 +183,7 @@ public class CenterPicker extends JFrame {
     fileMenu.addSeparator();
     fileMenu.add(exitItem);
     menuBar.add(fileMenu);
-  }// end constructor
+  } // end constructor
 
   /**
    * createImage(java.lang.String)

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -161,7 +161,7 @@ public class DecorationPlacer extends JFrame {
       System.out.println("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
-  }// end main
+  } // end main
 
   public DecorationPlacer(final String mapName) {
     super("Decoration Placer");
@@ -332,7 +332,7 @@ public class DecorationPlacer extends JFrame {
     editMenu.add(clearAction);
     menuBar.add(fileMenu);
     menuBar.add(editMenu);
-  }// end constructor
+  } // end constructor
 
   /**
    * createImage(java.lang.String)

--- a/src/main/java/tools/image/FileOpen.java
+++ b/src/main/java/tools/image/FileOpen.java
@@ -82,7 +82,7 @@ public class FileOpen {
       JOptionPane.showMessageDialog(null, ERR_MSG_1, "Warning!", JOptionPane.WARNING_MESSAGE);
       file = null;
     }
-  }// constructor
+  } // constructor
 
   /**
    * Returns the newly selected file.

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -118,7 +118,7 @@ public class PolygonGrabber extends JFrame {
       System.out.println("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
-  }// end main
+  } // end main
 
   /**
    * Constructor PolygonGrabber(java.lang.String)
@@ -293,7 +293,7 @@ public class PolygonGrabber extends JFrame {
     editMenu.add(autoItem);
     menuBar.add(fileMenu);
     menuBar.add(editMenu);
-  }// end constructor
+  } // end constructor
 
   /**
    * createImage(java.lang.String)
@@ -358,7 +358,7 @@ public class PolygonGrabber extends JFrame {
             g.fillPolygon(item.xpoints, item.ypoints, item.npoints);
           } // while
         } // if
-      }// paint
+      } // paint
     };
     return imagePanel;
   }

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -190,7 +190,7 @@ public class ConnectionFinder {
     } catch (final Exception ex) {
       ex.printStackTrace();
     }
-  }// end main
+  } // end main
 
   /**
    * Creates the xml territory definitions.

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -99,7 +99,7 @@ public class MapPropertiesMaker extends JFrame {
       System.out.println("No Map Folder Selected. Shutting down.");
       System.exit(0);
     }
-  }// end main
+  } // end main
 
   public MapPropertiesMaker() {
     super("Map Properties Maker");

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -128,7 +128,7 @@ public class PlacementPicker extends JFrame {
       System.out.println("No Image Map Selected. Shutting down.");
       System.exit(0);
     }
-  }// end main
+  } // end main
 
   /**
    * Constructor PlacementPicker(java.lang.String)
@@ -372,7 +372,7 @@ public class PlacementPicker extends JFrame {
     editMenu.add(showIncompleteModeItem);
     menuBar.add(fileMenu);
     menuBar.add(editMenu);
-  }// end
+  } // end
    // constructor
 
   /**
@@ -460,7 +460,7 @@ public class PlacementPicker extends JFrame {
             g.setColor(Color.red);
           }
         }
-      }// paint
+      } // paint
     };
     return imagePanel;
   }

--- a/src/main/java/tools/map/xml/creator/GameSettingsRow.java
+++ b/src/main/java/tools/map/xml/creator/GameSettingsRow.java
@@ -169,8 +169,8 @@ class GameSettingsRow extends DynamicRow {
     comboBoxEditable.setPreferredSize(dimension);
     comboBoxEditable.setSelectedIndex(Arrays.binarySearch(selectionTrueFalse, editable));
     comboBoxEditable.addFocusListener(FocusListenerFocusLost.withAction(() ->
-    // everything is okay with the new value name, lets rename everything
-    MapXmlHelper.getGameSettingsMap().get(currentRowName).set(1, (String) comboBoxEditable.getSelectedItem())));
+        // everything is okay with the new value name, lets rename everything
+        MapXmlHelper.getGameSettingsMap().get(currentRowName).set(1, (String) comboBoxEditable.getSelectedItem())));
 
     dimension = textFieldMinNumber.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_SMALL;

--- a/src/main/java/tools/map/xml/creator/PlayerAndAlliancesRow.java
+++ b/src/main/java/tools/map/xml/creator/PlayerAndAlliancesRow.java
@@ -111,8 +111,8 @@ class PlayerAndAlliancesRow extends DynamicRow {
     comboBoxPlayerAlliance.setPreferredSize(dimension);
     comboBoxPlayerAlliance.setSelectedIndex(Arrays.binarySearch(alliances, allianceName));
     comboBoxPlayerAlliance.addFocusListener(FocusListenerFocusLost.withAction(() ->
-    // everything is okay with the new technology name, lets rename everything
-    MapXmlHelper.getPlayerAllianceMap().put(playerName, (String) comboBoxPlayerAlliance.getSelectedItem())));
+        // everything is okay with the new technology name, lets rename everything
+        MapXmlHelper.getPlayerAllianceMap().put(playerName, (String) comboBoxPlayerAlliance.getSelectedItem())));
 
     dimension = textFieldInitialResource.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_SMALL;

--- a/src/main/java/tools/map/xml/creator/TechnologyDefinitionsRow.java
+++ b/src/main/java/tools/map/xml/creator/TechnologyDefinitionsRow.java
@@ -100,9 +100,9 @@ class TechnologyDefinitionsRow extends DynamicRow {
     comboBoxAlreadyEnabled.setPreferredSize(dimension);
     comboBoxAlreadyEnabled.setSelectedIndex(Arrays.binarySearch(selectionTrueFalse, alreadyEnabled));
     comboBoxAlreadyEnabled.addFocusListener(FocusListenerFocusLost.withAction(() ->
-    // everything is okay with the new technology name, lets rename everything
-    MapXmlHelper.getTechnologyDefinitionsMap().get(currentRowName).set(1,
-        (String) comboBoxAlreadyEnabled.getSelectedItem())));
+        // everything is okay with the new technology name, lets rename everything
+        MapXmlHelper.getTechnologyDefinitionsMap().get(currentRowName).set(1,
+            (String) comboBoxAlreadyEnabled.getSelectedItem())));
   }
 
   @Override


### PR DESCRIPTION
This PR fixes a number of violations for the following Checkstyle rules:

* WhitespaceAround
* Indentation
* CommentsIndentation
* JavadocTagContinuationIndentation

This PR contains whitespace-only changes (except for `gradle.properties`).  Please view this URL with `?w=1` to verify.