### PR TITLE
Checkstyle: Fix incomplete Javadoc sentences

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=8949
-checkstyleTestMaxWarnings=412
+checkstyleMainMaxWarnings=8144
+checkstyleTestMaxWarnings=385

--- a/src/main/java/games/strategy/debug/ErrorConsole.java
+++ b/src/main/java/games/strategy/debug/ErrorConsole.java
@@ -24,7 +24,7 @@ public class ErrorConsole extends GenericConsole {
     return getConsole();
   }
 
-  /** Creates a new instance of Console */
+  /** Creates a new instance of ErrorConsole. */
   public ErrorConsole() {
     super("TripleA Console");
   }

--- a/src/main/java/games/strategy/debug/GenericConsole.java
+++ b/src/main/java/games/strategy/debug/GenericConsole.java
@@ -68,7 +68,7 @@ public abstract class GenericConsole extends JFrame {
   }
 
   /**
-   * Displays standard error to the console
+   * Displays standard error to the console.
    */
   public void displayStandardError() {
     final SynchedByteArrayOutputStream out = new SynchedByteArrayOutputStream(System.err);

--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -155,7 +155,7 @@ public final class ClientFileSystemHelper {
     return mapsFolder;
   }
 
-  /** Create a temporary file, checked exceptions are re-thrown as unchecked */
+  /** Create a temporary file, checked exceptions are re-thrown as unchecked. */
   public static File createTempFile() {
     try {
       return File.createTempFile("triplea", "tmp");

--- a/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/src/main/java/games/strategy/engine/chat/Chat.java
@@ -87,7 +87,7 @@ public class Chat {
     return sb.toString();
   }
 
-  /** Creates a new instance of Chat */
+  /** Creates a new instance of Chat. */
   public Chat(final String chatName, final Messengers messengers, final CHAT_SOUND_PROFILE chatSoundProfile) {
     this.chatSoundProfile = chatSoundProfile;
     this.messengers = messengers;
@@ -157,7 +157,7 @@ public class Chat {
   }
 
   /**
-   * Call only when mutex for node is locked!
+   * Call only when mutex for node is locked.
    *
    * @param chatters
    *        map from node to tag

--- a/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -199,13 +199,13 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
     nextMessageKeymap.remove(KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_DOWN, 0, false));
   }
 
-  /** thread safe */
+  /** thread safe. */
   @Override
   public void addMessage(final String message, final String from, final boolean thirdperson) {
     addMessageWithSound(message, from, thirdperson, SoundPath.CLIP_CHAT_MESSAGE);
   }
 
-  /** thread safe */
+  /** thread safe. */
   @Override
   public void addMessageWithSound(final String message, final String from, final boolean thirdperson,
       final String sound) {
@@ -287,7 +287,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   }
 
   /**
-   * Show only the first n lines
+   * Show only the first n lines.
    */
   public static void trimLines(final Document doc, final int lineCount) {
     if (doc.getLength() < lineCount) {

--- a/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -25,7 +25,7 @@ public class ChatPanel extends JPanel implements IChatPanel {
   private ChatPlayerPanel chatPlayerPanel;
   private ChatMessagePanel chatMessagePanel;
 
-  /** Creates a new instance of ChatFrame */
+  /** Creates a new instance of ChatPanel. */
   public ChatPanel(final IMessenger messenger, final IChannelMessenger channelMessenger,
       final IRemoteMessenger remoteMessenger, final String chatName, final CHAT_SOUND_PROFILE chatSoundProfile) {
     init();

--- a/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -105,7 +105,7 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
   }
 
   /**
-   * set minimum size based on players (number and max name length) and distribution to playerIDs
+   * set minimum size based on players (number and max name length) and distribution to playerIDs.
    */
   private void setDynamicPreferredSize() {
     final List<INode> onlinePlayers = chat.getOnlinePlayers();
@@ -191,7 +191,7 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
   private void setWidgetActivation() {}
 
   /**
-   * The renderer will be passed in a string
+   * The renderer will be passed in a string.
    */
   public void setPlayerRenderer(final ListCellRenderer<Object> renderer) {
     setCellRenderer = renderer;

--- a/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -127,13 +127,13 @@ public class HeadlessChat implements IChatListener, IChatPanel {
     }
   }
 
-  /** thread safe */
+  /** thread safe. */
   @Override
   public void addMessage(final String message, final String from, final boolean thirdperson) {
     addMessageWithSound(message, from, thirdperson, SoundPath.CLIP_CHAT_MESSAGE);
   }
 
-  /** thread safe */
+  /** thread safe. */
   @Override
   public void addMessageWithSound(final String message, final String from, final boolean thirdperson,
       final String sound) {

--- a/src/main/java/games/strategy/engine/chat/IChatChannel.java
+++ b/src/main/java/games/strategy/engine/chat/IChatChannel.java
@@ -5,7 +5,7 @@ import games.strategy.engine.message.IChannelSubscribor;
 import games.strategy.net.INode;
 
 /**
- * Chat messages occur on this channel
+ * Chat messages occur on this channel.
  */
 public interface IChatChannel extends IChannelSubscribor {
   // we get the sender from MessageContext

--- a/src/main/java/games/strategy/engine/chat/IPlayerActionFactory.java
+++ b/src/main/java/games/strategy/engine/chat/IPlayerActionFactory.java
@@ -11,7 +11,7 @@ public interface IPlayerActionFactory {
   IPlayerActionFactory NULL_FACTORY = clickedOn -> Collections.emptyList();
 
   /**
-   * The mouse has been clicked on a player, create a list of actions to be displayed
+   * The mouse has been clicked on a player, create a list of actions to be displayed.
    */
   List<Action> mouseOnPlayer(INode clickedOn);
 }

--- a/src/main/java/games/strategy/engine/config/GameEnginePropertyFileReader.java
+++ b/src/main/java/games/strategy/engine/config/GameEnginePropertyFileReader.java
@@ -24,7 +24,7 @@ public class GameEnginePropertyFileReader implements PropertyReader {
     this(new File(GAME_ENGINE_PROPERTY_FILE));
   }
 
-  /** This constructor here for testing purposes, use the simple no-arg constructor instead */
+  /** This constructor here for testing purposes, use the simple no-arg constructor instead. */
   protected GameEnginePropertyFileReader(final File propertyFile) {
     this.propertyFile = propertyFile;
   }

--- a/src/main/java/games/strategy/engine/data/AllianceTracker.java
+++ b/src/main/java/games/strategy/engine/data/AllianceTracker.java
@@ -62,7 +62,7 @@ public class AllianceTracker implements Serializable {
   }
 
   /**
-   * @return a set of all the games alliances, this will return an empty set if you aren't using alliances
+   * @return a set of all the games alliances, this will return an empty set if you aren't using alliances.
    */
   public Set<String> getAlliances() {
     final Iterator<PlayerID> keys = alliances.keySet().iterator();
@@ -75,7 +75,7 @@ public class AllianceTracker implements Serializable {
 
   /**
    * Returns the PlayerID's that are members of the alliance
-   * specified by the String allianceName
+   * specified by the String allianceName.
    *
    * @param allianceName Alliance name
    * @return all the players in the given alliance

--- a/src/main/java/games/strategy/engine/data/BattleRecordsList.java
+++ b/src/main/java/games/strategy/engine/data/BattleRecordsList.java
@@ -9,7 +9,7 @@ import java.util.Map.Entry;
 import games.strategy.triplea.delegate.dataObjects.BattleRecords;
 
 /**
- * A holder for BattleRecords
+ * A holder for BattleRecords.
  */
 public class BattleRecordsList extends GameDataComponent {
   private static final long serialVersionUID = 7515693859612849475L;
@@ -115,7 +115,7 @@ public class BattleRecordsList extends GameDataComponent {
   }
 
   /**
-   * Determines if there were any battles that match the following criteria:
+   * Determines if there were any battles that match the specified criteria.
    *
    * @param attacker
    *        if null then any player

--- a/src/main/java/games/strategy/engine/data/CompositeChange.java
+++ b/src/main/java/games/strategy/engine/data/CompositeChange.java
@@ -51,7 +51,7 @@ public class CompositeChange extends Change {
   }
 
   /**
-   * @return true if this change is empty, or composed of empty changes
+   * @return true if this change is empty, or composed of empty changes.
    */
   @Override
   public boolean isEmpty() {

--- a/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -78,7 +78,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
 
   /**
    * @param property
-   * @return null or the toString() of the field value
+   * @return null or the toString() of the field value.
    */
   public String getRawPropertyString(final String property) {
     final Object obj = PropertyUtil.getPropertyFieldObject(property, this);

--- a/src/main/java/games/strategy/engine/data/DefaultNamed.java
+++ b/src/main/java/games/strategy/engine/data/DefaultNamed.java
@@ -10,7 +10,7 @@ public class DefaultNamed extends GameDataComponent implements Named {
   private static final long serialVersionUID = -5737716450699952621L;
   private final String m_name;
 
-  /** Creates new DefaultNamed */
+  /** Creates new DefaultNamed. */
   public DefaultNamed(final String name, final GameData data) {
     super(data);
     if (name == null || name.length() == 0) {

--- a/src/main/java/games/strategy/engine/data/GameData.java
+++ b/src/main/java/games/strategy/engine/data/GameData.java
@@ -98,7 +98,7 @@ public class GameData implements java.io.Serializable {
   private final Hashtable<String, TerritoryEffect> territoryEffectList = new Hashtable<>();
   private final BattleRecordsList battleRecordsList = new BattleRecordsList(this);
 
-  /** Creates new GameData */
+  /** Creates new GameData. */
   public GameData() {
     super();
     delegateList = new DelegateList(this);
@@ -122,7 +122,7 @@ public class GameData implements java.io.Serializable {
 
   /**
    * Print an exception report if we are testing the lock is held, and
-   * do not currently hold the read or write lock
+   * do not currently hold the read or write lock.
    */
   private void ensureLockHeld() {
     if (!testLockIsHeld) {
@@ -137,7 +137,7 @@ public class GameData implements java.io.Serializable {
   }
 
   /**
-   * @return a collection of all units in the game
+   * @return a collection of all units in the game.
    */
   public UnitsList getUnits() {
     // ensureLockHeld();
@@ -145,7 +145,7 @@ public class GameData implements java.io.Serializable {
   }
 
   /**
-   * @return list of Players in the game
+   * @return list of Players in the game.
    */
   public PlayerList getPlayerList() {
     return playerList;

--- a/src/main/java/games/strategy/engine/data/GameDataComponent.java
+++ b/src/main/java/games/strategy/engine/data/GameDataComponent.java
@@ -12,7 +12,7 @@ public class GameDataComponent implements java.io.Serializable {
   private GameData m_data;
 
   /**
-   * Creates new GameDataComponent
+   * Creates new GameDataComponent.
    *
    * @param data
    *        game data

--- a/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/src/main/java/games/strategy/engine/data/GameMap.java
@@ -239,7 +239,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   /**
    * @param s
    *        name of the searched territory (case sensitive)
-   * @return the territory with the given name, or null if no territory can be found (case sensitive)
+   * @return the territory with the given name, or null if no territory can be found (case sensitive).
    */
   public Territory getTerritory(final String s) {
     return m_territoryLookup.get(s);
@@ -397,7 +397,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *        start territory of the route
    * @param t2
    *        end territory of the route
-   * @return the shortest route between two territories or null if no route exists
+   * @return the shortest route between two territories or null if no route exists.
    */
   public Route getRoute(final Territory t1, final Territory t2) {
     return getRoute(t1, t2, Matches.TerritoryIsLandOrWater);
@@ -408,7 +408,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *        start territory of the route
    * @param t2
    *        end territory of the route
-   * @return the shortest land route between two territories or null if no route exists
+   * @return the shortest land route between two territories or null if no route exists.
    */
   public Route getLandRoute(final Territory t1, final Territory t2) {
     return getRoute(t1, t2, Matches.TerritoryIsLand);
@@ -419,7 +419,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *        start territory of the route
    * @param t2
    *        end territory of the route
-   * @return the shortest water route between two territories or null if no route exists
+   * @return the shortest water route between two territories or null if no route exists.
    */
   public Route getWaterRoute(final Territory t1, final Territory t2) {
     return getRoute(t1, t2, Matches.TerritoryIsWater);
@@ -433,7 +433,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param cond
    *        condition that covered territories of the route must match
    * @return the shortest route between two territories so that covered territories match the condition
-   *         or null if no route exists
+   *         or null if no route exists.
    */
   public Route getRoute(final Territory t1, final Territory t2, final Match<Territory> cond) {
     if (t1 == t2) {
@@ -493,7 +493,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *        start territory of the route
    * @param t2
    *        end territory of the route
-   * @return the distance between two territories or -1 if they are not connected
+   * @return the distance between two territories or -1 if they are not connected.
    */
   public int getDistance(final Territory t1, final Territory t2) {
     return getDistance(t1, t2, Matches.TerritoryIsLandOrWater);
@@ -504,7 +504,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *        start territory of the route
    * @param t2
    *        end territory of the route
-   * @return the land distance between two territories or -1 if they are not connected
+   * @return the land distance between two territories or -1 if they are not connected.
    */
   public int getLandDistance(final Territory t1, final Territory t2) {
     return getDistance(t1, t2, Matches.TerritoryIsLand);
@@ -515,7 +515,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *        start territory of the route
    * @param t2
    *        end territory of the route
-   * @return the water distance between two territories or -1 if they are not connected
+   * @return the water distance between two territories or -1 if they are not connected.
    */
   public int getWaterDistance(final Territory t1, final Territory t2) {
     return getDistance(t1, t2, Matches.TerritoryIsWater);
@@ -529,7 +529,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param cond
    *        condition that covered territories of the route must match
    * @return the distance between two territories where the covered territories of the route satisfy the condition
-   *         or -1 if they are not connected
+   *         or -1 if they are not connected.
    */
   public int getDistance(final Territory t1, final Territory t2, final Match<Territory> cond) {
     if (t1.equals(t2)) {
@@ -624,7 +624,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   /**
    * @param route
    *        route containing the territories in question
-   * @return whether each territory is connected to the preceding territory
+   * @return whether each territory is connected to the preceding territory.
    */
   public boolean isValidRoute(final Route route) {
     Territory previous = null;

--- a/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
+++ b/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
@@ -7,13 +7,13 @@ import java.io.ObjectInputStream;
 import games.strategy.engine.framework.GameObjectStreamFactory;
 
 /**
- * Please refer to the comments on GameObjectOutputStream
+ * Please refer to the comments on GameObjectOutputStream.
  */
 public class GameObjectInputStream extends ObjectInputStream {
   private final GameObjectStreamFactory m_dataSource;
 
   /**
-   * Creates new GameObjectReader
+   * Creates new GameObjectReader.
    *
    * @param dataSource
    *        data source

--- a/src/main/java/games/strategy/engine/data/GameObjectOutputStream.java
+++ b/src/main/java/games/strategy/engine/data/GameObjectOutputStream.java
@@ -17,7 +17,7 @@ import java.io.OutputStream;
  */
 public class GameObjectOutputStream extends ObjectOutputStream {
   /**
-   * Creates a new instance of GameObjectOutputStream
+   * Creates a new instance of GameObjectOutputStream.
    *
    * @param output
    *        output stream

--- a/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
+++ b/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
@@ -23,7 +23,7 @@ public class GameObjectStreamData implements Externalizable {
   public GameObjectStreamData() {}
 
   /**
-   * Creates a new instance of GameObjectStreamData
+   * Creates a new instance of GameObjectStreamData.
    *
    * @param named
    *        named entity

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -468,7 +468,7 @@ public class GameParser {
   }
 
   /**
-   * If optional is true, will not throw an exception if there are 0 children
+   * If optional is true, will not throw an exception if there are 0 children.
    */
   private Element getSingleChild(final String name, final Node node, final boolean optional) throws GameParseException {
     final List<Element> children = getChildren(name, node);
@@ -786,7 +786,7 @@ public class GameParser {
 
   /**
    * @param root
-   *        root node containing the playerList
+   *        root node containing the playerList.
    * @throws GameParseException
    */
   private void parsePlayerList(final Element root) {

--- a/src/main/java/games/strategy/engine/data/GameSequence.java
+++ b/src/main/java/games/strategy/engine/data/GameSequence.java
@@ -95,7 +95,7 @@ public class GameSequence extends GameDataComponent implements Iterable<GameStep
   }
 
   /**
-   * @return boolean wether the round has changed
+   * @return boolean whether the round has changed.
    */
   public boolean next() {
     synchronized (m_currentStepMutex) {

--- a/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/src/main/java/games/strategy/engine/data/GameStep.java
@@ -36,7 +36,7 @@ public class GameStep extends GameDataComponent {
   public static final String PROPERTY_repairPlayers = "repairPlayers";
 
   /**
-   * Creates new GameStep
+   * Creates new GameStep.
    *
    * @param name
    *        name of the game step
@@ -123,6 +123,7 @@ public class GameStep extends GameDataComponent {
   }
 
   /**
+   * Returns the properties of the game step.
    * Allowed Properties so far:<br>
    * EndTurn delegates -> skipPosting = true/false<br>
    * EndTurn delegates -> turnSummaryPlayers = colon separated list of players for this turn summary<br>

--- a/src/main/java/games/strategy/engine/data/NamedAttachable.java
+++ b/src/main/java/games/strategy/engine/data/NamedAttachable.java
@@ -8,7 +8,7 @@ public class NamedAttachable extends DefaultNamed implements Attachable {
   private static final long serialVersionUID = 8597712929519099255L;
   private final Map<String, IAttachment> m_attachments = new HashMap<>();
 
-  /** Creates new NamedAttachable */
+  /** Creates new NamedAttachable. */
   public NamedAttachable(final String name, final GameData data) {
     super(name, data);
   }

--- a/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -26,7 +26,7 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
     this(name, false, false, data);
   }
 
-  /** Creates new Player */
+  /** Creates new PlayerID. */
   public PlayerID(final String name, final boolean optional, final boolean canBeDisabled, final GameData data) {
     super(name, data);
     m_optional = optional;

--- a/src/main/java/games/strategy/engine/data/PlayerList.java
+++ b/src/main/java/games/strategy/engine/data/PlayerList.java
@@ -15,7 +15,7 @@ public class PlayerList extends GameDataComponent implements Iterable<PlayerID> 
   private final Map<String, PlayerID> m_players = new LinkedHashMap<>();
 
   /**
-   * Creates new PlayerCollection
+   * Creates new PlayerList.
    *
    * @param data
    *        game data
@@ -46,14 +46,14 @@ public class PlayerList extends GameDataComponent implements Iterable<PlayerID> 
   }
 
   /**
-   * @return a new arraylist copy of the players
+   * @return a new arraylist copy of the players.
    */
   public List<PlayerID> getPlayers() {
     return new ArrayList<>(m_players.values());
   }
 
   /**
-   * an iterator of a new arraylist copy of the players
+   * an iterator of a new arraylist copy of the players.
    */
   @Override
   public Iterator<PlayerID> iterator() {

--- a/src/main/java/games/strategy/engine/data/PlayerManager.java
+++ b/src/main/java/games/strategy/engine/data/PlayerManager.java
@@ -55,7 +55,7 @@ public class PlayerManager {
   /**
    * @param node
    *        referring node
-   * @return whether the given node playing as anyone
+   * @return whether the given node playing as anyone.
    */
   public boolean isPlaying(final INode node) {
     return m_playerMapping.containsValue(node);
@@ -77,7 +77,7 @@ public class PlayerManager {
 
   /**
    * Get a player from an opposing side, if possible, else
-   * get a player playing at a remote computer, if possible
+   * get a player playing at a remote computer, if possible.
    *
    * @param localNode
    *        local node

--- a/src/main/java/games/strategy/engine/data/ProductionFrontier.java
+++ b/src/main/java/games/strategy/engine/data/ProductionFrontier.java
@@ -11,7 +11,7 @@ public class ProductionFrontier extends DefaultNamed implements Iterable<Product
   private List<ProductionRule> m_cachedRules;
 
   /**
-   * Creates new ProductionFrontier
+   * Creates new ProductionFrontier.
    *
    * @param name
    *        name of production frontier

--- a/src/main/java/games/strategy/engine/data/ProductionRule.java
+++ b/src/main/java/games/strategy/engine/data/ProductionRule.java
@@ -10,12 +10,12 @@ public class ProductionRule extends DefaultNamed {
   private IntegerMap<Resource> m_cost = new IntegerMap<>();
   private IntegerMap<NamedAttachable> m_results = new IntegerMap<>();
 
-  /** Creates new ProductionRule */
+  /** Creates new ProductionRule. */
   public ProductionRule(final String name, final GameData data) {
     super(name, data);
   }
 
-  /** Creates new ProductionRule */
+  /** Creates new ProductionRule. */
   public ProductionRule(final String name, final GameData data, final IntegerMap<NamedAttachable> results,
       final IntegerMap<Resource> costs) {
     super(name, data);

--- a/src/main/java/games/strategy/engine/data/RelationshipInterpreter.java
+++ b/src/main/java/games/strategy/engine/data/RelationshipInterpreter.java
@@ -18,7 +18,7 @@ public class RelationshipInterpreter extends GameDataComponent {
    *        first referring player
    * @param p2
    *        second referring player
-   * @return whether player p1 is allied to player p2
+   * @return whether player p1 is allied to player p2.
    */
   public boolean isAllied(final PlayerID p1, final PlayerID p2) {
     return Matches.RelationshipTypeIsAllied.match((getRelationshipType(p1, p2)));
@@ -49,7 +49,7 @@ public class RelationshipInterpreter extends GameDataComponent {
   }
 
   /**
-   * returns true if p1 is at war with p2
+   * returns true if p1 is at war with p2.
    *
    * @param p1
    *        player1
@@ -86,7 +86,7 @@ public class RelationshipInterpreter extends GameDataComponent {
    *        player1
    * @param p2
    *        player2
-   * @return whether player1 is neutral to player2
+   * @return whether player1 is neutral to player2.
    */
   public boolean isNeutral(final PlayerID p1, final PlayerID p2) {
     return Matches.RelationshipTypeIsNeutral.match((getRelationshipType(p1, p2)));
@@ -158,7 +158,7 @@ public class RelationshipInterpreter extends GameDataComponent {
 
   /**
    * Convenience method to get RelationshipType so you can do relationshipChecks on the relationship between these 2
-   * players
+   * players.
    *
    * @return RelationshipType between these to players
    */

--- a/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -76,7 +76,7 @@ public class RelationshipTracker extends RelationshipInterpreter {
 
   /**
    * Convenience method to directly access relationshipTypeAttachment on the relationship that exists between two
-   * players
+   * players.
    *
    * @param p1
    *        Player 1 in the relationship
@@ -111,12 +111,12 @@ public class RelationshipTracker extends RelationshipInterpreter {
     }
   }
 
-  /** convenience method to get the SelfRelationshipType added for readability */
+  /** convenience method to get the SelfRelationshipType added for readability. */
   private RelationshipType getSelfRelationshipType() {
     return getData().getRelationshipTypeList().getSelfRelation();
   }
 
-  /** convenience method to get the NullRelationshipType (relationship with the Nullplayer) added for readability */
+  /** convenience method to get the NullRelationshipType (relationship with the Nullplayer) added for readability. */
   private RelationshipType getNullRelationshipType() {
     return getData().getRelationshipTypeList().getNullRelation();
   }
@@ -129,8 +129,7 @@ public class RelationshipTracker extends RelationshipInterpreter {
 
     /**
      * override hashCode to make sure that each new instance of this class can be matched in the Hashtable
-     * even if it was put in as (p1,p2) and you want to get it out as (p2,p1)
-     * and
+     * even if it was put in as (p1,p2) and you want to get it out as (p2,p1).
      */
     @Override
     public int hashCode() {

--- a/src/main/java/games/strategy/engine/data/RelationshipType.java
+++ b/src/main/java/games/strategy/engine/data/RelationshipType.java
@@ -6,7 +6,7 @@ public class RelationshipType extends NamedAttachable {
   private static final long serialVersionUID = 5348310616624709971L;
 
   /**
-   * create new RelationshipType
+   * create new RelationshipType.
    *
    * @param name
    *        name of the relationshipType
@@ -18,7 +18,7 @@ public class RelationshipType extends NamedAttachable {
   }
 
   /**
-   * convenience method to get the relationshipTypeAttachment of this relationshipType
+   * convenience method to get the relationshipTypeAttachment of this relationshipType.
    *
    * @return the relationshipTypeAttachment of this relationshipType
    */

--- a/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
+++ b/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
@@ -8,7 +8,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.RelationshipTypeAttachment;
 
 /**
- * A collection of Relationship types
+ * A collection of Relationship types.
  */
 public class RelationshipTypeList extends GameDataComponent implements Iterable<RelationshipType> {
   private static final long serialVersionUID = 6590541694575435151L;
@@ -33,7 +33,7 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
   }
 
   /**
-   * Constructs a new RelationshipTypeList
+   * Constructs a new RelationshipTypeList.
    *
    * @param data
    *        GameData used for construction
@@ -57,7 +57,7 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
   }
 
   /**
-   * Creates a default relationship
+   * Creates a default relationship.
    *
    * @param relationshipTypeConstant
    *        the type of relationship
@@ -94,7 +94,7 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
   }
 
   /**
-   * Gets a relationshipType from the list by name;
+   * Gets a relationshipType from the list by name.
    *
    * @param name
    *        name of the relationshipType
@@ -105,7 +105,7 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
   }
 
   /**
-   * returns a relationshipTypeIterator
+   * returns a relationshipTypeIterator.
    */
   @Override
   public Iterator<RelationshipType> iterator() {
@@ -113,7 +113,8 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
   }
 
   /**
-   * @return site of the relationshipTypeList, be aware that the standard size = 4 (Allied, War, Self and Null Relation)
+   * @return site of the relationshipTypeList, be aware that the standard size = 4 (Allied, War, Self and Null
+   *         Relation).
    */
   public int size() {
     return m_relationshipTypes.size();

--- a/src/main/java/games/strategy/engine/data/RepairFrontier.java
+++ b/src/main/java/games/strategy/engine/data/RepairFrontier.java
@@ -11,7 +11,7 @@ public class RepairFrontier extends DefaultNamed implements Iterable<RepairRule>
   private List<RepairRule> m_cachedRules;
 
   /**
-   * Creates new RepairFrontier
+   * Creates new RepairFrontier.
    *
    * @param name
    *        name of new repair frontier

--- a/src/main/java/games/strategy/engine/data/RepairRule.java
+++ b/src/main/java/games/strategy/engine/data/RepairRule.java
@@ -7,7 +7,7 @@ public class RepairRule extends DefaultNamed {
   private final IntegerMap<Resource> m_cost = new IntegerMap<>();
   private final IntegerMap<NamedAttachable> m_results = new IntegerMap<>();
 
-  /** Creates new RepairRule */
+  /** Creates new RepairRule. */
   public RepairRule(final String name, final GameData data) {
     super(name, data);
   }

--- a/src/main/java/games/strategy/engine/data/Resource.java
+++ b/src/main/java/games/strategy/engine/data/Resource.java
@@ -4,7 +4,7 @@ public class Resource extends NamedAttachable {
   private static final long serialVersionUID = 7471431759007499935L;
 
   /**
-   * Creates new Resource
+   * Creates new Resource.
    *
    * @param name
    *        name of the resource

--- a/src/main/java/games/strategy/engine/data/ResourceCollection.java
+++ b/src/main/java/games/strategy/engine/data/ResourceCollection.java
@@ -8,7 +8,7 @@ public class ResourceCollection extends GameDataComponent {
   private final IntegerMap<Resource> m_resources = new IntegerMap<>();
 
   /**
-   * Creates new ResourceCollection
+   * Creates new ResourceCollection.
    *
    * @param data
    *        game data
@@ -113,7 +113,7 @@ public class ResourceCollection extends GameDataComponent {
 
   /**
    * @param spent
-   * @return new ResourceCollection containing the difference between both collections
+   * @return new ResourceCollection containing the difference between both collections.
    */
   public ResourceCollection difference(final ResourceCollection otherCollection) {
     final ResourceCollection returnCollection = new ResourceCollection(getData(), m_resources);

--- a/src/main/java/games/strategy/engine/data/Route.java
+++ b/src/main/java/games/strategy/engine/data/Route.java
@@ -128,7 +128,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return start territory for this route
+   * @return start territory for this route.
    */
   public Territory getStart() {
     return m_start;
@@ -179,7 +179,7 @@ public class Route implements Serializable, Iterable<Territory> {
   /**
    * @param u
    *        unit that is moving on this route
-   * @return the total cost of the route including modifications due to territoryEffects and territoryConnections
+   * @return the total cost of the route including modifications due to territoryEffects and territoryConnections.
    */
   public int getMovementCost(final Unit u) {
     // TODO implement me
@@ -204,7 +204,7 @@ public class Route implements Serializable, Iterable<Territory> {
    * @param i
    *        step number
    * @return territory we will be in after the i'th step for this route has
-   *         been made
+   *         been made.
    */
   public Territory getTerritoryAtStep(final int i) {
     return m_steps.get(i);
@@ -213,7 +213,7 @@ public class Route implements Serializable, Iterable<Territory> {
   /**
    * @param aMatch
    *        referring match
-   * @return whether all territories in this route match the given match (start territory is not tested)
+   * @return whether all territories in this route match the given match (start territory is not tested).
    */
   public boolean allMatch(final Match<Territory> aMatch) {
     for (final Territory t : m_steps) {
@@ -227,7 +227,7 @@ public class Route implements Serializable, Iterable<Territory> {
   /**
    * @param aMatch
    *        referring match
-   * @return whether some territories in this route match the given match (start territory is not tested)
+   * @return whether some territories in this route match the given match (start territory is not tested).
    */
   public boolean someMatch(final Match<Territory> aMatch) {
     for (final Territory t : m_steps) {
@@ -241,7 +241,7 @@ public class Route implements Serializable, Iterable<Territory> {
   /**
    * @param aMatch
    *        referring match
-   * @return whether all territories in this route match the given match (start and end territories are not tested)
+   * @return whether all territories in this route match the given match (start and end territories are not tested).
    */
   public boolean allMatchMiddleSteps(final Match<Territory> aMatch, final boolean defaultWhenNoMiddleSteps) {
     final List<Territory> middle = getMiddleSteps();
@@ -259,7 +259,7 @@ public class Route implements Serializable, Iterable<Territory> {
   /**
    * @param aMatch
    *        referring match
-   * @return all territories in this route match the given match (start territory is not tested)
+   * @return all territories in this route match the given match (start territory is not tested).
    */
   public Collection<Territory> getMatches(final Match<Territory> aMatch) {
     return Match.getMatches(m_steps, aMatch);
@@ -282,7 +282,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return collection of all territories in this route, without the start
+   * @return collection of all territories in this route, without the start.
    */
   public List<Territory> getSteps() {
     if (numberOfSteps() > 0) {
@@ -293,7 +293,7 @@ public class Route implements Serializable, Iterable<Territory> {
 
   /**
    * @return collection of all territories in this route without the start or
-   *         the end
+   *         the end.
    */
   public List<Territory> getMiddleSteps() {
     if (numberOfSteps() > 1) {
@@ -303,7 +303,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return last territory in the route
+   * @return last territory in the route.
    */
   public Territory getEnd() {
     if (m_steps.isEmpty()) {
@@ -318,14 +318,14 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return whether this route has any steps
+   * @return whether this route has any steps.
    */
   public boolean hasSteps() {
     return !m_steps.isEmpty();
   }
 
   /**
-   * @return whether this route has no steps
+   * @return whether this route has no steps.
    */
   public boolean hasNoSteps() {
     return !hasSteps();
@@ -342,7 +342,7 @@ public class Route implements Serializable, Iterable<Territory> {
 
   /**
    * the territory before the end territory (this could be the start territory
-   * in the case of 1 step)
+   * in the case of 1 step).
    *
    * @return the territory before the end territory
    */
@@ -382,14 +382,14 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return whether this route has more then one step
+   * @return whether this route has more then one step.
    */
   public boolean hasMoreThenOneStep() {
     return m_steps.size() > 1;
   }
 
   /**
-   * @return whether there are territories before the end where the territory is owned by null and is not sea
+   * @return whether there are territories before the end where the territory is owned by null and is not sea.
    */
   public boolean hasNeutralBeforeEnd() {
     for (final Territory current : getMiddleSteps()) {
@@ -402,7 +402,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return whether there is some water in the route including start and end
+   * @return whether there is some water in the route including start and end.
    */
   public boolean hasWater() {
     if (getStart().isWater()) {
@@ -412,7 +412,7 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return whether there is some land in the route including start and end
+   * @return whether there is some land in the route including start and end.
    */
   public boolean hasLand() {
     if (!getStart().isWater()) {

--- a/src/main/java/games/strategy/engine/data/Rule.java
+++ b/src/main/java/games/strategy/engine/data/Rule.java
@@ -8,14 +8,14 @@ public class Rule extends NamedAttachable implements NamedUnitHolder, Comparable
   // In a grid-based game, stores the coordinate of the Territory
   int[] m_coordinate = null;
 
-  /** Creates new Territory */
+  /** Creates new Rule. */
   public Rule(final String name, final boolean water, final GameData data) {
     super(name, data);
     m_water = water;
     m_units = new UnitCollection(this, getData());
   }
 
-  /** Creates new Territory */
+  /** Creates new Rule. */
   public Rule(final String name, final boolean water, final GameData data, final int... coordinate) {
     super(name, data);
     m_water = water;
@@ -39,7 +39,7 @@ public class Rule extends NamedAttachable implements NamedUnitHolder, Comparable
   }
 
   /**
-   * Get the units in this territory
+   * Get the units in this territory.
    */
   @Override
   public UnitCollection getUnits() {

--- a/src/main/java/games/strategy/engine/data/Territory.java
+++ b/src/main/java/games/strategy/engine/data/Territory.java
@@ -12,7 +12,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
     this(name, false, data);
   }
 
-  /** Creates new Territory */
+  /** Creates new Territory. */
   public Territory(final String name, final boolean water, final GameData data) {
     super(name, data);
     m_water = water;
@@ -20,7 +20,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
     m_coordinate = null;
   }
 
-  /** Creates new Territory */
+  /** Creates new Territory. */
   public Territory(final String name, final boolean water, final GameData data, final int... coordinate) {
     super(name, data);
     m_water = water;
@@ -52,7 +52,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   }
 
   /**
-   * Get the units in this territory
+   * Get the units in this territory.
    */
   @Override
   public UnitCollection getUnits() {
@@ -60,7 +60,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   }
 
   /**
-   * refers to unit holder being changed
+   * refers to unit holder being changed.
    */
   @Override
   public void notifyChanged() {
@@ -69,7 +69,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
 
   /**
    * refers to attachment changing, and therefore needing a redraw on the map in case something like the production
-   * number is now different
+   * number is now different.
    */
   public void notifyAttachmentChanged() {
     getData().notifyTerritoryAttachmentChanged(this);

--- a/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -20,7 +20,7 @@ public class UnitCollection extends GameDataComponent implements Iterable<Unit> 
   private final NamedUnitHolder m_holder;
 
   /**
-   * Creates new UnitCollection
+   * Creates new UnitCollection.
    *
    * @param holder
    *        named unit holder
@@ -125,7 +125,7 @@ public class UnitCollection extends GameDataComponent implements Iterable<Unit> 
   }
 
   /**
-   * @return integer map of UnitType
+   * @return integer map of UnitType.
    */
   public IntegerMap<UnitType> getUnitsByType() {
     final IntegerMap<UnitType> units = new IntegerMap<>();
@@ -141,7 +141,7 @@ public class UnitCollection extends GameDataComponent implements Iterable<Unit> 
   /**
    * @param id
    *        referring player ID
-   * @return map of UnitType (only of units for the specified player)
+   * @return map of UnitType (only of units for the specified player).
    */
   public IntegerMap<UnitType> getUnitsByType(final PlayerID id) {
     final IntegerMap<UnitType> count = new IntegerMap<>();
@@ -156,7 +156,7 @@ public class UnitCollection extends GameDataComponent implements Iterable<Unit> 
   /**
    * @param types
    *        map of unit types
-   * @return collection of units of each type up to max
+   * @return collection of units of each type up to max.
    */
   public Collection<Unit> getUnits(final IntegerMap<UnitType> types) {
     final Collection<Unit> units = new ArrayList<>();

--- a/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -8,14 +8,14 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * A collection of unit types
+ * A collection of unit types.
  */
 public class UnitTypeList extends GameDataComponent implements Iterable<UnitType> {
   private static final long serialVersionUID = 9002927658524651749L;
   private final Map<String, UnitType> m_unitTypes = new HashMap<>();
 
   /**
-   * Creates new UnitTypeCollection
+   * Creates new UnitTypeCollection.
    *
    * @param data
    *        game data

--- a/src/main/java/games/strategy/engine/data/annotations/GameProperty.java
+++ b/src/main/java/games/strategy/engine/data/annotations/GameProperty.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 /**
  * Annotation that marks a method as a setter called through reflection by the GameParser (through the xml) and/or
  * PropertyUtil (through the
- * ChangeFactory)
+ * ChangeFactory).
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
@@ -10,7 +10,7 @@ import games.strategy.engine.data.UnitCollection;
 import games.strategy.engine.data.UnitHolder;
 
 /**
- * Add units
+ * Add units.
  */
 class AddUnits extends Change {
   private static final long serialVersionUID = 2694342784633196289L;

--- a/src/main/java/games/strategy/engine/data/changefactory/OwnerChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/OwnerChange.java
@@ -18,7 +18,7 @@ class OwnerChange extends Change {
   private final String m_territory;
 
   /**
-   * newOwner can be null
+   * newOwner can be null.
    */
   OwnerChange(final Territory territory, final PlayerID newOwner) {
     m_territory = territory.getName();

--- a/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/PlayerOwnerChange.java
@@ -16,7 +16,7 @@ import games.strategy.net.GUID;
  */
 class PlayerOwnerChange extends Change {
   /**
-   * Maps unit id -> owner as String
+   * Maps unit id -> owner as String.
    */
   private final Map<GUID, String> m_old;
   private final Map<GUID, String> m_new;

--- a/src/main/java/games/strategy/engine/data/events/GameDataChangeListener.java
+++ b/src/main/java/games/strategy/engine/data/events/GameDataChangeListener.java
@@ -3,7 +3,7 @@ package games.strategy.engine.data.events;
 import games.strategy.engine.data.Change;
 
 /**
- * A GameDataChangeListener will be notified on changes to the GameData
+ * A GameDataChangeListener will be notified on changes to the GameData.
  */
 public interface GameDataChangeListener {
   void gameDataChanged(Change aChange);

--- a/src/main/java/games/strategy/engine/data/export/AttachmentExportException.java
+++ b/src/main/java/games/strategy/engine/data/export/AttachmentExportException.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.data.export;
 
 /**
- * Exception used by the AttachmentExporters
+ * Exception used by the AttachmentExporters.
  */
 public class AttachmentExportException extends Exception {
   private static final long serialVersionUID = 6134166689856636372L;

--- a/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
+++ b/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
@@ -142,7 +142,7 @@ public class XmlGameElementMapper {
               attachmentData.attachable, attachmentData.gameData))
           .build();
 
-  /** Small data holder class */
+  /** Small data holder class. */
   private static class AttachmentData {
     private final String name;
     private final Attachable attachable;

--- a/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/BooleanProperty.java
@@ -28,7 +28,7 @@ public class BooleanProperty extends AEditableProperty {
   }
 
   /**
-   * @return component used to edit this property
+   * @return component used to edit this property.
    */
   @Override
   public JComponent getEditorComponent() {

--- a/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
@@ -10,7 +10,7 @@ import javax.swing.JComponent;
 import javax.swing.JTable;
 
 /**
- * @param <T>
+ * @param <T> The type of elements in the collection.
  */
 public class CollectionProperty<T> extends AEditableProperty {
   private static final long serialVersionUID = 5338055034530377261L;
@@ -18,7 +18,7 @@ public class CollectionProperty<T> extends AEditableProperty {
 
   /**
    * @param name
-   *        name of the property
+   *        name of the property.
    * @param defaultValue
    *        default string value
    * @param possibleValues

--- a/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -9,7 +9,7 @@ import javax.swing.JComboBox;
 import javax.swing.JComponent;
 
 /**
- * A String property that uses a list for selecting the value
+ * A String property that uses a list for selecting the value.
  */
 public class ComboProperty<T> extends AEditableProperty {
   private static final long serialVersionUID = -3098612299805630587L;
@@ -19,7 +19,7 @@ public class ComboProperty<T> extends AEditableProperty {
 
   /**
    * @param name
-   *        name of the property
+   *        name of the property.
    * @param defaultValue
    *        default string value
    * @param possibleValues

--- a/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -42,7 +42,7 @@ public class GameProperties extends GameDataComponent {
   private final List<String> ordering = new ArrayList<>();
 
   /**
-   * Creates a new instance of Properties
+   * Creates a new instance of GameProperties.
    *
    * @param data
    *        game data

--- a/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/IEditableProperty.java
@@ -3,29 +3,18 @@ package games.strategy.engine.data.properties;
 import javax.swing.JComponent;
 
 /**
- * <p>
- * Title:
- * </p>
- * <p>
- * Description:
- * </p>
- * <p>
- * Copyright: Copyright (c) 2002
- * </p>
- * <p>
- * Company:
- * </p>
+ * An editable property.
  */
 public interface IEditableProperty {
   /**
-   * get the name of the property
+   * get the name of the property.
    *
    * @return the name
    */
   String getName();
 
   /**
-   * Get the value of the property
+   * Get the value of the property.
    *
    * @return the value
    */
@@ -33,12 +22,12 @@ public interface IEditableProperty {
 
   /**
    * @param value
-   * @return is the object a valide object for setting as our value
+   * @return is the object a valid object for setting as our value.
    */
   boolean validate(Object value);
 
   /**
-   * Set the value of the property (programmatically), GUI would normally use the editor
+   * Set the value of the property (programmatically), GUI would normally use the editor.
    *
    * @param value
    *        the new value
@@ -48,12 +37,12 @@ public interface IEditableProperty {
   void setValue(Object value) throws ClassCastException;
 
   /**
-   * @return component used to edit this property
+   * @return component used to edit this property.
    */
   JComponent getEditorComponent();
 
   /**
-   * Get the view (read only) component for this property
+   * Get the view (read only) component for this property.
    */
   JComponent getViewComponent();
 

--- a/src/main/java/games/strategy/engine/data/properties/StringProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/StringProperty.java
@@ -8,7 +8,7 @@ import javax.swing.JComponent;
 import javax.swing.JTextField;
 
 /**
- * A string property with a simple text field editor
+ * A string property with a simple text field editor.
  */
 public class StringProperty extends AEditableProperty {
   private static final long serialVersionUID = 4382624884674152208L;

--- a/src/main/java/games/strategy/engine/delegate/AutoSave.java
+++ b/src/main/java/games/strategy/engine/delegate/AutoSave.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Delegates with this annotation will trigger the autosave when they start or end
+ * Delegates with this annotation will trigger the autosave when they start or end.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
+++ b/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
@@ -20,7 +20,7 @@ import games.strategy.engine.random.RandomStats;
 import games.strategy.sound.ISound;
 
 /**
- * Default implementation of DelegateBridge
+ * Default implementation of DelegateBridge.
  */
 public class DefaultDelegateBridge implements IDelegateBridge {
   private final GameData m_data;
@@ -30,7 +30,7 @@ public class DefaultDelegateBridge implements IDelegateBridge {
   private final DelegateExecutionManager m_delegateExecutionManager;
   private IRandomSource m_randomSource;
 
-  /** Creates new DefaultDelegateBridge */
+  /** Creates new DefaultDelegateBridge. */
   public DefaultDelegateBridge(final GameData data, final IGame game, final IDelegateHistoryWriter historyWriter,
       final RandomStats randomStats, final DelegateExecutionManager delegateExecutionManager) {
     m_data = data;
@@ -92,7 +92,7 @@ public class DefaultDelegateBridge implements IDelegateBridge {
   }
 
   /**
-   * Returns the current step name
+   * Returns the current step name.
    */
   @Override
   public String getStepName() {

--- a/src/main/java/games/strategy/engine/delegate/IDelegate.java
+++ b/src/main/java/games/strategy/engine/delegate/IDelegate.java
@@ -17,7 +17,7 @@ import games.strategy.engine.message.IRemote;
  */
 public interface IDelegate {
   /**
-   * Uses name as the internal unique name and displayName for display to users
+   * Uses name as the internal unique name and displayName for display to users.
    */
   void initialize(final String name, final String displayName);
 
@@ -46,13 +46,13 @@ public interface IDelegate {
   IDelegateBridge getBridge();
 
   /**
-   * @return state of the Delegate
+   * @return state of the Delegate.
    */
   Serializable saveState();
 
   /**
    * @param state
-   *        the delegates state
+   *        the delegates state.
    */
   void loadState(final Serializable state);
 

--- a/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
+++ b/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
@@ -35,7 +35,7 @@ public interface IDelegateBridge {
   PlayerID getPlayerID();
 
   /**
-   * Returns the current step name
+   * Returns the current step name.
    */
   String getStepName();
 
@@ -49,7 +49,7 @@ public interface IDelegateBridge {
   void addChange(Change aChange);
 
   /**
-   * equivalent to getRandom(max,1,annotation)[0]
+   * equivalent to getRandom(max,1,annotation)[0].
    */
   int getRandom(final int max, final PlayerID player, final DiceType diceType, final String annotation);
 

--- a/src/main/java/games/strategy/engine/display/DefaultDisplayBridge.java
+++ b/src/main/java/games/strategy/engine/display/DefaultDisplayBridge.java
@@ -6,6 +6,8 @@ public class DefaultDisplayBridge implements IDisplayBridge {
   private final GameData m_gameData;
 
   /**
+   * Constructs a DefaultDisplayBridge.
+   *
    * @param gameData
    */
   public DefaultDisplayBridge(final GameData gameData) {

--- a/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -61,9 +61,6 @@ public abstract class AbstractGame implements IGame {
     setupLocalPlayers(gamePlayers);
   }
 
-  /**
-   * @param localPlayers
-   */
   private void setupLocalPlayers(final Set<IGamePlayer> localPlayers) {
     final PlayerList playerList = m_data.getPlayerList();
     for (final IGamePlayer gp : localPlayers) {
@@ -78,7 +75,7 @@ public abstract class AbstractGame implements IGame {
 
   /**
    * @param stepName
-   *        step name
+   *        step name.
    * @param delegateName
    *        delegate name
    * @param player

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -32,7 +32,7 @@ import games.strategy.util.Version;
  * Title: TripleA
  * </p>
  * <p>
- * Description: Responsible for loading saved games, new games from xml, and saving games
+ * Description: Responsible for loading saved games, new games from xml, and saving games.
  * </p>
  */
 public class GameDataManager {

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -474,7 +474,7 @@ public class GameRunner {
   }
 
   /**
-   * @return true if we are out of date or this is the first time this triplea has ever been run
+   * @return true if we are out of date or this is the first time this triplea has ever been run.
    */
   private static boolean checkForLatestEngineVersionOut() {
     try {
@@ -533,7 +533,7 @@ public class GameRunner {
   }
 
   /**
-   * @return true if we have any out of date maps
+   * @return true if we have any out of date maps.
    */
   private static boolean checkForUpdatedMaps() {
     MapDownloadController downloadController = ClientContext.mapDownloadController();

--- a/src/main/java/games/strategy/engine/framework/IGame.java
+++ b/src/main/java/games/strategy/engine/framework/IGame.java
@@ -53,7 +53,7 @@ public interface IGame {
   void addDisplay(IDisplay display);
 
   /**
-   * remove a display
+   * remove a display.
    */
   void removeDisplay(IDisplay display);
 

--- a/src/main/java/games/strategy/engine/framework/IGameLoader.java
+++ b/src/main/java/games/strategy/engine/framework/IGameLoader.java
@@ -41,7 +41,7 @@ public interface IGameLoader extends Serializable {
   void startGame(IGame game, Set<IGamePlayer> players, boolean headless) throws Exception;
 
   /**
-   * Get the type of the display
+   * Get the type of the display.
    *
    * @return an interface that extends IChannelSubscrobor
    */

--- a/src/main/java/games/strategy/engine/framework/IGameModifiedChannel.java
+++ b/src/main/java/games/strategy/engine/framework/IGameModifiedChannel.java
@@ -24,7 +24,7 @@ public interface IGameModifiedChannel extends IChannelSubscribor {
    * @param round
    * @param displayName
    * @param loadedFromSavedGame
-   *        - true if the game step has changed because we were loaded from a saved game
+   *        - true if the game step has changed because we were loaded from a saved game.
    */
   void stepChanged(final String stepName, final String delegateName, final PlayerID player, final int round,
       final String displayName, final boolean loadedFromSavedGame);

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -82,7 +82,7 @@ public class ServerGame extends AbstractGame {
 
   /**
    * @param data
-   *        game data
+   *        game data.
    * @param localPlayers
    *        Set - A set of GamePlayers
    * @param remotePlayerMapping
@@ -441,7 +441,7 @@ public class ServerGame extends AbstractGame {
   }
 
   /**
-   * @return true if the step should autosave
+   * @return true if the step should autosave.
    */
   private boolean endStep() {
     m_delegateExecutionManager.enterDelegateExecution();

--- a/src/main/java/games/strategy/engine/framework/ServerPlayerSelector.java
+++ b/src/main/java/games/strategy/engine/framework/ServerPlayerSelector.java
@@ -26,7 +26,7 @@ public class ServerPlayerSelector extends JFrame {
   private Collection<String> m_remote;
   private final JTextField m_nameField;
 
-  /** Creates a new instance of PlayerSelecter */
+  /** Creates a new instance of ServerPlayerSelector. */
   public ServerPlayerSelector(final String[] players) {
     super("Choose players");
     final JPanel namePanel = new JPanel();

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -641,7 +641,7 @@ public class HeadlessGameServer {
 
   /**
    * todo, replace with something better
-   * Get the chat for the game, or null if there is no chat
+   * Get the chat for the game, or null if there is no chat.
    */
   public Chat getChat() {
     final ISetupPanel model = m_setupPanelModel.getPanel();

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -103,7 +103,7 @@ public class DownloadFileDescription {
     return downloadType == DownloadType.MAP_TOOL;
   }
 
-  /** @return Name of the zip file */
+  /** @return Name of the zip file. */
   public String getMapZipFileName() {
     if (url != null && url.contains("/")) {
       return url.substring(url.lastIndexOf('/') + 1, url.length());
@@ -112,7 +112,7 @@ public class DownloadFileDescription {
     }
   }
 
-  /** Translates the stored URL into a github new issue link */
+  /** Translates the stored URL into a github new issue link. */
   public String getFeedbackUrl() {
     if (url.contains("github.com") && url.contains("/releases/")) {
       return url.substring(0, url.indexOf("/releases/")) + "/issues/new";
@@ -121,7 +121,7 @@ public class DownloadFileDescription {
     }
   }
 
-  /** File reference for where to install the file */
+  /** File reference for where to install the file. */
   public File getInstallLocation() {
     String masterSuffix = (getMapZipFileName().toLowerCase().endsWith("master.zip")) ?
         "-master" : "";

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -11,7 +11,7 @@ import games.strategy.util.Version;
 
 /**
  * Utility class to parse an available map list file config file - used to determine which maps are available for
- * download
+ * download.
  */
 final class DownloadFileParser {
 

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
@@ -11,7 +11,7 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
 import games.strategy.util.Version;
 
-/** Properties file used to know which map versions have been installed */
+/** Properties file used to know which map versions have been installed. */
 public class DownloadFileProperties {
   protected static final String VERSION_PROPERTY = "map.version";
   private final Properties props = new Properties();

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -37,7 +37,7 @@ import games.strategy.ui.SwingComponents;
 import games.strategy.util.Version;
 
 
-/** Window that allows for map downloads and removal */
+/** Window that allows for map downloads and removal. */
 public class DownloadMapsWindow extends JFrame {
   private enum MapAction {
     INSTALL, UPDATE, REMOVE

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -13,7 +13,7 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 
 /**
- * Downlaods a map index file, parses it and returns a <code>List</code> of <code>DownloadFileDescription</code>
+ * Downloads a map index file, parses it and returns a <code>List</code> of <code>DownloadFileDescription</code>.
  */
 class DownloadRunnable {
   private final String urlString;

--- a/src/main/java/games/strategy/engine/framework/map/download/FeedbackDialog.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FeedbackDialog.java
@@ -12,7 +12,7 @@ import games.strategy.ui.SwingComponents;
 public final class FeedbackDialog {
   private FeedbackDialog() {}
 
-  /** Determines the selected map and opens a confirmation dialog asking the user if its okay to open an external URL */
+  /** Determines the selected map and opens a confirmation dialog asking the user if its okay to open an external URL. */
   public static void showFeedbackDialog(final List<String> selectedValuesList,
       final List<DownloadFileDescription> maps) {
     if (selectedValuesList.isEmpty()) {

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -16,7 +16,7 @@ import games.strategy.triplea.settings.SystemPreferences;
 import games.strategy.ui.SwingComponents;
 
 
-/** Controller for in-game map download actions */
+/** Controller for in-game map download actions. */
 public class MapDownloadController {
 
   private final MapListingSource mapDownloadProperties;
@@ -27,7 +27,7 @@ public class MapDownloadController {
 
   /**
    * Return true if all locally downloaded maps are latest versions, false if any can are out of date or their version
-   * not recognized
+   * not recognized.
    */
   public boolean checkDownloadedMapsAreLatest() {
     try {

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadHelpPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadHelpPanel.java
@@ -5,7 +5,7 @@ import javax.swing.JPanel;
 
 import games.strategy.engine.ClientFileSystemHelper;
 
-/** Simple panel that shows a list of map download help notes */
+/** Simple panel that shows a list of map download help notes. */
 public class MapDownloadHelpPanel extends JPanel {
   private static final long serialVersionUID = -7254964602067275442L;
 

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -17,7 +17,7 @@ import com.google.common.collect.Maps;
 import games.strategy.ui.SwingComponents;
 
 
-/** A small non-modal window that holds the progress bars for the current and pending map downloads */
+/** A small non-modal window that holds the progress bars for the current and pending map downloads. */
 public final class MapDownloadProgressPanel extends JPanel {
 
   private static final long serialVersionUID = -7288639737337542689L;

--- a/src/main/java/games/strategy/engine/framework/map/download/MapListingSource.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapListingSource.java
@@ -24,12 +24,12 @@ public class MapListingSource {
     mapListDownloadSite = propertyReader.readProperty(GameEngineProperty.MAP_LISTING_SOURCE_FILE);
   }
 
-  /** Return the URL where we can download a file that lists each map that is available */
+  /** Return the URL where we can download a file that lists each map that is available. */
   protected String getMapListDownloadSite() {
     return mapListDownloadSite;
   }
 
-  /** Return the URL where we can download a file that lists each map that is available */
+  /** Return the URL where we can download a file that lists each map that is available. */
   public URL getMapListDownloadURL() {
     try {
       return getUrlFollowingRedirects(mapListDownloadSite);

--- a/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -37,7 +37,7 @@ public class PlayerListing implements Serializable {
   private final Map<String, Collection<String>> m_playerNamesAndAlliancesInTurnOrder;
 
   /**
-   * Creates a new instance of PlayerListingMessage
+   * Creates a new instance of PlayerListing.
    */
   public PlayerListing(final Map<String, String> playerToNodeListing, final Map<String, Boolean> playersEnabledListing,
       final Map<String, String> localPlayerTypes, final Version gameVersion, final String gameName,

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/IServerReady.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/IServerReady.java
@@ -4,7 +4,7 @@ import games.strategy.engine.message.IRemote;
 
 /**
  * Allows for the server to wait for all clients to finish initialization before
- * starting the game
+ * starting the game.
  */
 public interface IServerReady extends IRemote {
   void clientReady();

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -196,7 +196,7 @@ public class GameSelectorModel extends Observable {
 
   /**
    * We dont have a gane data (ie we are a remote player and the data has not been sent yet), but
-   * we still want to display game info
+   * we still want to display game info.
    */
   public void clearDataButKeepGameInfo(final String gameName, final String gameRound, final String gameVersion) {
     synchronized (this) {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/IClientChannel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/IClientChannel.java
@@ -16,7 +16,7 @@ public interface IClientChannel extends IChannelSubscribor {
   /**
    * @param gameData
    * @param players
-   *        who is playing who
+   *        who is playing who.
    */
   void doneSelectingPlayers(byte[] gameData, Map<String, INode> players);
 

--- a/src/main/java/games/strategy/engine/framework/startup/mc/IRemoteModelListener.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/IRemoteModelListener.java
@@ -7,7 +7,7 @@ public interface IRemoteModelListener {
   void playerListChanged();
 
   /**
-   * The players taken have changed
+   * The players taken have changed.
    */
   void playersTakenChanged();
 

--- a/src/main/java/games/strategy/engine/framework/startup/mc/IServerStartupRemote.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/IServerStartupRemote.java
@@ -9,7 +9,7 @@ import games.strategy.net.INode;
 
 public interface IServerStartupRemote extends IRemote {
   /**
-   * @return a listing of the players in the game
+   * @return a listing of the players in the game.
    */
   PlayerListing getPlayerListing();
 

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -329,7 +329,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
 
     /**
      * This should not be called from within game, only from the game setup screen, while everyone is waiting for game
-     * to start
+     * to start.
      */
     @Override
     public byte[] getSaveGame() {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ClientOptions.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ClientOptions.java
@@ -29,7 +29,7 @@ public class ClientOptions extends JDialog {
   private boolean m_okPressed;
 
   /**
-   * Creates a new instance of ClientOptions
+   * Creates a new instance of ClientOptions.
    */
   public ClientOptions(final Component parent, final String defaultName, final int defaultPort,
       final String defaultAddress) {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -17,7 +17,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.properties.IEditableProperty;
 
 /**
- * A game options cache that uses files to store the game options
+ * A game options cache that uses files to store the game options.
  */
 public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
   // chars illegal on windows (on linux/mac anything that is allowed on windows works fine)
@@ -54,7 +54,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
   }
 
   /**
-   * Loads cached game options into the gameData
+   * Loads cached game options into the gameData.
    *
    * @param gameData
    *        the game to load the cached game options into
@@ -82,7 +82,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
   }
 
   /**
-   * Calculates the cache filename and location based on the game data
+   * Calculates the cache filename and location based on the game data.
    *
    * @param gameData
    *        the game data
@@ -94,7 +94,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
   }
 
   /**
-   * Removes any special characters from the file name
+   * Removes any special characters from the file name.
    *
    * @param gameName
    *        the name of the game

--- a/src/main/java/games/strategy/engine/framework/startup/ui/IGamePropertiesCache.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/IGamePropertiesCache.java
@@ -5,11 +5,11 @@ import games.strategy.engine.data.GameData;
 /**
  * Interface that identifies a class that can cache game options
  * the GameProperties can't be replaced, only modified, so the cache works by modifying the GameProperties inside
- * GameData
+ * GameData.
  */
 public interface IGamePropertiesCache {
   /**
-   * Caches the gameOptions stored in the game data, and associates with this game
+   * Caches the gameOptions stored in the game data, and associates with this game.
    *
    * @param gameData
    *        the game which options you want to cache
@@ -17,7 +17,7 @@ public interface IGamePropertiesCache {
   void cacheGameProperties(GameData gameData);
 
   /**
-   * Loads cached game options into the gameData
+   * Loads cached game options into the gameData.
    *
    * @param gameData
    *        the game to load the cached game options into

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ISetupPanel.java
@@ -27,14 +27,14 @@ public interface ISetupPanel extends java.io.Serializable {
   IChatPanel getChatPanel();
 
   /**
-   * Cleanup should occur here that occurs when we cancel
+   * Cleanup should occur here that occurs when we cancel.
    */
   void cancel();
 
   void shutDown();
 
   /**
-   * Can we start the game?
+   * Indicates we can start the game.
    */
   boolean canGameStart();
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/MainFrame.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/MainFrame.java
@@ -92,7 +92,7 @@ public class MainFrame extends JFrame {
 
   /**
    * todo, replace with something better
-   * Get the chat for the game, or null if there is no chat
+   * Get the chat for the game, or null if there is no chat.
    */
   public Chat getChat() {
     final ISetupPanel model = m_setupPanelModel.getPanel();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -82,7 +82,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   private final JButton m_localPlayerSelection = new JButton("Select Local Players and AI's");
 
   /**
-   * Creates a new instance
+   * Creates a new instance.
    *
    * @param model
    *        the GameSelectionModel, though which changes are obtained when new games are chosen, or save games loaded
@@ -164,7 +164,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   }
 
   /**
-   * Load the dice rollers from cache, if the game was a save game, the dice roller store is selected
+   * Load the dice rollers from cache, if the game was a save game, the dice roller store is selected.
    *
    * @param data
    *        the game data
@@ -290,7 +290,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   }
 
   /**
-   * Called when the current game changes
+   * Called when the current game changes.
    */
   @Override
   public void cancel() {
@@ -298,7 +298,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   }
 
   /**
-   * Called when the observers detect change, to see if the game is in a startable state
+   * Called when the observers detect change, to see if the game is in a startable state.
    */
   @Override
   public boolean canGameStart() {
@@ -383,7 +383,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   }
 
   /**
-   * Called when the user hits play
+   * Called when the user hits play.
    */
   @Override
   public ILauncher getLauncher() {
@@ -422,7 +422,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   }
 
   /**
-   * A property change listener that notify our observers
+   * A property change listener that notify our observers.
    */
   private class NotifyingPropertyChangeListener implements PropertyChangeListener {
     @Override
@@ -591,7 +591,7 @@ class PBEMLocalPlayerComboBoxSelector {
 }
 
 
-/** A bean cache used by PBEMSetupPanel */
+/** A bean cache used by PBEMSetupPanel. */
 enum LocalBeanCache {
   INSTANCE;
   private final File m_file;
@@ -650,7 +650,7 @@ enum LocalBeanCache {
   }
 
   /**
-   * Call to have the cache written to disk
+   * Call to have the cache written to disk.
    */
   public void writeToDisk() {
     synchronized (m_mutex) {
@@ -665,7 +665,7 @@ enum LocalBeanCache {
   }
 
   /**
-   * Get a serializable from the cache
+   * Get a serializable from the cache.
    *
    * @param key
    *        the key ot was stored under

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
@@ -37,7 +37,7 @@ public class ServerOptions extends JDialog {
   private boolean m_showComment = false;
 
   /**
-   * Creates a new instance of ServerOptions
+   * Creates a new instance of ServerOptions.
    */
   public ServerOptions(final Component owner, final String defaultName, final int defaultPort,
       final boolean showComment) {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -46,7 +46,7 @@ import games.strategy.engine.pbem.PBEMMessagePoster;
 import games.strategy.net.IServerMessenger;
 import games.strategy.util.ThreadUtil;
 
-/** Setup panel displayed for hosting a non-lobby network game (using host option from main panel) */
+/** Setup panel displayed for hosting a non-lobby network game (using host option from main panel). */
 public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener {
   private static final long serialVersionUID = -2849872641665561807L;
   private final ServerModel m_model;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -41,13 +41,13 @@ public abstract class SetupPanel extends JPanel implements ISetupPanel {
   }
 
   /**
-   * Cleanup should occur here that occurs when we cancel
+   * Cleanup should occur here that occurs when we cancel.
    */
   @Override
   public abstract void cancel();
 
   /**
-   * Can we start the game?
+   * Indicates we can start the game.
    */
   @Override
   public abstract boolean canGameStart();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
@@ -13,7 +13,7 @@ import games.strategy.engine.random.IRemoteDiceServer;
 import games.strategy.engine.random.PBEMDiceRoller;
 
 /**
- * An class for editing a Dice Server bean
+ * An class for editing a Dice Server bean.
  */
 public class DiceServerEditor extends EditorPanel {
   private static final long serialVersionUID = -451810815037661114L;
@@ -26,7 +26,7 @@ public class DiceServerEditor extends EditorPanel {
   private final IRemoteDiceServer m_bean;
 
   /**
-   * Creating a new instance
+   * Creating a new instance.
    *
    * @param diceServer
    *        the DiceServer bean to edit
@@ -65,7 +65,7 @@ public class DiceServerEditor extends EditorPanel {
   }
 
   /**
-   * Configures the listeners for the gui components
+   * Configures the listeners for the gui components.
    */
   private void setupListeners() {
     m_testDiceyButton.addActionListener(e -> {
@@ -96,7 +96,7 @@ public class DiceServerEditor extends EditorPanel {
   }
 
   /**
-   * Returns the currently configured dice server
+   * Returns the currently configured dice server.
    *
    * @return the dice server
    */

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/DisplayNameComboBoxRender.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/DisplayNameComboBoxRender.java
@@ -6,7 +6,7 @@ import javax.swing.DefaultListCellRenderer;
 import javax.swing.JList;
 
 /**
- * Render to render IBeans in a combo box
+ * Render to render IBeans in a combo box.
  */
 class DisplayNameComboBoxRender extends DefaultListCellRenderer {
   private static final long serialVersionUID = -93452907043224502L;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/EditorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/EditorPanel.java
@@ -112,7 +112,7 @@ public abstract class EditorPanel extends JPanel {
   public abstract IBean getBean();
 
   /**
-   * Returns the Label width, this can be used by wrapping editors to try to align label sizes
+   * Returns the Label width, this can be used by wrapping editors to try to align label sizes.
    *
    * @return the size of the largest label in the first column
    */
@@ -154,14 +154,14 @@ public abstract class EditorPanel extends JPanel {
 
   /**
    * Fires the EDITOR_CHANGE property change, to notify propertyChangeListeners which have registered to be
-   * notified when the editor modifies the bean
+   * notified when the editor modifies the bean.
    */
   protected void fireEditorChanged() {
     firePropertyChange(EDITOR_CHANGE, null, null);
   }
 
   /**
-   * Document listener which calls fireEditorChanged in response to any document change
+   * Document listener which calls fireEditorChanged in response to any document change.
    */
   protected class EditorChangedFiringDocumentListener implements DocumentListener {
     @Override

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -24,7 +24,7 @@ import games.strategy.engine.pbem.IEmailSender;
 import games.strategy.ui.ProgressWindow;
 
 /**
- * An editor for modifying email senders
+ * An editor for modifying email senders.
  */
 public class EmailSenderEditor extends EditorPanel {
   private static final long serialVersionUID = -4647781117491269926L;
@@ -43,7 +43,7 @@ public class EmailSenderEditor extends EditorPanel {
   private final JCheckBox m_alsoPostAfterCombatMove = new JCheckBox("Also Post After Combat Move");
 
   /**
-   * creates a new instance
+   * creates a new instance.
    *
    * @param bean
    *        the EmailSender to edit
@@ -208,7 +208,7 @@ public class EmailSenderEditor extends EditorPanel {
   }
 
   /**
-   * class for configuring the editor so some fields can be hidden
+   * class for configuring the editor so some fields can be hidden.
    */
   public static class EditorConfiguration {
     public boolean showHost;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -27,7 +27,7 @@ import games.strategy.engine.pbem.NullForumPoster;
 import games.strategy.ui.ProgressWindow;
 
 /**
- * A class for selecting which Forum poster to use
+ * A class for selecting which Forum poster to use.
  */
 public class ForumPosterEditor extends EditorPanel {
   private static final long serialVersionUID = -6069315084412575053L;
@@ -88,7 +88,7 @@ public class ForumPosterEditor extends EditorPanel {
   }
 
   /**
-   * Configures the listeners for the gui components
+   * Configures the listeners for the gui components.
    */
   private void setupListeners() {
     m_viewPosts.addActionListener(e -> ((IForumPoster) getBean()).viewPosted());
@@ -101,7 +101,7 @@ public class ForumPosterEditor extends EditorPanel {
   }
 
   /**
-   * Tests the Forum poster
+   * Tests the Forum poster.
    */
   void testForum() {
     final IForumPoster poster = (IForumPoster) getBean();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/IBean.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/IBean.java
@@ -4,18 +4,18 @@ import java.io.Serializable;
 
 /**
  * An interface specifying that this component is a bean that can provide an editor
- * Beans must have a default constructor
+ * Beans must have a default constructor.
  */
 public interface IBean extends Serializable {
   /**
-   * Get the displayName of the bean
+   * Get the displayName of the bean.
    *
    * @return the display name
    */
   String getDisplayName();
 
   /**
-   * Returns the editor for this IBean
+   * Returns the editor for this IBean.
    *
    * @return the editor
    */
@@ -23,7 +23,7 @@ public interface IBean extends Serializable {
 
   /**
    * Method to check of two beans are of the same type,
-   * this is used in the select and view to find an an bean in the list
+   * this is used in the select and view to find an an bean in the list.
    *
    * @param other
    *        the bean to check against
@@ -32,7 +32,7 @@ public interface IBean extends Serializable {
   boolean sameType(IBean other);
 
   /**
-   * Get the help text which the editor will display, the text should be HTML
+   * Get the help text which the editor will display, the text should be HTML.
    *
    * @return the help text
    */

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
@@ -36,7 +36,7 @@ import games.strategy.ui.ProgressWindow;
 import games.strategy.util.UrlStreams;
 
 /**
- * A class for displaying settings for the micro web site poster
+ * A class for displaying settings for the micro web site poster.
  */
 public class MicroWebPosterEditor extends EditorPanel {
   private static final long serialVersionUID = -6069315084412575053L;
@@ -99,7 +99,7 @@ public class MicroWebPosterEditor extends EditorPanel {
   }
 
   /**
-   * Configures the listeners for the gui components
+   * Configures the listeners for the gui components.
    */
   private void setupListeners() {
     m_viewSite.addActionListener(e -> ((IWebPoster) getBean()).viewSite());
@@ -213,7 +213,7 @@ public class MicroWebPosterEditor extends EditorPanel {
   }
 
   /**
-   * Tests the Forum poster
+   * Tests the Forum poster.
    */
   void testSite() {
     final IWebPoster poster = (IWebPoster) getBean();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/SelectAndViewEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/SelectAndViewEditor.java
@@ -39,7 +39,7 @@ public class SelectAndViewEditor extends EditorPanel {
   private final String m_defaultHelp;
 
   /**
-   * creates a new editor
+   * creates a new editor.
    *
    * @param labelTitle
    *        the title in front of the combo box
@@ -119,7 +119,7 @@ public class SelectAndViewEditor extends EditorPanel {
 
   /**
    * Aligns label of this editor with the nested editor, by either resizing this (if it is smaller)
-   * or resizing the labels on the nested editor (if it is bigger)
+   * or resizing the labels on the nested editor (if it is bigger).
    */
   private void alignLabels() {
     // resize the label to align with the nested editors labels
@@ -141,7 +141,7 @@ public class SelectAndViewEditor extends EditorPanel {
   }
 
   /**
-   * Sets the list of possible beans to choose from
+   * Sets the list of possible beans to choose from.
    *
    * @param beans
    *        the list of beans
@@ -157,7 +157,7 @@ public class SelectAndViewEditor extends EditorPanel {
   }
 
   /**
-   * Returns the bean being edited
+   * Returns the bean being edited.
    *
    * @return the current bean, or null if the bean doesn't have an editor (is disabled)
    */

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/EmailValidator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/EmailValidator.java
@@ -3,13 +3,13 @@ package games.strategy.engine.framework.startup.ui.editors.validators;
 import games.strategy.util.Util;
 
 /**
- * A validator which validates that a text string is an email
+ * A validator which validates that a text string is an email.
  */
 public class EmailValidator implements IValidator {
   private final boolean m_validIfEmpty;
 
   /**
-   * create a new instance
+   * create a new instance.
    *
    * @param validIfEmpty
    *        is the text valid if empty

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/IValidator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/IValidator.java
@@ -1,11 +1,11 @@
 package games.strategy.engine.framework.startup.ui.editors.validators;
 
 /**
- * A simple interface for validating data from text fields
+ * A simple interface for validating data from text fields.
  */
 public interface IValidator {
   /**
-   * Validates that the give input is valid
+   * Validates that the give input is valid.
    *
    * @param text
    *        the text to be validated

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/IntegerRangeValidator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/IntegerRangeValidator.java
@@ -1,14 +1,14 @@
 package games.strategy.engine.framework.startup.ui.editors.validators;
 
 /**
- * A validator that validates that a string is a integer, and within a given min/max range
+ * A validator that validates that a string is a integer, and within a given min/max range.
  */
 public class IntegerRangeValidator implements IValidator {
   private final int m_min;
   private final int m_max;
 
   /**
-   * create a new instance
+   * create a new instance.
    *
    * @param min
    *        the minimal value

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/NonEmptyValidator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/NonEmptyValidator.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.framework.startup.ui.editors.validators;
 
 /**
- * A validator that validates that the text is not empty
+ * A validator that validates that the text is not empty.
  */
 public class NonEmptyValidator implements IValidator {
   @Override

--- a/src/main/java/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
+++ b/src/main/java/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
@@ -47,7 +47,7 @@ public final class LocalSystemChecker {
     systemChecks = checks;
   }
 
-  /** Return any exceptions encountered while running each check */
+  /** Return any exceptions encountered while running each check. */
   public Set<Exception> getExceptions() {
     final Set<Exception> exceptions = Sets.newHashSet();
     for (final SystemCheck systemCheck : systemChecks) {

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooser.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooser.java
@@ -193,7 +193,7 @@ public class NewGameChooser extends JDialog {
     });
   }
 
-  /** Populates the NewGameChooserModel cache if empty, then returns the cached instance */
+  /** Populates the NewGameChooserModel cache if empty, then returns the cached instance. */
   public static synchronized NewGameChooserModel getNewGameChooserModel() {
     return new NewGameChooserModel();
   }

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -161,7 +161,7 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
 
   /**
    * @param entries
-   *        list of entries where to add the new entry
+   *        list of entries where to add the new entry.
    * @param uri
    *        URI of the new entry
    */

--- a/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.SwingUtilities;
 
 public class BackgroundTaskRunner {
-  /** Non-blocking */
+  /** Non-blocking. */
   public static void runInBackground(final String waitMessage, final Runnable r) {
     SwingUtilities.invokeLater(() -> {
       final WaitDialog window = new WaitDialog(null, waitMessage);

--- a/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
@@ -27,7 +27,7 @@ public class DefaultPlayerBridge implements IPlayerBridge {
   private String m_currentStep;
   private String m_currentDelegate;
 
-  /** Creates new DefaultPlayerBridge */
+  /** Creates new DefaultPlayerBridge. */
   public DefaultPlayerBridge(final IGame aGame) {
     m_game = aGame;
     final GameStepListener m_gameStepListener = (stepName, delegateName, player, round, displayName) -> {
@@ -57,7 +57,7 @@ public class DefaultPlayerBridge implements IPlayerBridge {
   }
 
   /**
-   * Return the game data
+   * Return the game data.
    */
   @Override
   public GameData getGameData() {

--- a/src/main/java/games/strategy/engine/gamePlayer/IGamePlayer.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/IGamePlayer.java
@@ -14,12 +14,12 @@ public interface IGamePlayer extends IRemotePlayer {
   void initialize(IPlayerBridge bridge, PlayerID id);
 
   /**
-   * @return the name of the game player (what nation we are)
+   * @return the name of the game player (what nation we are).
    */
   String getName();
 
   /**
-   * @return the type of player we are (human or a kind of ai)
+   * @return the type of player we are (human or a kind of ai).
    */
   String getType();
 

--- a/src/main/java/games/strategy/engine/gamePlayer/IPlayerBridge.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/IPlayerBridge.java
@@ -11,19 +11,19 @@ import games.strategy.engine.message.IRemote;
  */
 public interface IPlayerBridge {
   /**
-   * Return the game data
+   * Return the game data.
    */
   GameData getGameData();
 
   /**
    * Get a remote reference to the current delegate, the type of the reference
-   * is declared by the delegates getRemoteType() method
+   * is declared by the delegates getRemoteType() method.
    */
   IRemote getRemoteDelegate();
 
   /**
    * Get a remote reference to the named delegate, the type of the reference
-   * is declared by the delegates getRemoteType() method
+   * is declared by the delegates getRemoteType() method.
    */
   IRemote getRemotePersistentDelegate(String name);
 
@@ -42,7 +42,7 @@ public interface IPlayerBridge {
   Properties getStepProperties();
 
   /**
-   * is the game over?
+   * Indicates the game is over.
    */
   boolean isGameOver();
 }

--- a/src/main/java/games/strategy/engine/history/History.java
+++ b/src/main/java/games/strategy/engine/history/History.java
@@ -186,7 +186,7 @@ public class History extends DefaultTreeModel {
 
 /**
  * DefaultTreeModel is not serializable across jdk versions
- * Instead we use an instance of this class to store our data
+ * Instead we use an instance of this class to store our data.
  */
 class SerializedHistory implements Serializable {
   private static final long serialVersionUID = -5808427923253751651L;

--- a/src/main/java/games/strategy/engine/history/HistoryWriter.java
+++ b/src/main/java/games/strategy/engine/history/HistoryWriter.java
@@ -25,7 +25,7 @@ public class HistoryWriter implements java.io.Serializable {
   }
 
   /**
-   * Can only be called if we are currently in a round or a step
+   * Can only be called if we are currently in a round or a step.
    */
   public void startNextStep(final String stepName, final String delegateName, final PlayerID player,
       final String stepDisplayName) {

--- a/src/main/java/games/strategy/engine/history/Step.java
+++ b/src/main/java/games/strategy/engine/history/Step.java
@@ -8,7 +8,7 @@ public class Step extends IndexedHistoryNode {
   private final String m_stepName;
   private final String m_delegateName;
 
-  /** Creates a new instance of StepChangedMessage */
+  /** Creates a new instance of Step. */
   Step(final String stepName, final String delegateName, final PlayerID player, final int changeStartIndex,
       final String displayName) {
     super(displayName, changeStartIndex);

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTable.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTable.java
@@ -63,7 +63,7 @@ public class LobbyGameTable extends JTable {
   }
 
   /**
-   * record the id of the currently selected game
+   * record the id of the currently selected game.
    */
   private void markSelection() {
     final int selected = getSelectedRow();
@@ -75,7 +75,7 @@ public class LobbyGameTable extends JTable {
   }
 
   /**
-   * Restore the selection to the marked value
+   * Restore the selection to the marked value.
    */
   private void restoreSelection() {
     if (m_selectedGame == null) {

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -28,7 +28,7 @@ public class LobbyServer {
     return new String[] {TRIPLEA_LOBBY_PORT_PROPERTY};
   }
 
-  /** Creates a new instance of LobbyServer */
+  /** Creates a new instance of LobbyServer. */
   public LobbyServer(final int port) {
     IServerMessenger server;
     try {

--- a/src/main/java/games/strategy/engine/lobby/server/UserManager.java
+++ b/src/main/java/games/strategy/engine/lobby/server/UserManager.java
@@ -16,7 +16,7 @@ public class UserManager implements IUserManager {
   }
 
   /**
-   * Update hte user info, returning an error string if an error occurs
+   * Update the user info, returning an error string if an error occurs.
    */
   @Override
   public String updateUser(final String userName, final String emailAddress, final String hashedPassword) {
@@ -35,7 +35,7 @@ public class UserManager implements IUserManager {
   }
 
   /**
-   * Update hte user info, returning an error string if an error occurs
+   * Update the user info, returning an error string if an error occurs.
    */
   @Override
   public DBUser getUserInfo(final String userName) {

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/BannedMacController.java
@@ -18,7 +18,7 @@ public class BannedMacController {
   private static final Logger s_logger = Logger.getLogger(BannedMacController.class.getName());
 
   /**
-   * Ban the mac permanently
+   * Ban the mac permanently.
    */
   public void addBannedMac(final String mac) {
     addBannedMac(mac, null);
@@ -79,7 +79,7 @@ public class BannedMacController {
 
   /**
    * Is the given mac banned? This may have the side effect of removing from the
-   * database any mac's whose ban has expired
+   * database any mac's whose ban has expired.
    */
   public Tuple<Boolean, Timestamp> isMacBanned(final String mac) {
     boolean found = false;

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/BannedUsernameController.java
@@ -18,7 +18,7 @@ public class BannedUsernameController {
   private static final Logger s_logger = Logger.getLogger(BannedUsernameController.class.getName());
 
   /**
-   * Ban the username permanently
+   * Ban the username permanently.
    */
   public void addBannedUsername(final String username) {
     addBannedUsername(username, null);
@@ -80,7 +80,7 @@ public class BannedUsernameController {
 
   /**
    * Is the given username banned? This may have the side effect of removing from the
-   * database any username's whose ban has expired
+   * database any username's whose ban has expired.
    */
   public Tuple<Boolean, Timestamp> isUsernameBanned(final String username) {
     boolean found = false;

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/DBUserController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/DBUserController.java
@@ -16,7 +16,7 @@ public class DBUserController {
   private static final Logger s_logger = Logger.getLogger(DBUserController.class.getName());
 
   /**
-   * @return if this user is valid
+   * @return if this user is valid.
    */
   public String validate(final String userName, final String email, final String hashedPassword) {
     if (email == null || !Util.isMailValid(email)) {
@@ -47,7 +47,7 @@ public class DBUserController {
   }
 
   /**
-   * @return null if the user does not exist
+   * @return null if the user does not exist.
    */
   public String getPassword(final String userName) {
     final String sql = "select password from ta_users where username = ?";
@@ -183,7 +183,7 @@ public class DBUserController {
   }
 
   /**
-   * @return null if no such user
+   * @return null if no such user.
    */
   public DBUser getUser(final String userName) {
     final String sql = "select * from ta_users where username = ?";

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
@@ -165,7 +165,7 @@ public class Database {
   }
 
   /**
-   * Set up folders and environment variables for database
+   * Set up folders and environment variables for database.
    */
   private static void ensureDbIsSetup() {
     synchronized (s_dbSetupLock) {

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/MutedMacController.java
@@ -18,7 +18,7 @@ public class MutedMacController {
   private static final Logger s_logger = Logger.getLogger(MutedMacController.class.getName());
 
   /**
-   * Mute the mac permanently
+   * Mute the mac permanently.
    */
   public void addMutedMac(final String mac) {
     addMutedMac(mac, null);
@@ -79,7 +79,7 @@ public class MutedMacController {
 
   /**
    * Is the given mac muted? This may have the side effect of removing from the
-   * database any mac's whose mute has expired
+   * database any mac's whose mute has expired.
    */
   public boolean isMacMuted(final String mac) {
     final long muteTill = getMacUnmuteTime(mac);

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/MutedUsernameController.java
@@ -18,7 +18,7 @@ public class MutedUsernameController {
   private static final Logger s_logger = Logger.getLogger(MutedUsernameController.class.getName());
 
   /**
-   * Mute the username permanently
+   * Mute the username permanently.
    */
   public void addMutedUsername(final String username) {
     addMutedUsername(username, null);
@@ -80,7 +80,7 @@ public class MutedUsernameController {
 
   /**
    * Is the given username muted? This may have the side effect of removing from the
-   * database any username's whose mute has expired
+   * database any username's whose mute has expired.
    */
   public boolean isUsernameMuted(final String username) {
     final long muteTill = getUsernameUnmuteTime(username);

--- a/src/main/java/games/strategy/engine/message/ChannelMessenger.java
+++ b/src/main/java/games/strategy/engine/message/ChannelMessenger.java
@@ -7,7 +7,7 @@ import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
 import games.strategy.net.INode;
 
 /**
- * Implementation of IChannelMessenger built on top of an IMessenger
+ * Implementation of IChannelMessenger built on top of an IMessenger.
  */
 public class ChannelMessenger implements IChannelMessenger {
   private final UnifiedMessenger m_unifiedMessenger;

--- a/src/main/java/games/strategy/engine/message/DestinationChangeMessage.java
+++ b/src/main/java/games/strategy/engine/message/DestinationChangeMessage.java
@@ -1,14 +1,14 @@
 package games.strategy.engine.message;
 
 /**
- * A destination has been added or removed
+ * A destination has been added or removed.
  */
 class DestinationChangeMessage implements java.io.Serializable {
   private final boolean m_add;
   private final String m_destination;
   private static final long serialVersionUID = -168782943218162839L;
 
-  /** Creates a new instance of ManagerStateMessage */
+  /** Creates a new instance of DestinationChangeMessage. */
   DestinationChangeMessage(final String destination, final boolean add) {
     m_add = add;
     m_destination = destination;

--- a/src/main/java/games/strategy/engine/message/IChannelMessenger.java
+++ b/src/main/java/games/strategy/engine/message/IChannelMessenger.java
@@ -46,24 +46,24 @@ import games.strategy.net.INode;
 public interface IChannelMessenger {
   /**
    * Get a reference such that methods called on it will be multicast
-   * to all subscribors of the channel
+   * to all subscribers of the channel.
    */
   IChannelSubscribor getChannelBroadcastor(RemoteName channelName);
 
   /**
-   * register a subscribor to a channel
+   * register a subscriber to a channel.
    */
   void registerChannelSubscriber(Object implementor, RemoteName channelName);
 
   /**
-   * unregister a subscribor to a channel
+   * unregister a subscriber to a channel.
    */
   void unregisterChannelSubscriber(Object implementor, RemoteName channelName);
 
   INode getLocalNode();
 
   /**
-   * Is the underlying messenger a server?
+   * Indicates the underlying messenger is a server.
    */
   boolean isServer();
 }

--- a/src/main/java/games/strategy/engine/message/IRemoteMessenger.java
+++ b/src/main/java/games/strategy/engine/message/IRemoteMessenger.java
@@ -68,7 +68,7 @@ public interface IRemoteMessenger {
   /**
    * @param remoteInterface
    *        - the remote interface that implementor implements,
-   *        must be a subclass of IRemote
+   *        must be a subclass of IRemote.
    * @param implementor
    *        - an object that implements remoteInterface
    * @param name

--- a/src/main/java/games/strategy/engine/message/InvocationInProgress.java
+++ b/src/main/java/games/strategy/engine/message/InvocationInProgress.java
@@ -23,7 +23,7 @@ public class InvocationInProgress {
   }
 
   /**
-   * @return true if there are no more results to process
+   * @return true if there are no more results to process.
    */
   public boolean process(final HubInvocationResults hubresults, final INode from) {
     if (hubresults.results == null) {

--- a/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
+++ b/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
@@ -7,9 +7,8 @@ import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
 import games.strategy.triplea.util.WrappedInvocationHandler;
 
 /**
- * Invocation handler for the UnifiedMessenger
- */
-/**
+ * Invocation handler for the UnifiedMessenger.
+ *
  * Handles the invocation for a channel
  */
 class UnifiedInvocationHandler extends WrappedInvocationHandler {

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
@@ -69,7 +69,7 @@ class EndPoint {
   }
 
   /**
-   * @return is this the first implementor
+   * @return is this the first implementor.
    */
   public boolean addImplementor(final Object implementor) {
     if (!m_remoteClass.isAssignableFrom(implementor.getClass())) {
@@ -99,7 +99,7 @@ class EndPoint {
   }
 
   /**
-   * @return - we have no more implementors
+   * @return we have no more implementors.
    */
   boolean removeImplementor(final Object implementor) {
     synchronized (m_implementorsMutext) {
@@ -135,10 +135,6 @@ class EndPoint {
     }
   }
 
-  /**
-   * @param call
-   * @param rVal
-   */
   private List<RemoteMethodCallResults> invokeMultiple(final RemoteMethodCall call, final INode messageOriginator) {
     // copy the implementors
     List<Object> implementorsCopy;
@@ -152,10 +148,6 @@ class EndPoint {
     return results;
   }
 
-  /**
-   * @param call
-   * @param implementor
-   */
   private RemoteMethodCallResults invokeSingle(final RemoteMethodCall call, final Object implementor,
       final INode messageOriginator) {
     call.resolve(m_remoteClass);

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -57,6 +57,8 @@ public class UnifiedMessenger {
   private UnifiedMessengerHub m_hub;
 
   /**
+   * Creates a new instance of UnifiedMessanger.
+   *
    * @param messenger
    */
   public UnifiedMessenger(final IMessenger messenger) {
@@ -137,7 +139,7 @@ public class UnifiedMessenger {
   }
 
   /**
-   * invoke without waiting for remote nodes to respond
+   * invoke without waiting for remote nodes to respond.
    */
   public void invoke(final String endPointName, final RemoteMethodCall call) {
     // send the remote invocation

--- a/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/AbstractForumPoster.java
@@ -7,7 +7,7 @@ import games.strategy.engine.framework.startup.ui.editors.ForumPosterEditor;
 import games.strategy.engine.framework.startup.ui.editors.IBean;
 
 /**
- * Abstract Forum poster that takes care of storing the username, password, and other common properties
+ * Abstract Forum poster that takes care of storing the username, password, and other common properties.
  */
 public abstract class AbstractForumPoster implements IForumPoster {
   private static final String USE_TRANSITIVE_PASSWORD = "d0a11f0f-96d3-4303-8875-4965aefb2ce4";

--- a/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/GenericEmailSender.java
@@ -37,7 +37,7 @@ import games.strategy.triplea.help.HelpSupport;
 public class GenericEmailSender implements IEmailSender {
   private static final long serialVersionUID = 4644748856027574157L;
   /**
-   * a value to assign to the non-transitive password, as we can see that is was cleared
+   * a value to assign to the non-transitive password, as we can see that is was cleared.
    */
   private static final String USE_TRANSITIVE_PASSWORD = "d0a11f0f-96d3-4303-8875-4965aefb2ce4";
 
@@ -132,7 +132,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Get the user name used to login to the smtp server to send the email
+   * Get the user name used to login to the smtp server to send the email.
    *
    * @return the userName or null if no authentication is required
    */
@@ -142,7 +142,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Set the userName used for authentication with the smtp server
+   * Set the userName used for authentication with the smtp server.
    *
    * @param userName
    *        the userName or null if no authentication is required
@@ -153,7 +153,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Get the password used to authenticate
+   * Get the password used to authenticate.
    *
    * @return the password or null
    */
@@ -166,7 +166,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Set the password to authenticate with
+   * Set the password to authenticate with.
    *
    * @param password
    *        the password or null
@@ -178,7 +178,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Get the timeout (in milli seconds) before the send operation should be aborted
+   * Get the timeout (in milliseconds) before the send operation should be aborted.
    *
    * @return the timeout
    */
@@ -198,7 +198,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Get the SMTP host
+   * Get the SMTP host.
    *
    * @return the host to send to
    */
@@ -207,7 +207,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Set the smtp server host or IP address
+   * Set the smtp server host or IP address.
    *
    * @param host
    *        the host
@@ -217,7 +217,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Get the smtp server post
+   * Get the smtp server post.
    *
    * @return the port
    */
@@ -226,7 +226,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Set the SMTP servers port
+   * Set the SMTP server port.
    *
    * @param port
    *        the port
@@ -236,7 +236,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Get the message encryption
+   * Get the message encryption.
    *
    * @return the selected encryption
    */
@@ -245,7 +245,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Sets the message encryption
+   * Sets the message encryption.
    *
    * @param encryption
    *        the encryption
@@ -255,7 +255,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Sets the to address field, if multiple email addresses are given they must be separated by space
+   * Sets the to address field, if multiple email addresses are given they must be separated by space.
    *
    * @param to
    *        the to addresses
@@ -265,7 +265,7 @@ public class GenericEmailSender implements IEmailSender {
   }
 
   /**
-   * Get the To address configured
+   * Get the To address configured.
    *
    * @return the to address, or multiple separated by space
    */

--- a/src/main/java/games/strategy/engine/pbem/HotmailEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/HotmailEmailSender.java
@@ -6,7 +6,7 @@ import games.strategy.engine.framework.startup.ui.editors.IBean;
 import games.strategy.triplea.help.HelpSupport;
 
 /**
- * A pre configured Email sender that uses Hotmail's SMTP server
+ * A pre configured Email sender that uses Hotmail's SMTP server.
  */
 public class HotmailEmailSender extends GenericEmailSender {
   private static final long serialVersionUID = 3511375113962472063L;

--- a/src/main/java/games/strategy/engine/pbem/IEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/IEmailSender.java
@@ -35,7 +35,7 @@ public interface IEmailSender extends IBean {
   String getToAddress();
 
   /**
-   * Remove any sensitive information, like passwords before this object is saved in as a game properties
+   * Remove any sensitive information, like passwords before this object is saved in as a game properties.
    */
   void clearSensitiveInfo();
 
@@ -55,14 +55,14 @@ public interface IEmailSender extends IBean {
   void setPassword(String password);
 
   /**
-   * Should we also post at the end of combat move
+   * Should we also post at the end of combat move.
    *
    * @return true if the save game should be included in the summary
    */
   boolean getAlsoPostAfterCombatMove();
 
   /**
-   * Configure if we should also post at the end of combat move
+   * Configure if we should also post at the end of combat move.
    *
    * @param include
    *        true if the save game should be included

--- a/src/main/java/games/strategy/engine/pbem/IForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/IForumPoster.java
@@ -6,11 +6,11 @@ import games.strategy.engine.framework.startup.ui.editors.IBean;
 
 /**
  * An interface for classes that can post a turn summary, the summary may also include a save game if the
- * implementing class supports this
+ * implementing class supports this.
  */
 public interface IForumPoster extends IBean {
   /**
-   * Called when the turn summary should be posted
+   * Called when the turn summary should be posted.
    *
    * @param summary
    *        the forum summary
@@ -21,7 +21,7 @@ public interface IForumPoster extends IBean {
   boolean postTurnSummary(String summary, final String subject);
 
   /**
-   * Get the reference to the posted turn summary
+   * Get the reference to the posted turn summary.
    *
    * @return the reference string, often a URL
    */
@@ -36,7 +36,7 @@ public interface IForumPoster extends IBean {
   boolean getIncludeSaveGame();
 
   /**
-   * Configure if the save game should be included in the summary post
+   * Configure if the save game should be included in the summary post.
    *
    * @param include
    *        true if the save game should be included
@@ -44,14 +44,14 @@ public interface IForumPoster extends IBean {
   void setIncludeSaveGame(boolean include);
 
   /**
-   * Should we also post at the end of combat move
+   * Should we also post at the end of combat move.
    *
    * @return true if the save game should be included in the summary
    */
   boolean getAlsoPostAfterCombatMove();
 
   /**
-   * Configure if we should also post at the end of combat move
+   * Configure if we should also post at the end of combat move.
    *
    * @param include
    *        true if the save game should be included
@@ -59,7 +59,7 @@ public interface IForumPoster extends IBean {
   void setAlsoPostAfterCombatMove(boolean postAlso);
 
   /**
-   * Called to add the save game to the summary, this should only be called if getIncludeSaveGame returns true
+   * Called to add the save game to the summary, this should only be called if getIncludeSaveGame returns true.
    *
    * @param saveGame
    *        the save game file
@@ -68,53 +68,53 @@ public interface IForumPoster extends IBean {
   void addSaveGame(File saveGame, String fileName);
 
   /**
-   * Create a clone of this object
+   * Create a clone of this object.
    *
    * @return the clone
    */
   IForumPoster doClone();
 
   /**
-   * Returns true if this forum poster supports attaching save games
+   * Returns true if this forum poster supports attaching save games.
    *
    * @return true if save games are supported
    */
   boolean supportsSaveGame();
 
   /**
-   * Can you view the forum post with this poster
+   * Can you view the forum post with this poster.
    */
   boolean getCanViewPosted();
 
   /**
-   * Get the user name to login with
+   * Get the user name to login with.
    */
   @Override
   String getDisplayName();
 
   /**
-   * Get the forum id
+   * Get the forum id.
    *
    * @return the forum id
    */
   String getTopicId();
 
   /**
-   * get the user name to login
+   * get the user name to login.
    *
    * @return the user name
    */
   String getUsername();
 
   /**
-   * Get the password to login
+   * Get the password to login.
    *
    * @return the password
    */
   String getPassword();
 
   /**
-   * Set the forum id
+   * Set the forum id.
    *
    * @param forumId
    *        the new forum id
@@ -122,7 +122,7 @@ public interface IForumPoster extends IBean {
   void setTopicId(String forumId);
 
   /**
-   * Set the user name
+   * Set the user name.
    *
    * @param username
    *        the new user name
@@ -130,7 +130,7 @@ public interface IForumPoster extends IBean {
   void setUsername(String username);
 
   /**
-   * Set the password
+   * Set the password.
    *
    * @param password
    *        the new password
@@ -138,17 +138,17 @@ public interface IForumPoster extends IBean {
   void setPassword(String password);
 
   /**
-   * Opens a browser and go to the forum post, identified by the forumId
+   * Opens a browser and go to the forum post, identified by the forumId.
    */
   void viewPosted();
 
   /**
-   * Remove any sensitive information, like passwords before this object is saved in as a game properties
+   * Remove any sensitive information, like passwords before this object is saved in as a game properties.
    */
   void clearSensitiveInfo();
 
   /**
-   * Each poster provides a message that is displayed on the progress bar when testing the poster
+   * Each poster provides a message that is displayed on the progress bar when testing the poster.
    *
    * @return the progress bar message
    */

--- a/src/main/java/games/strategy/engine/pbem/IWebPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/IWebPoster.java
@@ -8,11 +8,11 @@ import games.strategy.engine.framework.startup.ui.editors.IBean;
 
 /**
  * An interface for classes that can post a turn summary, the summary may also include a save game if the
- * implementing class supports this
+ * implementing class supports this.
  */
 public interface IWebPoster extends IBean {
   /**
-   * Called when the turn summary should be posted
+   * Called when the turn summary should be posted.
    *
    * @return true if the post was successful
    */
@@ -23,7 +23,7 @@ public interface IWebPoster extends IBean {
   void setMailSaveGame(boolean mail);
 
   /**
-   * Called to add the save game to the summary, this should only be called if getIncludeSaveGame returns true
+   * Called to add the save game to the summary, this should only be called if getIncludeSaveGame returns true.
    *
    * @param saveGame
    *        the save game file
@@ -32,7 +32,7 @@ public interface IWebPoster extends IBean {
   void addSaveGame(File saveGame, String fileName);
 
   /**
-   * Create a clone of this object
+   * Create a clone of this object.
    *
    * @return the clone
    */
@@ -41,13 +41,13 @@ public interface IWebPoster extends IBean {
   void clearSensitiveInfo();
 
   /**
-   * Get the display name
+   * Get the display name.
    */
   @Override
   String getDisplayName();
 
   /**
-   * Get the site id
+   * Get the site id.
    *
    * @return the site id
    */
@@ -67,7 +67,7 @@ public interface IWebPoster extends IBean {
   void setGameName(String gameName);
 
   /**
-   * Set the host name
+   * Set the host name.
    */
   void setHost(String host);
 
@@ -76,12 +76,12 @@ public interface IWebPoster extends IBean {
   void addToAllHosts(String host);
 
   /**
-   * Opens a browser and go to the web site, identified by the site id
+   * Opens a browser and go to the web site, identified by the site id.
    */
   void viewSite();
 
   /**
-   * Each poster provides a message that is displayed on the progress bar when testing the poster
+   * Each poster provides a message that is displayed on the progress bar when testing the poster.
    *
    * @return the progress bar message
    */

--- a/src/main/java/games/strategy/engine/pbem/NullEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/NullEmailSender.java
@@ -7,7 +7,7 @@ import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 import games.strategy.engine.framework.startup.ui.editors.IBean;
 
 /**
- * A dummy Email sender, to use when Email sending is disabled
+ * A dummy Email sender, to use when Email sending is disabled.
  */
 public class NullEmailSender implements IEmailSender {
   private static final long serialVersionUID = 9138507282128548506L;

--- a/src/main/java/games/strategy/engine/pbem/NullForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/NullForumPoster.java
@@ -6,7 +6,7 @@ import games.strategy.engine.framework.startup.ui.editors.EditorPanel;
 import games.strategy.engine.framework.startup.ui.editors.IBean;
 
 /**
- * A dummy forum poster, for when Forum posting is disabled
+ * A dummy forum poster, for when Forum posting is disabled.
  */
 public class NullForumPoster implements IForumPoster {
   private static final long serialVersionUID = 6465230505089142268L;

--- a/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
+++ b/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
@@ -179,7 +179,7 @@ public class PBEMMessagePoster implements Serializable {
   }
 
   /**
-   * Converts text to html, by transforming \n to <br/>
+   * Converts text to html, by transforming \n to <br/>.
    *
    * @param string
    *        the string to transform
@@ -190,7 +190,7 @@ public class PBEMMessagePoster implements Serializable {
   }
 
   /**
-   * Get the configured email sender
+   * Get the configured email sender.
    *
    * @return return an email sender or null
    */

--- a/src/main/java/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
@@ -43,7 +43,7 @@ public class TripleAWarClubForumPoster extends AbstractForumPoster {
       Pattern.compile(".*XOOPS_TOKEN_REQUEST[^>]*value=\"([^\"]*)\".*", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
   /**
-   * Logs into the website
+   * Logs into the website.
    *
    * @throws Exception
    *         if login fails
@@ -83,7 +83,7 @@ public class TripleAWarClubForumPoster extends AbstractForumPoster {
   /**
    * Post the turn summary and save game to the forum
    * After login we must load the post page to get the XOOPS_TOKEN_REQUEST (which I think is CSRF nounce)
-   * then we can post the reply
+   * then we can post the reply.
    *
    * @param summary
    *        the forum summary

--- a/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
+++ b/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
@@ -15,7 +15,7 @@ public class CryptoRandomSource implements IRandomSource {
   private final IRandomSource m_plainRandom = new PlainRandomSource();
 
   /**
-   * converts an int[] to a bytep[
+   * converts an int[] to a byte[].
    */
   public static byte[] intsToBytes(final int[] ints) {
     final byte[] rVal = new byte[ints.length * 4];

--- a/src/main/java/games/strategy/engine/random/IRemoteDiceServer.java
+++ b/src/main/java/games/strategy/engine/random/IRemoteDiceServer.java
@@ -7,26 +7,26 @@ import games.strategy.engine.framework.startup.ui.editors.IBean;
 
 public interface IRemoteDiceServer extends IBean {
   /**
-   * Post a request to the dice server, and return the resulting html page as a string
+   * Post a request to the dice server, and return the resulting html page as a string.
    */
   String postRequest(int max, int numDice, String subjectMessage, String gameID, String gameUUID)
       throws IOException;
 
   /**
    * Given the html page returned from postRequest, return the dice []
-   * throw an InvocationTargetException to indicate an error message to be returned
+   * throw an InvocationTargetException to indicate an error message to be returned.
    */
   int[] getDice(String string, int count) throws IOException, InvocationTargetException;
 
   /**
-   * Get the to address
+   * Get the to address.
    *
    * @return returns the to address or null if not configured
    */
   String getToAddress();
 
   /**
-   * Set the to address
+   * Set the to address.
    *
    * @param toAddress
    *        the new to address
@@ -34,14 +34,14 @@ public interface IRemoteDiceServer extends IBean {
   void setToAddress(String toAddress);
 
   /**
-   * get the CC address
+   * get the CC address.
    *
    * @return the address or null if not configured
    */
   String getCcAddress();
 
   /**
-   * Set the cc address
+   * Set the cc address.
    *
    * @param ccAddress
    *        the address or null if not configured
@@ -49,21 +49,21 @@ public interface IRemoteDiceServer extends IBean {
   void setCcAddress(String ccAddress);
 
   /**
-   * Get the info text displayed for this Dice server
+   * Get the info text displayed for this Dice server.
    *
    * @return the info text
    */
   String getInfoText();
 
   /**
-   * True if this dice server sends email, and therefore requires email addresses
+   * True if this dice server sends email, and therefore requires email addresses.
    *
    * @return true if email addresses are required
    */
   boolean sendsEmail();
 
   /**
-   * True if this dice server requires a game id
+   * True if this dice server requires a game id.
    *
    * @return true if a game id is required
    */
@@ -79,7 +79,7 @@ public interface IRemoteDiceServer extends IBean {
   void setGameId(String gameId);
 
   /**
-   * Get the configured game id
+   * Get the configured game id.
    *
    * @return the game id or null if not configured
    */

--- a/src/main/java/games/strategy/engine/random/InternalDiceServer.java
+++ b/src/main/java/games/strategy/engine/random/InternalDiceServer.java
@@ -88,7 +88,7 @@ public class InternalDiceServer implements IRemoteDiceServer {
 
   /**
    * Dice servers has to be serializable, so we need to provide custom serialization since
-   * PlainRandomSource is not serializable
+   * PlainRandomSource is not serializable.
    *
    * @return a new InternalDiceServer
    * @throws ObjectStreamException

--- a/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
@@ -98,7 +98,7 @@ public class PBEMDiceRoller implements IRandomSource {
 
 
 /**
- * The dialog that will show while the dice are rolling
+ * The dialog that will show while the dice are rolling.
  */
 class HttpDiceRollerDialog extends JDialog {
   private static final long serialVersionUID = -4802403913826489223L;
@@ -120,7 +120,7 @@ class HttpDiceRollerDialog extends JDialog {
 
   /**
    * @param owner
-   *        owner frame
+   *        owner frame.
    * @param sides
    *        the number of sides on the dice
    * @param count
@@ -161,7 +161,7 @@ class HttpDiceRollerDialog extends JDialog {
 
   /**
    * There are three differences when we are testing, 1 dont close the window
-   * when we are done 2 remove the exit button 3 add a close button
+   * when we are done 2 remove the exit button 3 add a close button.
    */
   public void setTest() {
     m_test = true;

--- a/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -32,13 +32,13 @@ import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.util.Util;
 
 /**
- * A pbem dice roller that reads its configuration from a properties file
+ * A pbem dice roller that reads its configuration from a properties file.
  */
 public class PropertiesDiceRoller implements IRemoteDiceServer {
   private static final long serialVersionUID = 6481409417543119539L;
 
   /**
-   * Loads the property dice rollers from the properties file
+   * Loads the property dice rollers from the properties file.
    *
    * @return the collection of available dice rollers
    */
@@ -156,7 +156,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
 
   /**
    * @throws IOException
-   *         if there was an error parsing the string
+   *         if there was an error parsing the string.
    */
   @Override
   public int[] getDice(final String string, final int count) throws IOException, InvocationTargetException {

--- a/src/main/java/games/strategy/engine/random/RandomStatsDetails.java
+++ b/src/main/java/games/strategy/engine/random/RandomStatsDetails.java
@@ -65,9 +65,7 @@ public class RandomStatsDetails implements Serializable {
         tmp2 = calcMedian((total / 2) + 1, diceSides, stats);
         m_median = (tmp1 + tmp2) / 2;
       }
-      /**
-       * calculate variance
-       */
+      // calculate variance
       double variance = 0;
       // TODO: does this need to be updated to take data.getDiceSides() ?
       for (int i = 1; i <= diceSides; i++) {

--- a/src/main/java/games/strategy/engine/random/RemoteRandom.java
+++ b/src/main/java/games/strategy/engine/random/RemoteRandom.java
@@ -31,6 +31,8 @@ public class RemoteRandom implements IRemoteRandom {
   private int[] m_localNumbers;
 
   /**
+   * Creates a new instance of RemoteRandom.
+   *
    * @param id
    */
   public RemoteRandom(final IGame game) {

--- a/src/main/java/games/strategy/engine/vault/NotUnlockedException.java
+++ b/src/main/java/games/strategy/engine/vault/NotUnlockedException.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.vault;
 
 /**
- * Thrown when an attempt was made to access a vault id that had not been unlocked
+ * Thrown when an attempt was made to access a vault id that had not been unlocked.
  */
 public class NotUnlockedException extends Exception {
   private static final long serialVersionUID = -2580890952206381682L;

--- a/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/src/main/java/games/strategy/engine/vault/Vault.java
@@ -54,6 +54,8 @@ public class Vault {
   private final Object m_waitForLock = new Object();
 
   /**
+   * Creates a new instance of Vault.
+   *
    * @param channelMessenger
    */
   public Vault(final IChannelMessenger channelMessenger) {
@@ -307,7 +309,7 @@ public class Vault {
   }
 
   /**
-   * Wait until the given id is unlocked
+   * Wait until the given id is unlocked.
    */
   public void waitForIdToUnlock(final VaultID id, final long timeout) {
     if (timeout <= 0) {

--- a/src/main/java/games/strategy/engine/xml/TestAttachment.java
+++ b/src/main/java/games/strategy/engine/xml/TestAttachment.java
@@ -8,7 +8,7 @@ public class TestAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 4886924951201479496L;
   private String m_value;
 
-  /** Creates new TestAttachment */
+  /** Creates new TestAttachment. */
   public TestAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }

--- a/src/main/java/games/strategy/engine/xml/TestDelegate.java
+++ b/src/main/java/games/strategy/engine/xml/TestDelegate.java
@@ -64,7 +64,7 @@ public final class TestDelegate extends AbstractDelegate {
   }
 
   /**
-   * Loads the delegates state
+   * Loads the delegates state.
    */
   @Override
   public void loadState(final Serializable state) {}

--- a/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/src/main/java/games/strategy/net/ClientMessenger.java
@@ -194,9 +194,6 @@ public class ClientMessenger implements IClientMessenger, NIOSocketListener {
     }
   }
 
-  /**
-   * Get the local node
-   */
   @Override
   public INode getLocalNode() {
     return m_node;

--- a/src/main/java/games/strategy/net/CouldNotLogInException.java
+++ b/src/main/java/games/strategy/net/CouldNotLogInException.java
@@ -3,7 +3,7 @@ package games.strategy.net;
 import java.io.IOException;
 
 /**
- * Thrown when a ClientMessenger could not log in to a ServerMessenger
+ * Thrown when a ClientMessenger could not log in to a ServerMessenger.
  */
 public class CouldNotLogInException extends IOException {
   private static final long serialVersionUID = -7266754722803615270L;

--- a/src/main/java/games/strategy/net/IConnectionLogin.java
+++ b/src/main/java/games/strategy/net/IConnectionLogin.java
@@ -13,7 +13,7 @@ import java.util.Map;
  */
 public interface IConnectionLogin {
   /**
-   * Get the properties to log in given the challenge Properties
+   * Get the properties to log in given the challenge Properties.
    */
   Map<String, String> getProperties(Map<String, String> challengProperties);
 

--- a/src/main/java/games/strategy/net/IMessenger.java
+++ b/src/main/java/games/strategy/net/IMessenger.java
@@ -35,7 +35,7 @@ public interface IMessenger {
   void removeMessageListener(IMessageListener listener);
 
   /**
-   * Listen for errors
+   * Listen for errors.
    */
   void addErrorListener(IMessengerErrorListener listener);
 
@@ -45,7 +45,7 @@ public interface IMessenger {
   void removeErrorListener(IMessengerErrorListener listener);
 
   /**
-   * Get the local node
+   * Get the local node.
    */
   INode getLocalNode();
 

--- a/src/main/java/games/strategy/net/INode.java
+++ b/src/main/java/games/strategy/net/INode.java
@@ -15,22 +15,22 @@ import java.net.InetSocketAddress;
  */
 public interface INode extends Serializable, Comparable<INode> {
   /**
-   * @return the display/user name for the node
+   * @return the display/user name for the node.
    */
   String getName();
 
   /**
-   * @return the adress for the node as seen by the server
+   * @return the address for the node as seen by the server.
    */
   InetAddress getAddress();
 
   /**
-   * @return the port for the node as seen by the server
+   * @return the port for the node as seen by the server.
    */
   int getPort();
 
   /**
-   * @return the adress for the node as seen by the server
+   * @return the address for the node as seen by the server.
    */
   InetSocketAddress getSocketAddress();
 }

--- a/src/main/java/games/strategy/net/MacFinder.java
+++ b/src/main/java/games/strategy/net/MacFinder.java
@@ -21,7 +21,7 @@ import games.strategy.util.MD5Crypt;
 public class MacFinder {
 
   /**
-   * Should result in something like this: $1$MH$345ntXD4G3AKpAeHZdaGe3
+   * Should result in something like this: $1$MH$345ntXD4G3AKpAeHZdaGe3.
    */
   public static String getHashedMacAddress() {
     final String mac = getMacAddress();

--- a/src/main/java/games/strategy/net/MessageHeader.java
+++ b/src/main/java/games/strategy/net/MessageHeader.java
@@ -26,7 +26,7 @@ public class MessageHeader {
   }
 
   /**
-   * null if a broadcast
+   * null if a broadcast.
    */
   public INode getFor() {
     return m_for;

--- a/src/main/java/games/strategy/net/Node.java
+++ b/src/main/java/games/strategy/net/Node.java
@@ -27,14 +27,14 @@ public class Node implements INode, Externalizable {
   // needed to support Externalizable
   public Node() {}
 
-  /** Creates new Node */
+  /** Creates new Node. */
   public Node(final String name, final InetSocketAddress address) {
     this.name = name;
     m_address = address.getAddress();
     port = address.getPort();
   }
 
-  /** Creates new Node */
+  /** Creates new Node. */
   public Node(final String name, final InetAddress address, final int port) {
     this.name = name;
     m_address = address;

--- a/src/main/java/games/strategy/net/OpenFileUtility.java
+++ b/src/main/java/games/strategy/net/OpenFileUtility.java
@@ -9,7 +9,7 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.ui.SwingComponents;
 
 /**
- * A wrapper class for opening Files & URLs using the Desktop API
+ * A wrapper class for opening Files & URLs using the Desktop API.
  */
 public class OpenFileUtility {
 

--- a/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/src/main/java/games/strategy/net/ServerMessenger.java
@@ -88,7 +88,7 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
     return loginValidator;
   }
 
-  /** Creates new ServerMessenger */
+  /** Creates new ServerMessenger. */
   public ServerMessenger(final String name, final int portNumber) throws IOException {
     this(name, portNumber, new DefaultObjectStreamFactory());
   }
@@ -555,9 +555,6 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
     return acceptNewConnection;
   }
 
-  /**
-   * Get the local node
-   */
   @Override
   public INode getLocalNode() {
     return node;

--- a/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/src/main/java/games/strategy/net/nio/Encoder.java
@@ -12,7 +12,7 @@ import games.strategy.net.MessageHeader;
 import games.strategy.net.Node;
 
 /**
- * Encodes data to be written by a writer
+ * Encodes data to be written by a writer.
  */
 public class Encoder {
   private static final Logger s_logger = Logger.getLogger(Encoder.class.getName());

--- a/src/main/java/games/strategy/net/nio/IErrorReporter.java
+++ b/src/main/java/games/strategy/net/nio/IErrorReporter.java
@@ -4,7 +4,7 @@ import java.nio.channels.SocketChannel;
 
 public interface IErrorReporter {
   /**
-   * An io error occured while reading or writing to the socket, and it should be removed from the network
+   * An io error occurred while reading or writing to the socket, and it should be removed from the network.
    */
   void error(SocketChannel channel, Exception e);
 }

--- a/src/main/java/games/strategy/net/nio/NIOSocket.java
+++ b/src/main/java/games/strategy/net/nio/NIOSocket.java
@@ -86,7 +86,7 @@ public class NIOSocket implements IErrorReporter {
   }
 
   /**
-   * Close the channel, and clean up any data associated with it
+   * Close the channel, and clean up any data associated with it.
    */
   public void close(final SocketChannel channel) {
     try {

--- a/src/main/java/games/strategy/net/nio/NIOSocketListener.java
+++ b/src/main/java/games/strategy/net/nio/NIOSocketListener.java
@@ -6,7 +6,7 @@ import games.strategy.net.INode;
 import games.strategy.net.MessageHeader;
 
 /**
- * Call backs for an NIO Socket
+ * Call backs for an NIO Socket.
  */
 public interface NIOSocketListener {
   /**

--- a/src/main/java/games/strategy/net/nio/NIOWriter.java
+++ b/src/main/java/games/strategy/net/nio/NIOWriter.java
@@ -149,7 +149,7 @@ public class NIOWriter {
   }
 
   /**
-   * Remove the data for this channel
+   * Remove the data for this channel.
    */
   public void closed(final SocketChannel channel) {
     removeAll(channel);

--- a/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -21,7 +21,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
    * 4) server send null then client name and node info on success, or an error message if there is an error
    * 5) if the client reads an error message, the client sends an acknowledgment (we need to make sur the client gets
    * the message before
-   * closing the socket)
+   * closing the socket).
    */
   private static final Logger s_logger = Logger.getLogger(ServerQuarantineConversation.class.getName());
 

--- a/src/main/java/games/strategy/net/nio/SocketWriteData.java
+++ b/src/main/java/games/strategy/net/nio/SocketWriteData.java
@@ -45,7 +45,7 @@ public class SocketWriteData {
   }
 
   /**
-   * @return true if the write has written the entire message
+   * @return true if the write has written the entire message.
    */
   public boolean write(final SocketChannel channel) throws IOException {
     m_writeCalls++;

--- a/src/main/java/games/strategy/sound/SoundOptionCheckBox.java
+++ b/src/main/java/games/strategy/sound/SoundOptionCheckBox.java
@@ -11,7 +11,7 @@ class SoundOptionCheckBox extends BooleanProperty {
 
   /**
    * @param clipName
-   *        sound file name
+   *        sound file name.
    * @param title
    *        title to display
    */

--- a/src/main/java/games/strategy/sound/SoundOptions.java
+++ b/src/main/java/games/strategy/sound/SoundOptions.java
@@ -22,7 +22,7 @@ public final class SoundOptions {
 
   /**
    * @param parentMenu
-   *        menu where to add the menu item "Sound Options"
+   *        menu where to add the menu item "Sound Options".
    */
   public static void addToMenu(final JMenu parentMenu) {
     final JMenuItem soundOptions = new JMenuItem("Sound Options");

--- a/src/main/java/games/strategy/sound/SoundProperties.java
+++ b/src/main/java/games/strategy/sound/SoundProperties.java
@@ -52,7 +52,7 @@ public class SoundProperties {
   }
 
   /**
-   * @return the string property, or null if not found
+   * @return the string property, or null if not found.
    */
   public String getProperty(final String key) {
     return m_properties.getProperty(key);

--- a/src/main/java/games/strategy/triplea/Constants.java
+++ b/src/main/java/games/strategy/triplea/Constants.java
@@ -63,7 +63,7 @@ public interface Constants {
   String NEUTRALS_ARE_BLITZABLE = "Neutrals Are Blitzable";
   String PARTIAL_AMPHIBIOUS_RETREAT = "Partial Amphibious Retreat";
   // public static final String PREVIOUS_UNITS_FIGHT = "Previous Units Fight";
-  /**
+  /*
    * These are the individual rules from a game (All default to FALSE)
    */
   String PLACEMENT_RESTRICTED_BY_FACTORY = "Placement Restricted By Factory";
@@ -86,10 +86,10 @@ public interface Constants {
   String SURVIVING_AIR_MOVE_TO_LAND = "Surviving Air Move To Land";
   String BLITZ_THROUGH_FACTORIES_AND_AA_RESTRICTED = "Blitz Through Factories And AA Restricted";
   String AIR_ATTACK_SUB_RESTRICTED = "Air Attack Sub Restricted";
-  /**
+  /*
    * End individual rules (All default to FALSE)
    */
-  /**
+  /*
    * These are the individual rules for TripleA WW2V3 (All default to FALSE)
    */
   String NATIONAL_OBJECTIVES = "National Objectives";
@@ -110,7 +110,7 @@ public interface Constants {
   String IGNORE_TRANSPORT_IN_MOVEMENT = "Ignore Transport In Movement";
   String IGNORE_SUB_IN_MOVEMENT = "Ignore Sub In Movement";
   String UNPLACED_UNITS_LIVE = "Unplaced units live when not placed";
-  /**
+  /*
    * End individual rules for TripleA WW2V3 (All default to FALSE)
    */
   String PRODUCTION_PER_VALUED_TERRITORY_RESTRICTED = "Production Per Valued Territory Restricted";

--- a/src/main/java/games/strategy/triplea/Properties.java
+++ b/src/main/java/games/strategy/triplea/Properties.java
@@ -3,9 +3,7 @@ package games.strategy.triplea;
 import games.strategy.engine.data.GameData;
 
 /**
- * <p>
- * Title: TripleA
- * </p>
+ * Provides typed access to the properties of GameData.
  */
 public class Properties implements Constants {
   // These should always default to false, if boolean, and if not should default to whatever is the "default" behavior
@@ -157,7 +155,7 @@ public class Properties implements Constants {
 
   /**
    * Limit the TOTAL damage caused by Rockets in a turn to territory's
-   * production
+   * production.
    */
   public static boolean getLimitRocketDamagePerTurn(final GameData data) {
     return data.getProperties().get(LIMIT_ROCKET_DAMAGE_PER_TURN, false);
@@ -165,77 +163,77 @@ public class Properties implements Constants {
 
   /**
    * Limit the TOTAL PUs lost to Bombers/Rockets in a turn to territory's
-   * production
+   * production.
    */
   public static boolean getPUCap(final GameData data) {
     return data.getProperties().get(PU_CAP, false);
   }
 
   /**
-   * Reduce Victory Points by Strategic Bombing
+   * Reduce Victory Points by Strategic Bombing.
    */
   public static boolean getSBRVictoryPoint(final GameData data) {
     return data.getProperties().get(SBR_VICTORY_POINTS, false);
   }
 
   /**
-   * Allow x rocket attack(s) per defending factory
+   * Allow x rocket attack(s) per defending factory.
    */
   public static boolean getRocketAttacksPerFactoryInfinite(final GameData data) {
     return data.getProperties().get(ROCKET_ATTACKS_PER_FACTORY_INFINITE, false);
   }
 
   /**
-   * Are allied aircraft dependents of CVs
+   * Are allied aircraft dependents of CVs.
    */
   public static boolean getAlliedAirIndependent(final GameData data) {
     return data.getProperties().get(ALLIED_AIR_INDEPENDENT, false);
   }
 
   /**
-   * Defending subs sneak attack
+   * Defending subs sneak attack.
    */
   public static boolean getDefendingSubsSneakAttack(final GameData data) {
     return data.getProperties().get(DEFENDING_SUBS_SNEAK_ATTACK, false);
   }
 
   /**
-   * Attacker retreat planes from Amphib assault
+   * Attacker retreat planes from Amphib assault.
    */
   public static boolean getAttackerRetreatPlanes(final GameData data) {
     return data.getProperties().get(ATTACKER_RETREAT_PLANES, false);
   }
 
   /**
-   * Can surviving air at sea move to land on friendly land/carriers
+   * Can surviving air at sea move to land on friendly land/carriers.
    */
   public static boolean getSurvivingAirMoveToLand(final GameData data) {
     return data.getProperties().get(SURVIVING_AIR_MOVE_TO_LAND, false);
   }
 
   /**
-   * Naval Bombard casualties restricted from return fire
+   * Naval Bombard casualties restricted from return fire.
    */
   public static boolean getNavalBombardCasualtiesReturnFireRestricted(final GameData data) {
     return data.getProperties().get(NAVAL_BOMBARD_CASUALTIES_RETURN_FIRE_RESTRICTED, false);
   }
 
   /**
-   * Restricted from blitz through territories with factories/AA
+   * Restricted from blitz through territories with factories/AA.
    */
   public static boolean getBlitzThroughFactoriesAndAARestricted(final GameData data) {
     return data.getProperties().get(BLITZ_THROUGH_FACTORIES_AND_AA_RESTRICTED, false);
   }
 
   /**
-   * Can place new units in occupied sea zones
+   * Can place new units in occupied sea zones.
    */
   public static boolean getUnitPlacementInEnemySeas(final GameData data) {
     return data.getProperties().get(UNIT_PLACEMENT_IN_ENEMY_SEAS, false);
   }
 
   /**
-   * Subs restricted from controlling sea zones
+   * Subs restricted from controlling sea zones.
    */
   public static boolean getSubControlSeaZoneRestricted(final GameData data) {
     return data.getProperties().get(SUB_CONTROL_SEA_ZONE_RESTRICTED, false);
@@ -249,56 +247,56 @@ public class Properties implements Constants {
   }
 
   /**
-   * Production restricted to 1 unit per X owned territories
+   * Production restricted to 1 unit per X owned territories.
    */
   public static boolean getProductionPerXTerritoriesRestricted(final GameData data) {
     return data.getProperties().get(PRODUCTION_PER_X_TERRITORIES_RESTRICTED, false);
   }
 
   /**
-   * Production restricted to 1 unit per owned territory with an PU value
+   * Production restricted to 1 unit per owned territory with an PU value.
    */
   public static boolean getProductionPerValuedTerritoryRestricted(final GameData data) {
     return data.getProperties().get(PRODUCTION_PER_VALUED_TERRITORY_RESTRICTED, false);
   }
 
   /**
-   * Can units be placed in any owned territory
+   * Can units be placed in any owned territory.
    */
   public static boolean getPlaceInAnyTerritory(final GameData data) {
     return data.getProperties().get(PLACE_IN_ANY_TERRITORY, false);
   }
 
   /**
-   * Limit the number of units that can be in a territory
+   * Limit the number of units that can be in a territory.
    */
   public static boolean getUnitPlacementPerTerritoryRestricted(final GameData data) {
     return data.getProperties().get(UNIT_PLACEMENT_PER_TERRITORY_RESTRICTED, false);
   }
 
   /**
-   * Movement restricted for territories
+   * Movement restricted for territories.
    */
   public static boolean getMovementByTerritoryRestricted(final GameData data) {
     return data.getProperties().get(MOVEMENT_BY_TERRITORY_RESTRICTED, false);
   }
 
   /**
-   * Transports restricted from being taken as casualties
+   * Transports restricted from being taken as casualties.
    */
   public static boolean getTransportCasualtiesRestricted(final GameData data) {
     return data.getProperties().get(TRANSPORT_CASUALTIES_RESTRICTED, false);
   }
 
   /**
-   * Transports do not restrict movement of other units
+   * Transports do not restrict movement of other units.
    */
   public static boolean getIgnoreTransportInMovement(final GameData data) {
     return data.getProperties().get(IGNORE_TRANSPORT_IN_MOVEMENT, false);
   }
 
   /**
-   * Subs do not restrict movement of other units
+   * Subs do not restrict movement of other units.
    */
   public static boolean getIgnoreSubInMovement(final GameData data) {
     return data.getProperties().get(IGNORE_SUB_IN_MOVEMENT, false);
@@ -309,21 +307,21 @@ public class Properties implements Constants {
   }
 
   /**
-   * Air restricted from attacking subs unless DD present
+   * Air restricted from attacking subs unless DD present.
    */
   public static boolean getAirAttackSubRestricted(final GameData data) {
     return data.getProperties().get(AIR_ATTACK_SUB_RESTRICTED, false);
   }
 
   /**
-   * Allows units with zero movement to be selected to be moved
+   * Allows units with zero movement to be selected to be moved.
    */
   public static boolean getSelectableZeroMovementUnits(final GameData data) {
     return data.getProperties().get(SELECTABLE_ZERO_MOVEMENT_UNITS, false);
   }
 
   /**
-   * Allows paratroopers to move ground units to friendly territories during non-combat move phase
+   * Allows paratroopers to move ground units to friendly territories during non-combat move phase.
    */
   public static boolean getParatroopersCanMoveDuringNonCombat(final GameData data) {
     return data.getProperties().get(PARATROOPERS_CAN_MOVE_DURING_NON_COMBAT, false);
@@ -334,14 +332,14 @@ public class Properties implements Constants {
   }
 
   /**
-   * Shore Bombard per Ground Unit Restricted
+   * Shore Bombard per Ground Unit Restricted.
    */
   public static boolean getShoreBombardPerGroundUnitRestricted(final GameData data) {
     return data.getProperties().get(SHORE_BOMBARD_PER_GROUND_UNIT_RESTRICTED, false);
   }
 
   /**
-   * AA restricted to Attacked Territory Only
+   * AA restricted to Attacked Territory Only.
    */
   public static boolean getAATerritoryRestricted(final GameData data) {
     return data.getProperties().get(AA_TERRITORY_RESTRICTED, false);
@@ -368,7 +366,7 @@ public class Properties implements Constants {
   }
 
   /**
-   * Atomic units of the fighter/carrier production rules
+   * Atomic units of the fighter/carrier production rules.
    */
   public static boolean getProduceFightersOnCarriers(final GameData data) {
     return data.getProperties().get(CAN_PRODUCE_FIGHTERS_ON_CARRIERS, false);

--- a/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
+++ b/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 class ResourceLocationTracker {
 
   /**
-   * master zip is the zipped folder format you get when downloading from a map repo via the 'clone or download' button
+   * master zip is the zipped folder format you get when downloading from a map repo via the 'clone or download' button.
    */
   static final String MASTER_ZIP_MAGIC_PREFIX = "-master/map/";
 

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -74,7 +74,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
   private boolean m_soundPlayedAlreadyEndTurn = false;
   private boolean m_soundPlayedAlreadyPlacement = false;
 
-  /** Creates new TripleAPlayer */
+  /** Creates new TripleAPlayer. */
   public TripleAPlayer(final String name, final String type) {
     super(name, type);
   }

--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -355,7 +355,7 @@ public class TripleAUnit extends Unit {
 
   /**
    * How much more damage can this unit take?
-   * Will return 0 if the unit cannot be damaged, or is at max damage
+   * Will return 0 if the unit cannot be damaged, or is at max damage.
    */
   public int getHowMuchMoreDamageCanThisUnitTake(final Unit u, final Territory t) {
     if (!Matches.UnitCanBeDamaged.match(u)) {

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -25,7 +25,7 @@ import games.strategy.util.Match;
 public class AIUtils {
 
   /**
-   * @return a comparator that sorts cheaper units before expensive ones
+   * @return a comparator that sorts cheaper units before expensive ones.
    */
   public static Comparator<Unit> getCostComparator() {
     return (o1, o2) -> getCost(o1.getType(), o1.getOwner(), o1.getData())

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
@@ -395,7 +395,7 @@ public class ProBidAI {
     final List<Territory> factoryTerritories =
         Match.getMatches(findUnitTerr(data, ourFactory), Matches.isTerritoryOwnedBy(player));
     factoryTerritories.removeAll(impassableTerrs);
-    /**
+    /*
      * Bid place with following criteria:
      * 1) Has an enemy Neighbor
      * 2) Has the largest combination value:
@@ -622,7 +622,7 @@ public class ProBidAI {
   }
 
   /**
-   * All the territories that border one of our territories
+   * All the territories that border one of our territories.
    */
   private static List<Territory> getNeighboringEnemyLandTerritories(final GameData data, final PlayerID player) {
     final ArrayList<Territory> rVal = new ArrayList<>();
@@ -707,7 +707,7 @@ public class ProBidAI {
 
   /**
    * Recursive routine to determine the bestAttack and bestDefense set of purchase
-   * Expects bestAttack to already be filled with the rules
+   * Expects bestAttack to already be filled with the rules.
    *
    * @param parameters
    *        - set of parameters to be used (8 of them)
@@ -1067,7 +1067,7 @@ public class ProBidAI {
   }
 
   /**
-   * Returns a List of all territories with a water neighbor
+   * Returns a List of all territories with a water neighbor.
    *
    * @param allTerr - List of Territories
    */
@@ -1100,7 +1100,8 @@ public class ProBidAI {
   }
 
   /**
-   * Return Territories containing any unit depending on unitCondition
+   * Return Territories containing any unit depending on unitCondition.
+   *
    * Differs from findCertainShips because it doesn't require the units be owned
    */
   private static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
@@ -1117,7 +1118,7 @@ public class ProBidAI {
   }
 
   /**
-   * Territories we actually own in a modifiable List
+   * Territories we actually own in a modifiable List.
    */
   private static List<Territory> allOurTerritories(final GameData data, final PlayerID player) {
     final Collection<Territory> ours = data.getMap().getTerritoriesOwnedBy(player);
@@ -1127,7 +1128,7 @@ public class ProBidAI {
   }
 
   /**
-   * Territory ranking system
+   * Territory ranking system.
    *
    * @param waterBased - attack is Water Based - Remove all terr with no avail water
    * @param nonCombat - if nonCombat, emphasize threatened factories over their neighbors
@@ -1171,7 +1172,7 @@ public class ProBidAI {
         minDist = Math.min(minDist, dist);
       }
     }
-    /**
+    /*
      * Send units because:
      * 1) Production Value
      * 2) Victory City
@@ -1334,7 +1335,7 @@ public class ProBidAI {
   }
 
   /**
-   * Returns a list of all enemy players
+   * Returns a list of all enemy players.
    */
   private static List<PlayerID> getEnemyPlayers(final GameData data, final PlayerID player) {
     final List<PlayerID> enemyPlayers = new ArrayList<>();
@@ -1347,7 +1348,7 @@ public class ProBidAI {
   }
 
   /**
-   * List containing the enemy Capitals
+   * List containing the enemy Capitals.
    */
   private static List<Territory> getEnemyCapitals(final GameData data, final PlayerID player) {
     // generate a list of all enemy capitals
@@ -1364,7 +1365,7 @@ public class ProBidAI {
   }
 
   /**
-   * Returns the players current pus available
+   * Returns the players current pus available.
    */
   private static int getLeftToSpend(final GameData data, final PlayerID player) {
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
@@ -1577,7 +1578,7 @@ public class ProBidAI {
   }
 
   /**
-   * Find the Route to the nearest Territory
+   * Find the Route to the nearest Territory.
    *
    * @param start - starting territory
    * @param endCondition - condition for the ending Territory
@@ -1678,7 +1679,7 @@ public class ProBidAI {
   }
 
   /**
-   * Determine the enemy potential for blitzing a territory - all enemies are combined
+   * Determine the enemy potential for blitzing a territory - all enemies are combined.
    *
    * @param blitzHere
    *        - Territory expecting to be blitzed
@@ -1779,7 +1780,7 @@ public class ProBidAI {
   }
 
   /**
-   * does not count planes already in the starting territory
+   * does not count planes already in the starting territory.
    */
   private static List<Unit> findPlaneAttackersThatCanLand(final Territory start, final int maxDistance,
       final PlayerID player, final GameData data, final List<Territory> ignore, final List<Territory> checked) {
@@ -1913,7 +1914,7 @@ public class ProBidAI {
   }
 
   /**
-   * All allied Territories which have a Land Enemy Neighbor
+   * All allied Territories which have a Land Enemy Neighbor.
    *
    * @neutral - include neutral territories
    * @allied - include allied territories
@@ -1979,7 +1980,7 @@ public class ProBidAI {
   }
 
   /**
-   * All Enemy Territories in a modifiable List
+   * All Enemy Territories in a modifiable List.
    */
   private static List<Territory> allEnemyTerritories(final GameData data, final PlayerID player) {
     final List<Territory> badGuys = new ArrayList<>();
@@ -2010,7 +2011,7 @@ public class ProBidAI {
   /**
    * Look for an available sea Territory to place sea Units
    * if other owned sea units exist, place them with these units
-   * Otherwise, look for the location which is least likely to get them killed
+   * Otherwise, look for the location which is least likely to get them killed.
    *
    * @param landTerr
    *        - factory territory
@@ -2082,7 +2083,7 @@ public class ProBidAI {
 
   /**
    * distance to the closest enemy
-   * just uses findNearest
+   * just uses findNearest.
    */
   private static int distanceToEnemy(final Territory t, final GameData data, final PlayerID player, final boolean sea) {
     // note: neutrals are enemies
@@ -2110,7 +2111,7 @@ public class ProBidAI {
   }
 
   /**
-   * Determine the strength of a territory
+   * Determine the strength of a territory.
    *
    * @param attacking - attacking strength or defending
    * @param allied - allied = true - all allied units --> false - owned units only
@@ -2155,7 +2156,7 @@ public class ProBidAI {
   }
 
   /**
-   * Interleave infantry and artillery/armor for loading on transports
+   * Interleave infantry and artillery/armor for loading on transports.
    */
   private static List<Unit> sortTransportUnits(final List<Unit> transUnits) {
     final List<Unit> sorted = new ArrayList<>();
@@ -2214,7 +2215,7 @@ public class ProBidAI {
   }
 
   /**
-   * Assumes that water is passable to air units always
+   * Assumes that water is passable to air units always.
    */
   private static Match<Territory> TerritoryIsImpassableToAirUnits() {
     return new Match<Territory>() {
@@ -2248,7 +2249,7 @@ public class ProBidAI {
   /**
    * Gets the neighbors which are exactly a certain # of territories away (distance)
    * Removes the inner circle neighbors
-   * neutral - whether to include neutral countries
+   * neutral - whether to include neutral countries.
    */
   private static List<Territory> getExactNeighbors(final Territory territory, final int distance, final GameData data,
       final boolean neutral) {
@@ -2262,7 +2263,7 @@ public class ProBidAI {
   }
 
   /**
-   * Finds list of territories at exactly distance from the start
+   * Finds list of territories at exactly distance from the start.
    *
    * @param start
    * @param endCondition

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -339,7 +339,7 @@ public final class ProTechAI {
   }
 
   /**
-   * Returns a list of all enemy players
+   * Returns a list of all enemy players.
    */
   private static List<PlayerID> getEnemyPlayers(final GameData data, final PlayerID player) {
     final List<PlayerID> enemyPlayers = new ArrayList<>();
@@ -352,7 +352,7 @@ public final class ProTechAI {
   }
 
   /**
-   * Determine the enemy potential for blitzing a territory - all enemies are combined
+   * Determine the enemy potential for blitzing a territory - all enemies are combined.
    *
    * @param blitzHere
    *        - Territory expecting to be blitzed
@@ -449,7 +449,7 @@ public final class ProTechAI {
   }
 
   /**
-   * does not count planes already in the starting territory
+   * does not count planes already in the starting territory.
    */
   private static List<Unit> findPlaneAttackersThatCanLand(final Territory start, final int maxDistance,
       final PlayerID player, final GameData data, final List<Territory> ignore, final List<Territory> checked) {
@@ -602,7 +602,7 @@ public final class ProTechAI {
   /**
    * Gets the neighbors which are exactly a certain # of territories away (distance)
    * Removes the inner circle neighbors
-   * neutral - whether to include neutral countries
+   * neutral - whether to include neutral countries.
    */
   private static List<Territory> getExactNeighbors(final Territory territory, final int distance, final GameData data,
       final boolean neutral) {
@@ -616,7 +616,7 @@ public final class ProTechAI {
   }
 
   /**
-   * Finds list of territories at exactly distance from the start
+   * Finds list of territories at exactly distance from the start.
    *
    * @param start
    * @param endCondition
@@ -663,7 +663,7 @@ public final class ProTechAI {
 
   /**
    * Return Territories containing any unit depending on unitCondition
-   * Differs from findCertainShips because it doesn't require the units be owned
+   * Differs from findCertainShips because it doesn't require the units be owned.
    */
   private static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units
@@ -679,7 +679,7 @@ public final class ProTechAI {
   }
 
   /**
-   * Interleave infantry and artillery/armor for loading on transports
+   * Interleave infantry and artillery/armor for loading on transports.
    */
   private static List<Unit> sortTransportUnits(final List<Unit> transUnits) {
     final List<Unit> sorted = new ArrayList<>();
@@ -738,7 +738,7 @@ public final class ProTechAI {
   }
 
   /**
-   * Assumes that water is passable to air units always
+   * Assumes that water is passable to air units always.
    */
   private static Match<Territory> TerritoryIsImpassableToAirUnits() {
     return new Match<Territory>() {

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
@@ -22,7 +22,7 @@ import games.strategy.ui.SwingAction;
 public class ProLogWindow extends javax.swing.JDialog {
   private static final long serialVersionUID = -5989598624017028122L;
 
-  /** Creates new form SettingsWindow */
+  /** Creates new form ProLogWindow. */
   public ProLogWindow(final TripleAFrame frame) {
     super(frame);
     initComponents();

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -20,7 +20,7 @@ import games.strategy.util.Match;
 
 public class Utils {
   /**
-   * All the territories that border one of our territories
+   * All the territories that border one of our territories.
    */
   public static List<Territory> getNeighboringEnemyLandTerritories(final GameData data, final PlayerID player) {
     final ArrayList<Territory> rVal = new ArrayList<>();
@@ -102,7 +102,7 @@ public class Utils {
 
   /**
    * Return Territories containing any unit depending on unitCondition
-   * Differs from findCertainShips because it doesn't require the units be owned
+   * Differs from findCertainShips because it doesn't require the units be owned.
    */
   public static List<Territory> findUnitTerr(final GameData data, final PlayerID player,
       final Match<Unit> unitCondition) {

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -50,7 +50,7 @@ import games.strategy.util.Util;
 public class WeakAI extends AbstractAI {
   private static final Logger s_logger = Logger.getLogger(WeakAI.class.getName());
 
-  /** Creates new TripleAPlayer */
+  /** Creates new WeakAI. */
   public WeakAI(final String name, final String type) {
     super(name, type);
   }
@@ -295,7 +295,7 @@ public class WeakAI extends AbstractAI {
   }
 
   /**
-   * prepares moves for transports
+   * prepares moves for transports.
    *
    * @param nonCombat
    * @param data

--- a/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -306,7 +306,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   /**
-   * @return the number you need to roll to get the action to succeed format "1:10" for 10% chance
+   * @return the number you need to roll to get the action to succeed format "1:10" for 10% chance.
    */
   public String getChance() {
     return m_chance;

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -21,7 +21,7 @@ import games.strategy.triplea.delegate.OriginalOwnerTracker;
 import games.strategy.util.Match;
 
 /**
- * The Purpose of this class is to hold shared and simple methods used by RulesAttachment
+ * The Purpose of this class is to hold shared and simple methods used by RulesAttachment.
  */
 public abstract class AbstractRulesAttachment extends AbstractConditionsAttachment {
   private static final long serialVersionUID = -6977650137928964759L;

--- a/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -14,7 +14,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.util.Match;
 
 /**
- * Abstract class for holding various action/condition things for PoliticalActionAttachment and UserActionAttachment
+ * Abstract class for holding various action/condition things for PoliticalActionAttachment and UserActionAttachment.
  */
 public abstract class AbstractUserActionAttachment extends AbstractConditionsAttachment {
   private static final long serialVersionUID = 3569461523853104614L;
@@ -53,7 +53,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return true if there is no condition to this action or if the condition is satisfied
+   * @return true if there is no condition to this action or if the condition is satisfied.
    */
   public boolean canPerform(final HashMap<ICondition, Boolean> testedConditions) {
     return m_conditions == null || isSatisfied(testedConditions);
@@ -69,7 +69,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return the Key that is used in politicstext.properties or other .properties for all the texts
+   * @return the Key that is used in politicstext.properties or other .properties for all the texts.
    */
   public String getText() {
     return m_text;
@@ -81,7 +81,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
 
   /**
    * @param s
-   *        the amount you need to pay to perform the action
+   *        the amount you need to pay to perform the action.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setCostPU(final String s) {
@@ -94,7 +94,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return the amount you need to pay to perform the action
+   * @return the amount you need to pay to perform the action.
    */
   public int getCostPU() {
     return m_costPU;
@@ -145,7 +145,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
 
   /**
    * @param s
-   *        the amount of times you can try this Action per Round
+   *        the amount of times you can try this Action per Round.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setAttemptsPerTurn(final String s) {
@@ -160,7 +160,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return the amount of times you can try this Action per Round
+   * @return the amount of times you can try this Action per Round.
    */
   public int getAttemptsPerTurn() {
     return m_attemptsPerTurn;
@@ -172,7 +172,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
 
   /**
    * @param attempts
-   *        left this turn
+   *        left this turn.
    */
   @GameProperty(xmlProperty = false, gameProperty = true, adds = false)
   public void setAttemptsLeftThisTurn(final int attempts) {
@@ -185,7 +185,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return attempts that are left this turn
+   * @return attempts that are left this turn.
    */
   public int getAttemptsLeftThisTurn() {
     return m_attemptsLeftThisTurn;

--- a/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -74,7 +74,7 @@ public class PlayerAttachment extends DefaultAttachment {
   private HashSet<Triple<Integer, String, HashSet<UnitType>>> m_attackingLimit =
       new HashSet<>();
 
-  /** Creates new PlayerAttachment */
+  /** Creates new PlayerAttachment. */
   public PlayerAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }

--- a/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -123,7 +123,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
   }
 
   /**
-   * @return a set of all other players involved in this PoliticalAction
+   * @return a set of all other players involved in this PoliticalAction.
    */
   public Set<PlayerID> getOtherPlayers() {
     final HashSet<PlayerID> otherPlayers = new HashSet<>();

--- a/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -35,7 +35,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   private String m_rocketsCanFlyOver = PROPERTY_DEFAULT;
 
   /**
-   * Creates new RelationshipTypeAttachment
+   * Creates new RelationshipTypeAttachment.
    */
   public RelationshipTypeAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
@@ -97,7 +97,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   /**
    * @return the ArcheType of this relationshipType, this really shouldn't be called, typically you should call
    *         isNeutral, isAllied or
-   *         isWar();
+   *         isWar().
    */
   public String getArcheType() {
     return m_archeType;
@@ -348,21 +348,21 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   }
 
   /**
-   * @return whether this relationship is based on the WAR_ARCHETYPE
+   * @return whether this relationship is based on the WAR_ARCHETYPE.
    */
   public boolean isWar() {
     return m_archeType.equals(RelationshipTypeAttachment.ARCHETYPE_WAR);
   }
 
   /**
-   * @return whether this relationship is based on the ALLIED_ARCHETYPE
+   * @return whether this relationship is based on the ALLIED_ARCHETYPE.
    */
   public boolean isAllied() {
     return m_archeType.equals(RelationshipTypeAttachment.ARCHETYPE_ALLIED);
   }
 
   /**
-   * @return whether this relationship is based on the NEUTRAL_ARCHETYPE
+   * @return whether this relationship is based on the NEUTRAL_ARCHETYPE.
    */
   public boolean isNeutral() {
     return m_archeType.equals(RelationshipTypeAttachment.ARCHETYPE_NEUTRAL);

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -80,7 +80,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   private IntegerMap<String> m_unitPresence = new IntegerMap<>();
 
 
-  /** Creates new RulesAttachment */
+  /** Creates new RulesAttachment. */
   public RulesAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -88,7 +88,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   /**
-   * will return empty list if none controlled, never returns null
+   * will return empty list if none controlled, never returns null.
    */
   public static List<Territory> getAllCapitals(final PlayerID player, final GameData data) {
     final List<Territory> capitals = new ArrayList<>();
@@ -115,7 +115,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   /**
-   * will return empty list if none controlled, never returns null
+   * will return empty list if none controlled, never returns null.
    */
   public static List<Territory> getAllCurrentlyOwnedCapitals(final PlayerID player, final GameData data) {
     final List<Territory> capitals = new ArrayList<>();
@@ -192,7 +192,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   private ArrayList<String> m_whenCapturedByGoesTo = new ArrayList<>();
   private ResourceCollection m_resources = null;
 
-  /** Creates new TerritoryAttachment */
+  /** Creates new TerritoryAttachment. */
   public TerritoryAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }
@@ -312,7 +312,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   /**
-   * Sets only m_production
+   * Sets only m_production.
    *
    * @param value
    */

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -25,7 +25,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   private ArrayList<UnitType> m_unitsNotAllowed = new ArrayList<>();
 
   /**
-   * Creates new TerritoryEffectAttachment
+   * Creates new TerritoryEffectAttachment.
    */
   public TerritoryEffectAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -227,7 +227,7 @@ public class UnitAttachment extends DefaultAttachment {
   // currently used for: placement in original territories only
   private HashSet<String> m_special = new HashSet<>();
 
-  /** Creates new UnitAttachment */
+  /** Creates new UnitAttachment. */
   public UnitAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
   }
@@ -1213,7 +1213,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   /**
-   * DO NOT REMOVE
+   * DO NOT REMOVE.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setIsTwoHit(final String s) {
@@ -3283,12 +3283,12 @@ public class UnitAttachment extends DefaultAttachment {
     return stats.toString();
   }
 
-  /** @deprecated does nothing, kept to avoid breaking maps, do not remove */
+  /** @deprecated does nothing, kept to avoid breaking maps, do not remove. */
   @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
   public void setIsParatroop(final String s) {}
 
-  /** @deprecated does nothing, used to keep compatibility with older xml files, do not remove */
+  /** @deprecated does nothing, used to keep compatibility with older xml files, do not remove. */
   @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
   public void setIsMechanized(final String s) {}

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -164,7 +164,7 @@ class AAInMoveUtil implements Serializable {
   }
 
   /**
-   * Fire the aa units in the given territory, hits are removed from units
+   * Fire the aa units in the given territory, hits are removed from units.
    */
   private void fireAA(final Territory territory, final Collection<Unit> units, final UndoableMove currentMove) {
     if (units.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractDelegate.java
@@ -22,7 +22,7 @@ public abstract class AbstractDelegate implements IDelegate {
   protected IDelegateBridge m_bridge;
 
   /**
-   * Creates a new instance of the Delegate
+   * Creates a new instance of the Delegate.
    */
   public AbstractDelegate() {}
 
@@ -79,7 +79,7 @@ public abstract class AbstractDelegate implements IDelegate {
   }
 
   /**
-   * Loads the delegates state
+   * Loads the delegate state.
    */
   @Override
   public void loadState(final Serializable state) {

--- a/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -166,7 +166,7 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
 
   /**
    * @param unit
-   *        referring unit
+   *        referring unit.
    * @param end
    *        target territory
    * @return the route that a unit used to move into the given territory

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -132,7 +132,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
-   * @param t territory of interest
+   * @param t territory of interest.
    * @return a COPY of the collection of units that are produced at territory t
    */
   protected Collection<Unit> getAlreadyProduced(final Territory t) {
@@ -281,7 +281,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
   /**
    * @param producer
-   *        territory that produces the new units
+   *        territory that produces the new units.
    * @param placeableUnits
    *        the new units
    * @param at
@@ -1005,7 +1005,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
-   * Returns -1 if can place unlimited units
+   * Returns -1 if can place unlimited units.
    */
   protected int getMaxUnitsToBePlaced(final Collection<Unit> units, final Territory to, final PlayerID player,
       final boolean countSwitchedProductionToNeighbors) {
@@ -1022,7 +1022,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
-   * Returns -1 somewhere in the map if can place unlimited units
+   * Returns -1 somewhere in the map if can place unlimited units.
    */
   protected IntegerMap<Territory> getMaxUnitsToBePlacedMap(final Collection<Unit> units, final Territory to,
       final PlayerID player, final boolean countSwitchedProductionToNeighbors) {
@@ -1047,7 +1047,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
-   * Returns -1 if can place unlimited units
+   * Returns -1 if can place unlimited units.
    */
   protected int getMaxUnitsToBePlacedFrom(final Territory producer, final Collection<Unit> units, final Territory to,
       final PlayerID player) {
@@ -1055,7 +1055,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
-   * Returns -1 if can place unlimited units
+   * Returns -1 if can place unlimited units.
    */
   protected int getMaxUnitsToBePlacedFrom(final Territory producer, final Collection<Unit> units, final Territory to,
       final PlayerID player, final boolean countSwitchedProductionToNeighbors,
@@ -1216,7 +1216,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
-   * @return gets the production of the territory
+   * @return gets the production of the territory.
    */
   protected int getProduction(final Territory territory) {
     // Can be null!
@@ -1229,7 +1229,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
   /**
    * @param to
-   *        referring territory
+   *        referring territory.
    * @param units
    *        units to place
    * @param player
@@ -1513,7 +1513,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
   /**
    * @param to
-   *        referring territory
+   *        referring territory.
    * @return collection of units that were there at start of turn
    */
   public Collection<Unit> unitsAtStartOfStepInTerritory(final Territory to) {
@@ -1544,7 +1544,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
   /**
    * @param to
-   *        referring territory
+   *        referring territory.
    * @param player
    *        PlayerID
    * @return whether there was an owned unit capable of producing, in this territory at the start of this phase/step
@@ -1602,7 +1602,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
-   * Get what air units must move before the end of the players turn
+   * Get what air units must move before the end of the players turn.
    *
    * @return a list of Territories with air units that must move
    */

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -510,7 +510,7 @@ public class AirMovementValidator {
 
   /**
    * @param units
-   *        the units flying this route
+   *        the units flying this route.
    * @param route
    *        the route flown
    * @param player

--- a/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -23,7 +23,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
   private boolean m_endBaseStepsFinished = false;
 
   /**
-   * Creates a new instance of the Delegate
+   * Creates a new instance of the Delegate.
    */
   public BaseTripleADelegate() {
     super();
@@ -77,9 +77,6 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
     return state;
   }
 
-  /**
-   * Loads the delegates state
-   */
   @Override
   public void loadState(final Serializable state) {
     final BaseDelegateState s = (BaseDelegateState) state;

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -98,7 +98,7 @@ public class BattleCalculator {
   }
 
   /**
-   * Choose plane casualties according to specified rules
+   * Choose plane casualties according to specified rules.
    */
   public static CasualtyDetails getAACasualties(final boolean defending, final Collection<Unit> planes,
       final Collection<Unit> allFriendlyUnits, final Collection<Unit> defendingAA, final Collection<Unit> allEnemyUnits,
@@ -331,7 +331,7 @@ public class BattleCalculator {
   }
 
   /**
-   * Choose plane casualties randomly
+   * Choose plane casualties randomly.
    */
   public static CasualtyDetails RandomAACasualties(final Collection<Unit> planes, final DiceRoll dice,
       final IDelegateBridge bridge, final boolean allowMultipleHitsPerUnit) {
@@ -459,7 +459,7 @@ public class BattleCalculator {
 
   /**
    * @param battleID
-   *        may be null if we are not in a battle (eg, if this is an aa fire due to moving
+   *        may be null if we are not in a battle (eg, if this is an aa fire due to moving).
    */
   public static CasualtyDetails selectCasualties(final String step, final PlayerID player,
       final Collection<Unit> targetsToPickFrom, final Collection<Unit> friendlyUnits, final PlayerID enemyPlayer,
@@ -1306,35 +1306,35 @@ public class BattleCalculator {
   }
 
   /**
-   * @return Can transports be used as cannon fodder
+   * @return Can transports be used as cannon fodder.
    */
   private static boolean isTransportCasualtiesRestricted(final GameData data) {
     return games.strategy.triplea.Properties.getTransportCasualtiesRestricted(data);
   }
 
   /**
-   * @return Random AA Casualties - casualties randomly assigned
+   * @return Random AA Casualties - casualties randomly assigned.
    */
   private static boolean isRandomAACasualties(final GameData data) {
     return games.strategy.triplea.Properties.getRandomAACasualties(data);
   }
 
   /**
-   * @return Roll AA Individually - roll against each aircraft
+   * @return Roll AA Individually - roll against each aircraft.
    */
   private static boolean isRollAAIndividually(final GameData data) {
     return games.strategy.triplea.Properties.getRollAAIndividually(data);
   }
 
   /**
-   * @return Choose AA - attacker selects casualties
+   * @return Choose AA - attacker selects casualties.
    */
   private static boolean isChooseAA(final GameData data) {
     return games.strategy.triplea.Properties.getChoose_AA_Casualties(data);
   }
 
   /**
-   * @return Can the attacker retreat non-amphibious units
+   * @return Can the attacker retreat non-amphibious units.
    */
   private static boolean isPartialAmphibiousRetreat(final GameData data) {
     return games.strategy.triplea.Properties.getPartialAmphibiousRetreat(data);

--- a/src/main/java/games/strategy/triplea/delegate/BattleStepStrings.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleStepStrings.java
@@ -1,7 +1,7 @@
 package games.strategy.triplea.delegate;
 
 /**
- * Constants for the battle steps
+ * Constants for the battle steps.
  */
 public interface BattleStepStrings {
 

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -51,7 +51,7 @@ import games.strategy.util.Match;
 import games.strategy.util.Tuple;
 
 /**
- * Used to keep track of where battles have occurred
+ * Used to keep track of where battles have occurred.
  */
 public class BattleTracker implements java.io.Serializable {
   private static final long serialVersionUID = 8806010984321554662L;
@@ -86,7 +86,7 @@ public class BattleTracker implements java.io.Serializable {
 
   /**
    * @param t
-   *        referring territory
+   *        referring territory.
    * @param bombing
    * @return whether a battle is to be fought in the given territory
    */
@@ -107,7 +107,7 @@ public class BattleTracker implements java.io.Serializable {
 
   /**
    * @param t
-   *        referring territory
+   *        referring territory.
    * @return whether territory was conquered
    */
   public boolean wasConquered(final Territory t) {
@@ -120,7 +120,7 @@ public class BattleTracker implements java.io.Serializable {
 
   /**
    * @param t
-   *        referring territory
+   *        referring territory.
    * @return whether territory was conquered by blitz
    */
   public boolean wasBlitzed(final Territory t) {
@@ -944,7 +944,7 @@ public class BattleTracker implements java.io.Serializable {
 
   /**
    * @param bombing
-   *        whether only battles where there is bombing
+   *        whether only battles where there is bombing.
    * @return a collection of territories where battles are pending
    */
   public Collection<Territory> getPendingBattleSites(final boolean bombing) {
@@ -976,7 +976,7 @@ public class BattleTracker implements java.io.Serializable {
 
   /**
    * @param blocked
-   *        the battle that is blocked
+   *        the battle that is blocked.
    * @return the battle that must occur before dependent can occur
    */
   public Collection<IBattle> getDependentOn(final IBattle blocked) {
@@ -989,7 +989,7 @@ public class BattleTracker implements java.io.Serializable {
 
   /**
    * @param blocking
-   *        the battle that is blocking the other battles
+   *        the battle that is blocking the other battles.
    * @return the battles that cannot occur until the given battle occurs
    */
   public Collection<IBattle> getBlocked(final IBattle blocking) {

--- a/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPurchaseDelegate.java
@@ -66,7 +66,7 @@ public class BidPurchaseDelegate extends PurchaseDelegate {
   }
 
   /**
-   * subclasses can over ride this method to use different restrictions as to what a player can buy
+   * subclasses can over ride this method to use different restrictions as to what a player can buy.
    */
   @Override
   protected boolean canAfford(final IntegerMap<Resource> costs, final PlayerID player) {

--- a/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
@@ -14,7 +14,7 @@ import games.strategy.engine.data.Unit;
 
 /**
  * Battle with possible dependencies
- * Includes MustFightBattle and NonFightingBattle
+ * Includes MustFightBattle and NonFightingBattle.
  */
 public abstract class DependentBattle extends AbstractBattle {
   private static final long serialVersionUID = 9119442509652443015L;
@@ -36,7 +36,7 @@ public abstract class DependentBattle extends AbstractBattle {
   }
 
   /**
-   * @return territories where there are amphibious attacks
+   * @return territories where there are amphibious attacks.
    */
   public Collection<Territory> getAmphibiousAttackTerritories() {
     return m_amphibiousAttackFrom;

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -55,7 +55,7 @@ public class DiceRoll implements Externalizable {
 
   /**
    * Returns a Tuple with 2 values, the first is the max attack, the second is the max dice sides for the AA unit with
-   * that attack value
+   * that attack value.
    */
   public static Tuple<Integer, Integer> getAAattackAndMaxDiceSides(final Collection<Unit> defendingEnemyAA,
       final GameData data, final boolean defending) {
@@ -397,7 +397,7 @@ public class DiceRoll implements Externalizable {
 
   /**
    * @param unitsGettingPowerFor
-   *        should be sorted from weakest to strongest, before the method is called, for the actual battle
+   *        should be sorted from weakest to strongest, before the method is called, for the actual battle.
    */
   public static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
       final List<Unit> unitsGettingPowerFor, final List<Unit> allEnemyUnitsAliveOrWaitingToDie,
@@ -413,7 +413,7 @@ public class DiceRoll implements Externalizable {
 
   /**
    * @param unitsGettingPowerFor
-   *        should be sorted from weakest to strongest, before the method is called, for the actual battle
+   *        should be sorted from weakest to strongest, before the method is called, for the actual battle.
    */
   protected static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
       final List<Unit> unitsGettingPowerFor,

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -28,7 +28,7 @@ import games.strategy.util.Match;
 import games.strategy.util.Triple;
 
 /**
- * Edit game state
+ * Edit game state.
  */
 public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
   /**
@@ -121,7 +121,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
   }
 
   /**
-   * @return gets the production of the territory, ignores whether the territory was an original factory
+   * @return gets the production of the territory, ignores whether the territory was an original factory.
    */
   protected int getProduction(final Territory territory) {
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -42,7 +42,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   private boolean m_gameOver = false;
   private Collection<PlayerID> m_winners = new ArrayList<>();
 
-  /** Creates a new instance of EndRoundDelegate */
+  /** Creates a new instance of EndRoundDelegate. */
   public EndRoundDelegate() {}
 
   /**
@@ -310,7 +310,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   }
 
   /**
-   * if null, the game is not over yet
+   * if null, the game is not over yet.
    */
   public Collection<PlayerID> getWinners() {
     if (!m_gameOver) {

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -220,7 +220,7 @@ public class Fire implements IExecutable {
   }
 
   /**
-   * We must execute in atomic steps, push these steps onto the stack, and let them execute
+   * We must execute in atomic steps, push these steps onto the stack, and let them execute.
    */
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {

--- a/src/main/java/games/strategy/triplea/delegate/GameDelegateBridge.java
+++ b/src/main/java/games/strategy/triplea/delegate/GameDelegateBridge.java
@@ -13,14 +13,14 @@ import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.sound.ISound;
 
 /**
- * TripleA implementation of DelegateBridge
+ * TripleA implementation of DelegateBridge.
  */
 public class GameDelegateBridge implements IDelegateBridge {
   private final IDelegateBridge m_bridge;
   private final GameDelegateHistoryWriter m_historyWriter;
 
   /**
-   * Creates new TripleADelegateBridge to wrap an existing IDelegateBridge
+   * Creates new TripleADelegateBridge to wrap an existing IDelegateBridge.
    *
    * @param bridge
    *        delegate bridge
@@ -36,7 +36,7 @@ public class GameDelegateBridge implements IDelegateBridge {
   }
 
   /**
-   * Return our custom historyWriter instead of the default one
+   * Return our custom historyWriter instead of the default one.
    */
   @Override
   public IDelegateHistoryWriter getHistoryWriter() {
@@ -71,9 +71,6 @@ public class GameDelegateBridge implements IDelegateBridge {
     m_bridge.addChange(aChange);
   }
 
-  /**
-   * Returns the current step name
-   */
   @Override
   public String getStepName() {
     return m_bridge.getStepName();

--- a/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -14,7 +14,7 @@ import games.strategy.engine.data.PlayerID;
  */
 public class GameStepPropertiesHelper {
   /**
-   * Do we skip posting the game summary and save to a forum or email?
+   * Indicates we skip posting the game summary and save to a forum or email.
    */
   public static boolean isSkipPosting(final GameData data) {
     final boolean skipPosting;

--- a/src/main/java/games/strategy/triplea/delegate/IBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/IBattle.java
@@ -87,7 +87,7 @@ public interface IBattle extends java.io.Serializable {
   void fight(IDelegateBridge bridge);
 
   /**
-   * @return whether this battle is over or not
+   * @return whether this battle is over or not.
    */
   boolean isOver();
 
@@ -115,7 +115,7 @@ public interface IBattle extends java.io.Serializable {
   void addBombardingUnit(Unit u);
 
   /**
-   * @return whether battle is amphibious
+   * @return whether battle is amphibious.
    */
   boolean isAmphibious();
 
@@ -148,27 +148,27 @@ public interface IBattle extends java.io.Serializable {
   Collection<Unit> getDependentUnits(Collection<Unit> units);
 
   /**
-   * @return units which are actually assaulting amphibiously
+   * @return units which are actually assaulting amphibiously.
    */
   Collection<Unit> getAmphibiousLandAttackers();
 
   /**
-   * @return units which are actually bombarding
+   * @return units which are actually bombarding.
    */
   Collection<Unit> getBombardingUnits();
 
   /**
-   * @return what round this battle is in
+   * @return what round this battle is in.
    */
   int getBattleRound();
 
   /**
-   * @return units which are attacking
+   * @return units which are attacking.
    */
   Collection<Unit> getAttackingUnits();
 
   /**
-   * @return units which are defending
+   * @return units which are defending.
    */
   Collection<Unit> getDefendingUnits();
 

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -32,7 +32,7 @@ import games.strategy.util.Match;
 public class InitializationDelegate extends BaseTripleADelegate {
   private boolean m_needToInitialize = true;
 
-  /** Creates a new instance of InitializationDelegate */
+  /** Creates a new instance of InitializationDelegate. */
   public InitializationDelegate() {}
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1301,7 +1301,7 @@ public class Matches {
 
   /**
    * @param data
-   *        game data
+   *        game data.
    * @param player
    * @return true only if the route is land
    */
@@ -1711,7 +1711,7 @@ public class Matches {
   }
 
   /**
-   * Match units that have at least 1 movement left
+   * Match units that have at least 1 movement left.
    */
   public static final Match<Unit> unitHasMovementLeft = new Match<Unit>() {
     @Override
@@ -2280,7 +2280,7 @@ public class Matches {
 
   /**
    * @param units
-   *        referring unit
+   *        referring unit.
    * @param route
    *        referring route
    * @param currentPlayer
@@ -3421,6 +3421,6 @@ public class Matches {
     };
   }
 
-  /** Creates new Matches */
+  /** Creates new Matches. */
   private Matches() {}
 }

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -83,7 +83,7 @@ public class MovePerformer implements Serializable {
   }
 
   /**
-   * We assume that the move is valid
+   * We assume that the move is valid.
    */
   private void populateStack(final Collection<Unit> units, final Route route, final PlayerID id,
       final Collection<Unit> transportsToLoad) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1493,7 +1493,7 @@ public class MoveValidator {
   }
 
   /**
-   * Get the route ignoring forced territories
+   * Get the route ignoring forced territories.
    */
   public static Route getBestRoute(final Territory start, final Territory end, final GameData data,
       final PlayerID player, final Collection<Unit> units, final boolean forceLandOrSeaRoute) {
@@ -1657,6 +1657,6 @@ public class MoveValidator {
     return games.strategy.triplea.Properties.getIgnoreSubInMovement(data);
   }
 
-  /** Creates new MoveValidator */
+  /** Creates new MoveValidator. */
   private MoveValidator() {}
 }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -101,7 +101,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   /**
-   * Used for head-less battles
+   * Used for head-less battles.
    *
    * @param defending
    *        - defending units
@@ -1146,8 +1146,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private ReturnFire returnFireAgainstDefendingSubs() {
-    /** Attacker subs fire */
-    /*
+    /* Attacker subs fire
+     *
      * calculate here, this holds for the fight round, but can't be computed later
      * since destroyers may die
      */
@@ -1700,7 +1700,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   /**
-   * Check for suicide units and kill them immediately (they get to shoot back, which is the point)
+   * Check for suicide units and kill them immediately (they get to shoot back, which is the point).
    *
    * @param bridge
    * @param player
@@ -1722,7 +1722,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   /**
-   * Check for unescorted TRNS and kill them immediately
+   * Check for unescorted TRNS and kill them immediately.
    *
    * @param bridge
    * @param player
@@ -1813,7 +1813,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   /**
-   * Submerge attacking/defending SUBS if they're alone OR with TRNS against only AIRCRAFT
+   * Submerge attacking/defending SUBS if they're alone OR with TRNS against only AIRCRAFT.
    *
    * @param bridge
    * @param player

--- a/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/NoPUPurchaseDelegate.java
@@ -16,7 +16,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.util.IntegerMap;
 
 /**
- * At the end of the turn collect units, not income!
+ * At the end of the turn collect units, not income.
  */
 @MapSupport
 public class NoPUPurchaseDelegate extends PurchaseDelegate {

--- a/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/OriginalOwnerTracker.java
@@ -22,7 +22,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 public class OriginalOwnerTracker implements java.io.Serializable {
   private static final long serialVersionUID = 8462432412106180906L;
 
-  /** Creates new OriginalOwnerTracker */
+  /** Creates new OriginalOwnerTracker. */
   public OriginalOwnerTracker() {}
 
   public static Change addOriginalOwnerChange(final Territory t, final PlayerID player) {

--- a/src/main/java/games/strategy/triplea/delegate/PlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PlaceDelegate.java
@@ -20,7 +20,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 @MapSupport
 public class PlaceDelegate extends AbstractPlaceDelegate {
   /**
-   * @return gets the production of the territory
+   * @return gets the production of the territory.
    */
   @Override
   protected int getProduction(final Territory territory) {

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -34,13 +34,13 @@ import games.strategy.util.CompositeMatchOr;
 import games.strategy.util.Match;
 
 /**
- * Responsible allowing players to perform politicalActions
+ * Responsible allowing players to perform politicalActions.
  */
 @MapSupport
 public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDelegate {
   // protected HashMap<ICondition, Boolean> m_testedConditions = null;
   // private final boolean m_needToInitialize = true;
-  /** Creates new PoliticsDelegate */
+  /** Creates new PoliticsDelegate. */
   public PoliticsDelegate() {}
 
   /**
@@ -288,7 +288,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
 
   /**
    * @param paa
-   *        The Political Action the player should be charged for
+   *        The Political Action the player should be charged for.
    * @return false if the player can't afford the action
    */
   private boolean checkEnoughMoney(final PoliticalActionAttachment paa) {
@@ -326,7 +326,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
 
   /**
    * Send a notification to the other players involved in this action (all
-   * players except the player starting the action)
+   * players except the player starting the action).
    */
   private void notifyOtherPlayers(final String notification) {
     if (!"NONE".equals(notification)) {
@@ -340,7 +340,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   }
 
   /**
-   * Send a notification to the current player
+   * Send a notification to the current player.
    *
    * @param text
    *        if NONE don't send a notification
@@ -352,7 +352,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   }
 
   /**
-   * Changes all relationships
+   * Changes all relationships.
    *
    * @param paa
    *        the political action to change the relationships for

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -147,7 +147,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
   }
 
   /**
-   * subclasses can over ride this method to use different restrictions as to what a player can buy
+   * subclasses can over ride this method to use different restrictions as to what a player can buy.
    */
   protected boolean canAfford(final IntegerMap<Resource> costs, final PlayerID player) {
     return player.getResources().has(costs);

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -53,7 +53,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   private final IntegerMap<Unit> m_bombingRaidDamage = new IntegerMap<>();
 
   /**
-   * Creates new StrategicBombingRaidBattle
+   * Creates new StrategicBombingRaidBattle.
    *
    * @param battleSite
    *        - battle territory

--- a/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -29,7 +29,7 @@ import games.strategy.util.Util;
 public class TechActivationDelegate extends BaseTripleADelegate {
   private boolean m_needToInitialize = true;
 
-  /** Creates new TechActivationDelegate */
+  /** Creates new TechActivationDelegate. */
   public TechActivationDelegate() {}
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -195,7 +195,7 @@ public abstract class TechAdvance extends NamedAttachable {
 
   /**
    * @param data
-   * @return first is air&naval, second is land&production
+   * @return first is air&naval, second is land&production.
    */
   private static Tuple<List<TechAdvance>, List<TechAdvance>> getWW2v3CategoriesWithTheirAdvances(final GameData data) {
     List<TechAdvance> allAdvances;

--- a/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -17,7 +17,7 @@ import games.strategy.triplea.attachments.TechAttachment;
 public class TechTracker implements java.io.Serializable {
   private static final long serialVersionUID = 4705039229340373735L;
 
-  /** Creates new TechTracker */
+  /** Creates new TechTracker. */
   public TechTracker() {}
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -48,7 +48,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   private TechnologyFrontier m_techCategory;
   private boolean m_needToInitialize = true;
 
-  /** Creates new TechnolgoyDelegate */
+  /** Creates new TechnolgoyDelegate. */
   public TechnologyDelegate() {}
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
@@ -13,7 +13,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.TerritoryEffectAttachment;
 
 /**
- * Placeholder for all calculations to do with TerritoryEffects
+ * Placeholder for all calculations to do with TerritoryEffects.
  */
 public class TerritoryEffectHelper {
   public static Collection<TerritoryEffect> getEffects(final Territory location) {

--- a/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -113,7 +113,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
 
   /**
    * @param uaa
-   *        The UserActionAttachment the player should be charged for
+   *        The UserActionAttachment the player should be charged for.
    * @return false if the player can't afford the action
    */
   private boolean checkEnoughMoney(final UserActionAttachment uaa) {
@@ -193,7 +193,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
   }
 
   /**
-   * Fire triggers
+   * Fire triggers.
    *
    * @param uaa
    *        the UserActionAttachment to activate triggers for
@@ -216,7 +216,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
   }
 
   /**
-   * Send a notification to the current player
+   * Send a notification to the current player.
    *
    * @param text
    *        if NONE don't send a notification
@@ -230,7 +230,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
 
   /**
    * Send a notification to the other players involved in this action (all
-   * players except the player starting the action)
+   * players except the player starting the action).
    *
    * @param uaa
    * @param notification
@@ -264,7 +264,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
 
   /**
    * Let the player know he is being charged for money or that he hasn't got
-   * enough money
+   * enough money.
    * 
    * @param uaa
    *        the UserActionAttachment the player is notified about

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleListing.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleListing.java
@@ -19,7 +19,7 @@ public class BattleListing implements Serializable {
   private final Map<BattleType, Collection<Territory>> m_battles;
 
   /**
-   * Creates new BattleListingMessage
+   * Creates new BattleListing.
    *
    * @param battles
    *        battles to list

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecord.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecord.java
@@ -96,7 +96,7 @@ public class BattleRecord implements Serializable {
   }
 
   /**
-   * Convenience copy constructor
+   * Convenience copy constructor.
    */
   protected BattleRecord(final BattleRecord record) {
     battleSite = record.battleSite;

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/CasualtyList.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/CasualtyList.java
@@ -13,7 +13,7 @@ public class CasualtyList implements Serializable {
   protected List<Unit> m_damaged;
 
   /**
-   * Creates a new CasualtyList
+   * Creates a new CasualtyList.
    *
    * @param killed
    * @param damaged
@@ -31,7 +31,7 @@ public class CasualtyList implements Serializable {
   }
 
   /**
-   * Creates a new blank CasualtyList with empty lists
+   * Creates a new blank CasualtyList with empty lists.
    */
   public CasualtyList() {
     m_killed = new ArrayList<>();
@@ -39,7 +39,7 @@ public class CasualtyList implements Serializable {
   }
 
   /**
-   * @return list of killed units
+   * @return list of killed units.
    */
   public List<Unit> getKilled() {
     return m_killed;

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/MustMoveWithDetails.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/MustMoveWithDetails.java
@@ -19,7 +19,7 @@ public class MustMoveWithDetails implements java.io.Serializable {
   private final Map<Unit, Collection<Unit>> m_mapping;
 
   /**
-   * Creates new MustMoveWithReplay
+   * Creates new MustMoveWithDetails.
    *
    * @param mapping
    *        a mapping of unit (that must move) -> collection of units

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/PlaceableUnits.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/PlaceableUnits.java
@@ -11,7 +11,7 @@ public class PlaceableUnits implements java.io.Serializable {
   private int m_maxUnits;
 
   /**
-   * Creates new ProductionResponseMessage
+   * Creates new PlaceableUnits.
    *
    * @param errorMessage
    *        error message
@@ -30,7 +30,7 @@ public class PlaceableUnits implements java.io.Serializable {
   }
 
   /**
-   * @return -1 if no limit
+   * @return -1 if no limit.
    */
   public int getMaxUnits() {
     return m_maxUnits;

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/TechResults.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/TechResults.java
@@ -19,20 +19,22 @@ public class TechResults implements java.io.Serializable {
   }
 
   /**
-   * @return whether there was an error
+   * @return whether there was an error.
    */
   public boolean isError() {
     return m_errorString != null;
   }
 
   /**
-   * @return string error or null if no error occurred (use isError to see if there was an error)
+   * @return string error or null if no error occurred (use isError to see if there was an error).
    */
   public String getErrorString() {
     return m_errorString;
   }
 
   /**
+   * Creates a new TechResults.
+   *
    * @param rolls
    *        rolls
    * @param remainder
@@ -70,7 +72,7 @@ public class TechResults implements java.io.Serializable {
   }
 
   /**
-   * @return a List of Strings
+   * @return a List of Strings.
    */
   public List<String> getAdvances() {
     return m_advances;

--- a/src/main/java/games/strategy/triplea/delegate/remote/IAbstractMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IAbstractMoveDelegate.java
@@ -6,11 +6,11 @@ import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.message.IRemote;
 
 /**
- * Remote interface for MoveDelegate and PlaceDelegate
+ * Remote interface for MoveDelegate and PlaceDelegate.
  */
 public interface IAbstractMoveDelegate extends IRemote, IDelegate {
   /**
-   * Get the moves already made
+   * Get the moves already made.
    *
    * @return a list of UndoableMoves or UndoablePlacements
    */
@@ -19,7 +19,7 @@ public interface IAbstractMoveDelegate extends IRemote, IDelegate {
 
   /**
    * @param moveIndex
-   *        - an index in the list getMovesMade
+   *        - an index in the list getMovesMade.
    * @return an error string if the move could not be undone, null otherwise
    */
   String undoMove(int moveIndex);

--- a/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -9,7 +9,7 @@ import games.strategy.triplea.delegate.dataObjects.PlaceableUnits;
 public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate {
   /**
    * @param units
-   *        units to place
+   *        units to place.
    * @param at
    *        territory to place
    * @return an error code if the placement was not successful
@@ -39,12 +39,12 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate {
   /**
    * @return the number of placements made so far.
    *         this is not the number of units placed, but the number
-   *         of times we have made successful placements
+   *         of times we have made successful placements.
    */
   int getPlacementsMade();
 
   /**
-   * Get what air units must move before the end of the players turn
+   * Get what air units must move before the end of the players turn.
    *
    * @return a list of Territories with air units that must move
    */

--- a/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
@@ -9,12 +9,12 @@ import games.strategy.triplea.delegate.dataObjects.BattleListing;
 
 public interface IBattleDelegate extends IRemote, IDelegate {
   /**
-   * @return the battles currently waiting to be fought
+   * @return the battles currently waiting to be fought.
    */
   BattleListing getBattles();
 
   /**
-   * Fight the battle in the given country
+   * Fight the battle in the given country.
    *
    * @param where
    *        - where to fight
@@ -25,7 +25,7 @@ public interface IBattleDelegate extends IRemote, IDelegate {
   String fightBattle(Territory where, boolean bombing, BattleType type);
 
   /**
-   * Finish the current battle
+   * Finish the current battle.
    *
    * @return an error string if the battle could not be fought or an error occurred, null otherwise
    */

--- a/src/main/java/games/strategy/triplea/delegate/remote/IEditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IEditDelegate.java
@@ -13,7 +13,7 @@ import games.strategy.util.IntegerMap;
 import games.strategy.util.Triple;
 
 /**
- * Remote interface for EditDelegate
+ * Remote interface for EditDelegate.
  */
 public interface IEditDelegate extends IRemote, IPersistentDelegate {
   boolean getEditMode();

--- a/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
@@ -9,12 +9,12 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 
 /**
- * Remote interface for MoveDelegate
+ * Remote interface for MoveDelegate.
  */
 public interface IMoveDelegate extends IAbstractMoveDelegate, IAbstractForumPosterDelegate {
   /**
    * @param units
-   *        - the units to move
+   *        - the units to move.
    * @param route
    *        - the route to move along
    * @param m_transportsThatCanBeLoaded
@@ -25,7 +25,7 @@ public interface IMoveDelegate extends IAbstractMoveDelegate, IAbstractForumPost
 
   /**
    * @param units
-   *        - the units to move
+   *        - the units to move.
    * @param route
    *        - the route to move along
    * @param m_transportsThatCanBeLoaded
@@ -49,7 +49,7 @@ public interface IMoveDelegate extends IAbstractMoveDelegate, IAbstractForumPost
   String move(Collection<Unit> units, Route route);
 
   /**
-   * Get what air units must move before the end of the players turn
+   * Get what air units must move before the end of the players turn.
    *
    * @param player
    *        referring player ID
@@ -60,7 +60,7 @@ public interface IMoveDelegate extends IAbstractMoveDelegate, IAbstractForumPost
   Collection<Territory> getTerritoriesWhereAirCantLand();
 
   /**
-   * Get what units must have combat ability
+   * Get what units must have combat ability.
    *
    * @return a list of Territories with units that can't fight
    */

--- a/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
@@ -12,7 +12,7 @@ import games.strategy.util.IntegerMap;
 public interface IPurchaseDelegate extends IRemote, IDelegate {
   /**
    * @param productionRules
-   *        - units maps ProductionRule -> count
+   *        - units maps ProductionRule -> count.
    * @return null if units bought, otherwise an error message
    */
   String purchase(IntegerMap<ProductionRule> productionRules);

--- a/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
+++ b/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
@@ -111,9 +111,6 @@ public class MyFormatter {
     return pluralize(in);
   }
 
-  /**
-   * Is pluralize even a word?
-   */
   public static String pluralize(final String in) {
     if (s_plural.containsKey(in)) {
       return s_plural.get(in);
@@ -298,7 +295,7 @@ public class MyFormatter {
     return buf.toString().replaceFirst(separator, "");
   }
 
-  /** Creates a new instance of MyFormatter */
+  /** Creates a new instance of MyFormatter. */
   private MyFormatter() {}
 }
 

--- a/src/main/java/games/strategy/triplea/help/HelpSupport.java
+++ b/src/main/java/games/strategy/triplea/help/HelpSupport.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 
 /**
- * A class for loading help files from the data folder (merged with src at runtime)
+ * A class for loading help files from the data folder (merged with src at runtime).
  */
 public class HelpSupport {
   public static String loadHelp(final String fileName) {

--- a/src/main/java/games/strategy/triplea/image/BlendComposite.java
+++ b/src/main/java/games/strategy/triplea/image/BlendComposite.java
@@ -8,7 +8,7 @@ import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 
 /**
- * This class handles the various types of blends for base/relief tiles
+ * This class handles the various types of blends for base/relief tiles.
  */
 class BlendComposite implements java.awt.Composite {
   public enum BlendingMode {

--- a/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -17,7 +17,7 @@ import games.strategy.triplea.delegate.Die;
 import games.strategy.ui.Util;
 
 /**
- * Utility for creating dice images
+ * Utility for creating dice images.
  */
 public class DiceImageFactory {
   public int DIE_WIDTH = 32;

--- a/src/main/java/games/strategy/triplea/image/FlagIconImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/FlagIconImageFactory.java
@@ -11,7 +11,7 @@ public class FlagIconImageFactory extends ImageFactory {
   public static final int SMALL_FLAG_ICON_HEIGHT = 7;
   private final String PREFIX = "flags/";
 
-  /** Creates new IconImageFactory */
+  /** Creates new FlagIconImageFactory. */
   public FlagIconImageFactory() {}
 
   public Image getFlag(final PlayerID id) {

--- a/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -150,7 +150,7 @@ public class MapImage {
     PROPERTY_UNIT_HIT_DAMAGE_COLOR = Color.black;
   }
 
-  /** Creates a new instance of CountryImage */
+  /** Creates a new instance of MapImage. */
   public MapImage() {}
 
   public BufferedImage getSmallMapImage() {

--- a/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
@@ -23,7 +23,7 @@ public class ResourceImageFactory {
   private double m_scaleFactor;
   private ResourceLoader m_resourceLoader;
 
-  /** Creates new ResourceImageFactory */
+  /** Creates new ResourceImageFactory. */
   public ResourceImageFactory() {}
 
   public void setResourceLoader(final ResourceLoader loader, final double scaleFactor) {
@@ -33,7 +33,7 @@ public class ResourceImageFactory {
   }
 
   /**
-   * Set the scaling factor
+   * Set the scaling factor.
    */
   public void setScaleFactor(final double scaleFactor) {
     if (m_scaleFactor != scaleFactor) {
@@ -43,21 +43,21 @@ public class ResourceImageFactory {
   }
 
   /**
-   * Return the scaling factor
+   * Return the scaling factor.
    */
   public double getScaleFactor() {
     return m_scaleFactor;
   }
 
   /**
-   * Return the width of scaled
+   * Return the width of scaled.
    */
   public int getUnitImageWidth(final boolean large) {
     return (int) (m_scaleFactor * (large ? LARGE_RESOURCE_ICON_SIZE : DEFAULT_RESOURCE_ICON_SIZE));
   }
 
   /**
-   * Return the height of scaled
+   * Return the height of scaled.
    */
   public int getUnitImageHeight(final boolean large) {
     return (int) (m_scaleFactor * (large ? LARGE_RESOURCE_ICON_SIZE : DEFAULT_RESOURCE_ICON_SIZE));

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -142,9 +142,6 @@ public final class TileImageFactory {
 
   public TileImageFactory() {}
 
-  /**
-   * @param fileName
-   */
   private Image isImageLoaded(final String fileName) {
     if (getM_imageCache().get(fileName) == null) {
       return null;
@@ -175,9 +172,6 @@ public final class TileImageFactory {
     return fileName;
   }
 
-  /**
-   * @param fileName
-   */
   private Image getImage(final String fileName, final boolean transparent) {
     synchronized (m_mutex) {
       final Image rVal = isImageLoaded(fileName);

--- a/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -46,7 +46,7 @@ public class UnitImageFactory {
   private double m_scaleFactor;
   private ResourceLoader m_resourceLoader;
 
-  /** Creates new IconImageFactory */
+  /** Creates new UnitImageFactory. */
   public UnitImageFactory() {}
 
   public void setResourceLoader(final ResourceLoader loader, final double scaleFactor, final int initialUnitWidth,
@@ -61,7 +61,7 @@ public class UnitImageFactory {
   }
 
   /**
-   * Set the unitScaling factor
+   * Set the unitScaling factor.
    */
   public void setScaleFactor(final double scaleFactor) {
     if (m_scaleFactor != scaleFactor) {
@@ -71,7 +71,7 @@ public class UnitImageFactory {
   }
 
   /**
-   * Return the unit scaling factor
+   * Return the unit scaling factor.
    */
   public double getScaleFactor() {
     return m_scaleFactor;
@@ -85,7 +85,7 @@ public class UnitImageFactory {
   }
 
   /**
-   * Return the height of scaled units
+   * Return the height of scaled units.
    */
   public int getUnitImageHeight() {
     return (int) (m_scaleFactor * UNIT_ICON_HEIGHT);

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
@@ -36,7 +36,7 @@ public class AggregateResults implements Serializable {
   }
 
   /**
-   * This could be null if we have zero results!
+   * This could be null if we have zero results.
    */
   public BattleResults getBattleResultsClosestToAverage() {
     double closestBattleDif = Integer.MAX_VALUE;
@@ -78,7 +78,7 @@ public class AggregateResults implements Serializable {
   }
 
   /**
-   * First is Attacker, Second is Defender
+   * First is Attacker, Second is Defender.
    */
   public Tuple<Double, Double> getAverageTUVofUnitsLeftOver(final IntegerMap<UnitType> attackerCostsForTUV,
       final IntegerMap<UnitType> defenderCostsForTUV) {

--- a/src/main/java/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
+++ b/src/main/java/games/strategy/triplea/pbem/AxisAndAlliesForumPoster.java
@@ -243,7 +243,7 @@ public class AxisAndAlliesForumPoster extends AbstractForumPoster {
   }
 
   /**
-   * Create a clone of the poster
+   * Create a clone of the poster.
    *
    * @return a copy
    */

--- a/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
@@ -19,12 +19,12 @@ import games.strategy.util.IntegerMap;
 import games.strategy.util.Tuple;
 
 /**
- * Interface the TriplePlayer presents to Delegates through IRemoteMessenger
+ * Interface the TriplePlayer presents to Delegates through IRemoteMessenger.
  */
 public interface ITripleAPlayer extends IRemotePlayer {
 
   /**
-   * Select casualties
+   * Select casualties.
    *
    * @param selectFrom
    *        - the units to select casualties from
@@ -82,7 +82,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
 
   // TODO: Remove noneAvailable as it is always passed as 'true'
   /**
-   * Select the territory to bombard with the bombarding capable unit (eg battleship)
+   * Select the territory to bombard with the bombarding capable unit (eg battleship).
    *
    * @param unit
    *        - the bombarding unit
@@ -96,7 +96,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
       boolean noneAvailable);
 
   /**
-   * Ask if the player wants to attack lone subs
+   * Ask if the player wants to attack lone subs.
    *
    * @param unitTerritory
    *        - where the potential battle is
@@ -104,7 +104,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
   boolean selectAttackSubs(Territory unitTerritory);
 
   /**
-   * Ask if the player wants to attack lone transports
+   * Ask if the player wants to attack lone transports.
    *
    * @param unitTerritory
    *        - where the potential battle is
@@ -112,7 +112,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
   boolean selectAttackTransports(Territory unitTerritory);
 
   /**
-   * Ask if the player wants to attack units
+   * Ask if the player wants to attack units.
    *
    * @param unitTerritory
    *        - where the potential battle is
@@ -120,7 +120,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
   boolean selectAttackUnits(Territory unitTerritory);
 
   /**
-   * Ask if the player wants to shore bombard
+   * Ask if the player wants to shore bombard.
    *
    * @param unitTerritory
    *        - where the potential battle is
@@ -137,25 +137,25 @@ public interface ITripleAPlayer extends IRemotePlayer {
   void reportError(String error);
 
   /**
-   * report a message to the user
+   * report a message to the user.
    */
   void reportMessage(String message, String title);
 
   /**
    * One or more bombers have just moved into a territory where a strategic bombing
-   * raid can be conducted, should the bomber bomb?
+   * raid can be conducted, should the bomber bomb.
    */
   boolean shouldBomberBomb(Territory territory);
 
   /**
    * One or more bombers have just moved into a territory where a strategic bombing
-   * raid can be conducted, what should the bomber bomb?
+   * raid can be conducted, what should the bomber bomb.
    */
   Unit whatShouldBomberBomb(Territory territory, final Collection<Unit> potentialTargets,
       final Collection<Unit> bombers);
 
   /**
-   * Choose where my rockets should fire
+   * Choose where my rockets should fire.
    *
    * @param candidates
    *        - a collection of Territories, the possible territories to attack
@@ -166,7 +166,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
   Territory whereShouldRocketsAttack(Collection<Territory> candidates, Territory from);
 
   /**
-   * Get the fighters to move to a newly produced carrier
+   * Get the fighters to move to a newly produced carrier.
    *
    * @param fightersThatCanBeMoved
    *        - the fighters that can be moved
@@ -187,7 +187,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
       String unitMessage);
 
   /**
-   * The attempted move will incur aa fire, confirm that you still want to move
+   * The attempted move will incur aa fire, confirm that you still want to move.
    *
    * @param aaFiringTerritories
    *        - the territories where aa will fire
@@ -195,12 +195,12 @@ public interface ITripleAPlayer extends IRemotePlayer {
   boolean confirmMoveInFaceOfAA(Collection<Territory> aaFiringTerritories);
 
   /**
-   * The attempted move will kill some air units
+   * The attempted move will kill some air units.
    */
   boolean confirmMoveKamikaze();
 
   /**
-   * The attempted move will kill some units
+   * The attempted move will kill some units.
    */
   boolean confirmMoveHariKari();
 
@@ -238,14 +238,14 @@ public interface ITripleAPlayer extends IRemotePlayer {
   Collection<Unit> selectUnitsQuery(Territory current, Collection<Unit> possible, String message);
 
   /**
-   * Allows the user to pause and confirm enemy casualties
+   * Allows the user to pause and confirm enemy casualties.
    */
   void confirmEnemyCasualties(GUID battleId, String message, PlayerID hitPlayer);
 
   void confirmOwnCasualties(GUID battleId, String message);
 
   /**
-   * Does the player accept the proposed action?
+   * Indicates the player accepts the proposed action.
    *
    * @param acceptanceQuestion
    *        the question that should be asked to this player
@@ -256,7 +256,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
   boolean acceptAction(PlayerID playerSendingProposal, String acceptanceQuestion, boolean politics);
 
   /**
-   * Asks the player if they wish to perform any kamikaze suicide attacks
+   * Asks the player if they wish to perform any kamikaze suicide attacks.
    */
   HashMap<Territory, HashMap<Unit, IntegerMap<Resource>>> selectKamikazeSuicideAttacks(
       HashMap<Territory, Collection<Unit>> possibleUnitsToAttack);

--- a/src/main/java/games/strategy/triplea/printgenerator/InitialSetup.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/InitialSetup.java
@@ -19,7 +19,7 @@ public class InitialSetup {
 
   /**
    * @param GameData
-   *        data
+   *        data.
    * @param boolean useOriginalState
    */
   protected void run(final PrintGenerationData printData, final boolean useOriginalState) {

--- a/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
@@ -11,12 +11,12 @@ public class PrintGenerationData {
   private GameData m_data;
 
   /**
-   * General Constructor
+   * General Constructor.
    */
   protected PrintGenerationData() {}
 
   /**
-   * @return the outDir
+   * @return the outDir.
    */
   protected File getOutDir() {
     return m_outDir;
@@ -24,14 +24,14 @@ public class PrintGenerationData {
 
   /**
    * @param outDir
-   *        the outDir to set
+   *        the outDir to set.
    */
   protected void setOutDir(final File outDir) {
     m_outDir = outDir;
   }
 
   /**
-   * @return the samePUMap
+   * @return the samePUMap.
    */
   protected Map<Integer, Integer> getSamePUMap() {
     return m_SamePUMap;
@@ -39,14 +39,14 @@ public class PrintGenerationData {
 
   /**
    * @param samePUMap
-   *        the samePUMap to set
+   *        the samePUMap to set.
    */
   protected void setSamePUMap(final Map<Integer, Integer> samePUMap) {
     m_SamePUMap = samePUMap;
   }
 
   /**
-   * @return the data
+   * @return the data.
    */
   protected GameData getData() {
     return m_data;
@@ -54,7 +54,7 @@ public class PrintGenerationData {
 
   /**
    * @param data
-   *        the data to set
+   *        the data to set.
    */
   protected void setData(final GameData data) {
     m_data = data;

--- a/src/main/java/games/strategy/triplea/printgenerator/SetupFrame.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/SetupFrame.java
@@ -24,6 +24,8 @@ public class SetupFrame extends JPanel {
   private File m_outDir;
 
   /**
+   * Creates a new SetupFrame.
+   *
    * @param data
    */
   public SetupFrame(final GameData data) {

--- a/src/main/java/games/strategy/triplea/settings/InputValidator.java
+++ b/src/main/java/games/strategy/triplea/settings/InputValidator.java
@@ -18,7 +18,7 @@ public class InputValidator implements Function<String, Boolean> {
   }), "not a number");
 
   /**
-   * Verifies a value is an integer and falls inside of a given range (inclusive)
+   * Verifies a value is an integer and falls inside of a given range (inclusive).
    */
   static InputValidator inRange(final int min, final int max) {
     return new InputValidator((value) -> {

--- a/src/main/java/games/strategy/triplea/settings/SettingInputComponent.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingInputComponent.java
@@ -48,7 +48,7 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
 
   /**
    * In cases where we try to update to an invalid value, set Value is called to restore the default/previous valid
-   * value
+   * value.
    */
   void setValue(String valueToSet);
 

--- a/src/main/java/games/strategy/triplea/settings/SettingInputComponentFactory.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingInputComponentFactory.java
@@ -43,7 +43,7 @@ public final class SettingInputComponentFactory {
   }
 
   /**
-   * Factory method to create instances of this interface, backed by TextField component types
+   * Factory method to create instances of this interface, backed by TextField component types.
    */
   public static <Z extends HasDefaults> SettingInputComponent<Z> buildTextComponent(
       final String label,

--- a/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -145,7 +145,7 @@ public class SettingsWindow extends SwingComponents.ModalJDialog {
   }
 
   /**
-   * Each element is arranged in a row, with glue in between every element
+   * Each element is arranged in a row, with glue in between every element.
    */
   private <T extends HasDefaults> JPanel createButtonsPanel(final SettingsTab<T> settingTab) {
     final JPanel buttonsPanel = SwingComponents.newJPanelWithHorizontalBoxLayout();

--- a/src/main/java/games/strategy/triplea/settings/SystemPreferences.java
+++ b/src/main/java/games/strategy/triplea/settings/SystemPreferences.java
@@ -34,7 +34,7 @@ public class SystemPreferences {
   }
 
   /**
-   * Puts a value into system preferences (note: not actually persisted until flush is called)
+   * Puts a value into system preferences (note: not actually persisted until flush is called).
    */
   private static void putNoFlush(SystemPreferenceKey key, String value) {
     getPrefs().put(key.name(), value);
@@ -60,7 +60,7 @@ public class SystemPreferences {
   }
 
   /**
-   * Looks up a preference value by key (note: returns the last flushed value)
+   * Looks up a preference value by key (note: returns the last flushed value).
    *
    * @param key The preference key to look up
    * @param defaultValue A default value to use when the look up finds nothing

--- a/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -217,7 +217,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
   }
 
   /**
-   * sub-classes method for undo handling
+   * sub-classes method for undo handling.
    */
   protected abstract void undoMoveSpecific();
 

--- a/src/main/java/games/strategy/triplea/ui/AbstractUIContext.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractUIContext.java
@@ -88,7 +88,7 @@ public abstract class AbstractUIContext implements IUIContext {
   }
 
   /**
-   * Get the preferences for the map or map skin
+   * Get the preferences for the map or map skin.
    */
   protected static Preferences getPreferencesMapOrSkin(final String mapDir) {
     return Preferences.userNodeForPackage(AbstractUIContext.class).node(mapDir);

--- a/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -49,7 +49,7 @@ public class ActionButtons extends JPanel {
   private UserActionPanel m_userActionPanel;
   private PickTerritoryAndUnitsPanel m_pickTerritoryAndUnitsPanel;
 
-  /** Creates new ActionPanel */
+  /** Creates new ActionButtons. */
   public ActionButtons(final GameData data, final MapPanel map, final MovePanel movePanel, final TripleAFrame parent) {
     m_battlePanel = new BattlePanel(data, map);
     m_movePanel = movePanel;

--- a/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -21,7 +21,7 @@ public abstract class ActionPanel extends JPanel {
   private CountDownLatch m_latch;
   private final Object m_latchLock = new Object();
 
-  /** Creates new ActionPanel */
+  /** Creates new ActionPanel. */
   public ActionPanel(final GameData data, final MapPanel map) {
     m_data = data;
     m_map = map;

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -82,7 +82,7 @@ import games.strategy.util.Match;
 import games.strategy.util.Tuple;
 
 /**
- * Displays a running battle
+ * Displays a running battle.
  */
 public class BattleDisplay extends JPanel {
   private static final long serialVersionUID = -7939993104972562765L;
@@ -211,7 +211,7 @@ public class BattleDisplay extends JPanel {
 
 
   /**
-   * updates the panel content according to killed units for the player
+   * updates the panel content according to killed units for the player.
    *
    * @param aKilledUnits
    *        list of units killed
@@ -793,7 +793,7 @@ class BattleModel extends DefaultTableModel {
   }
 
   /**
-   * refresh the model from m_units
+   * refresh the model from m_units.
    */
   public void refresh() {
     // TODO Soft set the maximum bonus to-hit plus 1 for 0 based count(+2 total currently)

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -67,7 +67,7 @@ public class BattlePanel extends ActionPanel {
   private final JFrame m_battleFrame;
   Map<BattleType, Collection<Territory>> m_battles;
 
-  /** Creates new BattlePanel */
+  /** Creates new BattlePanel. */
   public BattlePanel(final GameData data, final MapPanel map) {
     super(data, map);
     m_battleFrame = new JFrame() {

--- a/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -201,7 +201,7 @@ public class CommentPanel extends JPanel {
     }
   }
 
-  /** thread safe */
+  /** thread safe. */
   public void addMessage(final String message) {
     final Runnable runner = () -> {
       try {
@@ -232,7 +232,7 @@ public class CommentPanel extends JPanel {
   }
 
   /**
-   * Show only the first n lines
+   * Show only the first n lines.
    */
   public static void trimLines(final Document doc, final int lineCount) {
     if (doc.getLength() < lineCount) {

--- a/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
@@ -28,7 +28,7 @@ public class EditProductionPanel extends ProductionPanel {
     return new EditProductionPanel(uiContext).show(id, parent, data, false, new IntegerMap<>());
   }
 
-  /** Creates new ProductionPanel */
+  /** Creates new EditProductionPanel. */
   private EditProductionPanel(final IUIContext uiContext) {
     super(uiContext);
   }

--- a/src/main/java/games/strategy/triplea/ui/JButtonDialog.java
+++ b/src/main/java/games/strategy/triplea/ui/JButtonDialog.java
@@ -12,7 +12,7 @@ import javax.swing.JOptionPane;
  */
 public class JButtonDialog {
   /**
-   * Show a new modal dialog and block until the user press a button of closes the dialog
+   * Show a new modal dialog and block until the user press a button of closes the dialog.
    *
    * @param frame
    *        the frame owner
@@ -30,7 +30,7 @@ public class JButtonDialog {
   }
 
   /**
-   * Show a new modal dialog and block until the user press a button of closes the dialog
+   * Show a new modal dialog and block until the user press a button of closes the dialog.
    *
    * @param component
    *        the component owner

--- a/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -100,7 +100,7 @@ public class MapPanel extends ImageScrollerLargeView {
   private final MapRouteDrawer routeDrawer;
 
 
-  /** Creates new MapPanel */
+  /** Creates new MapPanel. */
   public MapPanel(final GameData data, final MapPanelSmallView smallView, final IUIContext uiContext,
       final ImageScrollModel model, final Supplier<Integer> computeScrollSpeed) {
     super(uiContext.getMapData().getMapDimensions(), model);

--- a/src/main/java/games/strategy/triplea/ui/MapRouteDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/MapRouteDrawer.java
@@ -91,7 +91,7 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Draws Points on the Map
+   * Draws Points on the Map.
    *
    * @param graphics The {@linkplain Graphics2D} Object being drawn on
    * @param points The {@linkplain Point} array aka the "Joints" to be drawn
@@ -114,7 +114,7 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Draws a specified CursorImage if available
+   * Draws a specified CursorImage if available.
    *
    * @param graphics The {@linkplain Graphics2D} Object being drawn on
    * @param routeDescription The RouteDescription object containing the CursorImage
@@ -180,7 +180,7 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Draws a line to the Screen regarding the Map-Offset and scale
+   * Draws a line to the Screen regarding the Map-Offset and scale.
    *
    * @param graphics The {@linkplain Graphics2D} Object to be drawn on
    * @param line The Line to be drawn
@@ -197,7 +197,7 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Creates a {@linkplain Point} Array out of a {@linkplain RouteDescription} and a {@linkplain MapData} object
+   * Creates a {@linkplain Point} Array out of a {@linkplain RouteDescription} and a {@linkplain MapData} object.
    *
    * @param routeDescription {@linkplain RouteDescription} containing the Route information
    * @param mapData {@linkplain MapData} Object containing Information about the Map Coordinates
@@ -221,7 +221,7 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Creates double arrays of y or x coordinates of the given {@linkplain Point} Array
+   * Creates double arrays of y or x coordinates of the given {@linkplain Point} Array.
    *
    * @param points The {@linkplain Point} Array containing the Coordinates
    * @param extractor A function specifying which value to return
@@ -238,7 +238,7 @@ public class MapRouteDrawer {
 
   /**
    * Creates a double array containing y coordinates of a {@linkplain PolynomialSplineFunction} with the above specified
-   * {@code DETAIL_LEVEL}
+   * {@code DETAIL_LEVEL}.
    *
    * @param fuction The {@linkplain PolynomialSplineFunction} with the values
    * @param index the parameterized array to indicate the maximum Values
@@ -257,7 +257,7 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Draws how many moves are left
+   * Draws how many moves are left.
    *
    * @param graphics The {@linkplain Graphics2D} Object to be drawn on
    * @param points The {@linkplain Point} array of the unit's tour
@@ -354,7 +354,7 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Creates an Arrow-Shape
+   * Creates an Arrow-Shape.
    *
    * @param from The {@linkplain Point2D} specifying the direction of the Arrow
    * @param to The {@linkplain Point2D} where the arrow is placed
@@ -378,7 +378,7 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Draws an Arrow on the {@linkplain Graphics2D} Object
+   * Draws an Arrow on the {@linkplain Graphics2D} Object.
    *
    * @param graphics The {@linkplain Graphics2D} object to draw on
    * @param from The destination {@linkplain Point2D} form the Arrow

--- a/src/main/java/games/strategy/triplea/ui/MemoryLabel.java
+++ b/src/main/java/games/strategy/triplea/ui/MemoryLabel.java
@@ -59,7 +59,7 @@ public class MemoryLabel extends JLabel {
 
 
 /**
- * This thread will stop when the label is garbage collected
+ * This thread will stop when the label is garbage collected.
  */
 class Updater implements Runnable {
   private final WeakReference<MemoryLabel> m_label;

--- a/src/main/java/games/strategy/triplea/ui/MouseDetails.java
+++ b/src/main/java/games/strategy/triplea/ui/MouseDetails.java
@@ -49,7 +49,7 @@ public class MouseDetails {
   }
 
   /**
-   * @return this point is in the map co-ordinates, unscaled
+   * @return this point is in the map co-ordinates, unscaled.
    */
   public Point getMapPoint() {
     return new Point((int) m_x, (int) m_y);

--- a/src/main/java/games/strategy/triplea/ui/MouseOverUnitListener.java
+++ b/src/main/java/games/strategy/triplea/ui/MouseOverUnitListener.java
@@ -7,7 +7,7 @@ import games.strategy.engine.data.Unit;
 
 public interface MouseOverUnitListener {
   /**
-   * units will be empty if the mouse is not over any unit
+   * units will be empty if the mouse is not over any unit.
    */
   void mouseEnter(List<Unit> units, Territory territory, MouseDetails me);
 }

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -58,7 +58,7 @@ public class MovePanel extends AbstractMovePanel {
    * @param s_deselectNumber
    *        adds or removes 10 units (used to remove 1/s_deselectNumber of total units (useful for splitting large
    *        armies), but changed it
-   *        after feedback)
+   *        after feedback).
    */
   private static final int s_deselectNumber = 10;
   // access only through getter and setter!
@@ -85,7 +85,7 @@ public class MovePanel extends AbstractMovePanel {
   private String displayText = "Combat Move";
   private MoveType moveType = MoveType.DEFAULT;
 
-  /** Creates new MovePanel */
+  /** Creates new MovePanel. */
   public MovePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map, frame);
     m_undoableMovesPanel = new UndoableMovesPanel(data, this);
@@ -444,7 +444,7 @@ public class MovePanel extends AbstractMovePanel {
   }
 
   /**
-   * Get the route ignoring forced territories
+   * Get the route ignoring forced territories.
    */
   private Route getRouteNonForced(final Territory start, final Territory end, final Collection<Unit> selectedUnits) {
     // can't rely on current player being the unit owner in Edit Mode

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -35,7 +35,7 @@ public class PlacePanel extends AbstractMovePanel {
   private PlaceData m_placeData;
   private final SimpleUnitPanel m_unitsToPlace;
 
-  /** Creates new PlacePanel */
+  /** Creates new PlacePanel. */
   public PlacePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map, frame);
     m_undoableMovesPanel = new UndoablePlacementsPanel(data, this);

--- a/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
@@ -27,12 +27,12 @@ public class PlayerChooser extends JOptionPane {
   private final boolean m_allowNeutral;
 
   // private JOptionPane m_pane;
-  /** Creates new PlayerChooser */
+  /** Creates new PlayerChooser. */
   public PlayerChooser(final PlayerList players, final IUIContext uiContext, final boolean allowNeutral) {
     this(players, null, uiContext, allowNeutral);
   }
 
-  /** Creates new PlayerChooser */
+  /** Creates new PlayerChooser. */
   public PlayerChooser(final PlayerList players, final PlayerID defaultPlayer, final IUIContext uiContext,
       final boolean allowNeutral) {
     setMessageType(JOptionPane.PLAIN_MESSAGE);
@@ -74,7 +74,7 @@ public class PlayerChooser extends JOptionPane {
 
 
   /**
-   * Returns the selected player or null, or null if the dialog was closed
+   * Returns the selected player or null, or null if the dialog was closed.
    *
    * @return the player or null
    */

--- a/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
@@ -11,7 +11,7 @@ import games.strategy.engine.framework.IGame;
 import games.strategy.ui.SwingComponents;
 
 /**
- * Panel to show who is playing which players
+ * Panel to show who is playing which players.
  */
 public class PlayersPanel {
 

--- a/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -176,7 +176,7 @@ public class PoliticalStateOverview extends JPanel {
   }
 
   /**
-   * returns a color to represent the relationship
+   * returns a color to represent the relationship.
    *
    * @param relType
    *        which relationship to get the color for
@@ -198,7 +198,7 @@ public class PoliticalStateOverview extends JPanel {
   }
 
   /**
-   * Gets a label showing the flag + name of this player
+   * Gets a label showing the flag + name of this player.
    *
    * @param player
    *        the player to get the label for
@@ -209,7 +209,7 @@ public class PoliticalStateOverview extends JPanel {
   }
 
   /**
-   * Redraw this panel (because of changed politics)
+   * Redraw this panel (because of changed politics).
    */
   public void redrawPolitics() {
     this.removeAll();

--- a/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -77,7 +77,7 @@ public class PoliticsPanel extends ActionPanel {
 
   /**
    * waits till someone calls release() and then returns the political action
-   * chosen
+   * chosen.
    *
    * @return the choice of political action
    */
@@ -108,7 +108,7 @@ public class PoliticsPanel extends ActionPanel {
 
   /**
    * Fires up a JDialog showing the political landscape and valid actions,
-   * choosing an action will release this model and trigger waitForRelease()
+   * choosing an action will release this model and trigger waitForRelease().
    */
   private final Action SelectPoliticalActionAction = SwingAction.of("Do Politics...", e -> {
     final Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
@@ -191,7 +191,7 @@ public class PoliticsPanel extends ActionPanel {
   }
 
   /**
-   * This will stop the politicsPhase
+   * This will stop the politicsPhase.
    */
   private final Action DontBotherAction = SwingAction.of("Done", e -> {
     if (!m_firstRun || youSureDoNothing()) {

--- a/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -109,7 +109,7 @@ public class ProductionRepairPanel extends JPanel {
     m_dialog.getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(stroke, key);
   }
 
-  /** Creates new ProductionRepairPanel */
+  /** Creates new ProductionRepairPanel. */
   // the constructor can be accessed by subclasses
   public ProductionRepairPanel(final IUIContext uiContext) {
     m_uiContext = uiContext;

--- a/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -43,7 +43,7 @@ public class PurchasePanel extends ActionPanel {
   private static final String BUY = "Buy...";
   private static final String CHANGE = "Change...";
 
-  /** Creates new PurchasePanel */
+  /** Creates new PurchasePanel. */
   public PurchasePanel(final GameData data, final MapPanel map) {
     super(data, map);
     m_purchasedPreviousRoundsUnits = new SimpleUnitPanel(map.getUIContext());

--- a/src/main/java/games/strategy/triplea/ui/RepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/RepairPanel.java
@@ -33,7 +33,7 @@ public class RepairPanel extends ActionPanel {
   private final JLabel m_repairdSoFar = new JLabel();
   private final JButton m_buyButton;
 
-  /** Creates new RepairPanel */
+  /** Creates new RepairPanel. */
   public RepairPanel(final GameData data, final MapPanel map) {
     super(data, map);
     m_unitsPanel = new SimpleUnitPanel(map.getUIContext());

--- a/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -40,7 +40,7 @@ public class SimpleUnitPanel extends JPanel {
   /**
    * @param units
    *        a HashMap in the form ProductionRule -> number of units
-   *        assumes that each production rule has 1 result, which is simple the number of units
+   *        assumes that each production rule has 1 result, which is simple the number of units.
    */
   public void setUnitsFromProductionRuleMap(final IntegerMap<ProductionRule> units, final PlayerID player,
       final GameData data) {
@@ -59,7 +59,7 @@ public class SimpleUnitPanel extends JPanel {
   /**
    * @param units
    *        a HashMap in the form RepairRule -> number of units
-   *        assumes that each repair rule has 1 result, which is simply the number of units
+   *        assumes that each repair rule has 1 result, which is simply the number of units.
    */
   public void setUnitsFromRepairRuleMap(final HashMap<Unit, IntegerMap<RepairRule>> units, final PlayerID player,
       final GameData data) {
@@ -84,7 +84,7 @@ public class SimpleUnitPanel extends JPanel {
 
   /**
    * @param categories
-   *        a collection of UnitCategories
+   *        a collection of UnitCategories.
    */
   public void setUnitsFromCategories(final Collection<UnitCategory> categories, final GameData data) {
     removeAll();

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -53,7 +53,7 @@ public class StatPanel extends AbstractStatPanel {
   protected final Map<PlayerID, ImageIcon> m_mapPlayerImage = new HashMap<>();
   protected IUIContext m_uiContext;
 
-  /** Creates a new instance of InfoPanel */
+  /** Creates a new instance of StatPanel. */
   public StatPanel(final GameData data, final IUIContext uiContext2) {
     super(data);
     m_uiContext = uiContext2;
@@ -123,7 +123,7 @@ public class StatPanel extends AbstractStatPanel {
   }
 
   /**
-   * Gets the small flag for a given PlayerID
+   * Gets the small flag for a given PlayerID.
    *
    * @param player
    *        the player to get the flag for

--- a/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -44,7 +44,7 @@ public class TechPanel extends ActionPanel {
   private int m_quantity;
   private IntegerMap<PlayerID> m_whoPaysHowMuch = null;
 
-  /** Creates new BattlePanel */
+  /** Creates new TechPanel. */
   public TechPanel(final GameData data, final MapPanel map) {
     super(data, map);
   }

--- a/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
@@ -17,20 +17,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.triplea.delegate.Die;
 import games.strategy.triplea.delegate.dataObjects.TechResults;
 
-/**
- * <p>
- * Title:
- * </p>
- * <p>
- * Description:
- * </p>
- * <p>
- * Copyright: Copyright (c) 2003
- * </p>
- * <p>
- * Company:
- * </p>
- */
 public class TechResultsDisplay extends JPanel {
   private static final long serialVersionUID = -8303376983862918107L;
 

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -159,7 +159,7 @@ import games.strategy.util.ThreadUtil;
 import games.strategy.util.Tuple;
 
 /**
- * Main frame for the triple a game
+ * Main frame for the triple a game.
  */
 public class TripleAFrame extends MainGameFrame {
   private static final long serialVersionUID = 7640069668264418976L;
@@ -208,7 +208,7 @@ public class TripleAFrame extends MainGameFrame {
   private final ScrollSettings scrollSettings;
   private boolean isCtrlPressed = false;
 
-  /** Creates new TripleAFrame */
+  /** Creates new TripleAFrame. */
   public TripleAFrame(final IGame game, final LocalPlayers players) {
     super("TripleA - " + game.getData().getGameName(), players);
     scrollSettings = ClientContext.scrollSettings();
@@ -546,14 +546,14 @@ public class TripleAFrame extends MainGameFrame {
 
   /**
    * @param value
-   *        - a number between 15 and 100
+   *        a number between 15 and 100.
    */
   public void setScale(final double value) {
     getMapPanel().setScale(value / 100);
   }
 
   /**
-   * @return a scale between 15 and 100
+   * @return a scale between 15 and 100.
    */
   private double getScale() {
     return getMapPanel().getScale() * 100;

--- a/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -45,7 +45,7 @@ public class UnitChooser extends JPanel {
   private final IUIContext m_uiContext;
   private final Match<Collection<Unit>> m_match;
 
-  /** Creates new UnitChooser */
+  /** Creates new UnitChooser. */
   public UnitChooser(final Collection<Unit> units, final Map<Unit, Collection<Unit>> dependent, final GameData data,
       final boolean allowTwoHit, final IUIContext uiContext) {
     this(units, Collections.emptyList(), dependent, data, allowTwoHit, uiContext);
@@ -248,7 +248,7 @@ public class UnitChooser extends JPanel {
   }
 
   /**
-   * Only applicable if this dialog was constructed using multiple hit points
+   * Only applicable if this dialog was constructed using multiple hit points.
    */
   public List<Unit> getSelectedDamagedMultipleHitPointUnits() {
     final List<Unit> selectedUnits = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -78,7 +78,7 @@ public class UserActionPanel extends ActionPanel {
   }
 
   /**
-   * waits till someone calls release() and then returns the action chosen
+   * waits till someone calls release() and then returns the action chosen.
    *
    * @return the choice of action
    */
@@ -108,7 +108,7 @@ public class UserActionPanel extends ActionPanel {
 
   /**
    * Fires up a JDialog showing valid actions,
-   * choosing an action will release this model and trigger waitForRelease()
+   * choosing an action will release this model and trigger waitForRelease().
    */
   private final Action SelectUserActionAction = new AbstractAction("Take Action...") {
     private static final long serialVersionUID = 2389485901611958851L;
@@ -213,7 +213,7 @@ public class UserActionPanel extends ActionPanel {
   }
 
   /**
-   * This will stop the user action Phase
+   * This will stop the user action Phase.
    */
   private final Action DontBotherAction = new AbstractAction("Done") {
     private static final long serialVersionUID = 2835948679299520899L;

--- a/src/main/java/games/strategy/triplea/ui/VerifiedRandomNumbersDialog.java
+++ b/src/main/java/games/strategy/triplea/ui/VerifiedRandomNumbersDialog.java
@@ -48,9 +48,6 @@ public class VerifiedRandomNumbersDialog extends JDialog {
     buttons.add(close);
   }
 
-  /**
-   * @param verified
-   */
   private String[][] getTableValues(final List<VerifiedRandomNumbers> verified) {
     if (verified.isEmpty()) {
       return new String[][] {{"", ""}};

--- a/src/main/java/games/strategy/triplea/ui/display/ITripleADisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/ITripleADisplay.java
@@ -69,7 +69,7 @@ public interface ITripleADisplay extends IDisplay {
 
   /**
    * @param battleID
-   *        - the battle we are listing steps for
+   *        - the battle we are listing steps for.
    * @param currentStep
    *        - the current step
    * @param steps
@@ -83,13 +83,13 @@ public interface ITripleADisplay extends IDisplay {
   void battleEnd(GUID battleID, String message);
 
   /**
-   * Notify that the casualties occurred
+   * Notify that the casualties occurred.
    */
   void casualtyNotification(GUID battleID, String step, DiceRoll dice, PlayerID player, Collection<Unit> killed,
       Collection<Unit> damaged, Map<Unit, Collection<Unit>> dependents);
 
   /**
-   * Notify that the casualties occurred, and only the casualty
+   * Notify that the casualties occurred, and only the casualty.
    */
   void deadUnitNotification(GUID battleID, PlayerID player, Collection<Unit> dead,
       Map<Unit, Collection<Unit>> dependents);
@@ -98,7 +98,7 @@ public interface ITripleADisplay extends IDisplay {
       Collection<Unit> addedUnits, Map<Unit, Collection<Unit>> dependents);
 
   /**
-   * Notification of the results of a bombing raid
+   * Notification of the results of a bombing raid.
    */
   void bombingResults(GUID battleID, List<Die> dice, int cost);
 
@@ -110,7 +110,7 @@ public interface ITripleADisplay extends IDisplay {
   void notifyRetreat(GUID battleId, Collection<Unit> retreating);
 
   /**
-   * Show dice for the given battle and step
+   * Show dice for the given battle and step.
    */
   void notifyDice(DiceRoll dice, String stepName);
 

--- a/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
@@ -87,7 +87,7 @@ public class TripleADisplay implements ITripleADisplay {
   }
 
   /**
-   * Show dice for the given battle and step
+   * Show dice for the given battle and step.
    */
   @Override
   public void notifyDice(final DiceRoll dice, final String stepName) {

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -293,7 +293,7 @@ public class HistoryPanel extends JPanel {
   }
 
   /**
-   * collapses parents of last path if it is not in the list of expanded path until the new path is a descendant
+   * collapses parents of last path if it is not in the list of expanded path until the new path is a descendant.
    *
    * @param newPath
    *        new path
@@ -309,7 +309,7 @@ public class HistoryPanel extends JPanel {
 
   /**
    * @param parentPath
-   *        tree path for which descendants should be check
+   *        tree path for which descendants should be check.
    * @return whether the expanded path list contains a descendant of parentPath
    */
   private boolean stayExpandedContainsDescendantOf(final TreePath parentPath) {
@@ -322,7 +322,7 @@ public class HistoryPanel extends JPanel {
   }
 
   /**
-   * collapses expanded paths except if new path is a descendant
+   * collapses expanded paths except if new path is a descendant.
    *
    * @param newPath
    *        new path

--- a/src/main/java/games/strategy/triplea/ui/logic/Line.java
+++ b/src/main/java/games/strategy/triplea/ui/logic/Line.java
@@ -4,7 +4,7 @@ import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 
 /**
- * Framework independent Line class
+ * Framework independent Line class.
  */
 public class Line {
 

--- a/src/main/java/games/strategy/triplea/ui/logic/Point.java
+++ b/src/main/java/games/strategy/triplea/ui/logic/Point.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.ui.logic;
 
 import java.awt.geom.Point2D;
 /**
- * Framework independent point class
+ * Framework independent point class.
  */
 public class Point {
   private double x;

--- a/src/main/java/games/strategy/triplea/ui/logic/RouteCalculator.java
+++ b/src/main/java/games/strategy/triplea/ui/logic/RouteCalculator.java
@@ -21,7 +21,7 @@ public class RouteCalculator {
   }
 
   /**
-   * Algorithm for finding the shortest path for the given Route
+   * Algorithm for finding the shortest path for the given Route.
    * 
    * @param route The joints on the Map
    * @return A Point array which goes through Map Borders if necessary
@@ -53,7 +53,7 @@ public class RouteCalculator {
   }
 
   /**
-   * Returns the Closest Point out of the given Pool
+   * Returns the Closest Point out of the given Pool.
    * 
    * @param source the reference Point
    * @param pool Point List with all possible options
@@ -79,7 +79,7 @@ public class RouteCalculator {
 
   /**
    * Method for getting Points, which are a mapHeight/Width away from the actual Point
-   * Used to display routes with higher offsets than the map width/height
+   * Used to display routes with higher offsets than the map width/height.
    * 
    * @param point The Point to "clone"
    * @return A List of all possible Points depending in map Properties
@@ -115,7 +115,7 @@ public class RouteCalculator {
   }
 
   /**
-   * Matrix Transpose method to transpose the 2dimensional point list
+   * Matrix Transpose method to transpose the 2dimensional point list.
    * 
    * @param points A Point array
    * @return Offset Point Arrays including points
@@ -135,7 +135,7 @@ public class RouteCalculator {
   }
 
   /**
-   * Generates a List of Lines which represent "normalized forms" of the given arrays
+   * Generates a List of Lines which represent "normalized forms" of the given arrays.
    * 
    * @param xcoords an array of xCoordinates
    * @param ycoords an array of yCoordinates
@@ -155,7 +155,7 @@ public class RouteCalculator {
   }
 
   /**
-   * A List of Lines which represent all possible lines on multiple screens size may vary
+   * A List of Lines which represent all possible lines on multiple screens size may vary.
    * 
    * @param xcoords an array of xCoordinates
    * @param ycoords an array of yCoordinates

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -36,7 +36,7 @@ import games.strategy.util.PointFileReaderWriter;
 import games.strategy.util.UrlStreams;
 
 /**
- * contains data about the territories useful for drawing
+ * contains data about the territories useful for drawing.
  */
 public class MapData implements Closeable {
   public static final String PROPERTY_UNITS_SCALE = "units.scale";
@@ -471,14 +471,14 @@ public class MapData implements Closeable {
   }
 
   /**
-   * returns the named property, or null
+   * returns the named property, or null.
    */
   public String getProperty(final String propertiesKey) {
     return m_mapProperties.getProperty(propertiesKey);
   }
 
   /**
-   * returns the color for impassable territories
+   * returns the color for impassable territories.
    */
   public Color impassableColor() {
     // just use getPlayerColor, since it parses the properties
@@ -494,7 +494,7 @@ public class MapData implements Closeable {
   }
 
   /**
-   * Does this territory have any territories contained within it
+   * Does this territory have any territories contained within it.
    */
   public boolean hasContainedTerritory(final String territoryName) {
     return m_contains.containsKey(territoryName);

--- a/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -331,9 +331,6 @@ public class LobbyMenu extends JMenuBar {
     addHelpMenu(help);
   }
 
-  /**
-   * @param parentMenu
-   */
   private static void addHelpMenu(final JMenu parentMenu) {
     final JMenuItem hostingLink = new JMenuItem("How to host");
     hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HOSTING));

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -188,7 +188,7 @@ public class UnitsDrawer implements IDrawable {
   }
 
   /**
-   * This draws the given image onto the given graphics object
+   * This draws the given image onto the given graphics object.
    */
   private void drawUnit(final Graphics2D graphics, final Image image, final Rectangle bounds) {
     graphics.drawImage(image, placementPoint.x - bounds.x, placementPoint.y - bounds.y, null);

--- a/src/main/java/games/strategy/triplea/util/UnitCategory.java
+++ b/src/main/java/games/strategy/triplea/util/UnitCategory.java
@@ -150,7 +150,7 @@ public class UnitCategory implements Comparable<Object> {
   }
 
   /**
-   * Collection of UnitOwners, the type of our dependents, not the dependents
+   * Collection of UnitOwners, the type of our dependents, not the dependents.
    */
   public Collection<UnitOwner> getDependents() {
     return m_dependents;

--- a/src/main/java/games/strategy/twoIfBySea/delegate/PlaceDelegate.java
+++ b/src/main/java/games/strategy/twoIfBySea/delegate/PlaceDelegate.java
@@ -15,7 +15,7 @@ import games.strategy.util.Match;
 @MapSupport
 public class PlaceDelegate extends AbstractPlaceDelegate {
   /**
-   * @return gets the production of the territory, ignores whether the territory was an original factory
+   * @return gets the production of the territory, ignores whether the territory was an original factory.
    */
   @Override
   protected int getProduction(final Territory territory) {

--- a/src/main/java/games/strategy/ui/DoubleTextField.java
+++ b/src/main/java/games/strategy/ui/DoubleTextField.java
@@ -18,7 +18,7 @@ public class DoubleTextField extends JTextField {
   private final ListenerList<DoubleTextFieldChangeListener> m_listeners =
       new ListenerList<>();
 
-  /** Creates new IntTextBox */
+  /** Creates new DoubleTextField. */
   public DoubleTextField() {
     super(10);
     initTextField();

--- a/src/main/java/games/strategy/ui/ImageScroller.java
+++ b/src/main/java/games/strategy/ui/ImageScroller.java
@@ -4,13 +4,13 @@ import javax.swing.JPanel;
 import javax.swing.OverlayLayout;
 
 /**
- * Overlays the small view with the large view
+ * Overlays the small view with the large view.
  */
 public class ImageScroller extends JPanel {
   private static final long serialVersionUID = -794229118989828922L;
 
   /**
-   * Creates new ImageScroller
+   * Creates new ImageScroller.
    */
   public ImageScroller(final ImageScrollerLargeView large, final ImageScrollerSmallView small) {
     final OverlayLayout overlay = new OverlayLayout(this);

--- a/src/main/java/games/strategy/ui/IntTextField.java
+++ b/src/main/java/games/strategy/ui/IntTextField.java
@@ -22,7 +22,7 @@ public class IntTextField extends JTextField {
   private String m_terr = null;
   private final ListenerList<IntTextFieldChangeListener> m_listeners = new ListenerList<>();
 
-  /** Creates new IntTextBox */
+  /** Creates new IntTextField. */
   public IntTextField() {
     super(3);
     initTextField();

--- a/src/main/java/games/strategy/ui/ScrollableTextField.java
+++ b/src/main/java/games/strategy/ui/ScrollableTextField.java
@@ -32,7 +32,7 @@ public class ScrollableTextField extends JPanel {
   private final JButton m_min;
   private final ListenerList<ScrollableTextFieldListener> m_listeners = new ListenerList<>();
 
-  /** Creates new ScrollableTextField */
+  /** Creates new ScrollableTextField. */
   public ScrollableTextField(final int minVal, final int maxVal) {
     super();
     loadImages();

--- a/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/src/main/java/games/strategy/ui/SwingComponents.java
@@ -148,7 +148,7 @@ public class SwingComponents {
   private static final Set<String> visiblePrompts = new HashSet<>();
 
   /**
-   * Creates a JPanel with BorderLayout and adds a west component and an east component
+   * Creates a JPanel with BorderLayout and adds a west component and an east component.
    */
   public static JPanel horizontalJPanel(final Component westComponent, final Component eastComponent) {
     final JPanel panel = new JPanel();

--- a/src/main/java/games/strategy/util/AlphanumComparator.java
+++ b/src/main/java/games/strategy/util/AlphanumComparator.java
@@ -18,7 +18,7 @@ public class AlphanumComparator implements Comparator<String> {
     return ch >= 48 && ch <= 57;
   }
 
-  /** Length of string is passed in for improved efficiency (only need to calculate it once) **/
+  /** Length of string is passed in for improved efficiency (only need to calculate it once). **/
   private String getChunk(final String s, final int slength, int marker) {
     final StringBuilder chunk = new StringBuilder();
     char c = s.charAt(marker);

--- a/src/main/java/games/strategy/util/CompositeMatch.java
+++ b/src/main/java/games/strategy/util/CompositeMatch.java
@@ -12,7 +12,7 @@ import java.util.List;
 public abstract class CompositeMatch<T> extends Match<T> {
   private final List<Match<T>> m_matches = new ArrayList<>(4);
 
-  /** Creates new CompositeMatch */
+  /** Creates new CompositeMatch. */
   public CompositeMatch() {}
 
   /**

--- a/src/main/java/games/strategy/util/CompositeMatchOr.java
+++ b/src/main/java/games/strategy/util/CompositeMatchOr.java
@@ -7,7 +7,7 @@ import java.util.List;
  * True if one match returns true.
  */
 public class CompositeMatchOr<T> extends CompositeMatch<T> {
-  /** Creates new CompositeMatchOr */
+  /** Creates new CompositeMatchOr. */
   @SuppressWarnings("unchecked")
   public CompositeMatchOr(final Match<?>... matches) { // TODO rewrite in order to remove Suppressed Warning
     super();

--- a/src/main/java/games/strategy/util/CountUpAndDownLatch.java
+++ b/src/main/java/games/strategy/util/CountUpAndDownLatch.java
@@ -47,6 +47,8 @@ public class CountUpAndDownLatch implements Serializable {
   }
 
   /**
+   * Decrements the count of the latch, releasing all waiting threads if the count reaches zero.
+   *
    * @see CountDownLatch#countDown()
    */
   public void countDown() {
@@ -56,7 +58,7 @@ public class CountUpAndDownLatch implements Serializable {
   /**
    * @see CountDownLatch#countDown()
    * @param delta
-   *        the amount to increment (or if negative, decrement countDown)
+   *        the amount to increment (or if negative, decrement countDown).
    */
   public void applyDelta(final int delta) {
     sync.releaseShared(delta);
@@ -82,6 +84,8 @@ public class CountUpAndDownLatch implements Serializable {
   }
 
   /**
+   * Returns the current count.
+   *
    * @see CountDownLatch#getCount()
    */
   public int getCount() {
@@ -89,13 +93,15 @@ public class CountUpAndDownLatch implements Serializable {
   }
 
   /**
-   * @return the original count this latch was created with
+   * @return the original count this latch was created with.
    */
   public int getOriginalCount() {
     return originalCount;
   }
 
   /**
+   * Causes the current thread to wait until the latch has counted down to zero, unless the thread is interrupted.
+   *
    * @see CountDownLatch#await()
    */
   public void await() throws InterruptedException {
@@ -103,6 +109,9 @@ public class CountUpAndDownLatch implements Serializable {
   }
 
   /**
+   * Causes the current thread to wait until the latch has counted down to zero, unless the thread is interrupted, or
+   * the specified waiting time elapses.
+   *
    * @see CountDownLatch#await(long,TimeUnit)
    */
   public boolean await(final long timeout, final TimeUnit unit) throws InterruptedException {

--- a/src/main/java/games/strategy/util/IntegerMap.java
+++ b/src/main/java/games/strategy/util/IntegerMap.java
@@ -16,7 +16,7 @@ public class IntegerMap<T> implements Cloneable, Serializable {
   private static final long serialVersionUID = 6856531659284300930L;
   private final HashMap<T, Integer> mapValues;
 
-  /** Creates new IntegerMap */
+  /** Creates new IntegerMap. */
   public IntegerMap() {
     mapValues = new HashMap<>();
   }
@@ -315,7 +315,7 @@ public class IntegerMap<T> implements Cloneable, Serializable {
   }
 
   /**
-   * Add map * multiple
+   * Add map * multiple.
    */
   public void addMultiple(final IntegerMap<T> map, final int multiple) {
     for (final T key : map.keySet()) {

--- a/src/main/java/games/strategy/util/InverseMatch.java
+++ b/src/main/java/games/strategy/util/InverseMatch.java
@@ -6,7 +6,7 @@ package games.strategy.util;
 public class InverseMatch<T> extends Match<T> {
   private final Match<T> match;
 
-  /** Creates new CompositeMatchOr */
+  /** Creates new InverseMatch. */
   public InverseMatch(final Match<T> aMatch) {
     match = aMatch;
   }

--- a/src/main/java/games/strategy/util/LinkedIntegerMap.java
+++ b/src/main/java/games/strategy/util/LinkedIntegerMap.java
@@ -17,7 +17,7 @@ public class LinkedIntegerMap<T> implements Cloneable, Serializable {
   private static final long serialVersionUID = 6856531659284300930L;
   private final LinkedHashMap<T, Integer> m_values;
 
-  /** Creates new IntegerMap */
+  /** Creates new LinkedIntegerMap. */
   public LinkedIntegerMap() {
     m_values = new LinkedHashMap<>();
   }
@@ -332,7 +332,7 @@ public class LinkedIntegerMap<T> implements Cloneable, Serializable {
   }
 
   /**
-   * Add map * multiple
+   * Add map * multiple.
    */
   public void addMultiple(final LinkedIntegerMap<T> map, final int multiple) {
     for (final T key : map.keySet()) {

--- a/src/main/java/games/strategy/util/MD5Crypt.java
+++ b/src/main/java/games/strategy/util/MD5Crypt.java
@@ -61,7 +61,7 @@ public class MD5Crypt {
   }
 
   /**
-   * LINUX/BSD MD5Crypt function
+   * LINUX/BSD MD5Crypt function.
    *
    * @return The encrypted password as an MD5 hash
    * @param password
@@ -80,7 +80,7 @@ public class MD5Crypt {
   }
 
   /**
-   * LINUX/BSD MD5Crypt function
+   * LINUX/BSD MD5Crypt function.
    *
    * @return The encrypted password as an MD5 hash
    * @param salt
@@ -116,7 +116,7 @@ public class MD5Crypt {
     }
     byte finalState[];
     long l;
-    /**
+    /*
      * Two MD5 hashes are used
      */
     MessageDigest ctx, ctx1;

--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -115,7 +115,7 @@ public abstract class Match<T> {
   }
 
   /**
-   * return the keys where the value keyed by the key matches valueMatch
+   * return the keys where the value keyed by the key matches valueMatch.
    */
   public static <K, V> Set<K> getKeysWhereValueMatch(final Map<K, V> aMap, final Match<V> valueMatch) {
     final Set<K> rVal = new HashSet<>();

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -21,10 +21,10 @@ import games.strategy.debug.ClientLogger;
 
 /**
  * Utiltity to read and write files in the form of
- * String -> a list of points, or string-> list of polygons
+ * String -> a list of points, or string-> list of polygons.
  */
 public class PointFileReaderWriter {
-  /** Creates a new instance of PointFileReader */
+  /** Creates a new instance of PointFileReader. */
   public PointFileReaderWriter() {}
 
   /**

--- a/src/main/java/games/strategy/util/SHA512Crypt.java
+++ b/src/main/java/games/strategy/util/SHA512Crypt.java
@@ -7,7 +7,7 @@ import java.security.NoSuchAlgorithmException;
 
 /**
  * Replacement for MD5Crypt
- * using SHA512 instead
+ * using SHA512 instead.
  *
  * Do not use for Passwords!
  * Use the BCrypt library instead!
@@ -17,14 +17,14 @@ public class SHA512Crypt {
   public static final String SHA_512 = "SHA-512";
 
   /**
-   * Returns the SHA256-Hash of the given String
+   * Returns the SHA256-Hash of the given String.
    */
   public static String crypt(final String text) {
     return crypt(text, "");
   }
 
   /**
-   * Returns the SHA256-Hash of the given String using the specified Salt
+   * Returns the SHA256-Hash of the given String using the specified Salt.
    */
   public static String crypt(final String text, final String salt) {
     try {

--- a/src/main/java/games/strategy/util/ThreadUtil.java
+++ b/src/main/java/games/strategy/util/ThreadUtil.java
@@ -1,6 +1,6 @@
 package games.strategy.util;
 
-/** Utility class for java Thread related operations */
+/** Utility class for java Thread related operations. */
 public class ThreadUtil {
 
 

--- a/src/main/java/games/strategy/util/UrlStreams.java
+++ b/src/main/java/games/strategy/util/UrlStreams.java
@@ -44,7 +44,7 @@ public final class UrlStreams {
     }
   }
 
-  /** Used to obtain a connection from a given URL */
+  /** Used to obtain a connection from a given URL. */
   private final Function<URL, URLConnection> urlConnectionFactory;
 
 
@@ -60,7 +60,7 @@ public final class UrlStreams {
   }
 
   /**
-   * For test, a constructor that allows mock object injection
+   * For test, a constructor that allows mock object injection.
    */
   protected UrlStreams(final Function<URL, URLConnection> connectionFactory) {
     this.urlConnectionFactory = connectionFactory;

--- a/src/main/java/games/strategy/util/Util.java
+++ b/src/main/java/games/strategy/util/Util.java
@@ -96,7 +96,7 @@ public class Util {
   }
 
   /**
-   * returns a list of everything in source, with the first count units moved to the end
+   * returns a list of everything in source, with the first count units moved to the end.
    */
   public static <T> List<T> shiftElementsToEnd(final List<T> source, final int count) {
     final ArrayList<T> rVal = new ArrayList<>(source.size());
@@ -112,11 +112,11 @@ public class Util {
     return rVal;
   }
 
-  /** Creates new Util */
+  /** Creates new Util. */
   private Util() {}
 
   /**
-   * allow multiple fully qualified email adresses seperated by spaces, or a blank string
+   * allow multiple fully qualified email addresses separated by spaces, or a blank string.
    */
   public static boolean isMailValid(final String emailAddress) {
     final String QUOTEDSTRING = "\"(?:[^\"\\\\]|\\\\\\p{ASCII})*\"";

--- a/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/src/main/java/tools/image/ReliefImageBreaker.java
@@ -207,7 +207,7 @@ public class ReliefImageBreaker {
   }
 
   /**
-   * Sets the alpha channel to the same as that of the base image
+   * Sets the alpha channel to the same as that of the base image.
    */
   private static void blankOutline(final Image alphaChannelImage, final BufferedImage relief) {
     final Graphics2D gc = (Graphics2D) relief.getGraphics();

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -222,7 +222,7 @@ public class ConnectionFinder {
   }
 
   /**
-   * Converts a map of connections to XML formatted text with the connections
+   * Converts a map of connections to XML formatted text with the connections.
    *
    * @param connections
    *        a map of connections between Territories
@@ -243,7 +243,7 @@ public class ConnectionFinder {
   }
 
   /**
-   * Returns the size of the area of the boundingbox of the polygon
+   * Returns the size of the area of the bounding box of the polygon.
    *
    * @param area
    *        the area of which the boundingbox size is measured

--- a/src/main/java/tools/map/making/ImageIoCompletionWatcher.java
+++ b/src/main/java/tools/map/making/ImageIoCompletionWatcher.java
@@ -5,7 +5,7 @@ import java.awt.image.ImageObserver;
 import java.util.concurrent.CountDownLatch;
 
 /**
- * Code originally contributed by "Thomas Carvin"
+ * Code originally contributed by "Thomas Carvin".
  */
 public class ImageIoCompletionWatcher implements ImageObserver {
   // we countdown when we are done

--- a/src/main/java/tools/map/xml/creator/CanalDefinitionsPanel.java
+++ b/src/main/java/tools/map/xml/creator/CanalDefinitionsPanel.java
@@ -198,7 +198,7 @@ public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
   }
 
   /**
-   * @param newTerrName - territory name
+   * @param newTerrName - territory name.
    * @param newTerrIsWater - IS_WATER property of newTerrName territory
    * @param newTerrNeighborsDiffType - list of neighbor territories with/without (defined by newTerrIsWater) property
    *        IS_WATER
@@ -325,7 +325,7 @@ public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
   }
 
   /**
-   * @param newTerrName - base territory
+   * @param newTerrName - base territory.
    * @param newTerrIsWater - IS_WATER property of base territory
    * @param terrCanals - list of canals the base territory is linked to
    */
@@ -359,7 +359,7 @@ public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
   }
 
   /**
-   * @return suggested canal name
+   * @return suggested canal name.
    */
   private String getSuggestedCanalName() {
     String suggestedCanalName;
@@ -379,7 +379,7 @@ public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
 
   /**
    *
-   * @param newTerrName - territory name
+   * @param newTerrName - territory name.
    * @param waterNeighbors - whether IS_WATER property is supposed to be present or not
    * @return list of neighbor territories with/without (defined by waterNeighbors) property IS_WATER
    */
@@ -419,7 +419,7 @@ public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
   }
 
   /**
-   * @param terrList - list of territories for which neighbors should be evaluated
+   * @param terrList - list of territories for which neighbors should be evaluated.
    * @param typeIsWater - filter criteria of neighbors by their property IS_WATER
    * @return map of terrList list territory entry -> neighbor territories with/without (defined by typeIsWater) IS_WATER
    *         property

--- a/src/main/java/tools/map/xml/creator/DynamicRowsPanel.java
+++ b/src/main/java/tools/map/xml/creator/DynamicRowsPanel.java
@@ -115,7 +115,7 @@ public abstract class DynamicRowsPanel {
   }
 
   /**
-   * @return number of rows
+   * @return number of rows.
    */
   public int countRows() {
     return rows.size() + 1;

--- a/src/main/java/tools/map/xml/creator/GameSequencePanel.java
+++ b/src/main/java/tools/map/xml/creator/GameSequencePanel.java
@@ -68,7 +68,7 @@ public class GameSequencePanel extends DynamicRowsPanel {
 
   /**
    * @param gridBadConstLabelSequenceName GridBagConstraints object for "Sequence Name" label and default for other
-   *        labels
+   *        labels.
    */
   private void addLabelsRow(final GridBagConstraints gridBadConstLabelSequenceName) {
     final JLabel labelSequenceName = new JLabel("Sequence Name");
@@ -86,11 +86,6 @@ public class GameSequencePanel extends DynamicRowsPanel {
     getOwnPanel().add(labelDisplayName, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelSequenceName, 2, 0));
   }
 
-  /**
-   * @param gbcBase
-   * @param rowIndex
-   * @param rowEntry
-   */
   private void addMainInputRow(final GridBagConstraints gbcBase, final int rowIndex,
       final Entry<String, List<String>> rowEntry) {
     final List<String> defintionValues = rowEntry.getValue();

--- a/src/main/java/tools/map/xml/creator/ImageScrollPanePanel.java
+++ b/src/main/java/tools/map/xml/creator/ImageScrollPanePanel.java
@@ -102,9 +102,6 @@ public abstract class ImageScrollPanePanel {
     return imagePanel;
   }
 
-  /**
-   *
-   */
   protected void addMouseAdapterToImagePanel() {
     final MouseAdapter imageMouseAdapter = new MouseAdapter() {
       private final Cursor defCursor = Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR);

--- a/src/main/java/tools/map/xml/creator/MapXmlCreator.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlCreator.java
@@ -347,9 +347,6 @@ public class MapXmlCreator extends JFrame {
     }
   }
 
-  /**
-   * @return
-   */
   public File getDefaultMapXmlFile() {
     return new File(getDefaultMapFolderLocation() + File.separator + "new_world_order"
         + File.separator + "games" + File.separator + "new_world_order.xml");
@@ -359,9 +356,6 @@ public class MapXmlCreator extends JFrame {
     return ClientFileSystemHelper.getUserMapsFolder();
   }
 
-  /**
-   * @return
-   */
   private Action createMenuBar() {
     // set up the actions
     final Action openAction = SwingAction.of("Load Map XML", e -> {
@@ -682,9 +676,6 @@ public class MapXmlCreator extends JFrame {
     });
   }
 
-  /**
-   *
-   */
   private void addSouthCenterPanelButtons() {
     buttonBack = new JButton("Back");
     buttonBack.setMnemonic(KeyEvent.VK_B);
@@ -707,9 +698,6 @@ public class MapXmlCreator extends JFrame {
     southCenterPanel.add(nextButton);
   }
 
-  /**
-   *
-   */
   private void invokeLaterRepaintActionPanel() {
     SwingUtilities.invokeLater(() -> {
       actionPanel.validate();
@@ -1080,14 +1068,6 @@ public class MapXmlCreator extends JFrame {
     }
   }
 
-  /**
-   * @param gameXMLPath
-   * @return
-   * @throws FileNotFoundException
-   * @throws SAXException
-   * @throws IOException
-   * @throws ParserConfigurationException
-   */
   public static GameStep loadXmlFromFilePath(final String gameXMLPath)
       throws SAXException, IOException, ParserConfigurationException {
     final FileInputStream in = new FileInputStream(gameXMLPath);

--- a/src/main/java/tools/map/xml/creator/MapXmlHelper.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlHelper.java
@@ -470,7 +470,7 @@ public class MapXmlHelper {
 
   /**
    * @param gameNode
-   * @return step to go to
+   * @return step to go to.
    */
   public static GameStep parseGameNode(final Node gameNode) {
     GameStep stepToGo = MapXmlCreator.GAME_STEP_FIRST;
@@ -941,10 +941,6 @@ public class MapXmlHelper {
     return doc;
   }
 
-  /**
-   * @param doc
-   * @param game
-   */
   private static void appendInitialize(final Document doc, final Element game) {
     final Element initialize = doc.createElement(XML_NODE_NAME_INITIALIZE);
     game.appendChild(initialize);
@@ -956,10 +952,6 @@ public class MapXmlHelper {
     appendPropertyList(doc, game);
   }
 
-  /**
-   * @param doc
-   * @param game
-   */
   private static void appendPropertyList(final Document doc, final Element game) {
     final Element propertyList = doc.createElement(XML_NODE_NAME_PROPERTY_LIST);
     game.appendChild(propertyList);
@@ -1279,7 +1271,7 @@ public class MapXmlHelper {
 
   // TODO REPLACE 'endsWith("NonCombatMove")'-checks IN REMAINING PROJEKT
   /**
-   * @param stepName - string of the step name
+   * @param stepName - string of the step name.
    * @return true if string ends with "NonCombatMove", false otherwise
    */
   private static boolean stepNameIndicatesNonCombatMove(final String stepName) {

--- a/src/main/java/tools/map/xml/creator/MapXmlUIHelper.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlUIHelper.java
@@ -20,7 +20,7 @@ public class MapXmlUIHelper {
 
   /**
    *
-   * @param title - the title string for the dialog
+   * @param title - the title string for the dialog.
    * @param message - the Object to display
    * @param messageType - an integer designating the kind of message this is, primarily used to determine the icon from
    *        the pluggable Look and Feel: ERROR_MESSAGE, INFORMATION_MESSAGE, WARNING_MESSAGE, QUESTION_MESSAGE, or
@@ -57,7 +57,7 @@ public class MapXmlUIHelper {
 
   /**
    *
-   * @param title - the title string for the dialog
+   * @param title - the title string for the dialog.
    * @param message - the Object to display
    * @param messageType - an integer designating the kind of message this is, primarily used to determine the icon from
    *        the pluggable Look and Feel: ERROR_MESSAGE, INFORMATION_MESSAGE, WARNING_MESSAGE, QUESTION_MESSAGE, or
@@ -134,7 +134,7 @@ public class MapXmlUIHelper {
   }
 
   /**
-   * @param gbcToClone base GridBagConstraints object
+   * @param gbcToClone base GridBagConstraints object.
    * @param gridx gridx value for new GridBagConstraints object
    * @param gridy gridy value for new GridBagConstraints object
    * @param anchor anchor value for new GridBagConstraints object
@@ -148,7 +148,7 @@ public class MapXmlUIHelper {
   }
 
   /**
-   * @param gbcToClone base GridBagConstraints object
+   * @param gbcToClone base GridBagConstraints object.
    * @param gridx gridx value for new GridBagConstraints object
    * @param gridy gridy value for new GridBagConstraints object
    * @return cloned GridBagConstraints object with provided gridx and gridy values
@@ -176,7 +176,7 @@ public class MapXmlUIHelper {
 
   /**
    *
-   * @param gridx - gridx value for new GridBagConstraints object
+   * @param gridx - gridx value for new GridBagConstraints object.
    * @param gridy - gridx value for new GridBagConstraints object
    * @return new GridBagConstraints based on gbcTemplate and provided data
    */

--- a/src/main/java/tools/map/xml/creator/TerritoryConnectionsPanel.java
+++ b/src/main/java/tools/map/xml/creator/TerritoryConnectionsPanel.java
@@ -162,7 +162,7 @@ public class TerritoryConnectionsPanel extends ImageScrollPanePanel {
   }
 
   /**
-   * Forces the user to either enter nothing or a positive integer
+   * Forces the user to either enter nothing or a positive integer.
    *
    * @return input value or 0 if nothing has been entered
    */

--- a/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
+++ b/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
@@ -41,7 +41,7 @@ public class TestDelegateBridge implements ITestDelegateBridge {
   private final IDelegateHistoryWriter m_historyWriter;
   private IRemotePlayer m_remote;
 
-  /** Creates new TestDelegateBridge */
+  /** Creates new TestDelegateBridge. */
   public TestDelegateBridge(final GameData data, final PlayerID id, final IDisplay dummyDisplay) {
     m_data = data;
     m_id = id;
@@ -129,9 +129,6 @@ public class TestDelegateBridge implements ITestDelegateBridge {
     }
   }
 
-  /**
-   * Returns the current step name
-   */
   @Override
   public String getStepName() {
     return m_stepName;

--- a/src/test/java/games/strategy/engine/data/annotations/ExampleAttachment.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ExampleAttachment.java
@@ -8,7 +8,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.util.IntegerMap;
 
 /**
- * Test attachment that demonstrates how @GameProperty is used
+ * Test attachment that demonstrates how @GameProperty is used.
  */
 public class ExampleAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -5820318094331518742L;

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidClearExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidClearExample.java
@@ -8,7 +8,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.util.IntegerMap;
 
 /**
- * Class with an invalidly named clear method
+ * Class with an invalidly named clear method.
  */
 public class InvalidClearExample extends DefaultAttachment {
   private static final long serialVersionUID = 113427104352979892L;

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidFieldNameExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidFieldNameExample.java
@@ -6,7 +6,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 
 /**
- * Class with an invalid field that doesn't match the setter annotated with @GameProperty
+ * Class with an invalid field that doesn't match the setter annotated with @GameProperty.
  */
 public class InvalidFieldNameExample extends DefaultAttachment {
   private static final long serialVersionUID = 2902170223595163219L;

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidFieldTypeExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidFieldTypeExample.java
@@ -8,7 +8,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.util.IntegerMap;
 
 /**
- * Class with an invalid return for an adder (the return type must be an integerMap)
+ * Class with an invalid return for an adder (the return type must be an integerMap).
  */
 public class InvalidFieldTypeExample extends DefaultAttachment {
   private static final long serialVersionUID = 6465866180845982327L;

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidGetterExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidGetterExample.java
@@ -6,7 +6,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 
 /**
- * An example where the @GameProperty is used on a non-setter
+ * An example where the @GameProperty is used on a non-setter.
  */
 public class InvalidGetterExample extends DefaultAttachment {
   private static final long serialVersionUID = 8284101951970184012L;

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidResetExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidResetExample.java
@@ -8,7 +8,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.util.IntegerMap;
 
 /**
- * Class with an invalidly named clear method
+ * Class with an invalidly named clear method.
  */
 public class InvalidResetExample extends DefaultAttachment {
   private static final long serialVersionUID = 113427104352979892L;

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidReturnTypeExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidReturnTypeExample.java
@@ -6,7 +6,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 
 /**
- * Example that used @GameProperty and has a getter with an invalid return type
+ * Example that used @GameProperty and has a getter with an invalid return type.
  */
 public class InvalidReturnTypeExample extends DefaultAttachment {
   private static final long serialVersionUID = -4598237822854346073L;

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -40,11 +40,11 @@ import games.strategy.util.IntegerMap;
 import games.strategy.util.PropertyUtil;
 
 /**
- * A test that validates that all attachment classes have properties with valid setters and getters
+ * A test that validates that all attachment classes have properties with valid setters and getters.
  */
 public class ValidateAttachmentsTest {
   /**
-   * Test that the Example Attachment is valid
+   * Test that the Example Attachment is valid.
    */
   @Test
   public void testExample() {
@@ -53,7 +53,7 @@ public class ValidateAttachmentsTest {
   }
 
   /**
-   * Tests that the algorithm finds invalidly named field
+   * Tests that the algorithm finds invalidly named field.
    */
   @Test
   public void testInvalidField() {
@@ -63,7 +63,7 @@ public class ValidateAttachmentsTest {
   }
 
   /**
-   * tests that the algorithm will find invalid annotation on a getters
+   * tests that the algorithm will find invalid annotation on a getters.
    */
   @Test
   public void testAnnotationOnGetter() {
@@ -73,7 +73,7 @@ public class ValidateAttachmentsTest {
   }
 
   /**
-   * Tests that the algorithm will find invalid return types
+   * Tests that the algorithm will find invalid return types.
    */
   @Test
   public void testInvalidReturnType() {
@@ -83,7 +83,7 @@ public class ValidateAttachmentsTest {
   }
 
   /**
-   * Tests that the algorithm will find invalid clear method
+   * Tests that the algorithm will find invalid clear method.
    */
   @Test
   public void testInvalidClearMethod() {
@@ -93,7 +93,7 @@ public class ValidateAttachmentsTest {
   }
 
   /**
-   * Tests that the algorithm will find invalid clear method
+   * Tests that the algorithm will find invalid clear method.
    */
   @Test
   public void testInvalidResetMethod() {
@@ -103,7 +103,7 @@ public class ValidateAttachmentsTest {
   }
 
   /**
-   * Tests that the algorithm will find adders that doesn't have type IntegerMap
+   * Tests that the algorithm will find adders that doesn't have type IntegerMap.
    */
   @Test
   public void testInvalidFieldType() {
@@ -151,7 +151,7 @@ public class ValidateAttachmentsTest {
 
   /**
    * Scans the compiled /classes folder and finds all classes that implement IAttachment to verify that
-   * all @GameProperty have valid setters and getters
+   * all @GameProperty have valid setters and getters.
    */
   @Test
   public void testAllAttachments() {
@@ -182,7 +182,7 @@ public class ValidateAttachmentsTest {
 
   /**
    * Recursive method to find all classes that implement IAttachment and validate that they use the @GameProperty
-   * annotation correctly
+   * annotation correctly.
    *
    * @param file
    *        the file or directory
@@ -233,7 +233,7 @@ public class ValidateAttachmentsTest {
    * ReliefImageBreaker and TileImageBreaker has a static field that opens a save dialog!!!
    * "InvalidGetterExample", "InvalidFieldNameExample", "InvalidReturnTypeExample" are skipped because they are
    * purposely invalid, and use
-   * to test the validation algorithm
+   * to test the validation algorithm.
    */
   public static final List<String> SKIPCLASSES = Arrays.asList("ReliefImageBreaker", "TileImageBreaker",
       "InvalidGetterExample", "InvalidFieldNameExample", "InvalidReturnTypeExample", "InvalidClearExample",
@@ -242,7 +242,7 @@ public class ValidateAttachmentsTest {
   /**
    * Contains a list of classes which has static initializes, unfortunately you can't reflect this, since loading the
    * class triggers
-   * the initializer
+   * the initializer.
    *
    * @param className
    *        the class name

--- a/src/test/java/games/strategy/engine/data/gameparser/XmlGameElementMapperTest.java
+++ b/src/test/java/games/strategy/engine/data/gameparser/XmlGameElementMapperTest.java
@@ -16,7 +16,7 @@ import games.strategy.triplea.delegate.BattleDelegate;
 
 
 /**
- * Simple test of XmlGameElementMapper to verify error handling and a quick check of the happy case
+ * Simple test of XmlGameElementMapper to verify error handling and a quick check of the happy case.
  */
 public class XmlGameElementMapperTest {
   private static final String NAME_THAT_DOES_NOT_EXIST = "this is surely not a valid identifier";

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadPropertiesTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadPropertiesTest.java
@@ -14,7 +14,7 @@ import games.strategy.engine.config.PropertyReader;
 
 /**
  * Basic test of map listing source, make sure that the test object requests a specific property key,
- * we fake a return value, then verify that we get the same faked value back when calling 'getMapListDownloadSite()'
+ * we fake a return value, then verify that we get the same faked value back when calling 'getMapListDownloadSite()'.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class MapDownloadPropertiesTest {

--- a/src/test/java/games/strategy/engine/framework/ui/NewGameChooserModelTest.java
+++ b/src/test/java/games/strategy/engine/framework/ui/NewGameChooserModelTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 public class NewGameChooserModelTest {
 
-  /** Simply create the object to see that we can do that without exception */
+  /** Simply create the object to see that we can do that without exception. */
   @Test
   public void testCreate() {
     new NewGameChooserModel();

--- a/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -320,7 +320,7 @@ public class AirThatCantLandUtilTest {
     assertEquals(expectedCountCanada, postCountInt);
   }
 
-  /** @deprecated Use a mock object instead */
+  /** @deprecated Use a mock object instead. */
   @Deprecated
   private static ITripleAPlayer getDummyPlayer() {
     final InvocationHandler handler = new InvocationHandler() {

--- a/src/test/java/games/strategy/triplea/delegate/LHTRTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LHTRTest.java
@@ -232,7 +232,7 @@ public class LHTRTest {
 
 /**
  * a random source that throws when asked for random
- * usefule for testing
+ * useful for testing.
  */
 class ThrowingRandomSource implements IRandomSource {
   @Override

--- a/src/test/java/games/strategy/util/UrlStreamsTest.java
+++ b/src/test/java/games/strategy/util/UrlStreamsTest.java
@@ -39,7 +39,7 @@ public class UrlStreamsTest {
   }
 
   /**
-   * Check that we turned off caching on a mocked UrlConnection
+   * Check that we turned off caching on a mocked UrlConnection.
    */
   @Test
   public void cacheIsOff() throws Exception {


### PR DESCRIPTION
This PR fixes violations of the Checkstyle SummaryJavadoc rule.  Specifically, the subrule "First sentence of Javadoc is incomplete (period is missing) or not present."  These violations were nearly pure noise that account for almost 9% of the remaining Checkstyle violations.

This is a huge PR, but **all changes are to Javadocs; there are no changes to actual code.**  I don't expect that a careful review is required.  A few spot checks should be all that's necessary.

More than 95% of the changes simply add a period to the end of a sentence.  However, there were a few exceptions in which I did one of the following instead:

* Removed a useless Javadoc comment on a private method or an override.  By useless, I mean, for example, all it had were empty `@param` tags with no descriptions.
* Converted a Javadoc comment to a normal block comment if it was in a location that is not applicable to Javadoc.  For example, a Javadoc comment on a local variable or on some arbitrary statement within a method.

If I modified a line for one of the above reasons, and I happened to notice an obvious error on that line, I fixed it.  Such errors include:

* Misspelled words
* Wrong class name was used in the Javadocs for a constructor