### PR TITLE
Remove redundant prompts - attacking defenseless units or 

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -819,16 +819,23 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        if (Match.someMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1))) {
-          final List<Unit> sortedUnitsList = new ArrayList<>(Match.getMatches(m_defendingUnits,
-                 Matches.UnitCanBeInBattle(true, !m_battleSite.isWater(), m_data, 1, false, true, true)));
-          Collections.sort(sortedUnitsList, new UnitBattleComparator(false,
+        Match<Unit> UnitList = Matches.UnitCanBeInBattle(true, !m_battleSite.isWater(), m_data, 1, false, true, true);
+        final List<Unit> sortedAttackingUnits = new ArrayList<>(Match.getMatches(m_attackingUnits, UnitList));
+        Collections.sort(sortedAttackingUnits, new UnitBattleComparator(false,
+            BattleCalculator.getCostsForTUV(bridge.getPlayerID(), m_data),
+            TerritoryEffectHelper.getEffects(m_battleSite), m_data, false, false));
+        Collections.reverse(sortedAttackingUnits);
+        if (DiceRoll.getTotalPower(
+            DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedAttackingUnits, m_defendingUnits, false, false,
+                m_data, m_battleSite, TerritoryEffectHelper.getEffects(m_battleSite), false, null), m_data) > 0) {
+          final List<Unit> sortedDefendingUnits = new ArrayList<>(Match.getMatches(m_defendingUnits, UnitList));
+          Collections.sort(sortedDefendingUnits, new UnitBattleComparator(false,
                  BattleCalculator.getCostsForTUV(bridge.getPlayerID(), m_data),
                  TerritoryEffectHelper.getEffects(m_battleSite), m_data, false, false));
-          Collections.reverse(sortedUnitsList);
+          Collections.reverse(sortedDefendingUnits);
           if (DiceRoll.getTotalPower(
-              DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, m_defendingUnits, false, false, m_data,
-                  m_battleSite, TerritoryEffectHelper.getEffects(m_battleSite), false, null), m_data) == 0) {
+              DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedDefendingUnits, m_defendingUnits, false, false,
+                  m_data, m_battleSite, TerritoryEffectHelper.getEffects(m_battleSite), false, null), m_data) == 0) {
             remove(m_defendingUnits, bridge, m_battleSite, true);
           }
         }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -819,6 +819,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        if (Match.someMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1))
+            && Match.allMatch(m_defendingUnits, Matches.unitHasDefenseThatIsMoreThanOrEqualTo(1).invert())) {
+          remove(m_defendingUnits, bridge, m_battleSite, true);
+        }
         clearWaitingToDie(bridge);
       }
     });

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -819,8 +819,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        Match<Unit> UnitList = Matches.UnitCanBeInBattle(true, !m_battleSite.isWater(), m_data, 1, false, true, true);
-        final List<Unit> sortedAttackingUnits = new ArrayList<>(Match.getMatches(m_attackingUnits, UnitList));
+        Match<Unit> unitList = Matches.UnitCanBeInBattle(true, !m_battleSite.isWater(), m_data, 1, false, true, true);
+        final List<Unit> sortedAttackingUnits = new ArrayList<>(Match.getMatches(m_attackingUnits, unitList));
         Collections.sort(sortedAttackingUnits, new UnitBattleComparator(false,
             BattleCalculator.getCostsForTUV(bridge.getPlayerID(), m_data),
             TerritoryEffectHelper.getEffects(m_battleSite), m_data, false, false));
@@ -828,7 +828,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         if (DiceRoll.getTotalPower(
             DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedAttackingUnits, m_defendingUnits, false, false,
                 m_data, m_battleSite, TerritoryEffectHelper.getEffects(m_battleSite), false, null), m_data) > 0) {
-          final List<Unit> sortedDefendingUnits = new ArrayList<>(Match.getMatches(m_defendingUnits, UnitList));
+          final List<Unit> sortedDefendingUnits = new ArrayList<>(Match.getMatches(m_defendingUnits, unitList));
           Collections.sort(sortedDefendingUnits, new UnitBattleComparator(false,
                  BattleCalculator.getCostsForTUV(bridge.getPlayerID(), m_data),
                  TerritoryEffectHelper.getEffects(m_battleSite), m_data, false, false));

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -26,8 +26,6 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.message.ConnectionLostException;
 import games.strategy.sound.SoundPath;
 import games.strategy.triplea.TripleAUnit;
-import games.strategy.triplea.ai.proAI.ProData;
-import games.strategy.triplea.ai.proAI.util.ProBattleUtils;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -824,12 +822,13 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         if (Match.someMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1))) {
           final List<Unit> sortedUnitsList = new ArrayList<>(Match.getMatches(m_defendingUnits,
                  Matches.UnitCanBeInBattle(true, !m_battleSite.isWater(), m_data, 1, false, true, true)));
-          Collections.sort(sortedUnitsList, new UnitBattleComparator(false, ProData.unitValueMap,
+          Collections.sort(sortedUnitsList, new UnitBattleComparator(false,
+                 BattleCalculator.getCostsForTUV(bridge.getPlayerID(), m_data),
                  TerritoryEffectHelper.getEffects(m_battleSite), m_data, false, false));
           Collections.reverse(sortedUnitsList);
           if (DiceRoll.getTotalPower(
               DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, m_defendingUnits, false, false, m_data,
-                  m_battleSite, TerritoryEffectHelper.getEffects(m_battleSite), false, null), m_data) == 0) {          
+                  m_battleSite, TerritoryEffectHelper.getEffects(m_battleSite), false, null), m_data) == 0) {
             remove(m_defendingUnits, bridge, m_battleSite, true);
           }
         }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -26,6 +26,8 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.message.ConnectionLostException;
 import games.strategy.sound.SoundPath;
 import games.strategy.triplea.TripleAUnit;
+import games.strategy.triplea.ai.proAI.ProData;
+import games.strategy.triplea.ai.proAI.util.ProBattleUtils;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -819,9 +821,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        if (Match.someMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1))
-            && Match.allMatch(m_defendingUnits, Matches.unitHasDefenseThatIsMoreThanOrEqualTo(1).invert())) {
-          remove(m_defendingUnits, bridge, m_battleSite, true);
+        if (Match.someMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1))) {
+          final List<Unit> sortedUnitsList = new ArrayList<>(Match.getMatches(m_defendingUnits,
+                 Matches.UnitCanBeInBattle(true, !m_battleSite.isWater(), m_data, 1, false, true, true)));
+          Collections.sort(sortedUnitsList, new UnitBattleComparator(false, ProData.unitValueMap,
+                 TerritoryEffectHelper.getEffects(m_battleSite), m_data, false, false));
+          Collections.reverse(sortedUnitsList);
+          if (DiceRoll.getTotalPower(
+              DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, m_defendingUnits, false, false, m_data,
+                  m_battleSite, TerritoryEffectHelper.getEffects(m_battleSite), false, null), m_data) == 0) {          
+            remove(m_defendingUnits, bridge, m_battleSite, true);
+          }
         }
         clearWaitingToDie(bridge);
       }

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -425,13 +425,18 @@ public class BattleDisplay extends JPanel {
       // if you have eliminated the impossible, whatever remains, no matter
       // how improbable, must be the truth
       // retreat
-      final RetreatComponent comp = new RetreatComponent(possible);
-      final int option = JOptionPane.showConfirmDialog(BattleDisplay.this, comp, message,
-          JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null);
-      if (option == JOptionPane.OK_OPTION) {
-        if (comp.getSelection() != null) {
-          retreatTo[0] = comp.getSelection();
-          latch.countDown();
+      if (possible.size() == 1) {
+        retreatTo[0] = possible.iterator().next();
+        latch.countDown();
+      } else {
+        final RetreatComponent comp = new RetreatComponent(possible);
+        final int option = JOptionPane.showConfirmDialog(BattleDisplay.this, comp, message,
+            JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null);
+        if (option == JOptionPane.OK_OPTION) {
+          if (comp.getSelection() != null) {
+            retreatTo[0] = comp.getSelection();
+            latch.countDown();
+          }
         }
       }
     });

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -403,7 +403,7 @@ public class BattleDisplay extends JPanel {
     final Territory[] retreatTo = new Territory[1];
     final CountDownLatch latch = new CountDownLatch(1);
     final Action action = SwingAction.of("Retreat?", e -> {
-      final String yes = "Retreat";
+      final String yes = possible.size() == 1 ? "Retreat to " + possible.iterator().next().getName() : "Retreat";
       final String no = "Remain";
       final String cancel = "Ask Me Later";
       final String[] options = {yes, no, cancel};


### PR DESCRIPTION
retreating to a single territory

Part of #1632 #1615 #1599 #1621 

Only a few lines changed and shouldn't break serialisation from what I can see.