### PR TITLE
Checkstyle: Update thresholds after a successful Travis build (#747)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ script:
 - ruby -e "require 'yaml';puts YAML.load_file('./lobby_server.yaml')" > /dev/null || exit 1
 ## run the gradle build
 - ./gradlew --no-daemon check
+after_success:
+- chmod +x ./.travis/update_checkstyle_thresholds && ./.travis/update_checkstyle_thresholds
 before_deploy:
 ## Run the travis setup, will download install4j and configure it
 - chmod +x ./.travis/setup && ./.travis/setup

--- a/.travis/update_checkstyle_thresholds
+++ b/.travis/update_checkstyle_thresholds
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# This script updates the Checkstyle thresholds based on the most recent
+# Checkstyle run (therefore, this script must be run after the Gradle "check"
+# task has run).  If the thresholds have changed, the updated thresholds are
+# pushed back to the remote repository.
+#
+# NOTE: There is no danger in INCREASING the thresholds because the build will
+# have already failed at this point if the violation counts have increased.
+#
+
+readonly FALSE=1
+readonly GRADLE_PROPERTIES=gradle.properties
+readonly TRUE=0
+
+main() {
+  should_skip_build && exit 0
+
+  local -r old_hash=$(get_gradle_properties_hash)
+  update_local_thresholds
+  has_local_thresholds_changed $old_hash && update_remote_thresholds $old_hash
+}
+
+should_skip_build() {
+  echo "Checking if Checkstyle thresholds should be updated for this build..."
+  local skip=$FALSE
+  if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+    echo "  ...skipping because pull requests are not permitted."
+    skip=$TRUE
+  fi
+  if [[ "$TRAVIS_BRANCH" != "master" ]]; then
+    echo "  ...skipping because this branch is not permitted."
+    skip=$TRUE
+  fi
+  if [[ "$TRAVIS_REPO_SLUG" != "triplea-game/triplea" ]]; then
+    echo "  ...skipping because this repo is not permitted."
+    skip=$TRUE
+  fi
+  return $skip
+}
+
+get_gradle_properties_hash() {
+  git hash-object "$GRADLE_PROPERTIES"
+}
+
+update_local_thresholds() {
+  echo "Updating Checkstyle thresholds..."
+  local -r checkstyle_reports_dir=build/reports/checkstyle
+  local -r checkstyle_warning_pattern='<error [^>]*severity="warning"'
+  local -r main_warning_count=$(grep -P "$checkstyle_warning_pattern" $checkstyle_reports_dir/main.xml | wc -l)
+  sed -i -r 's/(checkstyleMainMaxWarnings)=[[:digit:]]+/\1='"$main_warning_count"'/' $GRADLE_PROPERTIES
+  local -r test_warning_count=$(grep -P "$checkstyle_warning_pattern" $checkstyle_reports_dir/test.xml | wc -l)
+  sed -i -r 's/(checkstyleTestMaxWarnings)=[[:digit:]]+/\1='"$test_warning_count"'/' $GRADLE_PROPERTIES
+}
+
+has_local_thresholds_changed() {
+  echo "Checking for changes to '$GRADLE_PROPERTIES'..."
+  local -r old_hash=$1
+  local -r new_hash=$(get_gradle_properties_hash)
+  if [[ "$old_hash" != "$new_hash" ]]; then
+    echo "  ...changes detected."
+    return $TRUE
+  else
+    echo "  ...no changes detected."
+    return $FALSE
+  fi
+}
+
+update_remote_thresholds() {
+  echo "Pushing '$GRADLE_PROPERTIES' changes to '$TRAVIS_REPO_SLUG:$TRAVIS_BRANCH'..."
+  local -r old_hash=$1
+  local -r update_request="{ \
+    \"message\": \"Bot: Update Checkstyle thresholds after build $TRAVIS_BUILD_NUMBER\", \
+    \"committer\": { \
+      \"name\": \"tripleabuilderbot\", \
+      \"email\": \"tripleabuilderbot@gmail.com\" \
+    }, \
+    \"branch\": \"$TRAVIS_BRANCH\", \
+    \"content\": \"$(base64 -w 0 $GRADLE_PROPERTIES)\", \
+    \"sha\": \"$old_hash\" \
+  }"
+  curl \
+      -X PUT \
+      --header "Accept: application/vnd.github.v3+json" \
+      --data "$update_request" \
+      "https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@api.github.com/repos/$TRAVIS_REPO_SLUG/contents/$GRADLE_PROPERTIES" \
+    2>&1 | sed -r 's|https://[^@]+@|https://[secure]@|'
+}
+
+main


### PR DESCRIPTION
This PR updates the Checkstyle thresholds stored in `gradle.properties` after each successful Travis build.

This change is intended to act as a safety valve in the event a developer introduces a net decrease of Checkstyle violations in a PR but does not update the thresholds in `gradle.properties`.  If we ever get the thresholds down to zero in the future, there will be no further need for this script, and it can be removed.

#### Functional changes
None.

#### Refactoring changes
None.

#### Other changes
* A new script was added to the `after_success` phase of the Travis build.  The script runs after the `script` phase ends successfully and before the `deploy` phase starts (if applicable).
* The script will only run under the following conditions:
  * The build is not a pull request.
  * The build was triggered on branch `master`.
  * The build was triggered on repo `triplea-game/triplea`.

#### Other issues for review
* The script uses the GitHub API instead of pushing directly from the repo on Travis due to Travis creating a shallow clone of the repo.  See the commit message for alternatives I considered.
* The commit message only contains the Travis build number (e.g. `3096`), not the full TripleA version (e.g. `1.9.0.0.3096`).  This is because the `TAGGED_VERSION` variable is not created until the `deploy` phase and the script runs before that phase.  I didn't want to duplicate the logic for how `TAGGED_VERSION` is constructed in the `after_success` phase.  I considered extracting the logic to an earlier phase (e.g. `before_script`) and exporting it so it can be used by downstream phases but wasn't sure if that was appropriate for this change.  Please advise if `TRAVIS_BUILD_NUMBER` is not sufficient and we have to figure out a way to use `TAGGED_VERSION`.
* I did as much testing as possible in my own fork (see below).  However, because of the guard conditions at the top of the script, I could not verify all execution branches in the Travis environment.  The only danger I see is if the check for a PR to `master` fails.  In that case, the script will run and possibly update the `master` branch before the PR is merged.  **If this risk is deemed too great, I would suggest breaking this PR into two:**
  * Leave this PR as-is, but comment out the push back to the remote.  This would allow us to monitor several builds (both PRs and non-PRs) to ensure our understanding of the Travis environment is correct.
  * Once the analysis from the first PR is complete, a second PR would be submitted to make any necessary changes to the script logic and to uncomment the push back to the remote.
* If this script is required to update the thresholds, a second `master` build will be triggered immediately while the first build is (most likely) still running.  This is because the `after_success` phase runs before the `deploy` phase.  Therefore, a new commit is pushed to `master` while the installers are being built.  In general, this shouldn't be a problem other than there are two releases created back-to-back.
* I was thinking there could be some kind of race condition if multiple PRs are merged in close succession (i.e. within the time of a build).  I don't believe this is a problem because the GitHub API uses an optimistic lock (the `sha` field) to prevent accidentally overwriting a blob without having the current version.  Worst case, all but the first pushes would fail (without failing the build because `after_success` can't affect the build status) and the last push would get through with the correct thresholds.

#### Testing
I created a separate [branch](https://github.com/ssoloff/triplea/commits/issue-747-test-checkstyle-auto-update-thresholds) to test the script.  Note that all of the tests I ran that updated the thresholds were prior to introducing the guard at the top of the script.  I only tested the guard by running the script locally with different combinations of `TRAVIS_PULL_REQUEST`, `TRAVIS_BRANCH`, and `TRAVIS_REPO_SLUG`.

You can see the script running from some of my Travis builds for this branch.  Some examples are below:

* [Build when guard prevents script from running](https://travis-ci.org/ssoloff/triplea/builds/220789621#L9924)

```
$ chmod +x ./.travis/update_checkstyle_thresholds && ./.travis/update_checkstyle_thresholds
Checking if Checkstyle thresholds should be updated for this build...
  ...skipping because this branch is not permitted.
  ...skipping because this repo is not permitted.
```

* [Build with no change in thresholds](https://travis-ci.org/ssoloff/triplea/builds/220737066#L9924) (guard was not present at the time of this run)

```
$ chmod +x ./.travis/update_checkstyle_thresholds && ./.travis/update_checkstyle_thresholds
Updating Checkstyle warning thresholds...
Checking for changes to 'gradle.properties'...
  ...no changes detected.
```

* [Build with net decrease in thresholds](https://travis-ci.org/ssoloff/triplea/builds/220735785#L9924) (guard was not present at the time of this run)

```
$ chmod +x ./.travis/update_checkstyle_thresholds && ./.travis/update_checkstyle_thresholds
Updating Checkstyle warning thresholds...
Checking for changes to 'gradle.properties'...
  ...changes detected.
Pushing 'gradle.properties' changes to 'ssoloff/triplea:issue-747-test-checkstyle-auto-update-thresholds'...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2665  100  2255  100   410   3531    642 --:--:-- --:--:-- --:--:--  3568
{
  "content": {
    "name": "gradle.properties",
    "path": "gradle.properties",
    "sha": "ca01a9452ad81fe146a3db4f9d704218e032fd5e",
    "size": 61,
    "url": "https://api.github.com/repos/ssoloff/triplea/contents/gradle.properties?ref=issue-747-test-checkstyle-auto-update-thresholds",
    "html_url": "https://github.com/ssoloff/triplea/blob/issue-747-test-checkstyle-auto-update-thresholds/gradle.properties",
    "git_url": "https://api.github.com/repos/ssoloff/triplea/git/blobs/ca01a9452ad81fe146a3db4f9d704218e032fd5e",
    "download_url": "https://raw.githubusercontent.com/ssoloff/triplea/issue-747-test-checkstyle-auto-update-thresholds/gradle.properties",
    "type": "file",
    "_links": {
      "self": "https://api.github.com/repos/ssoloff/triplea/contents/gradle.properties?ref=issue-747-test-checkstyle-auto-update-thresholds",
      "git": "https://api.github.com/repos/ssoloff/triplea/git/blobs/ca01a9452ad81fe146a3db4f9d704218e032fd5e",
      "html": "https://github.com/ssoloff/triplea/blob/issue-747-test-checkstyle-auto-update-thresholds/gradle.properties"
    }
  },
  "commit": {
    "sha": "259d8d52c28dbf659b32226f2e51b0fb0538a853",
    "url": "https://api.github.com/repos/ssoloff/triplea/git/commits/259d8d52c28dbf659b32226f2e51b0fb0538a853",
    "html_url": "https://github.com/ssoloff/triplea/commit/259d8d52c28dbf659b32226f2e51b0fb0538a853",
    "author": {
      "name": "tripleabuilderbot",
      "email": "tripleabuilderbot@gmail.com",
      "date": "2017-04-10T21:44:00Z"
    },
    "committer": {
      "name": "tripleabuilderbot",
      "email": "tripleabuilderbot@gmail.com",
      "date": "2017-04-10T21:44:00Z"
    },
    "tree": {
      "sha": "450044cbded5ffbeab18990dd33a8898719f1a1a",
      "url": "https://api.github.com/repos/ssoloff/triplea/git/trees/450044cbded5ffbeab18990dd33a8898719f1a1a"
    },
    "message": "Bot: Update Checkstyle warning thresholds after build 186",
    "parents": [
      {
        "sha": "eb5fc3844e03feefff5f80876b76cdf4523095f3",
        "url": "https://api.github.com/repos/ssoloff/triplea/git/commits/eb5fc3844e03feefff5f80876b76cdf4523095f3",
        "html_url": "https://github.com/ssoloff/triplea/commit/eb5fc3844e03feefff5f80876b76cdf4523095f3"
      }
    ]
  }
}
```