### PR TITLE
Ignore expected exception when parsing territory name (#1678)

### DIFF
--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -397,7 +397,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
           }
           continue;
         } catch (final Exception e) {
-          ClientLogger.logQuietly(e);
+          // territory name is not an integer; fall through
         }
       }
       if (name.equals("each")) {


### PR DESCRIPTION
This PR fixes #1678.

It is expected that the `getInt()` method on line 393 may throw an exception due to the territory name not being an integer.  In that case, the exception should be ignored instead of logged, and execution should fall through to the following code to handle the non-integer cases.