### PR TITLE
Checkstyle: Fix top-level class violations in test code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 checkstyleMainMaxWarnings=5409
-checkstyleTestMaxWarnings=286
+checkstyleTestMaxWarnings=269

--- a/src/test/java/games/strategy/engine/chat/ChatTest.java
+++ b/src/test/java/games/strategy/engine/chat/ChatTest.java
@@ -185,37 +185,36 @@ public class ChatTest {
     }
     assertEquals(m_serverChatListener.m_players.size(), 0);
   }
-}
 
+  private static class TestChatListener implements IChatListener {
+    public List<INode> m_players;
+    public List<String> m_messages = new ArrayList<>();
+    public List<Boolean> m_thirdPerson = new ArrayList<>();
+    public List<String> m_from = new ArrayList<>();
 
-class TestChatListener implements IChatListener {
-  public List<INode> m_players;
-  public List<String> m_messages = new ArrayList<>();
-  public List<Boolean> m_thirdPerson = new ArrayList<>();
-  public List<String> m_from = new ArrayList<>();
-
-  @Override
-  public void updatePlayerList(final Collection<INode> players) {
-    synchronized (this) {
-      m_players = new ArrayList<>(players);
+    @Override
+    public void updatePlayerList(final Collection<INode> players) {
+      synchronized (this) {
+        m_players = new ArrayList<>(players);
+      }
     }
-  }
 
-  @Override
-  public void addMessageWithSound(final String message, final String from, final boolean thirdperson,
-      final String sound) {
-    synchronized (this) {
-      m_messages.add(message);
-      m_thirdPerson.add(thirdperson);
-      m_from.add(from);
+    @Override
+    public void addMessageWithSound(final String message, final String from, final boolean thirdperson,
+        final String sound) {
+      synchronized (this) {
+        m_messages.add(message);
+        m_thirdPerson.add(thirdperson);
+        m_from.add(from);
+      }
     }
-  }
 
-  @Override
-  public void addMessage(final String message, final String from, final boolean thirdperson) {
-    addMessageWithSound(message, from, thirdperson, SoundPath.CLIP_CHAT_MESSAGE);
-  }
+    @Override
+    public void addMessage(final String message, final String from, final boolean thirdperson) {
+      addMessageWithSound(message, from, thirdperson, SoundPath.CLIP_CHAT_MESSAGE);
+    }
 
-  @Override
-  public void addStatusMessage(final String message) {}
+    @Override
+    public void addStatusMessage(final String message) {}
+  }
 }

--- a/src/test/java/games/strategy/engine/lobby/server/ModeratorControllerTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/ModeratorControllerTest.java
@@ -58,7 +58,7 @@ public class ModeratorControllerTest {
     m_controller.boot(booted);
     assertTrue(m_listener.getRemoved().contains(booted));
   }
-  
+
   @Test
   public void testCantResetAdminPassword() throws UnknownHostException {
     MessageContext.setSenderNodeForThread(m_adminNode);
@@ -77,21 +77,20 @@ public class ModeratorControllerTest {
     MessageContext.setSenderNodeForThread(m_adminNode);
     assertTrue(m_controller.isAdmin());
   }
-}
 
+  private static class ConnectionChangeListener implements IConnectionChangeListener {
+    final List<INode> m_removed = new ArrayList<>();
 
-class ConnectionChangeListener implements IConnectionChangeListener {
-  final List<INode> m_removed = new ArrayList<>();
+    @Override
+    public void connectionAdded(final INode to) {}
 
-  @Override
-  public void connectionAdded(final INode to) {}
+    @Override
+    public void connectionRemoved(final INode to) {
+      m_removed.add(to);
+    }
 
-  @Override
-  public void connectionRemoved(final INode to) {
-    m_removed.add(to);
-  }
-
-  public List<INode> getRemoved() {
-    return m_removed;
+    public List<INode> getRemoved() {
+      return m_removed;
+    }
   }
 }

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
@@ -142,49 +142,47 @@ public class ChannelMessengerTest {
     }
     assertEquals(expected, subscribor.getCallCount());
   }
-}
 
+  private interface IChannelBase extends IChannelSubscribor {
+    void testNoParams();
 
-interface IChannelBase extends IChannelSubscribor {
-  void testNoParams();
+    void testPrimitives(int a, short b, long c, byte d, boolean e, float f);
 
-  void testPrimitives(int a, short b, long c, byte d, boolean e, float f);
+    void testString(String a);
 
-  void testString(String a);
-
-  void testArray(int[] ints, short[] shorts, byte[] bytes, boolean[] bools, float[] floats, Object[] objects);
-}
-
-
-class ChannelSubscribor implements IChannelBase {
-  private int m_callCount = 0;
-
-  private synchronized void incrementCount() {
-    m_callCount++;
+    void testArray(int[] ints, short[] shorts, byte[] bytes, boolean[] bools, float[] floats, Object[] objects);
   }
 
-  public synchronized int getCallCount() {
-    return m_callCount;
-  }
+  private static class ChannelSubscribor implements IChannelBase {
+    private int m_callCount = 0;
 
-  @Override
-  public void testNoParams() {
-    incrementCount();
-  }
+    private synchronized void incrementCount() {
+      m_callCount++;
+    }
 
-  @Override
-  public void testPrimitives(final int a, final short b, final long c, final byte d, final boolean e, final float f) {
-    incrementCount();
-  }
+    public synchronized int getCallCount() {
+      return m_callCount;
+    }
 
-  @Override
-  public void testString(final String a) {
-    incrementCount();
-  }
+    @Override
+    public void testNoParams() {
+      incrementCount();
+    }
 
-  @Override
-  public void testArray(final int[] ints, final short[] shorts, final byte[] bytes, final boolean[] bools,
-      final float[] floats, final Object[] objects) {
-    incrementCount();
+    @Override
+    public void testPrimitives(final int a, final short b, final long c, final byte d, final boolean e, final float f) {
+      incrementCount();
+    }
+
+    @Override
+    public void testString(final String a) {
+      incrementCount();
+    }
+
+    @Override
+    public void testArray(final int[] ints, final short[] shorts, final byte[] bytes, final boolean[] bools,
+        final float[] floats, final Object[] objects) {
+      incrementCount();
+    }
   }
 }

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -323,44 +323,41 @@ public class RemoteMessengerTest {
       shutdownServerAndClient(server, client);
     }
   }
-}
 
-
-interface IFoo extends IRemote {
-  void foo();
-}
-
-
-interface ITestRemote extends IRemote {
-  int increment(int testVal);
-
-  void testVoid();
-
-  void throwException() throws Exception;
-}
-
-
-class TestRemote implements ITestRemote {
-  public static final String EXCEPTION_STRING = "AND GO";
-  private INode m_senderNode;
-
-  @Override
-  public int increment(final int testVal) {
-    m_senderNode = MessageContext.getSender();
-    return testVal + 1;
+  private interface IFoo extends IRemote {
+    void foo();
   }
 
-  @Override
-  public void testVoid() {
-    m_senderNode = MessageContext.getSender();
+  private interface ITestRemote extends IRemote {
+    int increment(int testVal);
+
+    void testVoid();
+
+    void throwException() throws Exception;
   }
 
-  @Override
-  public void throwException() throws Exception {
-    throw new Exception(EXCEPTION_STRING);
-  }
+  private static class TestRemote implements ITestRemote {
+    public static final String EXCEPTION_STRING = "AND GO";
+    private INode m_senderNode;
 
-  public INode getLastSenderNode() {
-    return m_senderNode;
+    @Override
+    public int increment(final int testVal) {
+      m_senderNode = MessageContext.getSender();
+      return testVal + 1;
+    }
+
+    @Override
+    public void testVoid() {
+      m_senderNode = MessageContext.getSender();
+    }
+
+    @Override
+    public void throwException() throws Exception {
+      throw new Exception(EXCEPTION_STRING);
+    }
+
+    public INode getLastSenderNode() {
+      return m_senderNode;
+    }
   }
 }

--- a/src/test/java/games/strategy/thread/ThreadPoolTest.java
+++ b/src/test/java/games/strategy/thread/ThreadPoolTest.java
@@ -88,37 +88,35 @@ public class ThreadPoolTest {
     }
     pool.shutDown();
   }
-}
 
+  private static class Task implements Runnable {
+    private boolean done = false;
 
-class Task implements Runnable {
-  private boolean done = false;
-
-  public synchronized boolean isDone() {
-    return done;
-  }
-
-  @Override
-  public void run() {
-    try {
-      Thread.sleep(0, 1);
-    } catch (final InterruptedException e) {
-      throw new IllegalStateException(e);
+    public synchronized boolean isDone() {
+      return done;
     }
-    done = true;
-  }
-}
 
-
-class BlockedTask extends Task {
-  @Override
-  public void run() {
-    synchronized (this) {
+    @Override
+    public void run() {
       try {
-        wait(10);
-      } catch (final InterruptedException ie) {
+        Thread.sleep(0, 1);
+      } catch (final InterruptedException e) {
+        throw new IllegalStateException(e);
       }
-      super.run();
+      done = true;
+    }
+  }
+
+  private static class BlockedTask extends Task {
+    @Override
+    public void run() {
+      synchronized (this) {
+        try {
+          wait(10);
+        } catch (final InterruptedException ie) {
+        }
+        super.run();
+      }
     }
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/LHTRTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LHTRTest.java
@@ -24,7 +24,6 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
-import games.strategy.engine.random.IRandomSource;
 import games.strategy.engine.random.ScriptedRandomSource;
 import games.strategy.test.TestUtil;
 import games.strategy.triplea.Constants;
@@ -226,22 +225,5 @@ public class LHTRTest {
     // bomber 2 hits at 2, so damage is 3, for a total of 8
     // Changed to match StrategicBombingRaidBattle changes
     assertEquals(PUsBeforeRaid - 8, PUsAfterRaid);
-  }
-}
-
-
-/**
- * a random source that throws when asked for random
- * useful for testing.
- */
-class ThrowingRandomSource implements IRandomSource {
-  @Override
-  public int getRandom(final int max, final String annotation) {
-    throw new IllegalStateException("not allowed");
-  }
-
-  @Override
-  public int[] getRandom(final int max, final int count, final String annotation) {
-    throw new IllegalStateException("not allowed");
   }
 }

--- a/src/test/java/games/strategy/util/PropertyUtilTest.java
+++ b/src/test/java/games/strategy/util/PropertyUtilTest.java
@@ -79,45 +79,38 @@ public class PropertyUtilTest {
         testClass.bar, is("default"));
   }
 
-
-}
-
-
-class NoSetterClass {
-  @SuppressWarnings("unused")
-  private final String bar = PropertyUtilTest.DEFAULT;
-}
-
-
-class InvalidSetterClass {
-  @SuppressWarnings("unused")
-  private final String bar = PropertyUtilTest.DEFAULT;
-
-  public void setBar() {}
-}
-
-
-class NoOpSetterClass {
-  protected String bar = PropertyUtilTest.DEFAULT;
-
-  public void setBar(final String value) {}
-}
-
-
-class PropertyClass {
-  protected String bar = PropertyUtilTest.DEFAULT;
-
-  public void setBar(final String newValue) {
-    bar = newValue;
+  private static class NoSetterClass {
+    @SuppressWarnings("unused")
+    private final String bar = PropertyUtilTest.DEFAULT;
   }
-}
 
+  private static class InvalidSetterClass {
+    @SuppressWarnings("unused")
+    private final String bar = PropertyUtilTest.DEFAULT;
 
-class mUnderBarClass {
-  @SuppressWarnings("unused")
-  private String m_bar = PropertyUtilTest.DEFAULT;
+    public void setBar() {}
+  }
 
-  public void setBar(final String newValue) {
-    m_bar = newValue;
+  private static class NoOpSetterClass {
+    protected String bar = PropertyUtilTest.DEFAULT;
+
+    public void setBar(final String value) {}
+  }
+
+  private static class PropertyClass {
+    protected String bar = PropertyUtilTest.DEFAULT;
+
+    public void setBar(final String newValue) {
+      bar = newValue;
+    }
+  }
+
+  private static class mUnderBarClass {
+    @SuppressWarnings("unused")
+    private String m_bar = PropertyUtilTest.DEFAULT;
+
+    public void setBar(final String newValue) {
+      m_bar = newValue;
+    }
   }
 }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle OneTopLevelClass rule in test code.

In most cases, the fix was simply to nest a top-level package-private class under the sole top-level class that used it.  In one case, I removed an unused class (`ThrowingRandomSource`).

The changes in this PR are more easily reviewed when whitespace changes are ignored (`?w=1`).