### PR TITLE
Checkstyle: Fix empty catch block violations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=5359
-checkstyleTestMaxWarnings=264
+checkstyleMainMaxWarnings=5292
+checkstyleTestMaxWarnings=263

--- a/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
+++ b/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
@@ -45,6 +45,7 @@ class SynchedByteArrayOutputStream extends ByteArrayOutputStream {
         try {
           lock.wait();
         } catch (final InterruptedException ie) {
+          Thread.currentThread().interrupt();
         }
       }
       final String s = toString();

--- a/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import javax.swing.DefaultListCellRenderer;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.chat.Chat.CHAT_SOUND_PROFILE;
 import games.strategy.engine.message.IChannelMessenger;
 import games.strategy.engine.message.IRemoteMessenger;
@@ -107,6 +108,7 @@ public class HeadlessChat implements IChatListener, IChatPanel {
             m_out.println();
           }
         } catch (final Exception e) {
+          ClientLogger.logQuietly(e);
         }
         for (final ChatMessage message : m_chat.getChatHistory()) {
           if (message.getFrom().equals(m_chat.getServerNode().getName())) {
@@ -177,6 +179,7 @@ public class HeadlessChat implements IChatListener, IChatPanel {
         m_out.print("CHAT: " + fullMessage);
       }
     } catch (final Exception e) {
+      ClientLogger.logQuietly(e);
     }
   }
 
@@ -193,6 +196,7 @@ public class HeadlessChat implements IChatListener, IChatPanel {
         m_out.print("CHAT: " + fullMessage);
       }
     } catch (final Exception e) {
+      ClientLogger.logQuietly(e);
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
@@ -55,6 +55,7 @@ public class EngineVersionProperties {
       try {
         latch.await(2, TimeUnit.SECONDS);
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
       if (ref.get() != null) {
         break;
@@ -64,6 +65,7 @@ public class EngineVersionProperties {
     try {
       latch.await(15, TimeUnit.SECONDS);
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
     return ref.get();
   }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -524,12 +524,14 @@ public class HeadlessGameServer {
         m_lobbyWatcherResetupThread.shutdown();
       }
     } catch (final Exception e) {
+      ClientLogger.logQuietly(e);
     }
     try {
       if (m_iGame != null) {
         m_iGame.stopGame();
       }
     } catch (final Exception e) {
+      ClientLogger.logQuietly(e);
     }
     try {
       if (m_setupPanelModel != null) {
@@ -542,12 +544,14 @@ public class HeadlessGameServer {
         }
       }
     } catch (final Exception e) {
+      ClientLogger.logQuietly(e);
     }
     try {
       if (m_gameSelectorModel != null && m_gameSelectorModel.getGameData() != null) {
         m_gameSelectorModel.getGameData().clearAllListeners();
       }
     } catch (final Exception e) {
+      ClientLogger.logQuietly(e);
     }
     s_instance = null;
     m_setupPanelModel = null;

--- a/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -31,6 +31,7 @@ public class LookAndFeel {
           try {
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
           } catch (final Exception e) {
+            ClientLogger.logQuietly(e);
           }
         }
       }

--- a/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -12,6 +12,7 @@ import javax.swing.DefaultListModel;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.ui.SwingComponents;
+import games.strategy.util.ThreadUtil;
 import games.strategy.util.Version;
 
 public class FileSystemAccessStrategy {
@@ -57,10 +58,7 @@ public class FileSystemAccessStrategy {
       }
 
       // now sleep a short while before we check our work
-      try {
-        Thread.sleep(10);
-      } catch (final InterruptedException e) {
-      }
+      ThreadUtil.sleep(10);
 
       // check our work, see if we actuall deleted stuff
       for (final DownloadFileDescription map : maps) {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -13,6 +13,7 @@ import java.util.prefs.Preferences;
 
 import javax.swing.JOptionPane;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameData;
@@ -93,6 +94,7 @@ public class GameSelectorModel extends Observable {
         return newData;
       }
     } catch (final IOException e) {
+      ClientLogger.logQuietly(e);
     }
     return null;
   }

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
@@ -164,6 +164,7 @@ public class Database {
         try {
           conn.close();
         } catch (final SQLException e) {
+          // ignore close errors
         }
         s_logger.log(Level.SEVERE, sqle.getMessage(), sqle);
         throw new IllegalStateException("Could not create tables");

--- a/src/main/java/games/strategy/net/UniversalPlugAndPlayHelper.java
+++ b/src/main/java/games/strategy/net/UniversalPlugAndPlayHelper.java
@@ -140,6 +140,7 @@ public class UniversalPlugAndPlayHelper {
     try {
       System.out.print(m_device.getExternalIPAddress());
     } catch (final UPNPResponseException | IOException e1) {
+      // ignore
     }
     System.out.println(":" + externalPort);
     System.out.println("To " + local.getHostAddress() + ":" + internalPort);

--- a/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
+++ b/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
@@ -75,6 +75,7 @@ public class ClientQuarantineConversation extends QuarantineConversation {
     try {
       showLatch.await();
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
     if (login != null && challengeProperties != null) {
       try {

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
@@ -33,6 +33,7 @@ public class ProLogSettings implements Serializable {
           result = (ProLogSettings) new ObjectInputStream(new ByteArrayInputStream(pool)).readObject();
         }
       } catch (final Exception ex) {
+        ClientLogger.logQuietly(ex);
       }
       if (result == null) {
         result = new ProLogSettings();

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameMap;
@@ -396,6 +397,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
           }
           continue;
         } catch (final Exception e) {
+          ClientLogger.logQuietly(e);
         }
       }
       if (name.equals("each")) {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
@@ -74,6 +74,7 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
         m_latchWorkerThreadsCreation.await();
         // we could have exited the synchronized block already.
       } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
       cancel();
       m_isDataSet = false;
@@ -168,6 +169,7 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
           try {
             workerLatch.await();
           } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
           }
         }
       } finally {
@@ -213,6 +215,7 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
       // setGameData
       m_latchSetData.await();
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -327,6 +327,7 @@ public class BattleDisplay extends JPanel {
       // wait for the button to be pressed.
       continueLatch.await();
     } catch (final InterruptedException ie) {
+      Thread.currentThread().interrupt();
     } finally {
       m_mapPanel.getUIContext().removeShutdownLatch(continueLatch);
     }
@@ -389,6 +390,7 @@ public class BattleDisplay extends JPanel {
     try {
       latch.await();
     } catch (final InterruptedException e1) {
+      Thread.currentThread().interrupt();
     } finally {
       m_mapPanel.getUIContext().removeShutdownLatch(latch);
     }

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -36,6 +36,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.NamedAttachable;
 import games.strategy.engine.data.PlayerID;
@@ -226,6 +227,7 @@ public class EditPanel extends ActionPanel {
         try {
           newTotal = Integer.parseInt(PUsField.getText());
         } catch (final Exception e) {
+          // ignore malformed input
         }
         final String result = m_frame.getEditDelegate().changePUs(player, newTotal);
         if (result != null) {
@@ -279,6 +281,7 @@ public class EditPanel extends ActionPanel {
             advance.add((TechAdvance) selection);
           }
         } catch (final Exception e) {
+          ClientLogger.logQuietly(e);
         }
         final String result = m_frame.getEditDelegate().addTechAdvance(player, advance);
         if (result != null) {
@@ -341,6 +344,7 @@ public class EditPanel extends ActionPanel {
             advance.add((TechAdvance) selection);
           }
         } catch (final Exception e) {
+          ClientLogger.logQuietly(e);
         }
         final String result = m_frame.getEditDelegate().removeTechAdvance(player, advance);
         if (result != null) {

--- a/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -226,6 +226,7 @@ public class GameMenu {
           JOptionPane.showMessageDialog(frame, panelDice, "Dice Rolled", JOptionPane.INFORMATION_MESSAGE);
         }
       } catch (final Exception ex) {
+        // ignore malformed input
       }
     });
     parentMenu.add(RollDiceBox);

--- a/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -20,6 +20,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.lobby.client.login.CreateUpdateAccountPanel;
 import games.strategy.engine.lobby.client.ui.LobbyFrame;
@@ -162,6 +163,7 @@ public class LobbyMenu extends JMenuBar {
       try {
         controller.banUsername(new Node(name1, InetAddress.getByName("0.0.0.0"), 0), new Date(expire));
       } catch (final UnknownHostException ex) {
+        ClientLogger.logQuietly(ex);
       }
     });
     item.setEnabled(true);
@@ -204,6 +206,7 @@ public class LobbyMenu extends JMenuBar {
         controller.banMac(new Node("None (Admin menu originated ban)", InetAddress.getByName("0.0.0.0"), 0), mac,
             new Date(expire));
       } catch (final UnknownHostException ex) {
+        ClientLogger.logQuietly(ex);
       }
     });
     item.setEnabled(true);
@@ -230,6 +233,7 @@ public class LobbyMenu extends JMenuBar {
       try {
         controller.banUsername(new Node(name1, InetAddress.getByName("0.0.0.0"), 0), new Date(0));
       } catch (final UnknownHostException ex) {
+        ClientLogger.logQuietly(ex);
       }
     });
     item.setEnabled(true);
@@ -270,6 +274,7 @@ public class LobbyMenu extends JMenuBar {
         controller.banMac(new Node("None (Admin menu originated unban)", InetAddress.getByName("0.0.0.0"), 0), mac,
             new Date(0));
       } catch (final UnknownHostException ex) {
+        ClientLogger.logQuietly(ex);
       }
     });
     item.setEnabled(true);

--- a/src/main/java/games/strategy/ui/DoubleTextField.java
+++ b/src/main/java/games/strategy/ui/DoubleTextField.java
@@ -149,6 +149,7 @@ public class DoubleTextField extends JTextField {
         Double.parseDouble(DoubleTextField.this.getText());
         notifyListeners();
       } catch (final NumberFormatException e) {
+        // ignore malformed input
       }
     }
   }

--- a/src/main/java/games/strategy/ui/IntTextField.java
+++ b/src/main/java/games/strategy/ui/IntTextField.java
@@ -168,6 +168,7 @@ public class IntTextField extends JTextField {
         Integer.parseInt(IntTextField.this.getText());
         notifyListeners();
       } catch (final NumberFormatException e) {
+        // ignore malformed input
       }
     }
   }

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -24,6 +24,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
@@ -112,6 +113,7 @@ public class AutoPlacementFinder {
                 scale = Double.parseDouble(line.substring(line.indexOf(scaleProperty) + scaleProperty.length()).trim());
                 found = true;
               } catch (final NumberFormatException ex) {
+                // ignore malformed input
               }
             }
             if (line.contains(widthProperty)) {
@@ -119,6 +121,7 @@ public class AutoPlacementFinder {
                 width = Integer.parseInt(line.substring(line.indexOf(widthProperty) + widthProperty.length()).trim());
                 found = true;
               } catch (final NumberFormatException ex) {
+                // ignore malformed input
               }
             }
             if (line.contains(heightProperty)) {
@@ -127,6 +130,7 @@ public class AutoPlacementFinder {
                     Integer.parseInt(line.substring(line.indexOf(heightProperty) + heightProperty.length()).trim());
                 found = true;
               } catch (final NumberFormatException ex) {
+                // ignore malformed input
               }
             }
           }
@@ -149,6 +153,7 @@ public class AutoPlacementFinder {
           }
         }
       } catch (final Exception ex) {
+        ClientLogger.logQuietly(ex);
       }
     }
     if (!placeDimensionsSet || JOptionPane.showConfirmDialog(new JPanel(),
@@ -161,6 +166,7 @@ public class AutoPlacementFinder {
         try {
           unit_zoom_percent = Double.parseDouble(result.toLowerCase());
         } catch (final NumberFormatException ex) {
+          // ignore malformed input
         }
         final String width = JOptionPane.showInputDialog(null,
             "Enter the unit's image width in pixels (unscaled / without zoom).\r\n(e.g. 48)");
@@ -168,6 +174,7 @@ public class AutoPlacementFinder {
           try {
             PLACEWIDTH = (int) (unit_zoom_percent * Integer.parseInt(width));
           } catch (final NumberFormatException ex) {
+            // ignore malformed input
           }
         }
         final String height = JOptionPane.showInputDialog(null,
@@ -176,10 +183,12 @@ public class AutoPlacementFinder {
           try {
             PLACEHEIGHT = (int) (unit_zoom_percent * Integer.parseInt(height));
           } catch (final NumberFormatException ex) {
+            // ignore malformed input
           }
         }
         placeDimensionsSet = true;
       } catch (final Exception ex) {
+        ClientLogger.logQuietly(ex);
       }
     }
     try {
@@ -469,6 +478,7 @@ public class AutoPlacementFinder {
         Double.parseDouble(value);
         System.setProperty(TRIPLEA_UNIT_ZOOM, value);
       } catch (final Exception ex) {
+        // ignore malformed input
       }
     } else if (args.length == 2) {
       String value0;
@@ -481,6 +491,7 @@ public class AutoPlacementFinder {
         Integer.parseInt(value0);
         System.setProperty(TRIPLEA_UNIT_WIDTH, value0);
       } catch (final Exception ex) {
+        // ignore malformed input
       }
       String value1;
       if (args[0].startsWith(TRIPLEA_UNIT_HEIGHT)) {
@@ -492,6 +503,7 @@ public class AutoPlacementFinder {
         Integer.parseInt(value1);
         System.setProperty(TRIPLEA_UNIT_HEIGHT, value1);
       } catch (final Exception ex) {
+        // ignore malformed input
       }
     }
     boolean usagePrinted = false;

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -90,6 +90,7 @@ public class TileImageReconstructor {
       try {
         sizeX = Integer.parseInt(width);
       } catch (final NumberFormatException ex) {
+        // ignore malformed input
       }
     }
     final String height = JOptionPane.showInputDialog(null, "Enter the map image's full height in pixels:");
@@ -97,6 +98,7 @@ public class TileImageReconstructor {
       try {
         sizeY = Integer.parseInt(height);
       } catch (final NumberFormatException ex) {
+        // ignore malformed input
       }
     }
     if (sizeX <= 0 || sizeY <= 0) {

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -107,6 +107,7 @@ public class ConnectionFinder {
         minOverlap = scalePixels * 4;
         dimensionsSet = true;
       } catch (final NumberFormatException ex) {
+        // ignore malformed input
       }
     }
     if (JOptionPane.showConfirmDialog(null,
@@ -120,6 +121,7 @@ public class ConnectionFinder {
       try {
         scalePixels = Integer.parseInt(scale);
       } catch (final NumberFormatException ex) {
+        // ignore malformed input
       }
       final String overlap = JOptionPane.showInputDialog(null,
           "Enter the minimum number of overlapping pixels for a connection? \r\n"
@@ -127,6 +129,7 @@ public class ConnectionFinder {
       try {
         minOverlap = Integer.parseInt(overlap);
       } catch (final NumberFormatException ex) {
+        // ignore malformed input
       }
     }
     final Map<String, Collection<String>> connections = new HashMap<>();

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -224,6 +224,7 @@ public class MapCreator extends JFrame {
           s_unit_zoom = Math.min(4.0, Math.max(0.1, Double.parseDouble(unitZoomText.getText())));
           System.setProperty(TRIPLEA_UNIT_ZOOM, "" + s_unit_zoom);
         } catch (final Exception ex) {
+          // ignore malformed input
         }
         unitZoomText.setText("" + s_unit_zoom);
       }
@@ -243,6 +244,7 @@ public class MapCreator extends JFrame {
           s_unit_width = Math.min(400, Math.max(1, Integer.parseInt(unitWidthText.getText())));
           System.setProperty(TRIPLEA_UNIT_WIDTH, "" + s_unit_width);
         } catch (final Exception ex) {
+          // ignore malformed input
         }
         unitWidthText.setText("" + s_unit_width);
       }
@@ -262,6 +264,7 @@ public class MapCreator extends JFrame {
           s_unit_height = Math.min(400, Math.max(1, Integer.parseInt(unitHeightText.getText())));
           System.setProperty(TRIPLEA_UNIT_HEIGHT, "" + s_unit_height);
         } catch (final Exception ex) {
+          // ignore malformed input
         }
         unitHeightText.setText("" + s_unit_height);
       }
@@ -283,6 +286,7 @@ public class MapCreator extends JFrame {
         try {
           s_memory = (long) 1024 * 1024 * Math.min(4096, Math.max(256, Integer.parseInt(memoryText.getText())));
         } catch (final Exception ex) {
+          // ignore malformed input
         }
         memoryText.setText("" + (s_memory / (1024 * 1024)));
       }

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -159,6 +159,7 @@ public class MapPropertiesMaker extends JFrame {
         try {
           s_mapProperties.setMapWidth(Integer.parseInt(widthField.getText()));
         } catch (final Exception ex) {
+          // ignore malformed input
         }
         widthField.setText("" + s_mapProperties.getMapWidth());
       }
@@ -178,6 +179,7 @@ public class MapPropertiesMaker extends JFrame {
         try {
           s_mapProperties.setMapHeight(Integer.parseInt(heightField.getText()));
         } catch (final Exception ex) {
+          // ignore malformed input
         }
         heightField.setText("" + s_mapProperties.getMapHeight());
       }
@@ -201,6 +203,7 @@ public class MapPropertiesMaker extends JFrame {
           // s_mapProperties.setUNITS_SCALE(Double.parseDouble(scaleField.getText()));
           s_mapProperties.setUnitsScale(scaleField.getText());
         } catch (final Exception ex) {
+          // ignore malformed input
         }
         scaleField.setText("" + s_mapProperties.getUnitsScale());
       }

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -178,6 +178,7 @@ public class PlacementPicker extends JFrame {
                 scale = Double.parseDouble(line.substring(line.indexOf(scaleProperty) + scaleProperty.length()).trim());
                 found = true;
               } catch (final NumberFormatException ex) {
+                // ignore malformed input
               }
             }
             if (line.contains(widthProperty)) {
@@ -185,6 +186,7 @@ public class PlacementPicker extends JFrame {
                 width = Integer.parseInt(line.substring(line.indexOf(widthProperty) + widthProperty.length()).trim());
                 found = true;
               } catch (final NumberFormatException ex) {
+                // ignore malformed input
               }
             }
             if (line.contains(heightProperty)) {
@@ -193,6 +195,7 @@ public class PlacementPicker extends JFrame {
                     Integer.parseInt(line.substring(line.indexOf(heightProperty) + heightProperty.length()).trim());
                 found = true;
               } catch (final NumberFormatException ex) {
+                // ignore malformed input
               }
             }
           }
@@ -215,6 +218,7 @@ public class PlacementPicker extends JFrame {
           }
         }
       } catch (final Exception ex) {
+        ClientLogger.logQuietly(ex);
       }
     }
     if (!placeDimensionsSet || JOptionPane.showConfirmDialog(new JPanel(),
@@ -227,6 +231,7 @@ public class PlacementPicker extends JFrame {
         try {
           unit_zoom_percent = Double.parseDouble(result.toLowerCase());
         } catch (final NumberFormatException ex) {
+          // ignore malformed input
         }
         final String width = JOptionPane.showInputDialog(null,
             "Enter the unit's image width in pixels (unscaled / without zoom).\r\n(e.g. 48)");
@@ -234,6 +239,7 @@ public class PlacementPicker extends JFrame {
           try {
             PLACEWIDTH = (int) (unit_zoom_percent * Integer.parseInt(width));
           } catch (final NumberFormatException ex) {
+            // ignore malformed input
           }
         }
         final String height = JOptionPane.showInputDialog(null,
@@ -242,10 +248,12 @@ public class PlacementPicker extends JFrame {
           try {
             PLACEHEIGHT = (int) (unit_zoom_percent * Integer.parseInt(height));
           } catch (final NumberFormatException ex) {
+            // ignore malformed input
           }
         }
         placeDimensionsSet = true;
       } catch (final Exception ex) {
+        ClientLogger.logQuietly(ex);
       }
     }
     File file = null;
@@ -588,6 +596,7 @@ public class PlacementPicker extends JFrame {
         Double.parseDouble(value);
         System.setProperty(TRIPLEA_UNIT_ZOOM, value);
       } catch (final Exception ex) {
+        // ignore malformed input
       }
     } else if (args.length == 2) {
       String value0;
@@ -600,6 +609,7 @@ public class PlacementPicker extends JFrame {
         Integer.parseInt(value0);
         System.setProperty(TRIPLEA_UNIT_WIDTH, value0);
       } catch (final Exception ex) {
+        // ignore malformed input
       }
       String value1;
       if (args[0].startsWith(TRIPLEA_UNIT_HEIGHT)) {
@@ -611,6 +621,7 @@ public class PlacementPicker extends JFrame {
         Integer.parseInt(value1);
         System.setProperty(TRIPLEA_UNIT_HEIGHT, value1);
       } catch (final Exception ex) {
+        // ignore malformed input
       }
     }
     boolean usagePrinted = false;

--- a/src/test/java/games/strategy/thread/ThreadPoolTest.java
+++ b/src/test/java/games/strategy/thread/ThreadPoolTest.java
@@ -114,6 +114,7 @@ public class ThreadPoolTest {
         try {
           wait(10);
         } catch (final InterruptedException ie) {
+          Thread.currentThread().interrupt();
         }
         super.run();
       }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle EmptyCatchBlock rule.

Summary of the fixes:
* All empty `InterruptedException` blocks were changed to call `Thread.currentThread().interrupt()` per #1448.
* Wherever it was obvious that an empty catch block was present to ignore malformed input from UI text fields or command line arguments, I added the comment `// ignore malformed input`
* If it wasn't entirely clear that the exception was being ignored for a legitimate reason, I logged it via `ClientLogger#logQuietly()`.
* In cases where it **seemed** that ignoring the exception was ok, but I wasn't 100% sure on the underlying reason, I added the comment `// ignore`.

I will call out some of these in a forthcoming review, especially those that I think need further scrutiny.