### PR TITLE
Restore the system check feature

### DIFF
--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -1,6 +1,7 @@
 package games.strategy.debug;
 
 import java.io.PrintStream;
+import java.util.Collection;
 
 public class ClientLogger {
   private static final PrintStream developerOutputStream = System.out;
@@ -34,5 +35,16 @@ public class ClientLogger {
   public static void logError(final String msg, final Throwable e) {
     logError(msg);
     logError(e);
+  }
+
+  /**
+   * Logs the specified message and collection of errors to the user output stream.
+   *
+   * @param msg The error message; may be {@code null}.
+   * @param throwables The collection of errors; must not be {@code null}.
+   */
+  public static void logError(final String msg, final Collection<? extends Throwable> throwables) {
+    logError(msg);
+    throwables.forEach(ClientLogger::logError);
   }
 }

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -34,6 +35,7 @@ import games.strategy.engine.framework.map.download.MapDownloadController;
 import games.strategy.engine.framework.startup.ui.MainFrame;
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.engine.framework.system.Memory;
+import games.strategy.engine.framework.systemcheck.LocalSystemChecker;
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.lobby.server.LobbyServer;
 import games.strategy.net.Messengers;
@@ -181,6 +183,7 @@ public class GameRunner {
     showMainFrame();
     new Thread(() -> setupLogging(GameMode.SWING_CLIENT)).start();
     HttpProxy.setupProxies();
+    checkLocalSystem();
     new Thread(() -> checkForUpdates()).start();
     handleCommandLineArgs(args, COMMAND_LINE_ARGS, GameMode.SWING_CLIENT);
   }
@@ -194,6 +197,16 @@ public class GameRunner {
     });
   }
 
+  private static void checkLocalSystem() {
+    final LocalSystemChecker localSystemChecker = new LocalSystemChecker();
+    final Collection<Exception> exceptions = localSystemChecker.getExceptions();
+    if (!exceptions.isEmpty()) {
+      final String msg = String.format(
+          "Warning!! %d system checks failed. Some game features may not be available or may not work correctly.\n%s",
+          exceptions.size(), localSystemChecker.getStatusMessage());
+      ClientLogger.logError(msg, exceptions);
+    }
+  }
 
   /**
    * Move command line arguments to System.properties

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -183,7 +183,7 @@ public class GameRunner {
     showMainFrame();
     new Thread(() -> setupLogging(GameMode.SWING_CLIENT)).start();
     HttpProxy.setupProxies();
-    checkLocalSystem();
+    new Thread(GameRunner::checkLocalSystem).start();
     new Thread(() -> checkForUpdates()).start();
     handleCommandLineArgs(args, COMMAND_LINE_ARGS, GameMode.SWING_CLIENT);
   }

--- a/src/main/java/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
+++ b/src/main/java/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
@@ -3,6 +3,7 @@ package games.strategy.engine.framework.systemcheck;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.Set;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -30,8 +31,11 @@ public final class LocalSystemChecker {
   private static SystemCheck defaultNetworkCheck() {
     return new SystemCheck("Can connect to github.com (check network connection)", () -> {
       try {
+        final int connectTimeoutInMilliseconds = 20000;
         final URL url = new URL("https://github.com");
-        url.openConnection().connect();
+        final URLConnection urlConnection = url.openConnection();
+        urlConnection.setConnectTimeout(connectTimeoutInMilliseconds);
+        urlConnection.connect();
       } catch (final Exception e) {
         Throwables.propagate(e);
       }

--- a/src/main/java/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
+++ b/src/main/java/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
@@ -35,7 +35,7 @@ public final class LocalSystemChecker {
   private static SystemCheck defaultFileSystemCheck() {
     return new SystemCheck("Can create temporary files (check disk usage, file permissions)", () -> {
       try {
-        File.createTempFile("prefix", "suffix");
+        File.createTempFile("prefix", "suffix").delete();
       } catch (final IOException e) {
         Throwables.propagate(e);
       }

--- a/src/main/java/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
+++ b/src/main/java/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
@@ -30,8 +30,8 @@ public final class LocalSystemChecker {
   private static SystemCheck defaultNetworkCheck() {
     return new SystemCheck("Can connect to github.com (check network connection)", () -> {
       try {
-        final URL url = new URL("http://www.github.com");
-        url.openConnection();
+        final URL url = new URL("https://github.com");
+        url.openConnection().connect();
       } catch (final Exception e) {
         Throwables.propagate(e);
       }

--- a/src/main/java/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
+++ b/src/main/java/games/strategy/engine/framework/systemcheck/LocalSystemChecker.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -19,6 +20,11 @@ public final class LocalSystemChecker {
 
   public LocalSystemChecker() {
     this(ImmutableSet.of(defaultNetworkCheck(), defaultFileSystemCheck()));
+  }
+
+  @VisibleForTesting
+  LocalSystemChecker(final Set<SystemCheck> checks) {
+    systemChecks = checks;
   }
 
   private static SystemCheck defaultNetworkCheck() {
@@ -40,11 +46,6 @@ public final class LocalSystemChecker {
         Throwables.propagate(e);
       }
     });
-  }
-
-
-  protected LocalSystemChecker(final Set<SystemCheck> checks) {
-    systemChecks = checks;
   }
 
   /** Return any exceptions encountered while running each check. */

--- a/src/test/java/games/strategy/engine/framework/systemcheck/LocalSystemCheckerTest.java
+++ b/src/test/java/games/strategy/engine/framework/systemcheck/LocalSystemCheckerTest.java
@@ -16,16 +16,14 @@ public class LocalSystemCheckerTest {
       new SystemCheck("throws exception", () -> Throwables.propagate(new Exception("test")));
 
   @Test
-  public void testHappyCase() {
+  public void testPassingCase() {
     final LocalSystemChecker checker = new LocalSystemChecker(ImmutableSet.of(PASSING_CHECK));
     assertThat(checker.getExceptions().size(), is(0));
   }
 
   @Test
-  public void testCheckingNetwork() {
-    final SystemCheck network = new SystemCheck("throws exception", () -> Throwables.propagate(new Exception("test")));
-
-    final LocalSystemChecker checker = new LocalSystemChecker(ImmutableSet.of(network));
+  public void testFailingCase() {
+    final LocalSystemChecker checker = new LocalSystemChecker(ImmutableSet.of(FAILING_CHECK));
     assertThat(checker.getExceptions().size(), is(1));
   }
 


### PR DESCRIPTION
This PR removes the unused system check feature in the `g.s.engine.framework.systemcheck` package.

⚠ Looking at the history on `master`, this feature was apparently accidentally removed during a merge and then re-added in [b4f366a](https://github.com/triplea-game/triplea/commit/b4f366a9336c2a7722515c4c05c850ed66ea9537#diff-baafe2209ef3b890ea000d7dca31772a) on 2016-03-03.  It was then removed a second time in [b02efec](https://github.com/triplea-game/triplea/commit/b02efece19c2f7f202c3e0e142a747b551b54388#diff-baafe2209ef3b890ea000d7dca31772a) on 2016-03-12.  However, the author dates of these commits are 2016-02-28 and 2016-02-17, respectively.  That is, the commit (b4f366a) that re-added the feature occurred chronologically later than the commit (b02efec) that removed it even though b4f366a occurs earlier in the commit history.

@DanVanAtta Can you please confirm if it was your intention to remove this feature in b02efec or if the re-add in b4f366a was the correct change?  If the latter, I will repurpose this PR to re-integrate the system check feature into `GameRunner`.

**EDIT:** Per the [comment](https://github.com/triplea-game/triplea/pull/1707#issuecomment-302898293) below, this PR has been repurposed to **restore** the system check feature.  I'm leaving the original description intact for reference.