### PR TITLE
Checkstyle: Fix Javadoc structural violations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 checkstyleMainMaxWarnings=5213
-checkstyleTestMaxWarnings=142
+checkstyleTestMaxWarnings=141

--- a/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -317,7 +317,9 @@ public class AirThatCantLandUtilTest {
     assertEquals(expectedCountCanada, postCountInt);
   }
 
-  /** @deprecated Use a mock object instead. */
+  /**
+   * @deprecated Use a mock object instead.
+   */
   @Deprecated
   private static ITripleAPlayer getDummyPlayer() {
     final InvocationHandler handler = new InvocationHandler() {


### PR DESCRIPTION
This PR fixes a single violation of the Checkstyle SingleLineJavadoc rule.

This violation was a regression from 5a42315.