### PR TITLE
Checkstyle: Remove or document empty blocks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=5409
+checkstyleMainMaxWarnings=5388
 checkstyleTestMaxWarnings=269

--- a/src/main/java/games/strategy/engine/framework/networkMaintenance/ChangeGameOptionsClientAction.java
+++ b/src/main/java/games/strategy/engine/framework/networkMaintenance/ChangeGameOptionsClientAction.java
@@ -47,8 +47,7 @@ public class ChangeGameOptionsClientAction extends AbstractAction {
       final JDialog window = pane.createDialog(JOptionPane.getFrameForComponent(m_parent), "Map Options");
       window.setVisible(true);
       final Object buttonPressed = pane.getValue();
-      if (buttonPressed == null || buttonPressed.equals(cancel)) {
-      } else {
+      if (buttonPressed != null && !buttonPressed.equals(cancel)) {
         // ok was clicked. changing them in the ui changes the underlying properties,
         // but it doesn't change the hosts, so we need to send it back to the host.
         byte[] newBytes = null;

--- a/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
+++ b/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
@@ -245,8 +245,7 @@ public class PBEMMessagePoster implements Serializable {
     }
     message = sb.toString();
     final int choice = JOptionPane.showConfirmDialog(mainGameFrame, message, "Post " + title + "?", 2, -1, null);
-    if (choice != 0) {
-    } else {
+    if (choice == 0) {
       if (postButton != null) {
         postButton.setEnabled(false);
       }

--- a/src/main/java/games/strategy/sound/SoundOptions.java
+++ b/src/main/java/games/strategy/sound/SoundOptions.java
@@ -48,6 +48,7 @@ public final class SoundOptions {
     final Object pressedButton = PropertiesSelector.getButton(parent, "Sound Options", properties,
         ok, selectAll, selectNone, cancel);
     if (pressedButton == null || pressedButton.equals(cancel)) {
+      // do nothing
     } else if (pressedButton.equals(ok)) {
       for (final IEditableProperty property : properties) {
         clipPlayer.setMute(((SoundOptionCheckBox) property).getClipName(), !(Boolean) property.getValue());

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -117,6 +117,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     if (name.endsWith("Tech")) {
       tech();
     } else if (name.endsWith("TechActivation")) {
+      // do nothing
     } else if (name.endsWith("Bid") || name.endsWith("Purchase")) { // the delegate handles everything
       purchase(GameStepPropertiesHelper.isBid(getGameData()));
     } else if (name.endsWith("Move")) {

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -466,6 +466,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
     } else if (name.endsWith("Move")) {
       final IMoveDelegate moveDel = (IMoveDelegate) getPlayerBridge().getRemoteDelegate();
       if (name.endsWith("AirborneCombatMove")) {
+        // do nothing
       } else {
         move(name.endsWith("NonCombatMove"), moveDel, getGameData(), id);
       }

--- a/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -200,6 +200,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
       final int cost = getInt(s[0]);
       if (s.length == 2) {
         if (s[1].equals(UPKEEP_FLAT)) {
+          // do nothing
         } else if (s[1].equals(UPKEEP_PERCENTAGE)) {
           if (cost > 100) {
             throw new GameParseException("upkeepCost may not have a percentage greater than 100" + thisErrorMsg());

--- a/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -253,6 +253,7 @@ public class UnitImageFactory {
           name.append("_ss");
         }
         if (TechTracker.hasRocket(id)) {
+          // do nothing
         }
       }
       if (type.getName().equals(Constants.UNIT_TYPE_FACTORY) || UnitAttachment.get(type).getCanProduceUnits()) {

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -140,8 +140,7 @@ public class HistoryLog extends JFrame {
         if (node instanceof Step) {
           final String title = node.getTitle();
           final PlayerID playerId = ((Step) node).getPlayerID();
-          if (title.equals("Initializing Delegates")) {
-          } else {
+          if (!title.equals("Initializing Delegates")) {
             if (playerId != null) {
               curPlayer = playerId;
             }
@@ -308,14 +307,23 @@ public class HistoryLog extends JFrame {
             logWriter.println(indent + title);
           } else if (details == null) {
             if (title.equals("Adding original owners")) {
+              // do nothing
             } else if (title.equals(MoveDelegate.CLEANING_UP_DURING_MOVEMENT_PHASE)) {
+              // do nothing
             } else if (title.equals("Game Loaded")) {
+              // do nothing
             } else if (title.contains("now being played by")) {
+              // do nothing
             } else if (title.contains("Turn Summary") || title.contains("Move Summary")) {
+              // do nothing
             } else if (title.contains("Setting uses for triggers used")) {
+              // do nothing
             } else if (title.equals("Resetting and Giving Bonus Movement to Units")) {
+              // do nothing
             } else if (title.equals("Recording Battle Statistics")) {
+              // do nothing
             } else if (title.equals("Preparing Airbases for Possible Scrambling")) {
+              // do nothing
             } else if (title.matches("\\w+ collect \\d+ PUs?.*")) {
               logWriter.println(indent + title);
             } else if (title.matches("\\w+ takes? .*? from \\w+")) {
@@ -329,6 +337,7 @@ public class HistoryLog extends JFrame {
             } else if (title.matches("\\w+ spend \\d+ on tech rolls")) {
               logWriter.println(indent + title);
             } else if (title.startsWith("Rolls to resolve tech hits:")) {
+              // do nothing
             } else if (title.matches("\\w+ discover .*")) {
               logWriter.println(indent + title);
             } else if (title.matches("AA raid costs .*")) {
@@ -343,8 +352,7 @@ public class HistoryLog extends JFrame {
           }
         } else if (node instanceof Step) {
           final PlayerID playerId = ((Step) node).getPlayerID();
-          if (title.equals("Initializing Delegates")) {
-          } else {
+          if (!title.equals("Initializing Delegates")) {
             logWriter.println();
             logWriter.print(indent + title);
             if (playerId != null) {

--- a/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -457,8 +457,7 @@ public class ViewMenu {
       final Object[] options = {"Set Properties", "Reset To Default", "Cancel"};
       final int result = JOptionPane.showOptionDialog(frame, ui, "Edit Map Font and Color",
           JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, options, 2);
-      if (result == 2) {
-      } else if (result == 1) {
+      if (result == 1) {
         MapImage.resetPropertyMapFont();
         MapImage.resetPropertyTerritoryNameAndPUAndCommentcolor();
         MapImage.resetPropertyUnitCountColor();

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -157,7 +157,6 @@ public class ConnectionFinder {
             testArea.intersect(otherArea);
             if (!testArea.isEmpty() && sizeOfArea(testArea) > minOverlap) {
               thisTerritoryConnections.add(otherTerritory);
-            } else if (!testArea.isEmpty()) {
             }
           }
         }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle EmptyBlock rule.

If it looked like the empty block was there to document that nothing should be done in a particular case, I left the block intact and simply added a `// do nothing` comment.  This seemed to be the case when empty blocks were present in the game engine.

If the empty block was the `if` part of a single `if`-`else` block, I De Morgan'ed the expression, removed the `if` block, and moved the `else` block up.

If I wasn't sure, I left the empty block in place and just documented it.  Please let me know if you notice any empty blocks I left intact that should be removed.