### PR TITLE
Add missing @Test annotations

### DIFF
--- a/src/test/java/games/strategy/engine/data/MapTest.java
+++ b/src/test/java/games/strategy/engine/data/MapTest.java
@@ -170,6 +170,7 @@ public class MapTest {
     assertTrue(-1 == map.getWaterDistance(aa, ab));
   }
 
+  @Test
   public void testNeighborSeaNoLandConnect() {
     assertTrue(-1 == map.getLandDistance(bc, bd));
   }

--- a/src/test/java/games/strategy/engine/lobby/server/ModeratorControllerTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/ModeratorControllerTest.java
@@ -66,6 +66,7 @@ public class ModeratorControllerTest {
     assertNotNull(moderatorController.setPassword(adminNode, newPassword));
   }
 
+  @Test
   public void testResetUserPasswordUnknownUser() throws UnknownHostException {
     MessageContext.setSenderNodeForThread(adminNode);
     final String newPassword = MD5Crypt.crypt("" + System.currentTimeMillis());
@@ -73,6 +74,7 @@ public class ModeratorControllerTest {
     assertNotNull(moderatorController.setPassword(node, newPassword));
   }
 
+  @Test
   public void testAssertAdmin() throws UnknownHostException {
     MessageContext.setSenderNodeForThread(adminNode);
     assertTrue(moderatorController.isAdmin());

--- a/src/test/java/games/strategy/engine/xml/ParserTest.java
+++ b/src/test/java/games/strategy/engine/xml/ParserTest.java
@@ -35,6 +35,7 @@ public class ParserTest {
     assertNotNull(gameData);
   }
 
+  @Test
   public void testTerritoriesCreated() {
     final GameMap map = gameData.getMap();
     final Collection<Territory> territories = map.getTerritories();

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -724,6 +724,7 @@ public class MoveDelegateTest extends DelegateTest {
     assertTrue(!DelegateFinder.battleDelegate(gameData).getBattleTracker().wasBlitzed(westAfrica));
   }
 
+  @Test
   public void testMoveTransportsTwice() {
     // move transports
     Route route = new Route();

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -1457,6 +1457,7 @@ public class RevisedTest {
     assertError(error);
   }
 
+  @Test
   public void testTransportIsTransport() {
     assertTrue(Matches.UnitIsTransport.match(transport(gameData).create(british(gameData))));
     assertFalse(Matches.UnitIsTransport.match(infantry(gameData).create(british(gameData))));


### PR DESCRIPTION
This PR adds missing `@Test` annotations to test methods where it was obvious that they were unintentionally omitted.  All such tests are currently passing and did not require any changes.