### PR TITLE
Checkstyle: Fix or remove unused Javadoc param tags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=7402
+checkstyleMainMaxWarnings=7381
 checkstyleTestMaxWarnings=358

--- a/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/CollectionProperty.java
@@ -19,10 +19,10 @@ public class CollectionProperty<T> extends AEditableProperty {
   /**
    * @param name
    *        name of the property.
-   * @param defaultValue
-   *        default string value
-   * @param possibleValues
-   *        collection of Strings
+   * @param description
+   *        description of the property.
+   * @param values
+   *        collection of values.
    */
   public CollectionProperty(final String name, final String description, final Collection<T> values) {
     super(name, description);

--- a/src/main/java/games/strategy/engine/message/IRemoteMessenger.java
+++ b/src/main/java/games/strategy/engine/message/IRemoteMessenger.java
@@ -86,13 +86,10 @@ public interface IRemoteMessenger {
   IRemote getRemote(RemoteName name, boolean ignoreResults);
 
   /**
-   * @param remoteInterface
-   *        - the remote interface that implementor implements,
-   *        must be a subclass of IRemote.
    * @param implementor
-   *        - an object that implements remoteInterface
+   *        An object that implements remoteInterface.
    * @param name
-   *        - the name that implementor will be registered under
+   *        The name that implementor will be registered under.
    */
   void registerRemote(Object implementor, RemoteName name);
 

--- a/src/main/java/games/strategy/engine/pbem/IEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/IEmailSender.java
@@ -64,7 +64,7 @@ public interface IEmailSender extends IBean {
   /**
    * Configure if we should also post at the end of combat move.
    *
-   * @param include
+   * @param postAlso
    *        true if the save game should be included
    */
   void setAlsoPostAfterCombatMove(boolean postAlso);

--- a/src/main/java/games/strategy/engine/pbem/IForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/IForumPoster.java
@@ -53,7 +53,7 @@ public interface IForumPoster extends IBean {
   /**
    * Configure if we should also post at the end of combat move.
    *
-   * @param include
+   * @param postAlso
    *        true if the save game should be included
    */
   void setAlsoPostAfterCombatMove(boolean postAlso);

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -61,11 +61,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
    *        - game data
    * @param attacker
    *        - attacker PlayerID
-   * @param defender
-   *        - defender PlayerID
    * @param battleTracker
    *        - BattleTracker
-   **/
+   */
   public StrategicBombingRaidBattle(final Territory battleSite, final GameData data, final PlayerID attacker,
       final BattleTracker battleTracker) {
     super(battleSite, attacker, battleTracker, true, BattleType.BOMBING_RAID, data);

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleListing.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleListing.java
@@ -23,8 +23,6 @@ public class BattleListing implements Serializable {
    *
    * @param battles
    *        battles to list
-   * @param strategicRaids
-   *        strategic raids
    */
   public BattleListing(final Map<BattleType, Collection<Territory>> battles) {
     m_battles = battles;

--- a/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
@@ -131,7 +131,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
   /**
    * Report an error to the user.
    *
-   * @param report
+   * @param error
    *        that an error occurred
    */
   void reportError(String error);

--- a/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
@@ -89,7 +89,7 @@ public class IndividualUnitPanel extends JPanel {
    * individually.
    * It lets you set a max number of points total AND per unit. It can return an IntegerMap with the points per unit.
    *
-   * @param units
+   * @param unitsAndTheirMaxMinAndCurrent
    *        mapped to their individual max, then min, then current values
    * @param title
    * @param data

--- a/src/main/java/games/strategy/triplea/ui/display/ITripleADisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/ITripleADisplay.java
@@ -70,8 +70,6 @@ public interface ITripleADisplay extends IDisplay {
   /**
    * @param battleID
    *        - the battle we are listing steps for.
-   * @param currentStep
-   *        - the current step
    * @param steps
    *        - a collection of strings denoting all steps in the battle
    */

--- a/src/main/java/games/strategy/triplea/util/UnitSeperator.java
+++ b/src/main/java/games/strategy/triplea/util/UnitSeperator.java
@@ -46,8 +46,8 @@ public class UnitSeperator {
    *        - whether to categorize by movement
    * @param categorizeTrnMovement
    *        - whether to categorize transports by movement
-   * @param - sort - if true then sort the categories in UnitCategory order
-   *        - if false, then leave categories in original order (based on units)
+   * @param sort If true then sort the categories in UnitCategory order;
+   *        if false, then leave categories in original order (based on units).
    * @return a Collection of UnitCategories
    */
   public static Set<UnitCategory> categorize(final Collection<Unit> units, final Map<Unit, Collection<Unit>> dependent,

--- a/src/main/java/games/strategy/ui/Util.java
+++ b/src/main/java/games/strategy/ui/Util.java
@@ -149,7 +149,7 @@ public final class Util {
    * Finds a land territory name or some sea zone name where the point is contained in according to the territory name
    * -> polygons map.
    *
-   * @param java.awt.point p - a point on the map
+   * @param p A point on the map.
    * @param terrPolygons a map territory name -> polygons
    * @return Optional&lt;String>
    */
@@ -162,9 +162,9 @@ public final class Util {
    * Finds a land territory name or some sea zone name where the point is contained in according to the territory name
    * -> polygons map. If no land or sea territory has been found a default name is returned.
    *
-   * @param java.awt.point p - a point on the map
+   * @param p A point on the map.
    * @param terrPolygons a map territory name -> polygons
-   * @param String defaultTerrName - default territory name that gets returns if nothing was found
+   * @param defaultTerrName Default territory name that gets returns if nothing was found.
    * @return found territory name of defaultTerrName
    */
   public static String findTerritoryName(final Point p, final Map<String, List<Polygon>> terrPolygons,

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -59,8 +59,7 @@ public class CenterPicker extends JFrame {
    * Asks the user to select the map then runs the
    * the actual picker.
    *
-   * @param java
-   *        .lang.String[] args the command line arguments
+   * @param args The command line arguments.
    */
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
@@ -102,8 +101,7 @@ public class CenterPicker extends JFrame {
    * default or needed values, and prepares the map for user
    * commands.
    *
-   * @param java
-   *        .lang.String mapName name of map file
+   * @param mapName Name of map file.
    */
   public CenterPicker(final String mapName) {
     super("Center Picker");

--- a/src/main/java/tools/image/FileOpen.java
+++ b/src/main/java/tools/image/FileOpen.java
@@ -11,8 +11,7 @@ public class FileOpen {
   /**
    * Default Constructor.
    *
-   * @param java
-   *        .lang.String title the title of the JFileChooser
+   * @param title The title of the JFileChooser.
    * @exception java.lang.Exception
    *            ex
    *            Creates a file selection dialog starting at the current

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -83,8 +83,7 @@ public class PolygonGrabber extends JFrame {
    * Asks the user to select the map then runs the
    * the actual polygon grabber program.
    *
-   * @param java
-   *        .lang.String[] args the command line arguments
+   * @param args The command line arguments.
    */
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
@@ -128,8 +127,7 @@ public class PolygonGrabber extends JFrame {
    * program will exit. We setup the mouse listenrs and toolbars
    * and load the actual image of the map here.
    *
-   * @param java
-   *        .lang.String mapName path to image map
+   * @param mapName Path to image map.
    */
   public PolygonGrabber(final String mapName) {
     super("Polygon grabber");

--- a/src/main/java/tools/image/TileImageBreaker.java
+++ b/src/main/java/tools/image/TileImageBreaker.java
@@ -43,9 +43,7 @@ public class TileImageBreaker {
    * Main program begins here. Creates a new instance of ReliefImageBreaker
    * and calls createMaps() method to start the computations.
    *
-   * @param java
-   *        .lang.String[]
-   *        args the command line parameters
+   * @param args The command line parameters.
    * @exception java.lang.Exception
    *            throws
    */

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -142,8 +142,7 @@ public class PlacementPicker extends JFrame {
    * default or needed values, and prepares the map for user
    * commands.
    *
-   * @param java
-   *        .lang.String mapName name of map file
+   * @param mapName Name of map file.
    */
   public PlacementPicker(final String mapName) {
     super("Placement Picker");


### PR DESCRIPTION
This PR fixes violations of the Checkstyle JavadocMethod rule of type "Unused X tag for 'X'."

These violations were caused by one of the following conditions:

* A method parameter was renamed, but the corresponding `@param` tag was not updated.
* A method parameter was removed, but the corresponding `@param` tag was not also removed.
* A `@param` tag included the parameter type before the parameter name, which caused Checkstyle to parse the parameter type as the (non-existent) parameter name.

**This change only affects Javadocs; no code was modified.**