### PR TITLE
autoSave upgrades

### DIFF
--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
@@ -358,18 +358,9 @@ public class HeadlessConsoleController {
       final boolean stop = readin.toLowerCase().startsWith("y");
       if (stop) {
         SaveGameFileChooser.ensureMapsFolderExists();
-        final File f1 =
-            new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName());
-        final File f2 =
-            new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSave2FileName());
-        final File f;
-        if (f1.lastModified() > f2.lastModified()) {
-          f = f2;
-        } else {
-          f = f1;
-        }
         try {
-          game.saveGame(f);
+          game.saveGame(new File(ClientContext.folderSettings().getSaveGamePath(),
+              SaveGameFileChooser.getAutoSaveFileName()));
         } catch (final Exception e) {
           ClientLogger.logQuietly(e);
         }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -199,18 +199,9 @@ public class HeadlessGameServer {
         (new Thread(() -> {
           System.out.println("Remote Stop Game Initiated.");
           SaveGameFileChooser.ensureMapsFolderExists();
-          final File f1 =
-              new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName());
-          final File f2 =
-              new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSave2FileName());
-          final File f;
-          if (f1.lastModified() > f2.lastModified()) {
-            f = f2;
-          } else {
-            f = f1;
-          }
           try {
-            iGame.saveGame(f);
+            iGame.saveGame(new File(
+                ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName()));
           } catch (final Exception e) {
             ClientLogger.logQuietly(e);
           }

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -254,22 +254,13 @@ public class ServerLauncher extends AbstractLauncher {
               }
               final File f1 =
                   new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName());
-              final File f2 =
-                  new File(ClientContext.folderSettings().getSaveGamePath(),
-                      SaveGameFileChooser.getAutoSave2FileName());
-              final File f;
-              if (!f1.exists() && !f2.exists()) {
-                m_gameSelectorModel.resetGameDataToNull();
+              if (f1.exists()) {
+                m_gameSelectorModel.load(f1, null);
               } else {
-                if (!f1.exists() || f1.lastModified() < f2.lastModified()) {
-                  f = f2;
-                } else {
-                  f = f1;
-                }
-                m_gameSelectorModel.load(f, null);
+                m_gameSelectorModel.resetGameDataToNull();
               }
-            } catch (final Exception e) {
-              ClientLogger.logQuietly(e);
+            } catch (final Exception e1) {
+              ClientLogger.logQuietly(e1);
               m_gameSelectorModel.resetGameDataToNull();
             }
           } else {
@@ -382,21 +373,10 @@ public class ServerLauncher extends AbstractLauncher {
     final DateFormat format = new SimpleDateFormat("MMM_dd_'at'_HH_mm");
     SaveGameFileChooser.ensureMapsFolderExists();
     // a hack, if headless save to the autosave to avoid polluting our savegames folder with a million saves
-    final File f;
-    if (m_headless) {
-      final File f1 =
-          new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName());
-      final File f2 =
-          new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSave2FileName());
-      if (f1.lastModified() > f2.lastModified()) {
-        f = f2;
-      } else {
-        f = f1;
-      }
-    } else {
-      f = new File(ClientContext.folderSettings().getSaveGamePath(),
-          "connection_lost_on_" + format.format(new Date()) + ".tsvg");
-    }
+    final File f = m_headless
+        ? new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName())
+        : new File(ClientContext.folderSettings().getSaveGamePath(),
+            "connection_lost_on_" + format.format(new Date()) + ".tsvg");
     try {
       m_serverGame.saveGame(f);
     } catch (final Exception e) {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -392,8 +392,6 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
       final File save;
       if (SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE.equals(typeOfAutosave)) {
         save = new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName());
-      } else if (SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE2.equals(typeOfAutosave)) {
-        save = new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSave2FileName());
       } else if (SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_ODD.equals(typeOfAutosave)) {
         save = new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveOddFileName());
       } else if (SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_EVEN.equals(typeOfAutosave)) {

--- a/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -12,7 +12,6 @@ import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 public class SaveGameFileChooser extends JFileChooser {
   private static final long serialVersionUID = 1548668790891292106L;
   private static final String AUTOSAVE_FILE_NAME = "autosave.tsvg";
-  private static final String AUTOSAVE_2_FILE_NAME = "autosave2.tsvg";
   private static final String AUTOSAVE_ODD_ROUND_FILE_NAME = "autosave_round_odd.tsvg";
   private static final String AUTOSAVE_EVEN_ROUND_FILE_NAME = "autosave_round_even.tsvg";
   private static SaveGameFileChooser s_instance;
@@ -30,17 +29,6 @@ public class SaveGameFileChooser extends JFileChooser {
       }
     }
     return AUTOSAVE_FILE_NAME;
-  }
-
-  public static String getAutoSave2FileName() {
-    if (HeadlessGameServer.headless()) {
-      final String saveSuffix = System.getProperty(GameRunner.TRIPLEA_NAME_PROPERTY,
-          System.getProperty(GameRunner.LOBBY_GAME_HOSTED_BY, ""));
-      if (saveSuffix.length() > 0) {
-        return saveSuffix + "_" + AUTOSAVE_2_FILE_NAME;
-      }
-    }
-    return AUTOSAVE_2_FILE_NAME;
   }
 
   public static String getAutoSaveOddFileName() {

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -20,7 +20,9 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.delegate.AutoSave;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
 import games.strategy.triplea.attachments.ICondition;
@@ -40,6 +42,8 @@ import games.strategy.util.Match;
  * Responsible for checking the validity of a move, and for moving the units.
  * </p>
  */
+@MapSupport
+@AutoSave(afterStepEnd = true)
 public class MoveDelegate extends AbstractMoveDelegate {
 
   public static String CLEANING_UP_DURING_MOVEMENT_PHASE = "Cleaning up during movement phase";


### PR DESCRIPTION
Short summary: meaningful names of after delegate saves, include move delegates, remove autosave2

This PR upgrades autosaves in a few ways. Currently you have to go fishing between autosave & autosave2 to maybe see something that works for you. This PR removes autosave2, saving a ton of code. Secondly, it gives a meaningful name to end of phase autosave files. autosaveAfterBattle is better than autosave2! Thirdly it adds an autosave to the end of the movement phases, with a full description such as "autosaveAftergermanscombatmove", saving before the move phase is locked off. Other delegates save after they are locked off. This doesn't allow anything that isn't possible at present BTW. Nothing stops you procedurally saving before ending each movement phase but you shouldn't have to think about that.

Now I know I didn't log an issue about this but it seems easy enough to resolve. Current autosave functionality is very marginally useful and I'm sure not understood by users.