### PR TITLE
Checkstyle: Document Unicode escape usage

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=5288
+checkstyleMainMaxWarnings=5287
 checkstyleTestMaxWarnings=262

--- a/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -272,8 +272,7 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
       }
       for (int i = 0; i < status.length(); i++) {
         final char c = status.charAt(i);
-        // skip combining characters
-        if (c >= '\u0300' && c <= '\u036F') {
+        if (c >= '\u0300' && c <= '\u036F') { // skip combining characters
           continue;
         }
         statusSB.append(c);


### PR DESCRIPTION
This PR fixes a single violation of the Checkstyle AvoidEscapedUnicodeCharacters rule.

The Google style guide recommends that printable Unicode characters be entered directly into source files instead of using Unicode escapes.  In this case, the code points are non-printable combining characters.  Thus, usage of a Unicode escape is acceptable.  The Checkstyle warning is suppressed by adding a tail comment to document the escape usage.