### PR TITLE
Replace missing check for dependent battles

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -1144,7 +1144,7 @@ public class BattleTracker implements java.io.Serializable {
       final List<Unit> defenders = new ArrayList<>();
       defenders.addAll(battle.getDefendingUnits());
       final List<Unit> sortedUnitsList = getSortedDefendingUnits(bridge, gameData, territory, defenders);
-      if (DiceRoll.getTotalPower(
+      if (getDependentOn(battle).isEmpty() && DiceRoll.getTotalPower(
           DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedUnitsList, defenders, false, false, gameData,
             territory, TerritoryEffectHelper.getEffects(territory), false, null), gameData) == 0) {
         battle.fight(bridge);


### PR DESCRIPTION
In the numerous iterations of this, it seems that the check of dependent battles was missed out for defenseless battles somewhere along the way. This adds it back.