### PR TITLE
Checkstyle: Fix token placement violations

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -54,10 +54,14 @@
         <module name="LeftCurly">
             <property name="maxLineLength" value="100"/>
         </module>
-        <module name="RightCurly"/>
         <module name="RightCurly">
+            <property name="id" value="RightCurlySame"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+        </module>
+        <module name="RightCurly">
+            <property name="id" value="RightCurlyAlone"/>
             <property name="option" value="alone"/>
-            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=7798
-checkstyleTestMaxWarnings=381
+checkstyleMainMaxWarnings=7656
+checkstyleTestMaxWarnings=375

--- a/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -68,8 +68,7 @@ public class CompositeRouteFinder {
           if (routeLeadersToProcess.contains(ter) || ter.equals(start)) {
             continue;
           }
-          if (previous.containsKey(ter)) // If we're bumping into an existing route
-          {
+          if (previous.containsKey(ter)) { // If we're bumping into an existing route
             if (routeScore >= routeScoreMap.get(ter)) {
               continue;
             }
@@ -124,8 +123,7 @@ public class CompositeRouteFinder {
     int bestMatchingScore = Integer.MAX_VALUE;
     for (final Match<Territory> match : m_matches.keySet()) {
       final int score = m_matches.get(match);
-      if (score < bestMatchingScore) // If this is a 'better' match
-      {
+      if (score < bestMatchingScore) { // If this is a 'better' match
         if (match.match(ter)) {
           bestMatchingScore = score;
         }

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -446,9 +446,8 @@ public class GameParser {
     try {
       final Class<?> instanceClass = Class.forName(className);
       instance = instanceClass.newInstance();
-    }
     // a lot can go wrong, the following list is just a subset of potential pitfalls
-    catch (final ClassNotFoundException cnfe) {
+    } catch (final ClassNotFoundException cnfe) {
       throw new GameParseException(mapName, "Class <" + className + "> could not be found.");
     } catch (final InstantiationException ie) {
       throw new GameParseException(mapName,

--- a/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -178,6 +178,7 @@ public class RelationshipTracker extends RelationshipInterpreter {
       return m_p1.getName() + "-" + m_p2.getName();
     }
   }
+
   public class Relationship implements Serializable {
     private static final long serialVersionUID = -6718866176901627180L;
 

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -125,8 +125,7 @@ public class DownloadFileDescription {
 
   /** File reference for where to install the file. */
   public File getInstallLocation() {
-    String masterSuffix = (getMapZipFileName().toLowerCase().endsWith("master.zip")) ?
-        "-master" : "";
+    String masterSuffix = (getMapZipFileName().toLowerCase().endsWith("master.zip")) ? "-master" : "";
     String normalizedMapName = getMapName().toLowerCase().replace(' ', '_') + masterSuffix + ".zip";
     return new File(ClientFileSystemHelper.getUserMapsFolder() + File.separator + normalizedMapName);
   }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -69,7 +69,7 @@ public class DownloadUtils {
     fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
     fos.close();
   }
-  
+
   public static void downloadFile(String urlString, File targetFile) throws IOException {
     downloadFile(getUrlFollowingRedirects(urlString), targetFile);
   }
@@ -85,6 +85,7 @@ public class DownloadUtils {
     }
     return url;
   }
+
   private static URL getUrlFollowingRedirects(URL url) throws IOException {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     int status = conn.getResponseCode();

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -123,10 +123,9 @@ public class GameSelectorModel extends Observable {
         try (FileInputStream fis = new FileInputStream(file)) {
           newData = (new GameParser(file.getAbsolutePath())).parse(fis, gameName, false);
         }
-      }
-      // the extension should be tsvg, but
-      // try to load it as a saved game whatever the extension
-      else {
+      } else {
+        // the extension should be tsvg, but
+        // try to load it as a saved game whatever the extension
         newData = manager.loadGame(file);
       }
       if (newData != null) {

--- a/src/main/java/games/strategy/engine/lobby/client/ui/TableSorter.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/TableSorter.java
@@ -304,6 +304,7 @@ class TableSorter extends AbstractTableModel {
       return 0;
     }
   }
+
   private class TableModelHandler implements TableModelListener {
     @Override
     public void tableChanged(final TableModelEvent e) {
@@ -348,6 +349,7 @@ class TableSorter extends AbstractTableModel {
       fireTableDataChanged();
     }
   }
+
   private class MouseHandler extends MouseAdapter {
     @Override
     public void mouseClicked(final MouseEvent e) {
@@ -369,6 +371,7 @@ class TableSorter extends AbstractTableModel {
       }
     }
   }
+
   private static class Arrow implements Icon {
     private final boolean descending;
     private final int size;
@@ -420,6 +423,7 @@ class TableSorter extends AbstractTableModel {
       return size;
     }
   }
+
   private class SortableHeaderRenderer implements TableCellRenderer {
     private final TableCellRenderer tableCellRenderer;
 
@@ -441,6 +445,7 @@ class TableSorter extends AbstractTableModel {
       return c;
     }
   }
+
   private static class Directive {
     private final int column;
     private final int direction;

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -55,7 +55,7 @@ public class LobbyServer {
     server.setAcceptNewConnections(true);
   }
 
-  public static void main(final String args[]) {
+  public static void main(final String[] args) {
     try {
       // send args to system properties
       handleCommandLineArgs(args);

--- a/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/LobbyLoginValidator.java
@@ -170,8 +170,7 @@ public class LobbyLoginValidator implements ILoginValidator {
     }
     // If this is a lobby watcher, use a different set of validation
     if (propertiesReadFromClient.get(LOBBY_WATCHER_LOGIN) != null
-        && propertiesReadFromClient.get(LOBBY_WATCHER_LOGIN).equals(Boolean.TRUE.toString())) 
-    {
+        && propertiesReadFromClient.get(LOBBY_WATCHER_LOGIN).equals(Boolean.TRUE.toString())) {
       if (!userName.endsWith(InGameLobbyWatcher.LOBBY_WATCHER_NAME)) {
         return "Lobby watcher usernames must end with 'lobby_watcher'";
       }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -315,9 +315,7 @@ public class UnifiedMessenger {
         }
       };
       threadPool.execute(task);
-    }
-    // a remote machine is returning results
-    else if (msg instanceof SpokeInvocationResults) {
+    } else if (msg instanceof SpokeInvocationResults) { // a remote machine is returning results
       // if this isn't the server, something is wrong
       // maybe an attempt to spoof a message
       assertIsServer(from);

--- a/src/main/java/games/strategy/engine/random/MersenneTwister.java
+++ b/src/main/java/games/strategy/engine/random/MersenneTwister.java
@@ -68,10 +68,10 @@ public class MersenneTwister extends Random {
   private static final int TEMPERING_MASK_B = 0x9d2c5680;
   private static final int TEMPERING_MASK_C = 0xefc60000;
   // the array for the state vector
-  private int m_mt[];
+  private int[] m_mt;
   // mti==N+1 means mt[N] is not initialized
   private int mti;
-  private int mag01[];
+  private int[] mag01;
   /*
    * implemented here because there's a bug in Random's implementation
    * of the Gaussian code (divide by zero, and log(0), ugh!), yet its
@@ -175,8 +175,7 @@ public class MersenneTwister extends Random {
   @Override
   protected synchronized int next(final int bits) {
     int y;
-    if (mti >= N) // generate N words at one time
-    {
+    if (mti >= N) { // generate N words at one time
       int kk;
       // locals are slightly faster
       final int[] mt = this.m_mt;

--- a/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
@@ -269,9 +269,7 @@ class HttpDiceRollerDialog extends JDialog {
       if (!m_test) {
         closeAndReturn();
       }
-    }
-    // an error in networking
-    catch (final SocketException ex) {
+    } catch (final SocketException ex) { // an error in networking
       appendText("Connection failure:" + ex.getMessage() + "\n"
           + "Please ensure your Internet connection is working, and try again.");
       notifyError();

--- a/src/main/java/games/strategy/net/IPFinder.java
+++ b/src/main/java/games/strategy/net/IPFinder.java
@@ -97,9 +97,7 @@ public class IPFinder {
           || (bytes[0] == _192 && bytes[1] == _168) || (bytes[0] == _169 && bytes[1] == _254)) {
         return true;
       }
-    }
-    // ip 6
-    else {
+    } else { // ip 6
       // http://en.wikipedia.org/wiki/IPv6#Addressing
       if ((bytes[0] == _252 && bytes[1] == 0) || bytes[0] == _254) {
         return true;

--- a/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/src/main/java/games/strategy/net/ServerMessenger.java
@@ -306,8 +306,7 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
     if (!expectedReceive.equals(msg.getFrom())) {
       throw new IllegalStateException("Expected: " + expectedReceive + " not: " + msg.getFrom());
     }
-    if (msg.getMessage() instanceof HubInvoke) // Chat messages are always HubInvoke's
-    {
+    if (msg.getMessage() instanceof HubInvoke) { // Chat messages are always HubInvoke's
       if (isLobby() && ((HubInvoke) msg.getMessage()).call.getRemoteName().equals("_ChatCtrl_LOBBY_CHAT")) {
         final String realName = msg.getFrom().getName().split(" ")[0];
         if (IsUsernameMuted(realName)) {

--- a/src/main/java/games/strategy/net/nio/NIOReader.java
+++ b/src/main/java/games/strategy/net/nio/NIOReader.java
@@ -88,11 +88,10 @@ public class NIOReader {
           logger.finest("selecting...");
         }
         try {
+          // exceptions can be thrown here, nothing we can do
+          // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4729342
           selector.select();
-        }
-        // exceptions can be thrown here, nothing we can do
-        // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4729342
-        catch (final Exception e) {
+        } catch (final Exception e) {
           logger.log(Level.INFO, "error reading selection", e);
         }
         if (!running) {

--- a/src/main/java/games/strategy/net/nio/NIOWriter.java
+++ b/src/main/java/games/strategy/net/nio/NIOWriter.java
@@ -81,11 +81,10 @@ public class NIOWriter {
           s_logger.finest("selecting...");
         }
         try {
+          // exceptions can be thrown here, nothing we can do
+          // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4729342
           m_selector.select();
-        }
-        // exceptions can be thrown here, nothing we can do
-        // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4729342
-        catch (final Exception e) {
+        } catch (final Exception e) {
           s_logger.log(Level.INFO, "error reading selection", e);
         }
         if (!m_running) {

--- a/src/main/java/games/strategy/performance/PerformanceConsole.java
+++ b/src/main/java/games/strategy/performance/PerformanceConsole.java
@@ -5,7 +5,7 @@ import games.strategy.debug.GenericConsole;
 public class PerformanceConsole extends GenericConsole {
   private static final long serialVersionUID = -1249524819991242464L;
 
-  private static PerformanceConsole consoleInstance = new PerformanceConsole();;
+  private static PerformanceConsole consoleInstance = new PerformanceConsole();
 
   public static PerformanceConsole getInstance() {
     return consoleInstance;

--- a/src/main/java/games/strategy/thread/LockUtil.java
+++ b/src/main/java/games/strategy/thread/LockUtil.java
@@ -46,9 +46,7 @@ public enum LockUtil {
     if (isLockHeld(aLock)) {
       final int current = locksHeld.get().get(aLock);
       locksHeld.get().put(aLock, current + 1);
-    }
-    // we don't have it
-    else {
+    } else { // we don't have it
       synchronized (mutex) {
         // all the locks currently held must be acquired before a lock
         if (!locksHeldWhenAcquired.containsKey(aLock)) {

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -117,8 +117,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     if (name.endsWith("Tech")) {
       tech();
     } else if (name.endsWith("TechActivation")) {
-    } // the delegate handles everything
-    else if (name.endsWith("Bid") || name.endsWith("Purchase")) {
+    } else if (name.endsWith("Bid") || name.endsWith("Purchase")) { // the delegate handles everything
       purchase(GameStepPropertiesHelper.isBid(getGameData()));
     } else if (name.endsWith("Move")) {
       final boolean nonCombat = GameStepPropertiesHelper.isNonCombatMove(getGameData(), false);

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -195,9 +195,7 @@ public class AIUtils {
             // Place next carrier right before this plane (which just filled the old carrier that was just moved)
             indexToPlaceCarrierAt = i;
             spaceLeftOnSeekedCarrier = UnitAttachment.get(seekedCarrier.getUnitType()).getCarrierCapacity();
-          } else
-          // If it's later in the list
-          {
+          } else { // If it's later in the list
             final int oldIndex = result.indexOf(seekedCarrier);
             int carrierPlaceLocation = indexToPlaceCarrierAt;
             // Place carrier where it's supposed to go

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
@@ -147,16 +147,15 @@ public class ProBidAI {
         subProductionRules.add(ruleCheck);
       }
       // might be more than 1 carrier rule...use the one which will hold the most fighters
-      if (Matches.UnitTypeIsCarrier.match(x))
-      {
+      if (Matches.UnitTypeIsCarrier.match(x)) {
         final int thisFighterLimit = UnitAttachment.get(x).getCarrierCapacity();
         if (thisFighterLimit >= carrierFighterLimit) {
           carrierRule = ruleCheck;
           carrierFighterLimit = thisFighterLimit;
         }
       }
-      if (Matches.UnitTypeCanLandOnCarrier.match(x)) // might be more than 1 fighter...use the one with the best attack
-      {
+      // might be more than 1 fighter...use the one with the best attack
+      if (Matches.UnitTypeCanLandOnCarrier.match(x)) {
         final int thisFighterAttack = UnitAttachment.get(x).getAttack(player);
         if (thisFighterAttack > maxFighterAttack) {
           fighterRule = ruleCheck;
@@ -166,8 +165,7 @@ public class ProBidAI {
     }
     // most sea units move at least 2 movement, so remove any sea units with 1 movement (dumb t-boats) (some maps like
     // 270BC have mostly 1 movement sea units, so we must be sure not to remove those)
-    if (averageSeaMove / seaProductionRules.size() >= 1.8)
-    {
+    if (averageSeaMove / seaProductionRules.size() >= 1.8) {
       final List<ProductionRule> seaProductionRulesCopy = new ArrayList<>(seaProductionRules);
       for (final ProductionRule seaRule : seaProductionRulesCopy) {
         final NamedAttachable resourceOrUnit = seaRule.getResults().keySet().iterator().next();
@@ -182,8 +180,7 @@ public class ProBidAI {
     }
     if (subProductionRules.size() > 0 && seaProductionRules.size() > 0) {
       // remove submarines from consideration, unless we are mostly subs
-      if (subProductionRules.size() / seaProductionRules.size() < 0.3)
-      {
+      if (subProductionRules.size() / seaProductionRules.size() < 0.3) {
         seaProductionRules.removeAll(subProductionRules);
       }
     }
@@ -311,8 +308,7 @@ public class ProBidAI {
     bestTransport.clear();
     bestMaxUnits.clear();
     bestMobileAttack.clear();
-    if (PUsToSpend > 0) // verify a run through the land units
-    {
+    if (PUsToSpend > 0) { // verify a run through the land units
       buyLimit = PUsToSpend / 2;
       findPurchaseMix(bestAttack, bestDefense, bestTransport, bestMaxUnits, bestMobileAttack, landProductionRules,
           PUsToSpend, buyLimit, data, player, 2);
@@ -571,12 +567,10 @@ public class ProBidAI {
   private void placeAllWeCanOn(final boolean bid, final GameData data, final Territory factoryPlace,
       final Territory placeAt, final IAbstractPlaceDelegate placeDelegate, final PlayerID player) {
     final CompositeMatch<Unit> landOrAir = new CompositeMatchOr<>(Matches.UnitIsAir, Matches.UnitIsLand);
-    if (factoryPlace != null) // place a factory?
-    {
+    if (factoryPlace != null) { // place a factory?
       final Collection<Unit> toPlace =
           new ArrayList<>(player.getUnits().getMatches(Matches.UnitCanProduceUnitsAndIsConstruction));
-      if (toPlace.size() == 1) // only 1 may have been purchased...anything greater is wrong
-      {
+      if (toPlace.size() == 1) { // only 1 may have been purchased...anything greater is wrong
         doPlace(factoryPlace, toPlace, placeDelegate);
         return;
       } else if (toPlace.size() > 1) {
@@ -834,8 +828,8 @@ public class ProBidAI {
       usableMaxUnits = usableMaxUnits / 2;
     }
     for (int i = 0; i <= (usableMaxUnits - totUnits); i++) {
-      if (i > 0) // allow 0 so that this unit might be skipped...due to low value...consider special capabilities later
-      {
+      // allow 0 so that this unit might be skipped...due to low value...consider special capabilities later
+      if (i > 0) {
         totCost += cost;
         if (totCost > maxCost) {
           continue;
@@ -896,8 +890,7 @@ public class ProBidAI {
         continue;
       }
       // parameters changed: 001: attack, 010: defense, 100: maxUnits, 1000: transport, 10000: mobileAttack
-      if (parametersChanged > 0) // change forced by another rule
-      {
+      if (parametersChanged > 0) { // change forced by another rule
         if ((parametersChanged - 3) % 4 == 0) {
           bestAttack.put(rule, i);
           bestDefense.put(rule, i);
@@ -950,8 +943,7 @@ public class ProBidAI {
         final Iterator<ProductionRule> changeIter = ruleCheck.iterator();
         ProductionRule changeThis = null;
         int countThis = 1;
-        while (changeIter.hasNext()) // have to clear the rules below this rule
-        {
+        while (changeIter.hasNext()) { // have to clear the rules below this rule
           changeThis = changeIter.next();
           if (countThis >= counter) {
             bestAttack.put(changeThis, 0);
@@ -971,8 +963,7 @@ public class ProBidAI {
         final Iterator<ProductionRule> changeIter = ruleCheck.iterator();
         ProductionRule changeThis = null;
         int countThis = 1;
-        while (changeIter.hasNext()) // have to clear the rules below this rule
-        {
+        while (changeIter.hasNext()) { // have to clear the rules below this rule
           changeThis = changeIter.next();
           if (countThis >= counter) {
             bestDefense.put(changeThis, 0);
@@ -994,8 +985,7 @@ public class ProBidAI {
         final Iterator<ProductionRule> changeIter = ruleCheck.iterator();
         ProductionRule changeThis = null;
         int countThis = 1;
-        while (changeIter.hasNext()) // have to clear the rules below this rule
-        {
+        while (changeIter.hasNext()) { // have to clear the rules below this rule
           changeThis = changeIter.next();
           if (countThis >= counter) {
             bestMaxUnits.put(changeThis, 0);
@@ -1456,9 +1446,8 @@ public class ProBidAI {
       }
       if (Matches.TerritoryIsLand.match(location)) {
         blitzStrength = determineEnemyBlitzStrength(location, blitzTerrRoutes, null, data, ePlayer);
-      } else
-      // get ships attack strength
-      { // old assumed fleets won't split up, new lets them. no biggie.
+      } else { // get ships attack strength
+        // old assumed fleets won't split up, new lets them. no biggie.
         // assumes max ship movement is 3.
         // note, both old and new implementations
         // allow units to be calculated that are in
@@ -2036,8 +2025,7 @@ public class ProBidAI {
     final Set<Territory> seaNeighbors = data.getMap().getNeighbors(landTerr, ourSeaTerr);
     // float eStrength = 0.0F;
     float minStrength = 1000.0F, maxStrength = -1000.0F;
-    for (final Territory t : seaNeighbors) // give preference to territory with units
-    {
+    for (final Territory t : seaNeighbors) { // give preference to territory with units
       float enemyStrength = getStrengthOfPotentialAttackers(t, data, player, tFirst, true, null);
       final float extraEnemy = strength(t.getUnits().getMatches(Matches.enemyUnit(player, data)), true, true, tFirst);
       enemyStrength += extraEnemy;
@@ -2057,8 +2045,7 @@ public class ProBidAI {
     }
     if (seaPlaceAt == null && bestSeaPlaceAt == null) {
       final Set<Territory> seaNeighbors2 = data.getMap().getNeighbors(landTerr, Matches.TerritoryIsWater);
-      for (final Territory t : seaNeighbors2) // find Terr away from enemy units
-      {
+      for (final Territory t : seaNeighbors2) { // find Terr away from enemy units
         final float enemyStrength = getStrengthOfPotentialAttackers(t, data, player, tFirst, true, null);
         final float ourStrength = strength(t.getUnits().getMatches(seaAirUnit), false, true, tFirst);
         if (t.getUnits().someMatch(Matches.enemyUnit(player, data))) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -157,9 +157,8 @@ public final class ProTechAI {
       }
       if (Matches.TerritoryIsLand.match(location)) {
         blitzStrength = determineEnemyBlitzStrength(location, blitzTerrRoutes, null, data, ePlayer);
-      } else
-      // get ships attack strength
-      { // old assumed fleets won't split up, new lets them. no biggie.
+      } else { // get ships attack strength
+        // old assumed fleets won't split up, new lets them. no biggie.
         // assumes max ship movement is 3.
         // note, both old and new implementations
         // allow units to be calculated that are in

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -463,8 +463,7 @@ public class ProTerritoryManager {
           // Find route over water
           boolean hasNoRoute = true;
           final List<Territory> eliminatedTerritories = new ArrayList<>();
-          while (true) // Need a loop to consider different route combinations to avoid canals
-          {
+          while (true) { // Need a loop to consider different route combinations to avoid canals
             Route myRoute = data.getMap().getRoute_IgnoreEnd(myUnitTerritory, potentialTerritory,
                 ProMatches.territoryCanMoveSeaUnitsThroughOrClearedAndNotInList(player, data, isCombatMove,
                     clearedTerritories, eliminatedTerritories));
@@ -960,8 +959,7 @@ public class ProTerritoryManager {
 
           // Populate attack territories with bombard unit
           for (final Territory bombardToTerritory : bombardToTerritories) {
-            if (moveMap.containsKey(bombardToTerritory)) // Should always contain it
-            {
+            if (moveMap.containsKey(bombardToTerritory)) { // Should always contain it
               moveMap.get(bombardToTerritory).addMaxBombardUnit(mySeaUnit);
               moveMap.get(bombardToTerritory).addBombardOptionsMap(mySeaUnit, bombardFromTerritory);
             }

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
@@ -310,8 +310,7 @@ public class ProLogWindow extends javax.swing.JDialog {
   private void v_settingsDetailsButtonActionPerformed() {
     final JDialog dialog = new JDialog(this, "Pro AI - Settings Details");
     String message = "";
-    if (v_tabPaneMain.getSelectedIndex() == 0) // Debugging
-    {
+    if (v_tabPaneMain.getSelectedIndex() == 0) { // Debugging
       message = "Debugging\r\n" + "\r\n"
           + "AI Logging: When this is checked, the AI's will output their logs, as they come in, so you can see exactly what the AI is thinking.\r\n"
           + "Note that if you check this on, you still have to press OK then reopen the settings window for the logs to actually start displaying.\r\n"
@@ -359,8 +358,7 @@ public class ProLogWindow extends javax.swing.JDialog {
         currentLogTextArea = v_aiOutputLogArea;
       }
       currentLogTextArea.append(message + "\r\n");
-    } catch (final NullPointerException ex) // This is bad, but we don't want TripleA crashing because of this...
-    {
+    } catch (final NullPointerException ex) { // This is bad, but we don't want TripleA crashing because of this...
       System.out.print("Error adding Pro log message! Level: " + level.getName() + " Message: " + message);
     }
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -141,16 +141,14 @@ public class ProOddsCalculator {
     final List<Unit> mainCombatDefenders =
         Match.getMatches(defendingUnits, Matches.UnitCanBeInBattle(false, !t.isWater(), data, 1, false, true, true));
     double TUVswing = results.getAverageTUVswing(attacker, mainCombatAttackers, defender, mainCombatDefenders, data);
-    if (Matches.TerritoryIsNeutralButNotWater.match(t)) // Set TUV swing for neutrals
-    {
+    if (Matches.TerritoryIsNeutralButNotWater.match(t)) { // Set TUV swing for neutrals
       final double attackingUnitValue = BattleCalculator.getTUV(mainCombatAttackers, ProData.unitValueMap);
       final double remainingUnitValue =
           results.getAverageTUVofUnitsLeftOver(ProData.unitValueMap, ProData.unitValueMap).getFirst();
       TUVswing = remainingUnitValue - attackingUnitValue;
     }
     final List<Unit> defendingTransportedUnits = Match.getMatches(defendingUnits, Matches.unitIsBeingTransported());
-    if (t.isWater() && !defendingTransportedUnits.isEmpty()) // Add TUV swing for transported units
-    {
+    if (t.isWater() && !defendingTransportedUnits.isEmpty()) { // Add TUV swing for transported units
       final double transportedUnitValue = BattleCalculator.getTUV(defendingTransportedUnits, ProData.unitValueMap);
       TUVswing += transportedUnitValue * winPercentage / 100;
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
@@ -260,9 +260,7 @@ public class ProTransportUtils {
     for (int i = result.size() - 1; i >= 0; i--) {
       final Unit unit = result.get(i);
       final UnitAttachment ua = UnitAttachment.get(unit.getUnitType());
-      if (ua.getCarrierCost() > 0 || i == 0) // If this is a plane or last unit
-      {
-
+      if (ua.getCarrierCost() > 0 || i == 0) { // If this is a plane or last unit
         // If we haven't ignored enough trailing planes and not last unit
         if (processedPlaneCount < planesThatDontNeedToLand && i > 0) {
           processedPlaneCount++; // Increase number of trailing planes ignored

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -504,9 +504,7 @@ public class WeakAI extends AbstractAI {
           route.add(firstStep);
           moveRoutes.add(route);
         }
-      }
-      // if we cant move to a capitol, move towards the enemy
-      else {
+      } else { // if we cant move to a capitol, move towards the enemy
         final CompositeMatchAnd<Territory> routeCondition =
             new CompositeMatchAnd<>(Matches.TerritoryIsLand, Matches.TerritoryIsImpassable.invert());
         Route newRoute = Utils.findNearest(t, Matches.territoryHasEnemyLandUnits(player, data), routeCondition, data);
@@ -871,8 +869,7 @@ public class WeakAI extends AbstractAI {
       //
       // if capitol is super safe, we don't have to do this. and if capitol is under siege, we should repair enough to
       // place all our units here
-      if ((capProduction <= maxUnits / 2 || rfactories.isEmpty()) && capUnit != null)
-      {
+      if ((capProduction <= maxUnits / 2 || rfactories.isEmpty()) && capUnit != null) {
         for (final RepairRule rrule : rrules) {
           if (!capUnit.getUnitType().equals(rrule.getResults().keySet().iterator().next())) {
             continue;

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -280,16 +280,14 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   protected Set<Territory> getTerritoriesBasedOnStringName(final String name, final Collection<PlayerID> players,
       final GameData data) {
     final GameMap gameMap = data.getMap();
-    if (name.equals("original") || name.equals("enemy")) // get all originally owned territories
-    {
+    if (name.equals("original") || name.equals("enemy")) { // get all originally owned territories
       final Set<Territory> originalTerrs = new HashSet<>();
       for (final PlayerID player : players) {
         originalTerrs.addAll(OriginalOwnerTracker.getOriginallyOwned(data, player));
       }
       setTerritoryCount(String.valueOf(originalTerrs.size()));
       return originalTerrs;
-    } else if (name.equals("originalNoWater")) // get all originally owned territories, but no water or impassables
-    {
+    } else if (name.equals("originalNoWater")) { // get all originally owned territories, but no water or impassables
       final Set<Territory> originalTerrs = new HashSet<>();
       for (final PlayerID player : players) {
         originalTerrs.addAll(Match.getMatches(OriginalOwnerTracker.getOriginallyOwned(data, player),

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2631,9 +2631,7 @@ public class UnitAttachment extends DefaultAttachment {
           || m_isAirTransport || m_isKamikaze) {
         throw new GameParseException("sea units cannot have certain properties, " + thisErrorMsg());
       }
-    } else
-    // if land
-    {
+    } else { // if land
       if (m_canBombard || m_isStrategicBomber || m_isSub || m_carrierCapacity != -1 || m_bombard != -1
           || m_transportCapacity != -1 || m_isAirTransport || m_isCombatTransport || m_isKamikaze) {
         throw new GameParseException("land units cannot have certain properties, " + thisErrorMsg());

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1088,8 +1088,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final RulesAttachment ra = (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
     final Collection<Unit> alreadProducedUnits = getAlreadyProduced(producer);
     final int unitCountAlreadyProduced = alreadProducedUnits.size();
-    if (originalFactory && playerIsOriginalOwner)
-    {
+    if (originalFactory && playerIsOriginalOwner) {
       if (ra != null && ra.getMaxPlacePerTerritory() != -1) {
         return Math.max(0, ra.getMaxPlacePerTerritory() - unitCountAlreadyProduced);
       }

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -145,8 +145,7 @@ public class AirBattle extends AbstractBattle {
       }
       steps.add(new AttackersFire());
       steps.add(new DefendersFire());
-      steps.add(new IExecutable() // just calculates lost TUV and kills off any suicide units
-      {
+      steps.add(new IExecutable() { // just calculates lost TUV and kills off any suicide units
         private static final long serialVersionUID = -5575569705493214941L;
 
         @Override
@@ -538,6 +537,7 @@ public class AirBattle extends AbstractBattle {
       }
     }
   }
+
   class AttackersFire implements IExecutable {
     private static final long serialVersionUID = -5289634214875797408L;
     DiceRoll m_dice;
@@ -582,6 +582,7 @@ public class AirBattle extends AbstractBattle {
       stack.push(roll);
     }
   }
+
   class DefendersFire implements IExecutable {
     private static final long serialVersionUID = -7277182945495744003L;
     DiceRoll m_dice;

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -45,8 +45,8 @@ public class AirMovementValidator {
         !Match.someMatch(units, Matches.UnitIsAir) || // No Airunits, nothing to check
         route.hasNoSteps() || // if there are no steps, we didn't move, so it is always OK!
         // we can land at the end, nothing left to check
-        Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data).match(route.getEnd()) ||
-        isKamikazeAircraft(data) // we do not do any validation at all, cus they can all die and we don't care
+        Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data).match(route.getEnd())
+        || isKamikazeAircraft(data) // we do not do any validation at all, cus they can all die and we don't care
     ) {
       return result;
     }

--- a/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -77,9 +77,7 @@ public class AirThatCantLandUtil {
     // if we cant land on land then none can
     if (!territory.isWater()) {
       toRemove.addAll(airUnits);
-    } else
-    // on water we may just no have enough carriers
-    {
+    } else { // on water we may just no have enough carriers
       // find the carrier capacity
       final Collection<Unit> carriers = territory.getUnits().getMatches(Matches.alliedUnit(player, m_bridge.getData()));
       int capacity = AirMovementValidator.carrierCapacity(carriers, territory);

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -622,9 +622,7 @@ public class BattleCalculator {
           killed.remove(unit);
           killed.add(amphibUnit);
           allAmphibUnits.remove(amphibUnit);
-        } else
-        // If there are no more units of that type, remove the type from the collection
-        {
+        } else { // If there are no more units of that type, remove the type from the collection
           amphibTypes.remove(unit.getType());
         }
       }

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -68,8 +68,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       }
     }
     // Check for Winning conditions
-    if (isTotalVictory()) // Check for Win by Victory Cities
-    {
+    if (isTotalVictory()) { // Check for Win by Victory Cities
       victoryMessage = " achieve TOTAL VICTORY with ";
       checkVictoryCities(m_bridge, victoryMessage, " Total Victory VCs");
     }
@@ -81,8 +80,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       victoryMessage = " achieve victory through a PROJECTION OF POWER with ";
       checkVictoryCities(m_bridge, victoryMessage, " Projection of Power VCs");
     }
-    if (isEconomicVictory()) // Check for regular economic victory
-    {
+    if (isEconomicVictory()) { // Check for regular economic victory
       final Iterator<String> allianceIter = data.getAllianceTracker().getAlliances().iterator();
       String allianceName = null;
       while (allianceIter.hasNext()) {

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -144,15 +144,11 @@ public class Fire implements IExecutable {
             !m_defending, m_battleID, m_isHeadless, extraHits, true);
         m_killed.addAll(message.getKilled());
         m_confirmOwnCasualties = true;
-      }
-      // exact number of combat units
-      else if (hitCount == numPossibleHits) {
+      } else if (hitCount == numPossibleHits) { // exact number of combat units
         m_killed = nonTransports;
         m_damaged = Collections.emptyList();
         m_confirmOwnCasualties = true;
-      }
-      // less than possible number
-      else {
+      } else { // less than possible number
         message = BattleCalculator.selectCasualties(m_stepName, m_hitPlayer, nonTransports,
             m_allEnemyUnitsNotIncludingWaitingToDie, m_firingPlayer, m_allFriendlyUnitsNotIncludingWaitingToDie,
             m_isAmphibious, m_amphibiousLandAttackers, m_battleSite, m_territoryEffects, bridge, m_text, m_dice,
@@ -161,18 +157,14 @@ public class Fire implements IExecutable {
         m_damaged = message.getDamaged();
         m_confirmOwnCasualties = message.getAutoCalculated();
       }
-    } else
-    // not isTransportCasualtiesRestricted
-    {
+    } else { // not isTransportCasualtiesRestricted
       // they all die
       if (hitCount >= AbstractBattle.getMaxHits(m_attackableUnits)) {
         m_killed = m_attackableUnits;
         m_damaged = Collections.emptyList();
         // everything died, so we need to confirm
         m_confirmOwnCasualties = true;
-      }
-      // Choose casualties
-      else {
+      } else { // Choose casualties
         CasualtyDetails message;
         message = BattleCalculator.selectCasualties(m_stepName, m_hitPlayer, m_attackableUnits,
             m_allEnemyUnitsNotIncludingWaitingToDie, m_firingPlayer, m_allFriendlyUnitsNotIncludingWaitingToDie,

--- a/src/main/java/games/strategy/triplea/delegate/IBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/IBattle.java
@@ -21,6 +21,7 @@ public interface IBattle extends java.io.Serializable {
   enum WhoWon {
     NOTFINISHED, DRAW, ATTACKER, DEFENDER
   }
+
   enum BattleType {
     NORMAL("Battle"), AIR_BATTLE("Air Battle"), AIR_RAID("Air Raid"), BOMBING_RAID("Bombing Raid");
     private final String m_type;

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -418,10 +418,9 @@ public class MoveValidator {
           && (!games.strategy.triplea.Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
         return result.setErrorReturnResult("Air units cannot fly over neutral territories in non combat");
       }
-    }
     // if sea units, or land units moving over/onto sea (ex: loading onto a transport), then only check if old rules
     // stop us
-    else if (Match.someMatch(units, Matches.UnitIsSea) || route.someMatch(Matches.TerritoryIsWater)) {
+    } else if (Match.someMatch(units, Matches.UnitIsSea) || route.someMatch(Matches.TerritoryIsWater)) {
       // if there are neutral or owned territories, we cannot move through them (only under old rules. under new rules
       // we can move through
       // owned sea zones.)
@@ -991,16 +990,14 @@ public class MoveValidator {
           for (final Unit unit : TransportTracker.transporting(transport)) {
             result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE, unit);
           }
-        }
         // check whether transport is restricted to another territory
-        else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport, route.getEnd())) {
+        } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport, route.getEnd())) {
           final Territory alreadyUnloadedTo = getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
           for (final Unit unit : TransportTracker.transporting(transport)) {
             result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO + alreadyUnloadedTo.getName(), unit);
           }
-        }
         // Check if the transport has already loaded after being in combat
-        else if (TransportTracker.isTransportUnloadRestrictedInNonCombat(transport)) {
+        } else if (TransportTracker.isTransportUnloadRestrictedInNonCombat(transport)) {
           for (final Unit unit : TransportTracker.transporting(transport)) {
             result.addDisallowedUnit(TRANSPORT_CANNOT_LOAD_AND_UNLOAD_AFTER_COMBAT, unit);
           }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -51,13 +51,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   public static enum ReturnFire {
     ALL, SUBS, NONE
   }
+
   public static enum RetreatType {
     DEFAULT, SUBS, PLANES, PARTIAL_AMPHIB
   }
-  // these class exist for testing
+
+  // this class exists for testing
   public abstract static class AttackSubs implements IExecutable {
     private static final long serialVersionUID = 4872551667582174716L;
   }
+
+  // this class exists for testing
   public abstract static class DefendSubs implements IExecutable {
     private static final long serialVersionUID = 3768066729336520095L;
   }
@@ -861,10 +865,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
               defenderWins(bridge);
             }
           }
-        }
         // changed to only look at units that can be destroyed in combat, and therefore not include factories, aaguns,
         // and infrastructure.
-        else if (Match.getMatches(m_defendingUnits, Matches.UnitIsNotInfrastructure).size() == 0) {
+        } else if (Match.getMatches(m_defendingUnits, Matches.UnitIsNotInfrastructure).size() == 0) {
           if (isTransportCasualtiesRestricted()) {
             // If there are undefended attacking transports, determine if they automatically die
             checkUndefendedTransports(bridge, m_defender);

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -374,9 +374,8 @@ public class RocketsFireHelper {
       damageMap.put(target, totalDamage);
       bridge.addChange(ChangeFactory.bombingUnitDamage(damageMap));
       // attackedTerritory.notifyChanged();
-    }
     // in WW2V2, limit rocket attack cost to production value of factory.
-    else if (isWW2V2(data) || isLimitRocketDamageToProduction(data)) {
+    } else if (isWW2V2(data) || isLimitRocketDamageToProduction(data)) {
       // If we are limiting total PUs lost then take that into account
       if (isPUCap(data) || isLimitRocketDamagePerTurn(data)) {
         final int alreadyLost = DelegateFinder.moveDelegate(data).PUsAlreadyLost(attackedTerritory);

--- a/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -227,9 +227,9 @@ public class TransportTracker {
       // if we are no longer being transported,
       // then we must have been transported on our own transport
       final TripleAUnit taUnit = (TripleAUnit) u;
-      if (taUnit.getWasLoadedThisTurn() && taUnit.getTransportedBy() != null &&
+      if (taUnit.getWasLoadedThisTurn() && taUnit.getTransportedBy() != null
           // an allied transport if the owner of the transport is not the owner of the unit
-          !taUnit.getTransportedBy().getOwner().equals(taUnit.getOwner())) {
+          && !taUnit.getTransportedBy().getOwner().equals(taUnit.getOwner())) {
         rVal.add(u);
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -170,16 +170,16 @@ public class UndoableMove extends AbstractUndoableMove {
         throw new IllegalStateException("other should not be null");
       }
       if ( // if the other move has moves that depend on this
-          !Util.intersection(other.getUnits(), this.getUnits()).isEmpty() ||
+          !Util.intersection(other.getUnits(), this.getUnits()).isEmpty()
           // if the other move has transports that we are loading
-          !Util.intersection(other.m_units, this.m_loaded).isEmpty() ||
+          || !Util.intersection(other.m_units, this.m_loaded).isEmpty()
           // or we are moving through a previously conqueured territory
           // we should be able to take this out later
           // we need to add logic for this move to take over the same territories
           // when the other move is undone
-          !Util.intersection(other.m_conquered, m_route.getAllTerritories()).isEmpty() ||
+          || !Util.intersection(other.m_conquered, m_route.getAllTerritories()).isEmpty()
           // or we are unloading transports that have moved in another turn
-          !Util.intersection(other.m_units, this.m_unloaded).isEmpty()
+          || !Util.intersection(other.m_units, this.m_unloaded).isEmpty()
           || !Util.intersection(other.m_unloaded, this.m_unloaded).isEmpty()) {
         m_iDependOn.add(other);
         other.m_dependOnMe.add(this);

--- a/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -23,6 +23,7 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate {
   enum BidMode {
     BID, NOT_BID
   }
+
   /**
    * Query what units can be produced in a given territory.
    * ProductionResponse may indicate an error string that there

--- a/src/main/java/games/strategy/triplea/image/BlendComposite.java
+++ b/src/main/java/games/strategy/triplea/image/BlendComposite.java
@@ -122,6 +122,7 @@ class BlendComposite implements java.awt.Composite {
       }
     }
   }
+
   abstract static class Blender {
     public abstract int[] blend(int[] src, int[] dst);
 

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
@@ -66,8 +66,7 @@ public class AggregateResults implements Serializable {
   }
 
   public double getAverageAttackingUnitsLeft() {
-    if (m_results.isEmpty()) // can be empty!
-    {
+    if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
     double count = 0;
@@ -82,8 +81,7 @@ public class AggregateResults implements Serializable {
    */
   public Tuple<Double, Double> getAverageTUVofUnitsLeftOver(final IntegerMap<UnitType> attackerCostsForTUV,
       final IntegerMap<UnitType> defenderCostsForTUV) {
-    if (m_results.isEmpty()) // can be empty!
-    {
+    if (m_results.isEmpty()) { // can be empty!
       return Tuple.of(0.0, 0.0);
     }
     double attackerTUV = 0;
@@ -97,8 +95,7 @@ public class AggregateResults implements Serializable {
 
   public double getAverageTUVswing(final PlayerID attacker, final Collection<Unit> attackers, final PlayerID defender,
       final Collection<Unit> defenders, final GameData data) {
-    if (m_results.isEmpty()) // can be empty!
-    {
+    if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
     final IntegerMap<UnitType> attackerCostsForTUV = BattleCalculator.getCostsForTUV(attacker, data);
@@ -113,8 +110,7 @@ public class AggregateResults implements Serializable {
   }
 
   public double getAverageAttackingUnitsLeftWhenAttackerWon() {
-    if (m_results.isEmpty()) // can be empty!
-    {
+    if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
     double count = 0;
@@ -132,8 +128,7 @@ public class AggregateResults implements Serializable {
   }
 
   public double getAverageDefendingUnitsLeft() {
-    if (m_results.isEmpty()) // can be empty!
-    {
+    if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
     double count = 0;
@@ -144,8 +139,7 @@ public class AggregateResults implements Serializable {
   }
 
   public double getAverageDefendingUnitsLeftWhenDefenderWon() {
-    if (m_results.isEmpty()) // can be empty!
-    {
+    if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
     double count = 0;
@@ -163,8 +157,7 @@ public class AggregateResults implements Serializable {
   }
 
   public double getAttackerWinPercent() {
-    if (m_results.isEmpty()) // can be empty!
-    {
+    if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
     double count = 0;
@@ -177,8 +170,7 @@ public class AggregateResults implements Serializable {
   }
 
   public double getDefenderWinPercent() {
-    if (m_results.isEmpty()) // can be empty!
-    {
+    if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
     double count = 0;
@@ -191,8 +183,7 @@ public class AggregateResults implements Serializable {
   }
 
   public double getAverageBattleRoundsFought() {
-    if (m_results.isEmpty()) // can be empty!
-    {
+    if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
     double count = 0;
@@ -207,8 +198,7 @@ public class AggregateResults implements Serializable {
   }
 
   public double getDrawPercent() {
-    if (m_results.isEmpty()) // can be empty!
-    {
+    if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
     double count = 0;

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
@@ -144,8 +144,8 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
         newData.acquireReadLock();
         int i = 0;
         // we are already in 1 executor thread, so we have MAX_THREADS-1 threads left to use
-        if (m_currentThreads <= 2 || MAX_THREADS <= 2)
-        { // if 2 or fewer threads, do not multi-thread the copying (we have already copied it once above, so at most
+        if (m_currentThreads <= 2 || MAX_THREADS <= 2) {
+          // if 2 or fewer threads, do not multi-thread the copying (we have already copied it once above, so at most
           // only 1 more copy to
           // make)
           while (m_cancelCurrentOperation >= 0 && i < m_currentThreads) {

--- a/src/main/java/games/strategy/triplea/ui/AbstractForumPosterPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractForumPosterPanel.java
@@ -28,8 +28,8 @@ public abstract class AbstractForumPosterPanel extends ActionPanel {
 
   private int getRound() {
     int round = 0;
-    final Object pathFromRoot[] = getData().getHistory().getLastNode().getPath();
-    final Object arr$[] = pathFromRoot;
+    final Object[] pathFromRoot = getData().getHistory().getLastNode().getPath();
+    final Object[] arr$ = pathFromRoot;
     final int len$ = arr$.length;
     int i$ = 0;
     do {

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -495,6 +495,7 @@ public class BattlePanel extends ActionPanel {
       }
     }
   }
+
   class FightBattleAction extends AbstractAction {
     private static final long serialVersionUID = 5510976406003707776L;
     Territory m_territory;

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -666,15 +666,11 @@ public class EditPanel extends ActionPanel {
           // remove the last element
           m_selectedUnits.remove(new ArrayList<>(m_selectedUnits).get(m_selectedUnits.size() - 1));
         }
-      }
-      // user has clicked on a specific unit
-      else {
+      } else { // user has clicked on a specific unit
         // deselect all if control is down
         if (md.isControlDown() || t != m_selectedTerritory) {
           m_selectedUnits.removeAll(units);
-        }
-        // deselect one
-        else {
+        } else { // deselect one
           // remove those with the least movement first
           for (final Unit unit : units) {
             if (m_selectedUnits.contains(unit)) {
@@ -724,9 +720,7 @@ public class EditPanel extends ActionPanel {
         m_selectedUnits.addAll(t.getUnits().getUnits());
       } else if (md.isControlDown()) {
         m_selectedUnits.addAll(units);
-      }
-      // select one
-      else {
+      } else { // select one
         for (final Unit unit : units) {
           if (!m_selectedUnits.contains(unit)) {
             m_selectedUnits.add(unit);

--- a/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
@@ -13,9 +13,9 @@ import games.strategy.ui.SwingAction;
 public class EndTurnPanel extends AbstractForumPosterPanel {
   private static final long serialVersionUID = -6282316384529504341L;
   protected AbstractAction m_doneAction = SwingAction.of("Done", e -> {
-    if (m_forumPosterComponent.getHasPostedTurnSummary() || JOptionPane.YES_OPTION ==
-        JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(EndTurnPanel.this),
-        "Are you sure you don't want to post?", "Bypass post", JOptionPane.YES_NO_OPTION)) {
+    if (m_forumPosterComponent.getHasPostedTurnSummary()
+        || JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(EndTurnPanel.this),
+            "Are you sure you don't want to post?", "Bypass post", JOptionPane.YES_NO_OPTION)) {
       release();
     }
   });

--- a/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -153,6 +153,7 @@ public class ExtendedStats extends StatPanel {
       return count;
     }
   }
+
   class GenericResourceStat extends AbstractStat {
     private String m_name = null;
 
@@ -170,6 +171,7 @@ public class ExtendedStats extends StatPanel {
       return player.getResources().getQuantity(m_name);
     }
   }
+
   class GenericTechNameStat extends AbstractStat {
     private TechAdvance m_ta = null;
 
@@ -190,6 +192,7 @@ public class ExtendedStats extends StatPanel {
       return 0;
     }
   }
+
   class GenericUnitNameStat extends AbstractStat {
     private UnitType m_ut = null;
 
@@ -213,6 +216,7 @@ public class ExtendedStats extends StatPanel {
       return rVal;
     }
   }
+
   class TechTokenStat extends ResourceStat {
     public TechTokenStat() {
       super(m_data.getResourceList().getResource(Constants.TECH_TOKENS));

--- a/src/main/java/games/strategy/triplea/ui/IUIContext.java
+++ b/src/main/java/games/strategy/triplea/ui/IUIContext.java
@@ -41,6 +41,7 @@ public interface IUIContext {
   enum UnitDamage {
     DAMAGED, NOT_DAMAGED
   }
+
   enum UnitEnable {
     DISABLED, ENABLED
   }

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -843,9 +843,7 @@ public class MovePanel extends AbstractMovePanel {
         selectedUnits.addAll(t.getUnits().getMatches(ownedNotFactory));
       } else if (me.isControlDown()) {
         selectedUnits.addAll(Match.getMatches(units, unitsToMoveMatch));
-      }
-      // add one
-      else {
+      } else { // add one
         // best candidate unit for route is chosen dynamically later
         // check for alt key - add 1/10 of total units (useful for splitting large armies)
         final List<Unit> unitsToMove = Match.getMatches(units, unitsToMoveMatch);
@@ -1040,9 +1038,7 @@ public class MovePanel extends AbstractMovePanel {
             }
           }
         }
-      }
-      // we have actually clicked on a specific unit
-      else {
+      } else { // we have actually clicked on a specific unit
         // remove all if control is down
         if (me.isControlDown()) {
           unitsToRemove.addAll(units);
@@ -1055,9 +1051,7 @@ public class MovePanel extends AbstractMovePanel {
               }
             }
           }
-        }
-        // remove one
-        else {
+        } else { // remove one
           if (!getFirstSelectedTerritory().equals(t)) {
             throw new IllegalStateException("Wrong selected territory");
           }

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -80,7 +80,7 @@ public class PlacePanel extends AbstractMovePanel {
       if (!getActive() || (e.getButton() != MouseEvent.BUTTON1)) {
         return;
       }
-      final int maxUnits[] = new int[1];
+      final int[] maxUnits = new int[1];
       final Collection<Unit> units = getUnitsToPlace(territory, maxUnits);
       if (units.isEmpty()) {
         return;
@@ -115,7 +115,7 @@ public class PlacePanel extends AbstractMovePanel {
     }
   };
 
-  private Collection<Unit> getUnitsToPlace(final Territory territory, final int maxUnits[]) {
+  private Collection<Unit> getUnitsToPlace(final Territory territory, final int[] maxUnits) {
     getData().acquireReadLock();
     try {
       // not our territory

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -161,6 +161,7 @@ public class StatPanel extends AbstractStatPanel {
       return (JComponent) value;
     }
   }
+
   /**
    * Custom table model.
    * This model is thread safe.
@@ -284,6 +285,7 @@ public class StatPanel extends AbstractStatPanel {
       repaint();
     }
   }
+
   class TechTableModel extends AbstractTableModel implements GameDataChangeListener {
     private static final long serialVersionUID = -4612476336419396081L;
     /* Flag to indicate whether data needs to be recalculated */
@@ -446,6 +448,7 @@ public class StatPanel extends AbstractStatPanel {
       isDirty = true;
     }
   }
+
   class ProductionStat extends AbstractStat {
     @Override
     public String getName() {
@@ -467,11 +470,13 @@ public class StatPanel extends AbstractStatPanel {
       return rVal;
     }
   }
+
   class PUStat extends ResourceStat {
     public PUStat() {
       super(getResourcePUs(m_data));
     }
   }
+
   class UnitsStat extends AbstractStat {
     @Override
     public String getName() {
@@ -488,6 +493,7 @@ public class StatPanel extends AbstractStatPanel {
       return rVal;
     }
   }
+
   class TUVStat extends AbstractStat {
     @Override
     public String getName() {
@@ -506,6 +512,7 @@ public class StatPanel extends AbstractStatPanel {
       return rVal;
     }
   }
+
   class VictoryCityStat extends AbstractStat {
     @Override
     public String getName() {
@@ -530,6 +537,7 @@ public class StatPanel extends AbstractStatPanel {
       return rVal;
     }
   }
+
   class VPStat extends AbstractStat {
     @Override
     public String getName() {

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1382,7 +1382,7 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   public static int save(final String filename, final GameData m_data) {
-    try (FileOutputStream fos = new FileOutputStream(filename); ObjectOutputStream oos = new ObjectOutputStream(fos);) {
+    try (FileOutputStream fos = new FileOutputStream(filename); ObjectOutputStream oos = new ObjectOutputStream(fos)) {
       oos.writeObject(m_data);
       return 0;
     } catch (final Throwable t) {

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -125,7 +125,7 @@ public class HistoryLog extends JFrame {
     final TreePath parentPath = (new TreePath(printNode.getPath())).getParentPath();
     PlayerID curPlayer = null;
     if (parentPath != null) {
-      final Object pathToNode[] = parentPath.getPath();
+      final Object[] pathToNode = parentPath.getPath();
       for (final Object pathNode : pathToNode) {
         final HistoryNode node = (HistoryNode) pathNode;
         if (node instanceof Step) {
@@ -163,7 +163,7 @@ public class HistoryLog extends JFrame {
     final TreePath parentPath = (new TreePath(printNode.getPath())).getParentPath();
     PlayerID currentPlayer = null;
     if (parentPath != null) {
-      final Object pathToNode[] = parentPath.getPath();
+      final Object[] pathToNode = parentPath.getPath();
       for (final Object pathNode : pathToNode) {
         final HistoryNode node = (HistoryNode) pathNode;
         for (int i = 0; i < node.getLevel(); i++) {

--- a/src/main/java/games/strategy/triplea/ui/logic/Point.java
+++ b/src/main/java/games/strategy/triplea/ui/logic/Point.java
@@ -1,13 +1,14 @@
 package games.strategy.triplea.ui.logic;
 
 import java.awt.geom.Point2D;
+
 /**
  * Framework independent point class.
  */
 public class Point {
   private double x;
   private double y;
-  
+
   public Point() {
     this(0, 0);
   }

--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -281,9 +281,7 @@ public class HelpMenu {
       parentMenu.addSeparator();
       parentMenu.add(SwingAction.of("About", e -> JOptionPane.showMessageDialog(null, editorPane,
           "About " + gameData.getGameName(), JOptionPane.PLAIN_MESSAGE))).setMnemonic(KeyEvent.VK_A);
-    } else
-    // On Mac OS X, put the About menu where Mac users expect it to be
-    {
+    } else { // On Mac OS X, put the About menu where Mac users expect it to be
       Application.getApplication().setAboutHandler(paramAboutEvent -> JOptionPane.showMessageDialog(null, editorPane,
           "About " + gameData.getGameName(), JOptionPane.PLAIN_MESSAGE));
     }

--- a/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -123,9 +123,7 @@ public class TripleAMenuBar extends JMenuBar {
         final File f = new File(dirName, fileName);
         return f;
       }
-    }
-    // Non-Mac platforms should use the normal Swing JFileChooser
-    else {
+    } else { // Non-Mac platforms should use the normal Swing JFileChooser
       final JFileChooser fileChooser = SaveGameFileChooser.getInstance();
       final int rVal = fileChooser.showSaveDialog(frame);
       if (rVal != JFileChooser.APPROVE_OPTION) {

--- a/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -221,6 +221,7 @@ public class ViewMenu {
         frame.getMapPanel().resetMap();
       }
     }
+
     final JMenu unitSizeMenu = new JMenu();
     unitSizeMenu.setMnemonic(KeyEvent.VK_S);
     unitSizeMenu.setText("Unit Size");

--- a/src/main/java/games/strategy/util/MD5Crypt.java
+++ b/src/main/java/games/strategy/util/MD5Crypt.java
@@ -46,7 +46,7 @@ public class MD5Crypt {
     return result.toString();
   }
 
-  private static void clearbits(final byte bits[]) {
+  private static void clearbits(final byte[] bits) {
     for (int i = 0; i < bits.length; i++) {
       bits[i] = 0;
     }
@@ -114,7 +114,7 @@ public class MD5Crypt {
     if (magic == null) {
       throw new IllegalArgumentException("Null salt!");
     }
-    byte finalState[];
+    byte[] finalState;
     long l;
     /*
      * Two MD5 hashes are used

--- a/src/main/java/games/strategy/util/Triple.java
+++ b/src/main/java/games/strategy/util/Triple.java
@@ -75,7 +75,7 @@ public class Triple<F, S, T> implements Serializable {
     }
 
     final Triple<?, ?, ?> other = (Triple<?, ?, ?>) obj;
-    return Objects.equals(tuple, other.tuple) &&
-        Objects.equals(getThird(), other.getThird());
+    return Objects.equals(tuple, other.tuple)
+        && Objects.equals(getThird(), other.getThird());
   }
 }

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -392,9 +392,9 @@ public class AutoPlacementFinder {
       final Collection<Polygon> containedCountryPolygons, final List<Rectangle2D> placementRects,
       final List<Point> placementPoints, final Rectangle2D place, final int x, final int y) {
     place.setFrame(x, y, PLACEWIDTH, PLACEHEIGHT);
-    if (containedIn(place, countryPolygons) && !intersectsOneOf(place, placementRects) &&
+    if (containedIn(place, countryPolygons) && !intersectsOneOf(place, placementRects)
         // make sure it is not in or intersects the contained country
-        (!containedIn(place, containedCountryPolygons) && !intersectsOneOf(place, containedCountryPolygons))) {
+        && (!containedIn(place, containedCountryPolygons) && !intersectsOneOf(place, containedCountryPolygons))) {
       placementPoints.add(new Point((int) place.getX(), (int) place.getY()));
       final Rectangle2D newRect = new Rectangle2D.Double();
       newRect.setFrame(place);

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -421,11 +421,9 @@ public class PolygonGrabber extends JFrame {
     if (p == null) {
       return;
     }
-    if (rightMouse && m_current != null) // right click and list of polys is not empty
-    {
+    if (rightMouse && m_current != null) { // right click and list of polys is not empty
       doneCurrentGroup();
-    } else if (pointInCurrentPolygon(point)) // point clicked is already highlighted
-    {
+    } else if (pointInCurrentPolygon(point)) { // point clicked is already highlighted
       System.out.println("rejecting");
       return;
     } else if (ctrlDown) {
@@ -701,8 +699,7 @@ public class PolygonGrabber extends JFrame {
         return null;
       }
       int tempDirection;
-      for (int i = 2; i >= -3; i--) // was -4
-      {
+      for (int i = 2; i >= -3; i--) { // was -4
         tempDirection = (currentDirection + i) % 8;
         if (tempDirection < 0) {
           tempDirection += 8;

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidClearExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidClearExample.java
@@ -24,8 +24,7 @@ public class InvalidClearExample extends DefaultAttachment {
 
   public void resetGivesMovement() {}
 
-  public void clearMovement() // badly named, should cause test to fail
-  {
+  public void clearMovement() { // badly named, should cause test to fail
     m_givesMovement.clear();
   }
 

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidGetterExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidGetterExample.java
@@ -18,8 +18,7 @@ public class InvalidGetterExample extends DefaultAttachment {
   private String m_attribute;
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public String getAttribute() // annotation put on a getter instead of a setter, should cause test to fail
-  {
+  public String getAttribute() { // annotation put on a getter instead of a setter, should cause test to fail
     return m_attribute;
   }
 

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidResetExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidResetExample.java
@@ -22,8 +22,7 @@ public class InvalidResetExample extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
   public void setGivesMovement(final String value) {}
 
-  public void resetGiveMovement() // badly named, should cause test to fail
-  {
+  public void resetGiveMovement() { // badly named, should cause test to fail
     m_givesMovement = new IntegerMap<>();
   }
 

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidReturnTypeExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidReturnTypeExample.java
@@ -18,8 +18,7 @@ public class InvalidReturnTypeExample extends DefaultAttachment {
   @SuppressWarnings("unused")
   private String m_attribute;
 
-  public int getAttribute() // is not returning our variable, so should cause test to fail
-  {
+  public int getAttribute() { // is not returning our variable, so should cause test to fail
     return 1;
   }
 

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -210,8 +210,7 @@ public class ValidateAttachmentsTest {
       Class<?> clazz;
       try {
         clazz = Class.forName(className);
-        if (!clazz.isInterface() && IAttachment.class.isAssignableFrom(clazz))
-        {
+        if (!clazz.isInterface() && IAttachment.class.isAssignableFrom(clazz)) {
           @SuppressWarnings("unchecked")
           final Class<? extends IAttachment> attachmentClass = (Class<? extends IAttachment>) clazz;
           // sb.append("Testing class: " + attachmentClass.getCanonicalName());

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListSortTest.java
@@ -17,6 +17,7 @@ public class MapDownloadListSortTest {
   // capitol B to ensure case insensitive sorting
   private static final DownloadFileDescription MAP_B = createDownload("B", "url");
   private static final DownloadFileDescription MAP_C = createDownload("c", "url");
+
   private static DownloadFileDescription createDownload(final String mapName, final String url) {
     final String description = "fake";
     final Version version = new Version("1");


### PR DESCRIPTION
This PR fixes violations of various Checkstyle rules related to token placement.

Specifically, the following types of violations were fixed:

* RightCurly
  * "'X' at column X should be alone on a line." 
  * "'X' at column X should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally)."
* LeftCurly
  * "'X' at column X should be on the previous line."
* EmptyLineSeparator
  * "'X' should be separated from previous statement."
* OneStatementPerLine
  * "Only one statement per line allowed."
* ArrayTypeStyle
  * "Array brackets at illegal position." 

:warning: There is a [bug](https://github.com/checkstyle/checkstyle/issues/3678) in the version (7.1) of the Checkstyle Google ruleset we are using.  It incorrectly requires changing a `do-while` block formatted like this:

```
do {
  // something
} while (/* condition */);
```

to this:

```
do {
  // something
}
while (/* condition */);
```

It has been subsequently fixed in version 7.6 of `google_checks.xml`.  I copied the updated rules into our Checkstyle configuration to remove the violations.

I probably should have updated our configuration to match (minus our few differences) version 7.6 of `google_checks.xml` when I upgraded the Checkstyle engine to 7.6.  I'll schedule this for a future change because it's possible it could include/exclude additional violations.