### PR TITLE
Checkstyle: Fix member name violations in g.s.triplea.* test code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 checkstyleMainMaxWarnings=5287
-checkstyleTestMaxWarnings=208
+checkstyleTestMaxWarnings=178

--- a/src/test/java/games/strategy/triplea/ai/AIUtilsTest.java
+++ b/src/test/java/games/strategy/triplea/ai/AIUtilsTest.java
@@ -15,28 +15,27 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
-import games.strategy.triplea.ai.AIUtils;
 import games.strategy.triplea.delegate.GameDataTestUtil;
 import games.strategy.triplea.xml.TestMapGameData;
 
 public class AIUtilsTest {
-  private GameData m_data;
+  private GameData gameData;
 
   @Before
   public void setUp() throws Exception {
-    m_data = TestMapGameData.REVISED.getGameData();
+    gameData = TestMapGameData.REVISED.getGameData();
   }
 
   @Test
   public void testCost() {
-    final UnitType infantry = GameDataTestUtil.infantry(m_data);
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    assertEquals(3, AIUtils.getCost(infantry, british, m_data));
+    final UnitType infantry = GameDataTestUtil.infantry(gameData);
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    assertEquals(3, AIUtils.getCost(infantry, british, gameData));
   }
 
   @Test
   public void testSortByCost() {
-    final Territory germany = m_data.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritory("Germany");
     final List<Unit> sorted = new ArrayList<>(germany.getUnits().getUnits());
     Collections.sort(sorted, AIUtils.getCostComparator());
     assertEquals(sorted.get(0).getUnitType().getName(), Constants.UNIT_TYPE_INFANTRY);

--- a/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -36,50 +36,50 @@ import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.Match;
 
 public class BattleCalculatorTest {
-  private ITestDelegateBridge m_bridge;
+  private ITestDelegateBridge bridge;
   private final ITripleAPlayer dummyPlayer = mock(ITripleAPlayer.class);
 
   @Before
   public void setUp() throws Exception {
     final GameData data = TestMapGameData.REVISED.getGameData();
-    m_bridge = getDelegateBridge(british(data), data);
+    bridge = getDelegateBridge(british(data), data);
   }
 
   @Test
   public void testAACasualtiesLowLuck() {
-    final GameData data = m_bridge.getData();
+    final GameData data = bridge.getData();
     makeGameLowLuck(data);
     setSelectAACasualties(data, false);
     final DiceRoll roll = new DiceRoll(new int[] {0}, 1, 1, false);
     final Collection<Unit> planes = bomber(data).create(5, british(data));
     final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
-    m_bridge.setRandomSource(randomSource);
+    bridge.setRandomSource(randomSource);
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 1);
     assertEquals(1, randomSource.getTotalRolled());
   }
 
   @Test
   public void testAACasualtiesLowLuckDifferentMovementLetf() {
-    final GameData data = m_bridge.getData();
+    final GameData data = bridge.getData();
     makeGameLowLuck(data);
     setSelectAACasualties(data, false);
     final DiceRoll roll = new DiceRoll(new int[] {0}, 1, 1, false);
     final List<Unit> planes = bomber(data).create(5, british(data));
     final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
-    m_bridge.setRandomSource(randomSource);
+    bridge.setRandomSource(randomSource);
     TripleAUnit.get(planes.get(0)).setAlreadyMoved(1);
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 1);
   }
 
   @Test
   public void testAACasualtiesLowLuckMixed() {
-    final GameData data = m_bridge.getData();
+    final GameData data = bridge.getData();
     makeGameLowLuck(data);
     setSelectAACasualties(data, false);
     // 6 bombers and 6 fighters
@@ -87,16 +87,16 @@ public class BattleCalculatorTest {
     planes.addAll(fighter(data).create(6, british(data)));
     final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // don't allow rolling, 6 of each is deterministic
-    m_bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
+    bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
         DiceRoll
             .rollAA(
                 Match.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, m_bridge, territory("Germany", data), true);
+                defendingAA, bridge, territory("Germany", data), true);
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // should be 1 fighter and 1 bomber
     assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);
@@ -105,7 +105,7 @@ public class BattleCalculatorTest {
 
   @Test
   public void testAACasualtiesLowLuckMixedMultipleDiceRolled() {
-    final GameData data = m_bridge.getData();
+    final GameData data = bridge.getData();
     makeGameLowLuck(data);
     setSelectAACasualties(data, false);
     // 5 bombers and 5 fighters
@@ -114,17 +114,17 @@ public class BattleCalculatorTest {
     final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // should roll once, a hit
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, 1, 1, ScriptedRandomSource.ERROR});
-    m_bridge.setRandomSource(randomSource);
+    bridge.setRandomSource(randomSource);
     final DiceRoll roll =
         DiceRoll
             .rollAA(
                 Match.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, m_bridge, territory("Germany", data), true);
+                defendingAA, bridge, territory("Germany", data), true);
     assertEquals(1, randomSource.getTotalRolled());
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // two extra rolls to pick which units are hit
     assertEquals(3, randomSource.getTotalRolled());
@@ -135,7 +135,7 @@ public class BattleCalculatorTest {
 
   @Test
   public void testAACasualtiesLowLuckMixedWithChooseAACasualties() {
-    final GameData data = m_bridge.getData();
+    final GameData data = bridge.getData();
     makeGameLowLuck(data);
     setSelectAACasualties(data, true);
     // 6 bombers and 6 fighters
@@ -154,18 +154,18 @@ public class BattleCalculatorTest {
             return new CasualtyDetails(selected, new ArrayList<>(), false);
           }
         });
-    m_bridge.setRemote(dummyPlayer);
+    bridge.setRemote(dummyPlayer);
     // don't allow rolling, 6 of each is deterministic
-    m_bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
+    bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
         DiceRoll
             .rollAA(
                 Match.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, m_bridge, territory("Germany", data), true);
+                defendingAA, bridge, territory("Germany", data), true);
     final Collection<Unit> casualties =
-        BattleCalculator.getAACasualties(false, planes, planes, defendingAA, defendingAA, roll, m_bridge, germans(data),
+        BattleCalculator.getAACasualties(false, planes, planes, defendingAA, defendingAA, roll, bridge, germans(data),
             british(data), null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // we selected all bombers
@@ -175,7 +175,7 @@ public class BattleCalculatorTest {
 
   @Test
   public void testAACasualtiesLowLuckMixedWithChooseAACasualtiesRoll() {
-    final GameData data = m_bridge.getData();
+    final GameData data = bridge.getData();
     makeGameLowLuck(data);
     setSelectAACasualties(data, true);
     // 7 bombers and 7 fighters
@@ -192,18 +192,18 @@ public class BattleCalculatorTest {
             return new CasualtyDetails(selected, new ArrayList<>(), false);
           }
         });
-    m_bridge.setRemote(dummyPlayer);
+    bridge.setRemote(dummyPlayer);
     // only 1 roll, a hit
-    m_bridge.setRandomSource(new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR}));
+    bridge.setRandomSource(new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
         DiceRoll
             .rollAA(
                 Match.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, m_bridge, territory("Germany", data), true);
+                defendingAA, bridge, territory("Germany", data), true);
     final Collection<Unit> casualties =
-        BattleCalculator.getAACasualties(false, planes, planes, defendingAA, defendingAA, roll, m_bridge, germans(data),
+        BattleCalculator.getAACasualties(false, planes, planes, defendingAA, defendingAA, roll, bridge, germans(data),
             british(data), null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // we selected all bombers
@@ -213,7 +213,7 @@ public class BattleCalculatorTest {
 
   @Test
   public void testAACasualtiesLowLuckMixedWithRolling() {
-    final GameData data = m_bridge.getData();
+    final GameData data = bridge.getData();
     makeGameLowLuck(data);
     setSelectAACasualties(data, false);
     // 7 bombers and 7 fighters
@@ -223,18 +223,18 @@ public class BattleCalculatorTest {
     final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // one roll, a hit
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0});
-    m_bridge.setRandomSource(randomSource);
+    bridge.setRandomSource(randomSource);
     final DiceRoll roll =
         DiceRoll
             .rollAA(
                 Match.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, m_bridge, territory("Germany", data), true);
+                defendingAA, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // a second roll for choosing which unit
     assertEquals(2, randomSource.getTotalRolled());
@@ -245,7 +245,7 @@ public class BattleCalculatorTest {
 
   @Test
   public void testAACasualtiesLowLuckMixedWithRollingMiss() {
-    final GameData data = m_bridge.getData();
+    final GameData data = bridge.getData();
     makeGameLowLuck(data);
     setSelectAACasualties(data, false);
     // 7 bombers and 7 fighters
@@ -256,18 +256,18 @@ public class BattleCalculatorTest {
     // one roll, a miss
     final ScriptedRandomSource randomSource =
         new ScriptedRandomSource(new int[] {2, 0, 0, 0, ScriptedRandomSource.ERROR});
-    m_bridge.setRandomSource(randomSource);
+    bridge.setRandomSource(randomSource);
     final DiceRoll roll =
         DiceRoll
             .rollAA(
                 Match.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, m_bridge, territory("Germany", data), true);
+                defendingAA, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     assertEquals(4, randomSource.getTotalRolled());
     // should be 1 fighter and 1 bomber
@@ -277,7 +277,7 @@ public class BattleCalculatorTest {
 
   @Test
   public void testAACasualtiesLowLuckMixedWithRollingForBombers() {
-    final GameData data = m_bridge.getData();
+    final GameData data = bridge.getData();
     makeGameLowLuck(data);
     setSelectAACasualties(data, false);
     // 6 bombers, 7 fighters
@@ -286,18 +286,18 @@ public class BattleCalculatorTest {
     final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // 1 roll for the extra fighter
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
-    m_bridge.setRandomSource(randomSource);
+    bridge.setRandomSource(randomSource);
     final DiceRoll roll =
         DiceRoll
             .rollAA(
                 Match.getMatches(planes,
                     Matches
                         .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, m_bridge, territory("Germany", data), true);
+                defendingAA, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // should be 2 fighters and 1 bombers
     assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);

--- a/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
@@ -16,21 +16,21 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.xml.TestMapGameData;
 
 public class BigWorldTest {
-  private GameData m_data;
+  private GameData gameData;
 
   @Before
   public void setUp() throws Exception {
-    m_data = TestMapGameData.BIG_WORLD_1942.getGameData();
+    gameData = TestMapGameData.BIG_WORLD_1942.getGameData();
   }
 
   @Test
   public void testCanalMovementNotStartingInCanalZone() {
-    final Territory sz28 = territory("SZ 28 Eastern Mediterranean", m_data);
-    final Territory sz27 = territory("SZ 27 Aegean Sea", m_data);
-    final Territory sz29 = territory("SZ 29 Black Sea", m_data);
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data), m_data);
+    final Territory sz28 = territory("SZ 28 Eastern Mediterranean", gameData);
+    final Territory sz27 = territory("SZ 27 Aegean Sea", gameData);
+    final Territory sz29 = territory("SZ 29 Black Sea", gameData);
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData), gameData);
     bridge.setStepName("CombatMove");
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
     final String error = moveDelegate.move(sz28.getUnits().getUnits(), new Route(sz28, sz27, sz29));

--- a/src/test/java/games/strategy/triplea/delegate/DelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/DelegateTest.java
@@ -16,7 +16,7 @@ import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.xml.TestMapGameData;
 
 public class DelegateTest {
-  protected GameData m_data;
+  protected GameData gameData;
   protected PlayerID british;
   protected PlayerID japanese;
   protected PlayerID russians;
@@ -76,74 +76,74 @@ public class DelegateTest {
   protected UnitType fighter;
   protected UnitType bomber;
   protected UnitType carrier;
-  protected Resource PUs;
+  protected Resource pus;
 
   @Test
   public void setUp() throws Exception {
-    m_data = TestMapGameData.DELEGATE_TEST.getGameData();
-    british = GameDataTestUtil.british(m_data);
+    gameData = TestMapGameData.DELEGATE_TEST.getGameData();
+    british = GameDataTestUtil.british(gameData);
     british.addAttachment(Constants.TECH_ATTACHMENT_NAME, new TechAttachment());
-    japanese = GameDataTestUtil.japanese(m_data);
+    japanese = GameDataTestUtil.japanese(gameData);
     japanese.addAttachment(Constants.TECH_ATTACHMENT_NAME, new TechAttachment());
-    russians = GameDataTestUtil.russians(m_data);
+    russians = GameDataTestUtil.russians(gameData);
     russians.addAttachment(Constants.TECH_ATTACHMENT_NAME, new TechAttachment());
-    germans = GameDataTestUtil.germans(m_data);
+    germans = GameDataTestUtil.germans(gameData);
     germans.addAttachment(Constants.TECH_ATTACHMENT_NAME, new TechAttachment());
-    northSea = m_data.getMap().getTerritory("North Sea Zone");
-    blackSea = m_data.getMap().getTerritory("Black Sea Zone");
-    uk = m_data.getMap().getTerritory("United Kingdom");
-    japan = m_data.getMap().getTerritory("Japan");
-    japanSeaZone = m_data.getMap().getTerritory("Japan Sea Zone");
-    sfeSeaZone = m_data.getMap().getTerritory("Soviet Far East Sea Zone");
-    brazil = m_data.getMap().getTerritory("Brazil");
-    westCanada = m_data.getMap().getTerritory("West Canada");
-    germany = m_data.getMap().getTerritory("Germany");
-    syria = m_data.getMap().getTerritory("Syria Jordan");
-    manchuria = m_data.getMap().getTerritory("Manchuria");
-    egypt = m_data.getMap().getTerritory("Anglo Sudan Egypt");
-    congo = m_data.getMap().getTerritory("Congo");
-    congoSeaZone = m_data.getMap().getTerritory("Congo Sea Zone");
-    northAtlantic = m_data.getMap().getTerritory("North Atlantic Sea Zone");
-    westAfricaSea = m_data.getMap().getTerritory("West Africa Sea Zone");
-    kenya = m_data.getMap().getTerritory("Kenya-Rhodesia");
-    eastAfrica = m_data.getMap().getTerritory("Italian East Africa");
-    libya = m_data.getMap().getTerritory("Libya");
-    algeria = m_data.getMap().getTerritory("Algeria");
-    equatorialAfrica = m_data.getMap().getTerritory("French Equatorial Africa");
-    redSea = m_data.getMap().getTerritory("Red Sea Zone");
-    westAfrica = m_data.getMap().getTerritory("French West Africa");
-    angola = m_data.getMap().getTerritory("Angola");
-    angolaSeaZone = m_data.getMap().getTerritory("Angola Sea Zone");
-    eastCompass = m_data.getMap().getTerritory("East Compass Sea Zone");
-    westCompass = m_data.getMap().getTerritory("West Compass Sea Zone");
-    mozambiqueSeaZone = m_data.getMap().getTerritory("Mozambique Sea Zone");
-    eastMediteranean = m_data.getMap().getTerritory("East Mediteranean Sea Zone");
-    indianOcean = m_data.getMap().getTerritory("Indian Ocean Sea Zone");
-    westAfricaSeaZone = m_data.getMap().getTerritory("West Africa Sea Zone");
-    southAfrica = m_data.getMap().getTerritory("South Africa");
-    saudiArabia = m_data.getMap().getTerritory("Saudi Arabia");
-    india = m_data.getMap().getTerritory("India");
-    southAtlantic = m_data.getMap().getTerritory("South Atlantic Sea Zone");
-    antarticSea = m_data.getMap().getTerritory("Antartic Sea Zone");
-    southAfricaSeaZone = m_data.getMap().getTerritory("South Africa Sea Zone");
-    southBrazilSeaZone = m_data.getMap().getTerritory("South Brazil Sea Zone");
-    russia = m_data.getMap().getTerritory("Russia");
-    spain = m_data.getMap().getTerritory("Spain");
-    gibraltar = m_data.getMap().getTerritory("Gibraltar");
-    balticSeaZone = m_data.getMap().getTerritory("Baltic Sea Zone");
-    karelia = m_data.getMap().getTerritory("Karelia S.S.R.");
-    westEurope = m_data.getMap().getTerritory("West Europe");
-    finlandNorway = m_data.getMap().getTerritory("Finland Norway");
-    armour = GameDataTestUtil.armour(m_data);
-    infantry = GameDataTestUtil.infantry(m_data);
-    transport = GameDataTestUtil.transport(m_data);
-    submarine = GameDataTestUtil.submarine(m_data);
-    factory = GameDataTestUtil.factory(m_data);
-    aaGun = GameDataTestUtil.aaGun(m_data);
-    fighter = GameDataTestUtil.fighter(m_data);
-    bomber = GameDataTestUtil.bomber(m_data);
-    carrier = GameDataTestUtil.carrier(m_data);
-    PUs = m_data.getResourceList().getResource("PUs");
+    northSea = gameData.getMap().getTerritory("North Sea Zone");
+    blackSea = gameData.getMap().getTerritory("Black Sea Zone");
+    uk = gameData.getMap().getTerritory("United Kingdom");
+    japan = gameData.getMap().getTerritory("Japan");
+    japanSeaZone = gameData.getMap().getTerritory("Japan Sea Zone");
+    sfeSeaZone = gameData.getMap().getTerritory("Soviet Far East Sea Zone");
+    brazil = gameData.getMap().getTerritory("Brazil");
+    westCanada = gameData.getMap().getTerritory("West Canada");
+    germany = gameData.getMap().getTerritory("Germany");
+    syria = gameData.getMap().getTerritory("Syria Jordan");
+    manchuria = gameData.getMap().getTerritory("Manchuria");
+    egypt = gameData.getMap().getTerritory("Anglo Sudan Egypt");
+    congo = gameData.getMap().getTerritory("Congo");
+    congoSeaZone = gameData.getMap().getTerritory("Congo Sea Zone");
+    northAtlantic = gameData.getMap().getTerritory("North Atlantic Sea Zone");
+    westAfricaSea = gameData.getMap().getTerritory("West Africa Sea Zone");
+    kenya = gameData.getMap().getTerritory("Kenya-Rhodesia");
+    eastAfrica = gameData.getMap().getTerritory("Italian East Africa");
+    libya = gameData.getMap().getTerritory("Libya");
+    algeria = gameData.getMap().getTerritory("Algeria");
+    equatorialAfrica = gameData.getMap().getTerritory("French Equatorial Africa");
+    redSea = gameData.getMap().getTerritory("Red Sea Zone");
+    westAfrica = gameData.getMap().getTerritory("French West Africa");
+    angola = gameData.getMap().getTerritory("Angola");
+    angolaSeaZone = gameData.getMap().getTerritory("Angola Sea Zone");
+    eastCompass = gameData.getMap().getTerritory("East Compass Sea Zone");
+    westCompass = gameData.getMap().getTerritory("West Compass Sea Zone");
+    mozambiqueSeaZone = gameData.getMap().getTerritory("Mozambique Sea Zone");
+    eastMediteranean = gameData.getMap().getTerritory("East Mediteranean Sea Zone");
+    indianOcean = gameData.getMap().getTerritory("Indian Ocean Sea Zone");
+    westAfricaSeaZone = gameData.getMap().getTerritory("West Africa Sea Zone");
+    southAfrica = gameData.getMap().getTerritory("South Africa");
+    saudiArabia = gameData.getMap().getTerritory("Saudi Arabia");
+    india = gameData.getMap().getTerritory("India");
+    southAtlantic = gameData.getMap().getTerritory("South Atlantic Sea Zone");
+    antarticSea = gameData.getMap().getTerritory("Antartic Sea Zone");
+    southAfricaSeaZone = gameData.getMap().getTerritory("South Africa Sea Zone");
+    southBrazilSeaZone = gameData.getMap().getTerritory("South Brazil Sea Zone");
+    russia = gameData.getMap().getTerritory("Russia");
+    spain = gameData.getMap().getTerritory("Spain");
+    gibraltar = gameData.getMap().getTerritory("Gibraltar");
+    balticSeaZone = gameData.getMap().getTerritory("Baltic Sea Zone");
+    karelia = gameData.getMap().getTerritory("Karelia S.S.R.");
+    westEurope = gameData.getMap().getTerritory("West Europe");
+    finlandNorway = gameData.getMap().getTerritory("Finland Norway");
+    armour = GameDataTestUtil.armour(gameData);
+    infantry = GameDataTestUtil.infantry(gameData);
+    transport = GameDataTestUtil.transport(gameData);
+    submarine = GameDataTestUtil.submarine(gameData);
+    factory = GameDataTestUtil.factory(gameData);
+    aaGun = GameDataTestUtil.aaGun(gameData);
+    fighter = GameDataTestUtil.fighter(gameData);
+    bomber = GameDataTestUtil.bomber(gameData);
+    carrier = GameDataTestUtil.carrier(gameData);
+    pus = gameData.getResourceList().getResource("PUs");
   }
 
   public void assertValid(final String string) {
@@ -155,7 +155,7 @@ public class DelegateTest {
   }
 
   protected ITestDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, m_data);
+    return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
   @Test

--- a/src/test/java/games/strategy/triplea/delegate/LHTRTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LHTRTest.java
@@ -33,38 +33,38 @@ import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.xml.TestMapGameData;
 
 public class LHTRTest {
-  private GameData m_data;
+  private GameData gameData;
 
   @Before
   public void setUp() throws Exception {
-    m_data = TestMapGameData.LHTR.getGameData();
+    gameData = TestMapGameData.LHTR.getGameData();
   }
 
   private ITestDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, m_data);
+    return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
   @Test
   public void testFightersCanLandOnNewPlacedCarrier() {
-    final MoveDelegate delegate = (MoveDelegate) m_data.getDelegateList().getDelegate("move");
+    final MoveDelegate delegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     delegate.initialize("MoveDelegate", "MoveDelegate");
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("germanNonCombatMove");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
-    final Territory baltic = m_data.getMap().getTerritory("5 Sea Zone");
-    final Territory easternEurope = m_data.getMap().getTerritory("Eastern Europe");
-    final UnitType carrirType = GameDataTestUtil.carrier(m_data);
+    final Territory baltic = gameData.getMap().getTerritory("5 Sea Zone");
+    final Territory easternEurope = gameData.getMap().getTerritory("Eastern Europe");
+    final UnitType carrirType = GameDataTestUtil.carrier(gameData);
     // move a fighter to the baltic
     final Route route = new Route();
     route.setStart(easternEurope);
     route.add(baltic);
-    final UnitType fighterType = GameDataTestUtil.fighter(m_data);
+    final UnitType fighterType = GameDataTestUtil.fighter(gameData);
     delegate.move(easternEurope.getUnits().getMatches(Matches.unitIsOfType(fighterType)), route);
     // add a carrier to be produced in germany
-    final TripleAUnit carrier = new TripleAUnit(carrirType, germans, m_data);
-    m_data.performChange(ChangeFactory.addUnits(germans, Collections.singleton((Unit) carrier)));
+    final TripleAUnit carrier = new TripleAUnit(carrirType, germans, gameData);
+    gameData.performChange(ChangeFactory.addUnits(germans, Collections.singleton((Unit) carrier)));
     // end the move phase
     delegate.end();
     // make sure the fighter is still there
@@ -74,20 +74,20 @@ public class LHTRTest {
 
   @Test
   public void testFightersDestroyedWhenNoPendingCarriers() {
-    final MoveDelegate delegate = (MoveDelegate) m_data.getDelegateList().getDelegate("move");
+    final MoveDelegate delegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     delegate.initialize("MoveDelegate", "MoveDelegate");
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("germanNonCombatMove");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
-    final Territory baltic = m_data.getMap().getTerritory("5 Sea Zone");
-    final Territory easternEurope = m_data.getMap().getTerritory("Eastern Europe");
+    final Territory baltic = gameData.getMap().getTerritory("5 Sea Zone");
+    final Territory easternEurope = gameData.getMap().getTerritory("Eastern Europe");
     // move a fighter to the baltic
     final Route route = new Route();
     route.setStart(easternEurope);
     route.add(baltic);
-    final UnitType fighterType = GameDataTestUtil.fighter(m_data);
+    final UnitType fighterType = GameDataTestUtil.fighter(gameData);
     delegate.move(easternEurope.getUnits().getMatches(Matches.unitIsOfType(fighterType)), route);
     // end the move phase
     delegate.end();
@@ -98,9 +98,9 @@ public class LHTRTest {
 
   @Test
   public void testAAGunsDontFireNonCombat() {
-    final MoveDelegate delegate = (MoveDelegate) m_data.getDelegateList().getDelegate("move");
+    final MoveDelegate delegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     delegate.initialize("MoveDelegate", "MoveDelegate");
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("germanNonCombatMove");
     delegate.setDelegateBridgeAndPlayer(bridge);
@@ -121,48 +121,48 @@ public class LHTRTest {
     bridge.setRemote(player);
     // move 1 fighter over the aa gun in caucus
     final Route route = new Route();
-    route.setStart(m_data.getMap().getTerritory("Ukraine S.S.R."));
-    route.add(m_data.getMap().getTerritory("Caucasus"));
-    route.add(m_data.getMap().getTerritory("West Russia"));
+    route.setStart(gameData.getMap().getTerritory("Ukraine S.S.R."));
+    route.add(gameData.getMap().getTerritory("Caucasus"));
+    route.add(gameData.getMap().getTerritory("West Russia"));
     final List<Unit> fighter = route.getStart().getUnits().getMatches(Matches.UnitIsAir);
     delegate.move(fighter, route);
   }
 
   @Test
   public void testSubDefenseBonus() {
-    final UnitType sub = GameDataTestUtil.submarine(m_data);
+    final UnitType sub = GameDataTestUtil.submarine(gameData);
     final UnitAttachment attachment = UnitAttachment.get(sub);
-    final PlayerID japanese = GameDataTestUtil.japanese(m_data);
+    final PlayerID japanese = GameDataTestUtil.japanese(gameData);
     // before the advance, subs defend and attack at 2
     assertEquals(2, attachment.getDefense(japanese));
     assertEquals(2, attachment.getAttack(japanese));
     final ITestDelegateBridge bridge = getDelegateBridge(japanese);
     TechTracker.addAdvance(japanese, bridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_SUPER_SUBS, m_data, japanese));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_SUPER_SUBS, gameData, japanese));
     // after tech advance, this is now 3
     assertEquals(3, attachment.getDefense(japanese));
     assertEquals(3, attachment.getAttack(japanese));
     // make sure this only changes for the player with the tech
-    final PlayerID americans = GameDataTestUtil.americans(m_data);
+    final PlayerID americans = GameDataTestUtil.americans(gameData);
     assertEquals(2, attachment.getDefense(americans));
     assertEquals(2, attachment.getAttack(americans));
   }
 
   @Test
   public void testLHTRBombingRaid() {
-    final Territory germany = m_data.getMap().getTerritory("Germany");
-    final Territory uk = m_data.getMap().getTerritory("United Kingdom");
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    final Territory germany = gameData.getMap().getTerritory("Germany");
+    final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final PlayerID british = GameDataTestUtil.british(gameData);
     final BattleTracker tracker = new BattleTracker();
-    final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, m_data, british, tracker);
-    battle.addAttackChange(m_data.getMap().getRoute(uk, germany),
+    final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
+    battle.addAttackChange(gameData.getMap().getRoute(uk, germany),
         uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), null);
     addTo(germany, uk.getUnits().getMatches(Matches.UnitIsStrategicBomber));
     tracker.getBattleRecords().addBattle(british, battle.getBattleID(), germany, battle.getBattleType());
     final ITestDelegateBridge bridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, m_data, british));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     // aa guns rolls 3, misses, bomber rolls 2 dice at 3 and 4
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {2, 2, 3}));
     // if we try to move aa, then the game will ask us if we want to move
@@ -177,9 +177,9 @@ public class LHTRTest {
         .newProxyInstance(Thread.currentThread().getContextClassLoader(),
             TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
     bridge.setRemote(player);
-    final int PUsBeforeRaid = germans.getResources().getQuantity(m_data.getResourceList().getResource(Constants.PUS));
+    final int PUsBeforeRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     battle.fight(bridge);
-    final int PUsAfterRaid = germans.getResources().getQuantity(m_data.getResourceList().getResource(Constants.PUS));
+    final int PUsAfterRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     // targets dice is 4, so damage is 1 + 4 = 5
     // Changed to match StrategicBombingRaidBattle changes
     assertEquals(PUsBeforeRaid - 5, PUsAfterRaid);
@@ -187,23 +187,23 @@ public class LHTRTest {
 
   @Test
   public void testLHTRBombingRaid2Bombers() {
-    final Territory germany = m_data.getMap().getTerritory("Germany");
-    final Territory uk = m_data.getMap().getTerritory("United Kingdom");
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    final Territory germany = gameData.getMap().getTerritory("Germany");
+    final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final PlayerID british = GameDataTestUtil.british(gameData);
     // add a unit
-    final Unit bomber = GameDataTestUtil.bomber(m_data).create(british);
+    final Unit bomber = GameDataTestUtil.bomber(gameData).create(british);
     final Change change = ChangeFactory.addUnits(uk, Collections.singleton(bomber));
-    m_data.performChange(change);
+    gameData.performChange(change);
     final BattleTracker tracker = new BattleTracker();
-    final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, m_data, british, tracker);
-    battle.addAttackChange(m_data.getMap().getRoute(uk, germany),
+    final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
+    battle.addAttackChange(gameData.getMap().getRoute(uk, germany),
         uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), null);
     addTo(germany, uk.getUnits().getMatches(Matches.UnitIsStrategicBomber));
     tracker.getBattleRecords().addBattle(british, battle.getBattleID(), germany, battle.getBattleType());
     final ITestDelegateBridge bridge = getDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, m_data, british));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     // aa guns rolls 3,3 both miss, bomber 1 rolls 2 dice at 3,4 and bomber 2 rolls dice at 1,2
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {3, 3, 2, 3, 0, 1}));
     // if we try to move aa, then the game will ask us if we want to move
@@ -218,9 +218,9 @@ public class LHTRTest {
         .newProxyInstance(Thread.currentThread().getContextClassLoader(),
             TestUtil.getClassArrayFrom(ITripleAPlayer.class), handler);
     bridge.setRemote(player);
-    final int PUsBeforeRaid = germans.getResources().getQuantity(m_data.getResourceList().getResource(Constants.PUS));
+    final int PUsBeforeRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     battle.fight(bridge);
-    final int PUsAfterRaid = germans.getResources().getQuantity(m_data.getResourceList().getResource(Constants.PUS));
+    final int PUsAfterRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     // targets dice is 4, so damage is 1 + 4 = 5
     // bomber 2 hits at 2, so damage is 3, for a total of 8
     // Changed to match StrategicBombingRaidBattle changes

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -29,24 +29,24 @@ import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
 public class MoveDelegateTest extends DelegateTest {
-  MoveDelegate m_delegate;
-  ITestDelegateBridge m_bridge;
+  MoveDelegate delegate;
+  ITestDelegateBridge bridge;
 
   @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    m_bridge = super.getDelegateBridge(british);
-    m_bridge.setStepName("britishCombatMove");
+    bridge = super.getDelegateBridge(british);
+    bridge.setStepName("britishCombatMove");
     final InitializationDelegate initDel =
-        (InitializationDelegate) m_data.getDelegateList().getDelegate("initDelegate");
-    initDel.setDelegateBridgeAndPlayer(m_bridge);
+        (InitializationDelegate) gameData.getDelegateList().getDelegate("initDelegate");
+    initDel.setDelegateBridgeAndPlayer(bridge);
     initDel.start();
     initDel.end();
-    m_delegate = new MoveDelegate();
-    m_delegate.initialize("MoveDelegate", "MoveDelegate");
-    m_delegate.setDelegateBridgeAndPlayer(m_bridge);
-    m_delegate.start();
+    delegate = new MoveDelegate();
+    delegate.initialize("MoveDelegate", "MoveDelegate");
+    delegate.setDelegateBridgeAndPlayer(bridge);
+    delegate.start();
   }
 
   private static Collection<Unit> getUnits(final IntegerMap<UnitType> units, final Territory from) {
@@ -66,7 +66,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(eastAfrica);
     final List<Unit> units = armour.create(1, british);
     units.addAll(units);
-    final String results = m_delegate.move(units, route);
+    final String results = delegate.move(units, route);
     assertError(results);
   }
 
@@ -75,7 +75,7 @@ public class MoveDelegateTest extends DelegateTest {
     final Route route = new Route();
     route.setStart(egypt);
     route.add(eastAfrica);
-    final String results = m_delegate.move(armour.create(10, british), route);
+    final String results = delegate.move(armour.create(10, british), route);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(2, eastAfrica.getUnits().size());
     assertError(results);
@@ -92,7 +92,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     assertEquals(1, algeria.getUnits().size());
     assertEquals(0, libya.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(1, algeria.getUnits().size());
     assertEquals(0, libya.getUnits().size());
@@ -107,7 +107,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(eastAfrica);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(2, eastAfrica.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(4, eastAfrica.getUnits().size());
@@ -123,7 +123,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(kenya);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(0, kenya.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(2, kenya.getUnits().size());
@@ -137,7 +137,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.setStart(congoSeaZone);
     route.add(southAtlantic);
     route.add(antarticSea);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -154,7 +154,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(redSea);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(6, redSea.getUnits().size());
@@ -174,7 +174,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(mozambiqueSeaZone);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
@@ -193,7 +193,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(redSea);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
@@ -209,7 +209,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(eastMediteranean);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(0, eastMediteranean.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(0, eastMediteranean.getUnits().size());
@@ -225,7 +225,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(mozambiqueSeaZone);
     assertEquals(4, redSea.getUnits().size());
     assertEquals(0, mozambiqueSeaZone.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(2, redSea.getUnits().size());
     assertEquals(2, mozambiqueSeaZone.getUnits().size());
@@ -241,7 +241,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(egypt);
     assertEquals(4, redSea.getUnits().size());
     assertEquals(18, egypt.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(4, redSea.getUnits().size());
     assertEquals(18, egypt.getUnits().size());
@@ -258,7 +258,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(congoSeaZone);
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(11, congoSeaZone.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(11, congoSeaZone.getUnits().size());
@@ -273,7 +273,7 @@ public class MoveDelegateTest extends DelegateTest {
     // exast movement to force landing
     route.add(redSea);
     route.add(syria);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -288,7 +288,7 @@ public class MoveDelegateTest extends DelegateTest {
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
     final String results =
-        m_delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+        delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(6, redSea.getUnits().size());
@@ -305,7 +305,7 @@ public class MoveDelegateTest extends DelegateTest {
     assertEquals(18, egypt.getUnits().size());
     assertEquals(1, algeria.getUnits().size());
     assertEquals(libya.getOwner(), japanese);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(3, algeria.getUnits().size());
@@ -320,8 +320,8 @@ public class MoveDelegateTest extends DelegateTest {
     route.setStart(egypt);
     route.add(libya);
     // Disable canBlitz attachment
-    m_data.performChange(ChangeFactory.attachmentPropertyChange(UnitAttachment.get(armour), "false", "canBlitz"));
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    gameData.performChange(ChangeFactory.attachmentPropertyChange(UnitAttachment.get(armour), "false", "canBlitz"));
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // Validate move happened
     assertEquals(1, libya.getUnits().size());
@@ -331,7 +331,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.setStart(libya);
     route.add(algeria);
     // Fail because not 'canBlitz'
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -345,7 +345,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(algeria);
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(1, algeria.getUnits().size());
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(1, algeria.getUnits().size());
@@ -361,13 +361,13 @@ public class MoveDelegateTest extends DelegateTest {
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(0, westAfrica.getUnits().size());
     assertEquals(westAfrica.getOwner(), PlayerID.NULL_PLAYERID);
-    assertEquals(35, british.getResources().getQuantity(PUs));
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    assertEquals(35, british.getResources().getQuantity(pus));
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(2, equatorialAfrica.getUnits().size());
     assertEquals(2, westAfrica.getUnits().size());
     assertEquals(westAfrica.getOwner(), british);
-    assertEquals(32, british.getResources().getQuantity(PUs));
+    assertEquals(32, british.getResources().getQuantity(pus));
   }
 
   @Test
@@ -379,7 +379,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     route.add(algeria);
     route.add(equatorialAfrica);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -390,14 +390,14 @@ public class MoveDelegateTest extends DelegateTest {
     Route route = new Route();
     route.setStart(equatorialAfrica);
     route.add(westAfrica);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     map = new IntegerMap<>();
     map.put(armour, 2);
     route = new Route();
     route.setStart(westAfrica);
     route.add(equatorialAfrica);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -410,7 +410,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(kenya);
     assertEquals(2, eastAfrica.getUnits().size());
     assertEquals(0, kenya.getUnits().size());
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(0, eastAfrica.getUnits().size());
     assertEquals(2, kenya.getUnits().size());
@@ -419,7 +419,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(egypt);
     assertEquals(2, kenya.getUnits().size());
     assertEquals(18, egypt.getUnits().size());
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(2, kenya.getUnits().size());
     assertEquals(18, egypt.getUnits().size());
@@ -435,7 +435,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(equatorialAfrica);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, equatorialAfrica.getUnits().size());
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(6, equatorialAfrica.getUnits().size());
@@ -448,7 +448,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(eastAfrica);
     assertEquals(6, equatorialAfrica.getUnits().size());
     assertEquals(2, eastAfrica.getUnits().size());
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(4, eastAfrica.getUnits().size());
@@ -461,14 +461,14 @@ public class MoveDelegateTest extends DelegateTest {
     Route route = new Route();
     route.setStart(egypt);
     route.add(redSea);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+    String results = delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     map = new IntegerMap<>();
     map.put(transport, 2);
     route = new Route();
     route.setStart(redSea);
     route.add(indianOcean);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -479,14 +479,14 @@ public class MoveDelegateTest extends DelegateTest {
     Route route = new Route();
     route.setStart(egypt);
     route.add(redSea);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+    String results = delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     map = new IntegerMap<>();
     map.put(armour, 2);
     route = new Route();
     route.setStart(redSea);
     route.add(indianOcean);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -497,24 +497,24 @@ public class MoveDelegateTest extends DelegateTest {
     final Route route = new Route();
     route.setStart(congoSeaZone);
     route.add(equatorialAfrica);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
   @Test
   public void testTransportCantLoadUnloadAfterBattle() {
-    m_bridge = super.getDelegateBridge(russians);
-    m_bridge.setStepName("russianCombatMove");
+    bridge = super.getDelegateBridge(russians);
+    bridge.setStepName("russianCombatMove");
     westEurope.setOwner(russians);
     // Attacking force
     final List<Unit> attackTrns = transport.create(1, russians);
     final List<Unit> attackList = bomber.create(2, russians);
     attackList.addAll(attackTrns);
-    m_bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
-    final DiceRoll roll = DiceRoll.rollDice(attackList, false, russians, m_bridge, new MockBattle(balticSeaZone), "",
+    bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
+    final DiceRoll roll = DiceRoll.rollDice(attackList, false, russians, bridge, new MockBattle(balticSeaZone), "",
         TerritoryEffectHelper.getEffects(balticSeaZone), null);
     assertEquals(2, roll.getHits());
-    m_bridge.setStepName("russianNonCombatMove");
+    bridge.setStepName("russianNonCombatMove");
     // Test the move
     final Collection<Unit> moveInf = infantry.create(2, russians);
     final Route route = new Route();
@@ -522,42 +522,42 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(balticSeaZone);
     route.add(westEurope);
     // Once loaded, shouldnt be able to unload
-    final String results = m_delegate.move(moveInf, route);
+    final String results = delegate.move(moveInf, route);
     assertError(results);
   }
 
   @Test
   public void testLoadUnloadLoadMoveTransports() {
-    m_bridge = super.getDelegateBridge(japanese);
-    m_bridge.setStepName("japaneseCombatMove");
-    m_bridge.setPlayerID(japanese);
-    m_delegate.setDelegateBridgeAndPlayer(m_bridge);
-    m_delegate.start();
+    bridge = super.getDelegateBridge(japanese);
+    bridge.setStepName("japaneseCombatMove");
+    bridge.setPlayerID(japanese);
+    delegate.setDelegateBridgeAndPlayer(bridge);
+    delegate.start();
     // Set up the test
     removeFrom(manchuria, manchuria.getUnits().getUnits());
     manchuria.setOwner(russians);
     removeFrom(japanSeaZone, japanSeaZone.getUnits().getUnits());
-    m_data.performChange(ChangeFactory.addUnits(japanSeaZone, transport.create(3, japanese)));
-    m_data.performChange(ChangeFactory.addUnits(japan, infantry.create(3, japanese)));
+    gameData.performChange(ChangeFactory.addUnits(japanSeaZone, transport.create(3, japanese)));
+    gameData.performChange(ChangeFactory.addUnits(japan, infantry.create(3, japanese)));
     // Perform the first load
     final Route load = new Route();
     load.setStart(japan);
     load.add(japanSeaZone);
-    String results = m_delegate.move(Match.getNMatches(japan.getUnits().getUnits(), 1, Matches.unitIsOfType(infantry)),
+    String results = delegate.move(Match.getNMatches(japan.getUnits().getUnits(), 1, Matches.unitIsOfType(infantry)),
         load, Match.getMatches(japanSeaZone.getUnits().getUnits(), Matches.unitIsOfType(transport)));
     assertNull(results);
     // Perform the first unload
     final Route unload = new Route();
     unload.setStart(japanSeaZone);
     unload.add(manchuria);
-    results = m_delegate.move(Match.getNMatches(japanSeaZone.getUnits().getUnits(), 1, Matches.unitIsOfType(infantry)),
+    results = delegate.move(Match.getNMatches(japanSeaZone.getUnits().getUnits(), 1, Matches.unitIsOfType(infantry)),
         unload);
     assertNull(results);
     // Load another trn
     final Route route2 = new Route();
     route2.setStart(japan);
     route2.add(japanSeaZone);
-    results = m_delegate.move(Match.getNMatches(japan.getUnits().getUnits(), 1, Matches.unitIsOfType(infantry)), route2,
+    results = delegate.move(Match.getNMatches(japan.getUnits().getUnits(), 1, Matches.unitIsOfType(infantry)), route2,
         Match.getMatches(japanSeaZone.getUnits().getUnits(), Matches.unitIsOfType(transport)));
     assertNull(results);
     // Move remaining units
@@ -566,7 +566,7 @@ public class MoveDelegateTest extends DelegateTest {
     route3.add(sfeSeaZone);
     final Collection<Unit> remainingTrns = Match.getMatches(japanSeaZone.getUnits().getUnits(),
         new CompositeMatchAnd<>(Matches.unitHasNotMoved, Matches.UnitWasNotLoadedThisTurn));
-    results = m_delegate.move(remainingTrns, route3);
+    results = delegate.move(remainingTrns, route3);
     assertNull(results);
   }
 
@@ -577,7 +577,7 @@ public class MoveDelegateTest extends DelegateTest {
     Route route = new Route();
     route.setStart(congoSeaZone);
     route.add(equatorialAfrica);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     map = new IntegerMap<>();
     // only 2 originially, would have to move the 2 we just unloaded
@@ -587,7 +587,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.setStart(equatorialAfrica);
     route.add(egypt);
     // units were unloaded, shouldnt be able to move any more
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -598,7 +598,7 @@ public class MoveDelegateTest extends DelegateTest {
     Route route = new Route();
     route.setStart(congoSeaZone);
     route.add(equatorialAfrica);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     map = new IntegerMap<>();
     map.put(transport, 2);
@@ -606,7 +606,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.setStart(congoSeaZone);
     route.add(westAfricaSeaZone);
     // the transports unloaded so they cant move
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -618,7 +618,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(redSea);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+    String results = delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     // move two infantry to red sea
     route = new Route();
@@ -626,7 +626,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(redSea);
     map = new IntegerMap<>();
     map.put(infantry, 2);
-    results = m_delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+    results = delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     // try to move 1 transport to indian ocean with 1 tank
     route = new Route();
@@ -635,7 +635,7 @@ public class MoveDelegateTest extends DelegateTest {
     map = new IntegerMap<>();
     map.put(armour, 1);
     map.put(transport, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // move the other transport to west compass
     route = new Route();
@@ -644,7 +644,7 @@ public class MoveDelegateTest extends DelegateTest {
     map = new IntegerMap<>();
     map.put(infantry, 2);
     map.put(transport, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -657,7 +657,7 @@ public class MoveDelegateTest extends DelegateTest {
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(transport, 1);
     map.put(infantry, 2);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // move transport back
     route = new Route();
@@ -666,7 +666,7 @@ public class MoveDelegateTest extends DelegateTest {
     map = new IntegerMap<>();
     map.put(transport, 1);
     map.put(infantry, 2);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // move the other transport south, should
     // figure out that only 1 can move
@@ -677,16 +677,16 @@ public class MoveDelegateTest extends DelegateTest {
     map = new IntegerMap<>();
     map.put(infantry, 2);
     map.put(transport, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
   @Test
   public void testCanOverrunNeutralWithoutFunds() {
-    assertEquals(35, british.getResources().getQuantity(PUs));
-    final Change makePoor = ChangeFactory.changeResourcesChange(british, PUs, -35);
-    m_bridge.addChange(makePoor);
-    assertEquals(0, british.getResources().getQuantity(PUs));
+    assertEquals(35, british.getResources().getQuantity(pus));
+    final Change makePoor = ChangeFactory.changeResourcesChange(british, pus, -35);
+    bridge.addChange(makePoor);
+    assertEquals(0, british.getResources().getQuantity(pus));
     // try to take over South Africa, cant because we cant afford it
     final Route route = new Route();
     route.setStart(egypt);
@@ -694,7 +694,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(southAfrica);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 2);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -706,7 +706,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(southAfrica);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 2);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -718,10 +718,10 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(westAfrica);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
-    assertTrue(DelegateFinder.battleDelegate(m_data).getBattleTracker().wasConquered(westAfrica));
-    assertTrue(!DelegateFinder.battleDelegate(m_data).getBattleTracker().wasBlitzed(westAfrica));
+    assertTrue(DelegateFinder.battleDelegate(gameData).getBattleTracker().wasConquered(westAfrica));
+    assertTrue(!DelegateFinder.battleDelegate(gameData).getBattleTracker().wasBlitzed(westAfrica));
   }
 
   public void testMoveTransportsTwice() {
@@ -732,13 +732,13 @@ public class MoveDelegateTest extends DelegateTest {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(infantry, 2);
     map.put(transport, 1);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // move again
     route = new Route();
     route.setStart(southAtlantic);
     route.add(angolaSeaZone);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -750,7 +750,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(westAfrica);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // make sure we cant move through it by land
     route = new Route();
@@ -759,7 +759,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(algeria);
     map = new IntegerMap<>();
     map.put(armour, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
     // make sure we can still move units to the territory
     route = new Route();
@@ -767,7 +767,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(westAfrica);
     map = new IntegerMap<>();
     map.put(armour, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // make sure air can though
     route = new Route();
@@ -777,7 +777,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(equatorialAfrica);
     map = new IntegerMap<>();
     map.put(fighter, 3);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -789,7 +789,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(infantry, 1);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // make sure we can still blitz through it
     route = new Route();
@@ -798,7 +798,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(algeria);
     map = new IntegerMap<>();
     map.put(armour, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -811,7 +811,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(southAfrica);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // move carriers to ensure they can't go anywhere
     route = new Route();
@@ -819,9 +819,9 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(westAfricaSea);
     route.add(northAtlantic);
     Collection<Unit> units = new ArrayList<>();
-    units.addAll(Match.getMatches(m_data.getMap().getTerritory(congoSeaZone.toString()).getUnits().getUnits(),
+    units.addAll(Match.getMatches(gameData.getMap().getTerritory(congoSeaZone.toString()).getUnits().getUnits(),
         Matches.UnitIsCarrier));
-    results = m_delegate.move(units, route);
+    results = delegate.move(units, route);
     assertValid(results);
     // move carriers to ensure they can't go anywhere
     route = new Route();
@@ -829,9 +829,9 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(eastMediteranean);
     route.add(blackSea);
     units = new ArrayList<>();
-    units.addAll(
-        Match.getMatches(m_data.getMap().getTerritory(redSea.toString()).getUnits().getUnits(), Matches.UnitIsCarrier));
-    results = m_delegate.move(units, route);
+    units.addAll(Match.getMatches(
+        gameData.getMap().getTerritory(redSea.toString()).getUnits().getUnits(), Matches.UnitIsCarrier));
+    results = delegate.move(units, route);
     assertValid(results);
     // make sure the place cant use it to land
     // the only possibility would be newly conquered south africa
@@ -842,7 +842,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(southAfricaSeaZone);
     map = new IntegerMap<>();
     map.put(fighter, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -855,14 +855,14 @@ public class MoveDelegateTest extends DelegateTest {
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(transport, 1);
     map.put(infantry, 2);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     route = new Route();
     route.setStart(westAfricaSeaZone);
     route.add(westAfrica);
     map = new IntegerMap<>();
     map.put(infantry, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -874,7 +874,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(bomber, 1);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     route = new Route();
     route.setStart(libya);
@@ -882,7 +882,7 @@ public class MoveDelegateTest extends DelegateTest {
     // planes cannot leave a battle zone, but the territory was empty so no battle occurred
     map = new IntegerMap<>();
     map.put(bomber, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -895,7 +895,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(bomber, 1);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -910,7 +910,7 @@ public class MoveDelegateTest extends DelegateTest {
     map.put(bomber, 6);
     map.put(fighter, 6);
     map.put(armour, 6);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -923,7 +923,7 @@ public class MoveDelegateTest extends DelegateTest {
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(transport, 2);
     map.put(infantry, 4);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // try to unload transports
     route = new Route();
@@ -931,22 +931,22 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(brazil);
     map = new IntegerMap<>();
     map.put(infantry, 4);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     final IBattle inBrazil =
-        DelegateFinder.battleDelegate(m_data).getBattleTracker().getPendingBattle(brazil, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(brazil, false, null);
     final IBattle inBrazilSea =
-        DelegateFinder.battleDelegate(m_data).getBattleTracker().getPendingBattle(southBrazilSeaZone, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(southBrazilSeaZone, false, null);
     assertNotNull(inBrazilSea);
     assertNotNull(inBrazil);
-    assertEquals(DelegateFinder.battleDelegate(m_data).getBattleTracker().getDependentOn(inBrazil).iterator().next(),
+    assertEquals(DelegateFinder.battleDelegate(gameData).getBattleTracker().getDependentOn(inBrazil).iterator().next(),
         inBrazilSea);
   }
 
   @Test
   public void testReloadTransportAfterRetreatAmphibious() {
-    m_bridge = super.getDelegateBridge(british);
-    m_bridge.setStepName("britishCombatMove");
+    bridge = super.getDelegateBridge(british);
+    bridge.setStepName("britishCombatMove");
     Route route = new Route();
     route.setStart(northSea);
     route.add(balticSeaZone);
@@ -954,7 +954,7 @@ public class MoveDelegateTest extends DelegateTest {
     map.put(transport, 1);
     map.put(infantry, 2);
     // Move from the NorthSea to the BalticSea and validate the move
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // Unload transports into Finland and validate
     route = new Route();
@@ -962,43 +962,43 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(finlandNorway);
     map = new IntegerMap<>();
     map.put(infantry, 2);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits = new ArrayList<>();
-    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, m_data)));
+    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
     final List<Unit> retreatingLandUnits = new ArrayList<>();
-    retreatingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(germans, m_data)));
+    retreatingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
     final List<Unit> defendingLandUnits = new ArrayList<>();
-    defendingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(british, m_data)));
+    defendingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(british, gameData)));
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
-        DelegateFinder.battleDelegate(m_data).getBattleTracker().getPendingBattle(finlandNorway, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(finlandNorway, false, null);
     final IBattle inBalticSeaZone =
-        DelegateFinder.battleDelegate(m_data).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
     assertNotNull(balticSeaZone);
     assertNotNull(finlandNorway);
     assertEquals(
-        DelegateFinder.battleDelegate(m_data).getBattleTracker().getDependentOn(inFinlandNorway).iterator().next(),
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getDependentOn(inFinlandNorway).iterator().next(),
         inBalticSeaZone);
     // Add some defending units in case there aren't any
     final List<Unit> defendList = transport.create(1, germans);
     final List<Unit> defendSub = submarine.create(1, germans);
     defendList.addAll(defendSub);
     // fire the defending transport then the submarine (both miss)
-    m_bridge.setRandomSource(new ScriptedRandomSource(new int[] {1, 2}));
+    bridge.setRandomSource(new ScriptedRandomSource(new int[] {1, 2}));
     // Execute the battle and verify no hits
-    final DiceRoll roll = DiceRoll.rollDice(defendList, true, germans, m_bridge, new MockBattle(balticSeaZone), "",
+    final DiceRoll roll = DiceRoll.rollDice(defendList, true, germans, bridge, new MockBattle(balticSeaZone), "",
         TerritoryEffectHelper.getEffects(balticSeaZone), null);
     assertEquals(0, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = finlandNorway.getUnits().size();
     // Retreat from the Baltic
-    ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, m_bridge);
+    ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, bridge);
     // Get the total number of units that should be left
     final int postCountInt = preCountInt - retreatingLandSizeInt;
     // Compare the number of units in Finland to begin with the number after retreating
@@ -1007,8 +1007,8 @@ public class MoveDelegateTest extends DelegateTest {
 
   @Test
   public void testReloadTransportAfterDyingAmphibious() {
-    m_bridge = super.getDelegateBridge(british);
-    m_bridge.setStepName("britishCombatMove");
+    bridge = super.getDelegateBridge(british);
+    bridge.setStepName("britishCombatMove");
     Route route = new Route();
     route.setStart(northSea);
     route.add(balticSeaZone);
@@ -1016,7 +1016,7 @@ public class MoveDelegateTest extends DelegateTest {
     map.put(transport, 1);
     map.put(infantry, 2);
     // Move from the NorthSea to the BalticSea and validate the move
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // Unload transports into Finland and validate
     route = new Route();
@@ -1024,43 +1024,43 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(finlandNorway);
     map = new IntegerMap<>();
     map.put(infantry, 2);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits = new ArrayList<>();
-    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, m_data)));
+    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
     final List<Unit> retreatingLandUnits = new ArrayList<>();
-    retreatingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(germans, m_data)));
+    retreatingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
     final List<Unit> defendingLandUnits = new ArrayList<>();
-    defendingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(british, m_data)));
+    defendingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(british, gameData)));
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
-        DelegateFinder.battleDelegate(m_data).getBattleTracker().getPendingBattle(finlandNorway, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(finlandNorway, false, null);
     final IBattle inBalticSeaZone =
-        DelegateFinder.battleDelegate(m_data).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
     assertNotNull(balticSeaZone);
     assertNotNull(finlandNorway);
     assertEquals(
-        DelegateFinder.battleDelegate(m_data).getBattleTracker().getDependentOn(inFinlandNorway).iterator().next(),
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getDependentOn(inFinlandNorway).iterator().next(),
         inBalticSeaZone);
     // Add some defending units in case there aren't any
     final List<Unit> defendList = transport.create(1, germans);
     final List<Unit> defendSub = submarine.create(1, germans);
     defendList.addAll(defendSub);
     // fire the defending transport then the submarine (One hit)
-    m_bridge.setRandomSource(new ScriptedRandomSource(new int[] {0, 2}));
+    bridge.setRandomSource(new ScriptedRandomSource(new int[] {0, 2}));
     // Execute the battle and verify no hits
-    final DiceRoll roll = DiceRoll.rollDice(defendList, true, germans, m_bridge, new MockBattle(balticSeaZone), "",
+    final DiceRoll roll = DiceRoll.rollDice(defendList, true, germans, bridge, new MockBattle(balticSeaZone), "",
         TerritoryEffectHelper.getEffects(balticSeaZone), null);
     assertEquals(1, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = finlandNorway.getUnits().size();
     // Retreat from the Baltic
-    ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, m_bridge);
+    ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, bridge);
     // Get the total number of units that should be left
     final int postCountInt = preCountInt - retreatingLandSizeInt;
     // Compare the number of units in Finland to begin with the number after retreating
@@ -1069,8 +1069,8 @@ public class MoveDelegateTest extends DelegateTest {
 
   @Test
   public void testReloadTransportAfterRetreatAllied() {
-    m_bridge = super.getDelegateBridge(british);
-    m_bridge.setStepName("britishCombatMove");
+    bridge = super.getDelegateBridge(british);
+    bridge.setStepName("britishCombatMove");
     Route route = new Route();
     route.setStart(northSea);
     route.add(balticSeaZone);
@@ -1078,7 +1078,7 @@ public class MoveDelegateTest extends DelegateTest {
     map.put(transport, 1);
     map.put(infantry, 2);
     // Move from the NorthSea to the BalticSea and validate the move
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // Unload transports into Finland and validate
     route = new Route();
@@ -1086,37 +1086,37 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(karelia);
     map = new IntegerMap<>();
     map.put(infantry, 2);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits = new ArrayList<>();
-    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, m_data)));
+    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
     final List<Unit> retreatingLandUnits = new ArrayList<>();
-    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(russians, m_data)));
+    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(russians, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
-    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(british, m_data)));
+    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(british, gameData)));
     final List<Unit> defendingLandUnits = new ArrayList<>();
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inBalticSeaZone =
-        DelegateFinder.battleDelegate(m_data).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
     assertNotNull(balticSeaZone);
     // Add some defending units in case there aren't any
     final List<Unit> defendList = transport.create(1, germans);
     final List<Unit> defendSub = submarine.create(1, germans);
     defendList.addAll(defendSub);
     // fire the defending transport then the submarine (both miss)
-    m_bridge.setRandomSource(new ScriptedRandomSource(new int[] {1, 2}));
+    bridge.setRandomSource(new ScriptedRandomSource(new int[] {1, 2}));
     // Execute the battle and verify no hits
-    final DiceRoll roll = DiceRoll.rollDice(defendList, true, germans, m_bridge, new MockBattle(balticSeaZone), "",
+    final DiceRoll roll = DiceRoll.rollDice(defendList, true, germans, bridge, new MockBattle(balticSeaZone), "",
         TerritoryEffectHelper.getEffects(balticSeaZone), null);
     assertEquals(0, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = karelia.getUnits().size();
     // Retreat from the Baltic
-    ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, m_bridge);
+    ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, bridge);
     // Get the total number of units that should be left
     final int postCountInt = preCountInt - retreatingLandSizeInt;
     // Compare the number of units in Finland to begin with the number after retreating
@@ -1125,8 +1125,8 @@ public class MoveDelegateTest extends DelegateTest {
 
   @Test
   public void testReloadTransportAfterDyingAllied() {
-    m_bridge = super.getDelegateBridge(british);
-    m_bridge.setStepName("britishCombatMove");
+    bridge = super.getDelegateBridge(british);
+    bridge.setStepName("britishCombatMove");
     Route route = new Route();
     route.setStart(northSea);
     route.add(balticSeaZone);
@@ -1134,7 +1134,7 @@ public class MoveDelegateTest extends DelegateTest {
     map.put(transport, 1);
     map.put(infantry, 2);
     // Move from the NorthSea to the BalticSea and validate the move
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // Unload transports into Finland and validate
     route = new Route();
@@ -1142,37 +1142,37 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(karelia);
     map = new IntegerMap<>();
     map.put(infantry, 2);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits = new ArrayList<>();
-    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, m_data)));
+    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
     final List<Unit> retreatingLandUnits = new ArrayList<>();
-    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(russians, m_data)));
+    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(russians, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
     final List<Unit> defendingLandUnits = new ArrayList<>();
-    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(british, m_data)));
+    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(british, gameData)));
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inBalticSeaZone =
-        DelegateFinder.battleDelegate(m_data).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
     assertNotNull(balticSeaZone);
     // Add some defending units in case there aren't any
     final List<Unit> defendList = transport.create(1, germans);
     final List<Unit> defendSub = submarine.create(1, germans);
     defendList.addAll(defendSub);
     // fire the defending transport then the submarine (One hit)
-    m_bridge.setRandomSource(new ScriptedRandomSource(new int[] {0, 2}));
+    bridge.setRandomSource(new ScriptedRandomSource(new int[] {0, 2}));
     // Execute the battle and verify no hits
-    final DiceRoll roll = DiceRoll.rollDice(defendList, true, germans, m_bridge, new MockBattle(balticSeaZone), "",
+    final DiceRoll roll = DiceRoll.rollDice(defendList, true, germans, bridge, new MockBattle(balticSeaZone), "",
         TerritoryEffectHelper.getEffects(balticSeaZone), null);
     assertEquals(1, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = karelia.getUnits().size();
     // Retreat from the Baltic
-    ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, m_bridge);
+    ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, bridge);
     // Get the total number of units that should be left
     final int postCountInt = preCountInt - retreatingLandSizeInt;
     // Compare the number of units in Finland to begin with the number after retreating
@@ -1187,35 +1187,35 @@ public class MoveDelegateTest extends DelegateTest {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 3);
     map.put(bomber, 3);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
   @Test
   public void testNonCombatAttack() {
-    m_bridge.setStepName("britishNonCombatMove");
-    m_delegate.setDelegateBridgeAndPlayer(m_bridge);
-    m_delegate.start();
+    bridge.setStepName("britishNonCombatMove");
+    delegate.setDelegateBridgeAndPlayer(bridge);
+    delegate.start();
     final Route route = new Route();
     route.setStart(equatorialAfrica);
     route.add(algeria);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 2);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
   @Test
   public void testNonCombatAttackNeutral() {
-    m_bridge.setStepName("britishNonCombatMove");
-    m_delegate.setDelegateBridgeAndPlayer(m_bridge);
-    m_delegate.start();
+    bridge.setStepName("britishNonCombatMove");
+    delegate.setDelegateBridgeAndPlayer(bridge);
+    delegate.start();
     final Route route = new Route();
     route.setStart(equatorialAfrica);
     route.add(westAfrica);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 2);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -1227,41 +1227,41 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // go to non combat
-    m_bridge.setStepName("britishNonCombatMove");
-    m_delegate.setDelegateBridgeAndPlayer(m_bridge);
-    m_delegate.start();
+    bridge.setStepName("britishNonCombatMove");
+    delegate.setDelegateBridgeAndPlayer(bridge);
+    delegate.start();
     // move more into libya
     route = new Route();
     route.setStart(equatorialAfrica);
     route.add(libya);
     map = new IntegerMap<>();
     map.put(armour, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
   @Test
   public void testAACantMoveToConquered() {
-    m_bridge.setStepName("japaneseCombatMove");
-    m_bridge.setPlayerID(japanese);
-    m_delegate.setDelegateBridgeAndPlayer(m_bridge);
-    m_delegate.start();
+    bridge.setStepName("japaneseCombatMove");
+    bridge.setPlayerID(japanese);
+    delegate.setDelegateBridgeAndPlayer(bridge);
+    delegate.start();
     final Route route = new Route();
     route.setStart(congo);
     route.add(kenya);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 2);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
-    final BattleTracker tracker = DelegateFinder.battleDelegate(m_data).getBattleTracker();
+    final BattleTracker tracker = DelegateFinder.battleDelegate(gameData).getBattleTracker();
     assertTrue(tracker.wasBlitzed(kenya));
     assertTrue(tracker.wasConquered(kenya));
     map.clear();
     map.put(aaGun, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -1272,19 +1272,19 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(westAfrica);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(infantry, 1);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
-    final BattleTracker tracker = DelegateFinder.battleDelegate(m_data).getBattleTracker();
+    final BattleTracker tracker = DelegateFinder.battleDelegate(gameData).getBattleTracker();
     assertTrue(!tracker.wasBlitzed(westAfrica));
     assertTrue(tracker.wasConquered(westAfrica));
     map.clear();
     map.put(armour, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     route = new Route();
     route.setStart(westAfrica);
     route.add(algeria);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -1293,15 +1293,15 @@ public class MoveDelegateTest extends DelegateTest {
     // create a factory to be taken
     final Collection<Unit> factCollection = factory.create(1, japanese);
     final Change addFactory = ChangeFactory.addUnits(libya, factCollection);
-    m_bridge.addChange(addFactory);
+    bridge.addChange(addFactory);
     final Route route = new Route();
     route.setStart(equatorialAfrica);
     route.add(libya);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(infantry, 1);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
-    final BattleTracker tracker = DelegateFinder.battleDelegate(m_data).getBattleTracker();
+    final BattleTracker tracker = DelegateFinder.battleDelegate(gameData).getBattleTracker();
     assertTrue(tracker.wasBlitzed(libya));
     assertTrue(tracker.wasConquered(libya));
     final Unit aFactory = factCollection.iterator().next();
@@ -1316,7 +1316,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(blackSea);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -1333,7 +1333,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(angolaSeaZone);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     route = new Route();
     route.setStart(congoSeaZone);
@@ -1342,13 +1342,13 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(angolaSeaZone);
     map = new IntegerMap<>();
     map.put(fighter, 1);
-    results = m_delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
   @Test
   public void testRoute() {
-    final Route route = m_data.getMap().getRoute(angola, russia);
+    final Route route = gameData.getMap().getRoute(angola, russia);
     assertNotNull(route);
     assertEquals(route.getEnd(), russia);
   }

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -29,18 +29,18 @@ public class MoveValidatorTest extends DelegateTest {
     // japanese unit in congo
     final Route bad = new Route();
     // the empty case
-    assertTrue(MoveValidator.noEnemyUnitsOnPathMiddleSteps(bad, british, m_data));
+    assertTrue(MoveValidator.noEnemyUnitsOnPathMiddleSteps(bad, british, gameData));
     bad.add(egypt);
     bad.add(congo);
     bad.add(kenya);
-    assertTrue(!MoveValidator.noEnemyUnitsOnPathMiddleSteps(bad, british, m_data));
+    assertTrue(!MoveValidator.noEnemyUnitsOnPathMiddleSteps(bad, british, gameData));
     final Route good = new Route();
     good.add(egypt);
     good.add(kenya);
-    assertTrue(MoveValidator.noEnemyUnitsOnPathMiddleSteps(good, british, m_data));
+    assertTrue(MoveValidator.noEnemyUnitsOnPathMiddleSteps(good, british, gameData));
     // at end so should still be good
     good.add(congo);
-    assertTrue(MoveValidator.noEnemyUnitsOnPathMiddleSteps(good, british, m_data));
+    assertTrue(MoveValidator.noEnemyUnitsOnPathMiddleSteps(good, british, gameData));
   }
 
   @Test
@@ -57,7 +57,7 @@ public class MoveValidatorTest extends DelegateTest {
   @Test
   public void testCarrierCapacity() {
     final Collection<Unit> units = carrier.create(5, british);
-    assertEquals(10, AirMovementValidator.carrierCapacity(units, new Territory("TestTerritory", true, m_data)));
+    assertEquals(10, AirMovementValidator.carrierCapacity(units, new Territory("TestTerritory", true, gameData)));
   }
 
   @Test
@@ -81,23 +81,23 @@ public class MoveValidatorTest extends DelegateTest {
   public void testCanLand() {
     final Collection<Unit> units = fighter.create(4, british);
     // 2 carriers in red sea
-    assertTrue(AirMovementValidator.canLand(units, redSea, british, m_data));
+    assertTrue(AirMovementValidator.canLand(units, redSea, british, gameData));
     // britian owns egypt
-    assertTrue(AirMovementValidator.canLand(units, egypt, british, m_data));
+    assertTrue(AirMovementValidator.canLand(units, egypt, british, gameData));
     // only 2 carriers
     final Collection<Unit> tooMany = fighter.create(6, british);
-    assertTrue(!AirMovementValidator.canLand(tooMany, redSea, british, m_data));
+    assertTrue(!AirMovementValidator.canLand(tooMany, redSea, british, gameData));
     // nowhere to land
-    assertTrue(!AirMovementValidator.canLand(units, japanSeaZone, british, m_data));
+    assertTrue(!AirMovementValidator.canLand(units, japanSeaZone, british, gameData));
     // nuetral
-    assertTrue(!AirMovementValidator.canLand(units, westAfrica, british, m_data));
+    assertTrue(!AirMovementValidator.canLand(units, westAfrica, british, gameData));
   }
 
   @Test
   public void testCanLandInfantry() {
     try {
       final Collection<Unit> units = infantry.create(1, british);
-      AirMovementValidator.canLand(units, redSea, british, m_data);
+      AirMovementValidator.canLand(units, redSea, british, gameData);
     } catch (final IllegalArgumentException e) {
       return;
     }
@@ -107,7 +107,7 @@ public class MoveValidatorTest extends DelegateTest {
   @Test
   public void testCanLandBomber() {
     final Collection<Unit> units = bomber.create(1, british);
-    assertTrue(!AirMovementValidator.canLand(units, redSea, british, m_data));
+    assertTrue(!AirMovementValidator.canLand(units, redSea, british, gameData));
   }
 
   @Test

--- a/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -35,72 +35,72 @@ public class PacificTest extends DelegateTest {
   PlayerID chinese;
   // Define territories
   Territory queensland;
-  Territory US;
-  Territory NewBrit;
-  Territory Midway;
-  Territory Mariana;
-  Territory Bonin;
+  Territory unitedStates;
+  Territory newBritain;
+  Territory midway;
+  Territory mariana;
+  Territory bonin;
   // Define Sea Zones
-  Territory SZ4;
-  Territory SZ5;
-  Territory SZ7;
-  Territory SZ8;
-  Territory SZ10;
-  Territory SZ16;
-  Territory SZ20;
-  Territory SZ24;
-  Territory SZ25;
-  Territory SZ27;
+  Territory sz4;
+  Territory sz5;
+  Territory sz7;
+  Territory sz8;
+  Territory sz10;
+  Territory sz16;
+  Territory sz20;
+  Territory sz24;
+  Territory sz25;
+  Territory sz27;
   ITestDelegateBridge bridge;
-  MoveDelegate m_delegate;
+  MoveDelegate delegate;
 
   @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    m_data = TestMapGameData.PACIFIC_INCOMPLETE.getGameData();
+    gameData = TestMapGameData.PACIFIC_INCOMPLETE.getGameData();
     // Define units
-    infantry = GameDataTestUtil.infantry(m_data);
-    armor = GameDataTestUtil.armour(m_data);
-    artillery = m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_ARTILLERY);
-    marine = m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_MARINE);
-    fighter = GameDataTestUtil.fighter(m_data);
-    bomber = GameDataTestUtil.bomber(m_data);
-    sub = GameDataTestUtil.submarine(m_data);
-    destroyer = GameDataTestUtil.destroyer(m_data);
-    carrier = GameDataTestUtil.carrier(m_data);
-    battleship = GameDataTestUtil.battleship(m_data);
-    transport = GameDataTestUtil.transport(m_data);
+    infantry = GameDataTestUtil.infantry(gameData);
+    armor = GameDataTestUtil.armour(gameData);
+    artillery = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_ARTILLERY);
+    marine = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_MARINE);
+    fighter = GameDataTestUtil.fighter(gameData);
+    bomber = GameDataTestUtil.bomber(gameData);
+    sub = GameDataTestUtil.submarine(gameData);
+    destroyer = GameDataTestUtil.destroyer(gameData);
+    carrier = GameDataTestUtil.carrier(gameData);
+    battleship = GameDataTestUtil.battleship(gameData);
+    transport = GameDataTestUtil.transport(gameData);
     // Define players
-    americans = GameDataTestUtil.americans(m_data);
-    chinese = GameDataTestUtil.chinese(m_data);
-    british = GameDataTestUtil.british(m_data);
-    japanese = GameDataTestUtil.japanese(m_data);
+    americans = GameDataTestUtil.americans(gameData);
+    chinese = GameDataTestUtil.chinese(gameData);
+    british = GameDataTestUtil.british(gameData);
+    japanese = GameDataTestUtil.japanese(gameData);
     // Define territories
-    queensland = m_data.getMap().getTerritory("Queensland");
-    japan = m_data.getMap().getTerritory("Japan");
-    US = m_data.getMap().getTerritory("United States");
-    NewBrit = m_data.getMap().getTerritory("New Britain");
-    Midway = m_data.getMap().getTerritory("Midway");
-    Mariana = m_data.getMap().getTerritory("Mariana");
-    Bonin = m_data.getMap().getTerritory("Bonin");
+    queensland = gameData.getMap().getTerritory("Queensland");
+    japan = gameData.getMap().getTerritory("Japan");
+    unitedStates = gameData.getMap().getTerritory("United States");
+    newBritain = gameData.getMap().getTerritory("New Britain");
+    midway = gameData.getMap().getTerritory("Midway");
+    mariana = gameData.getMap().getTerritory("Mariana");
+    bonin = gameData.getMap().getTerritory("Bonin");
     // Define Sea Zones
-    SZ4 = m_data.getMap().getTerritory("4 Sea Zone");
-    SZ5 = m_data.getMap().getTerritory("5 Sea Zone");
-    SZ7 = m_data.getMap().getTerritory("7 Sea Zone");
-    SZ8 = m_data.getMap().getTerritory("8 Sea Zone");
-    SZ10 = m_data.getMap().getTerritory("10 Sea Zone");
-    SZ16 = m_data.getMap().getTerritory("16 Sea Zone");
-    SZ20 = m_data.getMap().getTerritory("20 Sea Zone");
-    SZ24 = m_data.getMap().getTerritory("24 Sea Zone");
-    SZ25 = m_data.getMap().getTerritory("25 Sea Zone");
-    SZ27 = m_data.getMap().getTerritory("27 Sea Zone");
+    sz4 = gameData.getMap().getTerritory("4 Sea Zone");
+    sz5 = gameData.getMap().getTerritory("5 Sea Zone");
+    sz7 = gameData.getMap().getTerritory("7 Sea Zone");
+    sz8 = gameData.getMap().getTerritory("8 Sea Zone");
+    sz10 = gameData.getMap().getTerritory("10 Sea Zone");
+    sz16 = gameData.getMap().getTerritory("16 Sea Zone");
+    sz20 = gameData.getMap().getTerritory("20 Sea Zone");
+    sz24 = gameData.getMap().getTerritory("24 Sea Zone");
+    sz25 = gameData.getMap().getTerritory("25 Sea Zone");
+    sz27 = gameData.getMap().getTerritory("27 Sea Zone");
     bridge = getDelegateBridge(americans);
     bridge.setStepName("japaneseCombatMove");
-    m_delegate = new MoveDelegate();
-    m_delegate.initialize("MoveDelegate", "MoveDelegate");
-    m_delegate.setDelegateBridgeAndPlayer(bridge);
-    m_delegate.start();
+    delegate = new MoveDelegate();
+    delegate.initialize("MoveDelegate", "MoveDelegate");
+    delegate.setDelegateBridgeAndPlayer(bridge);
+    delegate.start();
   }
 
   private Collection<Unit> getUnits(final IntegerMap<UnitType> units, final Territory from) {
@@ -115,7 +115,7 @@ public class PacificTest extends DelegateTest {
 
   @Override
   protected ITestDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, m_data);
+    return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
   @Test
@@ -147,8 +147,8 @@ public class PacificTest extends DelegateTest {
   @Test
   public void testJapanAttackFirstRound() {
     bridge.setStepName("japaneseBattle");
-    while (!m_data.getSequence().getStep().getName().equals("japaneseBattle")) {
-      m_data.getSequence().next();
+    while (!gameData.getSequence().getStep().getName().equals("japaneseBattle")) {
+      gameData.getSequence().next();
     }
     // >>> After patch normal to-hits will miss <<<
     // Defending US infantry miss on a 2 (0 base)
@@ -191,16 +191,16 @@ public class PacificTest extends DelegateTest {
   public void testCanLand2Airfields() {
     bridge.setStepName("americanCombatMove");
     final Route route = new Route();
-    route.setStart(US);
-    route.add(SZ5);
-    route.add(SZ4);
-    route.add(SZ10);
-    route.add(SZ16);
-    route.add(SZ27);
-    route.add(NewBrit);
+    route.setStart(unitedStates);
+    route.add(sz5);
+    route.add(sz4);
+    route.add(sz10);
+    route.add(sz16);
+    route.add(sz27);
+    route.add(newBritain);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -208,15 +208,15 @@ public class PacificTest extends DelegateTest {
   public void testCanLand1AirfieldStart() {
     bridge.setStepName("americanCombatMove");
     final Route route = new Route();
-    route.setStart(US);
-    route.add(SZ5);
-    route.add(SZ7);
-    route.add(SZ8);
-    route.add(SZ20);
-    route.add(Midway);
+    route.setStart(unitedStates);
+    route.add(sz5);
+    route.add(sz7);
+    route.add(sz8);
+    route.add(sz20);
+    route.add(midway);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
     // assertError( results);
   }
@@ -225,15 +225,15 @@ public class PacificTest extends DelegateTest {
   public void testCanLand1AirfieldEnd() {
     bridge.setStepName("americanCombatMove");
     final Route route = new Route();
-    route.setStart(US);
-    route.add(SZ5);
-    route.add(SZ7);
-    route.add(SZ8);
-    route.add(SZ20);
-    route.add(Midway);
+    route.setStart(unitedStates);
+    route.add(sz5);
+    route.add(sz7);
+    route.add(sz8);
+    route.add(sz20);
+    route.add(midway);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -241,39 +241,39 @@ public class PacificTest extends DelegateTest {
   public void testCanMoveNavalBase() {
     bridge.setStepName("americanNonCombatMove");
     final Route route = new Route();
-    route.setStart(SZ5);
-    route.add(SZ7);
-    route.add(SZ8);
-    route.add(SZ20);
+    route.setStart(sz5);
+    route.add(sz7);
+    route.add(sz8);
+    route.add(sz20);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    final String results = m_delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
   @Test
   public void testJapaneseDestroyerTransport() {
     bridge = getDelegateBridge(japanese);
-    m_delegate = new MoveDelegate();
-    m_delegate.initialize("MoveDelegate", "MoveDelegate");
-    m_delegate.setDelegateBridgeAndPlayer(bridge);
+    delegate = new MoveDelegate();
+    delegate.initialize("MoveDelegate", "MoveDelegate");
+    delegate.setDelegateBridgeAndPlayer(bridge);
     bridge.setStepName("japaneseNonCombatMove");
-    m_delegate.start();
+    delegate.start();
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(infantry, 1);
     final Route route = new Route();
-    route.setStart(Bonin);
+    route.setStart(bonin);
     // movement to force boarding
-    route.add(SZ24);
+    route.add(sz24);
     // verify unit counts before move
-    assertEquals(2, Bonin.getUnits().size());
-    assertEquals(1, SZ24.getUnits().size());
+    assertEquals(2, bonin.getUnits().size());
+    assertEquals(1, sz24.getUnits().size());
     // validate movement
     final String results =
-        m_delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+        delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     // verify unit counts after move
-    assertEquals(1, Bonin.getUnits().size());
-    assertEquals(2, SZ24.getUnits().size());
+    assertEquals(1, bonin.getUnits().size());
+    assertEquals(2, sz24.getUnits().size());
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/Pacific_1940_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/Pacific_1940_Test.java
@@ -18,16 +18,16 @@ import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.IntegerMap;
 
 public class Pacific_1940_Test {
-  private GameData m_data;
+  private GameData gameData;
 
   @Before
   protected void setUp() throws Exception {
-    m_data = TestMapGameData.WW2PAC40.getGameData();
+    gameData = TestMapGameData.WW2PAC40.getGameData();
   }
 
   @SuppressWarnings("unused")
   private ITestDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, m_data);
+    return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
   public void test() {

--- a/src/test/java/games/strategy/triplea/delegate/Pact_of_Steel_2_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/Pact_of_Steel_2_Test.java
@@ -25,27 +25,27 @@ import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
 public class Pact_of_Steel_2_Test {
-  private GameData m_data;
+  private GameData gameData;
 
   @Before
   public void setUp() throws Exception {
-    m_data = TestMapGameData.PACT_OF_STEEL_2.getGameData();
+    gameData = TestMapGameData.PACT_OF_STEEL_2.getGameData();
   }
 
   private ITestDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, m_data);
+    return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
   @Test
   public void testDirectOwnershipTerritories() {
-    final Territory Norway = m_data.getMap().getTerritory("Norway");
-    final Territory Eastern_Europe = m_data.getMap().getTerritory("Eastern Europe");
-    final Territory East_Balkans = m_data.getMap().getTerritory("East Balkans");
-    final Territory Ukraine_S_S_R_ = m_data.getMap().getTerritory("Ukraine S.S.R.");
-    final Territory Belorussia = m_data.getMap().getTerritory("Belorussia");
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
+    final Territory Norway = gameData.getMap().getTerritory("Norway");
+    final Territory Eastern_Europe = gameData.getMap().getTerritory("Eastern Europe");
+    final Territory East_Balkans = gameData.getMap().getTerritory("East Balkans");
+    final Territory Ukraine_S_S_R_ = gameData.getMap().getTerritory("Ukraine S.S.R.");
+    final Territory Belorussia = gameData.getMap().getTerritory("Belorussia");
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(russians);
     // this National Objective russia has to own at least 3 of the 5 territories by itself
     final RulesAttachment russian_easternEurope =

--- a/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -23,22 +23,22 @@ import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.util.IntegerMap;
 
 public class PlaceDelegateTest extends DelegateTest {
-  protected PlaceDelegate m_delegate;
-  protected ITestDelegateBridge m_bridge;
+  protected PlaceDelegate delegate;
+  protected ITestDelegateBridge bridge;
 
   private Collection<Unit> getInfantry(final int count, final PlayerID player) {
-    return m_data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INFANTRY).create(count, player);
+    return gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INFANTRY).create(count, player);
   }
 
   @Override
   @Before
   public void setUp() throws Exception {
     super.setUp();
-    m_bridge = super.getDelegateBridge(british);
-    m_delegate = new PlaceDelegate();
-    m_delegate.initialize("place");
-    m_delegate.setDelegateBridgeAndPlayer(m_bridge);
-    m_delegate.start();
+    bridge = super.getDelegateBridge(british);
+    delegate = new PlaceDelegate();
+    delegate.initialize("place");
+    delegate.setDelegateBridgeAndPlayer(bridge);
+    delegate.start();
   }
 
   private Collection<Unit> getUnits(final IntegerMap<UnitType> units, final PlayerID from) {
@@ -55,14 +55,14 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testValid() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = m_delegate.placeUnits(getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    final String response = delegate.placeUnits(getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
   }
 
   @Test
   public void testNotCorrectUnitsValid() {
     final String response =
-        m_delegate.placeUnits(infantry.create(3, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
+        delegate.placeUnits(infantry.create(3, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertError(response);
   }
 
@@ -70,7 +70,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testOnlySeaInSeaZone() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = m_delegate.canUnitsBePlaced(northSea, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(northSea, getUnits(map, british), british);
     assertError(response);
   }
 
@@ -78,7 +78,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testSeaCanGoInSeaZone() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(transport, 2);
-    final String response = m_delegate.canUnitsBePlaced(northSea, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(northSea, getUnits(map, british), british);
     assertValid(response);
   }
 
@@ -86,7 +86,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testLandCanGoInLandZone() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = m_delegate.placeUnits(getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    final String response = delegate.placeUnits(getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
   }
 
@@ -94,7 +94,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testSeaCantGoInSeaInLandZone() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(transport, 2);
-    final String response = m_delegate.canUnitsBePlaced(uk, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(uk, getUnits(map, british), british);
     assertError(response);
   }
 
@@ -102,7 +102,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testNoGoIfOpposingTroopsSea() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(transport, 2);
-    final String response = m_delegate.canUnitsBePlaced(northSea, getUnits(map, japanese), japanese);
+    final String response = delegate.canUnitsBePlaced(northSea, getUnits(map, japanese), japanese);
     assertError(response);
   }
 
@@ -110,7 +110,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testNoGoIfOpposingTroopsLand() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = m_delegate.canUnitsBePlaced(japan, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(japan, getUnits(map, british), british);
     assertError(response);
   }
 
@@ -118,7 +118,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testOnlyOneFactoryPlaced() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(factory, 1);
-    final String response = m_delegate.canUnitsBePlaced(uk, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(uk, getUnits(map, british), british);
     assertError(response);
   }
 
@@ -126,7 +126,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testCantPlaceAAWhenOneAlreadyThere() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(aaGun, 1);
-    final String response = m_delegate.canUnitsBePlaced(uk, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(uk, getUnits(map, british), british);
     assertError(response);
   }
 
@@ -134,7 +134,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testCantPlaceTwoAA() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(aaGun, 2);
-    final String response = m_delegate.canUnitsBePlaced(westCanada, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(westCanada, getUnits(map, british), british);
     assertError(response);
   }
 
@@ -142,7 +142,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testProduceFactory() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(factory, 1);
-    final String response = m_delegate.canUnitsBePlaced(egypt, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(egypt, getUnits(map, british), british);
     assertValid(response);
   }
 
@@ -150,7 +150,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testMustOwnToPlace() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = m_delegate.canUnitsBePlaced(germany, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(germany, getUnits(map, british), british);
     assertError(response);
   }
 
@@ -158,7 +158,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testCanProduce() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final PlaceableUnits response = m_delegate.getPlaceableUnits(getUnits(map, british), westCanada);
+    final PlaceableUnits response = delegate.getPlaceableUnits(getUnits(map, british), westCanada);
     assertFalse(response.isError());
   }
 
@@ -166,7 +166,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testCanProduceInSea() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(transport, 2);
-    final PlaceableUnits response = m_delegate.getPlaceableUnits(getUnits(map, british), northSea);
+    final PlaceableUnits response = delegate.getPlaceableUnits(getUnits(map, british), northSea);
     assertFalse(response.isError());
   }
 
@@ -174,7 +174,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testCanNotProduceThatManyUnits() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 3);
-    final PlaceableUnits response = m_delegate.getPlaceableUnits(getUnits(map, british), westCanada);
+    final PlaceableUnits response = delegate.getPlaceableUnits(getUnits(map, british), westCanada);
     assertTrue(response.getMaxUnits() == 2);
   }
 
@@ -183,9 +183,9 @@ public class PlaceDelegateTest extends DelegateTest {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     final Map<Territory, Collection<Unit>> alreadyProduced = new HashMap<>();
     alreadyProduced.put(westCanada, getInfantry(2, british));
-    m_delegate.setProduced(alreadyProduced);
+    delegate.setProduced(alreadyProduced);
     map.add(infantry, 1);
-    final PlaceableUnits response = m_delegate.getPlaceableUnits(getUnits(map, british), westCanada);
+    final PlaceableUnits response = delegate.getPlaceableUnits(getUnits(map, british), westCanada);
     assertTrue(response.getMaxUnits() == 0);
   }
 
@@ -193,13 +193,13 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testMultipleFactories() {
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(factory, 1);
-    String response = m_delegate.canUnitsBePlaced(egypt, getUnits(map, british), british);
+    String response = delegate.canUnitsBePlaced(egypt, getUnits(map, british), british);
     // we can place 1 factory
     assertValid(response);
     // we cant place 2
     map = new IntegerMap<>();
     map.add(factory, 2);
-    response = m_delegate.canUnitsBePlaced(egypt, getUnits(map, british), british);
+    response = delegate.canUnitsBePlaced(egypt, getUnits(map, british), british);
     assertError(response);
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/StratBombTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/StratBombTest.java
@@ -28,30 +28,30 @@ import games.strategy.triplea.xml.TestMapGameData;
 // Test Global 1940 feature of having AA for each individual facility firing at bombers which are attacking it
 
 public class StratBombTest {
-  private GameData m_data;
+  private GameData gameData;
 
   @Before
   public void setUp() throws Exception {
-    m_data = TestMapGameData.GLOBAL1940.getGameData();
+    gameData = TestMapGameData.GLOBAL1940.getGameData();
   }
 
   private ITestDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, m_data);
+    return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
 
   @Test
   public void TestBombingRaidInvidualAA() {
-    final Territory wgermany = m_data.getMap().getTerritory("Western Germany");
-    final Territory uk = m_data.getMap().getTerritory("United Kingdom");
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    final Territory wgermany = gameData.getMap().getTerritory("Western Germany");
+    final Territory uk = gameData.getMap().getTerritory("United Kingdom");
+    final PlayerID british = GameDataTestUtil.british(gameData);
     // add a unit
-    final Unit stratBomber = GameDataTestUtil.bomber(m_data).create(british);
-    final Unit tacBomber1 = GameDataTestUtil.tacBomber(m_data).create(british);
-    final Unit tacBomber2 = GameDataTestUtil.tacBomber(m_data).create(british);
-    m_data.performChange(ChangeFactory.addUnits(uk, Collections.singleton(stratBomber)));
-    m_data.performChange(ChangeFactory.addUnits(uk, Collections.singleton(tacBomber1)));
-    m_data.performChange(ChangeFactory.addUnits(uk, Collections.singleton(tacBomber2)));
+    final Unit stratBomber = GameDataTestUtil.bomber(gameData).create(british);
+    final Unit tacBomber1 = GameDataTestUtil.tacBomber(gameData).create(british);
+    final Unit tacBomber2 = GameDataTestUtil.tacBomber(gameData).create(british);
+    gameData.performChange(ChangeFactory.addUnits(uk, Collections.singleton(stratBomber)));
+    gameData.performChange(ChangeFactory.addUnits(uk, Collections.singleton(tacBomber1)));
+    gameData.performChange(ChangeFactory.addUnits(uk, Collections.singleton(tacBomber2)));
     final BattleTracker tracker = new BattleTracker();
     List<Unit> attackers = new ArrayList<>();
     attackers.add(stratBomber);
@@ -84,7 +84,7 @@ public class StratBombTest {
 
     final StrategicBombingRaidBattle battle =
         (StrategicBombingRaidBattle) tracker.getPendingBattle(wgermany, true, null);
-    battle.addAttackChange(m_data.getMap().getRoute(uk, wgermany),
+    battle.addAttackChange(gameData.getMap().getRoute(uk, wgermany),
         uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), null);
     // addTo(wgermany, uk.getUnits().getMatches(Matches.UnitIsStrategicBomber));
     tracker.getBattleRecords().addBattle(british, battle.getBattleID(), wgermany, battle.getBattleType());

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -100,7 +100,7 @@ import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
 public class WW2V3_41_Test {
-  private GameData m_data;
+  private GameData gameData;
   private final ITripleAPlayer dummyPlayer = mock(ITripleAPlayer.class);
 
   @Before
@@ -116,11 +116,11 @@ public class WW2V3_41_Test {
             return null;
           }
         });
-    m_data = TestMapGameData.WW2V3_1941.getGameData();
+    gameData = TestMapGameData.WW2V3_1941.getGameData();
   }
 
   private ITestDelegateBridge getDelegateBridge(final PlayerID player) {
-    return GameDataTestUtil.getDelegateBridge(player, m_data);
+    return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
   public static String fight(final BattleDelegate battle, final Territory territory) {
@@ -135,16 +135,16 @@ public class WW2V3_41_Test {
   @Test
   public void testAACasualtiesLowLuckMixedRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge m_bridge = getDelegateBridge(british);
-    makeGameLowLuck(m_data);
+    makeGameLowLuck(gameData);
     // setSelectAACasualties(data, false);
-    givePlayerRadar(germans(m_data));
+    givePlayerRadar(germans(gameData));
     // 3 bombers and 3 fighters
-    final Collection<Unit> planes = bomber(m_data).create(3, british(m_data));
-    planes.addAll(fighter(m_data).create(3, british(m_data)));
+    final Collection<Unit> planes = bomber(gameData).create(3, british(gameData));
+    planes.addAll(fighter(gameData).create(3, british(gameData)));
     final Collection<Unit> defendingAA =
-        territory("Germany", m_data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+        territory("Germany", gameData).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // don't allow rolling, 6 of each is deterministic
     m_bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
@@ -152,10 +152,10 @@ public class WW2V3_41_Test {
             .rollAA(
                 Match.getMatches(planes,
                     Matches.unitIsOfTypes(
-                        UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(m_data))),
-                defendingAA, m_bridge, territory("Germany", m_data), true);
+                        UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(gameData))),
+                defendingAA, m_bridge, territory("Germany", gameData), true);
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", m_data), null, false, null).getKilled();
+        defendingAA, roll, m_bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // should be 1 fighter and 1 bomber
     assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);
@@ -165,16 +165,16 @@ public class WW2V3_41_Test {
   @Test
   public void testAACasualtiesLowLuckMixedWithRollingRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge m_bridge = getDelegateBridge(british);
-    makeGameLowLuck(m_data);
+    makeGameLowLuck(gameData);
     // setSelectAACasualties(data, false);
-    givePlayerRadar(germans(m_data));
+    givePlayerRadar(germans(gameData));
     // 4 bombers and 4 fighters
-    final Collection<Unit> planes = bomber(m_data).create(4, british(m_data));
-    planes.addAll(fighter(m_data).create(4, british(m_data)));
+    final Collection<Unit> planes = bomber(gameData).create(4, british(gameData));
+    planes.addAll(fighter(gameData).create(4, british(gameData)));
     final Collection<Unit> defendingAA =
-        territory("Germany", m_data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+        territory("Germany", gameData).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // 1 roll, a hit
     // then a dice to select the casualty
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, 1});
@@ -184,12 +184,12 @@ public class WW2V3_41_Test {
             .rollAA(
                 Match.getMatches(planes,
                     Matches.unitIsOfTypes(
-                        UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(m_data))),
-                defendingAA, m_bridge, territory("Germany", m_data), true);
+                        UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(gameData))),
+                defendingAA, m_bridge, territory("Germany", gameData), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", m_data), null, false, null).getKilled();
+        defendingAA, roll, m_bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // should be 1 fighter and 2 bombers
     assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 2);
@@ -199,16 +199,16 @@ public class WW2V3_41_Test {
   @Test
   public void testAACasualtiesLowLuckMixedWithRollingMissRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
-    final PlayerID british = GameDataTestUtil.british(m_data);
+    final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge m_bridge = getDelegateBridge(british);
-    makeGameLowLuck(m_data);
+    makeGameLowLuck(gameData);
     // setSelectAACasualties(data, false);
-    givePlayerRadar(germans(m_data));
+    givePlayerRadar(germans(gameData));
     // 4 bombers and 4 fighters
-    final Collection<Unit> planes = bomber(m_data).create(4, british(m_data));
-    planes.addAll(fighter(m_data).create(4, british(m_data)));
+    final Collection<Unit> planes = bomber(gameData).create(4, british(gameData));
+    planes.addAll(fighter(gameData).create(4, british(gameData)));
     final Collection<Unit> defendingAA =
-        territory("Germany", m_data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+        territory("Germany", gameData).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // 1 roll, a miss
     // then a dice to select the casualty
     final ScriptedRandomSource randomSource =
@@ -219,13 +219,13 @@ public class WW2V3_41_Test {
             .rollAA(
                 Match.getMatches(planes,
                     Matches.unitIsOfTypes(
-                        UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(m_data))),
-                defendingAA, m_bridge, territory("Germany", m_data), true);
+                        UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(gameData))),
+                defendingAA, m_bridge, territory("Germany", gameData), true);
     assertEquals(roll.getHits(), 2);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", m_data), null, false, null).getKilled();
+        defendingAA, roll, m_bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     assertEquals(4, randomSource.getTotalRolled());
     // should be 1 fighter and 2 bombers
@@ -235,10 +235,10 @@ public class WW2V3_41_Test {
 
   @Test
   public void testDefendingTrasnportsAutoKilled() {
-    final Territory sz13 = m_data.getMap().getTerritory("13 Sea Zone");
-    final Territory sz12 = m_data.getMap().getTerritory("12 Sea Zone");
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
+    final Territory sz13 = gameData.getMap().getTerritory("13 Sea Zone");
+    final Territory sz12 = gameData.getMap().getTerritory("12 Sea Zone");
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(british);
     bridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
@@ -252,28 +252,28 @@ public class WW2V3_41_Test {
     moveDelegate.end();
     // the transport was not removed automatically
     assertEquals(sz13.getUnits().size(), 3);
-    final BattleDelegate bd = battleDelegate(m_data);
+    final BattleDelegate bd = battleDelegate(gameData);
     assertFalse(bd.getBattleTracker().getPendingBattleSites(false).isEmpty());
   }
 
   @Test
   public void testUnplacedDie() {
-    final PlaceDelegate del = placeDelegate(m_data);
-    del.setDelegateBridgeAndPlayer(getDelegateBridge(british(m_data)));
+    final PlaceDelegate del = placeDelegate(gameData);
+    del.setDelegateBridgeAndPlayer(getDelegateBridge(british(gameData)));
     del.start();
-    addTo(british(m_data), transport(m_data).create(1, british(m_data)), m_data);
+    addTo(british(gameData), transport(gameData).create(1, british(gameData)), gameData);
     del.end();
     // unplaced units die
-    assertEquals(1, british(m_data).getUnits().size());
+    assertEquals(1, british(gameData).getUnits().size());
   }
 
   @Test
   public void testPlaceEmpty() {
-    final PlaceDelegate del = placeDelegate(m_data);
-    del.setDelegateBridgeAndPlayer(getDelegateBridge(british(m_data)));
+    final PlaceDelegate del = placeDelegate(gameData);
+    del.setDelegateBridgeAndPlayer(getDelegateBridge(british(gameData)));
     del.start();
-    addTo(british(m_data), transport(m_data).create(1, british(m_data)), m_data);
-    final String error = del.placeUnits(Collections.<Unit>emptyList(), territory("United Kingdom", m_data),
+    addTo(british(gameData), transport(gameData).create(1, british(gameData)), gameData);
+    final String error = del.placeUnits(Collections.<Unit>emptyList(), territory("United Kingdom", gameData),
         IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertNull(error);
   }
@@ -281,17 +281,17 @@ public class WW2V3_41_Test {
   @Test
   public void testTechTokens() {
     // Set up the test
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
     final ITestDelegateBridge delegateBridge = getDelegateBridge(germans);
     delegateBridge.setStepName("germanTech");
-    final TechnologyDelegate techDelegate = techDelegate(m_data);
+    final TechnologyDelegate techDelegate = techDelegate(gameData);
     techDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     techDelegate.start();
-    final TechnologyFrontier mech = new TechnologyFrontier("", m_data);
-    mech.addAdvance(TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_MECHANIZED_INFANTRY, m_data, null));
+    final TechnologyFrontier mech = new TechnologyFrontier("", gameData);
+    mech.addAdvance(TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_MECHANIZED_INFANTRY, gameData, null));
     // Add tech token
-    m_data.performChange(
-        ChangeFactory.changeResourcesChange(germans, m_data.getResourceList().getResource(Constants.TECH_TOKENS), 1));
+    gameData.performChange(
+        ChangeFactory.changeResourcesChange(germans, gameData.getResourceList().getResource(Constants.TECH_TOKENS), 1));
     // Check to make sure it was successful
     final int initTokens = germans.getResources().getQuantity("techTokens");
     assertEquals(1, initTokens);
@@ -313,26 +313,26 @@ public class WW2V3_41_Test {
 
   @Test
   public void testInfantryLoadOnlyTransports() {
-    final Territory gibraltar = territory("Gibraltar", m_data);
+    final Territory gibraltar = territory("Gibraltar", gameData);
     // add a tank to gibralter
-    final PlayerID british = british(m_data);
-    addTo(gibraltar, infantry(m_data).create(1, british));
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
+    final PlayerID british = british(gameData);
+    addTo(gibraltar, infantry(gameData).create(1, british));
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(british);
     bridge.setStepName("britishCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
     bridge.setRemote(dummyPlayer);
-    final Territory sz9 = territory("9 Sea Zone", m_data);
-    final Territory sz13 = territory("13 Sea Zone", m_data);
-    final Route sz9ToSz13 = new Route(sz9, territory("12 Sea Zone", m_data), sz13);
+    final Territory sz9 = territory("9 Sea Zone", gameData);
+    final Territory sz13 = territory("13 Sea Zone", gameData);
+    final Route sz9ToSz13 = new Route(sz9, territory("12 Sea Zone", gameData), sz13);
     // move the transport to attack, this is suicide but valid
     move(sz9.getUnits().getMatches(Matches.UnitIsTransport), sz9ToSz13);
     // load the transport
     load(gibraltar.getUnits().getUnits(), new Route(gibraltar, sz13));
     moveDelegate.end();
     bridge.setStepName("britishBattle");
-    final BattleDelegate battleDelegate = battleDelegate(m_data);
+    final BattleDelegate battleDelegate = battleDelegate(gameData);
     battleDelegate.setDelegateBridgeAndPlayer(bridge);
     battleDelegate.start();
     assertTrue(battleDelegate.getBattles().isEmpty());
@@ -340,28 +340,28 @@ public class WW2V3_41_Test {
 
   @Test
   public void testLoadedTransportAttackKillsLoadedUnits() {
-    final PlayerID british = british(m_data);
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
+    final PlayerID british = british(gameData);
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(british);
     bridge.setStepName("britishCombatMove");
     when(dummyPlayer.selectAttackSubs(any())).thenReturn(true);
     bridge.setRemote(dummyPlayer);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final Territory sz9 = territory("9 Sea Zone", m_data);
-    final Territory sz7 = territory("7 Sea Zone", m_data);
-    final Territory uk = territory("United Kingdom", m_data);
-    final Route sz9ToSz7 = new Route(sz9, territory("8 Sea Zone", m_data), sz7);
+    final Territory sz9 = territory("9 Sea Zone", gameData);
+    final Territory sz7 = territory("7 Sea Zone", gameData);
+    final Territory uk = territory("United Kingdom", gameData);
+    final Route sz9ToSz7 = new Route(sz9, territory("8 Sea Zone", gameData), sz7);
     // move the transport to attack, this is suicide but valid
     final List<Unit> transports = sz9.getUnits().getMatches(Matches.UnitIsTransport);
     move(transports, sz9ToSz7);
     // load the transport
     load(uk.getUnits().getMatches(Matches.UnitIsInfantry), new Route(uk, sz7));
-    moveDelegate(m_data).end();
+    moveDelegate(gameData).end();
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, 1});
     bridge.setRandomSource(randomSource);
     bridge.setStepName("britishBattle");
-    final BattleDelegate battleDelegate = battleDelegate(m_data);
+    final BattleDelegate battleDelegate = battleDelegate(gameData);
     battleDelegate.setDelegateBridgeAndPlayer(bridge);
     assertEquals(2, TransportTracker.transporting(transports.get(0)).size());
     battleDelegate.start();
@@ -372,17 +372,17 @@ public class WW2V3_41_Test {
 
   @Test
   public void testCanRetreatIntoEmptyEnemyTerritory() {
-    final Territory eastPoland = territory("East Poland", m_data);
-    final Territory ukraine = territory("Ukraine", m_data);
-    final Territory poland = territory("Poland", m_data);
+    final Territory eastPoland = territory("East Poland", gameData);
+    final Territory ukraine = territory("Ukraine", gameData);
+    final Territory poland = territory("Poland", gameData);
     // remove all units from east poland
     removeFrom(eastPoland, eastPoland.getUnits().getUnits());
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(germans(m_data));
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
     delegateBridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
-    final Territory bulgaria = territory("Bulgaria Romania", m_data);
+    final Territory bulgaria = territory("Bulgaria Romania", gameData);
     // attack from bulgraia
     move(bulgaria.getUnits().getUnits(), new Route(bulgaria, ukraine));
     // add an air attack from east poland
@@ -390,23 +390,23 @@ public class WW2V3_41_Test {
     // we should not be able to retreat to east poland!
     // that territory is still owned by the enemy
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(m_data).getPendingBattle(ukraine, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(ukraine, false, null);
     assertFalse(battle.getAttackerRetreatTerritories().contains(eastPoland));
   }
 
   @Test
   public void testCanRetreatIntoBlitzedTerritory() {
-    final Territory eastPoland = territory("East Poland", m_data);
-    final Territory ukraine = territory("Ukraine", m_data);
-    final Territory poland = territory("Poland", m_data);
+    final Territory eastPoland = territory("East Poland", gameData);
+    final Territory ukraine = territory("Ukraine", gameData);
+    final Territory poland = territory("Poland", gameData);
     // remove all units from east poland
     removeFrom(eastPoland, eastPoland.getUnits().getUnits());
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(germans(m_data));
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
     delegateBridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
-    final Territory bulgaria = territory("Bulgaria Romania", m_data);
+    final Territory bulgaria = territory("Bulgaria Romania", gameData);
     // attack from bulgraia
     move(bulgaria.getUnits().getUnits(), new Route(bulgaria, ukraine));
     // add a blitz attack
@@ -414,22 +414,22 @@ public class WW2V3_41_Test {
     // we should not be able to retreat to east poland!
     // that territory was just conquered
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(m_data).getPendingBattle(ukraine, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(ukraine, false, null);
     assertTrue(battle.getAttackerRetreatTerritories().contains(eastPoland));
   }
 
   @Test
   public void testCantBlitzFactoryOrAA() {
     // Set up territories
-    final Territory poland = territory("Poland", m_data);
-    final Territory eastPoland = territory("East Poland", m_data);
-    final Territory ukraine = territory("Ukraine", m_data);
+    final Territory poland = territory("Poland", gameData);
+    final Territory eastPoland = territory("East Poland", gameData);
+    final Territory ukraine = territory("Ukraine", gameData);
     // remove all units from east poland
     removeFrom(eastPoland, eastPoland.getUnits().getUnits());
     // Add a russian factory
-    addTo(eastPoland, factory(m_data).create(1, russians(m_data)));
-    MoveDelegate moveDelegate = moveDelegate(m_data);
-    ITestDelegateBridge delegateBridge = getDelegateBridge(germans(m_data));
+    addTo(eastPoland, factory(gameData).create(1, russians(gameData)));
+    MoveDelegate moveDelegate = moveDelegate(gameData);
+    ITestDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
     delegateBridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -443,9 +443,9 @@ public class WW2V3_41_Test {
     // remove all units from east poland
     removeFrom(eastPoland, eastPoland.getUnits().getUnits());
     // Add a russian factory
-    addTo(eastPoland, aaGun(m_data).create(1, russians(m_data)));
-    moveDelegate = moveDelegate(m_data);
-    delegateBridge = getDelegateBridge(germans(m_data));
+    addTo(eastPoland, aaGun(gameData).create(1, russians(gameData)));
+    moveDelegate = moveDelegate(gameData);
+    delegateBridge = getDelegateBridge(germans(gameData));
     delegateBridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -458,12 +458,12 @@ public class WW2V3_41_Test {
   @Test
   public void testMultipleAAInTerritory() {
     // Set up territories
-    final Territory poland = territory("Poland", m_data);
+    final Territory poland = territory("Poland", gameData);
     // Add a russian factory
-    final Territory germany = territory("Germany", m_data);
-    addTo(poland, aaGun(m_data).create(1, germans(m_data)));
-    MoveDelegate moveDelegate = moveDelegate(m_data);
-    ITestDelegateBridge delegateBridge = getDelegateBridge(germans(m_data));
+    final Territory germany = territory("Germany", gameData);
+    addTo(poland, aaGun(gameData).create(1, germans(gameData)));
+    MoveDelegate moveDelegate = moveDelegate(gameData);
+    ITestDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
     delegateBridge.setStepName("NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -478,11 +478,11 @@ public class WW2V3_41_Test {
     /*
      * Test unloading TRN
      */
-    final Territory finland = territory("Finland", m_data);
-    final Territory sz5 = territory("5 Sea Zone", m_data);
-    addTo(finland, aaGun(m_data).create(1, germans(m_data)));
-    moveDelegate = moveDelegate(m_data);
-    delegateBridge = getDelegateBridge(germans(m_data));
+    final Territory finland = territory("Finland", gameData);
+    final Territory sz5 = territory("5 Sea Zone", gameData);
+    addTo(finland, aaGun(gameData).create(1, germans(gameData)));
+    moveDelegate = moveDelegate(gameData);
+    delegateBridge = getDelegateBridge(germans(gameData));
     delegateBridge.setStepName("NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
@@ -497,17 +497,17 @@ public class WW2V3_41_Test {
     /*
      * Test Building one
      */
-    final UnitType aaGun = GameDataTestUtil.aaGun(m_data);
+    final UnitType aaGun = GameDataTestUtil.aaGun(gameData);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(aaGun, 1);
     // Set up the test
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final PlaceDelegate placeDelegate = placeDelegate(m_data);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final PlaceDelegate placeDelegate = placeDelegate(gameData);
     delegateBridge.setStepName("Place");
     delegateBridge.setPlayerID(germans);
-    placeDelegate.setDelegateBridgeAndPlayer(getDelegateBridge(germans(m_data)));
+    placeDelegate.setDelegateBridgeAndPlayer(getDelegateBridge(germans(gameData)));
     placeDelegate.start();
-    addTo(germans(m_data), aaGun(m_data).create(1, germans(m_data)), m_data);
+    addTo(germans(gameData), aaGun(gameData).create(1, germans(gameData)), gameData);
     errorResults = placeDelegate.placeUnits(getUnits(map, germans), germany, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(errorResults);
     assertEquals(germany.getUnits().getUnitCount(), preCount + 3);
@@ -516,21 +516,21 @@ public class WW2V3_41_Test {
   @Test
   public void testMechanizedInfantry() {
     // Set up tech
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(germans(m_data));
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
     TechTracker.addAdvance(germans, delegateBridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_MECHANIZED_INFANTRY, m_data, germans));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_MECHANIZED_INFANTRY, gameData, germans));
     // Set up the move delegate
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
     delegateBridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
     // Set up the territories
-    final Territory poland = territory("Poland", m_data);
-    final Territory eastPoland = territory("East Poland", m_data);
-    final Territory belorussia = territory("Belorussia", m_data);
+    final Territory poland = territory("Poland", gameData);
+    final Territory eastPoland = territory("East Poland", gameData);
+    final Territory belorussia = territory("Belorussia", gameData);
     // Set up the unit types
-    final UnitType infantryType = GameDataTestUtil.infantry(m_data);
+    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     // Remove all units from east poland
     removeFrom(eastPoland, eastPoland.getUnits().getUnits());
     // Get total number of units in territories to start
@@ -560,18 +560,18 @@ public class WW2V3_41_Test {
   @Test
   public void testJetPower() {
     // Set up tech
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(germans(m_data));
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
     TechTracker.addAdvance(germans, delegateBridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_JET_POWER, m_data, germans));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_JET_POWER, gameData, germans));
     // Set up the territories
-    final Territory poland = territory("Poland", m_data);
-    final Territory eastPoland = territory("East Poland", m_data);
+    final Territory poland = territory("Poland", gameData);
+    final Territory eastPoland = territory("East Poland", gameData);
     // Set up the unit types
-    final UnitType fighterType = GameDataTestUtil.fighter(m_data);
+    final UnitType fighterType = GameDataTestUtil.fighter(gameData);
     delegateBridge.setStepName("germanBattle");
-    while (!m_data.getSequence().getStep().getName().equals("germanBattle")) {
-      m_data.getSequence().next();
+    while (!gameData.getSequence().getStep().getName().equals("germanBattle")) {
+      gameData.getSequence().next();
     }
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(eastPoland);
     // With JET_POWER attacking fighter hits on 4 (0 base)
@@ -589,32 +589,32 @@ public class WW2V3_41_Test {
 
   @Test
   public void testBidPlace() {
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData));
     bridge.setStepName("BidPlace");
-    bidPlaceDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    bidPlaceDelegate(m_data).start();
+    bidPlaceDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    bidPlaceDelegate(gameData).start();
     // create 20 british infantry
-    addTo(british(m_data), infantry(m_data).create(20, british(m_data)), m_data);
-    final Territory uk = territory("United Kingdom", m_data);
-    final Collection<Unit> units = british(m_data).getUnits().getUnits();
-    final PlaceableUnits placeable = bidPlaceDelegate(m_data).getPlaceableUnits(units, uk);
+    addTo(british(gameData), infantry(gameData).create(20, british(gameData)), gameData);
+    final Territory uk = territory("United Kingdom", gameData);
+    final Collection<Unit> units = british(gameData).getUnits().getUnits();
+    final PlaceableUnits placeable = bidPlaceDelegate(gameData).getPlaceableUnits(units, uk);
     assertEquals(20, placeable.getMaxUnits());
     assertNull(placeable.getErrorMessage());
-    final String error = bidPlaceDelegate(m_data).placeUnits(units, uk);
+    final String error = bidPlaceDelegate(gameData).placeUnits(units, uk);
     assertNull(error);
   }
 
   @Test
   public void testFactoryPlace() {
     // Set up game
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(british(m_data));
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
     // Set up the territories
-    final Territory egypt = territory("Union of South Africa", m_data);
+    final Territory egypt = territory("Union of South Africa", gameData);
     // Set up the unit types
-    final UnitType factoryType = GameDataTestUtil.factory(m_data);
+    final UnitType factoryType = GameDataTestUtil.factory(gameData);
     // Set up the move delegate
-    final PlaceDelegate placeDelegate = placeDelegate(m_data);
+    final PlaceDelegate placeDelegate = placeDelegate(gameData);
     delegateBridge.setStepName("Place");
     delegateBridge.setPlayerID(british);
     placeDelegate.setDelegateBridgeAndPlayer(delegateBridge);
@@ -622,7 +622,7 @@ public class WW2V3_41_Test {
     // Add the factory
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(factoryType, 1);
-    addTo(british(m_data), factory(m_data).create(1, british(m_data)), m_data);
+    addTo(british(gameData), factory(gameData).create(1, british(gameData)), gameData);
     // Place the factory
     final String response = placeDelegate.placeUnits(getUnits(map, british), egypt);
     assertValid(response);
@@ -640,19 +640,19 @@ public class WW2V3_41_Test {
      * with up to 3 Chinese units in them.
      */
     // Set up game
-    final PlayerID chinese = GameDataTestUtil.chinese(m_data);
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(chinese(m_data));
+    final PlayerID chinese = GameDataTestUtil.chinese(gameData);
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(chinese(gameData));
     delegateBridge.setPlayerID(chinese);
     delegateBridge.setStepName("CombatMove");
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
     // Set up the territories
-    final Territory yunnan = territory("Yunnan", m_data);
-    final Territory kiangsu = territory("Kiangsu", m_data);
-    final Territory hupeh = territory("Hupeh", m_data);
+    final Territory yunnan = territory("Yunnan", gameData);
+    final Territory kiangsu = territory("Kiangsu", gameData);
+    final Territory hupeh = territory("Hupeh", gameData);
     // Set up the unit types
-    final UnitType infantryType = GameDataTestUtil.infantry(m_data);
+    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     // Remove all units
     removeFrom(kiangsu, kiangsu.getUnits().getUnits());
     // add a VALID attack
@@ -662,14 +662,14 @@ public class WW2V3_41_Test {
     /*
      * Place units in just captured territory
      */
-    final PlaceDelegate placeDelegate = placeDelegate(m_data);
+    final PlaceDelegate placeDelegate = placeDelegate(gameData);
     delegateBridge.setStepName("Place");
     placeDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     placeDelegate.start();
     // Add the infantry
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantryType, 3);
-    addTo(chinese(m_data), infantry(m_data).create(1, chinese(m_data)), m_data);
+    addTo(chinese(gameData), infantry(gameData).create(1, chinese(gameData)), gameData);
     // Get the number of units before placing
     int preCount = kiangsu.getUnits().getUnitCount();
     // Place the infantry
@@ -682,7 +682,7 @@ public class WW2V3_41_Test {
     // Add the infantry
     map = new IntegerMap<>();
     map.add(infantryType, 3);
-    addTo(chinese(m_data), infantry(m_data).create(3, chinese(m_data)), m_data);
+    addTo(chinese(gameData), infantry(gameData).create(3, chinese(gameData)), gameData);
     // Get the number of units before placing
     preCount = yunnan.getUnits().getUnitCount();
     // Place the infantry
@@ -696,7 +696,7 @@ public class WW2V3_41_Test {
      */
     map = new IntegerMap<>();
     map.add(infantryType, 1);
-    addTo(chinese(m_data), infantry(m_data).create(1, chinese(m_data)), m_data);
+    addTo(chinese(gameData), infantry(gameData).create(1, chinese(gameData)), gameData);
     response = placeDelegate.placeUnits(getUnits(map, chinese), yunnan, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertError(response);
     // Make sure none were placed
@@ -707,16 +707,16 @@ public class WW2V3_41_Test {
   @Test
   public void testPlaceInOccupiedSZ() {
     // Set up game
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(british(m_data));
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
     // Clear all units from the SZ and add an enemy unit
-    final Territory sz5 = territory("5 Sea Zone", m_data);
+    final Territory sz5 = territory("5 Sea Zone", gameData);
     removeFrom(sz5, sz5.getUnits().getUnits());
-    addTo(sz5, destroyer(m_data).create(1, british(m_data)));
+    addTo(sz5, destroyer(gameData).create(1, british(gameData)));
     // Set up the unit types
-    final UnitType transportType = GameDataTestUtil.transport(m_data);
+    final UnitType transportType = GameDataTestUtil.transport(gameData);
     // Set up the move delegate
-    final PlaceDelegate placeDelegate = placeDelegate(m_data);
+    final PlaceDelegate placeDelegate = placeDelegate(gameData);
     delegateBridge.setStepName("Place");
     delegateBridge.setPlayerID(germans);
     placeDelegate.setDelegateBridgeAndPlayer(delegateBridge);
@@ -724,7 +724,7 @@ public class WW2V3_41_Test {
     // Add the transport
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(transportType, 1);
-    addTo(germans(m_data), transport(m_data).create(1, germans(m_data)), m_data);
+    addTo(germans(gameData), transport(gameData).create(1, germans(gameData)), gameData);
     // Place it
     final String response = placeDelegate.placeUnits(getUnits(map, germans), sz5);
     assertValid(response);
@@ -732,74 +732,74 @@ public class WW2V3_41_Test {
 
   @Test
   public void testMoveUnitsThroughSubs() {
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData));
     bridge.setStepName("britishNonCombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
-    final Territory sz6 = territory("6 Sea Zone", m_data);
-    final Route route = new Route(sz6, territory("7 Sea Zone", m_data), territory("8 Sea Zone", m_data));
-    final String error = moveDelegate(m_data).move(sz6.getUnits().getUnits(), route);
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
+    final Territory sz6 = territory("6 Sea Zone", gameData);
+    final Route route = new Route(sz6, territory("7 Sea Zone", gameData), territory("8 Sea Zone", gameData));
+    final String error = moveDelegate(gameData).move(sz6.getUnits().getUnits(), route);
     assertNull(error, error);
   }
 
   @Test
   public void testMoveUnitsThroughTransports() {
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData));
     bridge.setStepName("britishCombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
-    final Territory sz12 = territory("12 Sea Zone", m_data);
-    final Route route = new Route(sz12, territory("13 Sea Zone", m_data), territory("14 Sea Zone", m_data));
-    final String error = moveDelegate(m_data).move(sz12.getUnits().getUnits(), route);
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
+    final Territory sz12 = territory("12 Sea Zone", gameData);
+    final Route route = new Route(sz12, territory("13 Sea Zone", gameData), territory("14 Sea Zone", gameData));
+    final String error = moveDelegate(gameData).move(sz12.getUnits().getUnits(), route);
     assertNull(error, error);
   }
 
   @Test
   public void testMoveUnitsThroughTransports2() {
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData));
     bridge.setStepName("britishNonCombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
-    final Territory sz12 = territory("12 Sea Zone", m_data);
-    final Territory sz14 = territory("14 Sea Zone", m_data);
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
+    final Territory sz12 = territory("12 Sea Zone", gameData);
+    final Territory sz14 = territory("14 Sea Zone", gameData);
     removeFrom(sz14, sz14.getUnits().getUnits());
-    final Route route = new Route(sz12, territory("13 Sea Zone", m_data), sz14);
-    final String error = moveDelegate(m_data).move(sz12.getUnits().getUnits(), route);
+    final Route route = new Route(sz12, territory("13 Sea Zone", gameData), sz14);
+    final String error = moveDelegate(gameData).move(sz12.getUnits().getUnits(), route);
     assertNull(error, error);
   }
 
   @Test
   public void testLoadThroughSubs() {
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData));
     bridge.setStepName("britishNonCombatMove");
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final Territory sz8 = territory("8 Sea Zone", m_data);
-    final Territory sz7 = territory("7 Sea Zone", m_data);
-    final Territory sz6 = territory("6 Sea Zone", m_data);
-    final Territory uk = territory("United Kingdom", m_data);
+    final Territory sz8 = territory("8 Sea Zone", gameData);
+    final Territory sz7 = territory("7 Sea Zone", gameData);
+    final Territory sz6 = territory("6 Sea Zone", gameData);
+    final Territory uk = territory("United Kingdom", gameData);
     // add a transport
-    addTo(sz8, transport(m_data).create(1, british(m_data)));
+    addTo(sz8, transport(gameData).create(1, british(gameData)));
     // move the transport where to the sub is
     assertValid(moveDelegate.move(sz8.getUnits().getUnits(), new Route(sz8, sz7)));
     // load the transport
     load(uk.getUnits().getMatches(Matches.UnitIsInfantry), new Route(uk, sz7));
     // move the transport out
     assertValid(
-        moveDelegate.move(sz7.getUnits().getMatches(Matches.unitOwnedBy(british(m_data))), new Route(sz7, sz6)));
+        moveDelegate.move(sz7.getUnits().getMatches(Matches.unitOwnedBy(british(gameData))), new Route(sz7, sz6)));
   }
 
   @Test
   public void testAttackUndoAndAttackAgain() {
-    final MoveDelegate move = moveDelegate(m_data);
-    final ITestDelegateBridge bridge = getDelegateBridge(italians(m_data));
+    final MoveDelegate move = moveDelegate(gameData);
+    final ITestDelegateBridge bridge = getDelegateBridge(italians(gameData));
     bridge.setStepName("CombatMove");
     move.setDelegateBridgeAndPlayer(bridge);
     move.start();
-    final Territory sz14 = territory("14 Sea Zone", m_data);
-    final Territory sz13 = territory("13 Sea Zone", m_data);
-    final Territory sz12 = territory("12 Sea Zone", m_data);
+    final Territory sz14 = territory("14 Sea Zone", gameData);
+    final Territory sz13 = territory("13 Sea Zone", gameData);
+    final Territory sz12 = territory("12 Sea Zone", gameData);
     final Route r = new Route(sz14, sz13, sz12);
     // move the battleship
     move(sz14.getUnits().getMatches(Matches.UnitHasMoreThanOneHitPointTotal), r);
@@ -810,7 +810,7 @@ public class WW2V3_41_Test {
     // move again
     move(sz14.getUnits().getMatches(Matches.UnitIsNotTransport), r);
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(m_data).getPendingBattle(sz12, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz12, false, null);
     // only 3 attacking units
     // the battleship and the two cruisers
     assertEquals(3, mfb.getAttackingUnits().size());
@@ -820,19 +820,19 @@ public class WW2V3_41_Test {
   public void testAttackSubsOnSubs() {
     final String defender = "Germans";
     final String attacker = "British";
-    final Territory attacked = territory("31 Sea Zone", m_data);
-    final Territory from = territory("32 Sea Zone", m_data);
+    final Territory attacked = territory("31 Sea Zone", gameData);
+    final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub attacks 1 sub
-    addTo(from, submarine(m_data).create(1, british(m_data)));
-    addTo(attacked, submarine(m_data).create(1, germans(m_data)));
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
+    addTo(from, submarine(gameData).create(1, british(gameData)));
+    addTo(attacked, submarine(gameData).create(1, germans(gameData)));
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData));
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     move(from.getUnits().getUnits(), new Route(from, attacked));
-    moveDelegate(m_data).end();
+    moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(m_data).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
     final List<String> steps = battle.determineStepStrings(true, bridge);
     assertEquals(
         Arrays.asList(attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE, attacker + SUBS_FIRE,
@@ -853,21 +853,21 @@ public class WW2V3_41_Test {
   public void testAttackSubsOnDestroyer() {
     final String defender = "Germans";
     final String attacker = "British";
-    final Territory attacked = territory("31 Sea Zone", m_data);
-    final Territory from = territory("32 Sea Zone", m_data);
+    final Territory attacked = territory("31 Sea Zone", gameData);
+    final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub attacks 1 sub and 1 destroyer
     // defender sneak attacks, not attacker
-    addTo(from, submarine(m_data).create(1, british(m_data)));
-    addTo(attacked, submarine(m_data).create(1, germans(m_data)));
-    addTo(attacked, destroyer(m_data).create(1, germans(m_data)));
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
+    addTo(from, submarine(gameData).create(1, british(gameData)));
+    addTo(attacked, submarine(gameData).create(1, germans(gameData)));
+    addTo(attacked, destroyer(gameData).create(1, germans(gameData)));
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData));
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     move(from.getUnits().getUnits(), new Route(from, attacked));
-    moveDelegate(m_data).end();
+    moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(m_data).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
     final List<String> steps = battle.determineStepStrings(true, bridge);
     assertEquals(
         Arrays.asList(defender + SUBS_SUBMERGE, defender + SUBS_FIRE, attacker + SELECT_SUB_CASUALTIES,
@@ -881,7 +881,7 @@ public class WW2V3_41_Test {
     bridge.setRandomSource(randomSource);
     battle.fight(bridge);
     assertEquals(1, randomSource.getTotalRolled());
-    assertTrue(attacked.getUnits().getMatches(Matches.unitIsOwnedBy(british(m_data))).isEmpty());
+    assertTrue(attacked.getUnits().getMatches(Matches.unitIsOwnedBy(british(gameData))).isEmpty());
     assertEquals(2, attacked.getUnits().size());
   }
 
@@ -889,21 +889,21 @@ public class WW2V3_41_Test {
   public void testAttackDestroyerAndSubsAgainstSub() {
     final String defender = "Germans";
     final String attacker = "British";
-    final Territory attacked = territory("31 Sea Zone", m_data);
-    final Territory from = territory("32 Sea Zone", m_data);
+    final Territory attacked = territory("31 Sea Zone", gameData);
+    final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub and 1 destroyer attack 1 sub
     // defender sneak attacks, not attacker
-    addTo(from, submarine(m_data).create(1, british(m_data)));
-    addTo(from, destroyer(m_data).create(1, british(m_data)));
-    addTo(attacked, submarine(m_data).create(1, germans(m_data)));
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
+    addTo(from, submarine(gameData).create(1, british(gameData)));
+    addTo(from, destroyer(gameData).create(1, british(gameData)));
+    addTo(attacked, submarine(gameData).create(1, germans(gameData)));
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData));
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     move(from.getUnits().getUnits(), new Route(from, attacked));
-    moveDelegate(m_data).end();
+    moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(m_data).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
     final List<String> steps = battle.determineStepStrings(true, bridge);
     assertEquals(
         Arrays.asList(attacker + SUBS_SUBMERGE, attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES,
@@ -917,7 +917,7 @@ public class WW2V3_41_Test {
     bridge.setRandomSource(randomSource);
     battle.fight(bridge);
     assertEquals(1, randomSource.getTotalRolled());
-    assertTrue(attacked.getUnits().getMatches(Matches.unitIsOwnedBy(germans(m_data))).isEmpty());
+    assertTrue(attacked.getUnits().getMatches(Matches.unitIsOwnedBy(germans(gameData))).isEmpty());
     assertEquals(2, attacked.getUnits().size());
   }
 
@@ -925,22 +925,22 @@ public class WW2V3_41_Test {
   public void testAttackDestroyerAndSubsAgainstSubAndDestroyer() {
     final String defender = "Germans";
     final String attacker = "British";
-    final Territory attacked = territory("31 Sea Zone", m_data);
-    final Territory from = territory("32 Sea Zone", m_data);
+    final Territory attacked = territory("31 Sea Zone", gameData);
+    final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub and 1 destroyer attack 1 sub and 1 destroyer
     // no sneak attacks
-    addTo(from, submarine(m_data).create(1, british(m_data)));
-    addTo(from, destroyer(m_data).create(1, british(m_data)));
-    addTo(attacked, submarine(m_data).create(1, germans(m_data)));
-    addTo(attacked, destroyer(m_data).create(1, germans(m_data)));
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
+    addTo(from, submarine(gameData).create(1, british(gameData)));
+    addTo(from, destroyer(gameData).create(1, british(gameData)));
+    addTo(attacked, submarine(gameData).create(1, germans(gameData)));
+    addTo(attacked, destroyer(gameData).create(1, germans(gameData)));
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData));
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     move(from.getUnits().getUnits(), new Route(from, attacked));
-    moveDelegate(m_data).end();
+    moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(m_data).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
     final List<String> steps = battle.determineStepStrings(true, bridge);
     assertEquals(
         Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, attacker + FIRE,
@@ -968,39 +968,39 @@ public class WW2V3_41_Test {
 
   @Test
   public void testLimitBombardtoNumberOfUnloaded() {
-    final MoveDelegate move = moveDelegate(m_data);
-    final ITestDelegateBridge bridge = getDelegateBridge(italians(m_data));
+    final MoveDelegate move = moveDelegate(gameData);
+    final ITestDelegateBridge bridge = getDelegateBridge(italians(gameData));
 
     when(dummyPlayer.selectShoreBombard(any())).thenReturn(true);
     bridge.setRemote(dummyPlayer);
     bridge.setStepName("CombatMove");
     move.setDelegateBridgeAndPlayer(bridge);
     move.start();
-    final Territory sz14 = territory("14 Sea Zone", m_data);
-    final Territory sz15 = territory("15 Sea Zone", m_data);
-    final Territory eg = territory("Egypt", m_data);
-    final Territory li = territory("Libya", m_data);
-    final Territory balkans = territory("Balkans", m_data);
+    final Territory sz14 = territory("14 Sea Zone", gameData);
+    final Territory sz15 = territory("15 Sea Zone", gameData);
+    final Territory eg = territory("Egypt", gameData);
+    final Territory li = territory("Libya", gameData);
+    final Territory balkans = territory("Balkans", gameData);
     // Clear all units from the attacked terr
     removeFrom(eg, eg.getUnits().getUnits());
     // Add 2 inf
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    addTo(eg, infantry(m_data).create(2, british));
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    addTo(eg, infantry(gameData).create(2, british));
     // load the transports
     load(balkans.getUnits().getMatches(Matches.UnitIsInfantry), new Route(balkans, sz14));
     // move the fleet
     move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
     // move troops from Libya
-    move(li.getUnits().getMatches(Matches.unitOwnedBy(italians(m_data))), new Route(li, eg));
+    move(li.getUnits().getMatches(Matches.unitOwnedBy(italians(gameData))), new Route(li, eg));
     // unload the transports
     move(sz15.getUnits().getMatches(Matches.UnitIsLand), new Route(sz15, eg));
     move.end();
     // start the battle phase, this will ask the user to bombard
-    battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    BattleDelegate.doInitialize(battleDelegate(m_data).getBattleTracker(), bridge);
-    battleDelegate(m_data).addBombardmentSources();
+    battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
+    battleDelegate(gameData).addBombardmentSources();
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(m_data).getPendingBattle(eg, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg, false, null);
     // only 2 ships are allowed to bombard (there are 1 battleship and 2 cruisers that COULD bombard, but only 2 ships
     // may bombard total)
     assertEquals(2, mfb.getBombardingUnits().size());
@@ -1008,35 +1008,35 @@ public class WW2V3_41_Test {
     // Note- the 3 & 2 hits below show default behavior of bombarding at attack strength
     // 2= Battleship hitting a 3, 2=Cruiser hitting a 3, 15=British infantry hitting once
     bridge.setRandomSource(new ScriptedRandomSource(2, 2, 1, 5, 5, 5, 5, 5));
-    battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    battleDelegate(m_data).start();
+    battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    battleDelegate(gameData).start();
     // end result should be 2 italian infantry.
     assertEquals(3, eg.getUnits().size());
   }
 
   @Test
   public void testBombardStrengthVariable() {
-    final MoveDelegate move = moveDelegate(m_data);
-    final ITestDelegateBridge bridge = getDelegateBridge(italians(m_data));
+    final MoveDelegate move = moveDelegate(gameData);
+    final ITestDelegateBridge bridge = getDelegateBridge(italians(gameData));
     when(dummyPlayer.selectShoreBombard(any())).thenReturn(true);
     bridge.setRemote(dummyPlayer);
     bridge.setStepName("CombatMove");
     move.setDelegateBridgeAndPlayer(bridge);
     move.start();
-    final Territory sz14 = territory("14 Sea Zone", m_data);
-    final Territory sz15 = territory("15 Sea Zone", m_data);
-    final Territory eg = territory("Egypt", m_data);
-    final Territory balkans = territory("Balkans", m_data);
+    final Territory sz14 = territory("14 Sea Zone", gameData);
+    final Territory sz15 = territory("15 Sea Zone", gameData);
+    final Territory eg = territory("Egypt", gameData);
+    final Territory balkans = territory("Balkans", gameData);
     // Clear all units
     removeFrom(eg, eg.getUnits().getUnits());
     removeFrom(sz14, sz14.getUnits().getUnits());
     // Add 2 inf to the attacked terr
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    addTo(eg, infantry(m_data).create(2, british));
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    addTo(eg, infantry(gameData).create(2, british));
     // create/load the destroyers and transports
-    final PlayerID italians = GameDataTestUtil.italians(m_data);
-    addTo(sz14, transport(m_data).create(1, italians));
-    addTo(sz14, destroyer(m_data).create(2, italians));
+    final PlayerID italians = GameDataTestUtil.italians(gameData);
+    addTo(sz14, transport(gameData).create(1, italians));
+    addTo(sz14, destroyer(gameData).create(2, italians));
     // load the transports
     load(balkans.getUnits().getMatches(Matches.UnitIsInfantry), new Route(balkans, sz14));
     // move the fleet
@@ -1047,7 +1047,7 @@ public class WW2V3_41_Test {
     // Set the tech for DDs bombard
     // ww2v3 doesn't have this tech, so this does nothing...
     // TechAttachment.get(italians).setDestroyerBombard("true");
-    UnitAttachment.get(destroyer(m_data)).setCanBombard("true");
+    UnitAttachment.get(destroyer(gameData)).setCanBombard("true");
     // Set the bombard strength for the DDs
     final Collection<Unit> dds = Match.getMatches(sz15.getUnits().getUnits(), Matches.UnitIsDestroyer);
     final Iterator<Unit> ddIter = dds.iterator();
@@ -1057,45 +1057,45 @@ public class WW2V3_41_Test {
       ua.setBombard("3");
     }
     // start the battle phase, this will ask the user to bombard
-    battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    BattleDelegate.doInitialize(battleDelegate(m_data).getBattleTracker(), bridge);
-    battleDelegate(m_data).addBombardmentSources();
+    battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
+    battleDelegate(gameData).addBombardmentSources();
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(m_data).getPendingBattle(eg, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg, false, null);
     assertNotNull(mfb);
     // Show that bombard casualties can return fire
     // destroyer bombard hit/miss on rolls of 4 & 3
     // landing inf miss
     // defending inf hit
     bridge.setRandomSource(new ScriptedRandomSource(3, 2, 6, 6, 1, 1));
-    battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    BattleDelegate.doInitialize(battleDelegate(m_data).getBattleTracker(), bridge);
-    battleDelegate(m_data).addBombardmentSources();
-    fight(battleDelegate(m_data), eg);
+    battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
+    battleDelegate(gameData).addBombardmentSources();
+    fight(battleDelegate(gameData), eg);
     // 1 defending inf remaining
     assertEquals(1, eg.getUnits().size());
   }
 
   @Test
   public void testAmphAttackUndoAndAttackAgainBombard() {
-    final MoveDelegate move = moveDelegate(m_data);
-    final ITestDelegateBridge bridge = getDelegateBridge(italians(m_data));
+    final MoveDelegate move = moveDelegate(gameData);
+    final ITestDelegateBridge bridge = getDelegateBridge(italians(gameData));
     when(dummyPlayer.selectShoreBombard(any())).thenReturn(true);
     bridge.setRemote(dummyPlayer);
     bridge.setStepName("CombatMove");
     move.setDelegateBridgeAndPlayer(bridge);
     move.start();
-    final Territory sz14 = territory("14 Sea Zone", m_data);
-    final Territory sz15 = territory("15 Sea Zone", m_data);
-    final Territory eg = territory("Egypt", m_data);
-    final Territory li = territory("Libya", m_data);
-    final Territory balkans = territory("Balkans", m_data);
+    final Territory sz14 = territory("14 Sea Zone", gameData);
+    final Territory sz15 = territory("15 Sea Zone", gameData);
+    final Territory eg = territory("Egypt", gameData);
+    final Territory li = territory("Libya", gameData);
+    final Territory balkans = territory("Balkans", gameData);
     // load the transports
     load(balkans.getUnits().getMatches(Matches.UnitIsInfantry), new Route(balkans, sz14));
     // move the fleet
     move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
     // move troops from Libya
-    move(li.getUnits().getMatches(Matches.unitOwnedBy(italians(m_data))), new Route(li, eg));
+    move(li.getUnits().getMatches(Matches.unitOwnedBy(italians(gameData))), new Route(li, eg));
     // unload the transports
     move(sz15.getUnits().getMatches(Matches.UnitIsLand), new Route(sz15, eg));
     // undo amphibious landing
@@ -1104,26 +1104,26 @@ public class WW2V3_41_Test {
     move(sz15.getUnits().getMatches(Matches.UnitIsLand), new Route(sz15, eg));
     move.end();
     // start the battle phase, this will ask the user to bombard
-    battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    BattleDelegate.doInitialize(battleDelegate(m_data).getBattleTracker(), bridge);
-    battleDelegate(m_data).addBombardmentSources();
+    battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
+    battleDelegate(gameData).addBombardmentSources();
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(m_data).getPendingBattle(eg, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg, false, null);
     // only 2 battleships are allowed to bombard
     assertEquals(2, mfb.getBombardingUnits().size());
   }
 
   @Test
   public void testCarrierWithAlliedPlanes() {
-    final Territory sz8 = territory("8 Sea Zone", m_data);
-    final Territory sz1 = territory("1 Sea Zone", m_data);
-    addTo(sz8, carrier(m_data).create(1, british(m_data)));
-    addTo(sz8, fighter(m_data).create(1, americans(m_data)));
+    final Territory sz8 = territory("8 Sea Zone", gameData);
+    final Territory sz1 = territory("1 Sea Zone", gameData);
+    addTo(sz8, carrier(gameData).create(1, british(gameData)));
+    addTo(sz8, fighter(gameData).create(1, americans(gameData)));
     final Route route = new Route(sz8, sz1);
-    final ITestDelegateBridge bridge = getDelegateBridge(british(m_data));
+    final ITestDelegateBridge bridge = getDelegateBridge(british(gameData));
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     move(sz8.getUnits().getUnits(), route);
     // make sure the fighter moved
     assertTrue(sz8.getUnits().getUnits().isEmpty());
@@ -1137,35 +1137,35 @@ public class WW2V3_41_Test {
     // the fighters should not be able to move from madagascar
     // to sz 40, since with the allied fighter, their is no room
     // on the carrier
-    final Territory madagascar = territory("French Madagascar", m_data);
-    final PlayerID germans = germans(m_data);
+    final Territory madagascar = territory("French Madagascar", gameData);
+    final PlayerID germans = germans(gameData);
     madagascar.setOwner(germans);
-    final Territory sz40 = territory("40 Sea Zone", m_data);
-    addTo(sz40, carrier(m_data).create(1, germans));
-    addTo(sz40, fighter(m_data).create(1, italians(m_data)));
-    addTo(madagascar, fighter(m_data).create(2, germans));
-    final Route route = m_data.getMap().getRoute(madagascar, sz40);
+    final Territory sz40 = territory("40 Sea Zone", gameData);
+    addTo(sz40, carrier(gameData).create(1, germans));
+    addTo(sz40, fighter(gameData).create(1, italians(gameData)));
+    addTo(madagascar, fighter(gameData).create(2, germans));
+    final Route route = gameData.getMap().getRoute(madagascar, sz40);
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     // don't allow kamikaze
     bridge.setRemote(dummyPlayer);
-    final String error = moveDelegate(m_data).move(madagascar.getUnits().getUnits(), route);
+    final String error = moveDelegate(gameData).move(madagascar.getUnits().getUnits(), route);
     assertError(error);
   }
 
   @Test
   public void testMechInfSimple() {
-    final PlayerID germans = germans(m_data);
-    final Territory france = territory("France", m_data);
-    final Territory germany = territory("Germany", m_data);
-    final Territory poland = territory("Poland", m_data);
+    final PlayerID germans = germans(gameData);
+    final Territory france = territory("France", gameData);
+    final Territory germany = territory("Germany", gameData);
+    final Territory poland = territory("Poland", gameData);
     TechAttachment.get(germans).setMechanizedInfantry("true");
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     final Route r = new Route(france, germany, poland);
     final List<Unit> toMove = new ArrayList<>();
     // 1 armour and 1 infantry
@@ -1176,68 +1176,68 @@ public class WW2V3_41_Test {
 
   @Test
   public void testMechInfUnitAlreadyMovedSimple() {
-    final PlayerID germans = germans(m_data);
-    final Territory france = territory("France", m_data);
-    final Territory germany = territory("Germany", m_data);
+    final PlayerID germans = germans(gameData);
+    final Territory france = territory("France", gameData);
+    final Territory germany = territory("Germany", gameData);
     TechAttachment.get(germans).setMechanizedInfantry("true");
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     // get rid of the infantry in france
     removeFrom(france, france.getUnits().getMatches(Matches.UnitIsInfantry));
     // move an infantry from germany to france
     move(germany.getUnits().getMatches(Matches.UnitIsInfantry).subList(0, 1), new Route(germany, france));
     // try to move all the units in france, the infantry should not be able to move
     final Route r = new Route(france, germany);
-    final String error = moveDelegate(m_data).move(france.getUnits().getUnits(), r);
+    final String error = moveDelegate(gameData).move(france.getUnits().getUnits(), r);
     assertFalse(error == null);
   }
 
   @Test
   public void testParatroopsWalkOnWater() {
-    final PlayerID germans = germans(m_data);
-    final Territory france = territory("France", m_data);
+    final PlayerID germans = germans(gameData);
+    final Territory france = territory("France", gameData);
     TechAttachment.get(germans).setParatroopers("true");
-    final Route r = m_data.getMap().getRoute(france, territory("7 Sea Zone", m_data));
+    final Route r = gameData.getMap().getRoute(france, territory("7 Sea Zone", gameData));
     final Collection<Unit> paratroopers = france.getUnits().getMatches(Matches.UnitIsAirTransportable);
     assertFalse(paratroopers.isEmpty());
     final MoveValidationResult results = MoveValidator.validateMove(paratroopers, r, germans,
-        Collections.<Unit>emptyList(), new HashMap<>(), false, null, m_data);
+        Collections.<Unit>emptyList(), new HashMap<>(), false, null, gameData);
     assertFalse(results.isMoveValid());
   }
 
   @Test
   public void testBomberWithTankOverWaterParatroopers() {
-    final PlayerID germans = germans(m_data);
+    final PlayerID germans = germans(gameData);
     TechAttachment.get(germans).setParatroopers("true");
-    final Territory sz5 = territory("5 Sea Zone", m_data);
-    final Territory germany = territory("Germany", m_data);
-    final Territory karelia = territory("Karelia S.S.R.", m_data);
-    addTo(germany, armour(m_data).create(1, germans));
+    final Territory sz5 = territory("5 Sea Zone", gameData);
+    final Territory germany = territory("Germany", gameData);
+    final Territory karelia = territory("Karelia S.S.R.", gameData);
+    addTo(germany, armour(gameData).create(1, germans));
     final Route r = new Route(germany, sz5, karelia);
     final Collection<Unit> toMove = germany.getUnits().getMatches(Matches.UnitCanBlitz);
     toMove.addAll(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber));
     assertEquals(2, toMove.size());
     final MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.<Unit>emptyList(),
-        new HashMap<>(), false, null, m_data);
+        new HashMap<>(), false, null, gameData);
     assertFalse(results.isMoveValid());
   }
 
   @Test
   public void testBomberTankOverWater() {
     // can't transport a tank over water using a bomber
-    final PlayerID germans = germans(m_data);
-    final Territory sz5 = territory("5 Sea Zone", m_data);
-    final Territory germany = territory("Germany", m_data);
-    final Territory karelia = territory("Karelia S.S.R.", m_data);
-    addTo(germany, armour(m_data).create(1, germans));
+    final PlayerID germans = germans(gameData);
+    final Territory sz5 = territory("5 Sea Zone", gameData);
+    final Territory germany = territory("Germany", gameData);
+    final Territory karelia = territory("Karelia S.S.R.", gameData);
+    addTo(germany, armour(gameData).create(1, germans));
     final Route r = new Route(germany, sz5, karelia);
     final Collection<Unit> toMove = germany.getUnits().getMatches(Matches.UnitCanBlitz);
     toMove.addAll(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber));
     assertEquals(2, toMove.size());
     final MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.<Unit>emptyList(),
-        new HashMap<>(), false, null, m_data);
+        new HashMap<>(), false, null, gameData);
     assertFalse(results.isMoveValid());
   }
 
@@ -1245,13 +1245,13 @@ public class WW2V3_41_Test {
   public void testMoveParatroopersAsNonPartroops() {
     // move a bomber and a paratrooper
     // one step, but as a normal movement
-    final PlayerID germans = germans(m_data);
-    final Territory germany = territory("Germany", m_data);
-    final Territory nwe = territory("Northwestern Europe", m_data);
+    final PlayerID germans = germans(gameData);
+    final Territory germany = territory("Germany", gameData);
+    final Territory nwe = territory("Northwestern Europe", gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     List<Unit> paratrooper = germany.getUnits().getMatches(Matches.UnitIsAirTransportable);
     paratrooper = paratrooper.subList(0, 1);
@@ -1264,68 +1264,68 @@ public class WW2V3_41_Test {
   @Test
   public void testCantMoveParatroopersThatMovedPreviously() {
     // make sure infantry can't be moved as paratroopers after moving
-    final PlayerID germans = germans(m_data);
-    final Territory germany = territory("Germany", m_data);
-    final Territory nwe = territory("Northwestern Europe", m_data);
-    final Territory poland = territory("Poland", m_data);
-    final Territory eastPoland = territory("East Poland", m_data);
+    final PlayerID germans = germans(gameData);
+    final Territory germany = territory("Germany", gameData);
+    final Territory nwe = territory("Northwestern Europe", gameData);
+    final Territory poland = territory("Poland", gameData);
+    final Territory eastPoland = territory("East Poland", gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     final List<Unit> paratrooper = nwe.getUnits().getMatches(Matches.UnitIsAirTransportable);
     move(paratrooper, new Route(nwe, germany));
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratrooper);
     bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));
     // move the units to east poland
-    final String error = moveDelegate(m_data).move(bomberAndParatroop, new Route(germany, poland, eastPoland));
+    final String error = moveDelegate(gameData).move(bomberAndParatroop, new Route(germany, poland, eastPoland));
     assertError(error);
   }
 
   @Test
   public void testCantTransportParatroopersWithBombersThatMovedPreviously() {
     // make sure bombers can't move then pick up paratroopers
-    final PlayerID germans = germans(m_data);
-    final Territory germany = territory("Germany", m_data);
-    final Territory bulgaria = territory("Bulgaria Romania", m_data);
-    final Territory poland = territory("Poland", m_data);
-    final Territory ukraine = territory("Ukraine", m_data);
+    final PlayerID germans = germans(gameData);
+    final Territory germany = territory("Germany", gameData);
+    final Territory bulgaria = territory("Bulgaria Romania", gameData);
+    final Territory poland = territory("Poland", gameData);
+    final Territory ukraine = territory("Ukraine", gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     // Move the bomber first
     final List<Unit> bomber = germany.getUnits().getMatches(Matches.UnitIsAirTransport);
     move(bomber, new Route(germany, poland));
     // Pick up a paratrooper
     final List<Unit> bomberAndParatroop = new ArrayList<>(bomber);
-    bomberAndParatroop.addAll(poland.getUnits().getUnits(GameDataTestUtil.infantry(m_data), 1));
+    bomberAndParatroop.addAll(poland.getUnits().getUnits(GameDataTestUtil.infantry(gameData), 1));
     // move them
-    final String error = moveDelegate(m_data).move(bomberAndParatroop, new Route(poland, bulgaria, ukraine));
+    final String error = moveDelegate(gameData).move(bomberAndParatroop, new Route(poland, bulgaria, ukraine));
     assertError(error);
   }
 
   @Test
   public void testMoveOneParatrooperPerBomber() {
     // make sure only 1 paratroop per bomber can be moved
-    final PlayerID germans = germans(m_data);
-    final Territory germany = territory("Germany", m_data);
-    // Territory nwe = territory("Northwestern Europe", m_data);
-    final Territory poland = territory("Poland", m_data);
-    final Territory eastPoland = territory("East Poland", m_data);
+    final PlayerID germans = germans(gameData);
+    final Territory germany = territory("Germany", gameData);
+    // Territory nwe = territory("Northwestern Europe", gameData);
+    final Territory poland = territory("Poland", gameData);
+    final Territory eastPoland = territory("East Poland", gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     final List<Unit> bomberAndParatroop = new ArrayList<>();
     bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));
     // add 2 infantry
-    bomberAndParatroop.addAll(germany.getUnits().getUnits(GameDataTestUtil.infantry(m_data), 2));
+    bomberAndParatroop.addAll(germany.getUnits().getUnits(GameDataTestUtil.infantry(gameData), 2));
     // move the units to east poland
-    final String error = moveDelegate(m_data).move(bomberAndParatroop, new Route(germany, poland, eastPoland));
+    final String error = moveDelegate(gameData).move(bomberAndParatroop, new Route(germany, poland, eastPoland));
     assertError(error);
   }
 
@@ -1334,15 +1334,15 @@ public class WW2V3_41_Test {
     // After a battle move to put a bomber + infantry (paratroop) in a first enemy
     // territory, you can make a new move (in the same battle move round) to put
     // bomber+ infantry in a more internal enemy territory.
-    final PlayerID germans = germans(m_data);
-    final Territory germany = territory("Germany", m_data);
-    final Territory poland = territory("Poland", m_data);
-    final Territory eastPoland = territory("East Poland", m_data);
-    final Territory beloRussia = territory("Belorussia", m_data);
+    final PlayerID germans = germans(gameData);
+    final Territory germany = territory("Germany", gameData);
+    final Territory poland = territory("Poland", gameData);
+    final Territory eastPoland = territory("East Poland", gameData);
+    final Territory beloRussia = territory("Belorussia", gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     List<Unit> paratroopers = germany.getUnits().getMatches(Matches.UnitIsAirTransportable);
     paratroopers = paratroopers.subList(0, 1);
@@ -1358,28 +1358,28 @@ public class WW2V3_41_Test {
     }
     // move the units to east poland
     // airTransports
-    String error = moveDelegate(m_data).move(bomberAndParatroop, route);
+    String error = moveDelegate(gameData).move(bomberAndParatroop, route);
     assertValid(error);
     // try to move them further, this should fail
-    error = moveDelegate(m_data).move(bomberAndParatroop, new Route(eastPoland, beloRussia));
+    error = moveDelegate(gameData).move(bomberAndParatroop, new Route(eastPoland, beloRussia));
     assertError(error);
   }
 
   @Test
   public void testParatroopersFlyOverBlitzedTerritory() {
     // We should be able to blitz a territory, then fly over it with paratroops to battle.
-    final PlayerID germans = germans(m_data);
-    final Territory germany = territory("Germany", m_data);
-    final Territory poland = territory("Poland", m_data);
-    final Territory eastPoland = territory("East Poland", m_data);
-    final Territory beloRussia = territory("Belorussia", m_data);
+    final PlayerID germans = germans(gameData);
+    final Territory germany = territory("Germany", gameData);
+    final Territory poland = territory("Poland", gameData);
+    final Territory eastPoland = territory("East Poland", gameData);
+    final Territory beloRussia = territory("Belorussia", gameData);
     // Clear East Poland
     removeFrom(eastPoland, eastPoland.getUnits().getUnits());
     // Set up test
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     List<Unit> paratrooper = germany.getUnits().getMatches(Matches.UnitIsAirTransportable);
     paratrooper = paratrooper.subList(0, 1);
@@ -1396,25 +1396,25 @@ public class WW2V3_41_Test {
     }
     // Verify paratroops can overfly blitzed territory
     final String error =
-        moveDelegate(m_data).move(bomberAndParatroop, new Route(germany, poland, eastPoland, beloRussia));
+        moveDelegate(gameData).move(bomberAndParatroop, new Route(germany, poland, eastPoland, beloRussia));
     assertValid(error);
   }
 
   @Test
   public void testAmphibAttackWithPlanesOnlyAskRetreatOnce() {
-    final PlayerID germans = germans(m_data);
+    final PlayerID germans = germans(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
-    final Territory france = territory("France", m_data);
-    final Territory egypt = territory("Egypt", m_data);
-    final Territory balkans = territory("Balkans", m_data);
-    final Territory libya = territory("Libya", m_data);
-    final Territory germany = territory("Germany", m_data);
-    final Territory sz13 = territory("13 Sea Zone", m_data);
-    final Territory sz14 = territory("14 Sea Zone", m_data);
-    final Territory sz15 = territory("15 Sea Zone", m_data);
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
+    final Territory france = territory("France", gameData);
+    final Territory egypt = territory("Egypt", gameData);
+    final Territory balkans = territory("Balkans", gameData);
+    final Territory libya = territory("Libya", gameData);
+    final Territory germany = territory("Germany", gameData);
+    final Territory sz13 = territory("13 Sea Zone", gameData);
+    final Territory sz14 = territory("14 Sea Zone", gameData);
+    final Territory sz15 = territory("15 Sea Zone", gameData);
     ;
     when(dummyPlayer.retreatQuery(any(), anyBoolean(), any(),
         any(), contains(BattleStepStrings.RETREAT_PLANES))).thenThrow(
@@ -1440,23 +1440,23 @@ public class WW2V3_41_Test {
     load(libya.getUnits().getMatches(Matches.UnitIsArtillery), new Route(libya, egypt));
     // air units
     move(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber), new Route(germany, balkans, sz14, sz15, egypt));
-    moveDelegate(m_data).end();
+    moveDelegate(gameData).end();
     bridge.setStepName("Combat");
     // cook the dice so that all miss first round,all hit second round
     bridge.setRandomSource(new ScriptedRandomSource(5, 5, 5, 5, 5, 5, 5, 5, 5, 1, 1, 1, 1, 1, 1, 1, 1, 1));
-    battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    battleDelegate(m_data).start();
+    battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    battleDelegate(gameData).start();
   }
 
   @Test
   public void testDefencelessTransportsDie() {
-    final PlayerID british = british(m_data);
+    final PlayerID british = british(gameData);
     final ITestDelegateBridge bridge = getDelegateBridge(british);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
-    final Territory uk = territory("United Kingdom", m_data);
-    final Territory sz5 = territory("5 Sea Zone", m_data);
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
+    final Territory uk = territory("United Kingdom", gameData);
+    final Territory sz5 = territory("5 Sea Zone", gameData);
     // remove the sub
     removeFrom(sz5, sz5.getUnits().getMatches(Matches.UnitIsSub));
 
@@ -1469,35 +1469,35 @@ public class WW2V3_41_Test {
           }
         });
     bridge.setRemote(dummyPlayer);
-    move(uk.getUnits().getMatches(Matches.UnitIsAir), m_data.getMap().getRoute(uk, sz5));
+    move(uk.getUnits().getMatches(Matches.UnitIsAir), gameData.getMap().getRoute(uk, sz5));
     // move units for amphib assault
-    moveDelegate(m_data).end();
+    moveDelegate(gameData).end();
     bridge.setStepName("Combat");
     // cook the dice so that 1 british fighters hits, and nothing else
     // this will leave 1 transport alone in the sea zone
     bridge.setRandomSource(new ScriptedRandomSource(1, 5, 5, 5, 5, 5, 5, 5, 5));
-    battleDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    battleDelegate(m_data).start();
+    battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    battleDelegate(gameData).start();
     // make sure the transports died
-    assertTrue(sz5.getUnits().getMatches(Matches.unitIsOwnedBy(germans(m_data))).isEmpty());
+    assertTrue(sz5.getUnits().getMatches(Matches.unitIsOwnedBy(germans(gameData))).isEmpty());
   }
 
   @Test
   public void testFighterLandsWhereCarrierCanBePlaced() {
-    final PlayerID germans = germans(m_data);
+    final PlayerID germans = germans(gameData);
     // germans have 1 carrier to place
-    addTo(germans, carrier(m_data).create(1, germans), m_data);
+    addTo(germans, carrier(gameData).create(1, germans), gameData);
     // start the move phase
     final ITestDelegateBridge bridge = getDelegateBridge(germans);
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     bridge.setRemote(dummyPlayer);
     // the fighter should be able to move and hover in the sea zone
     // the fighter has no movement left
-    final Territory neEurope = territory("Northwestern Europe", m_data);
-    final Route route = new Route(neEurope, territory("Germany", m_data), territory("Poland", m_data),
-        territory("Baltic States", m_data), territory("5 Sea Zone", m_data));
+    final Territory neEurope = territory("Northwestern Europe", gameData);
+    final Route route = new Route(neEurope, territory("Germany", gameData), territory("Poland", gameData),
+        territory("Baltic States", gameData), territory("5 Sea Zone", gameData));
     // the fighter should be able to move, and hover in the sea zone until the carrier is placed
     move(neEurope.getUnits().getMatches(Matches.UnitIsAir), route);
   }
@@ -1505,37 +1505,37 @@ public class WW2V3_41_Test {
   @Test
   public void testFighterCantHoverWithNoCarrierToPlace() {
     // start the move phase
-    final ITestDelegateBridge bridge = getDelegateBridge(germans(m_data));
+    final ITestDelegateBridge bridge = getDelegateBridge(germans(gameData));
     bridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
+    moveDelegate(gameData).start();
     bridge.setRemote(dummyPlayer);
     // the fighter should not be able to move and hover in the sea zone
     // since their are no carriers to place
     // the fighter has no movement left
-    final Territory neEurope = territory("Northwestern Europe", m_data);
-    final Route route = new Route(neEurope, territory("Germany", m_data), territory("Poland", m_data),
-        territory("Baltic States", m_data), territory("5 Sea Zone", m_data));
-    final String error = moveDelegate(m_data).move(neEurope.getUnits().getMatches(Matches.UnitIsAir), route);
+    final Territory neEurope = territory("Northwestern Europe", gameData);
+    final Route route = new Route(neEurope, territory("Germany", gameData), territory("Poland", gameData),
+        territory("Baltic States", gameData), territory("5 Sea Zone", gameData));
+    final String error = moveDelegate(gameData).move(neEurope.getUnits().getMatches(Matches.UnitIsAir), route);
     assertNotNull(error);
   }
 
   @Test
   public void testRepair() {
-    final Territory germany = territory("Germany", m_data);
+    final Territory germany = territory("Germany", gameData);
     final Unit factory = germany.getUnits().getMatches(Matches.UnitCanBeDamaged).get(0);
-    final PurchaseDelegate del = purchaseDelegate(m_data);
-    del.setDelegateBridgeAndPlayer(getDelegateBridge(germans(m_data)));
+    final PurchaseDelegate del = purchaseDelegate(gameData);
+    del.setDelegateBridgeAndPlayer(getDelegateBridge(germans(gameData)));
     del.start();
     // Set up player
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
     final int initPUs = germans.getResources().getQuantity("PUs");
     // damage a factory
     IntegerMap<Unit> startHits = new IntegerMap<>();
     startHits.put(factory, 1);
-    m_data.performChange(ChangeFactory.bombingUnitDamage(startHits));
+    gameData.performChange(ChangeFactory.bombingUnitDamage(startHits));
     assertEquals(((TripleAUnit) factory).getUnitDamage(), 1);
-    RepairRule repair = germans(m_data).getRepairFrontier().getRules().get(0);
+    RepairRule repair = germans(gameData).getRepairFrontier().getRules().get(0);
     IntegerMap<RepairRule> repairs = new IntegerMap<>();
     repairs.put(repair, 1);
     String error = del.purchaseRepair(Collections.singletonMap(
@@ -1549,15 +1549,15 @@ public class WW2V3_41_Test {
      * INCREASED_FACTORY_PRODUCTION repairs
      */
     // Set up INCREASED_FACTORY_PRODUCTION
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(germans(m_data));
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(germans(gameData));
     TechTracker.addAdvance(germans, delegateBridge,
-        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_INCREASED_FACTORY_PRODUCTION, m_data, germans));
+        TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_INCREASED_FACTORY_PRODUCTION, gameData, germans));
     // damage a factory
     startHits = new IntegerMap<>();
     startHits.put(factory, 2);
-    m_data.performChange(ChangeFactory.bombingUnitDamage(startHits));
+    gameData.performChange(ChangeFactory.bombingUnitDamage(startHits));
     assertEquals(((TripleAUnit) factory).getUnitDamage(), 2);
-    repair = germans(m_data).getRepairFrontier().getRules().get(0);
+    repair = germans(gameData).getRepairFrontier().getRules().get(0);
     repairs = new IntegerMap<>();
     repairs.put(repair, 2);
     error = del.purchaseRepair(Collections.singletonMap(
@@ -1571,17 +1571,17 @@ public class WW2V3_41_Test {
 
   @Test
   public void testRepairMoreThanDamaged() {
-    final Territory germany = territory("Germany", m_data);
+    final Territory germany = territory("Germany", gameData);
     final Unit factory = germany.getUnits().getMatches(Matches.UnitCanBeDamaged).get(0);
-    final PurchaseDelegate del = purchaseDelegate(m_data);
-    del.setDelegateBridgeAndPlayer(getDelegateBridge(germans(m_data)));
+    final PurchaseDelegate del = purchaseDelegate(gameData);
+    del.setDelegateBridgeAndPlayer(getDelegateBridge(germans(gameData)));
     del.start();
     // dame a factory
     final IntegerMap<Unit> startHits = new IntegerMap<>();
     startHits.put(factory, 1);
-    m_data.performChange(ChangeFactory.bombingUnitDamage(startHits));
+    gameData.performChange(ChangeFactory.bombingUnitDamage(startHits));
     assertEquals(((TripleAUnit) factory).getUnitDamage(), 1);
-    final RepairRule repair = germans(m_data).getRepairFrontier().getRules().get(0);
+    final RepairRule repair = germans(gameData).getRepairFrontier().getRules().get(0);
     final IntegerMap<RepairRule> repairs = new IntegerMap<>();
     // we have 1 damaged marker, but trying to repair 2
     repairs.put(repair, 2);
@@ -1595,21 +1595,21 @@ public class WW2V3_41_Test {
   @Test
   public void testOccupiedTerrOfAttachment() {
     // Set up test
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(british(m_data));
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
     // Set up the move delegate
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
     delegateBridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(delegateBridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(delegateBridge);
+    moveDelegate(gameData).start();
     // Set up the territories
-    final Territory hupeh = territory("Hupeh", m_data);
-    final Territory kiangsu = territory("Kiangsu", m_data);
+    final Territory hupeh = territory("Hupeh", gameData);
+    final Territory kiangsu = territory("Kiangsu", gameData);
     // Remove all units
     removeFrom(kiangsu, kiangsu.getUnits().getUnits());
     removeFrom(hupeh, hupeh.getUnits().getUnits());
     // Set up the unit types
-    addTo(hupeh, infantry(m_data).create(1, british));
+    addTo(hupeh, infantry(gameData).create(1, british));
     // Get units
     final Collection<Unit> moveUnits = hupeh.getUnits().getUnits();
     // Get Owner prior to battle
@@ -1628,17 +1628,17 @@ public class WW2V3_41_Test {
   @Test
   public void testOccupiedTerrOfAttachmentWithCapital() {
     // Set up test
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(british(m_data));
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
     // Set up the move delegate
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
     delegateBridge.setStepName("CombatMove");
-    moveDelegate(m_data).setDelegateBridgeAndPlayer(delegateBridge);
-    moveDelegate(m_data).start();
+    moveDelegate(gameData).setDelegateBridgeAndPlayer(delegateBridge);
+    moveDelegate(gameData).start();
     // Set up the territories
-    final Territory hupeh = territory("Hupeh", m_data);
-    final Territory kiangsu = territory("Kiangsu", m_data);
-    final Territory mongolia = territory("Mongolia", m_data);
+    final Territory hupeh = territory("Hupeh", gameData);
+    final Territory kiangsu = territory("Kiangsu", gameData);
+    final Territory mongolia = territory("Mongolia", gameData);
     // Remove original capital
     final TerritoryAttachment taMongolia = TerritoryAttachment.get(mongolia);
     final TerritoryAttachment taKiangsu = TerritoryAttachment.get(kiangsu);
@@ -1654,7 +1654,7 @@ public class WW2V3_41_Test {
     removeFrom(kiangsu, kiangsu.getUnits().getUnits());
     removeFrom(hupeh, hupeh.getUnits().getUnits());
     // Set up the unit types
-    addTo(hupeh, infantry(m_data).create(1, british));
+    addTo(hupeh, infantry(gameData).create(1, british));
     // Get units
     final Collection<Unit> moveUnits = hupeh.getUnits().getUnits();
     // Get Owner prior to battle
@@ -1672,21 +1672,21 @@ public class WW2V3_41_Test {
 
   @Test
   public void testTwoStepBlitz() {
-    final ITestDelegateBridge delegateBridge = getDelegateBridge(british(m_data));
+    final ITestDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
     // Set up the territories
-    final Territory libya = territory("Libya", m_data);
-    final Territory egypt = territory("Egypt", m_data);
-    final Territory morrocco = territory("Morocco Algeria", m_data);
+    final Territory libya = territory("Libya", gameData);
+    final Territory egypt = territory("Egypt", gameData);
+    final Territory morrocco = territory("Morocco Algeria", gameData);
     removeFrom(libya, libya.getUnits().getUnits());
     // Set up the move delegate
-    final MoveDelegate moveDelegate = moveDelegate(m_data);
+    final MoveDelegate moveDelegate = moveDelegate(gameData);
     delegateBridge.setStepName("CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
     // blitz in two steps
     final Collection<Unit> armour = egypt.getUnits().getMatches(Matches.UnitCanBlitz);
     move(armour, new Route(egypt, libya));
-    assertEquals(libya.getOwner(), british(m_data));
+    assertEquals(libya.getOwner(), british(gameData));
     move(armour, new Route(libya, morrocco));
   }
 

--- a/src/test/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorTest.java
@@ -24,22 +24,22 @@ import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.xml.TestMapGameData;
 
 public class OddsCalculatorTest {
-  private GameData m_data;
+  private GameData gameData;
 
   @Before
   public void setUp() throws Exception {
-    m_data = TestMapGameData.REVISED.getGameData();
+    gameData = TestMapGameData.REVISED.getGameData();
   }
 
   @Test
   public void testUnbalancedFight() {
-    final Territory germany = m_data.getMap().getTerritory("Germany");
+    final Territory germany = gameData.getMap().getTerritory("Germany");
     final List<Unit> defendingUnits = new ArrayList<>(germany.getUnits().getUnits());
-    final PlayerID russians = GameDataTestUtil.russians(m_data);
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final List<Unit> attackingUnits = GameDataTestUtil.infantry(m_data).create(100, russians);
+    final PlayerID russians = GameDataTestUtil.russians(gameData);
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final List<Unit> attackingUnits = GameDataTestUtil.infantry(gameData).create(100, russians);
     final List<Unit> bombardingUnits = Collections.emptyList();
-    final IOddsCalculator calculator = new OddsCalculator(m_data);
+    final IOddsCalculator calculator = new OddsCalculator(gameData);
     final AggregateResults results = calculator.setCalculateDataAndCalculate(russians, germans, germany, attackingUnits,
         defendingUnits, bombardingUnits, TerritoryEffectHelper.getEffects(germany), 200);
     calculator.shutdown();
@@ -54,14 +54,14 @@ public class OddsCalculatorTest {
     // 1 fighter
     // if one attacking inf must live, the odds
     // much worse
-    final PlayerID germans = GameDataTestUtil.germans(m_data);
-    final PlayerID british = GameDataTestUtil.british(m_data);
-    final Territory eastCanada = m_data.getMap().getTerritory("Eastern Canada");
-    final List<Unit> defendingUnits = GameDataTestUtil.fighter(m_data).create(1, british, false);
-    final List<Unit> attackingUnits = GameDataTestUtil.infantry(m_data).create(1, germans, false);
-    attackingUnits.addAll(GameDataTestUtil.bomber(m_data).create(1, germans, false));
+    final PlayerID germans = GameDataTestUtil.germans(gameData);
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    final Territory eastCanada = gameData.getMap().getTerritory("Eastern Canada");
+    final List<Unit> defendingUnits = GameDataTestUtil.fighter(gameData).create(1, british, false);
+    final List<Unit> attackingUnits = GameDataTestUtil.infantry(gameData).create(1, germans, false);
+    attackingUnits.addAll(GameDataTestUtil.bomber(gameData).create(1, germans, false));
     final List<Unit> bombardingUnits = Collections.emptyList();
-    final OddsCalculator calculator = new OddsCalculator(m_data);
+    final OddsCalculator calculator = new OddsCalculator(gameData);
     calculator.setKeepOneAttackingLandUnit(true);
     final AggregateResults results = calculator.setCalculateDataAndCalculate(germans, british, eastCanada,
         attackingUnits, defendingUnits, bombardingUnits, TerritoryEffectHelper.getEffects(eastCanada), 1000);
@@ -72,12 +72,12 @@ public class OddsCalculatorTest {
 
   @Test
   public void testAttackingTransports() {
-    final Territory sz1 = territory("1 Sea Zone", m_data);
-    final List<Unit> attacking = transport(m_data).create(2, americans(m_data));
-    final List<Unit> defending = submarine(m_data).create(2, germans(m_data));
-    final OddsCalculator calculator = new OddsCalculator(m_data);
+    final Territory sz1 = territory("1 Sea Zone", gameData);
+    final List<Unit> attacking = transport(gameData).create(2, americans(gameData));
+    final List<Unit> defending = submarine(gameData).create(2, germans(gameData));
+    final OddsCalculator calculator = new OddsCalculator(gameData);
     calculator.setKeepOneAttackingLandUnit(false);
-    final AggregateResults results = calculator.setCalculateDataAndCalculate(americans(m_data), germans(m_data), sz1,
+    final AggregateResults results = calculator.setCalculateDataAndCalculate(americans(gameData), germans(gameData), sz1,
         attacking, defending, Collections.<Unit>emptyList(), TerritoryEffectHelper.getEffects(sz1), 1);
     calculator.shutdown();
     assertEquals(results.getAttackerWinPercent(), 0.0, 0.0);
@@ -87,13 +87,13 @@ public class OddsCalculatorTest {
   @Test
   public void testDefendingTransports() throws Exception {
     // use v3 rule set
-    m_data = TestMapGameData.WW2V3_1942.getGameData();
-    final Territory sz1 = territory("1 Sea Zone", m_data);
-    final List<Unit> attacking = submarine(m_data).create(2, americans(m_data));
-    final List<Unit> defending = transport(m_data).create(2, germans(m_data));
-    final OddsCalculator calculator = new OddsCalculator(m_data);
+    gameData = TestMapGameData.WW2V3_1942.getGameData();
+    final Territory sz1 = territory("1 Sea Zone", gameData);
+    final List<Unit> attacking = submarine(gameData).create(2, americans(gameData));
+    final List<Unit> defending = transport(gameData).create(2, germans(gameData));
+    final OddsCalculator calculator = new OddsCalculator(gameData);
     calculator.setKeepOneAttackingLandUnit(false);
-    final AggregateResults results = calculator.setCalculateDataAndCalculate(americans(m_data), germans(m_data), sz1,
+    final AggregateResults results = calculator.setCalculateDataAndCalculate(americans(gameData), germans(gameData), sz1,
         attacking, defending, Collections.<Unit>emptyList(), TerritoryEffectHelper.getEffects(sz1), 1);
     calculator.shutdown();
     assertEquals(results.getAttackerWinPercent(), 1.0, 0.0);


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName rule in test code under package `g.s.triplea`.

It's pretty much just removing the `m_` prefix on fields.  However, in many cases, the field was renamed to be more descriptive.