### PR TITLE
Remove redundant prompts and inappropriate retreat options. Bump version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_deploy:
 ## Add the travis build number to the game engine version
 - GAME_CONFIG=game_engine.properties
 - VERSION_SOURCE=src/main/java/games/strategy/engine/config/GameEnginePropertyFileReader.java
-- ENGINE_VERSION=$(grep "public static final String GAME_ENGINE_VERSION *=" $VERSION_SOURCE | sed 's/.*="//g' | cut -d\" -f2)
-- [ "$ENGINE_VERSION"="" ] && echo "$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER" >> $GAME_CONFIG
+- ENGINE_VERSION=$(grep "public static final String GAME_ENGINE_VERSION *=" $VERSION_SOURCE | sed 's/.*=//g' | cut -d\" -f2)
+- test "$ENGINE_VERSION" = "" && echo "$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER" >> $GAME_CONFIG
 - sed -i "s/engine_version.*/engine_version = $TAGGED_VERSION/" $GAME_CONFIG
 ## Run the gradle release build process - creates the installers
 - ./gradlew --no-daemon release

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_deploy:
 - chmod +x ./.travis/setup && ./.travis/setup
 ## Add the travis build number to the game engine version
 - GAME_CONFIG=game_engine.properties
-- ENGINE_VERSION=$(grep "engine_version" $GAME_CONFIG | sed 's/.*= *//g')
+- VERSION_SOURCE=src/main/java/games/strategy/engine/config/GameEnginePropertyFileReader.java
+- ENGINE_VERSION=$(grep "public static final String GAME_ENGINE_VERSION *=" $VERSION_SOURCE | sed 's/.*="//g' | cut -d\" -f2)
 - export TAGGED_VERSION="$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER"
 - sed -i "s/engine_version.*/engine_version = $TAGGED_VERSION/" $GAME_CONFIG
 ## Run the gradle release build process - creates the installers

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_deploy:
 - GAME_CONFIG=game_engine.properties
 - VERSION_SOURCE=src/main/java/games/strategy/engine/config/GameEnginePropertyFileReader.java
 - ENGINE_VERSION=$(grep "public static final String GAME_ENGINE_VERSION *=" $VERSION_SOURCE | sed 's/.*="//g' | cut -d\" -f2)
-- export TAGGED_VERSION="$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER"
+- [ "$ENGINE_VERSION"="" ] && echo "$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER" >> $GAME_CONFIG
 - sed -i "s/engine_version.*/engine_version = $TAGGED_VERSION/" $GAME_CONFIG
 ## Run the gradle release build process - creates the installers
 - ./gradlew --no-daemon release

--- a/game_engine.properties
+++ b/game_engine.properties
@@ -1,4 +1,3 @@
-engine_version = 1.9.1.0
 
 ## Map_List_File
 # URL if the value begins with http, otherwise assumed to be a file. This file lists which maps are available

--- a/game_engine.properties
+++ b/game_engine.properties
@@ -1,4 +1,4 @@
-engine_version = 1.9.0.0
+engine_version = 1.9.1.0
 
 ## Map_List_File
 # URL if the value begins with http, otherwise assumed to be a file. This file lists which maps are available

--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -34,8 +34,9 @@ public final class ClientFileSystemHelper {
     }
 
     final String tripleaJarNameWithEngineVersion = getTripleaJarWithEngineVersionStringPath();
-    if (fileName.contains("triplea_" + tripleaJarNameWithEngineVersion + ".jar!")) {
-      return getRootFolderRelativeToJar(fileName, tripleaJarNameWithEngineVersion);
+    final int locn = fileName.indexOf("triplea_" + tripleaJarNameWithEngineVersion + ".jar!");
+    if (locn >= 0) {
+      return new File(fileName.substring(0, locn - 1));
     }
 
     return getRootRelativeToClassFile(fileName);
@@ -68,7 +69,8 @@ public final class ClientFileSystemHelper {
 
   private static File getRootFolderRelativeToJar(final String fileName, final String tripleaJarName) {
     final String subString =
-        fileName.substring("file:/".length() - (SystemProperties.isWindows() ? 0 : 1), fileName.indexOf(tripleaJarName) - 1);
+        fileName.substring("file:/".length() - (SystemProperties.isWindows() ? 0 : 1),
+            fileName.indexOf(tripleaJarName) - 1);
     final File f = new File(subString).getParentFile();
     if (!f.exists()) {
       throw new IllegalStateException("File not found:" + f);
@@ -97,7 +99,10 @@ public final class ClientFileSystemHelper {
     return f;
   }
 
-  private static boolean folderContainsGamePropsFile(final File folder) {
+  private static boolean folderContainsGamePropsFile(File folder) {
+    if (!folder.isDirectory()) {
+      folder = new File(folder.toString().substring(5));
+    }
     final File[] files = folder.listFiles();
     final List<String> fileNames =
         Arrays.asList(files).stream().map(file -> file.getName()).collect(Collectors.toList());

--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -101,7 +101,7 @@ public final class ClientFileSystemHelper {
 
   private static boolean folderContainsGamePropsFile(File folder) {
     if (!folder.isDirectory()) {
-      folder = new File(folder.toString().substring(5));
+      folder = new File(folder.toString().substring(5));                // strip off "file:" prefix
     }
     final File[] files = folder.listFiles();
     final List<String> fileNames =

--- a/src/main/java/games/strategy/engine/config/GameEnginePropertyFileReader.java
+++ b/src/main/java/games/strategy/engine/config/GameEnginePropertyFileReader.java
@@ -18,19 +18,25 @@ import games.strategy.engine.ClientFileSystemHelper;
 public class GameEnginePropertyFileReader implements PropertyReader {
 
   public static final String GAME_ENGINE_PROPERTY_FILE = "game_engine.properties";
+  public static final String GAME_ENGINE_VERSION = "1.9.1";
   private final File propertyFile;
 
   public GameEnginePropertyFileReader() {
     this(new File(GAME_ENGINE_PROPERTY_FILE));
   }
 
-  /** This constructor here for testing purposes, use the simple no-arg constructor instead. */
+  /**
+   * This constructor here for testing purposes, use the simple no-arg constructor instead.
+   */
   protected GameEnginePropertyFileReader(final File propertyFile) {
     this.propertyFile = propertyFile;
   }
 
   @Override
   public String readProperty(final GameEngineProperty propertyKey) {
+    if (propertyKey == GameEngineProperty.ENGINE_VERSION) {
+      return GAME_ENGINE_VERSION;
+    }
     try (FileInputStream inputStream = new FileInputStream(propertyFile)) {
       final Properties props = new Properties();
       props.load(inputStream);

--- a/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
@@ -99,7 +99,8 @@ public class EngineVersionProperties {
     text.append("<h2>A new version of TripleA is out.  Please Update TripleA!</h2>");
     text.append("<br />Your current version: ").append(ClientContext.engineVersion().getFullVersion());
     text.append("<br />Latest version available for download: ").append(getLatestVersionOut());
-    text.append("<br /><br />Click to download: <a class=\"external\" href=\"").append(getLinkToDownloadLatestVersion())
+    text.append("<br /><br />Click to download: <a class=\"external\" href=\"")
+        .append(getLinkToDownloadLatestVersion())
         .append("\">").append(getLinkToDownloadLatestVersion()).append("</a>");
     text.append("<br />Backup Mirror: <a class=\"external\" href=\"").append(getLinkAltToDownloadLatestVersion())
         .append("\">").append(getLinkAltToDownloadLatestVersion()).append("</a>");

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -444,8 +444,8 @@ public class UnitAttachment extends DefaultAttachment {
   public void setWhenCapturedChangesInto(final String value) throws GameParseException {
     final String[] s = value.split(":");
     if (s.length < 5 || (s.length - 1) % 2 != 0) {
-      throw new GameParseException("whenCapturedChangesInto must have 5 or more values, "
-          + "playerFrom:playerTo:keepAttributes:unitType:howMany (you may have additional unitType:howMany:unitType:howMany, etc"
+      throw new GameParseException("whenCapturedChangesInto must have 5 or more values, playerFrom:playerTo:"
+          + "keepAttributes:unitType:howMany (you may have additional unitType:howMany:unitType:howMany, etc"
           + thisErrorMsg());
     }
     final PlayerID pfrom = getData().getPlayerList().getPlayerID(s[0]);

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -513,6 +513,21 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           }
         }
       }
+      // See if there any unescorted trns
+      if (m_battleSite.isWater() && isTransportCasualtiesRestricted()) {
+        if (Match.someMatch(m_attackingUnits, Matches.UnitIsTransport)
+            || Match.someMatch(m_defendingUnits, Matches.UnitIsTransport)) {
+          steps.add(REMOVE_UNESCORTED_TRANSPORTS);
+        }
+      }
+    }
+    // Air only Units can't attack subs without Destroyers present
+    if (isAirAttackSubRestricted()) {
+      final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
+      units.addAll(m_attackingUnits);
+      if (Match.someMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
+        steps.add(SUBMERGE_SUBS_VS_AIR_ONLY);
+      }
     }
     // Check if defending subs can submerge before battle
     if (isSubRetreatBeforeBattle()) {
@@ -523,13 +538,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       if (!Match.someMatch(m_attackingUnits, Matches.UnitIsDestroyer)
           && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
         steps.add(m_defender.getName() + SUBS_SUBMERGE);
-      }
-    }
-    // See if there any unescorted trns
-    if (m_battleSite.isWater() && isTransportCasualtiesRestricted()) {
-      if (Match.someMatch(m_attackingUnits, Matches.UnitIsTransport)
-          || Match.someMatch(m_defendingUnits, Matches.UnitIsTransport)) {
-        steps.add(REMOVE_UNESCORTED_TRANSPORTS);
       }
     }
     // if attacker has no sneak attack subs, then defendering sneak attack subs fire first and remove casualties
@@ -569,16 +577,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         && (returnFireAgainstDefendingSubs() != ReturnFire.ALL || returnFireAgainstAttackingSubs() != ReturnFire.ALL)) {
       steps.add(REMOVE_SNEAK_ATTACK_CASUALTIES);
     }
-    // Air only Units can't attack subs without Destroyers present
-    if (isAirAttackSubRestricted()) {
-      final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
-      units.addAll(m_attackingUnits);
-      // if(!Match.someMatch(m_attackingUnits, Matches.UnitIsDestroyer) && Match.allMatch(m_attackingUnits,
-      // Matches.UnitIsAir))
-      if (Match.someMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
-        steps.add(SUBMERGE_SUBS_VS_AIR_ONLY);
-      }
-    }
     // Air Units can't attack subs without Destroyers present
     if (m_battleSite.isWater() && isAirAttackSubRestricted()) {
       final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
@@ -611,9 +609,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final Collection<Unit> units = new ArrayList<>(m_defendingUnits.size() + m_defendingWaitingToDie.size());
       units.addAll(m_defendingUnits);
       units.addAll(m_defendingWaitingToDie);
-      // if(!Match.someMatch(m_defendingUnits, Matches.UnitIsDestroyer) && Match.someMatch(m_defendingUnits,
-      // Matches.UnitIsAir) &&
-      // Match.someMatch(m_attackingUnits, Matches.UnitIsSub))
       if (Match.someMatch(m_defendingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_attackingUnits, units)) {
         steps.add(AIR_DEFEND_NON_SUBS);
       }
@@ -646,6 +641,13 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
             steps.add(m_defender.getName() + SUBS_WITHDRAW);
           }
         }
+      }
+    }
+    // See if there any unescorted trns
+    if (m_battleSite.isWater() && isTransportCasualtiesRestricted()) {
+      if (Match.someMatch(m_attackingUnits, Matches.UnitIsTransport)
+          || Match.someMatch(m_defendingUnits, Matches.UnitIsTransport)) {
+        steps.add(REMOVE_UNESCORTED_TRANSPORTS);
       }
     }
     // if we are a sea zone, then we may not be able to retreat
@@ -715,6 +717,22 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       });
     }
     if (firstRun) {
+      /** Remove undefended trns */
+      if (isTransportCasualtiesRestricted()) {
+        steps.add(new IExecutable() {
+          private static final long serialVersionUID = 99989L;
+
+          @Override
+          public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+            checkUndefendedTransports(bridge, m_defender);
+            checkUndefendedTransports(bridge, m_attacker);
+            checkForUnitsThatCanRollLeft(bridge, true);
+            checkForUnitsThatCanRollLeft(bridge, false);
+            clearWaitingToDie(bridge);
+            // ?? This appears to remove both sides undefended transports twice
+          }
+        });
+      }
       steps.add(new IExecutable() {
         private static final long serialVersionUID = -2255284529092427441L;
 
@@ -815,9 +833,24 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        if (Match.someMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1))
+            && Match.allMatch(m_defendingUnits, Matches.unitHasDefenseThatIsMoreThanOrEqualTo(1).invert())) {
+          remove(m_defendingUnits, bridge, m_battleSite, true);
+        }
         clearWaitingToDie(bridge);
       }
     });
+    /** Submerge subs if -vs air only & air restricted from attacking subs */
+    if (isAirAttackSubRestricted()) {
+      steps.add(new IExecutable() {
+        private static final long serialVersionUID = 99990L;
+
+        @Override
+        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+          submergeSubsVsOnlyAir(bridge);
+        }
+      });
+    }
     steps.add(new IExecutable() {
       // not compatible with 0.9.0.2 saved games. this is new for 1.2.6.0
       private static final long serialVersionUID = 6387198382888361848L;
@@ -865,15 +898,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         // changed to only look at units that can be destroyed in combat, and therefore not include factories, aaguns,
         // and infrastructure.
         else if (Match.getMatches(m_defendingUnits, Matches.UnitIsNotInfrastructure).size() == 0) {
-          if (isTransportCasualtiesRestricted()) {
-            // If there are undefended attacking transports, determine if they automatically die
-            checkUndefendedTransports(bridge, m_defender);
-          }
-          checkForUnitsThatCanRollLeft(bridge, false);
           endBattle(bridge);
           attackerWins(bridge);
-        } else if (shouldEndBattleDueToMaxRounds()
-            || (Match.allMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1).invert())
+        } else if (shouldEndBattleDueToMaxRounds() ||
+                (Match.allMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1).invert())
                 && Match.allMatch(m_defendingUnits, Matches.unitHasDefendValueOfAtLeast(1).invert()))) {
           endBattle(bridge);
           nobodyWins(bridge);
@@ -1017,31 +1045,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         checkSuicideUnits(bridge);
       }
     });
-    /** Remove undefended trns */
-    if (isTransportCasualtiesRestricted()) {
-      steps.add(new IExecutable() {
-        private static final long serialVersionUID = 99989L;
-
-        @Override
-        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          checkUndefendedTransports(bridge, m_defender);
-          checkUndefendedTransports(bridge, m_attacker);
-          checkForUnitsThatCanRollLeft(bridge, true);
-          checkForUnitsThatCanRollLeft(bridge, false);
-        }
-      });
-    }
-    /** Submerge subs if -vs air only & air restricted from attacking subs */
-    if (isAirAttackSubRestricted()) {
-      steps.add(new IExecutable() {
-        private static final long serialVersionUID = 99990L;
-
-        @Override
-        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          submergeSubsVsOnlyAir(bridge);
-        }
-      });
-    }
     final ReturnFire returnFireAgainstAttackingSubs = returnFireAgainstAttackingSubs();
     final ReturnFire returnFireAgainstDefendingSubs = returnFireAgainstDefendingSubs();
     if (defenderSubsFireFirst()) {

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -161,9 +161,6 @@ public class NonFightingBattle extends DependentBattle {
     }
   }
 
-  /*
-  * Add dependent units - suppress javadoc error
-  */
   public void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
     for (final Unit holder : dependencies.keySet()) {
       final Collection<Unit> transporting = dependencies.get(holder);

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -25,7 +25,7 @@ import games.strategy.util.Match;
 import games.strategy.util.Util;
 
 /**
- * Battle in which no fighting occurs. <b>
+ * Battle in which no fighting occurs.
  * Example is a naval invasion into an empty country,
  * but the battle cannot be fought until a naval battle
  * occurs.
@@ -161,6 +161,9 @@ public class NonFightingBattle extends DependentBattle {
     }
   }
 
+  /*
+  * Add dependent units - suppress javadoc error
+  */
   public void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
     for (final Unit holder : dependencies.keySet()) {
       final Collection<Unit> transporting = dependencies.get(holder);

--- a/src/main/java/games/strategy/triplea/delegate/PlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PlaceDelegate.java
@@ -6,6 +6,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 
 /**
  * Logic for placing units.
+ * <p>
  *
  * Known limitations.
  * Doesnt take into account limits on number of factories that can be produced.
@@ -16,6 +17,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
  * factory in b, leaving no capacity to produce in f.
  * If anyone ever accidently runs into this situation then they can
  * undo the production, produce in f first, and then produce in e.
+ * </p>
  */
 @MapSupport
 public class PlaceDelegate extends AbstractPlaceDelegate {

--- a/src/main/java/games/strategy/triplea/delegate/PlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PlaceDelegate.java
@@ -6,7 +6,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 
 /**
  * Logic for placing units.
- * <p>
+ *
  * Known limitations.
  * Doesnt take into account limits on number of factories that can be produced.
  * The situation where one has two non original factories a,b each with production 2.

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -95,7 +95,7 @@ public class BattleDisplay extends JPanel {
   private final PlayerID m_attacker;
   private final Territory m_location;
   private final GameData m_data;
-  private final JButton m_actionButton = new JButton("");
+  private final JButton actionButton = new JButton("");
   private final BattleModel m_defenderModel;
   private final BattleModel m_attackerModel;
   private BattleStepsPanel m_steps;
@@ -153,7 +153,7 @@ public class BattleDisplay extends JPanel {
   }
 
   public void cleanUp() {
-    m_actionButton.setAction(m_nullAction);
+    actionButton.setAction(m_nullAction);
     m_steps.deactivate();
     m_mapPanel.getUIContext().removeActive(m_steps);
     m_steps = null;
@@ -163,7 +163,7 @@ public class BattleDisplay extends JPanel {
     // we want a component on this frame to take focus
     // so that pressing space will work (since it requires in focused
     // window). Only seems to be an issue on windows
-    m_actionButton.requestFocus();
+    actionButton.requestFocus();
   }
 
   public Territory getBattleLocation() {
@@ -305,7 +305,7 @@ public class BattleDisplay extends JPanel {
 
     final CountDownLatch continueLatch = new CountDownLatch(1);
     final AbstractAction buttonAction = SwingAction.of(message, e -> continueLatch.countDown());
-    SwingUtilities.invokeLater(() -> m_actionButton.setAction(buttonAction));
+    SwingUtilities.invokeLater(() -> actionButton.setAction(buttonAction));
     m_mapPanel.getUIContext().addShutdownLatch(continueLatch);
 
     // Set a auto-wait expiration if the option is set.
@@ -317,7 +317,7 @@ public class BattleDisplay extends JPanel {
         public void run() {
           continueLatch.countDown();
           if (continueLatch.getCount() > 0) {
-            SwingUtilities.invokeLater(() -> m_actionButton.setAction(m_nullAction));
+            SwingUtilities.invokeLater(() -> actionButton.setAction(m_nullAction));
           }
         }
       }, maxWaitTime);
@@ -330,14 +330,14 @@ public class BattleDisplay extends JPanel {
     } finally {
       m_mapPanel.getUIContext().removeShutdownLatch(continueLatch);
     }
-    SwingUtilities.invokeLater(() -> m_actionButton.setAction(m_nullAction));
+    SwingUtilities.invokeLater(() -> actionButton.setAction(m_nullAction));
   }
 
 
   public void endBattle(final String message, final Window enclosingFrame) {
     m_steps.walkToLastStep();
     final Action close = SwingAction.of(message + " : (Press Space to Close)", e -> enclosingFrame.setVisible(false));
-    SwingUtilities.invokeLater(() -> m_actionButton.setAction(close));
+    SwingUtilities.invokeLater(() -> actionButton.setAction(close));
   }
 
   public void notifyRetreat(final Collection<Unit> retreating) {
@@ -383,7 +383,7 @@ public class BattleDisplay extends JPanel {
       retreatTo[0] = m_location;
       latch.countDown();
     });
-    SwingUtilities.invokeLater(() -> m_actionButton.setAction(action));
+    SwingUtilities.invokeLater(() -> actionButton.setAction(action));
     SwingUtilities.invokeLater(() -> action.actionPerformed(null));
     m_mapPanel.getUIContext().addShutdownLatch(latch);
     try {
@@ -392,7 +392,7 @@ public class BattleDisplay extends JPanel {
     } finally {
       m_mapPanel.getUIContext().removeShutdownLatch(latch);
     }
-    SwingUtilities.invokeLater(() -> m_actionButton.setAction(m_nullAction));
+    SwingUtilities.invokeLater(() -> actionButton.setAction(m_nullAction));
     return retreatTo[0];
   }
 
@@ -425,17 +425,22 @@ public class BattleDisplay extends JPanel {
       // if you have eliminated the impossible, whatever remains, no matter
       // how improbable, must be the truth
       // retreat
-      final RetreatComponent comp = new RetreatComponent(possible);
-      final int option = JOptionPane.showConfirmDialog(BattleDisplay.this, comp, message,
-          JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null);
-      if (option == JOptionPane.OK_OPTION) {
-        if (comp.getSelection() != null) {
-          retreatTo[0] = comp.getSelection();
-          latch.countDown();
+      if (possible.size() == 1) {
+        retreatTo[0] = possible.iterator().next();
+        latch.countDown();
+      } else {
+        final RetreatComponent comp = new RetreatComponent(possible);
+        final int option = JOptionPane.showConfirmDialog(BattleDisplay.this, comp, message,
+            JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null);
+        if (option == JOptionPane.OK_OPTION) {
+          if (comp.getSelection() != null) {
+            retreatTo[0] = comp.getSelection();
+            latch.countDown();
+          }
         }
       }
     });
-    SwingUtilities.invokeLater(() -> m_actionButton.setAction(action));
+    SwingUtilities.invokeLater(() -> actionButton.setAction(action));
     SwingUtilities.invokeLater(() -> action.actionPerformed(null));
     m_mapPanel.getUIContext().addShutdownLatch(latch);
     try {
@@ -445,7 +450,7 @@ public class BattleDisplay extends JPanel {
     } finally {
       m_mapPanel.getUIContext().removeShutdownLatch(latch);
     }
-    SwingUtilities.invokeLater(() -> m_actionButton.setAction(m_nullAction));
+    SwingUtilities.invokeLater(() -> actionButton.setAction(m_nullAction));
     return retreatTo[0];
   }
 
@@ -511,7 +516,7 @@ public class BattleDisplay extends JPanel {
       final String countStr = isEditMode ? "" : "" + count;
       final String btnText =
           hit.getName() + ", press space to select " + countStr + (plural ? " casualties" : " casualty");
-      m_actionButton.setAction(new AbstractAction(btnText) {
+      actionButton.setAction(new AbstractAction(btnText) {
         private static final long serialVersionUID = -2156028313292233568L;
         private UnitChooser chooser;
         private JScrollPane chooserScrollPane;
@@ -559,8 +564,8 @@ public class BattleDisplay extends JPanel {
             final CasualtyDetails response = new CasualtyDetails(killed, damaged, false);
             casualtyDetails.set(response);
             m_dicePanel.clear();
-            m_actionButton.setEnabled(false);
-            m_actionButton.setAction(m_nullAction);
+            actionButton.setEnabled(false);
+            actionButton.setAction(m_nullAction);
             continueLatch.countDown();
           }
         }
@@ -633,16 +638,16 @@ public class BattleDisplay extends JPanel {
     setLayout(new BorderLayout());
     add(north, BorderLayout.NORTH);
     add(diceAndSteps, BorderLayout.CENTER);
-    add(m_actionButton, BorderLayout.SOUTH);
-    m_actionButton.setEnabled(false);
+    add(actionButton, BorderLayout.SOUTH);
+    actionButton.setEnabled(false);
     if (!SystemProperties.isMac()) {
-      m_actionButton.setBackground(Color.lightGray.darker());
-      m_actionButton.setForeground(Color.white);
+      actionButton.setBackground(Color.lightGray.darker());
+      actionButton.setForeground(Color.white);
     }
     setDefaultWidths(defenderTable);
     setDefaultWidths(attackerTable);
     final Action continueAction = SwingAction.of(e -> {
-      final Action a = m_actionButton.getAction();
+      final Action a = actionButton.getAction();
       if (a != null) {
         a.actionPerformed(null);
       }

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -1005,14 +1005,13 @@ public class WW2V3_41_Test {
     assertEquals(2, mfb.getBombardingUnits().size());
     // Show that bombard casualties can return fire
     // Note- the 3 & 2 hits below show default behavior of bombarding at attack strength
-    // 3= Battleship hitting a 4, 2=Cruiser hitting a 3, 5555=italian infantry missing on 6s, 00= british getting return
-    // fire on 1.
-    bridge.setRandomSource(new ScriptedRandomSource(3, 2, 5, 5, 5, 5, 0, 0));
+    // 2= Battleship hitting a 3, 2=Cruiser hitting a 3, 15=British infantry hitting once
+    bridge.setRandomSource(new ScriptedRandomSource(2, 2, 1, 5, 5, 5, 5, 5));
     battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
     battleDelegate(m_data).start();
     fight(battleDelegate(m_data), eg);
     // end result should be 2 italian infantry.
-    assertEquals(2, eg.getUnits().size());
+    assertEquals(3, eg.getUnits().size());
   }
 
   @Test


### PR DESCRIPTION
Replaces #1599, #1615 #1621 

Resolves issues in #1270. Also auto submerges subs against air only when they can't hit the sub rather than asking to submerge and then auto submerging.

Breaks serialisation in many cases so bump version but don't update lastest_version.properties because this will cause most users of 1.9 to hang.

Also update game_engine.properties in the build so this doesn't need to be updated any more. Jar file will know what version it is.