### PR TITLE
Checkstyle: Fix Javadoc structural violations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=8144
-checkstyleTestMaxWarnings=385
+checkstyleMainMaxWarnings=7798
+checkstyleTestMaxWarnings=381

--- a/src/main/java/games/strategy/engine/ClientContext.java
+++ b/src/main/java/games/strategy/engine/ClientContext.java
@@ -14,14 +14,19 @@ import games.strategy.triplea.settings.scrolling.ScrollSettings;
  * IOC container for storing objects needed by the TripleA Swing client
  * A full blow dependency injection framework would deprecate this class.
  *
+ * <p>
  * This class roughly follows the singleton pattern. The singleton instance
  * can be updated, this is allowed to enable a mock instance of this class to
  * be used.
+ * </p>
  *
+ * <p>
  * Caution: the public API of this class will grow to be fairly large. For every object we wish to return, we'll have an
  * "object()" method that will returns that same object. When things become hard to manage it'll be a good time
  * to move to an annotation or configuration based IOC framework.
+ * </p>
  *
+ * <p>
  * Second note, try to put as much class specific construction logic into the constructor of each class managed by this
  * container. This class should focus on just creating and wiring classes together. Contrast that with generating the
  * data
@@ -32,10 +37,13 @@ import games.strategy.triplea.settings.scrolling.ScrollSettings;
  * pass that intermediary class to the new class we wish to create. Said in another way, this class should not contain
  * any 'business'
  * logic.
+ * </p>
  *
+ * <p>
  * Third Note: Any classes created by ClientContext cannot call ClientContext in their constructor, all dependencies
  * must be passed to them.
  * Since GameRunner creates ClientContext, similar none of the classes created by Client Context can game runner 2
+ * </p>
  */
 public final class ClientContext {
   private static final ClientContext instance = new ClientContext();

--- a/src/main/java/games/strategy/engine/GameOverException.java
+++ b/src/main/java/games/strategy/engine/GameOverException.java
@@ -2,11 +2,15 @@ package games.strategy.engine;
 
 /**
  * Thrown when the game is over.
+ *
  * <p>
  * Normally delegates should not catch this, but let it propogate.
+ * </p>
+ *
  * <p>
  * Displays and players should handle this as it may be thrown by delegates remotes if a method is executed after the
  * game is finished.
+ * </p>
  */
 public class GameOverException extends RuntimeException {
   private static final long serialVersionUID = -167666722695780120L;

--- a/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/src/main/java/games/strategy/engine/chat/Chat.java
@@ -22,9 +22,10 @@ import games.strategy.util.Tuple;
 
 /**
  * chat logic.
+ *
  * <p>
  * A chat can be bound to multiple chat panels.
- * <p>
+ * </p>
  */
 public class Chat {
   private final List<IChatListener> listeners = new CopyOnWriteArrayList<>();

--- a/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -35,9 +35,14 @@ import games.strategy.ui.SwingAction;
 
 /**
  * A Chat window.
+ *
+ * <p>
  * Mutiple chat panels can be connected to the same Chat.
+ * </p>
+ *
  * <p>
  * We can change the chat we are connected to using the setChat(...) method.
+ * </p>
  */
 public class ChatMessagePanel extends JPanel implements IChatListener {
   private static final long serialVersionUID = 118727200083595226L;

--- a/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -15,9 +15,14 @@ import games.strategy.net.IMessenger;
 
 /**
  * A Chat window.
+ *
+ * <p>
  * Mutiple chat panels can be connected to the same Chat.
+ * </p>
+ *
  * <p>
  * We can change the chat we are connected to using the setChat(...) method.
+ * </p>
  */
 public class ChatPanel extends JPanel implements IChatPanel {
   private static final long serialVersionUID = -6177517517279779486L;

--- a/src/main/java/games/strategy/engine/chat/IChatController.java
+++ b/src/main/java/games/strategy/engine/chat/IChatController.java
@@ -8,13 +8,16 @@ import games.strategy.util.Tuple;
 
 /**
  * A central controller of who is in the chat.
+ *
  * <p>
  * When joining you get a list of all the players currently in the chat
+ * </p>
+ *
  * <p>
  * To handle un-ordered comings and going into the chat, we send a version number with each chat change. The init method
  * is the sum of all
  * changes &lt; the version number returned in the init message.
- * <p>
+ * </p>
  */
 public interface IChatController extends IRemote {
   /**

--- a/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -28,7 +28,7 @@ public class CompositeRouteFinder {
    * way.
    *
    * @param map
-   *        - Game map found through <gamedata>.getMap()
+   *        - Game map found through &lt;gamedata>.getMap()
    * @param matches
    *        - Set of matches and scores. The lower a match is scored, the more favorable it is.
    */

--- a/src/main/java/games/strategy/engine/data/GameData.java
+++ b/src/main/java/games/strategy/engine/data/GameData.java
@@ -30,12 +30,18 @@ import games.strategy.util.Version;
 
 /**
  * Central place to find all the information for a running game.
+ *
+ * <p>
  * Using this object you can find the territories, connections, production rules,
  * unit types...
+ * </p>
+ *
  * <p>
  * Threading. The game data, and all parts of the game data (such as Territories, Players, Units...) are protected by a
  * read/write lock. If
  * you are reading the game data, you should read while you have the read lock as below.
+ * </p>
+ *
  * <p>
  * <code>
  * data.acquireReadLock();
@@ -51,11 +57,13 @@ import games.strategy.util.Version;
  * The exception is delegates within a start(), end() or any method called from an IGamePlayer through the delegates
  * remote interface. The
  * delegate will have a read lock for the duration of those methods.
+ * </p>
+ *
  * <p>
  * Non engine code must NOT acquire the games writeLock(). All changes to game Data must be made through a
  * DelegateBridge or through a
  * History object.
- * <p>
+ * </p>
  */
 public class GameData implements java.io.Serializable {
   private static final long serialVersionUID = -2612710634080125728L;

--- a/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/src/main/java/games/strategy/engine/data/GameStep.java
@@ -6,9 +6,11 @@ import games.strategy.engine.delegate.IDelegate;
 
 /**
  * A single step in a game.
+ *
  * <p>
  * Typically turn based strategy games are composed of a set of distinct phases (in chess this would be two, white move,
  * black move).
+ * </p>
  */
 public class GameStep extends GameDataComponent {
   private static final long serialVersionUID = -7944468945162840931L;

--- a/src/main/java/games/strategy/engine/data/Route.java
+++ b/src/main/java/games/strategy/engine/data/Route.java
@@ -17,6 +17,7 @@ import games.strategy.util.Util;
 
 /**
  * A route between two territories.
+ *
  * <p>
  * A route consists of a start territory, and a sequence of steps. To create a route do,
  * <code>
@@ -25,6 +26,7 @@ import games.strategy.util.Util;
  * route.add(anotherTerritory);
  * route.add(yetAnotherTerritory);
  * </code>
+ * </p>
  */
 public class Route implements Serializable, Iterable<Territory> {
   private static final long serialVersionUID = 8743882455488948557L;

--- a/src/main/java/games/strategy/engine/data/SerializationProxySupport.java
+++ b/src/main/java/games/strategy/engine/data/SerializationProxySupport.java
@@ -3,43 +3,54 @@ package games.strategy.engine.data;
 
 /**
  * Annotation to mark magic 'writeReplace' methods that are used to support the serialization proxy pattern:
- * - https://github.com/triplea-game/triplea/issues/814
- * - http://blog.codefx.org/design/patterns/serialization-proxy-pattern/
- * - https://dzone.com/articles/serialization-proxy-pattern
- * - http://vard-lokkur.blogspot.com/2014/06/serialization-proxy-pattern-example.html
- * - https://youtu.be/V1vQf4qyMXg?t=56m12s
  *
+ * <ul>
+ * <li>https://github.com/triplea-game/triplea/issues/814</li>
+ * <li>http://blog.codefx.org/design/patterns/serialization-proxy-pattern/</li>
+ * <li>https://dzone.com/articles/serialization-proxy-pattern</li>
+ * <li>http://vard-lokkur.blogspot.com/2014/06/serialization-proxy-pattern-example.html</li>
+ * <li>https://youtu.be/V1vQf4qyMXg?t=56m12s</li>
+ * </ul>
+ *
+ * <p>
  * A typical usage of this annotation will and pattern will look like this:
- * Code formatted below for easy copy paste:<code>
-     &#64;SerializationProxySupport
-     protected Object writeReplace() {
-       return new SerializationProxy(this);
-     }
-
-     private static class SerializationProxy implements Serializable {
-       private static final long serialVersionUID = -4193924040595347947L;
-       private final Multimap<PlayerID, String> alliances;
-
-       // Copy constructor is okay using private API
-       public SerializationProxy(AllianceTracker allianceTracker) {
-         alliances = ImmutableMultimap.copyOf(allianceTracker.alliances);
-       }
-
-       // This method MUST only use public APIs
-       protected Object readResolve() {
-         return new AllianceTracker(alliances);
-       }
-     }
- * </code>
+ * Code formatted below for easy copy paste:
+ * </p>
  *
+ * <pre>
+ * &#64;SerializationProxySupport
+ * protected Object writeReplace() {
+ *   return new SerializationProxy(this);
+ * }
+ *
+ * private static class SerializationProxy implements Serializable {
+ *   private static final long serialVersionUID = -4193924040595347947L;
+ *   private final Multimap&lt;PlayerID, String> alliances;
+ *
+ *   // Copy constructor is okay using private API
+ *   public SerializationProxy(AllianceTracker allianceTracker) {
+ *     alliances = ImmutableMultimap.copyOf(allianceTracker.alliances);
+ *   }
+ *
+ *   // This method MUST only use public APIs
+ *   protected Object readResolve() {
+ *     return new AllianceTracker(alliances);
+ *   }
+ * }
+ * </pre>
+ *
+ * <p>
  * IMPORTANT: It is critical that the 'readResolve' method only calls public APIs on the
  * proxied object.
  * On the other hand, it is okay for the serialization proxy constructor to use class private
  * data members.
+ * </p>
  *
+ * <p>
  * This way you only are using public methods to recreate your object on a read, so long as
  * those methods are left
  * in place, we will be able to load games between versions.
+ * </p>
  */
 public @interface SerializationProxySupport {
 }

--- a/src/main/java/games/strategy/engine/data/annotations/InternalDoNotExport.java
+++ b/src/main/java/games/strategy/engine/data/annotations/InternalDoNotExport.java
@@ -9,8 +9,10 @@ import java.lang.annotation.Target;
  * Annotation that marks a method setter or field as being only used within this class and any class that extends it,
  * and NOT being used through reflection by the GameParser (through the xml) and also not by PropertyUtil (through the
  * ChangeFactory).
+ *
  * <p>
  * Do NOT export anything marked with this.
+ * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})

--- a/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
@@ -28,13 +28,20 @@ import games.strategy.triplea.delegate.dataObjects.BattleRecords;
 import games.strategy.util.IntegerMap;
 
 /**
- * All changes made to GameData should be made through changes produced here. <br>
- * The way to change game data is to <br>
- * 1) Create a change with a ChangeFactory.change** or ChangeFactory.set**
- * method <br>
- * 2) Execute that change through DelegateBridge.addChange()).
+ * All changes made to GameData should be made through changes produced here.
+ *
+ * <p>
+ * The way to change game data is to
+ * </p>
+ *
+ * <ol>
+ * <li>Create a change with a ChangeFactory.change** or ChangeFactory.set** method</li>
+ * <li>Execute that change through DelegateBridge.addChange()</li>
+ * </ol>
+ *
  * <p>
  * In this way changes to the game data can be co-ordinated across the network.
+ * </p>
  */
 public class ChangeFactory {
   public static final Change EMPTY_CHANGE = new Change() {

--- a/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
+++ b/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
@@ -50,14 +50,20 @@ import games.strategy.twoIfBySea.delegate.InitDelegate;
 /**
  * This class creates objects referred to by game XMLs via the 'javaClass' property, eg:
  *
- * <attachment name="territoryAttachment" attachTo="Rason"
+ * <pre>
+ * &lt;attachment name="territoryAttachment" attachTo="Rason"
  * javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+ * </pre>
  *
+ * <p>
  * In the above example, we are going to map the String value "games.strategy.triplea.attachments.TerritoryAttachment"
  * to a class constructor.
+ * </p>
  *
+ * <p>
  * Note: attachments and delegates are initialized slightly differently, one is is no-arg the other has initialization
  * parameters.
+ * </p>
  */
 public class XmlGameElementMapper {
 

--- a/src/main/java/games/strategy/engine/data/properties/ColorProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/ColorProperty.java
@@ -13,9 +13,11 @@ import javax.swing.SwingUtilities;
 
 /**
  * User editable property representing a color.
+ *
  * <p>
  * Presents a clickable label with the currently selected color, through which a color swatch panel is accessable to
  * change the color.
+ * </p>
  */
 public class ColorProperty extends AEditableProperty {
   private static final long serialVersionUID = 6826763550643504789L;

--- a/src/main/java/games/strategy/engine/data/properties/FileProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/FileProperty.java
@@ -17,9 +17,11 @@ import games.strategy.engine.framework.system.SystemProperties;
 
 /**
  * User editable property representing a file.
+ *
  * <p>
  * Presents a clickable label with the currently selected file name, through which a file dialog panel is accessible to
  * change the file.
+ * </p>
  */
 public class FileProperty extends AEditableProperty {
   private static final long serialVersionUID = 6826763550643504789L;

--- a/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
+++ b/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
@@ -16,15 +16,18 @@ import games.strategy.triplea.util.WrappedInvocationHandler;
 
 /**
  * Manages when delegates are allowed to execute.
+ *
  * <p>
  * When saving a game, we want to ensure that no delegate is executing, otherwise the delegate could modify the state of
  * the game while the
  * game is being saved, resulting in an invalid save game.
+ * </p>
+ *
  * <p>
  * This class effectivly keeps a count of how many threads are executing in the delegates, and provides a way of
  * blocking further threads
  * from starting execution in a delegate.
- * <p>
+ * </p>
  */
 public class DelegateExecutionManager {
   private final Logger sm_logger = Logger.getLogger(DelegateExecutionManager.class.getName());
@@ -44,11 +47,14 @@ public class DelegateExecutionManager {
   /**
    * When this method returns true, threads will not be able to enter delegates until
    * a call to resumeDelegateExecution is made.
+   *
    * <p>
    * When delegateExecution is blocked, it also blocks subsequent cals to blockDelegateExecution(...)
+   * </p>
+   *
    * <p>
    * If timeToWaitMS is > 0, we will give up trying to block delegate execution after timeTiWaitMS has elapsed.
-   * <p>
+   * </p>
    *
    * @param timeToWait
    */
@@ -94,9 +100,11 @@ public class DelegateExecutionManager {
 
   /**
    * Used to create an object the exits delegate execution.
+   *
    * <p>
    * Objects on this method will decrement the thread lock count when called, and will increment it again when execution
    * is finished.
+   * </p>
    */
   public Object createOutboundImplementation(final Object implementor, final Class<?>[] interfaces) {
     assertGameNotOver();
@@ -130,9 +138,11 @@ public class DelegateExecutionManager {
 
   /**
    * Use to create an object that begins delegate execution.
+   *
    * <p>
    * Objects on this method will increment the thread lock count when called, and will decrement it again when execution
    * is finished.
+   * </p>
    */
   public Object createInboundImplementation(final Object implementor, final Class<?>[] interfaces) {
     assertGameNotOver();

--- a/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
+++ b/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
@@ -69,42 +69,45 @@ public interface IDelegateBridge {
 
   /**
    * return the delegate history writer for this game.
+   *
    * <p>
    * The delegate history writer allows writing to the game history.
-   * <p>
+   * </p>
    */
   IDelegateHistoryWriter getHistoryWriter();
 
   /**
    * Return an object that implements the IDisplay interface for the game.
+   *
    * <p>
    * Methods called on this returned object will be invoked on all displays in the game, including those on remote
    * machines
-   * <p>
+   * </p>
    */
   IDisplay getDisplayChannelBroadcaster();
 
   /**
    * Return an object that implements the ISound interface for the game.
+   *
    * <p>
    * Methods called on this returned object will be invoked on all sound channels in the game, including those on remote
    * machines
-   * <p>
+   * </p>
    */
   ISound getSoundChannelBroadcaster();
 
   /**
    * @return the propertie for this step.
-   *         <p>
    */
   Properties getStepProperties();
 
   /**
    * After this step finishes executing, the next delegate will not be called.
+   *
    * <p>
    * This methd allows the delegate to signal that the game is over, but does not force the ui or the display to
    * shutdown.
-   * <p>
+   * </p>
    */
   void stopGameSequence();
 

--- a/src/main/java/games/strategy/engine/framework/IGame.java
+++ b/src/main/java/games/strategy/engine/framework/IGame.java
@@ -17,8 +17,10 @@ import games.strategy.sound.ISound;
 
 /**
  * Represents a running game.
+ *
  * <p>
  * Allows access to the games communication interfaces, and to listen to the current game step.
+ * </p>
  */
 public interface IGame {
   RemoteName GAME_MODIFICATION_CHANNEL =
@@ -64,7 +66,6 @@ public interface IGame {
   /**
    * Is the game over. Game over does not relate to the state of the game (eg check-mate in chess)
    * but to the game being shut down and all players have left.
-   * <p>
    */
   boolean isGameOver();
 

--- a/src/main/java/games/strategy/engine/framework/IGameLoader.java
+++ b/src/main/java/games/strategy/engine/framework/IGameLoader.java
@@ -51,8 +51,10 @@ public interface IGameLoader extends Serializable {
 
   /**
    * Get the type of the GamePlayer.
+   *
    * <p>
    * The type must extend IRemote, and is to be used by an IRemoteManager to allow a player to be contacted remotately
+   * </p>
    */
   Class<? extends IRemote> getRemotePlayerType();
 
@@ -61,9 +63,10 @@ public interface IGameLoader extends Serializable {
   /**
    * A game may use a subclass of Unit to allow associating data with a particular unit. The
    * game does this by specifying a IUnitFactory that should be used to create units.
+   *
    * <p>
    * Games that do not want to subclasses of units should simply return a DefaultUnitFactory.
-   * <p>
+   * </p>
    */
   IUnitFactory getUnitFactory();
 }

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -72,7 +72,6 @@ public class ServerGame extends AbstractGame {
   /**
    * When the delegate execution is stopped, we countdown on this latch to prevent the startgame(...) method from
    * returning.
-   * <p>
    */
   private final CountDownLatch m_delegateExecutionStoppedLatch = new CountDownLatch(1);
   /**

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -103,7 +103,9 @@ public class DownloadFileDescription {
     return downloadType == DownloadType.MAP_TOOL;
   }
 
-  /** @return Name of the zip file. */
+  /**
+   * @return Name of the zip file.
+   */
   public String getMapZipFileName() {
     if (url != null && url.contains("/")) {
       return url.substring(url.lastIndexOf('/') + 1, url.length());

--- a/src/main/java/games/strategy/engine/framework/map/download/MapListingSource.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapListingSource.java
@@ -14,7 +14,9 @@ import games.strategy.engine.config.PropertyReader;
  * to find the "triplea_map.xml" file, whether that be a URL, or a local file path relative to
  * the game root folder.
  *
+ * <p>
  * Can be used to create a <code>MapDownloadAction</code>
+ * </p>
  */
 public class MapListingSource {
   private final String mapListDownloadSite;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -41,9 +41,10 @@ import games.strategy.net.UniversalPlugAndPlayHelper;
 
 /**
  * Watches a game in progress, and updates the Lobby with the state of the game.
+ *
  * <p>
  * This class opens its own connection to the lobby, and its own messenger.
- * <p>
+ * </p>
  */
 public class InGameLobbyWatcher {
   public static final String LOBBY_WATCHER_NAME = "lobby_watcher";
@@ -69,9 +70,10 @@ public class InGameLobbyWatcher {
 
   /**
    * Reads SystemProperties to see if we should connect to a lobby server
+   *
    * <p>
    * After creation, those properties are cleared, since we should watch the first start game.
-   * <p>
+   * </p>
    *
    * @return null if no watcher should be created
    */

--- a/src/main/java/games/strategy/engine/gamePlayer/IGamePlayer.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/IGamePlayer.java
@@ -4,8 +4,10 @@ import games.strategy.engine.data.PlayerID;
 
 /**
  * A player of the game.
+ *
  * <p>
  * Game players communicate to the game through a PlayerBridge.
+ * </p>
  */
 public interface IGamePlayer extends IRemotePlayer {
   /**

--- a/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -30,8 +30,10 @@ public class LobbyLogin {
 
   /**
    * Attempt to login to the LobbyServer
+   *
    * <p>
    * If we could not login, return null.
+   * </p>
    */
   public LobbyClient login() {
     if (!m_serverProperties.isServerAvailable()) {

--- a/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -4,14 +4,19 @@ import java.util.Map;
 
 /**
  * Server properties.
+ *
  * <p>
  * Generally there is one lobby server, but that server may move.
+ * </p>
+ *
  * <p>
  * To keep track of this, we always have a properties file in a constant location that points to the current lobby
  * server.
+ * </p>
+ *
  * <p>
  * The properties file may indicate that the server is not available using the ERROR_MESSAGE key.
- * <p>
+ * </p>
  */
 public class LobbyServerProperties {
   public final String host;

--- a/src/main/java/games/strategy/engine/lobby/server/ILobbyGameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ILobbyGameController.java
@@ -20,9 +20,10 @@ public interface ILobbyGameController extends IRemote {
    * Test if the server can connect to the game at this address. This is used to see if the client address is network
    * accessible
    * (this will not be true if the client is behind a nat or firewall that is not properly configured)
+   *
    * <p>
    * This method may only be called by the node that is hosting this game.
-   * <p>
+   * </p>
    */
   String testGame(GUID gameID);
 }

--- a/src/main/java/games/strategy/engine/lobby/server/IModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/IModeratorController.java
@@ -8,8 +8,10 @@ import games.strategy.net.INode;
 public interface IModeratorController extends IRemote {
   /**
    * Boot the given INode from the network.
+   *
    * <p>
    * This method can only be called by admin users.
+   * </p>
    */
   void boot(INode node);
 
@@ -20,6 +22,7 @@ public interface IModeratorController extends IRemote {
 
   /**
    * Ban the ip of the given INode.
+   *
    * @deprecated Remove usages of this, banUserName and banMac are sufficient
    */
   @Deprecated
@@ -42,6 +45,7 @@ public interface IModeratorController extends IRemote {
 
   /**
    * Mute the ip of the given INode.
+   *
    * @deprecated Remove usages of this, muteUserName and muteMac are sufficient
    */
   @Deprecated
@@ -96,9 +100,11 @@ public interface IModeratorController extends IRemote {
 
   /**
    * Reset the password of the given user. Returns null if the password was updated without error.
+   *
    * <p>
    * You cannot change the password of an anonymous node, and you cannot change the password for an admin user.
-   * <p>
+   * </p>
+   *
    * @deprecated Remove usages of this. Does not make sense for moderators to be able to reset passwords of logged
    *             in users.
    */

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/BannedMacController.java
@@ -26,8 +26,10 @@ public class BannedMacController {
 
   /**
    * Ban the given mac. If banTill is not null, the ban will expire when banTill is reached.
+   *
    * <p>
    * If this mac is already banned, this call will update the ban_end.
+   * </p>
    */
   public void addBannedMac(final String mac, final Date banTill) {
     if (isMacBanned(mac).getFirst()) {

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/BannedUsernameController.java
@@ -26,8 +26,10 @@ public class BannedUsernameController {
 
   /**
    * Ban the given username. If banTill is not null, the ban will expire when banTill is reached.
+   *
    * <p>
    * If this username is already banned, this call will update the ban_end.
+   * </p>
    */
   public void addBannedUsername(final String username, final Date banTill) {
     if (isUsernameBanned(username).getFirst()) {

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
@@ -23,15 +23,22 @@ import games.strategy.util.ThreadUtil;
 
 /**
  * Utility to get connections to the database.
+ *
  * <p>
  * The database is embedded within the jvm.
+ * </p>
+ *
  * <p>
  * Getting a connection will cause the database (and the neccessary tables) to be created if it does not already exist.
+ * </p>
+ *
  * <p>
  * The database will be shutdown on System.exit through a shutdown hook.
+ * </p>
+ *
  * <p>
  * Getting a connection will also schedule backups at regular intervals.
- * <p>
+ * </p>
  */
 public class Database {
   private static final Logger s_logger = Logger.getLogger(Database.class.getName());

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/MutedMacController.java
@@ -26,8 +26,10 @@ public class MutedMacController {
 
   /**
    * Mute the given mac. If muteTill is not null, the mute will expire when muteTill is reached.
+   *
    * <p>
    * If this mac is already muted, this call will update the mute_end.
+   * </p>
    */
   public void addMutedMac(final String mac, final Date muteTill) {
     if (isMacMuted(mac)) {

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/MutedUsernameController.java
@@ -26,8 +26,10 @@ public class MutedUsernameController {
 
   /**
    * Mute the given username. If muteTill is not null, the mute will expire when muteTill is reached.
+   *
    * <p>
    * If this username is already muted, this call will update the mute_end.
+   * </p>
    */
   public void addMutedUsername(final String username, final Date muteTill) {
     if (isUsernameMuted(username)) {

--- a/src/main/java/games/strategy/engine/message/ConnectionLostException.java
+++ b/src/main/java/games/strategy/engine/message/ConnectionLostException.java
@@ -2,9 +2,10 @@ package games.strategy.engine.message;
 
 /**
  * Called when the connection to a node is lost while invoking a remote method.
+ *
  * <p>
  * Only returned on remotes or channels that wait for the results of the method invocation.
- * <p>
+ * </p>
  */
 public class ConnectionLostException extends MessengerException {
   private static final long serialVersionUID = -5310065420171098696L;

--- a/src/main/java/games/strategy/engine/message/IChannelMessenger.java
+++ b/src/main/java/games/strategy/engine/message/IChannelMessenger.java
@@ -3,10 +3,16 @@ package games.strategy.engine.message;
 import games.strategy.net.INode;
 
 /**
- * A simple way to multicast method calls over several machines and possibly several objects on each machine.<br>
- * A channel can be created such that all channel subscribers must implement the same<br>
+ * A simple way to multicast method calls over several machines and possibly several objects on each machine.
+ *
+ * <p>
+ * A channel can be created such that all channel subscribers must implement the same
  * interface. Channel subscribors can be on multiple machines.
+ * </p>
+ *
+ * <p>
  * On VM A
+ * </p>
  *
  * <pre>
  * RemoteName FOO = new RemoteName(&quot;Foo&quot;, IFoo.class);
@@ -14,7 +20,9 @@ import games.strategy.net.INode;
  * someChannelMessenger.registerChannelSubscribor(aFoo, FOO);
  * </pre>
  *
+ * <p>
  * On VM B
+ * </p>
  *
  * <pre>
  * IFoo anotherFoo = new Foo();
@@ -23,25 +31,39 @@ import games.strategy.net.INode;
  * multicastFoo.fee();
  * </pre>
  *
+ * <p>
  * The <code>multicast.fee()</code> line results in two method calls, one on VM B to anotherFoo, and
- * another call on VM A to aFoo.<br>
- * The magic is done using reflection and dynamic proxies (java.lang.reflect.Proxy)<br>
+ * another call on VM A to aFoo.
+ * </p>
+ *
+ * <p>
+ * The magic is done using reflection and dynamic proxies (java.lang.reflect.Proxy)
+ * </p>
+ *
+ * <p>
  * To avoid naming conflicts, it is advised to use the fully qualified java name and
- * and a constant as channel names. For example channel names should be in the form<br>
- * <br>
- * "foo.fee.Fi.SomeConstant"<br>
- * <br>
- * where SomeConstant is defined in the class foo.fee.Fi<br>
- * <br>
+ * and a constant as channel names. For example channel names should be in the form
+ * </p>
+ *
+ * <pre>
+ * "foo.fee.Fi.SomeConstant"
+ * </pre>
+ *
+ * <p>
+ * where SomeConstant is defined in the class foo.fee.Fi
+ * </p>
+ *
  * <p>
  * <b>Channels and threading</b>
+ * </p>
+ *
  * <p>
  * There will only be one thread calling methods in a channel at one time. Methods will be called on subscribors in the
  * order that they are
  * called on broadcasters. This means that if you block the current thread during a client invocation, no further
  * methods can be called on
  * that channel.
- * <p>
+ * </p>
  */
 public interface IChannelMessenger {
   /**

--- a/src/main/java/games/strategy/engine/message/IRemote.java
+++ b/src/main/java/games/strategy/engine/message/IRemote.java
@@ -2,14 +2,22 @@ package games.strategy.engine.message;
 
 /**
  * A marker interface, used to indicate that the interface
- * can be used by IRemoteMessenger.<br>
+ * can be used by IRemoteMessenger.
+ *
+ * <p>
  * All arguments and return values to all methods of
  * an IRemote must be serializable, since the methods
- * may be called by a remote VM.<br>
- * Modifications to the paramaters of an IRemote may or may not
- * be visible to the calling object. <br>
- * All methods declared by an IRemote may though a MessengerException.
+ * may be called by a remote VM.
+ * </p>
+ *
  * <p>
+ * Modifications to the paramaters of an IRemote may or may not
+ * be visible to the calling object.
+ * </p>
+ *
+ * <p>
+ * All methods declared by an IRemote may though a MessengerException.
+ * </p>
  */
 public interface IRemote {
 }

--- a/src/main/java/games/strategy/engine/message/IRemoteMessenger.java
+++ b/src/main/java/games/strategy/engine/message/IRemoteMessenger.java
@@ -1,20 +1,26 @@
 package games.strategy.engine.message;
 
 /**
- * Very similar to RMI<br>
- * <br>
+ * Very similar to RMI
+ *
+ * <p>
  * Objects can be registered with a remote messenger under a public name and
  * declared to implement a particular interface. Methods on this registered
- * object can then be called on different vms.<br>
- * <br>
+ * object can then be called on different vms.
+ * </p>
+ *
+ * <p>
  * To call a method on the registered object, you get a remote reference to it using the
  * getRemote(...) method. This returns an object that can be used and called
- * as if it were the original implementor. <br>
- * <br>
+ * as if it were the original implementor.
+ * </p>
+ *
+ * <p>
  * The getRemote(...) method though may be called on a different vm than
  * the registerRemote(...) method. In that case the calls on the return value of
  * getRemote(...) will be routed to the implementor object passed to registerRemote(...)
  * On VM A you have code like
+ * </p>
  *
  * <pre>
  * RemoteName FOO = new RemoteName(&quot;Foo&quot;, IFoo.class);
@@ -22,31 +28,45 @@ package games.strategy.engine.message;
  * aRemoteMessenger.registerRemote(IFoo.class, aFoo, FOO);
  * </pre>
  *
+ * <p>
  * After this runs, on VM B you can do
+ * </p>
  *
  * <pre>
- *
  * IFoo someFoo = anotherRemoteMessenger.getRemote(FOO);
  * boolean rVal = someFoo.fee();
  * if(rVal)
  *   ...
  * </pre>
  *
- * What will happen is that the fee() call in VM B will be invoked on aFoo in VM A.<br>
- * This is done using reflection and dynamic proxies (java.lang.reflect.Proxy)<br>
+ * <p>
+ * What will happen is that the fee() call in VM B will be invoked on aFoo in VM A.
+ * </p>
+ *
+ * <p>
+ * This is done using reflection and dynamic proxies (java.lang.reflect.Proxy)
+ * </p>
+ *
+ * <p>
  * To avoid naming conflicts, it is advised to use the fully qualified java name and
- * and a constant be used as the channel name. For example names should be in the form<br>
- * <br>
- * <br>
- * "foo.fee.Fi.SomeConstant" <br>
- * <br>
- * where SomeConstant is defined in the class foo.fee.Fi<br>
- * <br>
- * <br>
+ * and a constant be used as the channel name. For example names should be in the form
+ * </p>
+ *
+ * <pre>
+ * "foo.fee.Fi.SomeConstant"
+ * </pre>
+ *
+ * <p>
+ * where SomeConstant is defined in the class foo.fee.Fi
+ * </p>
+ *
  * <p>
  * <b>Remotes and threading</b>
+ * </p>
+ *
  * <p>
  * Remotes are multithreaded. Method calls may arrive out of order that methods were called.
+ * </p>
  */
 public interface IRemoteMessenger {
   /**

--- a/src/main/java/games/strategy/engine/message/MessageContext.java
+++ b/src/main/java/games/strategy/engine/message/MessageContext.java
@@ -17,13 +17,16 @@ public class MessageContext {
   /**
    * Within the invocation on a remote method on an IRemote or an IChannelSubscriber,
    * this method will return the node that originated the message.
+   *
    * <p>
    * Will return null if the current thread is not currenlty executing a remote method of an IRemote or
    * IChannelSubscrobor.
+   * </p>
+   *
    * <p>
    * This is set by the server, and cannot be overwritten by the client, and can be used to verify where messages come
    * from.
-   * <p>
+   * </p>
    *
    * @return the node that originated the message being received
    */

--- a/src/main/java/games/strategy/engine/message/RemoteNotFoundException.java
+++ b/src/main/java/games/strategy/engine/message/RemoteNotFoundException.java
@@ -2,14 +2,20 @@ package games.strategy.engine.message;
 
 /**
  * No Remote could be found.
+ *
  * <p>
  * This can be thrown by the remote messenger in two cases,
- * <p>
- * 1) looking up a someRemoteMessenger.getRemote(...)<br>
- * 2) invoking a method on the object returned by someRemoteMessenger.getRemote(...).
+ * </p>
+ *
+ * <ol>
+ * <li>looking up a someRemoteMessenger.getRemote(...)</li>
+ * <li>invoking a method on the object returned by someRemoteMessenger.getRemote(...)</li>
+ * </ol>
+ *
  * <p>
  * There are two possibel causes. Either the remote never existed, or a remote was once bound to that name, but is no
  * longer bound.
+ * </p>
  */
 public class RemoteNotFoundException extends MessengerException {
   private static final long serialVersionUID = 7169515572485196188L;

--- a/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
+++ b/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
@@ -9,7 +9,9 @@ import games.strategy.triplea.util.WrappedInvocationHandler;
 /**
  * Invocation handler for the UnifiedMessenger.
  *
+ * <p>
  * Handles the invocation for a channel
+ * </p>
  */
 class UnifiedInvocationHandler extends WrappedInvocationHandler {
   private final UnifiedMessenger m_messenger;

--- a/src/main/java/games/strategy/engine/random/MersenneTwister.java
+++ b/src/main/java/games/strategy/engine/random/MersenneTwister.java
@@ -5,45 +5,54 @@ import java.util.Random;
 /**
  * <h3>MersenneTwister and MersenneTwisterFast</h3>
  *
+ * <p>
  * Version 9, based on version MT199937(99/10/29) of the Mersenne Twister algorithm found at
  * <a href="http://www.math.keio.ac.jp/matumoto/emt.html"> The Mersenne Twister Home Page</a>, with the initialization
  * improved using the new 2002/1/26 initialization algorithm By Sean Luke, October 2004.
+ * </p>
  *
- *
+ * <p>
  * MersenneTwister is a drop-in subclass replacement for java.tools.Random. It is properly synchronized and can be
  * used in a multithreaded environment. On modern VMs such as HotSpot, it is approximately 1/3 slower than
  * java.tools.Random.
+ * </p>
  *
+ * <p>
  * MersenneTwisterFast is not a subclass of java.tools.Random. It has the same public methods as Random does, however,
  * and it is
  * algorithmically identical to MersenneTwister. MersenneTwisterFast has hard-code inlined all of its methods directly,
  * and made all of them
  * final (well, the ones of consequence anyway). Further, these methods are <i>not</i> synchronized, so the same
+ * </p>
  *
+ * <p>
  * MersenneTwisterFast
  * instance cannot be shared by multiple threads. But all this helps MersenneTwisterFast achieve well over twice the
  * speed of
  * MersenneTwister. java.tools.Random is about 1/3 slower than MersenneTwisterFast.
- *
+ * </p>
  *
  * <h3>About the Mersenne Twister</h3>
  *
+ * <p>
  * This is a Java version of the C-program for MT19937: Integer version. The MT19937 algorithm was created by Makoto
  * Matsumoto and Takuji
  * Nishimura, who ask:
  * "When you use this, send an email to: matumoto@math.keio.ac.jp with an appropriate reference to your work". Indicate
  * that this is a translation of their algorithm into Java.
+ * </p>
  *
- *
+ * <p>
  * <b>Reference. </b> Makato Matsumoto and Takuji Nishimura,
  * "Mersenne Twister: A 623-Dimensionally Equidistributed Uniform Pseudo-Random Number Generator", <i>ACM Transactions
  * on Modeling and Computer Simulation,</i> Vol. 8, No. 1, January 1998, pp 3--30.
+ * </p>
  *
- *
+ * <p>
  * The MersenneTwister code is based on standard MT19937 C/C++ code by Takuji Nishimura, with suggestions from Topher
  * Cooper and Marc Rieffel, July 1997. The code was originally translated into Java by Michael Lecuyer, January 1999,
  * and the original code is Copyright (c) 1999 by Michael Lecuyer.
- *
+ * </p>
  */
 public class MersenneTwister extends Random {
   private static final long serialVersionUID = -6946159560323874784L;

--- a/src/main/java/games/strategy/engine/random/ScriptedRandomSource.java
+++ b/src/main/java/games/strategy/engine/random/ScriptedRandomSource.java
@@ -4,15 +4,23 @@ import java.util.StringTokenizer;
 
 /**
  * A random source for use while debugging.
+ *
  * <p>
  * Returns the random numbers designated in the system property triplea.scriptedRandom
+ * </p>
+ *
  * <p>
  * for example, to roll 1,2,3 use -Dtriplea.scriptedRandom=1,2,3
+ * </p>
+ *
  * <p>
  * When scripted random runs out of numbers, the numbers will repeat.
+ * </p>
+ *
  * <p>
  * Special characters are also allowed in the sequence.
  * e - the random source will throw an error p - the random source will pause and never return.
+ * </p>
  */
 public class ScriptedRandomSource implements IRandomSource {
   public static final int PAUSE = -2;

--- a/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/src/main/java/games/strategy/engine/vault/Vault.java
@@ -23,15 +23,21 @@ import games.strategy.engine.message.RemoteName;
 /**
  * A vault is a secure way for the client and server to share information without
  * trusting each other.
+ *
  * <p>
  * Data can be locked in the vault by a node. This data then is not readable by other nodes until the data is unlocked.
+ * </p>
+ *
  * <p>
  * When the data is unlocked by the original node, other nodes can read the data. When data is put in the vault, it cant
  * be changed by the
  * originating node.
+ * </p>
+ *
  * <p>
- * NOTE: to allow the data locked in the vault to be gc'd, the <code>release(VaultID id)<code> method
+ * NOTE: to allow the data locked in the vault to be gc'd, the <code>release(VaultID id)</code> method
  * should be called when it is no longer needed.
+ * </p>
  */
 public class Vault {
   private static final RemoteName VAULT_CHANNEL =
@@ -104,8 +110,10 @@ public class Vault {
   /**
    * place data in the vault. An encrypted form of the data is sent at this
    * time to all nodes.
+   *
    * <p>
    * The same key used to encrypt the KNOWN_VALUE so that nodes can verify the key when it is used to decrypt the data.
+   * </p>
    *
    * @param data
    *        - the data to lock
@@ -143,8 +151,10 @@ public class Vault {
 
   /**
    * Join known and data into one array.
+   *
    * <p>
    * package access so we can test.
+   * </p>
    */
   static byte[] joinDataAndKnown(final byte[] data) {
     final byte[] dataAndCheck = new byte[KNOWN_VAL.length + data.length];
@@ -155,8 +165,10 @@ public class Vault {
 
   /**
    * allow other nodes to see the data.
+   *
    * <p>
    * You can only unlock data that was locked by the same instance of the Vault
+   * </p>
    *
    * @param id
    *        - the vault id to unlock
@@ -209,10 +221,14 @@ public class Vault {
 
   /**
    * Allow all data associated with the given vault id to be released and garbage collected
+   *
    * <p>
    * An id can be released by any node.
+   * </p>
+   *
    * <p>
    * If the id has already been released, then nothing will happen.
+   * </p>
    */
   public void release(final VaultID id) {
     getRemoteBroadcaster().release(id);

--- a/src/main/java/games/strategy/net/IConnectionLogin.java
+++ b/src/main/java/games/strategy/net/IConnectionLogin.java
@@ -4,12 +4,13 @@ import java.util.Map;
 
 /**
  * An IConnectionLogin responds to login challenges.
+ *
  * <p>
  * An IConnectionLogin is generally paired with an ILoginValidator. The validator will send a challenge string, to which
  * the
  * IConnectionLogin will respond with a key/value map of credentials. The validator will then allow the login, or return
  * an error message.
- * <p>
+ * </p>
  */
 public interface IConnectionLogin {
   /**

--- a/src/main/java/games/strategy/net/ILoginValidator.java
+++ b/src/main/java/games/strategy/net/ILoginValidator.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 /**
  * Code to validate a login attempt.
- * <p>
  */
 public interface ILoginValidator {
   /**

--- a/src/main/java/games/strategy/net/INode.java
+++ b/src/main/java/games/strategy/net/INode.java
@@ -6,12 +6,17 @@ import java.net.InetSocketAddress;
 
 /**
  * A Node in a network.
+ *
+ * <p>
  * Node identity is based on address/port. The name is just a display name
+ * </p>
+ *
  * <p>
  * Since different nodes may appear as different adresses to different nodes (eg the server sees a node as its nat
  * accesseble adress, while
  * the node itself sees itself as a subnet address), the address for a node is defined as the address that the server
  * sees!
+ * </p>
  */
 public interface INode extends Serializable, Comparable<INode> {
   /**

--- a/src/main/java/games/strategy/net/nio/QuarantineConversation.java
+++ b/src/main/java/games/strategy/net/nio/QuarantineConversation.java
@@ -2,13 +2,18 @@ package games.strategy.net.nio;
 
 /**
  * When a connection is first made, it is quarantined until it logs in.
+ *
  * <p>
  * When quaratined, all messages sent by the node are sent to this quarntine conversation.
+ * </p>
+ *
  * <p>
  * The quarantine conversation can only write to the node across the socket from it.
+ * </p>
+ *
  * <p>
  * All messages sent to a conversation must be done in the Decode thread.
- * <p>
+ * </p>
  */
 public abstract class QuarantineConversation {
   public static enum ACTION {

--- a/src/main/java/games/strategy/net/nio/SocketReadData.java
+++ b/src/main/java/games/strategy/net/nio/SocketReadData.java
@@ -9,9 +9,10 @@ import java.util.logging.Logger;
 
 /**
  * A packet of data being read over the network.
+ *
  * <p>
  * A Packet does not correspond to a network packet, rather it is the bytes for 1 serialized java object.
- * <p>
+ * </p>
  */
 class SocketReadData {
   public static final int MAX_MESSAGE_SIZE = 1000 * 1000 * 10;
@@ -38,8 +39,10 @@ class SocketReadData {
 
   /**
    * Read data from the channel, returning true if this packet is done.
+   *
    * <p>
    * If we detect the socket is closed, we will throw an IOExcpetion
+   * </p>
    */
   public boolean read(final SocketChannel channel) throws IOException {
     readCalls++;

--- a/src/main/java/games/strategy/net/nio/SocketWriteData.java
+++ b/src/main/java/games/strategy/net/nio/SocketWriteData.java
@@ -9,10 +9,14 @@ import java.util.logging.Logger;
 
 /**
  * A packet of data to be written over the network.
+ *
  * <p>
  * Packets do not correspond to ip packets. A packet is just the data for one serialized object.
+ * </p>
+ *
  * <p>
  * The packet is written over the network as 32 bits indicating the size in bytes, then the data itself.
+ * </p>
  */
 public class SocketWriteData {
   private static final Logger s_logger = Logger.getLogger(SocketWriteData.class.getName());

--- a/src/main/java/games/strategy/thread/LockUtil.java
+++ b/src/main/java/games/strategy/thread/LockUtil.java
@@ -14,15 +14,18 @@ import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Utility class for ensuring that locks are acquired in a consistent order.
+ *
  * <p>
  * Simply use this class and call acquireLock(aLock) releaseLock(aLock) instead of lock.lock(), lock.release(). If locks
  * are acquired in an
  * inconsistent order, an error message will be printed.
+ * </p>
+ *
  * <p>
  * This class is not terribly good for multithreading as it locks globally on all calls, but that is ok, as this code is
  * meant more for when
  * you are considering your ambitious multi-threaded code a mistake, and you are trying to limit the damage.
- * <p>
+ * </p>
  */
 public enum LockUtil {
   INSTANCE;

--- a/src/main/java/games/strategy/triplea/MapSupport.java
+++ b/src/main/java/games/strategy/triplea/MapSupport.java
@@ -3,8 +3,10 @@ package games.strategy.triplea;
 /**
  * The annoation indicates a class is used in Map XMLs
  *
+ * <p>
  * As a tough example:
  * <delegate name="politics" javaClass="games.strategy.triplea.delegate.PoliticsDelegate" display="Politics"/>
+ * </p>
  */
 public @interface MapSupport {
 }

--- a/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
+++ b/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
@@ -20,9 +20,9 @@ class ResourceLocationTracker {
   /**
    *
    * @param mapName Used to construct any special resource loading path prefixes, used as needed depending upon which
-   *                resources are in the path
+   *        resources are in the path
    * @param resourcePaths The list of paths used for a map as resources. From this we can determine if the map is being
-   *                      loaded from a zip or a directory, and if zip, if it matches any particular naming.
+   *        loaded from a zip or a directory, and if zip, if it matches any particular naming.
    */
   ResourceLocationTracker(String mapName, URL[] resourcePaths) {
     boolean isUsingMasterZip = Arrays.asList(resourcePaths)
@@ -38,13 +38,15 @@ class ResourceLocationTracker {
   }
 
   /**
-   * Will return an empty string unless a special prefix is needed, in which case  that prefix is constructed
+   * Will return an empty string unless a special prefix is needed, in which case that prefix is constructed
    * based on the map name.
    *
+   * <p>
    * The 'mapPrefix' is the path within a map zip file where we will then find any map contents.
    * For example, if the map prefix is "map", then when we expand the map zip, we would expect
    * "/map" to be the first folder we see, and we woudl expect things like "/map/game" and
    * "/map/polygons.txt" to exist.
+   * </p>
    */
   String getMapPrefix() {
     return mapPrefix;

--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -25,11 +25,12 @@ import games.strategy.util.Tuple;
 
 /**
  * Extended unit for triplea games.
+ *
  * <p>
  * As with all game data components, changes made to this unit must be made through a Change instance. Calling setters
  * on this directly will
  * not serialize the changes across the network.
- * <p>
+ * </p>
  */
 public class TripleAUnit extends Unit {
   // compatable with 0.9.2

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -34,9 +34,10 @@ public class AIUtils {
 
   /**
    * How many PU's does it cost the given player to produce the given unit type.
+   *
    * <p>
    * If the player cannot produce the given unit, return Integer.MAX_VALUE
-   * <p>
+   * </p>
    */
   static int getCost(final UnitType unitType, final PlayerID player, final GameData data) {
     final Resource PUs = data.getResourceList().getResource(Constants.PUS);
@@ -50,8 +51,10 @@ public class AIUtils {
 
   /**
    * Get the production rule for the given player, for the given unit type.
+   *
    * <p>
    * If no such rule can be found, then return null.
+   * </p>
    */
   private static ProductionRule getProductionRule(final UnitType unitType, final PlayerID player) {
     final ProductionFrontier frontier = player.getProductionFrontier();

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -50,20 +50,25 @@ import games.strategy.util.Tuple;
 
 /**
  * Base class for AIs.
+ *
  * <p>
  * Control pausing with the AI pause menu option.
  * AIs should note that any data that is stored in the AI instance, will be lost when the game is restarted.
  * We cannot save data with an AI, since the player may choose to restart the game with a different AI,
  * or with a human player.
+ * </p>
+ *
  * <p>
  * If an AI finds itself starting in the middle of a move phase, or the middle of a purchase phase,
  * (as would happen if a player saved the game during the middle of an AI's move phase) it is acceptable
  * for the AI to play badly for a turn, but the AI should recover, and play correctly when the next phase
  * of the game starts.
+ * </p>
+ *
  * <p>
  * As a rule, nothing that changes GameData should be in here (it should be in a delegate, and done
  * through an IDelegate using a change).
- * <p>
+ * </p>
  */
 public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAPlayer {
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
@@ -1102,7 +1102,9 @@ public class ProBidAI {
   /**
    * Return Territories containing any unit depending on unitCondition.
    *
+   * <p>
    * Differs from findCertainShips because it doesn't require the units be owned
+   * </p>
    */
   private static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -287,8 +287,10 @@ public class ProPurchaseUtils {
 
   /**
    * Get the production rule for the given player, for the given unit type.
+   *
    * <p>
    * If no such rule can be found, then return null.
+   * </p>
    */
   private static ProductionRule getProductionRule(final UnitType unitType, final PlayerID player) {
     final ProductionFrontier frontier = player.getProductionFrontier();

--- a/src/main/java/games/strategy/triplea/attachments/ICondition.java
+++ b/src/main/java/games/strategy/triplea/attachments/ICondition.java
@@ -62,7 +62,7 @@ public interface ICondition extends IAttachment {
    * like
    * alliedOwnershipTerritories, unitPresence, etc etc.
    * IDelegateBridge is only needed for actually testing the conditions. Once they have been tested, (once you have
-   * HashMap<ICondition,
+   * HashMap&lt;ICondition,
    * Boolean> testedConditions filled out),
    * then IDelegateBridge is not required and can be null (or use the shortcut method). Therefore use this method while
    * testing the
@@ -74,7 +74,7 @@ public interface ICondition extends IAttachment {
   boolean isSatisfied(HashMap<ICondition, Boolean> testedConditions, final IDelegateBridge aBridge);
 
   /**
-   * HashMap<ICondition, Boolean> testedConditions must be filled with completed tests of all conditions already, or
+   * HashMap&lt;ICondition, Boolean> testedConditions must be filled with completed tests of all conditions already, or
    * this will give you
    * errors.
    *

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3283,12 +3283,16 @@ public class UnitAttachment extends DefaultAttachment {
     return stats.toString();
   }
 
-  /** @deprecated does nothing, kept to avoid breaking maps, do not remove. */
+  /**
+   * @deprecated does nothing, kept to avoid breaking maps, do not remove.
+   */
   @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
   public void setIsParatroop(final String s) {}
 
-  /** @deprecated does nothing, used to keep compatibility with older xml files, do not remove. */
+  /**
+   * @deprecated does nothing, used to keep compatibility with older xml files, do not remove.
+   */
   @Deprecated
   @GameProperty(xmlProperty = true, gameProperty = false, adds = false)
   public void setIsMechanized(final String s) {}

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -40,6 +40,7 @@ import games.strategy.util.Tuple;
 
 /**
  * Logic for placing units.
+ *
  * <p>
  * Known limitations.
  * Doesn't take into account limits on number of factories that can be produced.
@@ -51,6 +52,7 @@ import games.strategy.util.Tuple;
  * capacity to produce in f.
  * A workaround was that if anyone ever accidently run into this situation
  * then they could undo the production, produce in f first, and then produce in e.
+ * </p>
  */
 public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implements IAbstractPlaceDelegate {
   // maps Territory-> Collection of units

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -40,9 +40,14 @@ import games.strategy.util.Tuple;
 
 /**
  * Used to store information about a dice roll.
+ *
+ * <p>
  * # of rolls at 5, at 4, etc.
+ * </p>
+ *
  * <p>
  * Externalizable so we can efficiently write out our dice as ints rather than as full objects.
+ * </p>
  */
 public class DiceRoll implements Externalizable {
   private static final long serialVersionUID = -1167204061937566271L;

--- a/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
+++ b/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
@@ -8,17 +8,23 @@ import games.strategy.engine.delegate.IDelegateBridge;
 
 /**
  * Utilility for tracking a sequence of executables.
+ *
+ * <p>
  * It works like this,
  * We pop the top of the stack, store it in current, then execute it.
  * While exececuting the current element, the current element can push
  * more execution items onto the stack.
+ * </p>
+ *
  * <p>
  * After execution has finished, we pop the next item, and execute it, repeating till nothing is left to exectue.
+ * </p>
+ *
  * <p>
  * If an exception occurs during execution, we retain a reference to the current item. When we start executing again, we
  * first push current
  * onto the stack. In this way, an item may execute more than once. An IExecutable should be aware of this.
- * <p>
+ * </p>
  */
 public class ExecutionStack implements Serializable {
   private static final long serialVersionUID = -8675285470515074530L;

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -46,7 +46,10 @@ import games.strategy.util.Util;
 
 /**
  * Useful match interfaces.
+ *
+ * <p>
  * Rather than writing code like,
+ * </p>
  *
  * <pre>
  * boolean hasLand = false;
@@ -61,9 +64,17 @@ import games.strategy.util.Util;
  * }
  * </pre>
  *
+ * <p>
  * You can write code like,
+ * </p>
+ *
+ * <pre>
  * boolean hasLand = Match.someMatch(someCollection, Matches.UnitIsAir);
+ * </pre>
+ *
+ * <p>
  * The benefits should be obvious to any right minded person.
+ * </p>
  */
 public class Matches {
   public static final Match<Object> IsTerritory = new Match<Object>() {
@@ -1275,7 +1286,7 @@ public class Matches {
    * @param data
    *        game data
    * @param player
-   * @return Match<Territory> that tests if there is a route to an enemy capital from the given territory
+   * @return Match&lt;Territory> that tests if there is a route to an enemy capital from the given territory.
    */
   public static Match<Territory> territoryHasRouteToEnemyCapital(final GameData data, final PlayerID player) {
     return new Match<Territory>() {

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -35,8 +35,10 @@ import games.strategy.util.Match;
 
 /**
  * Responsible for moving units on the board.
+ *
  * <p>
- * Responsible for checking the validity of a move, and for moving the units. <br>
+ * Responsible for checking the validity of a move, and for moving the units.
+ * </p>
  */
 public class MoveDelegate extends AbstractMoveDelegate {
 

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -25,7 +25,7 @@ import games.strategy.util.Match;
 import games.strategy.util.Util;
 
 /**
- * Battle in which no fighting occurs. <b>
+ * Battle in which no fighting occurs.
  * Example is a naval invasion into an empty country,
  * but the battle cannot be fought until a naval battle
  * occurs.

--- a/src/main/java/games/strategy/triplea/delegate/PlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PlaceDelegate.java
@@ -6,6 +6,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 
 /**
  * Logic for placing units.
+ *
  * <p>
  * Known limitations.
  * Doesnt take into account limits on number of factories that can be produced.
@@ -16,6 +17,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
  * factory in b, leaving no capacity to produce in f.
  * If anyone ever accidently runs into this situation then they can
  * undo the production, produce in f first, and then produce in e.
+ * </p>
  */
 @MapSupport
 public class PlaceDelegate extends AbstractPlaceDelegate {

--- a/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -28,13 +28,28 @@ import games.strategy.ui.SwingComponents;
  * game settings. The window handles generic logic around preferences, each tab will specify configuration values for
  * the settings.
  *
+ * <p>
  * Overall layout:
- * - Primary element is a JTabbed pain, the contents are organized into rows, one row per option presented to the user.
+ * </p>
+ *
+ * <ul>
+ * <li>Primary element is a JTabbed pain, the contents are organized into rows, one row per option presented to the
+ * user.</li>
+ * </ul>
+ *
+ * <p>
  * Each row consists of: label, swing input, detailed description
- * - Then we have some buttons:
- * - default (revert) settings
- * - save settings
- * - close window
+ * </p>
+ *
+ * <p>
+ * Then we have some buttons:
+ * </p>
+ *
+ * <ul>
+ * <li>default (revert) settings</li>
+ * <li>save settings</li>
+ * <li>close window</li>
+ * </ul>
  */
 public class SettingsWindow extends SwingComponents.ModalJDialog {
 

--- a/src/main/java/games/strategy/triplea/settings/SystemPreferences.java
+++ b/src/main/java/games/strategy/triplea/settings/SystemPreferences.java
@@ -9,17 +9,21 @@ import java.util.prefs.Preferences;
  * Preferences are stored with the 'system', and should persist between restarts and even installations
  * of the application
  *
+ * <p>
  * Note: Game engine properties are similar, but different in that they are stored in the game engines config file.
  * System properties will always have a default value hardcoded in code, while game engine properties will get their
  * value from config (and presumably have error handling if the config is mangled).
+ * </p>
  */
 public class SystemPreferences {
 
   /**
    * Puts a value into system preferences, and flushes when done. Note: The 'flush' operation is very slow
    *
+   * <p>
    * Note: If there is a need to do many of these one after another,
    * then call 'putNoFlush' followed by a single'flush'.
+   * </p>
    */
   public static void put(SystemPreferenceKey key, String value) {
     putNoFlush(key, value);
@@ -27,7 +31,7 @@ public class SystemPreferences {
   }
 
   /**
-   * @see SystemPreferences.put( SystemPreferenceKey , String)
+   * @see SystemPreferences#put(SystemPreferenceKey, String).
    */
   public static void put(SystemPreferenceKey key, boolean value) {
     put(key, String.valueOf(value));
@@ -71,14 +75,14 @@ public class SystemPreferences {
 
 
   /**
-   * @see SystemPreferences.get( SystemPreferenceKey , String)
+   * @see SystemPreferences#get(SystemPreferenceKey, String).
    */
   public static boolean get(SystemPreferenceKey key, boolean defaultValue) {
     return Boolean.parseBoolean(getPrefs().get(key.name(), String.valueOf(defaultValue)));
   }
 
   /**
-   * @see SystemPreferences.get( SystemPreferenceKey , String)
+   * @see SystemPreferences#get(SystemPreferenceKey, String).
    */
   public static int get(SystemPreferenceKey key, int defaultValue) {
     return getPrefs().getInt(key.name(), defaultValue);

--- a/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -147,9 +147,11 @@ public abstract class AbstractMovePanel extends ActionPanel {
   /**
    * Executes an undo move for any of the units passed in as a parameter.
    *
+   * <p>
    * "Cannot undo" Error messages are suppressed if any moves cannot be undone
    * (at least until we come up with a way to deal with "n" reasons for an undo
    * failure rather than just one)
+   * </p>
    */
   public void undoMoves(final Set<Unit> units) {
     @SuppressWarnings("unchecked")

--- a/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -247,9 +247,7 @@ public class ActionButtons extends JPanel {
   }
 
   /**
-   * Blocks until the user selects an end-of-turn action
-   *
-   * @return null if no action was made.
+   * Blocks until the user selects an end-of-turn action.
    */
   public void waitForEndTurn(final TripleAFrame frame, final IPlayerBridge bridge) {
     m_endTurnPanel.waitForEndTurn(frame, bridge);

--- a/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -49,11 +49,14 @@ public abstract class ActionPanel extends JPanel {
   /**
    * Waitfor another thread to call release.
    * If the thread is interupted, we will return silently.
+   *
    * <p>
    * A memory barrier will be crossed both on entering and before exiting this method.
+   * </p>
+   *
    * <p>
    * This method will return in the event of the game shutting down.
-   * <p>
+   * </p>
    */
   protected void waitForRelease() {
     if (Thread.currentThread().isInterrupted()) {
@@ -79,9 +82,10 @@ public abstract class ActionPanel extends JPanel {
 
   /**
    * Release the latch acquired by waitOnNewLatch()
+   *
    * <p>
    * This method will crossed on entering this method.
-   * <p>
+   * </p>
    */
   protected void release() {
     synchronized (m_latchLock) {

--- a/src/main/java/games/strategy/triplea/ui/ErrorHandler.java
+++ b/src/main/java/games/strategy/triplea/ui/ErrorHandler.java
@@ -8,8 +8,10 @@ import games.strategy.debug.ClientLogger;
  * will get a stack trace that points to where you started the thread and not to the actual line within
  * the thread that had the problem.
  *
+ * <p>
  * To solve this unhandled exception handlers get registered. For more details, see:
  * http://stackoverflow.com/questions/75218/how-can-i-detect-when-an-exceptions-been-thrown-globally-in-java#75439
+ * </p>
  */
 public class ErrorHandler implements Thread.UncaughtExceptionHandler, ErrorHandlerAwtEvents {
 

--- a/src/main/java/games/strategy/triplea/ui/ErrorHandlerAwtEvents.java
+++ b/src/main/java/games/strategy/triplea/ui/ErrorHandlerAwtEvents.java
@@ -5,12 +5,17 @@ package games.strategy.triplea.ui;
  * The intent of this class is to allow child class to mark the required method as "@Override" so that
  * static checkers will not think it is unused. The AWT system auto-magically calls that method.
  *
+ * <p>
  * Otherwise, to implement this interface successfully, a class would also need to:
- * - have a zero arg constructor
- * - register the class name with a system property, like this:
- * System.setProperty("sun.awt.exception.handler", <your_implementing_instance>.class.getName());
+ * </p>
  *
- * @see ErrorHandler.java
+ * <ul>
+ * <li>have a zero arg constructor</li>
+ * <li>register the class name with a system property, like this:
+ * <code>System.setProperty("sun.awt.exception.handler", &lt;your_implementing_instance>.class.getName());</code></li>
+ * </ul>
+ *
+ * @see ErrorHandler
  */
 public interface ErrorHandlerAwtEvents {
   void handle(Throwable throwable);

--- a/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
@@ -25,12 +25,14 @@ import games.strategy.util.Triple;
 
 /**
  * For when you do not want things condensed into categories.
+ *
  * <p>
  * This creates a panel which shows a group of units individually, and lets you put points/hits towards each unit
  * individually.
  * It lets you set a max number of points total (though max per unit is not allowed yet). It can return an IntegerMap
  * with the points per
  * unit.
+ * </p>
  */
 public class IndividualUnitPanel extends JPanel {
   private static final long serialVersionUID = -4222938655315991715L;

--- a/src/main/java/games/strategy/triplea/ui/IndividualUnitPanelGrouped.java
+++ b/src/main/java/games/strategy/triplea/ui/IndividualUnitPanelGrouped.java
@@ -28,10 +28,12 @@ import games.strategy.util.Tuple;
 
 /**
  * For when you want multiple individual unit panels, perhaps one for each territory, etc.
+ *
  * <p>
  * This lets you create multiple IndividualUnitPanel into a single panel, and have them integrated to use the same MAX.
  * IndividualUnitPanel is a group of units each displayed individually, and you can set an integer up to max for each
  * unit.
+ * </p>
  */
 public class IndividualUnitPanelGrouped extends JPanel {
   private static final long serialVersionUID = 3573683064535306664L;

--- a/src/main/java/games/strategy/triplea/ui/MacQuitMenuWrapper.java
+++ b/src/main/java/games/strategy/triplea/ui/MacQuitMenuWrapper.java
@@ -7,10 +7,14 @@ import com.apple.eawt.QuitResponse;
 
 /**
  * Utility class to wrap Mac OS X-specific shutdown handler.
+ *
  * <p>
  * Based on TripleA code.
+ * </p>
+ *
  * <p>
  * Needs AppleJavaExtensions.jar to compile on non-Mac platform.
+ * </p>
  */
 public class MacQuitMenuWrapper {
   private static MainGameFrame shutdownFrame;

--- a/src/main/java/games/strategy/triplea/ui/MapRouteDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/MapRouteDrawer.java
@@ -160,10 +160,12 @@ public class MapRouteDrawer {
   }
 
   /**
-   * Centripetal parameterization<br>
+   * Centripetal parameterization
    *
+   * <p>
    * Check <a href="http://stackoverflow.com/a/37370620/5769952">http://stackoverflow.com/a/37370620/5769952</a> for
    * more information
+   * </p>
    *
    * @param points - The Points which should be parameterized
    * @return A Parameter-Array called the "Index"
@@ -289,13 +291,18 @@ public class MapRouteDrawer {
 
   /**
    * Draws a smooth curve through the given array of points
+   *
+   * <p>
    * This algorithm is called Spline-Interpolation
    * because the Apache-commons-math library we are using here does not accept
    * values but {@code f(x)=y} with x having to increase all the time
    * the idea behind this is to use a parameter array - the so called index
    * as x array and splitting the points into a x and y coordinates array.
+   * </p>
    *
+   * <p>
    * Finally those 2 interpolated arrays get unified into a single {@linkplain Point} array and drawn to the Map
+   * </p>
    *
    * @param graphics The {@linkplain Graphics2D} Object to be drawn on
    * @param points The Knot Points for the Spline-Interpolator aka the joints

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/IDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/IDrawable.java
@@ -35,8 +35,10 @@ public interface IDrawable {
   /**
    * Draw the tile
    * If the graphics are scaled, then unscaled and scaled will be non null.
+   *
    * <p>
    * The affine transform will be set to the scaled version.
+   * </p>
    */
   void draw(Rectangle bounds, GameData data, Graphics2D graphics, MapData mapData, AffineTransform unscaled,
       AffineTransform scaled);

--- a/src/main/java/games/strategy/ui/ImageScrollModel.java
+++ b/src/main/java/games/strategy/ui/ImageScrollModel.java
@@ -6,9 +6,10 @@ import java.util.Observable;
 /**
  * Model for an ImageScroller. Generally one large view and one small view will be
  * connected to the same model.
+ *
  * <p>
  * notifies its observers when changes occur.
- * <p>
+ * </p>
  */
 public class ImageScrollModel extends Observable {
   private int m_x;

--- a/src/main/java/games/strategy/ui/SwingAction.java
+++ b/src/main/java/games/strategy/ui/SwingAction.java
@@ -13,19 +13,24 @@ import games.strategy.debug.ClientLogger;
 /**
  * Builder class for using Lambda expressions to create 'AbstractAction'
  *
+ * <p>
  * For example, instead of:
- * <code>
+ * </p>
+ *
+ * <pre>
  *   new AbstractionAction("text") {
  *         private final long serialVersion = ..
  *         &#64;Override public void actionPerformed(ActionEvent e ) { doSomething(); }
  *   }
- * </code>
+ * </pre>
  *
+ * <p>
  * You can rewrite the above using 'SwingAction.of(..)':
+ * </p>
  *
- * <code>
- *    SwingAction.of( e -> doSomething() );
- * </code>
+ * <pre>
+ * SwingAction.of(e -> doSomething());
+ * </pre>
  */
 public class SwingAction {
 

--- a/src/main/java/games/strategy/ui/Util.java
+++ b/src/main/java/games/strategy/ui/Util.java
@@ -150,8 +150,8 @@ public final class Util {
    * -> polygons map.
    *
    * @param java.awt.point p - a point on the map
-   * @param Map<String, List<Polygon>> terrPolygons - a map territory name -> polygons
-   * @return Optional<String>
+   * @param terrPolygons a map territory name -> polygons
+   * @return Optional&lt;String>
    */
   public static Optional<String> findTerritoryName(final Point p, final Map<String, List<Polygon>> terrPolygons) {
     return Optional.ofNullable(findTerritoryName(p, terrPolygons, null));
@@ -163,7 +163,7 @@ public final class Util {
    * -> polygons map. If no land or sea territory has been found a default name is returned.
    *
    * @param java.awt.point p - a point on the map
-   * @param Map<String, List<Polygon>> terrPolygons - a map territory name -> polygons
+   * @param terrPolygons a map territory name -> polygons
    * @param String defaultTerrName - default territory name that gets returns if nothing was found
    * @return found territory name of defaultTerrName
    */

--- a/src/main/java/games/strategy/util/AlphanumComparator.java
+++ b/src/main/java/games/strategy/util/AlphanumComparator.java
@@ -6,7 +6,7 @@ import java.util.Comparator;
  * This is an updated version with enhancements made by Daniel Migowski,
  * Andre Bogus, and David Koelle
  * To convert to use Templates (Java 1.5+):
- * - Change "implements Comparator" to "implements Comparator<String>"
+ * - Change "implements Comparator" to "implements Comparator&lt;String>"
  * - Change "compare(Object o1, Object o2)" to "compare(String s1, String s2)"
  * - Remove the type checking and casting in compare().
  * To use this class:

--- a/src/main/java/games/strategy/util/MD5Crypt.java
+++ b/src/main/java/games/strategy/util/MD5Crypt.java
@@ -31,11 +31,11 @@ public class MD5Crypt {
   /**
    * Function to return a string from the set: A-Za-z0-9./
    *
-   * @return A string of size (size) from the set A-Za-z0-9./
    * @param size
    *        Length of the string
    * @param v
    *        value to be converted
+   * @return A string of size (size) from the set A-Za-z0-9./
    */
   private static String to64(long v, int size) {
     final StringBuffer result = new StringBuffer();
@@ -63,9 +63,9 @@ public class MD5Crypt {
   /**
    * LINUX/BSD MD5Crypt function.
    *
-   * @return The encrypted password as an MD5 hash
    * @param password
    *        Password to be encrypted
+   * @return The encrypted password as an MD5 hash
    */
   public static String crypt(final String password) {
     final StringBuffer salt = new StringBuffer();
@@ -82,11 +82,11 @@ public class MD5Crypt {
   /**
    * LINUX/BSD MD5Crypt function.
    *
-   * @return The encrypted password as an MD5 hash
    * @param salt
    *        Random string used to initialize the MD5 engine
    * @param password
    *        Password to be encrypted
+   * @return The encrypted password as an MD5 hash
    */
   public static String crypt(final String password, final String salt) {
     return crypt(password, salt, MAGIC);
@@ -95,14 +95,14 @@ public class MD5Crypt {
   /**
    * Linux/BSD MD5Crypt function
    *
-   * @throws java.lang.Exception
-   * @return The encrypted password as an MD5 hash
    * @param magic
    *        $1$ for Linux/BSB, $apr1$ for Apache crypt
    * @param salt
    *        8 byte permutation string
    * @param password
    *        user password
+   * @return The encrypted password as an MD5 hash
+   * @throws java.lang.Exception
    */
   public static String crypt(final String password, String salt, final String magic) {
     if (password == null) {

--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -11,11 +11,15 @@ import java.util.Set;
 
 /**
  * A utilty for seeing which elements in a collection satisfy a given condition.
+ *
  * <p>
  * An instance of match allows you to test that an object matches some condition.
+ * </p>
+ *
  * <p>
- * Static utility methods allow you to find what elements in a collection satisfy a match, <br>
+ * Static utility methods allow you to find what elements in a collection satisfy a match,
  * count the number of matches, see if any elements match etc.
+ * </p>
  */
 public abstract class Match<T> {
 

--- a/src/main/java/games/strategy/util/SHA512Crypt.java
+++ b/src/main/java/games/strategy/util/SHA512Crypt.java
@@ -9,8 +9,10 @@ import java.security.NoSuchAlgorithmException;
  * Replacement for MD5Crypt
  * using SHA512 instead.
  *
+ * <p>
  * Do not use for Passwords!
  * Use the BCrypt library instead!
+ * </p>
  */
 public class SHA512Crypt {
 
@@ -41,8 +43,7 @@ public class SHA512Crypt {
   }
 
   /**
-   *
-   * Same as {@link SHA512Crypt.crypt(text, salt)}, but passing the salt as well
+   * Same as {@link SHA512Crypt#crypt(text, salt)}, but passing the salt as well.
    */
   public static String cryptPassSalt(final String text, final String salt) {
     return "$" + salt + crypt(text, salt);

--- a/src/main/java/games/strategy/util/TimeManager.java
+++ b/src/main/java/games/strategy/util/TimeManager.java
@@ -7,7 +7,6 @@ import java.util.SimpleTimeZone;
 
 public class TimeManager {
   /**
-   *
    * Replacement for Date.toGMTString();
    *
    * @param date The Date being returned as String

--- a/src/main/java/games/strategy/util/Triple.java
+++ b/src/main/java/games/strategy/util/Triple.java
@@ -13,10 +13,21 @@ public class Triple<F, S, T> implements Serializable {
   /**
    * Static creation method to create a new instance of a triple with the parameters provided.
    *
+   * <p>
    * This method allows for nicer triple creation syntax, namely:
-   * Triple<String,Integer,String> myTriple = Triple.of("abc",123,"xyz");
+   * </p>
+   *
+   * <pre>
+   * Triple&lt;String, Integer, String> myTriple = Triple.of("abc", 123, "xyz");
+   * </pre>
+   *
+   * <p>
    * Instead of:
-   * Triple<String,Integer,String> myTriple = new Triple<String,Integer,String>("abc",123,"xyz");
+   * </p>
+   *
+   * <pre>
+   * Triple&lt;String, Integer, String> myTriple = new Triple&lt;String, Integer, String>("abc", 123, "xyz");
+   * </pre>
    */
   public static <F, S, T> Triple<F, S, T> of(final F first, final S second, final T third) {
     return new Triple<>(first, second, third);

--- a/src/main/java/games/strategy/util/Tuple.java
+++ b/src/main/java/games/strategy/util/Tuple.java
@@ -14,10 +14,21 @@ public class Tuple<T, S> implements Serializable {
   /**
    * Static creation method to create a new instance of a tuple with the parameters provided.
    *
+   * <p>
    * This method allows for nicer tuple creation syntax, namely:
-   * Tuple<String,Integer> myTuple = Tuple.of("abc",123);
+   * </p>
+   *
+   * <pre>
+   * Tuple&lt;String, Integer> myTuple = Tuple.of("abc", 123);
+   * </pre>
+   *
+   * <p>
    * Instead of:
-   * Tuple<String,Integer> myTuple = new Tuple<String,Integer>("abc",123);
+   * </p>
+   *
+   * <pre>
+   * Tuple&lt;String, Integer> myTuple = new Tuple&lt;String, Integer>("abc", 123);
+   * </pre>
    */
   public static <T, S> Tuple<T, S> of(final T first, final S second) {
     return new Tuple<>(first, second);

--- a/src/main/java/games/strategy/util/UrlStreams.java
+++ b/src/main/java/games/strategy/util/UrlStreams.java
@@ -31,10 +31,10 @@ public final class UrlStreams {
   /**
    * Opens an input stream to a given uri.
    *
-   * @throws IllegalStateException if the given uri is malformed
-   *
    * @return Optional.empty() if there was a failure opening the strema, otherwise an optional
    *         containing an input stream to the parameter uri.
+   *
+   * @throws IllegalStateException if the given uri is malformed
    */
   public static Optional<InputStream> openStream(final URI uri) {
     try {

--- a/src/main/java/tools/map/xml/creator/MapXmlCreator.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlCreator.java
@@ -1043,11 +1043,12 @@ public class MapXmlCreator extends JFrame {
 
   /**
    * Log a message, with no arguments.
+   *
    * <p>
    * If the logger is currently enabled for the given message
    * level then the given message is forwarded to all the
    * registered output Handler objects.
-   * <p>
+   * </p>
    *
    * @param level One of the message level identifiers, e.g., SEVERE
    * @param msg The string message (or a key in the message catalog)

--- a/src/main/java/tools/map/xml/creator/MapXmlData.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlData.java
@@ -269,9 +269,12 @@ public class MapXmlData {
    *
    * <p>
    * <b>Example:</b>
+   * </p>
    *
    * <p>
    * Output:
+   * </p>
+   *
    * <ul>
    * <li>map1 { land1 -> {water1, water2} }
    * <li>map2 { water3 -> {land2, land3} }
@@ -311,14 +314,21 @@ public class MapXmlData {
    *
    * <p>
    * <b>Example:</b>
+   * </p>
+   *
    * <p>
    * Input:
+   * </p>
+   *
    * <ul>
    * <li>map1 = { land1 -> {water1, water2} }
    * <li>map2 = { water3 -> {land2, land3} }
    * </ul>
+   *
    * <p>
    * Output:
+   * </p>
+   *
    * <ul>
    * <li>map1 = { land1 -> {water1, water2, water3} }
    * <li>map2 = { water3 -> {land2, land3} }

--- a/src/main/java/tools/map/xml/creator/MapXmlHelper.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlHelper.java
@@ -1479,7 +1479,7 @@ public class MapXmlHelper {
 
   /**
    * @return HTML string listing the canal definitions in the following format:
-   *         ' - <canal name>: <water territory 1>-<water territory 2>- ...'
+   *         ' - &lt;canal name>: &lt;water territory 1>-&lt;water territory 2>- ...'
    */
   public static String getHtmlStringFromCanalDefinitions() {
     final StringBuilder sb = new StringBuilder();

--- a/src/test/java/games/strategy/test/TestUtil.java
+++ b/src/test/java/games/strategy/test/TestUtil.java
@@ -49,8 +49,10 @@ public class TestUtil {
   /**
    * Blocks until all Swing event thread actions have completed.
    *
+   * <p>
    * Task is accomplished by adding a do-nothing event with SwingUtilities
    * to the event thread and then blocking until the do-nothing event is done.
+   * </p>
    */
   public static void waitForSwingThreads() {
     // add a no-op action to the end of the swing event queue, and then wait for it

--- a/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -320,7 +320,9 @@ public class AirThatCantLandUtilTest {
     assertEquals(expectedCountCanada, postCountInt);
   }
 
-  /** @deprecated Use a mock object instead. */
+  /**
+   * @deprecated Use a mock object instead.
+   */
   @Deprecated
   private static ITripleAPlayer getDummyPlayer() {
     final InvocationHandler handler = new InvocationHandler() {

--- a/src/test/java/games/strategy/util/PropertyUtilTest.java
+++ b/src/test/java/games/strategy/util/PropertyUtilTest.java
@@ -10,9 +10,13 @@ import games.strategy.triplea.attachments.RulesAttachment;
 /**
  * PropertyUtil test sets / gets variables via reflection.
  *
+ * <p>
  * The set in PropertyUtil done through a setter method, the get is done by reading the private variable value directly.
+ * </p>
  *
+ * <p>
  * To test we set up some sample test objects and do read/set property operations on them.
+ * </p>
  */
 public class PropertyUtilTest {
   @Test


### PR DESCRIPTION
This PR fixes violations of various Checkstyle rules related to Javadoc structure.

This is another large PR, but, once again, **it only consists of Javadoc changes; no code changes.**

Specifically, the following types of violations were fixed:

* JavadocMethod
  * "Unused Javadoc tag."
* SingleLineJavadoc
  * "Single-line Javadoc comment should be multi-line."
* JavadocParagraph
  * "&lt;p> tag should be placed immediately before the first word, with no space after."
  * "Empty line should be followed by &lt;p> tag on the next line."
  * "Javadoc comment at column X has parse error. Details: 'X' while parsing 'X'"
  * "Javadoc comment at column X has parse error. Missed HTML close tag 'X'. Sometimes it means that close tag missed for one of previous tags."
  * "Javadoc comment at column X has parse error. Unrecognized error from ANTLR parser: X"
* AtclauseOrder
  * "At-clauses have to appear in the order 'X'."

The majority of the changes were related to paragraph tag (`<p>`) structure.  I didn't fix these violations with the minimum possible change; rather I had to be a little more verbose in order to ensure the Eclipse Formatter was happy.  For example, consider the following Javadoc that caused a violation:

```
/**
 * <p>
 * foo bar baz
 */
```

The Google Checkstyle ruleset is happy if it is simply changed to the following:

```
/**
 * <p>foo bar baz
 */
```

However, upon executing the Eclipse Formatter, it is reverted to the previous state, which obviously reintroduces the Checkstyle violation.  So, to keep both Checkstyle and the Eclipse formatter happy, the following more verbose form was used:

```
/**
 * <p>
 * foo bar baz
 * </p>
 */
```

In some cases, I did a bit more restructuring.  For example, introducing ordered (`<ol>`) or unordered (`<ul>`) lists where such a list was implied.  However, I didn't go nuts in the restructuring and kept everything to the minimum required to fix the violations.