### PR TITLE
Checkstyle: Fix Javadoc forbidden summary fragments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=7003
+checkstyleMainMaxWarnings=6969
 checkstyleTestMaxWarnings=355

--- a/src/main/java/games/strategy/engine/EngineVersion.java
+++ b/src/main/java/games/strategy/engine/EngineVersion.java
@@ -15,7 +15,7 @@ public class EngineVersion {
 
 
   /**
-   * @return the game engine 'Version' used for in-game compatibility checks.
+   * @return The game engine 'Version' used for in-game compatibility checks.
    */
   public Version getVersion() {
     return version;

--- a/src/main/java/games/strategy/engine/chat/IStatusController.java
+++ b/src/main/java/games/strategy/engine/chat/IStatusController.java
@@ -16,7 +16,7 @@ public interface IStatusController extends IRemote {
   void setStatus(String newStatus);
 
   /**
-   * @return the status for all nodes.
+   * @return The status for all nodes.
    */
   Map<INode, String> getAllStatus();
 }

--- a/src/main/java/games/strategy/engine/data/GameData.java
+++ b/src/main/java/games/strategy/engine/data/GameData.java
@@ -184,14 +184,14 @@ public class GameData implements java.io.Serializable {
   }
 
   /**
-   * @return the Technology Frontier for this game.
+   * @return The Technology Frontier for this game.
    */
   public TechnologyFrontier getTechnologyFrontier() {
     return technologyFrontier;
   }
 
   /**
-   * @return the list of production Frontiers for this game.
+   * @return The list of production Frontiers for this game.
    */
   public RepairFrontierList getRepairFrontierList() {
     ensureLockHeld();
@@ -199,7 +199,7 @@ public class GameData implements java.io.Serializable {
   }
 
   /**
-   * @return the list of Production Rules for the game.
+   * @return The list of Production Rules for the game.
    */
   public RepairRuleList getRepairRuleList() {
     ensureLockHeld();
@@ -207,7 +207,7 @@ public class GameData implements java.io.Serializable {
   }
 
   /**
-   * @return the Alliance Tracker for the game.
+   * @return The Alliance Tracker for the game.
    */
   public AllianceTracker getAllianceTracker() {
     ensureLockHeld();

--- a/src/main/java/games/strategy/engine/data/Route.java
+++ b/src/main/java/games/strategy/engine/data/Route.java
@@ -189,14 +189,14 @@ public class Route implements Serializable, Iterable<Territory> {
   }
 
   /**
-   * @return the number of steps in this route. Does not include start.
+   * @return The number of steps in this route. Does not include start.
    */
   public int numberOfSteps() {
     return m_steps.size();
   }
 
   /**
-   * @return the number of steps in this route. DOES include start.
+   * @return The number of steps in this route. DOES include start.
    */
   public int numberOfStepsIncludingStart() {
     return this.getAllTerritories().size();

--- a/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -191,7 +191,7 @@ public class UnitCollection extends GameDataComponent implements Iterable<Unit> 
   }
 
   /**
-   * @return the count of units each player has in this collection.
+   * @return The count of units each player has in this collection.
    */
   public IntegerMap<PlayerID> getPlayerUnitCounts() {
     final IntegerMap<PlayerID> count = new IntegerMap<>();

--- a/src/main/java/games/strategy/engine/delegate/IDelegate.java
+++ b/src/main/java/games/strategy/engine/delegate/IDelegate.java
@@ -57,7 +57,7 @@ public interface IDelegate {
   void loadState(final Serializable state);
 
   /**
-   * @return the remote type of this delegate for use
+   * @return The remote type of this delegate for use
    *         by a RemoteMessenger (Class must be an interface that extends IRemote.
    *         If the return value is null, then it indicates that this
    *         delegate should not be used as in IRemote.)

--- a/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
+++ b/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
@@ -95,7 +95,7 @@ public interface IDelegateBridge {
   ISound getSoundChannelBroadcaster();
 
   /**
-   * @return the propertie for this step.
+   * @return The properties for this step.
    */
   Properties getStepProperties();
 

--- a/src/main/java/games/strategy/engine/gamePlayer/IGamePlayer.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/IGamePlayer.java
@@ -16,12 +16,12 @@ public interface IGamePlayer extends IRemotePlayer {
   void initialize(IPlayerBridge bridge, PlayerID id);
 
   /**
-   * @return the name of the game player (what nation we are).
+   * @return The name of the game player (what nation we are).
    */
   String getName();
 
   /**
-   * @return the type of player we are (human or a kind of ai).
+   * @return The type of player we are (human or a kind of ai).
    */
   String getType();
 

--- a/src/main/java/games/strategy/engine/gamePlayer/IRemotePlayer.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/IRemotePlayer.java
@@ -10,7 +10,7 @@ import games.strategy.engine.message.IRemote;
  */
 public interface IRemotePlayer extends IRemote {
   /**
-   * @return the id of this player. This id is initialized by the initialize method in IGamePlayer.
+   * @return The id of this player. This id is initialized by the initialize method in IGamePlayer.
    */
   PlayerID getPlayerID();
 }

--- a/src/main/java/games/strategy/net/INode.java
+++ b/src/main/java/games/strategy/net/INode.java
@@ -20,22 +20,22 @@ import java.net.InetSocketAddress;
  */
 public interface INode extends Serializable, Comparable<INode> {
   /**
-   * @return the display/user name for the node.
+   * @return The display/user name for the node.
    */
   String getName();
 
   /**
-   * @return the address for the node as seen by the server.
+   * @return The address for the node as seen by the server.
    */
   InetAddress getAddress();
 
   /**
-   * @return the port for the node as seen by the server.
+   * @return The port for the node as seen by the server.
    */
   int getPort();
 
   /**
-   * @return the address for the node as seen by the server.
+   * @return The address for the node as seen by the server.
    */
   InetSocketAddress getSocketAddress();
 }

--- a/src/main/java/games/strategy/sound/SoundProperties.java
+++ b/src/main/java/games/strategy/sound/SoundProperties.java
@@ -52,7 +52,7 @@ public class SoundProperties {
   }
 
   /**
-   * @return the string property, or null if not found.
+   * @return The string property, or null if not found.
    */
   public String getProperty(final String key) {
     return m_properties.getProperty(key);

--- a/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -291,7 +291,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
   }
 
   /**
-   * @return the number you need to roll to get the action to succeed format "1:10" for 10% chance.
+   * @return The number you need to roll to get the action to succeed format "1:10" for 10% chance.
    */
   public String getChance() {
     return m_chance;

--- a/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -69,7 +69,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return the Key that is used in politicstext.properties or other .properties for all the texts.
+   * @return The Key that is used in politicstext.properties or other .properties for all the texts.
    */
   public String getText() {
     return m_text;
@@ -94,7 +94,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return the amount you need to pay to perform the action.
+   * @return The amount you need to pay to perform the action.
    */
   public int getCostPU() {
     return m_costPU;
@@ -157,7 +157,7 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   }
 
   /**
-   * @return the amount of times you can try this Action per Round.
+   * @return The amount of times you can try this Action per Round.
    */
   public int getAttemptsPerTurn() {
     return m_attemptsPerTurn;

--- a/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -95,7 +95,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   }
 
   /**
-   * @return the ArcheType of this relationshipType, this really shouldn't be called, typically you should call
+   * @return The ArcheType of this relationshipType, this really shouldn't be called, typically you should call
    *         isNeutral, isAllied or
    *         isWar().
    */

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -156,7 +156,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   /**
-   * @return the actual m_produced variable, allowing direct editing of the variable.
+   * @return The actual m_produced variable, allowing direct editing of the variable.
    */
   protected final Map<Territory, Collection<Unit>> getProduced() {
     return m_produced;

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -596,7 +596,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
   }
 
   /**
-   * @return the number of PUs that have been lost by bombing, rockets, etc.
+   * @return The number of PUs that have been lost by bombing, rockets, etc.
    */
   @Override
   public int PUsAlreadyLost(final Territory t) {

--- a/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -38,7 +38,7 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate {
   PlaceableUnits getPlaceableUnits(Collection<Unit> units, Territory at);
 
   /**
-   * @return the number of placements made so far.
+   * @return The number of placements made so far.
    *         this is not the number of units placed, but the number
    *         of times we have made successful placements.
    */

--- a/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
@@ -9,7 +9,7 @@ import games.strategy.triplea.delegate.dataObjects.BattleListing;
 
 public interface IBattleDelegate extends IRemote, IDelegate {
   /**
-   * @return the battles currently waiting to be fought.
+   * @return The battles currently waiting to be fought.
    */
   BattleListing getBattles();
 

--- a/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
@@ -16,7 +16,7 @@ public class PrintGenerationData {
   protected PrintGenerationData() {}
 
   /**
-   * @return the outDir.
+   * @return The outDir.
    */
   protected File getOutDir() {
     return m_outDir;
@@ -31,7 +31,7 @@ public class PrintGenerationData {
   }
 
   /**
-   * @return the samePUMap.
+   * @return The samePUMap.
    */
   protected Map<Integer, Integer> getSamePUMap() {
     return m_SamePUMap;
@@ -46,7 +46,7 @@ public class PrintGenerationData {
   }
 
   /**
-   * @return the data.
+   * @return The data.
    */
   protected GameData getData() {
     return m_data;

--- a/src/main/java/games/strategy/util/CountUpAndDownLatch.java
+++ b/src/main/java/games/strategy/util/CountUpAndDownLatch.java
@@ -93,7 +93,7 @@ public class CountUpAndDownLatch implements Serializable {
   }
 
   /**
-   * @return the original count this latch was created with.
+   * @return The original count this latch was created with.
    */
   public int getOriginalCount() {
     return originalCount;

--- a/src/main/java/games/strategy/util/IntegerMap.java
+++ b/src/main/java/games/strategy/util/IntegerMap.java
@@ -247,7 +247,7 @@ public class IntegerMap<T> implements Cloneable, Serializable {
   }
 
   /**
-   * @return the sum of all keys.
+   * @return The sum of all keys.
    */
   public int totalValues() {
     int sum = 0;

--- a/src/main/java/games/strategy/util/LinkedIntegerMap.java
+++ b/src/main/java/games/strategy/util/LinkedIntegerMap.java
@@ -264,7 +264,7 @@ public class LinkedIntegerMap<T> implements Cloneable, Serializable {
   }
 
   /**
-   * @return the sum of all keys.
+   * @return The sum of all keys.
    */
   public int totalValues() {
     int sum = 0;


### PR DESCRIPTION
This PR fixes violations of the Checkstyle SummaryJavadoc rule.

All of the fixes in this PR simply change an initial "the" in a `@return` tag to "The" because the Google Checkstyle ruleset forbids `@return` tags from beginning wih the word "the" (all lower case).  If I were to try to read their minds, I believe Google's reason for this rule is that the Eclipse **Generate Getters and Setters...** command automatically provides a value of "`the <property_name>`" for the `@return` tag on getters it generates, and they wanted devs to have something to remind them to go back and review the auto-generated Javadoc before committing.

**This change only affects Javadocs; no code was modified.**