### PR TITLE
Pre battle post

### DIFF
--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -122,11 +122,8 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     } else if (name.endsWith("Move")) {
       final boolean nonCombat = GameStepPropertiesHelper.isNonCombatMove(getGameData(), false);
       move(nonCombat, name);
-      if (!nonCombat) {
-        ui.waitForMoveForumPoster(getPlayerID(), getPlayerBridge());
-        // TODO only do forum post if there is a combat
-      }
     } else if (name.endsWith("Battle")) {
+      ui.waitForMoveForumPoster(getPlayerID(), getPlayerBridge());
       battle();
     } else if (name.endsWith("Place")) {
       place();

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -26,6 +26,7 @@ import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.AutoSave;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.message.IRemote;
+import games.strategy.engine.pbem.PBEMMessagePoster;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.TripleAUnit;
@@ -167,6 +168,21 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     m_needToCheckDefendingPlanesCanLand = s.m_needToCheckDefendingPlanesCanLand;
     m_needToCleanup = s.m_needToCleanup;
     m_currentBattle = s.m_currentBattle;
+  }
+
+  @Override
+  public void setHasPostedTurnSummary(final boolean hasPostedTurnSummary) {
+    // nothing for now
+  }
+
+  @Override
+  public boolean getHasPostedTurnSummary() {
+    return false;
+  }
+
+  @Override
+  public boolean postTurnSummary(final PBEMMessagePoster poster, final String title, final boolean includeSaveGame) {
+    return poster.post(m_bridge.getHistoryWriter(), title, includeSaveGame);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
@@ -7,7 +7,7 @@ import games.strategy.triplea.delegate.IBattle;
 import games.strategy.triplea.delegate.IBattle.BattleType;
 import games.strategy.triplea.delegate.dataObjects.BattleListing;
 
-public interface IBattleDelegate extends IRemote, IDelegate {
+public interface IBattleDelegate extends IAbstractForumPosterDelegate {
   /**
    * @return The battles currently waiting to be fought.
    */


### PR DESCRIPTION
Instead of posting at the end of combat movement, do it at the beginning of combat. This is better when combat move is before purchase. Resolves #1452.

Rebased now.

If I can figure out handling SBR properly, I'll incorporate that.