### PR TITLE
Fix out-of-date map check (#1522)

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -530,7 +530,7 @@ public class GameRunner {
     messageBuilder.append("command if you don't want to do it now.)");
     messageBuilder.append("</html>");
     SwingComponents.promptUser("Welcome to TripleA", messageBuilder.toString(), () -> {
-      DownloadMapsWindow.showDownloadMapsWindow("Tutorial");
+      DownloadMapsWindow.showDownloadMapsWindowAndDownload("Tutorial");
     });
     return true;
   }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -8,9 +8,9 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.event.ActionListener;
-import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -34,8 +34,7 @@ import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import games.strategy.ui.SwingComponents;
-import games.strategy.util.Version;
-
+import games.strategy.util.OptionalUtils;
 
 /** Window that allows for map downloads and removal. */
 public class DownloadMapsWindow extends JFrame {
@@ -50,33 +49,44 @@ public class DownloadMapsWindow extends JFrame {
 
   private final MapDownloadProgressPanel progressPanel;
 
-
-  public static Version getVersion(final File zipFile) {
-    final DownloadFileProperties props = DownloadFileProperties.loadForZip(zipFile);
-    return props.getVersion();
+  public static void showDownloadMapsWindow() {
+    showDownloadMapsWindowAndDownload(Collections.emptyList());
   }
 
   /**
-   * Shows the download window and begins downloading the specified map right away.
-   * If the map cannot be downloaded a message prompt is shown to the user.
+   * Shows the Download Maps window and immediately begins downloading the specified map in the background.
+   *
+   * <p>
+   * The user will be notified if the specified map is unknown.
+   * </p>
+   *
+   * @param mapName The name of the map to download; must not be {@code null}.
    */
-  public static void showDownloadMapsWindow(final String mapName) {
-    showDownloadMapsWindow(Optional.of(mapName));
+  public static void showDownloadMapsWindowAndDownload(final String mapName) {
+    checkNotNull(mapName);
+
+    showDownloadMapsWindowAndDownload(Collections.singletonList(mapName));
   }
 
-  public static void showDownloadMapsWindow() {
-    showDownloadMapsWindow(Optional.empty());
-  }
+  /**
+   * Shows the Download Maps window and immediately begins downloading the specified maps in the background.
+   *
+   * <p>
+   * The user will be notified if any of the specified maps are unknown.
+   * </p>
+   *
+   * @param mapNames The collection containing the names of the maps to download; must not be {@code null}.
+   */
+  public static void showDownloadMapsWindowAndDownload(final Collection<String> mapNames) {
+    checkNotNull(mapNames);
 
-
-  private static void showDownloadMapsWindow(Optional<String> mapName) {
     Runnable downloadAndShowWindow = () -> {
-      final List<DownloadFileDescription> games =
+      final List<DownloadFileDescription> allDownloads =
           new DownloadRunnable(ClientContext.mapListingSource().getMapListDownloadSite()).getDownloads();
-      checkNotNull(games);
+      checkNotNull(allDownloads);
 
       SwingUtilities.invokeLater(() -> {
-        final DownloadMapsWindow dia = new DownloadMapsWindow(mapName, games);
+        final DownloadMapsWindow dia = new DownloadMapsWindow(mapNames, allDownloads);
         dia.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
         dia.setLocationRelativeTo(null);
         dia.setMinimumSize(new Dimension(200, 200));
@@ -85,34 +95,49 @@ public class DownloadMapsWindow extends JFrame {
         dia.toFront();
       });
     };
-    final String popupWindowTitle = "Downloading list of availabe maps....";
+    final String popupWindowTitle = "Downloading list of available maps...";
     BackgroundTaskRunner.runInBackground(popupWindowTitle, downloadAndShowWindow);
   }
 
-  private DownloadMapsWindow(final Optional<String> mapName, final List<DownloadFileDescription> games) {
+  private DownloadMapsWindow(
+      final Collection<String> pendingDownloadMapNames,
+      final List<DownloadFileDescription> allDownloads) {
     super("Download Maps");
     setIconImage(GameRunner.getGameIcon(this));
     progressPanel = new MapDownloadProgressPanel(this);
-    if (mapName.isPresent()) {
-      final Optional<DownloadFileDescription> mapDownload = findMap(mapName.get(), games);
-      if (mapDownload.isPresent()) {
-        progressPanel.download(Arrays.asList(mapDownload.get()));
-      } else {
-        SwingComponents.newMessageDialog("Unable to download map, could not find: " + mapName.get());
-      }
+
+    final List<DownloadFileDescription> pendingDownloads = new ArrayList<>();
+    final Collection<String> unknownMapNames = new ArrayList<>();
+    for (final String mapName : pendingDownloadMapNames) {
+      OptionalUtils.ifPresentOrElse(findMap(mapName, allDownloads),
+          pendingDownloads::add,
+          () -> unknownMapNames.add(mapName));
     }
+
+    if (!pendingDownloads.isEmpty()) {
+      progressPanel.download(pendingDownloads);
+    }
+
+    if (!unknownMapNames.isEmpty()) {
+      SwingComponents.newMessageDialog(formatUnknownPendingMapsMessage(unknownMapNames));
+    }
+
+    final Optional<String> selectedMapName = pendingDownloadMapNames.isEmpty()
+        ? Optional.empty()
+        : Optional.of(pendingDownloadMapNames.iterator().next());
+
     SwingComponents.addWindowCloseListener(this, () -> progressPanel.cancel());
 
     final JTabbedPane outerTabs = new JTabbedPane();
 
-    final List<DownloadFileDescription> maps = filterMaps(games, download -> download.isMap());
-    outerTabs.add("Maps", createdTabbedPanelForMaps(maps));
+    final List<DownloadFileDescription> maps = filterMaps(allDownloads, download -> download.isMap());
+    outerTabs.add("Maps", createdTabbedPanelForMaps(maps, pendingDownloads));
 
-    final List<DownloadFileDescription> skins = filterMaps(games, download -> download.isMapSkin());
-    outerTabs.add("Skins", createAvailableInstalledTabbedPanel(mapName, skins));
+    final List<DownloadFileDescription> skins = filterMaps(allDownloads, download -> download.isMapSkin());
+    outerTabs.add("Skins", createAvailableInstalledTabbedPanel(selectedMapName, skins, pendingDownloads));
 
-    final List<DownloadFileDescription> tools = filterMaps(games, download -> download.isMapTool());
-    outerTabs.add("Tools", createAvailableInstalledTabbedPanel(mapName, tools));
+    final List<DownloadFileDescription> tools = filterMaps(allDownloads, download -> download.isMapTool());
+    outerTabs.add("Tools", createAvailableInstalledTabbedPanel(selectedMapName, tools, pendingDownloads));
 
     final JSplitPane splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, outerTabs,
         SwingComponents.newJScrollPane(progressPanel));
@@ -120,17 +145,32 @@ public class DownloadMapsWindow extends JFrame {
     add(splitPane);
   }
 
-  private Component createdTabbedPanelForMaps(List<DownloadFileDescription> maps) {
+  private static String formatUnknownPendingMapsMessage(final Collection<String> mapNames) {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("<html>");
+    sb.append("Unable to download map(s).<br>");
+    sb.append("<br>");
+    sb.append("Could not find the following map(s):<br>");
+    sb.append("<ul>");
+    for (final String mapName : mapNames) {
+      sb.append("<li>").append(mapName).append("</li>");
+    }
+    sb.append("</ul>");
+    sb.append("</html>");
+    return sb.toString();
+  }
 
-    JTabbedPane mapTabs = SwingComponents.newJTabbedPane();
-
-    for (DownloadFileDescription.MapCategory mapCategory : Arrays
-        .asList(DownloadFileDescription.MapCategory.values())) {
-
-      List<DownloadFileDescription> mapsByCategory =
-          maps.stream().filter(map -> map.getMapCategory() == mapCategory).collect(Collectors.toList());
-      if (!mapsByCategory.isEmpty()) {
-        JTabbedPane subTab = createAvailableInstalledTabbedPanel(Optional.of(mapCategory.toString()), mapsByCategory);
+  private Component createdTabbedPanelForMaps(
+      final List<DownloadFileDescription> downloads,
+      final List<DownloadFileDescription> pendingDownloads) {
+    final JTabbedPane mapTabs = SwingComponents.newJTabbedPane();
+    for (final DownloadFileDescription.MapCategory mapCategory : DownloadFileDescription.MapCategory.values()) {
+      final List<DownloadFileDescription> categorizedDownloads = downloads.stream()
+          .filter(download -> download.getMapCategory() == mapCategory)
+          .collect(Collectors.toList());
+      if (!categorizedDownloads.isEmpty()) {
+        final JTabbedPane subTab = createAvailableInstalledTabbedPanel(Optional.of(mapCategory.toString()),
+            categorizedDownloads, pendingDownloads);
         mapTabs.add(mapCategory.toString(), subTab);
       }
     }
@@ -162,23 +202,24 @@ public class DownloadMapsWindow extends JFrame {
     return maps.stream().filter(map -> filter.apply(map)).collect(Collectors.toList());
   }
 
-  private JTabbedPane createAvailableInstalledTabbedPanel(final Optional<String> mapName,
-      final List<DownloadFileDescription> games) {
-    final MapDownloadList mapList = new MapDownloadList(games, new FileSystemAccessStrategy());
+  private JTabbedPane createAvailableInstalledTabbedPanel(
+      final Optional<String> selectedMapName,
+      final List<DownloadFileDescription> downloads,
+      final List<DownloadFileDescription> pendingDownloads) {
+    final MapDownloadList mapList = new MapDownloadList(downloads, new FileSystemAccessStrategy());
 
     final JTabbedPane tabbedPane = new JTabbedPane();
 
-
-    JPanel outOfDate = null;
-    if (!mapList.getOutOfDate().isEmpty()) {
-      outOfDate = createMapSelectionPanel(mapName, mapList.getOutOfDate(), MapAction.UPDATE);
-    }
+    final List<DownloadFileDescription> outOfDateDownloads = mapList.getOutOfDateExcluding(pendingDownloads);
+    final JPanel outOfDate = outOfDateDownloads.isEmpty()
+        ? null
+        : createMapSelectionPanel(selectedMapName, outOfDateDownloads, MapAction.UPDATE);
     // For the UX, always show an available maps tab, even if it is empty
-    final JPanel available = createMapSelectionPanel(mapName, mapList.getAvailable(), MapAction.INSTALL);
+    final JPanel available = createMapSelectionPanel(selectedMapName, mapList.getAvailable(), MapAction.INSTALL);
 
 
     // if there is a map to preselect, show the available map list first
-    if (mapName.isPresent()) {
+    if (selectedMapName.isPresent()) {
       tabbedPane.addTab("Available", available);
     }
 
@@ -189,12 +230,12 @@ public class DownloadMapsWindow extends JFrame {
 
     // finally make sure we are always showing the 'available' tab, this condition will be
     // true if the first 'mapName.isPresent()' is false
-    if (!mapName.isPresent()) {
+    if (!selectedMapName.isPresent()) {
       tabbedPane.addTab("Available", available);
     }
 
     if (!mapList.getInstalled().isEmpty()) {
-      final JPanel installed = createMapSelectionPanel(mapName, mapList.getInstalled(), MapAction.REMOVE);
+      final JPanel installed = createMapSelectionPanel(selectedMapName, mapList.getInstalled(), MapAction.REMOVE);
       tabbedPane.addTab("Installed", installed);
     }
     return tabbedPane;
@@ -231,7 +272,7 @@ public class DownloadMapsWindow extends JFrame {
     return main;
   }
 
-  private DownloadFileDescription determineCurrentMapSelection(final List<DownloadFileDescription> maps,
+  private static DownloadFileDescription determineCurrentMapSelection(final List<DownloadFileDescription> maps,
       final Optional<String> mapToSelect) {
     checkArgument(maps.size() > 0);
     if (mapToSelect.isPresent()) {

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -49,9 +49,9 @@ public class MapDownloadController {
 
       SystemPreferences.put(SystemPreferenceKey.TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES, year + ":" + month);
 
-      final Collection<DownloadFileDescription> downloadFileDescriptions =
+      final Collection<DownloadFileDescription> allDownloads =
           new DownloadRunnable(mapDownloadProperties.getMapListDownloadSite()).getDownloads();
-      final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+      final Collection<String> outOfDateMapNames = getOutOfDateMapNames(allDownloads);
       if (!outOfDateMapNames.isEmpty()) {
         final StringBuilder text = new StringBuilder();
         text.append("<html>Some of the maps you have are out of date, and newer versions of those maps exist.<br><br>");
@@ -70,28 +70,24 @@ public class MapDownloadController {
     return false;
   }
 
-  private static Collection<String> getOutOfDateMapNames(
-      final Collection<DownloadFileDescription> downloadFileDescriptions) {
-    return getOutOfDateMapNames(downloadFileDescriptions, getDownloadedMaps());
+  private static Collection<String> getOutOfDateMapNames(final Collection<DownloadFileDescription> downloads) {
+    return getOutOfDateMapNames(downloads, getDownloadedMaps());
   }
 
   @VisibleForTesting
   static Collection<String> getOutOfDateMapNames(
-      final Collection<DownloadFileDescription> downloadFileDescriptions,
+      final Collection<DownloadFileDescription> downloads,
       final DownloadedMaps downloadedMaps) {
-    return downloadFileDescriptions.stream()
+    return downloads.stream()
         .filter(Objects::nonNull)
         .filter(it -> isMapOutOfDate(it, downloadedMaps))
         .map(DownloadFileDescription::getMapName)
         .collect(Collectors.toList());
   }
 
-  private static boolean isMapOutOfDate(
-      final DownloadFileDescription downloadFileDescription,
-      final DownloadedMaps downloadedMaps) {
-    final Optional<Version> latestVersion = Optional.ofNullable(downloadFileDescription.getVersion());
-    final Optional<Version> downloadedVersion =
-        getDownloadedVersion(downloadFileDescription.getMapName(), downloadedMaps);
+  private static boolean isMapOutOfDate(final DownloadFileDescription download, final DownloadedMaps downloadedMaps) {
+    final Optional<Version> latestVersion = Optional.ofNullable(download.getVersion());
+    final Optional<Version> downloadedVersion = getDownloadedVersion(download.getMapName(), downloadedMaps);
 
     final AtomicBoolean mapOutOfDate = new AtomicBoolean(false);
     latestVersion.ifPresent(latest -> {

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -54,13 +54,14 @@ public class MapDownloadController {
       final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
       if (!outOfDateMapNames.isEmpty()) {
         final StringBuilder text = new StringBuilder();
-        text.append("<html>Some of the maps you have are out of date, and newer versions of those maps exist.<br>");
-        text.append("Would you like to update (re-download) the following maps now?:<br><ul>");
+        text.append("<html>Some of the maps you have are out of date, and newer versions of those maps exist.<br><br>");
+        text.append("Would you like to update (re-download) the following maps now?<br><ul>");
         for (final String mapName : outOfDateMapNames) {
           text.append("<li> ").append(mapName).append("</li>");
         }
         text.append("</ul></html>");
-        SwingComponents.promptUser("Update Your Maps?", text.toString(), DownloadMapsWindow::showDownloadMapsWindow);
+        SwingComponents.promptUser("Update Your Maps?", text.toString(),
+            () -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(outOfDateMapNames));
         return true;
       }
     } catch (final Exception e) {

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -1,20 +1,23 @@
 package games.strategy.engine.framework.map.download;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.settings.SystemPreferenceKey;
 import games.strategy.triplea.settings.SystemPreferences;
 import games.strategy.ui.SwingComponents;
-
+import games.strategy.util.Version;
 
 /** Controller for in-game map download actions. */
 public class MapDownloadController {
@@ -46,16 +49,15 @@ public class MapDownloadController {
 
       SystemPreferences.put(SystemPreferenceKey.TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES, year + ":" + month);
 
-      final List<DownloadFileDescription> downloads =
+      final Collection<DownloadFileDescription> downloadFileDescriptions =
           new DownloadRunnable(mapDownloadProperties.getMapListDownloadSite()).getDownloads();
-
-      final Collection<String> outOfDateMaps = populateOutOfDateMapsListing(downloads);
-      if (!outOfDateMaps.isEmpty()) {
-        final StringBuilder text =
-            new StringBuilder("<html>Some of the maps you have are out of date, and newer versions of those maps exist."
-                + "<br>Would you like to update (re-download) the following maps now?:<br><ul>");
-        for (final String map : outOfDateMaps) {
-          text.append("<li> ").append(map).append("</li>");
+      final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+      if (!outOfDateMapNames.isEmpty()) {
+        final StringBuilder text = new StringBuilder();
+        text.append("<html>Some of the maps you have are out of date, and newer versions of those maps exist.<br>");
+        text.append("Would you like to update (re-download) the following maps now?:<br><ul>");
+        for (final String mapName : outOfDateMapNames) {
+          text.append("<li> ").append(mapName).append("</li>");
         }
         text.append("</ul></html>");
         SwingComponents.promptUser("Update Your Maps?", text.toString(), DownloadMapsWindow::showDownloadMapsWindow);
@@ -67,23 +69,65 @@ public class MapDownloadController {
     return false;
   }
 
+  private static Collection<String> getOutOfDateMapNames(
+      final Collection<DownloadFileDescription> downloadFileDescriptions) {
+    return getOutOfDateMapNames(downloadFileDescriptions, getDownloadedMaps());
+  }
 
-  private static Collection<String> populateOutOfDateMapsListing(
-      final Collection<DownloadFileDescription> gamesDownloadFileDescriptions) {
+  @VisibleForTesting
+  static Collection<String> getOutOfDateMapNames(
+      final Collection<DownloadFileDescription> downloadFileDescriptions,
+      final DownloadedMaps downloadedMaps) {
+    return downloadFileDescriptions.stream()
+        .filter(Objects::nonNull)
+        .filter(it -> isMapOutOfDate(it, downloadedMaps))
+        .map(DownloadFileDescription::getMapName)
+        .collect(Collectors.toList());
+  }
 
-    final Collection<String> listingToBeAddedTo = new ArrayList<>();
+  private static boolean isMapOutOfDate(
+      final DownloadFileDescription downloadFileDescription,
+      final DownloadedMaps downloadedMaps) {
+    final Optional<Version> latestVersion = Optional.ofNullable(downloadFileDescription.getVersion());
+    final Optional<Version> downloadedVersion =
+        getDownloadedVersion(downloadFileDescription.getMapName(), downloadedMaps);
 
-    for (final DownloadFileDescription d : gamesDownloadFileDescriptions) {
-      if (d != null) {
-        final File installed = new File(ClientFileSystemHelper.getUserMapsFolder(), d.getMapName() + ".zip");
-        if (installed.exists()) {
-          if (d.getVersion() != null && d.getVersion().isGreaterThan(DownloadMapsWindow.getVersion(installed), true)) {
-            listingToBeAddedTo.add(d.getMapName());
-          }
-        }
+    final AtomicBoolean mapOutOfDate = new AtomicBoolean(false);
+    latestVersion.ifPresent(latest -> {
+      downloadedVersion.ifPresent(downloaded -> {
+        mapOutOfDate.set(latest.isGreaterThan(downloaded));
+      });
+    });
+    return mapOutOfDate.get();
+  }
+
+  private static Optional<Version> getDownloadedVersion(final String mapName, final DownloadedMaps downloadedMaps) {
+    return downloadedMaps.getZipFileCandidates(mapName).stream()
+        .map(downloadedMaps::getVersionForZipFile)
+        .filter(Optional::isPresent)
+        .findFirst()
+        .orElseGet(Optional::empty);
+  }
+
+  @VisibleForTesting
+  interface DownloadedMaps {
+    Optional<Version> getVersionForZipFile(File mapZipFile);
+
+    List<File> getZipFileCandidates(String mapName);
+  }
+
+  private static DownloadedMaps getDownloadedMaps() {
+    return new DownloadedMaps() {
+      @Override
+      public Optional<Version> getVersionForZipFile(final File mapZipFile) {
+        return Optional.ofNullable(DownloadFileProperties.loadForZip(mapZipFile).getVersion());
       }
-    }
-    return listingToBeAddedTo;
+
+      @Override
+      public List<File> getZipFileCandidates(final String mapName) {
+        return ResourceLoader.getMapZipFileCandidates(mapName);
+      }
+    };
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
@@ -3,7 +3,9 @@ package games.strategy.engine.framework.map.download;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+import games.strategy.util.PredicateUtils;
 import games.strategy.util.Version;
 
 public class MapDownloadList {
@@ -40,5 +42,11 @@ public class MapDownloadList {
 
   public List<DownloadFileDescription> getOutOfDate() {
     return outOfDate;
+  }
+
+  List<DownloadFileDescription> getOutOfDateExcluding(final List<DownloadFileDescription> excluded) {
+    return outOfDate.stream()
+        .filter(PredicateUtils.not(excluded::contains))
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
@@ -1,11 +1,12 @@
 package games.strategy.engine.framework.map.download;
 
+import static games.strategy.util.PredicateUtils.not;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import games.strategy.util.PredicateUtils;
 import games.strategy.util.Version;
 
 public class MapDownloadList {
@@ -46,7 +47,7 @@ public class MapDownloadList {
 
   List<DownloadFileDescription> getOutOfDateExcluding(final List<DownloadFileDescription> excluded) {
     return outOfDate.stream()
-        .filter(PredicateUtils.not(excluded::contains))
+        .filter(not(excluded::contains))
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -57,7 +57,7 @@ public class ResourceLoader implements Closeable {
       SwingComponents.promptUser("Download Map?",
           "Map missing: " + mapName + ", could not join game.\nWould you like to download the map now?"
               + "\nOnce the download completes, you may reconnect to this game.",
-          () -> DownloadMapsWindow.showDownloadMapsWindow(mapName));
+          () -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(mapName));
 
       throw new MapNotFoundException();
     }

--- a/src/main/java/games/strategy/util/OptionalUtils.java
+++ b/src/main/java/games/strategy/util/OptionalUtils.java
@@ -1,0 +1,36 @@
+package games.strategy.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * A collection of useful methods for working with instances of {@link Optional}.
+ */
+public final class OptionalUtils {
+  private OptionalUtils() {}
+
+  /**
+   * If a value is present in the specified {@code Optional}, performs the given action with the value, otherwise
+   * performs the given empty-based action.
+   *
+   * @param optional The {@code Optional} on which to operate; must not be {@code null}.
+   * @param presentAction The action to be performed, if a value is present; must not be {@code null}.
+   * @param emptyAction The empty-based action to be performed, if no value is present; must not be {@code null}.
+   */
+  public static <T> void ifPresentOrElse(
+      final Optional<T> optional,
+      final Consumer<? super T> presentAction,
+      final Runnable emptyAction) {
+    checkNotNull(optional);
+    checkNotNull(presentAction);
+    checkNotNull(emptyAction);
+
+    if (optional.isPresent()) {
+      presentAction.accept(optional.get());
+    } else {
+      emptyAction.run();
+    }
+  }
+}

--- a/src/main/java/games/strategy/util/PredicateUtils.java
+++ b/src/main/java/games/strategy/util/PredicateUtils.java
@@ -1,0 +1,25 @@
+package games.strategy.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.function.Predicate;
+
+/**
+ * A collection of useful methods for working with instances of {@link Predicate}.
+ */
+public final class PredicateUtils {
+  private PredicateUtils() {}
+
+  /**
+   * Returns a predicate that represents the logical negation of the specified predicate.
+   *
+   * @param p The predicate to negate; must not be {@code null}.
+   *
+   * @return A predicate that represents the logical negation of the specified predicate; never {@code null}.
+   */
+  public static <T> Predicate<T> not(final Predicate<T> p) {
+    checkNotNull(p);
+
+    return p.negate();
+  }
+}

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerOutOfDateMapsTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerOutOfDateMapsTest.java
@@ -40,24 +40,23 @@ public final class MapDownloadControllerOutOfDateMapsTest {
 
   @Test
   public void getOutOfDateMapNames_ShouldIncludeMapWhenMapIsOutOfDate() {
-    final Collection<DownloadFileDescription> downloadFileDescriptions = givenLatestMapVersionIs(VERSION_2);
+    final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(VERSION_2);
     givenDownloadedMapVersionIs(VERSION_1);
 
-    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 
     assertThat(outOfDateMapNames, contains(MAP_NAME));
   }
 
   private static Collection<DownloadFileDescription> givenLatestMapVersionIs(final Version version) {
-    return givenDownloadFileDescription(newDownloadFileDescriptionWithVersion(version));
+    return givenDownload(newDownloadWithVersion(version));
   }
 
-  private static Collection<DownloadFileDescription> givenDownloadFileDescription(
-      final DownloadFileDescription downloadFileDescription) {
-    return Collections.singletonList(downloadFileDescription);
+  private static Collection<DownloadFileDescription> givenDownload(final DownloadFileDescription download) {
+    return Collections.singletonList(download);
   }
 
-  private static DownloadFileDescription newDownloadFileDescriptionWithVersion(final Version version) {
+  private static DownloadFileDescription newDownloadWithVersion(final Version version) {
     return new DownloadFileDescription(
         "url",
         "description",
@@ -73,26 +72,26 @@ public final class MapDownloadControllerOutOfDateMapsTest {
     when(downloadedMaps.getVersionForZipFile(MAP_ZIP_FILE_2)).thenReturn(Optional.of(version));
   }
 
-  private Collection<String> getOutOfDateMapNames(final Collection<DownloadFileDescription> downloadFileDescriptions) {
-    return MapDownloadController.getOutOfDateMapNames(downloadFileDescriptions, downloadedMaps);
+  private Collection<String> getOutOfDateMapNames(final Collection<DownloadFileDescription> downloads) {
+    return MapDownloadController.getOutOfDateMapNames(downloads, downloadedMaps);
   }
 
   @Test
   public void getOutOfDateMapNames_ShouldExcludeMapWhenMapIsUpToDate() {
-    final Collection<DownloadFileDescription> downloadFileDescriptions = givenLatestMapVersionIs(VERSION_1);
+    final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(VERSION_1);
     givenDownloadedMapVersionIs(VERSION_1);
 
-    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 
     assertThat(outOfDateMapNames, not(contains(MAP_NAME)));
   }
 
   @Test
   public void getOutOfDateMapNames_ShouldExcludeMapWhenDownloadedVersionIsUnknown() {
-    final Collection<DownloadFileDescription> downloadFileDescriptions = givenLatestMapVersionIs(VERSION_1);
+    final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(VERSION_1);
     givenDownloadedMapVersionIsUnknown();
 
-    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 
     assertThat(outOfDateMapNames, not(contains(MAP_NAME)));
   }
@@ -104,20 +103,20 @@ public final class MapDownloadControllerOutOfDateMapsTest {
 
   @Test
   public void getOutOfDateMapNames_ShouldExcludeMapWhenLatestVersionIsUnknown() {
-    final Collection<DownloadFileDescription> downloadFileDescriptions = givenLatestMapVersionIs(VERSION_UNKNOWN);
+    final Collection<DownloadFileDescription> downloads = givenLatestMapVersionIs(VERSION_UNKNOWN);
     givenDownloadedMapVersionIs(VERSION_1);
 
-    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 
     assertThat(outOfDateMapNames, not(contains(MAP_NAME)));
   }
 
   @Test
-  public void getOutOfDateMapNames_ShouldExcludeMapWhenDownloadFileDescriptionIsNull() {
-    final Collection<DownloadFileDescription> downloadFileDescriptions = givenDownloadFileDescription(null);
+  public void getOutOfDateMapNames_ShouldExcludeMapWhenDownloadIsNull() {
+    final Collection<DownloadFileDescription> downloads = givenDownload(null);
     givenDownloadedMapVersionIs(VERSION_1);
 
-    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloads);
 
     assertThat(outOfDateMapNames, empty());
   }

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerOutOfDateMapsTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerOutOfDateMapsTest.java
@@ -1,0 +1,124 @@
+package games.strategy.engine.framework.map.download;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import games.strategy.engine.framework.map.download.MapDownloadController.DownloadedMaps;
+import games.strategy.util.Version;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class MapDownloadControllerOutOfDateMapsTest {
+  private static final String MAP_NAME = "myMap";
+
+  private static final File MAP_ZIP_FILE_1 = new File("file1.zip");
+
+  private static final File MAP_ZIP_FILE_2 = new File("file2.zip");
+
+  private static final Version VERSION_1 = new Version(1, 0);
+
+  private static final Version VERSION_2 = new Version(2, 0);
+
+  private static final Version VERSION_UNKNOWN = null;
+
+  @Mock
+  private DownloadedMaps downloadedMaps;
+
+  @Test
+  public void getOutOfDateMapNames_ShouldIncludeMapWhenMapIsOutOfDate() {
+    final Collection<DownloadFileDescription> downloadFileDescriptions = givenLatestMapVersionIs(VERSION_2);
+    givenDownloadedMapVersionIs(VERSION_1);
+
+    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+
+    assertThat(outOfDateMapNames, contains(MAP_NAME));
+  }
+
+  private static Collection<DownloadFileDescription> givenLatestMapVersionIs(final Version version) {
+    return givenDownloadFileDescription(newDownloadFileDescriptionWithVersion(version));
+  }
+
+  private static Collection<DownloadFileDescription> givenDownloadFileDescription(
+      final DownloadFileDescription downloadFileDescription) {
+    return Collections.singletonList(downloadFileDescription);
+  }
+
+  private static DownloadFileDescription newDownloadFileDescriptionWithVersion(final Version version) {
+    return new DownloadFileDescription(
+        "url",
+        "description",
+        MAP_NAME,
+        version,
+        DownloadFileDescription.DownloadType.MAP,
+        DownloadFileDescription.MapCategory.BEST);
+  }
+
+  private void givenDownloadedMapVersionIs(final Version version) {
+    when(downloadedMaps.getZipFileCandidates(MAP_NAME)).thenReturn(Arrays.asList(MAP_ZIP_FILE_1, MAP_ZIP_FILE_2));
+    when(downloadedMaps.getVersionForZipFile(MAP_ZIP_FILE_1)).thenReturn(Optional.empty());
+    when(downloadedMaps.getVersionForZipFile(MAP_ZIP_FILE_2)).thenReturn(Optional.of(version));
+  }
+
+  private Collection<String> getOutOfDateMapNames(final Collection<DownloadFileDescription> downloadFileDescriptions) {
+    return MapDownloadController.getOutOfDateMapNames(downloadFileDescriptions, downloadedMaps);
+  }
+
+  @Test
+  public void getOutOfDateMapNames_ShouldExcludeMapWhenMapIsUpToDate() {
+    final Collection<DownloadFileDescription> downloadFileDescriptions = givenLatestMapVersionIs(VERSION_1);
+    givenDownloadedMapVersionIs(VERSION_1);
+
+    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+
+    assertThat(outOfDateMapNames, not(contains(MAP_NAME)));
+  }
+
+  @Test
+  public void getOutOfDateMapNames_ShouldExcludeMapWhenDownloadedVersionIsUnknown() {
+    final Collection<DownloadFileDescription> downloadFileDescriptions = givenLatestMapVersionIs(VERSION_1);
+    givenDownloadedMapVersionIsUnknown();
+
+    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+
+    assertThat(outOfDateMapNames, not(contains(MAP_NAME)));
+  }
+
+  private void givenDownloadedMapVersionIsUnknown() {
+    when(downloadedMaps.getZipFileCandidates(MAP_NAME)).thenReturn(Arrays.asList(MAP_ZIP_FILE_1, MAP_ZIP_FILE_2));
+    when(downloadedMaps.getVersionForZipFile(any())).thenReturn(Optional.empty());
+  }
+
+  @Test
+  public void getOutOfDateMapNames_ShouldExcludeMapWhenLatestVersionIsUnknown() {
+    final Collection<DownloadFileDescription> downloadFileDescriptions = givenLatestMapVersionIs(VERSION_UNKNOWN);
+    givenDownloadedMapVersionIs(VERSION_1);
+
+    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+
+    assertThat(outOfDateMapNames, not(contains(MAP_NAME)));
+  }
+
+  @Test
+  public void getOutOfDateMapNames_ShouldExcludeMapWhenDownloadFileDescriptionIsNull() {
+    final Collection<DownloadFileDescription> downloadFileDescriptions = givenDownloadFileDescription(null);
+    givenDownloadedMapVersionIs(VERSION_1);
+
+    final Collection<String> outOfDateMapNames = getOutOfDateMapNames(downloadFileDescriptions);
+
+    assertThat(outOfDateMapNames, empty());
+  }
+}

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerPromptToDownloadTutorialMapTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerPromptToDownloadTutorialMapTest.java
@@ -14,7 +14,7 @@ import games.strategy.engine.framework.map.download.MapDownloadController.Tutori
 import games.strategy.engine.framework.map.download.MapDownloadController.UserMaps;
 
 @RunWith(MockitoJUnitRunner.class)
-public final class MapDownloadControllerTest {
+public final class MapDownloadControllerPromptToDownloadTutorialMapTest {
   @Mock
   private TutorialMapPreferences tutorialMapPreferences;
 
@@ -22,7 +22,7 @@ public final class MapDownloadControllerTest {
   private UserMaps userMaps;
 
   @Test
-  public void testShouldPromptToDownloadTutorialMap_ShouldReturnTrueWhenCanPromptToDownloadAndUserMapsIsEmpty() {
+  public void shouldPromptToDownloadTutorialMap_ShouldReturnTrueWhenCanPromptToDownloadAndUserMapsIsEmpty() {
     when(tutorialMapPreferences.canPromptToDownload()).thenReturn(true);
     when(userMaps.isEmpty()).thenReturn(true);
 
@@ -34,7 +34,7 @@ public final class MapDownloadControllerTest {
   }
 
   @Test
-  public void testShouldPromptToDownloadTutorialMap_ShouldReturnFalseWhenCanPromptToDownloadAndUserMapsIsNotEmpty() {
+  public void shouldPromptToDownloadTutorialMap_ShouldReturnFalseWhenCanPromptToDownloadAndUserMapsIsNotEmpty() {
     when(tutorialMapPreferences.canPromptToDownload()).thenReturn(true);
     when(userMaps.isEmpty()).thenReturn(false);
 
@@ -42,14 +42,14 @@ public final class MapDownloadControllerTest {
   }
 
   @Test
-  public void testShouldPromptToDownloadTutorialMap_ShouldReturnFalseWhenCannotPromptToDownload() {
+  public void shouldPromptToDownloadTutorialMap_ShouldReturnFalseWhenCannotPromptToDownload() {
     when(tutorialMapPreferences.canPromptToDownload()).thenReturn(false);
 
     assertThat(shouldPromptToDownloadTutorialMap(), is(false));
   }
 
   @Test
-  public void testPreventPromptToDownloadTutorialMap_ShouldChangePreventPromptToDownloadPreference() {
+  public void preventPromptToDownloadTutorialMap_ShouldChangePreventPromptToDownloadPreference() {
     preventPromptToDownloadTutorialMap();
 
     verify(tutorialMapPreferences).preventPromptToDownload();

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -82,5 +83,28 @@ public class MapDownloadListTest {
 
     final List<DownloadFileDescription> outOfDate = testObj.getOutOfDate();
     assertThat(outOfDate.size(), is(1));
+  }
+
+  @Test
+  public void testOutOfDateExcluding() {
+    when(strategy.getMapVersion(any())).thenReturn(Optional.of(lowVersion));
+    final DownloadFileDescription map1 = newMapWithUrl("url1");
+    final DownloadFileDescription map2 = newMapWithUrl("url2");
+    final DownloadFileDescription map3 = newMapWithUrl("url3");
+    final MapDownloadList testObj = new MapDownloadList(Arrays.asList(map1, map2, map3), strategy);
+
+    final List<DownloadFileDescription> outOfDate = testObj.getOutOfDateExcluding(Arrays.asList(map1, map3));
+
+    assertThat(outOfDate, is(Arrays.asList(map2)));
+  }
+
+  private static DownloadFileDescription newMapWithUrl(final String url) {
+    return new DownloadFileDescription(
+        url,
+        "description",
+        "mapName",
+        MAP_VERSION,
+        DownloadFileDescription.DownloadType.MAP,
+        DownloadFileDescription.MapCategory.BEST);
   }
 }

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -88,17 +88,17 @@ public class MapDownloadListTest {
   @Test
   public void testOutOfDateExcluding() {
     when(strategy.getMapVersion(any())).thenReturn(Optional.of(lowVersion));
-    final DownloadFileDescription map1 = newMapWithUrl("url1");
-    final DownloadFileDescription map2 = newMapWithUrl("url2");
-    final DownloadFileDescription map3 = newMapWithUrl("url3");
-    final MapDownloadList testObj = new MapDownloadList(Arrays.asList(map1, map2, map3), strategy);
+    final DownloadFileDescription download1 = newDownloadWithUrl("url1");
+    final DownloadFileDescription download2 = newDownloadWithUrl("url2");
+    final DownloadFileDescription download3 = newDownloadWithUrl("url3");
+    final MapDownloadList testObj = new MapDownloadList(Arrays.asList(download1, download2, download3), strategy);
 
-    final List<DownloadFileDescription> outOfDate = testObj.getOutOfDateExcluding(Arrays.asList(map1, map3));
+    final List<DownloadFileDescription> outOfDate = testObj.getOutOfDateExcluding(Arrays.asList(download1, download3));
 
-    assertThat(outOfDate, is(Arrays.asList(map2)));
+    assertThat(outOfDate, is(Arrays.asList(download2)));
   }
 
-  private static DownloadFileDescription newMapWithUrl(final String url) {
+  private static DownloadFileDescription newDownloadWithUrl(final String url) {
     return new DownloadFileDescription(
         url,
         "description",

--- a/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -3,14 +3,56 @@ package games.strategy.triplea;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.StreamSupport;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 
 import com.google.common.collect.Maps;
 
 public class ResourceLoaderTest {
+  @Test
+  public void testGetMapZipFileCandidates_ShouldIncludeDefaultZipFile() {
+    final List<File> candidates = ResourceLoader.getMapZipFileCandidates("MapName");
+
+    assertThat(candidates, containsFileWithName("MapName.zip"));
+  }
+
+  @Test
+  public void testGetMapZipFileCandidates_ShouldIncludeNormalizedZipFile() {
+    final List<File> candidates = ResourceLoader.getMapZipFileCandidates("MapName");
+
+    assertThat(candidates, containsFileWithName("map_name.zip"));
+  }
+
+  @Test
+  public void testGetMapZipFileCandidates_ShouldIncludeGitHubZipFile() {
+    final List<File> candidates = ResourceLoader.getMapZipFileCandidates("MapName");
+
+    assertThat(candidates, containsFileWithName("map_name-master.zip"));
+  }
+
+  private static Matcher<Iterable<File>> containsFileWithName(final String name) {
+    return new TypeSafeMatcher<Iterable<File>>() {
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText("iterable containing file with name ").appendValue(name);
+      }
+
+      @Override
+      protected boolean matchesSafely(final Iterable<File> files) {
+        return StreamSupport.stream(files.spliterator(), false)
+            .map(File::getName)
+            .anyMatch(name::equals);
+      }
+    };
+  }
 
   @Test
   public void testMapNameNormalization() {
@@ -22,7 +64,7 @@ public class ResourceLoaderTest {
     testPairs.put("LOWER.zip", "lower.zip");
 
     for (final Entry<String, String> testPair : testPairs.entrySet()) {
-      assertThat(ResourceLoader.normalizeMapZipName(testPair.getKey()), is(testPair.getValue()));
+      assertThat(ResourceLoader.normalizeMapName(testPair.getKey()), is(testPair.getValue()));
     }
   }
 }

--- a/src/test/java/games/strategy/util/OptionalUtilsTest.java
+++ b/src/test/java/games/strategy/util/OptionalUtilsTest.java
@@ -1,0 +1,46 @@
+package games.strategy.util;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public final class OptionalUtilsTest {
+  @Test
+  public void ifPresentOrElse_ShouldInvokePresentActionWhenValueIsPresent() {
+    final Object value = new Object();
+    final AtomicBoolean presentActionInvoked = new AtomicBoolean(false);
+
+    OptionalUtils.ifPresentOrElse(
+        Optional.of(value),
+        it -> {
+          presentActionInvoked.set(true);
+          assertThat(it, is(value));
+        },
+        () -> {
+          fail("empty action should not have been invoked");
+        });
+
+    assertThat(presentActionInvoked.get(), is(true));
+  }
+
+  @Test
+  public void ifPresentOrElse_ShouldInvokeEmptyActionWhenValueIsAbsent() {
+    final AtomicBoolean emptyActionInvoked = new AtomicBoolean(false);
+
+    OptionalUtils.ifPresentOrElse(
+        Optional.empty(),
+        it -> {
+          fail("present action should not have been invoked");
+        },
+        () -> {
+          emptyActionInvoked.set(true);
+        });
+
+    assertThat(emptyActionInvoked.get(), is(true));
+  }
+}

--- a/src/test/java/games/strategy/util/PredicateUtilsTest.java
+++ b/src/test/java/games/strategy/util/PredicateUtilsTest.java
@@ -1,0 +1,16 @@
+package games.strategy.util;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public final class PredicateUtilsTest {
+  @Test
+  public void not_ShouldReturnLogicalNegationOfPredicate() {
+    final Object t = new Object();
+
+    assertThat(PredicateUtils.not(it -> false).test(t), is(true));
+    assertThat(PredicateUtils.not(it -> true).test(t), is(false));
+  }
+}


### PR DESCRIPTION
This PR fixes the broken out-of-date map check reported in issue #1522.

The out-of-date map check was using the wrong file name when looking for a map's download properties.  It only considered the property file `<mapName>.zip.properties`, which does not exist for map's downloaded from GitHub.  When the map download properties cannot be found, it is assumed the map is up-to-date.

Since migrating the maps to GitHub, `ResourceLoader` considers the following map zip file candidates when attempting to load a map:

1. `<mapName>.zip`
1. `<normalizedMapName>-master.zip`
1. `<normalizedMapName>.zip`

The fix for this issue was to modify the out-of-date map check to also consider all these map zip file names when attempting to locate the corresponding download properties file (the same name with `.properties` appended).

#### Functional changes
* The out-of-date map check in `MapDownloadController` now considers all possible map zip file candidates (see above) when looking for the corresponding download properties file.  Previously, it only considered candidate (1).

#### Functional issues for review
None.

#### Refactoring changes
* I extracted a new interface and several new methods in `MapDownloadController` in order to write unit tests for the out-of-date map check functionality.
* I modified `ResourceLoader#getPaths()` to use the new `ResourceLoader#getMapZipFileCandidates()` method in order to be DRY.

#### Refactoring issues for review
* The changes to `ResourceLoader#getPaths()` were not necessary to implement the fix in this PR.  As I said above, I simply did it to avoid duplication in map path candidates (which was essentially the root cause of this issue).  Please advise if that hunk should be reverted.
* The out-of-date map check has only ever considered maps whose shape is a zip file; maps with a directory shape are not supported by this feature.  Some of the names I used when refactoring reflect this limitation to make it explicitly clear.

#### Testing
I first confirmed I could reproduce the issue on `master` (1.9.0.0.4208).  I performed the following steps:

* Delete the `TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES` key from the user preferences to force an out-of-date map check.
* Locally modify my `tutorial-master.zip.properties` and `the_pact_of_steel-master.zip.properties` files and change the `map.version` keys to `0.9` (they previously had the value `1.0`).  (I have a total of six maps installed, so there are still four maps present that are up-to-date.)
* Run TripleA.

After waiting for about a minute, I was not prompted to download the updated maps.

I then repeated the steps on this branch.  I confirmed I was prompted to download both updated maps.  I answered **Yes** to the prompt, downloaded the two maps in question, and exited TripleA.

I deleted the `TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES` key once again and restarted TripleA.  I waited for about a minute to confirm I was not prompted to download any maps.

I also started a few games from maps whose shape is a zip file to confirm the changes in `ResourceLoader#getPaths()` did not break map loading.