### PR TITLE
Make map name less unforgiving

### DIFF
--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -98,7 +98,6 @@ public class ResourceLoader implements Closeable {
     // clicking github 'clone or download' and downloading the zip gives a zip that ends with "-master.zip"
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), normalizeMapZipName(mapName) + "-master.zip"));
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), mapName + "-master.zip"));
-    candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), zipName));
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), normalizedZipName));
 
     final Optional<File> match = candidates.stream().filter(file -> file.exists()).findFirst();

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -97,6 +97,8 @@ public class ResourceLoader implements Closeable {
 
     // clicking github 'clone or download' and downloading the zip gives a zip that ends with "-master.zip"
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), normalizeMapZipName(mapName) + "-master.zip"));
+    candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), mapName + "-master.zip"));
+    candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), zipName));
     candidates.add(new File(ClientFileSystemHelper.getUserMapsFolder(), normalizedZipName));
 
     final Optional<File> match = candidates.stream().filter(file -> file.exists()).findFirst();


### PR DESCRIPTION
Similar to #1651 but keeps the mapName property alive - just removes arbitrary restrictions on what it can be called - as well as trying the mangled names, also try the unmangled names. Should get rid of that extremely frustrating message after downloading and starting a map - "Please download the map".