### PR TITLE
Add download version for Empire map (#1704)

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -1545,6 +1545,7 @@
 - mapName: Empire
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/empire/archive/master.zip
+  version: 1
   img: http://tripleamaps.sourceforge.net/images/TripleA_empire_mini.png
   description: |
     <br>


### PR DESCRIPTION
This PR fixes issue #1704.

The Empire map was missing the `version` attribute in `triplea_maps.yaml`.  Thus, the associated `DownloadFileDescription` had a `null` value for the version property.  This caused the `MapDownloadList#MapDownloadList` constructor to always classify the map as available:

```java
      if (mapVersion.isPresent()) {
        installed.add(download);
        if (download.getVersion() != null && download.getVersion().isGreaterThan(mapVersion.get())) {
          outOfDate.add(download);
        }
      } else {
        available.add(download);
      }
```

I reproduced the OPs problem using the current `triplea_maps.yaml` in the remote repo.  I then:

* Stopped TripleA
* Modified my `game_engine.properties` to point to my locally-modified `triplea_maps.yaml` containing the Empire map download version
* Restarted TripleA
* Opened the Download Maps window and re-installed Empire
* Observed Empire removed from the Available list
* Closed and re-opened the Download Maps window

I verified Empire did not appear in the Available list but instead appeared in the Installed list:

![issue-1704-available](https://cloud.githubusercontent.com/assets/4826349/25978759/5b4f26dc-3692-11e7-91ac-59fef02c613c.png)

![issue-1704-installed](https://cloud.githubusercontent.com/assets/4826349/25978763/5e96f89c-3692-11e7-8828-c7ed5b55421a.png)