### PR TITLE
Checkstyle: Fix variable declaration usage distance violations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=5255
-checkstyleTestMaxWarnings=151
+checkstyleMainMaxWarnings=5240
+checkstyleTestMaxWarnings=142

--- a/src/main/java/games/strategy/engine/framework/startup/ui/MainPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/MainPanel.java
@@ -51,7 +51,7 @@ public class MainPanel extends JPanel implements Observer {
 
   public MainPanel(final SetupPanelModel typePanelModel) {
     gameTypePanelModel = typePanelModel;
-    GameSelectorModel gameSelectorModel = typePanelModel.getGameSelectorModel();
+    final GameSelectorModel gameSelectorModel = typePanelModel.getGameSelectorModel();
 
     playButton = new JButton("Play");
     playButton.setToolTipText("<html>Start your game! <br>"

--- a/src/main/java/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
@@ -49,7 +49,7 @@ public class TripleAWarClubForumPoster extends AbstractForumPoster {
    *         if login fails
    */
   private HttpContext login(CloseableHttpClient client) throws Exception {
-    HttpPost httpPost = new HttpPost("http://www.tripleawarclub.org/user.php");
+    final HttpPost httpPost = new HttpPost("http://www.tripleawarclub.org/user.php");
     CookieStore cookieStore = new BasicCookieStore();
     HttpContext httpContext = new BasicHttpContext();
     httpContext.setAttribute(HttpClientContext.COOKIE_STORE, cookieStore);

--- a/src/main/java/games/strategy/engine/random/MersenneTwister.java
+++ b/src/main/java/games/strategy/engine/random/MersenneTwister.java
@@ -139,11 +139,10 @@ public class MersenneTwister extends Random {
    * they're not *all* zero.
    */
   public synchronized void setSeed(final int[] array) {
-    int i, j, k;
     setSeed(19650218);
-    i = 1;
-    j = 0;
-    k = (N > array.length ? N : array.length);
+    int i = 1;
+    int j = 0;
+    int k = (N > array.length ? N : array.length);
     for (; k != 0; k--) {
       m_mt[i] = (m_mt[i] ^ ((m_mt[i - 1] ^ (m_mt[i - 1] >>> 30)) * 1664525)) + array[j] + j; /* non linear */
       m_mt[i] &= 0xffffffff; /* for WORDSIZE > 32 machines */

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -831,7 +831,6 @@ public class WeakAI extends AbstractAI {
       int capProduction = 0;
       Unit capUnit = null;
       Territory capUnitTerritory = null;
-      int maxUnits = (totPU - 1) / minimumUnitPrice;
       int currentProduction = 0;
       // we should sort this
       Collections.shuffle(rfactories);
@@ -864,6 +863,7 @@ public class WeakAI extends AbstractAI {
       //
       // if capitol is super safe, we don't have to do this. and if capitol is under siege, we should repair enough to
       // place all our units here
+      int maxUnits = (totPU - 1) / minimumUnitPrice;
       if ((capProduction <= maxUnits / 2 || rfactories.isEmpty()) && capUnit != null) {
         for (final RepairRule rrule : rrules) {
           if (!capUnit.getUnitType().equals(rrule.getResults().keySet().iterator().next())) {

--- a/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -119,7 +119,6 @@ public class PoliticsPanel extends ActionPanel {
 
     final JDialog politicalChoiceDialog = new JDialog(m_parent, "Political Actions", true);
     final Insets insets = new Insets(1, 1, 1, 1);
-    int row = 0;
     final JPanel politicalChoicePanel = new JPanel();
     politicalChoicePanel.setLayout(new GridBagLayout());
     final PoliticalStateOverview overview = new PoliticalStateOverview(getData(), getMap().getUIContext(), false);
@@ -149,12 +148,12 @@ public class PoliticsPanel extends ActionPanel {
     final JSplitPane splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT, overviewScroll, choiceScroll);
     splitPane.setOneTouchExpandable(true);
     splitPane.setDividerSize(8);
-    politicalChoicePanel.add(splitPane, new GridBagConstraints(0, row++, 1, 1, 100.0, 100.0,
+    politicalChoicePanel.add(splitPane, new GridBagConstraints(0, 0, 1, 1, 100.0, 100.0,
         GridBagConstraints.CENTER, GridBagConstraints.BOTH, insets, 0, 0));
     final JButton noActionButton =
         new JButton(SwingAction.of("No Actions", event -> politicalChoiceDialog.setVisible(false)));
     SwingUtilities.invokeLater(() -> noActionButton.requestFocusInWindow());
-    politicalChoicePanel.add(noActionButton, new GridBagConstraints(0, row, 20, 1, 1.0, 1.0, GridBagConstraints.EAST,
+    politicalChoicePanel.add(noActionButton, new GridBagConstraints(0, 1, 20, 1, 1.0, 1.0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, insets, 0, 0));
     politicalChoiceDialog.add(politicalChoicePanel);
     politicalChoiceDialog.pack();

--- a/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -158,7 +158,6 @@ public class TechPanel extends ActionPanel {
       JOptionPane.showMessageDialog(TechPanel.this, "No more available tech advances");
       return;
     }
-    TechnologyFrontier category = null;
     final JList<TechnologyFrontier> list = new JList<TechnologyFrontier>(new Vector<>(techCategories)) {
       private static final long serialVersionUID = 35094445315520702L;
 
@@ -179,7 +178,7 @@ public class TechPanel extends ActionPanel {
     list.setSelectedIndex(0);
     JOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(TechPanel.this), panel, "Select chart",
         JOptionPane.PLAIN_MESSAGE);
-    category = list.getSelectedValue();
+    final TechnologyFrontier category = list.getSelectedValue();
 
     final int PUs = currentPlayer.getResources().getQuantity(Constants.PUS);
     final String message = "Purchase Tech Tokens";
@@ -214,7 +213,6 @@ public class TechPanel extends ActionPanel {
       if (techCategories.isEmpty()) {
         return;
       }
-      TechnologyFrontier category = null;
       final JList<TechnologyFrontier> list = new JList<TechnologyFrontier>(new Vector<>(techCategories)) {
         private static final long serialVersionUID = -8415987764855418565L;
 
@@ -235,7 +233,7 @@ public class TechPanel extends ActionPanel {
       list.setSelectedIndex(0);
       JOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(TechPanel.this), panel, "Select chart",
           JOptionPane.PLAIN_MESSAGE);
-      category = list.getSelectedValue();
+      final TechnologyFrontier category = list.getSelectedValue();
       m_techRoll = new TechRoll(category, m_currTokens);
     } else {
       m_techRoll = null;

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1168,7 +1168,6 @@ public class TripleAFrame extends MainGameFrame {
         panel2.setBorder(BorderFactory.createEmptyBorder());
         panel2.setLayout(new FlowLayout());
         for (final Territory from : possibleScramblers.keySet()) {
-          JScrollPane chooserScrollPane;
           final JPanel panelChooser = new JPanel();
           panelChooser.setLayout(new BoxLayout(panelChooser, BoxLayout.Y_AXIS));
           panelChooser.setBorder(BorderFactory.createLineBorder(getBackground()));
@@ -1184,7 +1183,7 @@ public class TripleAFrame extends MainGameFrame {
           chooser.setMaxAndShowMaxButton(maxAllowed);
           choosers.add(Tuple.of(from, chooser));
           panelChooser.add(chooser);
-          chooserScrollPane = new JScrollPane(panelChooser);
+          final JScrollPane chooserScrollPane = new JScrollPane(panelChooser);
           panel2.add(chooserScrollPane);
         }
         panel.add(panel2, BorderLayout.CENTER);
@@ -1256,7 +1255,6 @@ public class TripleAFrame extends MainGameFrame {
         final JLabel messageLabel = new JLabel(message);
         messageLabel.setFont(new Font("Arial", Font.ITALIC, 12));
         panel.add(messageLabel, BorderLayout.NORTH);
-        JScrollPane chooserScrollPane;
         final JPanel panelChooser = new JPanel();
         panelChooser.setLayout(new BoxLayout(panelChooser, BoxLayout.Y_AXIS));
         panelChooser.setBorder(BorderFactory.createLineBorder(getBackground()));
@@ -1269,7 +1267,7 @@ public class TripleAFrame extends MainGameFrame {
         final UnitChooser chooser = new UnitChooser(possible, Collections.emptyMap(), data, false, uiContext);
         chooser.setMaxAndShowMaxButton(maxAllowed);
         panelChooser.add(chooser);
-        chooserScrollPane = new JScrollPane(panelChooser);
+        final JScrollPane chooserScrollPane = new JScrollPane(panelChooser);
         panel.add(chooserScrollPane, BorderLayout.CENTER);
         final String optionSelect = "Select";
         final String optionNone = "None";

--- a/src/main/java/games/strategy/util/MD5Crypt.java
+++ b/src/main/java/games/strategy/util/MD5Crypt.java
@@ -113,8 +113,6 @@ public class MD5Crypt {
     if (magic == null) {
       throw new IllegalArgumentException("Null salt!");
     }
-    byte[] finalState;
-    long l;
     /*
      * Two MD5 hashes are used
      */
@@ -152,7 +150,7 @@ public class MD5Crypt {
     ctx1.update(salt.getBytes());
     ctx1.update(password.getBytes());
     // ctx1.Final();
-    finalState = ctx1.digest();
+    byte[] finalState = ctx1.digest();
     for (int pl = password.length(); pl > 0; pl -= 16) {
       ctx.update(finalState, 0, pl > 16 ? 16 : pl);
     }
@@ -210,7 +208,7 @@ public class MD5Crypt {
     /**
      * Build a 22 byte output string from the set: A-Za-z0-9./
      */
-    l = (bytes2u(finalState[0]) << 16) | (bytes2u(finalState[6]) << 8) | bytes2u(finalState[12]);
+    long l = (bytes2u(finalState[0]) << 16) | (bytes2u(finalState[6]) << 8) | bytes2u(finalState[12]);
     result.append(to64(l, 4));
     l = (bytes2u(finalState[1]) << 16) | (bytes2u(finalState[7]) << 8) | bytes2u(finalState[13]);
     result.append(to64(l, 4));

--- a/src/main/java/tools/map/xml/creator/TerritoryDefinitionsPanel.java
+++ b/src/main/java/tools/map/xml/creator/TerritoryDefinitionsPanel.java
@@ -44,7 +44,6 @@ class TerritoryDefinitionsPanel extends ImageScrollPanePanel {
           .entrySet()) {
         if (definitionEntry.getValue()) {
           final int x_value = x_text_start + oneCharacterWidthSpace * definitionCount;
-          int w;
           String character = null;
           switch (definitionEntry.getKey()) {
             case IS_WATER:
@@ -67,7 +66,7 @@ class TerritoryDefinitionsPanel extends ImageScrollPanePanel {
           }
           g.fillOval(x_value, y_value, 16, 16);
           g.setColor(Color.red);
-          w = fm.stringWidth(character);
+          final int w = fm.stringWidth(character);
           h = fm.getAscent();
           g.drawString(character, x_value + 8 - (w / 2), y_value + 8 + (h / 2));
         }

--- a/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
@@ -58,12 +58,12 @@ public class BattleTrackerTest {
   @Test
   public void verifyRaids() {
     Territory territory = new Territory("terrName", mockGameData);
-    Route route = new Route(territory);
+    final Route route = new Route(territory);
     PlayerID playerId = new PlayerID("name", mockGameData);
 
     // need at least one attacker for there to be considered a battle.
     Unit unit = new TripleAUnit(new UnitType("unit", mockGameData), playerId, mockGameData);
-    List<Unit> attackers = Collections.singletonList(unit);
+    final List<Unit> attackers = Collections.singletonList(unit);
 
     when(mockDelegateBridge.getData()).thenReturn(mockGameData);
     when(mockGameData.getProperties()).thenReturn(mockGameProperties);

--- a/src/test/java/games/strategy/triplea/ui/RouteTest.java
+++ b/src/test/java/games/strategy/triplea/ui/RouteTest.java
@@ -75,7 +75,7 @@ public class RouteTest {
   @Test
   public void testCorrectParameterHandling() {
     final MapPanel mockedMapPanel = mock(MapPanel.class);
-    MapRouteDrawer routeDrawer = spy(new MapRouteDrawer(mockedMapPanel, dummyMapData));
+    final MapRouteDrawer routeDrawer = spy(new MapRouteDrawer(mockedMapPanel, dummyMapData));
     when(mockedMapPanel.getXOffset()).thenReturn(0);
     when(mockedMapPanel.getYOffset()).thenReturn(0);
     when(mockedMapPanel.getScale()).thenReturn(0.0);

--- a/src/test/java/games/strategy/triplea/ui/logic/RouteCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/ui/logic/RouteCalculatorTest.java
@@ -82,15 +82,15 @@ public class RouteCalculatorTest {
 
   @Test
   public void testMatrixTransposal() {
-    Point[] input = new Point[] {point(0, 0), point(1, 1)};
-    Point[] nw = new Point[] {point(-1000, -1000), point(-999, -999)};
-    Point[] n = new Point[] {point(0, -1000), point(1, -999)};
-    Point[] ne = new Point[] {point(1000, -1000), point(1001, -999)};
-    Point[] w = new Point[] {point(-1000, 0), point(-999, 1)};
-    Point[] e = new Point[] {point(1000, 0), point(1001, 1)};
-    Point[] sw = new Point[] {point(-1000, 1000), point(-999, 1001)};
-    Point[] s = new Point[] {point(0, 1000), point(1, 1001)};
-    Point[] se = new Point[] {point(1000, 1000), point(1001, 1001)};
+    final Point[] input = new Point[] {point(0, 0), point(1, 1)};
+    final Point[] nw = new Point[] {point(-1000, -1000), point(-999, -999)};
+    final Point[] n = new Point[] {point(0, -1000), point(1, -999)};
+    final Point[] ne = new Point[] {point(1000, -1000), point(1001, -999)};
+    final Point[] w = new Point[] {point(-1000, 0), point(-999, 1)};
+    final Point[] e = new Point[] {point(1000, 0), point(1001, 1)};
+    final Point[] sw = new Point[] {point(-1000, 1000), point(-999, 1001)};
+    final Point[] s = new Point[] {point(0, 1000), point(1, 1001)};
+    final Point[] se = new Point[] {point(1000, 1000), point(1001, 1001)};
 
     List<Point[]> points = new RouteCalculator(true, true, 1000, 1000).getAllPoints(input);
     // This may be changed along with the RouteOptimizer#getPossiblePoints method


### PR DESCRIPTION
This PR fixes violations of the Checkstyle VariableDeclarationUsageDistance rule.

The majority of violations were fixed simply by making the variable `final`.

There were a few violation fixes that were low risk but required a bit of reasoning.  I will call those out in a review.

I didn't fix any violations that I considered moderate risk or higher due to lack of test coverage over those units.  Seven violations remain at the time I write this.