### PR TITLE
Checkstyle: Fix member name violations in g.s.engine.* test code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 checkstyleMainMaxWarnings=5287
-checkstyleTestMaxWarnings=262
+checkstyleTestMaxWarnings=208

--- a/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
+++ b/src/test/java/games/strategy/engine/data/AllianceTrackerTest.java
@@ -10,19 +10,19 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.xml.TestMapGameData;
 
 public class AllianceTrackerTest {
-  private GameData m_data;
+  private GameData gameData;
 
   @Before
   public void setUp() throws Exception {
-    m_data = TestMapGameData.TEST.getGameData();
+    gameData = TestMapGameData.TEST.getGameData();
   }
 
   @Test
   public void testAddAlliance() throws Exception {
-    final PlayerID bush = m_data.getPlayerList().getPlayerID("bush");
-    final PlayerID castro = m_data.getPlayerList().getPlayerID("castro");
-    final AllianceTracker allianceTracker = m_data.getAllianceTracker();
-    final RelationshipTracker relationshipTracker = m_data.getRelationshipTracker();
+    final PlayerID bush = gameData.getPlayerList().getPlayerID("bush");
+    final PlayerID castro = gameData.getPlayerList().getPlayerID("castro");
+    final AllianceTracker allianceTracker = gameData.getAllianceTracker();
+    final RelationshipTracker relationshipTracker = gameData.getRelationshipTracker();
     assertFalse(relationshipTracker.isAllied(bush, castro));
     // the alliance tracker now only keeps track of GUI elements like the stats panel alliance TUV totals, and does not
     // affect gameplay
@@ -31,7 +31,7 @@ public class AllianceTrackerTest {
     // Note that changing
     // the relationship between bush and castro, does not change the relationship between bush and chretian
     relationshipTracker.setRelationship(bush, castro,
-        m_data.getRelationshipTypeList().getRelationshipType(Constants.RELATIONSHIP_TYPE_DEFAULT_ALLIED));
+        gameData.getRelationshipTypeList().getRelationshipType(Constants.RELATIONSHIP_TYPE_DEFAULT_ALLIED));
     assertTrue(relationshipTracker.isAllied(bush, castro));
   }
 

--- a/src/test/java/games/strategy/engine/data/ChangeTest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTest.java
@@ -21,11 +21,11 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.xml.TestMapGameData;
 
 public class ChangeTest {
-  private GameData m_data;
+  private GameData gameData;
 
   @Before
   public void setUp() throws Exception {
-    m_data = TestMapGameData.TEST.getGameData();
+    gameData = TestMapGameData.TEST.getGameData();
   }
 
   private Change serialize(final Change aChange) throws Exception {
@@ -36,7 +36,7 @@ public class ChangeTest {
     // System.out.println("bytes:" + sink.toByteArray().length);
     final InputStream source = new ByteArrayInputStream(sink.toByteArray());
     final ObjectInputStream input =
-        new GameObjectInputStream(new games.strategy.engine.framework.GameObjectStreamFactory(m_data), source);
+        new GameObjectInputStream(new games.strategy.engine.framework.GameObjectStreamFactory(gameData), source);
     final Change newChange = (Change) input.readObject();
     input.close();
     output.close();
@@ -46,31 +46,31 @@ public class ChangeTest {
   @Test
   public void testUnitsAddTerritory() {
     // make sure we know where we are starting
-    final Territory can = m_data.getMap().getTerritory("canada");
+    final Territory can = gameData.getMap().getTerritory("canada");
     assertEquals(5, can.getUnits().getUnitCount());
     // add some units
     final Change change =
-        ChangeFactory.addUnits(can, m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF).create(10, null));
-    m_data.performChange(change);
+        ChangeFactory.addUnits(can, gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF).create(10, null));
+    gameData.performChange(change);
     assertEquals(15, can.getUnits().getUnitCount());
     // invert the change
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(5, can.getUnits().getUnitCount());
   }
 
   @Test
   public void testUnitsRemoveTerritory() {
     // make sure we now where we are starting
-    final Territory can = m_data.getMap().getTerritory("canada");
+    final Territory can = gameData.getMap().getTerritory("canada");
     assertEquals(5, can.getUnits().getUnitCount());
     // remove some units
     final Collection<Unit> units =
-        can.getUnits().getUnits(m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
+        can.getUnits().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
     final Change change = ChangeFactory.removeUnits(can, units);
-    m_data.performChange(change);
+    gameData.performChange(change);
 
     assertEquals(2, can.getUnits().getUnitCount());
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals("last change inverted, should have gained units.", 5,
         can.getUnits().getUnitCount());
   }
@@ -78,157 +78,157 @@ public class ChangeTest {
   @Test
   public void testSerializeUnitsRemoteTerritory() throws Exception {
     // make sure we now where we are starting
-    final Territory can = m_data.getMap().getTerritory("canada");
+    final Territory can = gameData.getMap().getTerritory("canada");
     assertEquals(5, can.getUnits().getUnitCount());
     // remove some units
     final Collection<Unit> units =
-        can.getUnits().getUnits(m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
+        can.getUnits().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
     Change change = ChangeFactory.removeUnits(can, units);
     change = serialize(change);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(2, can.getUnits().getUnitCount());
     // invert the change
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(5, can.getUnits().getUnitCount());
   }
 
   @Test
   public void testUnitsAddPlayer() {
     // make sure we know where we are starting
-    final PlayerID chretian = m_data.getPlayerList().getPlayerID("chretian");
+    final PlayerID chretian = gameData.getPlayerList().getPlayerID("chretian");
     assertEquals(10, chretian.getUnits().getUnitCount());
     // add some units
     final Change change =
         ChangeFactory.addUnits(chretian,
-            m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF).create(10, null));
-    m_data.performChange(change);
+            gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF).create(10, null));
+    gameData.performChange(change);
     assertEquals(20, chretian.getUnits().getUnitCount());
     // invert the change
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(10, chretian.getUnits().getUnitCount());
   }
 
   @Test
   public void testUnitsRemovePlayer() {
     // make sure we know where we are starting
-    final PlayerID chretian = m_data.getPlayerList().getPlayerID("chretian");
+    final PlayerID chretian = gameData.getPlayerList().getPlayerID("chretian");
     assertEquals(10, chretian.getUnits().getUnitCount());
     // remove some units
     final Collection<Unit> units =
-        chretian.getUnits().getUnits(m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
+        chretian.getUnits().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
     final Change change = ChangeFactory.removeUnits(chretian, units);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(chretian.getUnits().getUnitCount(), 7);
     // invert the change
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(chretian.getUnits().getUnitCount(), 10);
   }
 
   @Test
   public void testUnitsMove() {
-    final Territory canada = m_data.getMap().getTerritory("canada");
-    final Territory greenland = m_data.getMap().getTerritory("greenland");
+    final Territory canada = gameData.getMap().getTerritory("canada");
+    final Territory greenland = gameData.getMap().getTerritory("greenland");
     assertEquals(canada.getUnits().getUnitCount(), 5);
     assertEquals(greenland.getUnits().getUnitCount(), 0);
     final Collection<Unit> units =
-        canada.getUnits().getUnits(m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
+        canada.getUnits().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
     final Change change = ChangeFactory.moveUnits(canada, greenland, units);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(canada.getUnits().getUnitCount(), 2);
     assertEquals(greenland.getUnits().getUnitCount(), 3);
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(canada.getUnits().getUnitCount(), 5);
     assertEquals(greenland.getUnits().getUnitCount(), 0);
   }
 
   @Test
   public void testUnitsMoveSerialization() throws Exception {
-    final Territory canada = m_data.getMap().getTerritory("canada");
-    final Territory greenland = m_data.getMap().getTerritory("greenland");
+    final Territory canada = gameData.getMap().getTerritory("canada");
+    final Territory greenland = gameData.getMap().getTerritory("greenland");
     assertEquals(canada.getUnits().getUnitCount(), 5);
     assertEquals(greenland.getUnits().getUnitCount(), 0);
     final Collection<Unit> units =
-        canada.getUnits().getUnits(m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
+        canada.getUnits().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
     Change change = ChangeFactory.moveUnits(canada, greenland, units);
     change = serialize(change);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(canada.getUnits().getUnitCount(), 2);
     assertEquals(greenland.getUnits().getUnitCount(), 3);
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(canada.getUnits().getUnitCount(), 5);
     assertEquals(greenland.getUnits().getUnitCount(), 0);
   }
 
   @Test
   public void testProductionFrontierChange() {
-    final PlayerID can = m_data.getPlayerList().getPlayerID("chretian");
-    final ProductionFrontier uspf = m_data.getProductionFrontierList().getProductionFrontier("usProd");
-    final ProductionFrontier canpf = m_data.getProductionFrontierList().getProductionFrontier("canProd");
+    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final ProductionFrontier uspf = gameData.getProductionFrontierList().getProductionFrontier("usProd");
+    final ProductionFrontier canpf = gameData.getProductionFrontierList().getProductionFrontier("canProd");
     assertEquals(can.getProductionFrontier(), canpf);
     final Change change = ChangeFactory.changeProductionFrontier(can, uspf);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(can.getProductionFrontier(), uspf);
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(can.getProductionFrontier(), canpf);
   }
 
   @Test
   public void testChangeResourcesChange() {
-    final PlayerID can = m_data.getPlayerList().getPlayerID("chretian");
-    final Resource gold = m_data.getResourceList().getResource("gold");
+    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final Resource gold = gameData.getResourceList().getResource("gold");
     final Change change = ChangeFactory.changeResourcesChange(can, gold, 50);
     assertEquals(can.getResources().getQuantity(gold), 100);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(can.getResources().getQuantity(gold), 150);
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(can.getResources().getQuantity(gold), 100);
   }
 
   @Test
   public void testSerializeResourceChange() throws Exception {
-    final PlayerID can = m_data.getPlayerList().getPlayerID("chretian");
-    final Resource gold = m_data.getResourceList().getResource("gold");
+    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final Resource gold = gameData.getResourceList().getResource("gold");
     Change change = ChangeFactory.changeResourcesChange(can, gold, 50);
     change = serialize(change);
     assertEquals(can.getResources().getQuantity(gold), 100);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(can.getResources().getQuantity(gold), 150);
   }
 
   @Test
   public void testChangeOwner() {
-    final PlayerID can = m_data.getPlayerList().getPlayerID("chretian");
-    final PlayerID us = m_data.getPlayerList().getPlayerID("bush");
-    final Territory greenland = m_data.getMap().getTerritory("greenland");
+    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID us = gameData.getPlayerList().getPlayerID("bush");
+    final Territory greenland = gameData.getMap().getTerritory("greenland");
     final Change change = ChangeFactory.changeOwner(greenland, us);
     assertEquals(greenland.getOwner(), can);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(greenland.getOwner(), us);
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(greenland.getOwner(), can);
   }
 
   @Test
   public void testChangeOwnerSerialize() throws Exception {
-    final PlayerID can = m_data.getPlayerList().getPlayerID("chretian");
-    final PlayerID us = m_data.getPlayerList().getPlayerID("bush");
-    final Territory greenland = m_data.getMap().getTerritory("greenland");
+    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID us = gameData.getPlayerList().getPlayerID("bush");
+    final Territory greenland = gameData.getMap().getTerritory("greenland");
     Change change = ChangeFactory.changeOwner(greenland, us);
     change = serialize(change);
     assertEquals(greenland.getOwner(), can);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(greenland.getOwner(), us);
     change = change.invert();
     change = serialize(change);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(greenland.getOwner(), can);
   }
 
   @Test
   public void testPlayerOwnerChange() throws Exception {
-    final PlayerID can = m_data.getPlayerList().getPlayerID("chretian");
-    final PlayerID us = m_data.getPlayerList().getPlayerID("bush");
-    final UnitType infantry = m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);
+    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID us = gameData.getPlayerList().getPlayerID("bush");
+    final UnitType infantry = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);
     final Unit inf1 = infantry.create(1, can).iterator().next();
     final Unit inf2 = infantry.create(1, us).iterator().next();
     final Collection<Unit> units = new ArrayList<>();
@@ -236,21 +236,21 @@ public class ChangeTest {
     units.add(inf2);
     assertEquals(can, inf1.getOwner());
     assertEquals(us, inf2.getOwner());
-    Change change = ChangeFactory.changeOwner(units, can, m_data.getMap().getTerritory("greenland"));
-    m_data.performChange(change);
+    Change change = ChangeFactory.changeOwner(units, can, gameData.getMap().getTerritory("greenland"));
+    gameData.performChange(change);
     assertEquals(can, inf1.getOwner());
     assertEquals(can, inf2.getOwner());
     change = change.invert();
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(can, inf1.getOwner());
     assertEquals(us, inf2.getOwner());
   }
 
   @Test
   public void testPlayerOwnerChangeSerialize() throws Exception {
-    final PlayerID can = m_data.getPlayerList().getPlayerID("chretian");
-    final PlayerID us = m_data.getPlayerList().getPlayerID("bush");
-    final UnitType infantry = m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);
+    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
+    final PlayerID us = gameData.getPlayerList().getPlayerID("bush");
+    final UnitType infantry = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);
     final Unit inf1 = infantry.create(1, can).iterator().next();
     final Unit inf2 = infantry.create(1, us).iterator().next();
     final Collection<Unit> units = new ArrayList<>();
@@ -258,36 +258,36 @@ public class ChangeTest {
     units.add(inf2);
     assertEquals(can, inf1.getOwner());
     assertEquals(us, inf2.getOwner());
-    Change change = ChangeFactory.changeOwner(units, can, m_data.getMap().getTerritory("greenland"));
+    Change change = ChangeFactory.changeOwner(units, can, gameData.getMap().getTerritory("greenland"));
     change = serialize(change);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(can, inf1.getOwner());
     assertEquals(can, inf2.getOwner());
     change = change.invert();
     change = serialize(change);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(can, inf1.getOwner());
     assertEquals(us, inf2.getOwner());
   }
 
   @Test
   public void testChangeProductionFrontier() throws Exception {
-    final ProductionFrontier usProd = m_data.getProductionFrontierList().getProductionFrontier("usProd");
-    final ProductionFrontier canProd = m_data.getProductionFrontierList().getProductionFrontier("canProd");
-    final PlayerID can = m_data.getPlayerList().getPlayerID("chretian");
+    final ProductionFrontier usProd = gameData.getProductionFrontierList().getProductionFrontier("usProd");
+    final ProductionFrontier canProd = gameData.getProductionFrontierList().getProductionFrontier("canProd");
+    final PlayerID can = gameData.getPlayerList().getPlayerID("chretian");
     assertEquals(can.getProductionFrontier(), canProd);
     Change prodChange = ChangeFactory.changeProductionFrontier(can, usProd);
-    m_data.performChange(prodChange);
+    gameData.performChange(prodChange);
 
     assertEquals(can.getProductionFrontier(), usProd);
     prodChange = prodChange.invert();
-    m_data.performChange(prodChange);
+    gameData.performChange(prodChange);
     assertEquals(can.getProductionFrontier(), canProd);
     prodChange = serialize(prodChange.invert());
-    m_data.performChange(prodChange);
+    gameData.performChange(prodChange);
     assertEquals(can.getProductionFrontier(), usProd);
     prodChange = serialize(prodChange.invert());
-    m_data.performChange(prodChange);
+    gameData.performChange(prodChange);
     assertEquals(can.getProductionFrontier(), canProd);
   }
 
@@ -297,7 +297,7 @@ public class ChangeTest {
     assertTrue(compositeChange.isEmpty());
     compositeChange.add(new CompositeChange());
     assertTrue(compositeChange.isEmpty());
-    final Territory can = m_data.getMap().getTerritory("canada");
+    final Territory can = gameData.getMap().getTerritory("canada");
     final Collection<Unit> units = Collections.emptyList();
     compositeChange.add(ChangeFactory.removeUnits(can, units));
     assertFalse(compositeChange.isEmpty());

--- a/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
@@ -17,13 +17,13 @@ import games.strategy.triplea.delegate.GameDataTestUtil;
 import games.strategy.triplea.xml.TestMapGameData;
 
 public class ChangeTripleATest {
-  private GameData m_data;
+  private GameData gameData;
   private Territory can;
 
   @Before
   public void setUp() throws Exception {
-    m_data = TestMapGameData.BIG_WORLD_1942.getGameData();
-    can = m_data.getMap().getTerritory("Western Canada");
+    gameData = TestMapGameData.BIG_WORLD_1942.getGameData();
+    can = gameData.getMap().getTerritory("Western Canada");
     assertEquals(can.getUnits().getUnitCount(), 2);
   }
 
@@ -35,7 +35,7 @@ public class ChangeTripleATest {
     // System.out.println("bytes:" + sink.toByteArray().length);
     final InputStream source = new ByteArrayInputStream(sink.toByteArray());
     final ObjectInputStream input =
-        new GameObjectInputStream(new games.strategy.engine.framework.GameObjectStreamFactory(m_data), source);
+        new GameObjectInputStream(new games.strategy.engine.framework.GameObjectStreamFactory(gameData), source);
     final Change newChange = (Change) input.readObject();
     input.close();
     output.close();
@@ -46,36 +46,36 @@ public class ChangeTripleATest {
   public void testUnitsAddTerritory() {
     // add some units
     final Change change =
-        ChangeFactory.addUnits(can, GameDataTestUtil.infantry(m_data).create(10, null));
-    m_data.performChange(change);
+        ChangeFactory.addUnits(can, GameDataTestUtil.infantry(gameData).create(10, null));
+    gameData.performChange(change);
     assertEquals(can.getUnits().getUnitCount(), 12);
     // invert the change
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(can.getUnits().getUnitCount(), 2);
   }
 
   @Test
   public void testUnitsRemoveTerritory() {
     // remove some units
-    final Collection<Unit> units = can.getUnits().getUnits(GameDataTestUtil.infantry(m_data), 1);
+    final Collection<Unit> units = can.getUnits().getUnits(GameDataTestUtil.infantry(gameData), 1);
     final Change change = ChangeFactory.removeUnits(can, units);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(can.getUnits().getUnitCount(), 1);
     // invert the change
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(can.getUnits().getUnitCount(), 2);
   }
 
   @Test
   public void testSerializeUnitsRemoteTerritory() throws Exception {
     // remove some units
-    final Collection<Unit> units = can.getUnits().getUnits(GameDataTestUtil.infantry(m_data), 1);
+    final Collection<Unit> units = can.getUnits().getUnits(GameDataTestUtil.infantry(gameData), 1);
     Change change = ChangeFactory.removeUnits(can, units);
     change = serialize(change);
-    m_data.performChange(change);
+    gameData.performChange(change);
     assertEquals(can.getUnits().getUnitCount(), 1);
     // invert the change
-    m_data.performChange(change.invert());
+    gameData.performChange(change.invert());
     assertEquals(can.getUnits().getUnitCount(), 2);
   }
 }

--- a/src/test/java/games/strategy/engine/data/SerializationTest.java
+++ b/src/test/java/games/strategy/engine/data/SerializationTest.java
@@ -16,13 +16,13 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.xml.TestMapGameData;
 
 public class SerializationTest {
-  private GameData m_dataSource;
-  private GameData m_dataSink;
+  private GameData gameDataSource;
+  private GameData gameDataSink;
 
   @Before
   public void setUp() throws Exception {
-    m_dataSource = TestMapGameData.TEST.getGameData();
-    m_dataSink = TestMapGameData.TEST.getGameData();
+    gameDataSource = TestMapGameData.TEST.getGameData();
+    gameDataSink = TestMapGameData.TEST.getGameData();
   }
 
   private Object serialize(final Object anObject) throws Exception {
@@ -32,7 +32,7 @@ public class SerializationTest {
     output.flush();
     final InputStream source = new ByteArrayInputStream(sink.toByteArray());
     final ObjectInputStream input =
-        new GameObjectInputStream(new GameObjectStreamFactory(m_dataSource), source);
+        new GameObjectInputStream(new GameObjectStreamFactory(gameDataSource), source);
     final Object obj = input.readObject();
     input.close();
     output.close();
@@ -41,33 +41,33 @@ public class SerializationTest {
 
   @Test
   public void testWritePlayerID() throws Exception {
-    final PlayerID id = m_dataSource.getPlayerList().getPlayerID("chretian");
+    final PlayerID id = gameDataSource.getPlayerList().getPlayerID("chretian");
     final PlayerID readID = (PlayerID) serialize(id);
-    final PlayerID localID = m_dataSink.getPlayerList().getPlayerID("chretian");
+    final PlayerID localID = gameDataSink.getPlayerList().getPlayerID("chretian");
     assertTrue(localID != readID);
   }
 
   @Test
   public void testWriteUnitType() throws Exception {
-    final Object orig = m_dataSource.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);
+    final Object orig = gameDataSource.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);
     final Object read = serialize(orig);
-    final Object local = m_dataSink.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);
+    final Object local = gameDataSink.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF);
     assertTrue(local != read);
   }
 
   @Test
   public void testWriteTerritory() throws Exception {
-    final Object orig = m_dataSource.getMap().getTerritory("canada");
+    final Object orig = gameDataSource.getMap().getTerritory("canada");
     final Object read = serialize(orig);
-    final Object local = m_dataSink.getMap().getTerritory("canada");
+    final Object local = gameDataSink.getMap().getTerritory("canada");
     assertTrue(local != read);
   }
 
   @Test
   public void testWriteProductionRulte() throws Exception {
-    final Object orig = m_dataSource.getProductionRuleList().getProductionRule("infForSilver");
+    final Object orig = gameDataSource.getProductionRuleList().getProductionRule("infForSilver");
     final Object read = serialize(orig);
-    final Object local = m_dataSink.getProductionRuleList().getProductionRule("infForSilver");
+    final Object local = gameDataSink.getProductionRuleList().getProductionRule("infForSilver");
     assertTrue(local != read);
   }
 }

--- a/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
+++ b/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
@@ -32,21 +32,21 @@ import games.strategy.triplea.ui.display.ITripleADisplay;
  */
 @Deprecated
 public class TestDelegateBridge implements ITestDelegateBridge {
-  private final GameData m_data;
-  private PlayerID m_id;
-  private String m_stepName = "no name specified";
-  private IDisplay m_dummyDisplay;
-  private final ISound m_soundChannel = mock(ISound.class);
-  private IRandomSource m_randomSource;
-  private final IDelegateHistoryWriter m_historyWriter;
-  private IRemotePlayer m_remote;
+  private final GameData gameData;
+  private PlayerID playerId;
+  private String stepName = "no name specified";
+  private IDisplay dummyDisplay;
+  private final ISound soundChannel = mock(ISound.class);
+  private IRandomSource randomSource;
+  private final IDelegateHistoryWriter delegateHistoryWriter;
+  private IRemotePlayer remotePlayer;
 
   /** Creates new TestDelegateBridge. */
   public TestDelegateBridge(final GameData data, final PlayerID id, final IDisplay dummyDisplay) {
-    m_data = data;
-    m_id = id;
-    m_dummyDisplay = dummyDisplay;
-    final History history = new History(m_data);
+    gameData = data;
+    playerId = id;
+    this.dummyDisplay = dummyDisplay;
+    final History history = new History(gameData);
     final HistoryWriter historyWriter = new HistoryWriter(history);
     historyWriter.startNextStep("", "", PlayerID.NULL_PLAYERID, "");
     final IServerMessenger messenger = mock(IServerMessenger.class);
@@ -58,12 +58,12 @@ public class TestDelegateBridge implements ITestDelegateBridge {
     when(messenger.isServer()).thenReturn(true);
     final ChannelMessenger channelMessenger =
         new ChannelMessenger(new UnifiedMessenger(messenger));
-    m_historyWriter = new DelegateHistoryWriter(channelMessenger);
+    delegateHistoryWriter = new DelegateHistoryWriter(channelMessenger);
   }
 
   @Override
   public void setDisplay(final ITripleADisplay display) {
-    m_dummyDisplay = display;
+    dummyDisplay = display;
   }
 
   /**
@@ -71,13 +71,13 @@ public class TestDelegateBridge implements ITestDelegateBridge {
    */
   @Override
   public int getRandom(final int max, final PlayerID player, final DiceType diceType, final String annotation) {
-    return m_randomSource.getRandom(max, annotation);
+    return randomSource.getRandom(max, annotation);
   }
 
   @Override
   public int[] getRandom(final int max, final int count, final PlayerID player, final DiceType diceType,
       final String annotation) {
-    return m_randomSource.getRandom(max, count, annotation);
+    return randomSource.getRandom(max, count, annotation);
   }
 
   /**
@@ -86,7 +86,7 @@ public class TestDelegateBridge implements ITestDelegateBridge {
    */
   @Override
   public void setPlayerID(final PlayerID aPlayer) {
-    m_id = aPlayer;
+    playerId = aPlayer;
   }
 
   public boolean inTransaction() {
@@ -95,12 +95,12 @@ public class TestDelegateBridge implements ITestDelegateBridge {
 
   @Override
   public PlayerID getPlayerID() {
-    return m_id;
+    return playerId;
   }
 
   @Override
   public void addChange(final Change aChange) {
-    m_data.performChange(aChange);
+    gameData.performChange(aChange);
   }
 
   @Override
@@ -110,53 +110,53 @@ public class TestDelegateBridge implements ITestDelegateBridge {
 
   @Override
   public void setStepName(final String name, final boolean doNotChangeSequence) {
-    m_stepName = name;
+    stepName = name;
     if (!doNotChangeSequence) {
-      m_data.acquireWriteLock();
+      gameData.acquireWriteLock();
       try {
-        final int length = m_data.getSequence().size();
+        final int length = gameData.getSequence().size();
         int i = 0;
-        while (i < length && m_data.getSequence().getStep().getName().indexOf(name) == -1) {
-          m_data.getSequence().next();
+        while (i < length && gameData.getSequence().getStep().getName().indexOf(name) == -1) {
+          gameData.getSequence().next();
           i++;
         }
-        if (i > +length && m_data.getSequence().getStep().getName().indexOf(name) == -1) {
+        if (i > +length && gameData.getSequence().getStep().getName().indexOf(name) == -1) {
           throw new IllegalStateException("Step not found: " + name);
         }
       } finally {
-        m_data.releaseWriteLock();
+        gameData.releaseWriteLock();
       }
     }
   }
 
   @Override
   public String getStepName() {
-    return m_stepName;
+    return stepName;
   }
 
   @Override
   public IDelegateHistoryWriter getHistoryWriter() {
-    return m_historyWriter;
+    return delegateHistoryWriter;
   }
 
   @Override
   public IRemotePlayer getRemotePlayer() {
-    return m_remote;
+    return remotePlayer;
   }
 
   @Override
   public IRemotePlayer getRemotePlayer(final PlayerID id) {
-    return m_remote;
+    return remotePlayer;
   }
 
   @Override
   public IDisplay getDisplayChannelBroadcaster() {
-    return m_dummyDisplay;
+    return dummyDisplay;
   }
 
   @Override
   public ISound getSoundChannelBroadcaster() {
-    return m_soundChannel;
+    return soundChannel;
   }
 
   @Override
@@ -172,12 +172,12 @@ public class TestDelegateBridge implements ITestDelegateBridge {
 
   @Override
   public void setRandomSource(final IRandomSource randomSource) {
-    m_randomSource = randomSource;
+    this.randomSource = randomSource;
   }
 
   @Override
   public void setRemote(final IRemotePlayer remote) {
-    m_remote = remote;
+    remotePlayer = remote;
   }
 
   @Override
@@ -185,6 +185,6 @@ public class TestDelegateBridge implements ITestDelegateBridge {
 
   @Override
   public GameData getData() {
-    return m_data;
+    return gameData;
   }
 }

--- a/src/test/java/games/strategy/engine/vault/VaultTest.java
+++ b/src/test/java/games/strategy/engine/vault/VaultTest.java
@@ -33,37 +33,37 @@ import games.strategy.test.TestUtil;
  */
 public class VaultTest {
   private static int SERVER_PORT = -1;
-  private IServerMessenger m_server;
-  private IMessenger m_client1;
-  private Vault m_clientVault;
-  private Vault m_serverVault;
+  private IServerMessenger serverMessenger;
+  private IMessenger clientMessenger;
+  private Vault clientVault;
+  private Vault serverVault;
 
   @Before
   public void setUp() throws IOException {
     SERVER_PORT = TestUtil.getUniquePort();
-    m_server = new ServerMessenger("Server", SERVER_PORT);
-    m_server.setAcceptNewConnections(true);
+    serverMessenger = new ServerMessenger("Server", SERVER_PORT);
+    serverMessenger.setAcceptNewConnections(true);
     final String mac = MacFinder.getHashedMacAddress();
-    m_client1 = new ClientMessenger("localhost", SERVER_PORT, "client1", mac);
-    final UnifiedMessenger serverUM = new UnifiedMessenger(m_server);
-    final UnifiedMessenger clientUM = new UnifiedMessenger(m_client1);
-    m_serverVault = new Vault(new ChannelMessenger(serverUM));
-    m_clientVault = new Vault(new ChannelMessenger(clientUM));
+    clientMessenger = new ClientMessenger("localhost", SERVER_PORT, "client1", mac);
+    final UnifiedMessenger serverUM = new UnifiedMessenger(serverMessenger);
+    final UnifiedMessenger clientUM = new UnifiedMessenger(clientMessenger);
+    serverVault = new Vault(new ChannelMessenger(serverUM));
+    clientVault = new Vault(new ChannelMessenger(clientUM));
     Thread.yield();
   }
 
   @After
   public void tearDown() {
     try {
-      if (m_server != null) {
-        m_server.shutDown();
+      if (serverMessenger != null) {
+        serverMessenger.shutDown();
       }
     } catch (final Exception e) {
       ClientLogger.logQuietly(e);
     }
     try {
-      if (m_client1 != null) {
-        m_client1.shutDown();
+      if (clientMessenger != null) {
+        clientMessenger.shutDown();
       }
     } catch (final Exception e) {
       ClientLogger.logQuietly(e);
@@ -95,29 +95,29 @@ public class VaultTest {
    */
   public void temporarilyDisabledSoPleaseRunManuallytestServerLock() throws NotUnlockedException {
     final byte[] data = new byte[] {0, 1, 2, 3, 4, 5};
-    final VaultID id = m_serverVault.lock(data);
-    m_clientVault.waitForID(id, 1000);
-    assertTrue(m_clientVault.knowsAbout(id));
-    m_serverVault.unlock(id);
-    m_clientVault.waitForIdToUnlock(id, 1000);
-    assertTrue(m_clientVault.isUnlocked(id));
-    assertEquals(data, m_clientVault.get(id));
-    assertEquals(m_serverVault.get(id), m_clientVault.get(id));
-    m_clientVault.release(id);
+    final VaultID id = serverVault.lock(data);
+    clientVault.waitForID(id, 1000);
+    assertTrue(clientVault.knowsAbout(id));
+    serverVault.unlock(id);
+    clientVault.waitForIdToUnlock(id, 1000);
+    assertTrue(clientVault.isUnlocked(id));
+    assertEquals(data, clientVault.get(id));
+    assertEquals(serverVault.get(id), clientVault.get(id));
+    clientVault.release(id);
   }
 
   @Test
   public void testClientLock() throws NotUnlockedException {
     final byte[] data = new byte[] {0, 1, 2, 3, 4, 5};
-    final VaultID id = m_clientVault.lock(data);
-    m_serverVault.waitForID(id, 1000);
-    assertTrue(m_serverVault.knowsAbout(id));
-    m_clientVault.unlock(id);
-    m_serverVault.waitForIdToUnlock(id, 1000);
-    assertTrue(m_serverVault.isUnlocked(id));
-    assertArrayEquals(data, m_serverVault.get(id));
-    assertArrayEquals(m_clientVault.get(id), m_serverVault.get(id));
-    m_clientVault.release(id);
+    final VaultID id = clientVault.lock(data);
+    serverVault.waitForID(id, 1000);
+    assertTrue(serverVault.knowsAbout(id));
+    clientVault.unlock(id);
+    serverVault.waitForIdToUnlock(id, 1000);
+    assertTrue(serverVault.isUnlocked(id));
+    assertArrayEquals(data, serverVault.get(id));
+    assertArrayEquals(clientVault.get(id), serverVault.get(id));
+    clientVault.release(id);
   }
 
   /**
@@ -127,22 +127,22 @@ public class VaultTest {
   public void temporarilyDisabledSoPleaseRunManuallytestMultiple() throws NotUnlockedException {
     final byte[] data1 = new byte[] {0, 1, 2, 3, 4, 5};
     final byte[] data2 = new byte[] {0xE, 0xF, 2, 1, 3, 1, 2, 12, 3, 31, 124, 12, 1};
-    final VaultID id1 = m_serverVault.lock(data1);
-    final VaultID id2 = m_serverVault.lock(data2);
-    m_clientVault.waitForID(id1, 2000);
-    m_clientVault.waitForID(id2, 2000);
-    assertTrue(m_clientVault.knowsAbout(id1));
-    assertTrue(m_clientVault.knowsAbout(id2));
-    m_serverVault.unlock(id1);
-    m_serverVault.unlock(id2);
-    m_clientVault.waitForIdToUnlock(id1, 1000);
-    m_clientVault.waitForIdToUnlock(id2, 1000);
-    assertTrue(m_clientVault.isUnlocked(id1));
-    assertTrue(m_clientVault.isUnlocked(id2));
-    assertEquals(data1, m_clientVault.get(id1));
-    assertEquals(data2, m_clientVault.get(id2));
-    m_clientVault.release(id1);
-    m_clientVault.release(id2);
+    final VaultID id1 = serverVault.lock(data1);
+    final VaultID id2 = serverVault.lock(data2);
+    clientVault.waitForID(id1, 2000);
+    clientVault.waitForID(id2, 2000);
+    assertTrue(clientVault.knowsAbout(id1));
+    assertTrue(clientVault.knowsAbout(id2));
+    serverVault.unlock(id1);
+    serverVault.unlock(id2);
+    clientVault.waitForIdToUnlock(id1, 1000);
+    clientVault.waitForIdToUnlock(id2, 1000);
+    assertTrue(clientVault.isUnlocked(id1));
+    assertTrue(clientVault.isUnlocked(id2));
+    assertEquals(data1, clientVault.get(id1));
+    assertEquals(data2, clientVault.get(id2));
+    clientVault.release(id1);
+    clientVault.release(id2);
   }
 
   @Test


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName rule in test code under package `g.s.engine`.

It's pretty much just removing the `m_` prefix on fields.  However, in many cases, the field was renamed to be more descriptive.

I purposefully avoided touching code in `g.s.engine.data.annotations`, as the tests rely on property fields having the `m_` prefix.  It will require further scrutiny to see if changing this code is safe; that can be done at some time in the future.