### PR TITLE
Remove unused parameters from Matches methods

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -82,7 +82,7 @@ public class ProPurchaseAI {
       ProLogger.debug("Factories can be damaged");
       final Map<Unit, Territory> unitsThatCanProduceNeedingRepair = new HashMap<>();
       for (final Territory fixTerr : rfactories) {
-        if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(data, player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
+        if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
             .match(fixTerr)) {
           continue;
         }
@@ -99,7 +99,7 @@ public class ProPurchaseAI {
           if (fixUnit == null || !fixUnit.getType().equals(rrule.getResults().keySet().iterator().next())) {
             continue;
           }
-          if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(data, player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
+          if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
               .match(unitsThatCanProduceNeedingRepair.get(fixUnit))) {
             continue;
           }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -80,7 +80,7 @@ public class ProBattleUtils {
     final GameData data = ProData.getData();
 
     List<Unit> unitsThatCanFight =
-        Match.getMatches(myUnits, Matches.UnitCanBeInBattle(attacking, !t.isWater(), data, 1, false, true, true));
+        Match.getMatches(myUnits, Matches.UnitCanBeInBattle(attacking, !t.isWater(), 1, false, true, true));
     if (Properties.getTransportCasualtiesRestricted(data)) {
       unitsThatCanFight = Match.getMatches(unitsThatCanFight, Matches.UnitIsTransportButNotCombatTransport.invert());
     }
@@ -94,7 +94,7 @@ public class ProBattleUtils {
     final GameData data = ProData.getData();
 
     final List<Unit> unitsThatCanFight =
-        Match.getMatches(myUnits, Matches.UnitCanBeInBattle(attacking, !t.isWater(), data, 1, false, true, true));
+        Match.getMatches(myUnits, Matches.UnitCanBeInBattle(attacking, !t.isWater(), 1, false, true, true));
     final List<Unit> sortedUnitsList = new ArrayList<>(unitsThatCanFight);
     Collections.sort(sortedUnitsList, new UnitBattleComparator(!attacking, ProData.unitValueMap,
         TerritoryEffectHelper.getEffects(t), data, false, false));

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -137,9 +137,9 @@ public class ProOddsCalculator {
     final List<Unit> averageAttackersRemaining = results.getAverageAttackingUnitsRemaining();
     final List<Unit> averageDefendersRemaining = results.getAverageDefendingUnitsRemaining();
     final List<Unit> mainCombatAttackers =
-        Match.getMatches(attackingUnits, Matches.UnitCanBeInBattle(true, !t.isWater(), data, 1, false, true, true));
+        Match.getMatches(attackingUnits, Matches.UnitCanBeInBattle(true, !t.isWater(), 1, false, true, true));
     final List<Unit> mainCombatDefenders =
-        Match.getMatches(defendingUnits, Matches.UnitCanBeInBattle(false, !t.isWater(), data, 1, false, true, true));
+        Match.getMatches(defendingUnits, Matches.UnitCanBeInBattle(false, !t.isWater(), 1, false, true, true));
     double TUVswing = results.getAverageTUVswing(attacker, mainCombatAttackers, defender, mainCombatDefenders, data);
     if (Matches.TerritoryIsNeutralButNotWater.match(t)) { // Set TUV swing for neutrals
       final double attackingUnitValue = BattleCalculator.getTUV(mainCombatAttackers, ProData.unitValueMap);

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -836,7 +836,7 @@ public class WeakAI extends AbstractAI {
       // we should sort this
       Collections.shuffle(rfactories);
       for (final Territory fixTerr : rfactories) {
-        if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(data, player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
+        if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
             .match(fixTerr)) {
           continue;
         }
@@ -869,7 +869,7 @@ public class WeakAI extends AbstractAI {
           if (!capUnit.getUnitType().equals(rrule.getResults().keySet().iterator().next())) {
             continue;
           }
-          if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(data, player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
+          if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
               .match(capitol)) {
             continue;
           }
@@ -908,8 +908,7 @@ public class WeakAI extends AbstractAI {
             if (fixUnit == null || !fixUnit.getType().equals(rrule.getResults().keySet().iterator().next())) {
               continue;
             }
-            if (!Matches
-                .territoryIsOwnedAndHasOwnedUnitMatching(data, player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
+            if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
                 .match(unitsThatCanProduceNeedingRepair.get(fixUnit))) {
               continue;
             }

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -917,7 +917,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (Match.someMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
       final Collection<Unit> unitsWhichConsume = Match.getMatches(placeableUnits, Matches.UnitConsumesUnitsOnCreation);
       for (final Unit unit : unitsWhichConsume) {
-        if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO, to).invert().match(unit)) {
+        if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO).invert().match(unit)) {
           placeableUnits.remove(unit);
         }
       }
@@ -971,7 +971,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final Collection<Unit> removedUnits = new ArrayList<>();
     final Collection<Unit> unitsWhichConsume = Match.getMatches(units, Matches.UnitConsumesUnitsOnCreation);
     for (final Unit unit : unitsWhichConsume) {
-      if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO, to).invert().match(unit)) {
+      if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO).invert().match(unit)) {
         weCanConsume = false;
       }
       if (!weCanConsume) {
@@ -1281,7 +1281,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       }
       // remove any units that require other units to be consumed on creation (veqryn)
       if (Matches.UnitConsumesUnitsOnCreation.match(currentUnit)
-          && Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO, to).invert().match(currentUnit)) {
+          && Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO).invert().match(currentUnit)) {
         continue;
       }
       unitMapHeld.add(ua.getConstructionType(), 1);

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -500,7 +500,7 @@ public class BattleTracker implements java.io.Serializable {
       // Also subtract transports & subs (if they can't control sea zones)
       totalMatches = arrivedUnits.size() - Match.countMatches(arrivedUnits, Matches.UnitIsLand)
           - Match.countMatches(arrivedUnits, Matches.UnitIsAir)
-          - Match.countMatches(arrivedUnits, Matches.unitIsSubmerged(data));
+          - Match.countMatches(arrivedUnits, Matches.UnitIsSubmerged);
       // If transports are restricted from controlling sea zones, subtract them
       final CompositeMatch<Unit> transportsCanNotControl = new CompositeMatchAnd<>();
       transportsCanNotControl.add(Matches.UnitIsTransportAndNotDestroyer);
@@ -1162,7 +1162,7 @@ public class BattleTracker implements java.io.Serializable {
   private List<Unit> getSortedDefendingUnits(final IDelegateBridge bridge, final GameData gameData,
       final Territory territory, final List<Unit> defenders) {
     final List<Unit> sortedUnitsList = new ArrayList<>(Match.getMatches(defenders,
-               Matches.UnitCanBeInBattle(true, !territory.isWater(), gameData, 1, false, true, true)));
+        Matches.UnitCanBeInBattle(true, !territory.isWater(), 1, false, true, true)));
     Collections.sort(sortedUnitsList,
         new UnitBattleComparator(false, BattleCalculator.getCostsForTUV(bridge.getPlayerID(), gameData),
         TerritoryEffectHelper.getEffects(territory), gameData, false, false));

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -142,7 +142,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     if (Match.someMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
       final Collection<Unit> unitsWhichConsume = Match.getMatches(placeableUnits, Matches.UnitConsumesUnitsOnCreation);
       for (final Unit unit : unitsWhichConsume) {
-        if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO, to).invert().match(unit)) {
+        if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO).invert().match(unit)) {
           placeableUnits.remove(unit);
         }
       }

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -538,11 +538,11 @@ public class Matches {
   /**
    * Checks for having attack/defense and for providing support. Does not check for having AA ability.
    */
-  public static Match<Unit> UnitIsSupporterOrHasCombatAbility(final boolean attack, final GameData data) {
+  public static Match<Unit> UnitIsSupporterOrHasCombatAbility(final boolean attack) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unit) {
-        return Matches.UnitTypeIsSupporterOrHasCombatAbility(attack, unit.getOwner(), data).match(unit.getType());
+        return Matches.UnitTypeIsSupporterOrHasCombatAbility(attack, unit.getOwner()).match(unit.getType());
       }
     };
   }
@@ -550,9 +550,7 @@ public class Matches {
   /**
    * Checks for having attack/defense and for providing support. Does not check for having AA ability.
    */
-  private static Match<UnitType> UnitTypeIsSupporterOrHasCombatAbility(final boolean attack,
-      final PlayerID player,
-      final GameData data) {
+  private static Match<UnitType> UnitTypeIsSupporterOrHasCombatAbility(final boolean attack, final PlayerID player) {
     return new Match<UnitType>() {
       @Override
       public boolean match(final UnitType ut) {
@@ -1345,7 +1343,7 @@ public class Matches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        return data.getMap().getNeighbors(t, Matches.territoryIsOwnedAndHasOwnedUnitMatching(data, player, unitMatch))
+        return data.getMap().getNeighbors(t, Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, unitMatch))
             .size() > 0;
       }
     };
@@ -1385,7 +1383,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryIsOwnedAndHasOwnedUnitMatching(final GameData data, final PlayerID player,
+  public static Match<Territory> territoryIsOwnedAndHasOwnedUnitMatching(final PlayerID player,
       final Match<Unit> unitMatch) {
     return new Match<Territory>() {
       @Override
@@ -1398,8 +1396,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryHasOwnedIsFactoryOrCanProduceUnits(final GameData data,
-      final PlayerID player) {
+  public static Match<Territory> territoryHasOwnedIsFactoryOrCanProduceUnits(final PlayerID player) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -2147,7 +2144,7 @@ public class Matches {
   public static Match<Territory> territoryHasNonSubmergedEnemyUnits(final PlayerID player, final GameData data) {
     final CompositeMatch<Unit> match = new CompositeMatchAnd<>();
     match.add(enemyUnit(player, data));
-    match.add(new InverseMatch<>(unitIsSubmerged(data)));
+    match.add(UnitIsSubmerged.invert());
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -2365,23 +2362,12 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> unitIsSubmerged(final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        return TripleAUnit.get(u).getSubmerged();
-      }
-    };
-  }
-
-  public static Match<Unit> unitIsNotSubmerged(final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        return !TripleAUnit.get(u).getSubmerged();
-      }
-    };
-  }
+  public static final Match<Unit> UnitIsSubmerged = new Match<Unit>() {
+    @Override
+    public boolean match(final Unit u) {
+      return TripleAUnit.get(u).getSubmerged();
+    }
+  };
 
   public static final Match<UnitType> UnitTypeIsSub = new Match<UnitType>() {
     @Override
@@ -2660,8 +2646,7 @@ public class Matches {
   };
 
   public static Match<Unit> UnitWhichConsumesUnitsHasRequiredUnits(
-      final Collection<Unit> unitsInTerritoryAtStartOfTurn,
-      final Territory territory) {
+      final Collection<Unit> unitsInTerritoryAtStartOfTurn) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unitWhichRequiresUnits) {
@@ -3335,19 +3320,19 @@ public class Matches {
   }
 
   public static Match<Unit> UnitCanBeInBattle(final boolean attack, final boolean isLandBattle,
-      final GameData data, final int battleRound, final boolean includeAttackersThatCanNotMove,
+      final int battleRound, final boolean includeAttackersThatCanNotMove,
       final boolean doNotIncludeAA, final boolean doNotIncludeBombardingSeaUnits) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        return Matches.UnitTypeCanBeInBattle(attack, isLandBattle, u.getOwner(), data, battleRound,
+        return Matches.UnitTypeCanBeInBattle(attack, isLandBattle, u.getOwner(), battleRound,
             includeAttackersThatCanNotMove, doNotIncludeAA, doNotIncludeBombardingSeaUnits).match(u.getType());
       }
     };
   }
 
   public static Match<UnitType> UnitTypeCanBeInBattle(final boolean attack, final boolean isLandBattle,
-      final PlayerID player, final GameData data, final int battleRound, final boolean includeAttackersThatCanNotMove,
+      final PlayerID player, final int battleRound, final boolean includeAttackersThatCanNotMove,
       final boolean doNotIncludeAA, final boolean doNotIncludeBombardingSeaUnits) {
     return new Match<UnitType>() {
       @Override
@@ -3359,7 +3344,7 @@ public class Matches {
         // combat abilities.
         final Match<UnitType> supporterOrNotInfrastructure =
             new CompositeMatchOr<>(Matches.UnitTypeIsInfrastructure.invert(),
-                Matches.UnitTypeIsSupporterOrHasCombatAbility(attack, player, data));
+                Matches.UnitTypeIsSupporterOrHasCombatAbility(attack, player));
         final Match<UnitType> combat;
         if (attack) {
           // AND match

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -396,7 +396,7 @@ public class MoveValidator {
       if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
         final CompositeMatch<Unit> friendlyOrSubmerged = new CompositeMatchOr<>();
         friendlyOrSubmerged.add(Matches.enemyUnit(player, data).invert());
-        friendlyOrSubmerged.add(Matches.unitIsSubmerged(data));
+        friendlyOrSubmerged.add(Matches.UnitIsSubmerged);
         if (!end.getUnits().allMatch(friendlyOrSubmerged)
             && !(Match.allMatch(units, Matches.UnitIsAir) && end.isWater())) {
           if (!Match.allMatch(units, Matches.UnitIsSub)
@@ -714,7 +714,7 @@ public class MoveValidator {
   static boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final PlayerID player, final GameData data) {
     final CompositeMatch<Unit> alliedOrNonCombat =
         new CompositeMatchOr<>(Matches.UnitIsInfrastructure, Matches.enemyUnit(player, data).invert(),
-            Matches.unitIsSubmerged(data));
+            Matches.UnitIsSubmerged);
     // Submerged units do not interfere with movement
     for (final Territory current : route.getMiddleSteps()) {
       if (!current.getUnits().allMatch(alliedOrNonCombat)) {
@@ -1057,8 +1057,7 @@ public class MoveValidator {
         return result.setErrorReturnResult("Units cannot move before loading onto transports");
       }
       final CompositeMatch<Unit> enemyNonSubmerged =
-          new CompositeMatchAnd<>(Matches.enemyUnit(player, data), new InverseMatch<>(
-              Matches.unitIsSubmerged(data)));
+          new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.UnitIsSubmerged.invert());
       if (route.getEnd().getUnits().someMatch(enemyNonSubmerged) && nonParatroopersPresent(player, landAndAir)) {
         if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
           if (!AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(player,

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -148,7 +148,7 @@ public class RocketsFireHelper {
 
   CompositeMatch<Unit> rocketMatch(final PlayerID player, final GameData data) {
     return new CompositeMatchAnd<>(Matches.UnitIsRocket, Matches.unitIsOwnedBy(player), Matches.UnitIsNotDisabled,
-        Matches.unitIsBeingTransported().invert(), Matches.unitIsSubmerged(data).invert(), Matches.unitHasNotMoved);
+        Matches.unitIsBeingTransported().invert(), Matches.UnitIsSubmerged.invert(), Matches.unitHasNotMoved);
   }
 
   private Set<Territory> getTargetsWithinRange(final Territory territory, final GameData data, final PlayerID player) {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -441,9 +441,9 @@ public class OddsCalculatorPanel extends JPanel {
       m_draw.setText(formatPercentage(results.get().getDrawPercent()));
       final boolean isLand = isLand();
       final List<Unit> mainCombatAttackers =
-          Match.getMatches(attackers.get(), Matches.UnitCanBeInBattle(true, isLand, m_data, 1, false, true, true));
+          Match.getMatches(attackers.get(), Matches.UnitCanBeInBattle(true, isLand, 1, false, true, true));
       final List<Unit> mainCombatDefenders =
-          Match.getMatches(defenders.get(), Matches.UnitCanBeInBattle(false, isLand, m_data, 1, false, true, true));
+          Match.getMatches(defenders.get(), Matches.UnitCanBeInBattle(false, isLand, 1, false, true, true));
       final int attackersTotal = mainCombatAttackers.size();
       final int defendersTotal = mainCombatDefenders.size();
       m_defenderLeft.setText(formatValue(results.get().getAverageDefendingUnitsLeft()) + " /" + defendersTotal);
@@ -480,7 +480,7 @@ public class OddsCalculatorPanel extends JPanel {
       units = Collections.emptyList();
     }
     final boolean isLand = isLand();
-    units = Match.getMatches(units, Matches.UnitCanBeInBattle(false, isLand, m_data, 1, false, false, false));
+    units = Match.getMatches(units, Matches.UnitCanBeInBattle(false, isLand, 1, false, false, false));
     m_defendingUnitsPanel.init(getDefender(), units, isLand);
   }
 
@@ -489,7 +489,7 @@ public class OddsCalculatorPanel extends JPanel {
       units = Collections.emptyList();
     }
     final boolean isLand = isLand();
-    units = Match.getMatches(units, Matches.UnitCanBeInBattle(true, isLand, m_data, 1, false, false, false));
+    units = Match.getMatches(units, Matches.UnitCanBeInBattle(true, isLand, 1, false, false, false));
     m_attackingUnitsPanel.init(getAttacker(), units, isLand);
   }
 
@@ -766,9 +766,9 @@ public class OddsCalculatorPanel extends JPanel {
       m_data.acquireReadLock();
       // do not include bombardment and aa guns in our "total" labels
       final List<Unit> attackers = Match.getMatches(m_attackingUnitsPanel.getUnits(),
-          Matches.UnitCanBeInBattle(true, isLand, m_data, 1, false, true, true));
+          Matches.UnitCanBeInBattle(true, isLand, 1, false, true, true));
       final List<Unit> defenders = Match.getMatches(m_defendingUnitsPanel.getUnits(),
-          Matches.UnitCanBeInBattle(false, isLand, m_data, 1, false, true, true));
+          Matches.UnitCanBeInBattle(false, isLand, 1, false, true, true));
       m_attackerUnitsTotalNumber.setText("Units: " + attackers.size());
       m_defenderUnitsTotalNumber.setText("Units: " + defenders.size());
       m_attackerUnitsTotalTUV.setText("TUV: " + BattleCalculator.getTUV(attackers, getAttacker(),
@@ -966,7 +966,7 @@ class PlayerUnitsPanel extends JPanel {
     // they have other
     // combat abilities.
     rVal = Match.getMatches(rVal,
-        Matches.UnitTypeCanBeInBattle(!m_defender, m_isLand, player, m_data, 1, false, false, false));
+        Matches.UnitTypeCanBeInBattle(!m_defender, m_isLand, player, 1, false, false, false));
     return rVal;
   }
 

--- a/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -163,7 +163,7 @@ public class PurchasePanel extends ActionPanel {
         getData().acquireReadLock();
         try {
           for (final Territory t : Match.getMatches(getData().getMap().getTerritories(),
-              Matches.territoryHasOwnedIsFactoryOrCanProduceUnits(getData(), getCurrentPlayer()))) {
+              Matches.territoryHasOwnedIsFactoryOrCanProduceUnits(getCurrentPlayer()))) {
             totalProd += TripleAUnit.getProductionPotentialOfTerritory(t.getUnits().getUnits(), t, getCurrentPlayer(),
                 getData(), true, true);
           }


### PR DESCRIPTION
This PR removes unused parameters from methods in the `Matches` class.

For the most part, the unused parameters were instances of `GameData`, and the changes at the call sites were straightforward.

There were two exceptions:

1. After removing the unused parameter, the `unitIsSubmerged()` method now accepts zero arguments.  The convention in the `Matches` class seems to be to use fields instead of methods if a `Match` instance doesn't require any configuration when it is instantiated.  Therefore, I converted the `unitIsSubmerged()` method to the `UnitIsSubmerged` field.
1. I removed the `unitIsNotSubmerged()` method and replaced its three uses with `UnitIsSubmerged.invert()`.  There were a few instances of `new InverseMatch<>(unitIsSubmerged())` that I also replaced replaced with `UnitIsSubmerged.invert()`.

Please advise if either of these two changes should be reverted.  If they are acceptable, please scrutinize the changes related to item (2) to ensure I didn't mess up any of the inversions.