### PR TITLE
Checkstyle: Fix comments indentation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=8990
-checkstyleTestMaxWarnings=416
+checkstyleMainMaxWarnings=8949
+checkstyleTestMaxWarnings=412

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
@@ -389,8 +389,9 @@ public class HeadlessConsoleController {
         if (server.getSetupPanelModel() != null) {
           final ISetupPanel setup = server.getSetupPanelModel().getPanel();
           if (setup != null && setup instanceof ServerSetupPanel) {
-            setup.shutDown();// this is causing a deadlock when in a shutdown hook, due to swing/awt. so we will shut
-                             // it down here instead.
+            // this is causing a deadlock when in a shutdown hook, due to swing/awt. so we will shut it down here
+            // instead.
+            setup.shutDown();
           }
         }
         System.exit(0);

--- a/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -168,11 +168,9 @@ public class LobbyLoginValidator implements ILoginValidator {
     if (new DBUserController().doesUserExist(userName)) {
       return "Can't login anonymously, username already exists";
     }
+    // If this is a lobby watcher, use a different set of validation
     if (propertiesReadFromClient.get(LOBBY_WATCHER_LOGIN) != null
-        && propertiesReadFromClient.get(LOBBY_WATCHER_LOGIN).equals(Boolean.TRUE.toString())) // If this is a lobby
-                                                                                              // watcher, use a
-                                                                                              // different
-                                                                                              // set of validation
+        && propertiesReadFromClient.get(LOBBY_WATCHER_LOGIN).equals(Boolean.TRUE.toString())) 
     {
       if (!userName.endsWith(InGameLobbyWatcher.LOBBY_WATCHER_NAME)) {
         return "Lobby watcher usernames must end with 'lobby_watcher'";

--- a/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -406,10 +406,9 @@ public class ClipPlayer {
         if (zipFilePath.length() > 5 && zipFilePath.endsWith(".zip")) {
           String decoded;
           try {
-            decoded = URLDecoder.decode(zipFilePath, "UTF-8"); // the file path may have spaces, which in a URL are
-                                                               // equal to %20, but if
-                                                               // we make a file using that it will fail, so we need to
-                                                               // decode
+            // the file path may have spaces, which in a URL are equal to %20, but if we make a file using that it will
+            // fail, so we need to decode
+            decoded = URLDecoder.decode(zipFilePath, "UTF-8");
           } catch (final UnsupportedEncodingException uee) {
             decoded = zipFilePath.replaceAll("%20", " ");
           }

--- a/src/main/java/games/strategy/sound/SoundProperties.java
+++ b/src/main/java/games/strategy/sound/SoundProperties.java
@@ -39,8 +39,8 @@ public class SoundProperties {
   }
 
   public static SoundProperties getInstance(final ResourceLoader loader) {
-    if (s_op == null || Calendar.getInstance().getTimeInMillis() > timestamp + 1000) { // cache properties for 1
-                                                                                       // second
+    // cache properties for 1 second
+    if (s_op == null || Calendar.getInstance().getTimeInMillis() > timestamp + 1000) {
       s_op = new SoundProperties(loader);
       timestamp = Calendar.getInstance().getTimeInMillis();
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
@@ -146,8 +146,8 @@ public class ProBidAI {
       if (Matches.UnitTypeIsSub.match(x)) {
         subProductionRules.add(ruleCheck);
       }
-      if (Matches.UnitTypeIsCarrier.match(x)) // might be more than 1 carrier rule...use the one which will hold the
-                                              // most fighters
+      // might be more than 1 carrier rule...use the one which will hold the most fighters
+      if (Matches.UnitTypeIsCarrier.match(x))
       {
         final int thisFighterLimit = UnitAttachment.get(x).getCarrierCapacity();
         if (thisFighterLimit >= carrierFighterLimit) {
@@ -164,11 +164,9 @@ public class ProBidAI {
         }
       }
     }
-    if (averageSeaMove / seaProductionRules.size() >= 1.8) // most sea units move at least 2 movement, so remove any sea
-                                                           // units with 1
-                                                           // movement (dumb t-boats) (some maps like 270BC have mostly
-                                                           // 1 movement sea
-                                                           // units, so we must be sure not to remove those)
+    // most sea units move at least 2 movement, so remove any sea units with 1 movement (dumb t-boats) (some maps like
+    // 270BC have mostly 1 movement sea units, so we must be sure not to remove those)
+    if (averageSeaMove / seaProductionRules.size() >= 1.8)
     {
       final List<ProductionRule> seaProductionRulesCopy = new ArrayList<>(seaProductionRules);
       for (final ProductionRule seaRule : seaProductionRulesCopy) {
@@ -183,8 +181,8 @@ public class ProBidAI {
       }
     }
     if (subProductionRules.size() > 0 && seaProductionRules.size() > 0) {
-      if (subProductionRules.size() / seaProductionRules.size() < 0.3) // remove submarines from consideration, unless
-                                                                       // we are mostly subs
+      // remove submarines from consideration, unless we are mostly subs
+      if (subProductionRules.size() / seaProductionRules.size() < 0.3)
       {
         seaProductionRules.removeAll(subProductionRules);
       }
@@ -222,9 +220,8 @@ public class ProBidAI {
             PUsToSpend, buyLimit, data, player, 2);
       }
     } else if (Math.random() < 0.35) {
-      if (Math.random() > 0.55 && carrierRule != null && fighterRule != null) { // force a carrier purchase if enough
-                                                                                // available $$ for it and
-                                                                                // at least 1 fighter
+      // force a carrier purchase if enough available $$ for it and at least 1 fighter
+      if (Math.random() > 0.55 && carrierRule != null && fighterRule != null) {
         final int cost = carrierRule.getCosts().getInt(pus);
         final int fighterCost = fighterRule.getCosts().getInt(pus);
         if ((cost + fighterCost) <= PUsToSpend) {
@@ -1352,8 +1349,8 @@ public class ProBidAI {
   /**
    * List containing the enemy Capitals
    */
-  private static List<Territory> getEnemyCapitals(final GameData data, final PlayerID player) { // generate a list of
-                                                                                                // all enemy capitals
+  private static List<Territory> getEnemyCapitals(final GameData data, final PlayerID player) {
+    // generate a list of all enemy capitals
     final List<Territory> enemyCapitals = new ArrayList<>();
     final List<PlayerID> ePlayers = getEnemyPlayers(data, player);
     for (final PlayerID otherPlayer : ePlayers) {
@@ -2136,11 +2133,8 @@ public class ProBidAI {
    * @neutral - count an attackable neutral as a land neighbor
    * @return boolean (true if a land territory is a neighbor to t
    */
-  private static boolean doesLandExistAt(final Territory t, final GameData data, final boolean neutral) { // simply: is
-                                                                                                          // this
-                                                                                                          // territory
-                                                                                                          // surrounded
-                                                                                                          // by water
+  private static boolean doesLandExistAt(final Territory t, final GameData data, final boolean neutral) {
+    // simply: is this territory surrounded by water
     boolean isLand = false;
     final Set<Territory> checkList = data.getMap().getNeighbors(t, Matches.TerritoryIsLand);
     if (!neutral) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOption.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOption.java
@@ -297,8 +297,8 @@ public class ProPurchaseOption {
 
   private double calculateLandDistanceFactor(final int enemyDistance) {
     final double distance = Math.max(0, enemyDistance - 1.5);
-    final double moveFactor = 1 + 2 * (Math.pow(2, movement - 1) - 1) / Math.pow(2, movement - 1); // 1, 2, 2.5, 2.75,
-                                                                                                   // etc
+    // 1, 2, 2.5, 2.75, etc
+    final double moveFactor = 1 + 2 * (Math.pow(2, movement - 1) - 1) / Math.pow(2, movement - 1);
     final double distanceFactor = Math.pow(moveFactor, distance / 5);
     return distanceFactor;
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
@@ -273,8 +273,8 @@ public class ProLogWindow extends javax.swing.JDialog {
     final int result = JOptionPane.showConfirmDialog(rootPane, "Are you sure you want to reset all AI settings?",
         "Reset Default Settings", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
     if (result == JOptionPane.OK_OPTION) {
-      final ProLogSettings defaultSettings = new ProLogSettings(); // Default settings are already contained in a new
-                                                                   // DSettings instance
+      // Default settings are already contained in a new DSettings instance
+      final ProLogSettings defaultSettings = new ProLogSettings();
       loadSettings(defaultSettings);
       JOptionPane.showMessageDialog(rootPane,
           "Default settings restored.\r\n\r\n(If you don't want to keep these default settings, just hit cancel)",

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -868,12 +868,10 @@ public class WeakAI extends AbstractAI {
       // assume minimum unit price is 3, and that we are buying only that... if we over repair, oh well, that is better
       // than under-repairing
       // goal is to be able to produce all our units, and at least half of that production in the capitol
-      if ((capProduction <= maxUnits / 2 || rfactories.isEmpty()) && capUnit != null) // if capitol is super safe, we
-                                                                                      // don't have to do this.
-                                                                                      // and if capitol is under siege,
-                                                                                      // we should repair
-                                                                                      // enough to place all our units
-                                                                                      // here
+      //
+      // if capitol is super safe, we don't have to do this. and if capitol is under siege, we should repair enough to
+      // place all our units here
+      if ((capProduction <= maxUnits / 2 || rfactories.isEmpty()) && capUnit != null)
       {
         for (final RepairRule rrule : rrules) {
           if (!capUnit.getUnitType().equals(rrule.getResults().keySet().iterator().next())) {

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -66,24 +66,25 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   private IntegerMap<UnitType> m_purchase = null;
   private String m_resource = null;
   private int m_resourceCount = 0;
-  private LinkedHashMap<String, Boolean> m_support = null; // never use a map of other attachments, inside of an
-                                                           // attachment. java will not be able to deserialize it.
-  private ArrayList<String> m_relationshipChange = new ArrayList<>(); // List of relationshipChanges that should be
-                                                                      // executed when this trigger hits.
+  // never use a map of other attachments, inside of an attachment. java will not be able to deserialize it.
+  private LinkedHashMap<String, Boolean> m_support = null;
+  // List of relationshipChanges that should be executed when this trigger hits.
+  private ArrayList<String> m_relationshipChange = new ArrayList<>();
   private String m_victory = null;
   private ArrayList<Tuple<String, String>> m_activateTrigger = new ArrayList<>();
   private ArrayList<String> m_changeOwnership = new ArrayList<>();
   // raw property changes below:
-  private ArrayList<UnitType> m_unitType = new ArrayList<>(); // really m_unitTypes, but we are not going to rename
-                                                              // because it will break all existing maps
+  //
+  // really m_unitTypes, but we are not going to rename because it will break all existing maps
+  private ArrayList<UnitType> m_unitType = new ArrayList<>();
   private Tuple<String, String> m_unitAttachmentName = null; // covers UnitAttachment, UnitSupportAttachment
   private ArrayList<Tuple<String, String>> m_unitProperty = null;
   private ArrayList<Territory> m_territories = new ArrayList<>();
   private Tuple<String, String> m_territoryAttachmentName = null; // covers TerritoryAttachment, CanalAttachment
   private ArrayList<Tuple<String, String>> m_territoryProperty = null;
   private ArrayList<PlayerID> m_players = new ArrayList<>();
-  private Tuple<String, String> m_playerAttachmentName = null; // covers PlayerAttachment, TriggerAttachment,
-                                                               // RulesAttachment, TechAttachment, UserActionAttachment
+  // covers PlayerAttachment, TriggerAttachment, RulesAttachment, TechAttachment, UserActionAttachment
+  private Tuple<String, String> m_playerAttachmentName = null;
   private ArrayList<Tuple<String, String>> m_playerProperty = null;
   private ArrayList<RelationshipType> m_relationshipTypes = new ArrayList<>();
   private Tuple<String, String> m_relationshipTypeAttachmentName = null; // covers RelationshipTypeAttachment
@@ -790,9 +791,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (m_unitProperty == null) {
       m_unitProperty = new ArrayList<>();
     }
-    final String property = s[s.length - 1]; // the last one is the property we are changing, while the rest is the
-                                             // string we are changing
-                                             // it to
+    // the last one is the property we are changing, while the rest is the string we are changing it to
+    final String property = s[s.length - 1];
     m_unitProperty.add(Tuple.of(property, getValueFromStringArrayForAllExceptLastSubstring(s)));
   }
 
@@ -910,9 +910,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (m_territoryProperty == null) {
       m_territoryProperty = new ArrayList<>();
     }
-    final String property = s[s.length - 1]; // the last one is the property we are changing, while the rest is the
-                                             // string we are changing
-                                             // it to
+    // the last one is the property we are changing, while the rest is the string we are changing it to
+    final String property = s[s.length - 1];
     m_territoryProperty.add(Tuple.of(property, getValueFromStringArrayForAllExceptLastSubstring(s)));
   }
 
@@ -1050,9 +1049,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (m_playerProperty == null) {
       m_playerProperty = new ArrayList<>();
     }
-    final String property = s[s.length - 1]; // the last one is the property we are changing, while the rest is the
-                                             // string we are changing
-                                             // it to
+    // the last one is the property we are changing, while the rest is the string we are changing it to
+    final String property = s[s.length - 1];
     m_playerProperty.add(Tuple.of(property, getValueFromStringArrayForAllExceptLastSubstring(s)));
   }
 
@@ -1168,9 +1166,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (m_relationshipTypeProperty == null) {
       m_relationshipTypeProperty = new ArrayList<>();
     }
-    final String property = s[s.length - 1]; // the last one is the property we are changing, while the rest is the
-                                             // string we are changing
-                                             // it to
+    // the last one is the property we are changing, while the rest is the string we are changing it to
+    final String property = s[s.length - 1];
     m_relationshipTypeProperty
         .add(Tuple.of(property, getValueFromStringArrayForAllExceptLastSubstring(s)));
   }
@@ -1287,9 +1284,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     if (m_territoryEffectProperty == null) {
       m_territoryEffectProperty = new ArrayList<>();
     }
-    final String property = s[s.length - 1]; // the last one is the property we are changing, while the rest is the
-                                             // string we are changing
-                                             // it to
+    // the last one is the property we are changing, while the rest is the string we are changing it to
+    final String property = s[s.length - 1];
     m_territoryEffectProperty
         .add(Tuple.of(property, getValueFromStringArrayForAllExceptLastSubstring(s)));
   }
@@ -1644,10 +1640,10 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         final String notificationMessageKey = t.getNotification().trim();
         final String sounds = NotificationMessages.getInstance().getSoundsKey(notificationMessageKey);
         if (sounds != null) {
+          // play to observers if we are playing to everyone
           aBridge.getSoundChannelBroadcaster().playSoundToPlayers(
               SoundPath.CLIP_TRIGGERED_NOTIFICATION_SOUND + sounds.trim(), t.getPlayers(), null,
-              t.getPlayers().containsAll(data.getPlayerList().getPlayers())); // play to observers if we are playing to
-                                                                              // everyone
+              t.getPlayers().containsAll(data.getPlayerList().getPlayers()));
         }
         final String message = NotificationMessages.getInstance().getMessage(notificationMessageKey);
         if (message != null) {
@@ -1887,18 +1883,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
             final TerritoryAttachment attachment =
                 TerritoryAttachment.get(aTerritory, t.getTerritoryAttachmentName().getSecond());
             if (attachment == null) {
-              throw new IllegalStateException("Triggers: No territory attachment for:" + aTerritory.getName()); // water
-                                                                                                                // territories
-                                                                                                                // may
-                                                                                                                // not
-                                                                                                                // have
-                                                                                                                // an
-                                                                                                                // attachment,
-                                                                                                                // so
-                                                                                                                // this
-                                                                                                                // could
-                                                                                                                // be
-                                                                                                                // null
+              // water territories may not have an attachment, so this could be null
+              throw new IllegalStateException("Triggers: No territory attachment for:" + aTerritory.getName());
             }
             if (newValue.equals(attachment.getRawPropertyString(property.getFirst()))) {
               continue;
@@ -2353,8 +2339,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
           final Territory territorySet = data.getMap().getTerritory(s[0]);
           territories.add(territorySet);
         }
-        final PlayerID oldOwner = data.getPlayerList().getPlayerID(s[1]); // if null, then is must be "any", so then any
-                                                                          // player
+        // if null, then is must be "any", so then any player
+        final PlayerID oldOwner = data.getPlayerList().getPlayerID(s[1]);
         final PlayerID newOwner = data.getPlayerList().getPlayerID(s[2]);
         final boolean captured = getBool(s[3]);
         for (final Territory terr : territories) {

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1086,8 +1086,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final RulesAttachment ra = (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
     final Collection<Unit> alreadProducedUnits = getAlreadyProduced(producer);
     final int unitCountAlreadyProduced = alreadProducedUnits.size();
-    if (originalFactory && playerIsOriginalOwner) // && !placementRestrictedByFactory &&
-                                                  // !unitPlacementPerTerritoryRestricted
+    if (originalFactory && playerIsOriginalOwner)
     {
       if (ra != null && ra.getMaxPlacePerTerritory() != -1) {
         return Math.max(0, ra.getMaxPlacePerTerritory() - unitCountAlreadyProduced);

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -44,10 +44,8 @@ public class AirMovementValidator {
     if (getEditMode(data) || // Edit Mode, no need to check
         !Match.someMatch(units, Matches.UnitIsAir) || // No Airunits, nothing to check
         route.hasNoSteps() || // if there are no steps, we didn't move, so it is always OK!
-        Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data).match(route.getEnd()) || // we can land at
-                                                                                                       // the end,
-                                                                                                       // nothing
-                                                                                                       // left to check
+        // we can land at the end, nothing left to check
+        Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data).match(route.getEnd()) ||
         isKamikazeAircraft(data) // we do not do any validation at all, cus they can all die and we don't care
     ) {
       return result;
@@ -592,10 +590,9 @@ public class AirMovementValidator {
     final PlayerID player = unit.getOwner();
     final List<Territory> possibleSpots = Match.getMatches(data.getMap().getNeighbors(current, movementLeft),
         Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data));
-    for (final Territory landingSpot : possibleSpots) { // TODO EW: Assuming movement cost of 1, this could get VERY
-                                                        // slow when the
-                                                        // movementcost is very high and airunits have a lot of
-                                                        // movementcapacity.
+    // TODO EW: Assuming movement cost of 1, this could get VERY slow when the movement cost is very high and air units
+    // have a lot of movement capacity.
+    for (final Territory landingSpot : possibleSpots) {
       if (canAirReachThisSpot(data, player, unit, current, movementLeft, landingSpot, areNeutralsPassableByAir)) {
         return true;
       }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -615,8 +615,7 @@ public class MoveValidator {
             + (route.numberOfSteps() > 1 ? "these territories" : "this territory"));
       }
     } // !isEditMode
-    // make sure that no non sea non transportable no carriable units
-    // end at sea
+    // make sure that no non sea non transportable no carriable units end at sea
     if (route.getEnd() != null && route.getEnd().isWater()) {
       for (final Unit unit : MoveValidator.getUnitsThatCantGoOnWater(units)) {
         result.addDisallowedUnit("Not all units can end at water", unit);

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
@@ -130,10 +130,9 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
       final long startTime = System.currentTimeMillis();
       final long startMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
       final GameData newData;
-      try { // make first copy, then release lock on it so game can continue (ie: we don't want to lock on it while we
-            // copy it 16 times,
-            // when once is enough)
-        // don't let the data change while we make the first copy
+      try {
+        // make first copy, then release lock on it so game can continue (ie: we don't want to lock on it while we copy
+        // it 16 times, when once is enough) don't let the data change while we make the first copy
         data.acquireReadLock();
         newData = GameDataUtils.cloneGameData(data, false);
       } finally {
@@ -144,8 +143,8 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
         // make sure all workers are using the same data
         newData.acquireReadLock();
         int i = 0;
-        if (m_currentThreads <= 2 || MAX_THREADS <= 2) // we are already in 1 executor thread, so we have MAX_THREADS-1
-                                                       // threads left to use
+        // we are already in 1 executor thread, so we have MAX_THREADS-1 threads left to use
+        if (m_currentThreads <= 2 || MAX_THREADS <= 2)
         { // if 2 or fewer threads, do not multi-thread the copying (we have already copied it once above, so at most
           // only 1 more copy to
           // make)

--- a/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -42,8 +42,8 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
   protected final GameData m_data;
   protected final AbstractMovePanel m_movePanel;
   protected JScrollPane scroll;
-  protected Integer scrollBarPreviousValue = null;// TODO replace this Integer with a int primitive... Using null as
-                                                  // toggle switch is bad code
+  // TODO replace this Integer with a int primitive... Using null as toggle switch is bad code
+  protected Integer scrollBarPreviousValue = null;
   protected Integer previousVisibleIndex = null;
 
   public AbstractUndoableMovesPanel(final GameData data, final AbstractMovePanel movePanel) {

--- a/src/main/java/games/strategy/triplea/ui/NotificationMessages.java
+++ b/src/main/java/games/strategy/triplea/ui/NotificationMessages.java
@@ -36,8 +36,8 @@ public class NotificationMessages {
   }
 
   public static NotificationMessages getInstance() {
-    if (s_nm == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 10000) { // cache properties for 10
-                                                                                          // seconds
+    // cache properties for 10 seconds
+    if (s_nm == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 10000) {
       s_nm = new NotificationMessages();
       s_timestamp = Calendar.getInstance().getTimeInMillis();
     }

--- a/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -461,8 +461,8 @@ class ObjectiveProperties {
   }
 
   public static ObjectiveProperties getInstance() {
-    if (s_op == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 1000) { // cache properties for 1
-                                                                                         // second
+    // cache properties for 1 second
+    if (s_op == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 1000) {
       s_op = new ObjectiveProperties();
       s_timestamp = Calendar.getInstance().getTimeInMillis();
     }

--- a/src/main/java/games/strategy/triplea/ui/PoliticsText.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticsText.java
@@ -45,8 +45,8 @@ public class PoliticsText {
   }
 
   public static PoliticsText getInstance() {
-    if (s_pt == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 10000) { // cache properties for 10
-                                                                                          // seconds
+    // cache properties for 10 seconds
+    if (s_pt == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 10000) {
       s_pt = new PoliticsText();
       s_timestamp = Calendar.getInstance().getTimeInMillis();
     }

--- a/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
+++ b/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
@@ -38,8 +38,8 @@ public class TooltipProperties {
   }
 
   public static TooltipProperties getInstance() {
-    if (s_ttp == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 5000) { // cache properties for 5
-                                                                                          // seconds
+    // cache properties for 5 seconds
+    if (s_ttp == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 5000) {
       s_ttp = new TooltipProperties();
       s_timestamp = Calendar.getInstance().getTimeInMillis();
     }

--- a/src/main/java/games/strategy/triplea/ui/UserActionText.java
+++ b/src/main/java/games/strategy/triplea/ui/UserActionText.java
@@ -43,8 +43,8 @@ public class UserActionText {
   }
 
   public static UserActionText getInstance() {
-    if (s_text == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 10000) { // cache properties for 10
-                                                                                            // seconds
+    // cache properties for 10 seconds
+    if (s_text == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 10000) {
       s_text = new UserActionText();
       s_timestamp = Calendar.getInstance().getTimeInMillis();
     }

--- a/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -105,8 +105,8 @@ public class TripleAMenuBar extends JMenuBar {
 
 
       fileDialog.setDirectory(ClientContext.folderSettings().getSaveGamePath());
-      fileDialog.setFilenameFilter((dir, name) -> { // the extension should be .tsvg, but find svg
-                                                    // extensions as well
+      fileDialog.setFilenameFilter((dir, name) -> {
+        // the extension should be .tsvg, but find svg extensions as well
         return name.endsWith(".tsvg") || name.endsWith(".svg");
       });
       fileDialog.setVisible(true);

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -372,8 +372,7 @@ public class PlacementPicker extends JFrame {
     editMenu.add(showIncompleteModeItem);
     menuBar.add(fileMenu);
     menuBar.add(editMenu);
-  } // end
-   // constructor
+  } // end constructor
 
   /**
    * createImage(java.lang.String)

--- a/src/main/java/tools/map/xml/creator/ImageScrollPanePanel.java
+++ b/src/main/java/tools/map/xml/creator/ImageScrollPanePanel.java
@@ -50,8 +50,8 @@ public abstract class ImageScrollPanePanel {
     return mapXmlCreator;
   }
 
-  protected static Map<String, List<Polygon>> polygons = Maps.newHashMap(); // hash map for polygon
-                                                                            // points
+  // hash map for polygon points
+  protected static Map<String, List<Polygon>> polygons = Maps.newHashMap();
   public static boolean polygonsInvalid = true;
 
   private JPanel imagePanel;

--- a/src/main/java/tools/map/xml/creator/MapXmlCreator.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlCreator.java
@@ -589,12 +589,7 @@ public class MapXmlCreator extends JFrame {
               "Help For Current Step");
           break;
 
-        case TERRITORY_DEFINITIONS: // showInfoMessage("To add a new territory, click somewhere on the map and enter a
-                                    // name for the
-          // territory in the window that appears. \r If you want to change the properties of a territory,
-          // left click on it and answer each question. The color of the territory label changes for each
-          // property that is applies. If you want to remove a territory label, right click on it and click yes
-          // when it asks for confirmation.", "Help For Current Step");
+        case TERRITORY_DEFINITIONS:
           showInfoMessage(
               "Right click to rename a territory. \r If you want to change the properties of a territory, left click on it. \r The color of the territory label changes for each property that is applied.",
               "Help For Current Step");

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -210,8 +210,7 @@ public class ValidateAttachmentsTest {
       Class<?> clazz;
       try {
         clazz = Class.forName(className);
-        if (!clazz.isInterface() && IAttachment.class.isAssignableFrom(clazz)) // &&
-                                                                               // !Modifier.isAbstract(clazz.getModifiers())
+        if (!clazz.isInterface() && IAttachment.class.isAssignableFrom(clazz))
         {
           @SuppressWarnings("unchecked")
           final Class<? extends IAttachment> attachmentClass = (Class<? extends IAttachment>) clazz;

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
@@ -14,8 +14,8 @@ import games.strategy.util.Version;
 public class MapDownloadListSortTest {
 
   private static final DownloadFileDescription MAP_A = createDownload("a", "url");
-  private static final DownloadFileDescription MAP_B = createDownload("B", "url"); // capitol B to ensure case
-                                                                                   // insensitive sorting
+  // capitol B to ensure case insensitive sorting
+  private static final DownloadFileDescription MAP_B = createDownload("B", "url");
   private static final DownloadFileDescription MAP_C = createDownload("c", "url");
   private static DownloadFileDescription createDownload(final String mapName, final String url) {
     final String description = "fake";

--- a/src/test/java/games/strategy/triplea/ui/RouteTest.java
+++ b/src/test/java/games/strategy/triplea/ui/RouteTest.java
@@ -37,8 +37,8 @@ public class RouteTest {
 
   @Before
   public void setUp() {
-    dummyRoute.add(mock(Territory.class));// This will be overridden with the startPoint, since it's the origin
-                                          // territory
+    // This will be overridden with the startPoint, since it's the origin territory
+    dummyRoute.add(mock(Territory.class));
     dummyRoute.add(mock(Territory.class));
     when(dummyMapData.getCenter(any(Territory.class))).thenReturn(dummyPoints[1].toPoint());
     when(dummyMapData.getMapDimensions()).thenReturn(new Dimension(1000, 1000));


### PR DESCRIPTION
This PR fixes violations of the Checkstyle CommentsIndentation rule.

In most cases, the changes consist of moving "multiline" end-of-line comments to the line before the statement which they target.  The remaining cases are commented out code at the end of a line that I simply removed.