### PR TITLE
 Resolve remaining issues with Rockets

### DIFF
--- a/src/main/java/games/strategy/triplea/Constants.java
+++ b/src/main/java/games/strategy/triplea/Constants.java
@@ -75,7 +75,6 @@ public interface Constants {
   String ROLL_AA_INDIVIDUALLY = "Roll AA Individually";
   String LIMIT_ROCKET_AND_SBR_DAMAGE_TO_PRODUCTION = "Limit SBR Damage To Factory Production";
   String SBR_VICTORY_POINTS = "SBR Victory Points";
-  String ROCKET_ATTACKS_PER_FACTORY_INFINITE = "Rocket Attacks Per Factory Infinite";
   String LIMIT_SBR_DAMAGE_PER_TURN = "Limit SBR Damage Per Turn";
   String LIMIT_ROCKET_DAMAGE_PER_TURN = "Limit Rocket Damage Per Turn";
   String ALLIED_AIR_INDEPENDENT = "Allied Air Independent";

--- a/src/main/java/games/strategy/triplea/Properties.java
+++ b/src/main/java/games/strategy/triplea/Properties.java
@@ -59,6 +59,10 @@ public class Properties implements Constants {
     return data.getProperties().get(ROCKETS_CAN_FLY_OVER_IMPASSABLES, false);
   }
 
+  public static boolean getStrictRockets(final GameData data) {
+    return data.getProperties().get("Strictly rule compliant rockets", false);
+  }
+
   /*
    * Pacific Theater
    */
@@ -174,13 +178,6 @@ public class Properties implements Constants {
    */
   public static boolean getSBRVictoryPoint(final GameData data) {
     return data.getProperties().get(SBR_VICTORY_POINTS, false);
-  }
-
-  /**
-   * Allow x rocket attack(s) per defending factory.
-   */
-  public static boolean getRocketAttacksPerFactoryInfinite(final GameData data) {
-    return data.getProperties().get(ROCKET_ATTACKS_PER_FACTORY_INFINITE, false);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -89,7 +89,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   // bombingBonus and bombingMaxDieSides
   private IntegerMap<UnitType> m_rocketDiceNumber = new IntegerMap<>();
   private int m_rocketDistance = 0;
-  private int m_rocketNumberPerTerritory = 0;
+  private int m_rocketNumberPerTerritory = 1;
   private HashMap<UnitType, HashSet<String>> m_unitAbilitiesGained = new HashMap<>();
   private boolean m_airborneForces = false;
   private IntegerMap<UnitType> m_airborneCapacity = new IntegerMap<>();
@@ -524,8 +524,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setRocketNumberPerTerritory(final String value) throws GameParseException {
     final int v = getInt(value);
-    if (v < 0 || v > 200) {
-      throw new GameParseException("rocketNumberPerTerritory must be between 0 and 200" + thisErrorMsg());
+    if (v < -1 || v > 200) {
+      throw new GameParseException("rocketNumberPerTerritory must be between -1 and 200" + thisErrorMsg());
     }
     m_rocketNumberPerTerritory = v;
   }

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -60,6 +60,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   private boolean m_needToRecordBattleStatistics = true;
   private boolean m_needToCheckDefendingPlanesCanLand = true;
   private boolean m_needToCleanup = true;
+  private RocketsFireHelper rocketHelper;
   protected IBattle m_currentBattle = null;
 
   /**
@@ -78,14 +79,19 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     super.start();
     // we may start multiple times due to loading after saving
     // only initialize once
+    final PlayerID player = m_bridge.getPlayerID();
     if (m_needToInitialize) {
       doInitialize(m_battleTracker, m_bridge);
       m_needToInitialize = false;
     }
+    // Ideally this could be included in the save game but this breaks backwards compatibility
     // do pre-combat stuff, like scrambling, after we have setup all battles, but before we have bombardment, etc.
     // the order of all of this stuff matters quite a bit.
     if (m_needToScramble) {
+      rocketHelper = new RocketsFireHelper(m_bridge, getData(), player);
+      // TODO: Save rocketHelper in tsvg file and move rocketHelper.fireRockets() to after SBR. Requires version bump.
       doScrambling();
+      rocketHelper.fireRockets();
       m_needToScramble = false;
     }
     if (m_needToKamikazeSuicideAttacks) {

--- a/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -129,8 +129,8 @@ public class GameStepPropertiesHelper {
   }
 
   /**
-   * Fire rockets after phase is over. Normally would occur after combat move for WW2v2 and WW2v3, and after noncombat
-   * move for WW2v1.
+   * Fire rockets after phase is over. This method is here for legacy support. Ideally, all maps with rockets will set
+   * PROPERTY_fireRockets for move and battle phases
    */
   static boolean isFireRockets(final GameData data) {
     final boolean isFireRockets;
@@ -139,8 +139,9 @@ public class GameStepPropertiesHelper {
       final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PROPERTY_fireRockets);
       if (prop != null) {
         isFireRockets = Boolean.parseBoolean(prop);
-      } else if (games.strategy.triplea.Properties.getWW2V2(data) || games.strategy.triplea.Properties.getWW2V3(data)) {
-        isFireRockets = isCombatDelegate(data);
+      } else if (data.getSequence().getStep().getDelegate().getName().compareTo("battle") == 0) {
+        isFireRockets =
+          games.strategy.triplea.Properties.getWW2V2(data) || games.strategy.triplea.Properties.getWW2V3(data);
       } else {
         isFireRockets = isNonCombatDelegate(data);
       }
@@ -346,6 +347,7 @@ public class GameStepPropertiesHelper {
   }
 
   private static boolean isCombatDelegate(final GameData data) {
+    // NonCombatMove endsWith CombatMove so check for NCM first
     if (data.getSequence().getStep().getName().endsWith("NonCombatMove")) {
       return false;
     } else if (data.getSequence().getStep().getName().endsWith("CombatMove")) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -29,6 +29,7 @@ import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.dataObjects.MoveValidationResult;
+import games.strategy.triplea.delegate.RocketsFireHelper.RocketType;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.CompositeMatchOr;
@@ -197,12 +198,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
     // WW2V2/WW2V3, fires at end of combat move
     // WW2V1, fires at end of non combat move
-    if (GameStepPropertiesHelper.isFireRockets(data)) {
-      if (m_needToDoRockets && TechTracker.hasRocket(m_bridge.getPlayerID())) {
-        final RocketsFireHelper helper = new RocketsFireHelper();
-        helper.fireRockets(m_bridge, m_bridge.getPlayerID());
-        m_needToDoRockets = false;
-      }
+    if (m_needToDoRockets && GameStepPropertiesHelper.isNonCombatMove(data, true)) {
+      new RocketsFireHelper(m_bridge, m_bridge.getPlayerID(), RocketType.ww2v1);
+      m_needToDoRockets = false;
     }
 
     // do at the end of the round, if we do it at the start of non combat, then we may do it in the middle of the round,

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.delegate;
 
+import java.lang.Integer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,7 +39,45 @@ import games.strategy.util.Match;
  * Logic to fire rockets.
  */
 public class RocketsFireHelper {
-  private static boolean isWW2V2(final GameData data) {
+  private Set<Territory> attackingFromTerritories = new HashSet<>();
+  private Map<Territory, Territory> attackedTerritories;
+  private Map<Territory, Unit> attackedUnits;
+  private IDelegateBridge bridge;
+  private GameData data;
+  private PlayerID player;
+  private boolean needToFindRocketTargets;
+
+  enum RocketType {
+    ww2v1
+  }
+
+  RocketsFireHelper(final IDelegateBridge passedBridge, final GameData passedData, final PlayerID passedPlayer) {
+    bridge = passedBridge;
+    data = passedData;
+    player = passedPlayer;
+    // WW2V2/WW2V3, fires at end of combat move - now moved to the start of the BattleDelegate
+    // WW2V1, fires at end of non combat move so does not call here
+    needToFindRocketTargets = false;
+    if (GameStepPropertiesHelper.isFireRockets(data) && TechTracker.hasRocket(player)) {
+      if (games.strategy.triplea.Properties.getStrictRockets(data)) {
+        needToFindRocketTargets = true;
+      } else {
+        findRocketTargets();
+      }
+    }
+  }
+
+  RocketsFireHelper(final IDelegateBridge passedBridge, final PlayerID passedPlayer, final RocketType test) {
+    bridge = passedBridge;
+    data = bridge.getData();
+    player = passedPlayer;
+    if (isWW2V2(data) || isAllRocketsAttack(data)) {
+      return;
+    }
+    fireWW2V1();
+  }
+
+  private boolean isWW2V2(final GameData data) {
     return games.strategy.triplea.Properties.getWW2V2(data);
   }
 
@@ -54,10 +93,6 @@ public class RocketsFireHelper {
     return games.strategy.triplea.Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
   }
 
-  private static boolean isRocketAttacksPerFactoryInfinite(final GameData data) {
-    return games.strategy.triplea.Properties.getRocketAttacksPerFactoryInfinite(data);
-  }
-
   private static boolean isPUCap(final GameData data) {
     return games.strategy.triplea.Properties.getPUCap(data);
   }
@@ -70,52 +105,103 @@ public class RocketsFireHelper {
     return games.strategy.triplea.Properties.getLimitRocketAndSBRDamageToProduction(data);
   }
 
-  public RocketsFireHelper() {}
-
-  public void fireRockets(final IDelegateBridge bridge, final PlayerID player) {
-    final GameData data = bridge.getData();
-    final Set<Territory> rocketTerritories = getTerritoriesWithRockets(data, player);
-    if (rocketTerritories.isEmpty()) {
-      bridge.getHistoryWriter().startEvent(player.getName() + " has no rockets to fire");
-      // getRemote(bridge).reportMessage("No rockets to fire", "No rockets to fire");
-      return;
-    }
-    if (isWW2V2(data) || isAllRocketsAttack(data)) {
-      fireWW2V2(bridge, player, rocketTerritories);
-    } else {
-      fireWW2V1(bridge, player, rocketTerritories);
-    }
-  }
-
-  private void fireWW2V2(final IDelegateBridge bridge, final PlayerID player, final Set<Territory> rocketTerritories) {
-    final GameData data = bridge.getData();
-    final Set<Territory> attackedTerritories = new HashSet<>();
-    final Map<Territory,Territory> attackingFromTerritories = new LinkedHashMap<>();
-    final boolean oneAttackPerTerritory = !isRocketAttacksPerFactoryInfinite(data);
-    for (final Territory territory : rocketTerritories) {
-      final Set<Territory> targets = getTargetsWithinRange(territory, data, player);
-      if (oneAttackPerTerritory) {
-        targets.removeAll(attackedTerritories);
+  /**
+   *  Find Rocket Targets and load up fire rockets for later execution if necessary. Directly fired with strict rockets.
+   */
+  private void findRocketTargets() {
+    attackingFromTerritories = new HashSet<>();
+    attackedTerritories = new LinkedHashMap<>();
+    attackedUnits = new LinkedHashMap<>();
+    final Map<Territory,Integer> previouslyAttackedTerritories = new LinkedHashMap<>();
+    for (final Territory attackFrom : getTerritoriesWithRockets(bridge, data, player)) {
+      final Set<Territory> targets = getTargetsWithinRange(attackFrom, data, player);
+      final int maxAttacks = TechAbilityAttachment.getRocketNumberPerTerritory(player, data);
+      for (final Territory t : previouslyAttackedTerritories.keySet()) {
+        // negative Rocket Number per Territory == unlimited
+        if (maxAttacks < 0 || maxAttacks <= previouslyAttackedTerritories.get(t).intValue()) {
+          targets.remove(t);
+        }
       }
       if (targets.isEmpty()) {
         continue;
       }
       // Ask the user where each rocket launcher should target.
-      final Territory target = getTarget(targets, bridge, territory);
-      if (target != null) {
-        attackedTerritories.add(target);
-        attackingFromTerritories.put(target,territory);
+      Territory targetTerritory;
+      while (true) {
+        targetTerritory = getTarget(targets, bridge, attackFrom);
+        if (targetTerritory == null) {
+          break;
+        }
+        final Collection<Unit> enemyUnits = targetTerritory.getUnits().getMatches(
+            new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
+        final Collection<Unit> enemyTargetsTotal =
+            Match.getMatches(enemyUnits, Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(targetTerritory).invert());
+        Unit unitTarget = null;
+        if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+          final Collection<Unit> rocketTargets = new ArrayList<>(
+              Match.getMatches(attackFrom.getUnits().getUnits(), rocketMatch(player, data)));
+          final HashSet<UnitType> legalTargetsForTheseRockets = new HashSet<>();
+          if (rocketTargets == null) {
+            legalTargetsForTheseRockets.addAll(data.getUnitTypeList().getAllUnitTypes());
+          } else {
+            // a hack for now, we let the rockets fire at anyone who could be targetted by any rocket
+            for (final Unit r : rocketTargets) {
+              legalTargetsForTheseRockets.addAll(UnitAttachment.get(r.getType()).getBombingTargets(data));
+            }
+          }
+          final Collection<Unit> enemyTargets =
+              Match.getMatches(enemyTargetsTotal, Matches.unitIsOfTypes(legalTargetsForTheseRockets));
+          if (enemyTargets.isEmpty()) {
+            // TODO: this sucks
+            continue;
+          }
+          if (enemyTargets.size() == 1) {
+            unitTarget = enemyTargets.iterator().next();
+          } else {
+            final ITripleAPlayer iplayer = (ITripleAPlayer) bridge.getRemotePlayer(player);
+            unitTarget = iplayer.whatShouldBomberBomb(targetTerritory, enemyTargets, rocketTargets);
+          }
+          if (unitTarget == null) {
+            continue;
+            // Ask them if they now want to attack a different territory
+          }
+        }
+        attackedTerritories.put(attackFrom, targetTerritory);
+        attackedUnits.put(attackFrom, unitTarget);
+        // Strict Rockets are target, fire, target, fire ...
+        // Sensible (non-strict) Rockets are target, target, target, fire, fire, fire.
+        if (games.strategy.triplea.Properties.getStrictRockets(data)) {
+          fireRocket(attackFrom, targetTerritory);
+          break;
+        }
+        // Can't add this value above because it would cause the rocket to fire twice in a strict rocket scenario
+        attackingFromTerritories.add(attackFrom);
+        break;
+      } // while (true)
+      if (targetTerritory != null) {
+        final Integer numAttacks = previouslyAttackedTerritories.get(targetTerritory);
+        previouslyAttackedTerritories.put(targetTerritory,
+            new Integer(numAttacks == null ? 1 : numAttacks.intValue() + 1));
       }
     }
-    for (final Territory target : attackedTerritories) {
+  }
+
+  /**
+  *  Fire rockets which have been previously targetted (if any), or for strict rockets target them too.
+  */
+  public void fireRockets() {
+    if (needToFindRocketTargets) {
+      findRocketTargets();
+    }
+    for (final Territory attackingFrom : attackingFromTerritories) {
       // Roll dice for the rocket attack damage and apply it
-      fireRocket(player, target, bridge, attackingFromTerritories.get(target));
+      fireRocket(attackingFrom, attackedTerritories.get(attackingFrom));
     }
   }
 
   /** In this rule set, each player only gets one rocket attack per turn. */
-  private void fireWW2V1(final IDelegateBridge bridge, final PlayerID player, final Set<Territory> rocketTerritories) {
-    final GameData data = bridge.getData();
+  private void fireWW2V1() {
+    final Set<Territory> rocketTerritories = getTerritoriesWithRockets(bridge, data, player);
     final Set<Territory> targets = new HashSet<>();
     for (final Territory territory : rocketTerritories) {
       targets.addAll(getTargetsWithinRange(territory, data, player));
@@ -127,11 +213,12 @@ public class RocketsFireHelper {
     final Territory attacked = getTarget(targets, bridge, null);
 
     if (attacked != null) {
-      fireRocket(player, attacked, bridge, null);
+      fireRocket(null, attacked);
     }
   }
 
-  Set<Territory> getTerritoriesWithRockets(final GameData data, final PlayerID player) {
+  static Set<Territory> getTerritoriesWithRockets(
+      final IDelegateBridge bridge, final GameData data, final PlayerID player) {
     final Set<Territory> territories = new HashSet<>();
     final CompositeMatch<Unit> ownedRockets = rocketMatch(player, data);
     final BattleTracker tracker = AbstractMoveDelegate.getBattleTracker(data);
@@ -143,10 +230,14 @@ public class RocketsFireHelper {
         territories.add(current);
       }
     }
+    if (territories.isEmpty()) {
+      bridge.getHistoryWriter().startEvent(player.getName() + " has no rockets to fire");
+      // getRemote(bridge).reportMessage("No rockets to fire", "No rockets to fire");
+    }
     return territories;
   }
 
-  CompositeMatch<Unit> rocketMatch(final PlayerID player, final GameData data) {
+  static CompositeMatch<Unit> rocketMatch(final PlayerID player, final GameData data) {
     return new CompositeMatchAnd<>(Matches.UnitIsRocket, Matches.unitIsOwnedBy(player), Matches.UnitIsNotDisabled,
         Matches.unitIsBeingTransported().invert(), Matches.UnitIsSubmerged.invert(), Matches.unitHasNotMoved);
   }
@@ -181,9 +272,7 @@ public class RocketsFireHelper {
     return ((ITripleAPlayer) bridge.getRemotePlayer()).whereShouldRocketsAttack(targets, from);
   }
 
-  private void fireRocket(final PlayerID player, final Territory attackedTerritory, final IDelegateBridge bridge,
-      final Territory attackFrom) {
-    final GameData data = bridge.getData();
+  private void fireRocket(final Territory attackFrom, final Territory attackedTerritory) {
     final PlayerID attacked = attackedTerritory.getOwner();
     final Resource PUs = data.getResourceList().getResource(Constants.PUS);
     final boolean DamageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
@@ -192,58 +281,20 @@ public class RocketsFireHelper {
         new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
     final Collection<Unit> enemyTargetsTotal =
         Match.getMatches(enemyUnits, Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).invert());
-    final Collection<Unit> targets = new ArrayList<>();
-    final Collection<Unit> rockets;
-    // attackFrom could be null if WW2V1
-    if (attackFrom == null) {
-      rockets = null;
-    } else {
-      rockets = new ArrayList<>(Match.getMatches(attackFrom.getUnits().getUnits(), rocketMatch(player, data)));
-    }
-    final int numberOfAttacks = (rockets == null ? 1
+    final Collection<Unit> rockets = attackFrom == null ? null
+        : new ArrayList<>(Match.getMatches(attackFrom.getUnits().getUnits(), rocketMatch(player, data)));
+    final int numberOfAttacks = attackFrom == null ? 1
         : Math.min(TechAbilityAttachment.getRocketNumberPerTerritory(player, data),
-            TechAbilityAttachment.getRocketDiceNumber(rockets, data)));
+            TechAbilityAttachment.getRocketDiceNumber(rockets, data));
     if (numberOfAttacks <= 0) {
       return;
     }
     final String transcript;
-    if (DamageFromBombingDoneToUnits) {
-      // TODO: rockets needs to be completely redone to allow for multiple rockets to fire at different targets, etc
-      // etc.
-      final HashSet<UnitType> legalTargetsForTheseRockets = new HashSet<>();
-      if (rockets == null) {
-        legalTargetsForTheseRockets.addAll(data.getUnitTypeList().getAllUnitTypes());
-      } else {
-        // a hack for now, we let the rockets fire at anyone who could be targetted by any rocket
-        for (final Unit r : rockets) {
-          legalTargetsForTheseRockets.addAll(UnitAttachment.get(r.getType()).getBombingTargets(data));
-        }
-      }
-      final Collection<Unit> enemyTargets =
-          Match.getMatches(enemyTargetsTotal, Matches.unitIsOfTypes(legalTargetsForTheseRockets));
-      if (enemyTargets.isEmpty()) {
-        // TODO: this sucks
-        return;
-      }
-      Unit target = null;
-      if (enemyTargets.size() == 1) {
-        target = enemyTargets.iterator().next();
-      } else {
-        while (target == null) {
-          final ITripleAPlayer iplayer = (ITripleAPlayer) bridge.getRemotePlayer(player);
-          target = iplayer.whatShouldBomberBomb(attackedTerritory, enemyTargets, rockets);
-        }
-      }
-      if (target == null) {
-        throw new IllegalStateException("No Targets in " + attackedTerritory.getName());
-      }
-      targets.add(target);
-    }
     final boolean doNotUseBombingBonus =
-        !games.strategy.triplea.Properties.getUseBombingMaxDiceSidesAndBonus(data) || rockets == null;
+        !games.strategy.triplea.Properties.getUseBombingMaxDiceSidesAndBonus(data) || attackFrom == null;
     int cost = 0;
     if (!games.strategy.triplea.Properties.getLL_DAMAGE_ONLY(data)) {
-      if (doNotUseBombingBonus || rockets == null) {
+      if (doNotUseBombingBonus || attackFrom == null) {
         // no low luck, and no bonus, so just roll based on the map's dice sides
         final int[] rolls = bridge.getRandom(data.getDiceSides(), numberOfAttacks, player, DiceType.BOMBING,
             "Rocket fired by " + player.getName() + " at " + attacked.getName());
@@ -360,19 +411,16 @@ public class RocketsFireHelper {
       }
     }
     int territoryProduction = TerritoryAttachment.getProduction(attackedTerritory);
-    if (DamageFromBombingDoneToUnits && !targets.isEmpty()) {
-      // we are doing damage to 'target', not to the territory
-      final Unit target = targets.iterator().next();
-      // UnitAttachment ua = UnitAttachment.get(target.getType());
-      final TripleAUnit taUnit = (TripleAUnit) target;
-      final int damageLimit = taUnit.getHowMuchMoreDamageCanThisUnitTake(target, attackedTerritory);
+    final TripleAUnit taUnit = attackFrom == null ? null : (TripleAUnit) attackedUnits.get(attackFrom);
+    if (DamageFromBombingDoneToUnits && attackFrom != null) {
+      final int damageLimit = taUnit.getHowMuchMoreDamageCanThisUnitTake(taUnit, attackedTerritory);
       cost = Math.max(0, Math.min(cost, damageLimit));
       final int totalDamage = taUnit.getUnitDamage() + cost;
       // Record production lost
       // DelegateFinder.moveDelegate(data).PUsLost(attackedTerritory, cost);
       // apply the hits to the targets
       final IntegerMap<Unit> damageMap = new IntegerMap<>();
-      damageMap.put(target, totalDamage);
+      damageMap.put(taUnit, totalDamage);
       bridge.addChange(ChangeFactory.bombingUnitDamage(damageMap));
       // attackedTerritory.notifyChanged();
     // in WW2V2, limit rocket attack cost to production value of factory.
@@ -389,14 +437,10 @@ public class RocketsFireHelper {
     }
     // Record the PUs lost
     DelegateFinder.moveDelegate(data).PUsLost(attackedTerritory, cost);
-    if (DamageFromBombingDoneToUnits && !targets.isEmpty()) {
-      getRemote(bridge).reportMessage(
-          "Rocket attack in " + attackedTerritory.getName() + " does " + cost + " damage to "
-              + targets.iterator().next(),
-          "Rocket attack in " + attackedTerritory.getName() + " does " + cost + " damage to "
-              + targets.iterator().next());
-      bridge.getHistoryWriter().startEvent("Rocket attack in " + attackedTerritory.getName() + " does " + cost
-          + " damage to " + targets.iterator().next());
+    if (DamageFromBombingDoneToUnits && taUnit != null) {
+      final String msg = "Rocket attack in " + attackedTerritory.getName() + " does " + cost + " damage to " + taUnit;
+      getRemote(bridge).reportMessage(msg, msg);
+      bridge.getHistoryWriter().startEvent(msg);
     } else {
       cost *= Properties.getPU_Multiplier(data);
       getRemote(bridge).reportMessage("Rocket attack in " + attackedTerritory.getName() + " costs:" + cost,
@@ -424,8 +468,9 @@ public class RocketsFireHelper {
       }
     }
     // kill any units that can die if they have reached max damage (veqryn)
-    if (Match.someMatch(targets, Matches.UnitCanDieFromReachingMaxDamage)) {
-      final List<Unit> unitsCanDie = Match.getMatches(targets, Matches.UnitCanDieFromReachingMaxDamage);
+    final Collection<Unit> targetUnitCol = taUnit == null ? enemyTargetsTotal : Collections.singleton(taUnit);
+    if (Match.someMatch(targetUnitCol, Matches.UnitCanDieFromReachingMaxDamage)) {
+      final List<Unit> unitsCanDie = Match.getMatches(targetUnitCol, Matches.UnitCanDieFromReachingMaxDamage);
       unitsCanDie
           .retainAll(Match.getMatches(unitsCanDie, Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory)));
       if (!unitsCanDie.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -946,8 +946,8 @@ public class TripleAFrame extends MainGameFrame {
     });
     final JPanel panel = comps.getFirst();
     final JList<?> list = comps.getSecond();
-    final String[] options = {"OK"};
-    final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_OPTION,
+    final String[] options = {"OK", "Cancel"};
+    final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_CANCEL_OPTION,
         JOptionPane.PLAIN_MESSAGE, null, options, null, getUIContext().getCountDownLatchHandler());
     if (selection == 0) {
       selected.set((Unit) list.getSelectedValue());

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -1319,7 +1319,7 @@ public class RevisedTest {
     // blitz
     final Territory wr = territory("West Russia", gameData);
     move(wr.getUnits().getMatches(Matches.UnitCanBlitz), new Route(wr, cauc));
-    final Set<Territory> fire = new RocketsFireHelper().getTerritoriesWithRockets(gameData, germans(gameData));
+    final Set<Territory> fire = RocketsFireHelper.getTerritoriesWithRockets(bridge, gameData, germans(gameData));
     // germany, WE, SE, but not caucusus
     assertEquals(fire.size(), 3);
   }

--- a/src/test/resources/pact_of_steel_2_test.xml
+++ b/src/test/resources/pact_of_steel_2_test.xml
@@ -4965,10 +4965,6 @@
                 </property>
 
                         <!-- if true allows infinite attacks against a factory by many rockets, if false,will only allow a max of 1 rocket to attack each factory -->
-                <property name="Rocket Attacks Per Factory Infinite" value="false" editable="false">
-                        <boolean/>
-                </property>
-
                 <property name="Rockets Can Fly Over Impassables" value="false" editable="false">
                         <boolean/>
                 </property>

--- a/src/test/resources/ww2_g40_balanced.xml
+++ b/src/test/resources/ww2_g40_balanced.xml
@@ -14947,9 +14947,6 @@
     <property name="All Rockets Attack" value="true" editable="false">
       <boolean/>
     </property>
-    <property name="Rocket Attacks Per Factory Infinite" value="true" editable="false">
-      <boolean/>
-    </property>
     <property name="Rockets Can Fly Over Impassables" value="false" editable="false">
       <boolean/>
     </property>


### PR DESCRIPTION
- Scramble should not be prevented by Rockets hitting an airbase
- There should be a map option (IMO) to go with the strict rules for rockets as clarified (http://www.axisandallies.org/forums/index.php?topic=28562.msg1648393#msg1648393)
- Otherwise, rockets should be declared before any other dice are rolled.
- There should be a cancel button for selecting between airfield/harbour/factory therefore allowing targetting a different territory

Reopened from #1664 and #1673 because it picked up extra files for some reason.