### PR TITLE
Auto save upgrades

### DIFF
--- a/src/main/java/games/strategy/engine/delegate/AutoSave.java
+++ b/src/main/java/games/strategy/engine/delegate/AutoSave.java
@@ -11,9 +11,20 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface AutoSave {
-  // should we auto save before the step starts
+  /**
+   *  Should we auto save before the step starts?
+   */
   boolean beforeStepStart() default false;
 
-  // should we auto save after the step ends
+  /**
+   *  Should we auto save after the step starts?
+   *  Useful for the EndTurnDelegate in PBEM/PBF which allows the autosave before the "Done" button is clicked.
+   *  Still a problem if the "User Report" is on though - doesn't save until "OK" is clicked.
+   */
+  boolean afterStepStart() default false;
+
+  /**
+   *  Should we auto save after the step starts?
+   */
   boolean afterStepEnd() default false;
 }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
@@ -358,18 +358,9 @@ public class HeadlessConsoleController {
       final boolean stop = readin.toLowerCase().startsWith("y");
       if (stop) {
         SaveGameFileChooser.ensureMapsFolderExists();
-        final File f1 =
-            new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName());
-        final File f2 =
-            new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSave2FileName());
-        final File f;
-        if (f1.lastModified() > f2.lastModified()) {
-          f = f2;
-        } else {
-          f = f1;
-        }
         try {
-          game.saveGame(f);
+          game.saveGame(new File(ClientContext.folderSettings().getSaveGamePath(),
+              SaveGameFileChooser.getAutoSaveFileName()));
         } catch (final Exception e) {
           ClientLogger.logQuietly(e);
         }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -199,18 +199,9 @@ public class HeadlessGameServer {
         (new Thread(() -> {
           System.out.println("Remote Stop Game Initiated.");
           SaveGameFileChooser.ensureMapsFolderExists();
-          final File f1 =
-              new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName());
-          final File f2 =
-              new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSave2FileName());
-          final File f;
-          if (f1.lastModified() > f2.lastModified()) {
-            f = f2;
-          } else {
-            f = f1;
-          }
           try {
-            iGame.saveGame(f);
+            iGame.saveGame(new File(
+                ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName()));
           } catch (final Exception e) {
             ClientLogger.logQuietly(e);
           }

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -254,22 +254,13 @@ public class ServerLauncher extends AbstractLauncher {
               }
               final File f1 =
                   new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName());
-              final File f2 =
-                  new File(ClientContext.folderSettings().getSaveGamePath(),
-                      SaveGameFileChooser.getAutoSave2FileName());
-              final File f;
-              if (!f1.exists() && !f2.exists()) {
-                m_gameSelectorModel.resetGameDataToNull();
+              if (f1.exists()) {
+                m_gameSelectorModel.load(f1, null);
               } else {
-                if (!f1.exists() || f1.lastModified() < f2.lastModified()) {
-                  f = f2;
-                } else {
-                  f = f1;
-                }
-                m_gameSelectorModel.load(f, null);
+                m_gameSelectorModel.resetGameDataToNull();
               }
-            } catch (final Exception e) {
-              ClientLogger.logQuietly(e);
+            } catch (final Exception e1) {
+              ClientLogger.logQuietly(e1);
               m_gameSelectorModel.resetGameDataToNull();
             }
           } else {
@@ -382,21 +373,10 @@ public class ServerLauncher extends AbstractLauncher {
     final DateFormat format = new SimpleDateFormat("MMM_dd_'at'_HH_mm");
     SaveGameFileChooser.ensureMapsFolderExists();
     // a hack, if headless save to the autosave to avoid polluting our savegames folder with a million saves
-    final File f;
-    if (m_headless) {
-      final File f1 =
-          new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName());
-      final File f2 =
-          new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSave2FileName());
-      if (f1.lastModified() > f2.lastModified()) {
-        f = f2;
-      } else {
-        f = f1;
-      }
-    } else {
-      f = new File(ClientContext.folderSettings().getSaveGamePath(),
-          "connection_lost_on_" + format.format(new Date()) + ".tsvg");
-    }
+    final File f = m_headless
+        ? new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName())
+        : new File(ClientContext.folderSettings().getSaveGamePath(),
+            "connection_lost_on_" + format.format(new Date()) + ".tsvg");
     try {
       m_serverGame.saveGame(f);
     } catch (final Exception e) {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -392,8 +392,6 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
       final File save;
       if (SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE.equals(typeOfAutosave)) {
         save = new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName());
-      } else if (SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE2.equals(typeOfAutosave)) {
-        save = new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSave2FileName());
       } else if (SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_ODD.equals(typeOfAutosave)) {
         save = new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveOddFileName());
       } else if (SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_EVEN.equals(typeOfAutosave)) {

--- a/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -12,7 +12,6 @@ import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 public class SaveGameFileChooser extends JFileChooser {
   private static final long serialVersionUID = 1548668790891292106L;
   private static final String AUTOSAVE_FILE_NAME = "autosave.tsvg";
-  private static final String AUTOSAVE_2_FILE_NAME = "autosave2.tsvg";
   private static final String AUTOSAVE_ODD_ROUND_FILE_NAME = "autosave_round_odd.tsvg";
   private static final String AUTOSAVE_EVEN_ROUND_FILE_NAME = "autosave_round_even.tsvg";
   private static SaveGameFileChooser s_instance;
@@ -30,17 +29,6 @@ public class SaveGameFileChooser extends JFileChooser {
       }
     }
     return AUTOSAVE_FILE_NAME;
-  }
-
-  public static String getAutoSave2FileName() {
-    if (HeadlessGameServer.headless()) {
-      final String saveSuffix = System.getProperty(GameRunner.TRIPLEA_NAME_PROPERTY,
-          System.getProperty(GameRunner.LOBBY_GAME_HOSTED_BY, ""));
-      if (saveSuffix.length() > 0) {
-        return saveSuffix + "_" + AUTOSAVE_2_FILE_NAME;
-      }
-    }
-    return AUTOSAVE_2_FILE_NAME;
   }
 
   public static String getAutoSaveOddFileName() {

--- a/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/DependentBattle.java
@@ -18,13 +18,16 @@ import games.strategy.engine.data.Unit;
  */
 public abstract class DependentBattle extends AbstractBattle {
   private static final long serialVersionUID = 9119442509652443015L;
-  protected Map<Territory, Collection<Unit>> m_attackingFromMap = new HashMap<>();
-  protected Set<Territory> m_attackingFrom = new HashSet<>();
-  protected final Collection<Territory> m_amphibiousAttackFrom = new ArrayList<>();
+  protected Map<Territory, Collection<Unit>> m_attackingFromMap;
+  protected Set<Territory> m_attackingFrom;
+  private Collection<Territory> m_amphibiousAttackFrom;
 
   DependentBattle(final Territory battleSite, final PlayerID attacker, final BattleTracker battleTracker,
       final boolean isBombingRun, final BattleType battleType, final GameData data) {
     super(battleSite, attacker, battleTracker, isBombingRun, battleType, data);
+    m_attackingFromMap = new HashMap<>();
+    m_attackingFrom = new HashSet<>();
+    m_amphibiousAttackFrom = new ArrayList<>();
   }
 
   public Collection<Territory> getAttackingFrom() {

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -43,7 +43,7 @@ import games.strategy.util.ThreadUtil;
  * At the end of the turn collect income.
  */
 @MapSupport
-@AutoSave(afterStepEnd = true)
+@AutoSave(afterStepStart = true)
 public class EndTurnDelegate extends AbstractEndTurnDelegate {
   @Override
   protected String doNationalObjectivesAndOtherEndTurnEffects(final IDelegateBridge bridge) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -20,7 +20,9 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.delegate.AutoSave;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
 import games.strategy.triplea.attachments.ICondition;
@@ -40,6 +42,8 @@ import games.strategy.util.Match;
  * Responsible for checking the validity of a move, and for moving the units.
  * </p>
  */
+@MapSupport
+@AutoSave(afterStepEnd = true)
 public class MoveDelegate extends AbstractMoveDelegate {
 
   public static String CLEANING_UP_DURING_MOVEMENT_PHASE = "Cleaning up during movement phase";

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -161,9 +161,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       // if none of the units is a land unit, the attack from
       // that territory is no longer an amphibious assault
       if (Match.noneMatch(attackingFromMapUnits, Matches.UnitIsLand)) {
-        m_amphibiousAttackFrom.remove(attackingFrom);
+        getAmphibiousAttackTerritories().remove(attackingFrom);
         // do we have any amphibious attacks left?
-        m_isAmphibious = !m_amphibiousAttackFrom.isEmpty();
+        m_isAmphibious = !getAmphibiousAttackTerritories().isEmpty();
       }
     }
     final Iterator<Unit> dependentHolders = m_dependentUnits.keySet().iterator();
@@ -197,7 +197,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()
         && Match.someMatch(attackingUnits, Matches.UnitIsLand)) {
-      m_amphibiousAttackFrom.add(route.getTerritoryBeforeEnd());
+      getAmphibiousAttackTerritories().add(route.getTerritoryBeforeEnd());
       m_amphibiousLandAttackers.addAll(Match.getMatches(attackingUnits, Matches.UnitIsLand));
       m_isAmphibious = true;
     }

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -58,7 +58,7 @@ public class NonFightingBattle extends DependentBattle {
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()
         && Match.someMatch(units, Matches.UnitIsLand)) {
-      m_amphibiousAttackFrom.add(route.getTerritoryBeforeEnd());
+      getAmphibiousAttackTerritories().add(route.getTerritoryBeforeEnd());
       m_amphibiousLandAttackers.addAll(Match.getMatches(units, Matches.UnitIsLand));
       m_isAmphibious = true;
     }
@@ -126,9 +126,9 @@ public class NonFightingBattle extends DependentBattle {
       // if none of the units is a land unit, the attack from
       // that territory is no longer an amphibious assault
       if (Match.noneMatch(attackingFromMapUnits, Matches.UnitIsLand)) {
-        m_amphibiousAttackFrom.remove(attackingFrom);
+        getAmphibiousAttackTerritories().remove(attackingFrom);
         // do we have any amphibious attacks left?
-        m_isAmphibious = !m_amphibiousAttackFrom.isEmpty();
+        m_isAmphibious = !getAmphibiousAttackTerritories().isEmpty();
       }
     }
     final Iterator<Unit> dependents = m_dependentUnits.keySet().iterator();


### PR DESCRIPTION
Short summary: meaningful names of after delegate saves, include move delegates, remove autosave2

This PR upgrades autosaves in a few ways. Currently you have to go fishing between autosave & autosave2 to maybe see something that works for you. This PR removes autosave2, saving a ton of code. Secondly, it gives a meaningful name to end of phase autosave files. autosaveAfterBattle is better than autosave2! Thirdly it adds an autosave to the end of the movement phases, with a full description such as "autosaveAftergermanscombatmove", saving before the move phase is locked off. Other delegates save after they are locked off. This doesn't allow anything that isn't possible at present BTW. Nothing stops you procedurally saving before ending each movement phase but you shouldn't have to think about that.

Now I know I didn't log an issue about this but it seems easy enough to resolve. Current autosave functionality is very marginally useful and I'm sure not understood by users.

Re-opened from #1661 due to rebasing problems.