### PR TITLE
Remove unused exception declarations

### DIFF
--- a/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
+++ b/src/main/java/games/strategy/debug/SynchedByteArrayOutputStream.java
@@ -1,7 +1,6 @@
 package games.strategy.debug;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
 
 /**
@@ -17,7 +16,7 @@ class SynchedByteArrayOutputStream extends ByteArrayOutputStream {
     m_mirror = mirror;
   }
 
-  public void write(final byte b) throws IOException {
+  public void write(final byte b) {
     synchronized (lock) {
       m_mirror.write(b);
       super.write(b);

--- a/src/main/java/games/strategy/engine/history/History.java
+++ b/src/main/java/games/strategy/engine/history/History.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.history;
 
-import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -170,7 +169,7 @@ public class History extends DefaultTreeModel {
     }
   }
 
-  private Object writeReplace() throws ObjectStreamException {
+  private Object writeReplace() {
     return new SerializedHistory(this, m_data, m_changes);
   }
 
@@ -217,7 +216,7 @@ class SerializedHistory implements Serializable {
     }
   }
 
-  public Object readResolve() throws ObjectStreamException {
+  public Object readResolve() {
     final History rVal = new History(m_data);
     final HistoryWriter historyWriter = rVal.getHistoryWriter();
     for (final SerializationWriter element : m_Writers) {

--- a/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
+++ b/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.pbem;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
 
@@ -84,7 +83,7 @@ public class PBEMMessagePoster implements Serializable {
     m_turnSummary = turnSummary;
   }
 
-  public void setSaveGame(final File saveGameFile) throws FileNotFoundException {
+  public void setSaveGame(final File saveGameFile) {
     m_saveGameFile = saveGameFile;
   }
 

--- a/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractPlayerRulesAttachment.java
@@ -75,7 +75,7 @@ public abstract class AbstractPlayerRulesAttachment extends AbstractRulesAttachm
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setMovementRestrictionTerritories(final String value) throws GameParseException {
+  public void setMovementRestrictionTerritories(final String value) {
     if (value == null) {
       m_movementRestrictionTerritories = null;
       return;

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -364,7 +364,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     }
   }
 
-  protected void validateNames(final String[] terrList) throws GameParseException {
+  protected void validateNames(final String[] terrList) {
     if (terrList != null && terrList.length > 0) {
       getListedTerritories(terrList, true, true);
       // removed checks for length & group commands because it breaks the setTerritoryCount feature.

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -292,7 +292,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAlliedOwnershipTerritories(final String value) throws GameParseException {
+  public void setAlliedOwnershipTerritories(final String value) {
     if (value == null) {
       m_alliedOwnershipTerritories = null;
       return;
@@ -316,7 +316,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
 
   // exclusion types = controlled, controlledNoWater, original, all, or list
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAlliedExclusionTerritories(final String value) throws GameParseException {
+  public void setAlliedExclusionTerritories(final String value) {
     if (value == null) {
       m_alliedExclusionTerritories = null;
       return;
@@ -339,7 +339,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDirectExclusionTerritories(final String value) throws GameParseException {
+  public void setDirectExclusionTerritories(final String value) {
     if (value == null) {
       m_directExclusionTerritories = null;
       return;
@@ -363,7 +363,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
 
   // exclusion types = original or list
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setEnemyExclusionTerritories(final String value) throws GameParseException {
+  public void setEnemyExclusionTerritories(final String value) {
     if (value == null) {
       m_enemyExclusionTerritories = null;
       return;
@@ -386,7 +386,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDirectPresenceTerritories(final String value) throws GameParseException {
+  public void setDirectPresenceTerritories(final String value) {
     if (value == null) {
       m_directPresenceTerritories = null;
       return;
@@ -409,7 +409,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAlliedPresenceTerritories(final String value) throws GameParseException {
+  public void setAlliedPresenceTerritories(final String value) {
     if (value == null) {
       m_alliedPresenceTerritories = null;
       return;
@@ -432,7 +432,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setEnemyPresenceTerritories(final String value) throws GameParseException {
+  public void setEnemyPresenceTerritories(final String value) {
     if (value == null) {
       m_enemyPresenceTerritories = null;
       return;
@@ -456,7 +456,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
 
   // exclusion types = original or list
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setEnemySurfaceExclusionTerritories(final String value) throws GameParseException {
+  public void setEnemySurfaceExclusionTerritories(final String value) {
     if (value == null) {
       m_enemySurfaceExclusionTerritories = null;
       return;
@@ -479,7 +479,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setDirectOwnershipTerritories(final String value) throws GameParseException {
+  public void setDirectOwnershipTerritories(final String value) {
     if (value == null) {
       m_directOwnershipTerritories = null;
       return;

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -594,7 +594,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
-  public void setAirborneForces(final String value) throws GameParseException {
+  public void setAirborneForces(final String value) {
     m_airborneForces = getBool(value);
   }
 

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -744,7 +744,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setUnitProperty(final String prop) throws GameParseException {
+  public void setUnitProperty(final String prop) {
     if (prop == null) {
       m_unitProperty = null;
       return;
@@ -857,7 +857,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setTerritoryProperty(final String prop) throws GameParseException {
+  public void setTerritoryProperty(final String prop) {
     if (prop == null) {
       m_territoryProperty = null;
       return;
@@ -990,7 +990,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setPlayerProperty(final String prop) throws GameParseException {
+  public void setPlayerProperty(final String prop) {
     if (prop == null) {
       m_playerProperty = null;
       return;
@@ -1101,7 +1101,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setRelationshipTypeProperty(final String prop) throws GameParseException {
+  public void setRelationshipTypeProperty(final String prop) {
     if (prop == null) {
       m_relationshipTypeProperty = null;
       return;
@@ -1213,7 +1213,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    * Adds to, not sets. Anything that adds to instead of setting needs a clear function as well.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
-  public void setTerritoryEffectProperty(final String prop) throws GameParseException {
+  public void setTerritoryEffectProperty(final String prop) {
     if (prop == null) {
       m_territoryEffectProperty = null;
       return;

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -2043,7 +2043,7 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   // Beagle Code Called to Change Mapskin
-  public void updateMap(final String mapdir) throws IOException {
+  public void updateMap(final String mapdir) {
     uiContext.setMapDir(data, mapdir);
     // when changing skins, always show relief images
     if (uiContext.getMapData().getHasRelief()) {

--- a/src/test/java/games/strategy/engine/lobby/server/ModeratorControllerTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/ModeratorControllerTest.java
@@ -60,7 +60,7 @@ public class ModeratorControllerTest {
   }
 
   @Test
-  public void testCantResetAdminPassword() throws UnknownHostException {
+  public void testCantResetAdminPassword() {
     MessageContext.setSenderNodeForThread(adminNode);
     final String newPassword = MD5Crypt.crypt("" + System.currentTimeMillis());
     assertNotNull(moderatorController.setPassword(adminNode, newPassword));
@@ -75,7 +75,7 @@ public class ModeratorControllerTest {
   }
 
   @Test
-  public void testAssertAdmin() throws UnknownHostException {
+  public void testAssertAdmin() {
     MessageContext.setSenderNodeForThread(adminNode);
     assertTrue(moderatorController.isAdmin());
   }

--- a/src/test/java/games/strategy/net/MessengerTest.java
+++ b/src/test/java/games/strategy/net/MessengerTest.java
@@ -107,7 +107,7 @@ public class MessengerTest {
   }
 
   @Test
-  public void testClientSendToClient() throws InterruptedException {
+  public void testClientSendToClient() {
     final String message = "Hello";
     client1Messenger.send(message, client2Messenger.getLocalNode());
     assertEquals(client2MessageListener.getLastMessage(), message);
@@ -117,7 +117,7 @@ public class MessengerTest {
   }
 
   @Test
-  public void testClientSendToClientLargeMessage() throws InterruptedException {
+  public void testClientSendToClientLargeMessage() {
     final int count = 1 * 1000 * 1000;
     final StringBuilder builder = new StringBuilder(count);
     for (int i = 0; i < count; i++) {
@@ -196,7 +196,7 @@ public class MessengerTest {
   }
 
   @Test
-  public void testCorrectNodeCountInRemove() throws InterruptedException {
+  public void testCorrectNodeCountInRemove() {
     // when we receive the notification that a
     // connection has been lost, the node list
     // should reflect that change
@@ -230,7 +230,7 @@ public class MessengerTest {
   }
 
   @Test
-  public void testDisconnect() throws InterruptedException {
+  public void testDisconnect() {
     for (int i = 0; i < 100; i++) {
       if (serverMessenger.getNodes().size() == 3) {
         break;
@@ -251,7 +251,7 @@ public class MessengerTest {
   }
 
   @Test
-  public void testClose() throws InterruptedException {
+  public void testClose() {
     final AtomicBoolean closed = new AtomicBoolean(false);
     client1Messenger.addErrorListener(new IMessengerErrorListener() {
       @Override
@@ -269,7 +269,7 @@ public class MessengerTest {
   }
 
   @Test
-  public void testManyClients() throws UnknownHostException, CouldNotLogInException, IOException, InterruptedException {
+  public void testManyClients() throws UnknownHostException, CouldNotLogInException, IOException {
     final int count = 5;
     final List<ClientMessenger> clients = new ArrayList<>();
     final List<MessageListener> listeners = new ArrayList<>();


### PR DESCRIPTION
This PR removes any checked exception declaration for methods where the exception is not thrown either directly or transitively (as flagged by the Eclipse JDT static analyzer).