### PR TITLE
Checkstyle: Fix member name violations in tool code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=5184
+checkstyleMainMaxWarnings=5125
 checkstyleTestMaxWarnings=139

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -44,12 +44,12 @@ import games.strategy.util.PointFileReaderWriter;
 public class CenterPicker extends JFrame {
   private static final long serialVersionUID = -5633998810385136625L;
   // The map image will be stored here
-  private Image m_image;
+  private Image image;
   // hash map for center points
-  private Map<String, Point> m_centers = new HashMap<>();
+  private Map<String, Point> centers = new HashMap<>();
   // hash map for polygon points
-  private Map<String, List<Polygon>> m_polygons = new HashMap<>();
-  private final JLabel m_location = new JLabel();
+  private Map<String, List<Polygon>> polygons = new HashMap<>();
+  private final JLabel locationLabel = new JLabel();
   private static File s_mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
 
@@ -118,7 +118,7 @@ public class CenterPicker extends JFrame {
             + "names?",
         "File Suggestion", 1) == 0) {
       try {
-        m_polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(file.getPath()));
+        polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(file.getPath()));
       } catch (final IOException ex1) {
         System.out.println("Something wrong with your Polygons file: " + ex1);
         ex1.printStackTrace();
@@ -127,7 +127,7 @@ public class CenterPicker extends JFrame {
       try {
         final String polyPath = new FileOpen("Select A Polygon File", s_mapFolderLocation, ".txt").getPathString();
         if (polyPath != null) {
-          m_polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
+          polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
         }
       } catch (final IOException ex1) {
         System.out.println("Something wrong with your Polygons file: " + ex1);
@@ -144,7 +144,7 @@ public class CenterPicker extends JFrame {
     imagePanel.addMouseMotionListener(new MouseMotionAdapter() {
       @Override
       public void mouseMoved(final MouseEvent e) {
-        m_location.setText("x:" + e.getX() + " y:" + e.getY());
+        locationLabel.setText("x:" + e.getX() + " y:" + e.getY());
       }
     });
     // Add a mouse listener to monitor for right mouse button being clicked.
@@ -155,13 +155,13 @@ public class CenterPicker extends JFrame {
       }
     });
     // set up the image panel size dimensions ...etc
-    imagePanel.setMinimumSize(new Dimension(m_image.getWidth(this), m_image.getHeight(this)));
-    imagePanel.setPreferredSize(new Dimension(m_image.getWidth(this), m_image.getHeight(this)));
-    imagePanel.setMaximumSize(new Dimension(m_image.getWidth(this), m_image.getHeight(this)));
+    imagePanel.setMinimumSize(new Dimension(image.getWidth(this), image.getHeight(this)));
+    imagePanel.setPreferredSize(new Dimension(image.getWidth(this), image.getHeight(this)));
+    imagePanel.setMaximumSize(new Dimension(image.getWidth(this), image.getHeight(this)));
     // set up the layout manager
     this.getContentPane().setLayout(new BorderLayout());
     this.getContentPane().add(new JScrollPane(imagePanel), BorderLayout.CENTER);
-    this.getContentPane().add(m_location, BorderLayout.SOUTH);
+    this.getContentPane().add(locationLabel, BorderLayout.SOUTH);
     // set up the actions
     final Action openAction = SwingAction.of("Load Centers", e -> loadCenters());
     openAction.putValue(Action.SHORT_DESCRIPTION, "Load An Existing Center Points File");
@@ -196,8 +196,8 @@ public class CenterPicker extends JFrame {
    *        .lang.String mapName the path of image map
    */
   private void createImage(final String mapName) {
-    m_image = Toolkit.getDefaultToolkit().createImage(mapName);
-    Util.ensureImageLoaded(m_image);
+    image = Toolkit.getDefaultToolkit().createImage(mapName);
+    Util.ensureImageLoaded(image);
   }
 
   /**
@@ -214,10 +214,10 @@ public class CenterPicker extends JFrame {
       @Override
       public void paint(final Graphics g) {
         // super.paint(g);
-        g.drawImage(m_image, 0, 0, this);
+        g.drawImage(image, 0, 0, this);
         g.setColor(Color.red);
-        for (final String centerName : m_centers.keySet()) {
-          final Point item = m_centers.get(centerName);
+        for (final String centerName : centers.keySet()) {
+          final Point item = centers.get(centerName);
           g.fillOval(item.x, item.y, 15, 15);
           g.drawString(centerName, item.x + 17, item.y + 13);
         }
@@ -238,7 +238,7 @@ public class CenterPicker extends JFrame {
         return;
       }
       final FileOutputStream out = new FileOutputStream(fileName);
-      PointFileReaderWriter.writeOneToOne(out, m_centers);
+      PointFileReaderWriter.writeOneToOne(out, centers);
       out.flush();
       out.close();
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
@@ -259,7 +259,7 @@ public class CenterPicker extends JFrame {
         return;
       }
       final FileInputStream in = new FileInputStream(centerName);
-      m_centers = PointFileReaderWriter.readOneToOne(in);
+      centers = PointFileReaderWriter.readOneToOne(in);
       repaint();
     } catch (final HeadlessException | IOException ex) {
       ClientLogger.logQuietly(ex);
@@ -275,7 +275,7 @@ public class CenterPicker extends JFrame {
    *        .awt.point p a point on the map
    */
   private String findTerritoryName(final Point p) {
-    return Util.findTerritoryName(p, m_polygons, "unknown");
+    return Util.findTerritoryName(p, polygons, "unknown");
   }
 
   /**
@@ -295,14 +295,14 @@ public class CenterPicker extends JFrame {
       if (name == null || name.trim().length() == 0) {
         return;
       }
-      if (m_centers.containsKey(name) && JOptionPane.showConfirmDialog(this,
+      if (centers.containsKey(name) && JOptionPane.showConfirmDialog(this,
           "Another center exists with the same name. Are you sure you want to replace it with this one?") != 0) {
         return;
       }
-      m_centers.put(name, point);
+      centers.put(name, point);
     } else {
       String centerClicked = null;
-      for (final Entry<String, Point> cur : m_centers.entrySet()) {
+      for (final Entry<String, Point> cur : centers.entrySet()) {
         if (new Rectangle(cur.getValue(), new Dimension(15, 15))
             .intersects(new Rectangle(point, new Dimension(1, 1)))) {
           centerClicked = cur.getKey();
@@ -310,7 +310,7 @@ public class CenterPicker extends JFrame {
       }
       if (centerClicked != null
           && JOptionPane.showConfirmDialog(this, "Are you sure you want to remove this center?") == 0) {
-        m_centers.remove(centerClicked);
+        centers.remove(centerClicked);
       }
     }
     repaint();

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -95,22 +95,21 @@ import games.strategy.util.Tuple;
 public class DecorationPlacer extends JFrame {
   private static final long serialVersionUID = 6385408390173085656L;
   // The map image will be stored here
-  private Image m_image;
+  private Image image;
   // hash map for image points
-  private Map<String, List<Point>> m_currentPoints = new HashMap<>();
+  private Map<String, List<Point>> currentPoints = new HashMap<>();
   // hash map for center points
-  private Map<String, Point> m_centers = new HashMap<>();
+  private Map<String, Point> centers = new HashMap<>();
   // hash map for polygon points
-  private Map<String, List<Polygon>> m_polygons = new HashMap<>();
-  private final JLabel m_location = new JLabel();
+  private Map<String, List<Polygon>> polygons = new HashMap<>();
+  private final JLabel locationLabel = new JLabel();
   private static File s_mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
   private static File s_currentImageFolderLocation = null;
   private static File s_currentImagePointsTextFile = null;
-  private Point m_currentMousePoint = new Point(0, 0);
-  private Triple<String, Image, Point> m_currentSelectedImage = null;
-  private Map<String, Tuple<Image, List<Point>>> m_currentImagePoints =
-      new HashMap<>();
+  private Point currentMousePoint = new Point(0, 0);
+  private Triple<String, Image, Point> currentSelectedImage = null;
+  private Map<String, Tuple<Image, List<Point>>> currentImagePoints = new HashMap<>();
   private static boolean s_highlightAll = false;
   private static boolean s_createNewImageOnRightClick = false;
   private static Image s_staticImageForPlacing = null;
@@ -198,7 +197,7 @@ public class DecorationPlacer extends JFrame {
         "File Suggestion", 1) == 0) {
       try {
         System.out.println("Centers : " + fileCenters.getPath());
-        m_centers = PointFileReaderWriter.readOneToOne(new FileInputStream(fileCenters.getPath()));
+        centers = PointFileReaderWriter.readOneToOne(new FileInputStream(fileCenters.getPath()));
       } catch (final IOException ex1) {
         System.out.println("Something wrong with Centers file");
         ex1.printStackTrace();
@@ -210,7 +209,7 @@ public class DecorationPlacer extends JFrame {
         final String centerPath = new FileOpen("Select A Center File", s_mapFolderLocation, ".txt").getPathString();
         if (centerPath != null) {
           System.out.println("Centers : " + centerPath);
-          m_centers = PointFileReaderWriter.readOneToOne(new FileInputStream(centerPath));
+          centers = PointFileReaderWriter.readOneToOne(new FileInputStream(centerPath));
         } else {
           System.out.println("You must specify a centers file.");
           System.out.println("Shutting down.");
@@ -235,7 +234,7 @@ public class DecorationPlacer extends JFrame {
         "File Suggestion", 1) == 0) {
       try {
         System.out.println("Polygons : " + filePoly.getPath());
-        m_polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(filePoly.getPath()));
+        polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(filePoly.getPath()));
       } catch (final IOException ex1) {
         System.out.println("Something wrong with your Polygons file");
         ex1.printStackTrace();
@@ -247,7 +246,7 @@ public class DecorationPlacer extends JFrame {
         final String polyPath = new FileOpen("Select A Polygon File", s_mapFolderLocation, ".txt").getPathString();
         if (polyPath != null) {
           System.out.println("Polygons : " + polyPath);
-          m_polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
+          polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
         } else {
           System.out.println("You must specify a Polgyon file.");
           System.out.println("Shutting down.");
@@ -259,7 +258,7 @@ public class DecorationPlacer extends JFrame {
         System.exit(0);
       }
     }
-    m_image = createImage(mapName);
+    image = createImage(mapName);
     final JPanel imagePanel = createMainPanel();
     /*
      * Add a mouse listener to show
@@ -269,13 +268,13 @@ public class DecorationPlacer extends JFrame {
     imagePanel.addMouseMotionListener(new MouseMotionAdapter() {
       @Override
       public void mouseMoved(final MouseEvent e) {
-        m_location.setText((m_currentSelectedImage == null ? "" : m_currentSelectedImage.getFirst()) + "    x:"
+        locationLabel.setText((currentSelectedImage == null ? "" : currentSelectedImage.getFirst()) + "    x:"
             + e.getX() + " y:" + e.getY());
-        m_currentMousePoint = new Point(e.getPoint());
+        currentMousePoint = new Point(e.getPoint());
         DecorationPlacer.this.repaint();
       }
     });
-    m_location.setFont(new Font("Ariel", Font.BOLD, 16));
+    locationLabel.setFont(new Font("Ariel", Font.BOLD, 16));
     /*
      * Add a mouse listener to monitor
      * for right mouse button being
@@ -288,13 +287,13 @@ public class DecorationPlacer extends JFrame {
       }
     });
     // set up the image panel size dimensions ...etc
-    imagePanel.setMinimumSize(new Dimension(m_image.getWidth(this), m_image.getHeight(this)));
-    imagePanel.setPreferredSize(new Dimension(m_image.getWidth(this), m_image.getHeight(this)));
-    imagePanel.setMaximumSize(new Dimension(m_image.getWidth(this), m_image.getHeight(this)));
+    imagePanel.setMinimumSize(new Dimension(image.getWidth(this), image.getHeight(this)));
+    imagePanel.setPreferredSize(new Dimension(image.getWidth(this), image.getHeight(this)));
+    imagePanel.setMaximumSize(new Dimension(image.getWidth(this), image.getHeight(this)));
     // set up the layout manager
     this.getContentPane().setLayout(new BorderLayout());
     this.getContentPane().add(new JScrollPane(imagePanel), BorderLayout.CENTER);
-    this.getContentPane().add(m_location, BorderLayout.SOUTH);
+    this.getContentPane().add(locationLabel, BorderLayout.SOUTH);
     // set up the actions
     final Action openAction = SwingAction.of("Load Image Locations", e -> loadImagesAndPoints());
     openAction.putValue(Action.SHORT_DESCRIPTION, "Load An Existing Image Points File");
@@ -341,7 +340,7 @@ public class DecorationPlacer extends JFrame {
         DecorationPlacer.this.repaint();
       }
     });
-    final Action clearAction = SwingAction.of("Clear All Current Points.", e -> m_currentImagePoints.clear());
+    final Action clearAction = SwingAction.of("Clear All Current Points.", e -> currentImagePoints.clear());
     clearAction.putValue(Action.SHORT_DESCRIPTION, "Delete all points.");
     final JMenu editMenu = new JMenu("Edit");
     editMenu.setMnemonic('E');
@@ -391,13 +390,13 @@ public class DecorationPlacer extends JFrame {
     if (s_cheapMutex) {
       return;
     }
-    g.drawImage(m_image, 0, 0, this);
+    g.drawImage(image, 0, 0, this);
     g.setColor(Color.red);
-    for (final Entry<String, Tuple<Image, List<Point>>> entry : m_currentImagePoints.entrySet()) {
+    for (final Entry<String, Tuple<Image, List<Point>>> entry : currentImagePoints.entrySet()) {
       for (final Point p : entry.getValue().getSecond()) {
         g.drawImage(entry.getValue().getFirst(), p.x,
             p.y - (s_showFromTopLeft ? 0 : entry.getValue().getFirst().getHeight(null)), null);
-        if (m_currentSelectedImage != null && m_currentSelectedImage.getThird().equals(p)) {
+        if (currentSelectedImage != null && currentSelectedImage.getThird().equals(p)) {
           g.setColor(Color.green);
           g.drawRect(p.x, p.y - (s_showFromTopLeft ? 0 : entry.getValue().getFirst().getHeight(null)),
               entry.getValue().getFirst().getWidth(null), entry.getValue().getFirst().getHeight(null));
@@ -412,25 +411,25 @@ public class DecorationPlacer extends JFrame {
         }
       }
     }
-    if (m_currentSelectedImage != null) {
+    if (currentSelectedImage != null) {
       g.setColor(Color.green);
-      g.drawImage(m_currentSelectedImage.getSecond(), m_currentMousePoint.x,
-          m_currentMousePoint.y - (s_showFromTopLeft ? 0 : m_currentSelectedImage.getSecond().getHeight(null)), null);
+      g.drawImage(currentSelectedImage.getSecond(), currentMousePoint.x,
+          currentMousePoint.y - (s_showFromTopLeft ? 0 : currentSelectedImage.getSecond().getHeight(null)), null);
       if (s_highlightAll) {
-        g.drawRect(m_currentMousePoint.x,
-            m_currentMousePoint.y - (s_showFromTopLeft ? 0 : m_currentSelectedImage.getSecond().getHeight(null)),
-            m_currentSelectedImage.getSecond().getWidth(null), m_currentSelectedImage.getSecond().getHeight(null));
+        g.drawRect(currentMousePoint.x,
+            currentMousePoint.y - (s_showFromTopLeft ? 0 : currentSelectedImage.getSecond().getHeight(null)),
+            currentSelectedImage.getSecond().getWidth(null), currentSelectedImage.getSecond().getHeight(null));
       }
       if (s_showPointNames) {
-        g.drawString(m_currentSelectedImage.getFirst(), m_currentMousePoint.x,
-            m_currentMousePoint.y - (s_showFromTopLeft ? 0 : m_currentSelectedImage.getSecond().getHeight(null)));
+        g.drawString(currentSelectedImage.getFirst(), currentMousePoint.x,
+            currentMousePoint.y - (s_showFromTopLeft ? 0 : currentSelectedImage.getSecond().getHeight(null)));
       }
     }
   }
 
   private void saveCurrentToMapPicture() {
     final BufferedImage bufferedImage =
-        new BufferedImage(m_image.getWidth(null), m_image.getHeight(null), BufferedImage.TYPE_INT_ARGB);
+        new BufferedImage(image.getWidth(null), image.getHeight(null), BufferedImage.TYPE_INT_ARGB);
     final Graphics g = bufferedImage.getGraphics();
     final boolean saveHighlight = s_highlightAll;
     final boolean saveNames = s_showPointNames;
@@ -440,7 +439,7 @@ public class DecorationPlacer extends JFrame {
     g.dispose();
     s_highlightAll = saveHighlight;
     s_showPointNames = saveNames;
-    m_image = bufferedImage;
+    image = bufferedImage;
   }
 
   /**
@@ -448,14 +447,14 @@ public class DecorationPlacer extends JFrame {
    * Saves the centers to disk.
    */
   private void saveImagePoints() {
-    m_currentPoints = new HashMap<>();
-    for (final Entry<String, Tuple<Image, List<Point>>> entry : m_currentImagePoints.entrySet()) {
+    currentPoints = new HashMap<>();
+    for (final Entry<String, Tuple<Image, List<Point>>> entry : currentImagePoints.entrySet()) {
       // remove duplicates
       final LinkedHashSet<Point> pointSet = new LinkedHashSet<>();
       pointSet.addAll(entry.getValue().getSecond());
       entry.getValue().getSecond().clear();
       entry.getValue().getSecond().addAll(pointSet);
-      m_currentPoints.put(entry.getKey(), entry.getValue().getSecond());
+      currentPoints.put(entry.getKey(), entry.getValue().getSecond());
     }
     try {
       final String fileName = new FileSave("Where To Save Image Points Text File?", JFileChooser.FILES_ONLY,
@@ -465,7 +464,7 @@ public class DecorationPlacer extends JFrame {
       }
       final FileOutputStream out = new FileOutputStream(fileName);
 
-      PointFileReaderWriter.writeOneToMany(out, new HashMap<>(m_currentPoints));
+      PointFileReaderWriter.writeOneToMany(out, new HashMap<>(currentPoints));
 
       out.flush();
       out.close();
@@ -524,8 +523,8 @@ public class DecorationPlacer extends JFrame {
 
   private void loadImagesAndPoints() {
     s_cheapMutex = true;
-    m_currentImagePoints = new HashMap<>();
-    m_currentSelectedImage = null;
+    currentImagePoints = new HashMap<>();
+    currentSelectedImage = null;
     selectImagePointType();
     final Object[] miscOrNamesOptions = {"Folder Full of Images", "Text File Full of Points"};
     final Object[] pointsAreNamesOptions = {"Points end in .png", "Points do NOT end in .png"};
@@ -608,9 +607,9 @@ public class DecorationPlacer extends JFrame {
       if (centerName != null && centerName.getFile() != null && centerName.getFile().exists()
           && centerName.getPathString() != null) {
         final FileInputStream in = new FileInputStream(centerName.getPathString());
-        m_currentPoints = PointFileReaderWriter.readOneToMany(in);
+        currentPoints = PointFileReaderWriter.readOneToMany(in);
       } else {
-        m_currentPoints = new HashMap<>();
+        currentPoints = new HashMap<>();
       }
     } catch (final HeadlessException | IOException ex) {
       ClientLogger.logQuietly(ex);
@@ -641,8 +640,8 @@ public class DecorationPlacer extends JFrame {
     final int addY = (s_imagePointType == ImagePointType.comments ? ((-ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS))
         : (s_imagePointType == ImagePointType.pu_place ? (ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS) : 0));
     if (fillInAllTerritories) {
-      for (final Entry<String, Point> entry : m_centers.entrySet()) {
-        List<Point> points = m_currentPoints.get(entry.getKey());
+      for (final Entry<String, Point> entry : centers.entrySet()) {
+        List<Point> points = currentPoints.get(entry.getKey());
         if (points == null) {
           System.out.println("Did NOT find point for: " + entry.getKey());
           points = new ArrayList<>();
@@ -652,11 +651,11 @@ public class DecorationPlacer extends JFrame {
         } else {
           System.out.println("Found point for: " + entry.getKey());
         }
-        m_currentImagePoints.put(entry.getKey(), Tuple.of(s_staticImageForPlacing, points));
+        currentImagePoints.put(entry.getKey(), Tuple.of(s_staticImageForPlacing, points));
       }
     } else {
-      for (final Entry<String, List<Point>> entry : m_currentPoints.entrySet()) {
-        m_currentImagePoints.put(entry.getKey(),
+      for (final Entry<String, List<Point>> entry : currentPoints.entrySet()) {
+        currentImagePoints.put(entry.getKey(),
             Tuple.of(s_staticImageForPlacing, entry.getValue()));
       }
     }
@@ -667,7 +666,7 @@ public class DecorationPlacer extends JFrame {
   private void fillCurrentImagePointsBasedOnImageFolder(final boolean pointsAreExactlyTerritoryNames) {
     final int addY = (s_imagePointType == ImagePointType.comments ? ((-ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS))
         : (s_imagePointType == ImagePointType.pu_place ? (ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS) : 0));
-    final List<String> allTerritories = new ArrayList<>(m_centers.keySet());
+    final List<String> allTerritories = new ArrayList<>(centers.keySet());
     for (final File file : s_currentImageFolderLocation.listFiles()) {
       if (!file.getPath().endsWith(".png") && !file.getPath().endsWith(".gif")) {
         continue;
@@ -675,11 +674,11 @@ public class DecorationPlacer extends JFrame {
       final String imageName = file.getName();
       final String possibleTerritoryName = imageName.substring(0, imageName.length() - 4);
       final Image image = createImage(file.getPath());
-      List<Point> points = (m_currentPoints != null
-          ? m_currentPoints.get((pointsAreExactlyTerritoryNames ? possibleTerritoryName : imageName)) : null);
+      List<Point> points = (currentPoints != null
+          ? currentPoints.get((pointsAreExactlyTerritoryNames ? possibleTerritoryName : imageName)) : null);
       if (points == null) {
         points = new ArrayList<>();
-        Point p = m_centers.get(possibleTerritoryName);
+        Point p = centers.get(possibleTerritoryName);
         if (p == null) {
           System.out.println("Did NOT find point for: " + possibleTerritoryName);
           points.add(new Point(50, 50));
@@ -693,7 +692,7 @@ public class DecorationPlacer extends JFrame {
       } else {
         allTerritories.remove(possibleTerritoryName);
       }
-      m_currentImagePoints.put((pointsAreExactlyTerritoryNames ? possibleTerritoryName : imageName),
+      currentImagePoints.put((pointsAreExactlyTerritoryNames ? possibleTerritoryName : imageName),
           Tuple.of(image, points));
     }
     if (!allTerritories.isEmpty() && s_imagePointType == ImagePointType.name_place) {
@@ -714,72 +713,72 @@ public class DecorationPlacer extends JFrame {
     if (s_cheapMutex) {
       return;
     }
-    if (!rightMouse && !ctrlDown && m_currentSelectedImage == null) {
+    if (!rightMouse && !ctrlDown && currentSelectedImage == null) {
       // find whatever image we are left clicking on
       Point testPoint = null;
-      for (final Entry<String, Tuple<Image, List<Point>>> entry : m_currentImagePoints.entrySet()) {
+      for (final Entry<String, Tuple<Image, List<Point>>> entry : currentImagePoints.entrySet()) {
         for (final Point p : entry.getValue().getSecond()) {
-          if (testPoint == null || p.distance(m_currentMousePoint) < testPoint.distance(m_currentMousePoint)) {
+          if (testPoint == null || p.distance(currentMousePoint) < testPoint.distance(currentMousePoint)) {
             testPoint = p;
-            m_currentSelectedImage = Triple.of(entry.getKey(), entry.getValue().getFirst(), p);
+            currentSelectedImage = Triple.of(entry.getKey(), entry.getValue().getFirst(), p);
           }
         }
       }
-    } else if (!rightMouse && !ctrlDown && m_currentSelectedImage != null) {
+    } else if (!rightMouse && !ctrlDown && currentSelectedImage != null) {
       // save the image
-      final Tuple<Image, List<Point>> imagePoints = m_currentImagePoints.get(m_currentSelectedImage.getFirst());
+      final Tuple<Image, List<Point>> imagePoints = currentImagePoints.get(currentSelectedImage.getFirst());
       final List<Point> points = imagePoints.getSecond();
-      points.remove(m_currentSelectedImage.getThird());
-      points.add(new Point(m_currentMousePoint));
-      m_currentImagePoints.put(m_currentSelectedImage.getFirst(),
-          Tuple.of(m_currentSelectedImage.getSecond(), points));
-      m_currentSelectedImage = null;
+      points.remove(currentSelectedImage.getThird());
+      points.add(new Point(currentMousePoint));
+      currentImagePoints.put(currentSelectedImage.getFirst(),
+          Tuple.of(currentSelectedImage.getSecond(), points));
+      currentSelectedImage = null;
     } else if (rightMouse && !ctrlDown && s_createNewImageOnRightClick && s_staticImageForPlacing != null
-        && m_currentSelectedImage == null) {
+        && currentSelectedImage == null) {
       // create a new point here in this territory
-      final Optional<String> territoryName = Util.findTerritoryName(m_currentMousePoint, m_polygons);
+      final Optional<String> territoryName = Util.findTerritoryName(currentMousePoint, polygons);
       if (territoryName.isPresent()) {
         final List<Point> points = new ArrayList<>();
-        points.add(new Point(m_currentMousePoint));
-        m_currentImagePoints.put(territoryName.get(), Tuple.of(s_staticImageForPlacing, points));
+        points.add(new Point(currentMousePoint));
+        currentImagePoints.put(territoryName.get(), Tuple.of(s_staticImageForPlacing, points));
       }
     } else if (rightMouse && !ctrlDown && s_imagePointType.isCanHaveMultiplePoints()) {
       // if none selected find the image we are clicking on, and duplicate it (not replace/move it)
-      if (m_currentSelectedImage == null) {
+      if (currentSelectedImage == null) {
         Point testPoint = null;
-        for (final Entry<String, Tuple<Image, List<Point>>> entry : m_currentImagePoints.entrySet()) {
+        for (final Entry<String, Tuple<Image, List<Point>>> entry : currentImagePoints.entrySet()) {
           for (final Point p : entry.getValue().getSecond()) {
-            if (testPoint == null || p.distance(m_currentMousePoint) < testPoint.distance(m_currentMousePoint)) {
+            if (testPoint == null || p.distance(currentMousePoint) < testPoint.distance(currentMousePoint)) {
               testPoint = p;
-              m_currentSelectedImage =
+              currentSelectedImage =
                   Triple.of(entry.getKey(), entry.getValue().getFirst(), null);
             }
           }
         }
       } else {
-        m_currentSelectedImage = Triple.of(m_currentSelectedImage.getFirst(),
-            m_currentSelectedImage.getSecond(), null);
+        currentSelectedImage = Triple.of(currentSelectedImage.getFirst(),
+            currentSelectedImage.getSecond(), null);
       }
       // then save (same code as above for saving)
-      final Tuple<Image, List<Point>> imagePoints = m_currentImagePoints.get(m_currentSelectedImage.getFirst());
+      final Tuple<Image, List<Point>> imagePoints = currentImagePoints.get(currentSelectedImage.getFirst());
       final List<Point> points = imagePoints.getSecond();
-      points.remove(m_currentSelectedImage.getThird());
-      points.add(new Point(m_currentMousePoint));
-      m_currentImagePoints.put(m_currentSelectedImage.getFirst(),
-          Tuple.of(m_currentSelectedImage.getSecond(), points));
-      m_currentSelectedImage = null;
+      points.remove(currentSelectedImage.getThird());
+      points.add(new Point(currentMousePoint));
+      currentImagePoints.put(currentSelectedImage.getFirst(),
+          Tuple.of(currentSelectedImage.getSecond(), points));
+      currentSelectedImage = null;
     } else if (rightMouse && ctrlDown) {
       // must be right click AND ctrl down to delete an image
-      if (m_currentSelectedImage == null) {
+      if (currentSelectedImage == null) {
         return;
       }
-      final Tuple<Image, List<Point>> current = m_currentImagePoints.get(m_currentSelectedImage.getFirst());
+      final Tuple<Image, List<Point>> current = currentImagePoints.get(currentSelectedImage.getFirst());
       final List<Point> points = current.getSecond();
-      points.remove(m_currentSelectedImage.getThird());
+      points.remove(currentSelectedImage.getThird());
       if (points.isEmpty()) {
-        m_currentImagePoints.remove(m_currentSelectedImage.getFirst());
+        currentImagePoints.remove(currentSelectedImage.getFirst());
       }
-      m_currentSelectedImage = null;
+      currentSelectedImage = null;
     }
     repaint();
   }
@@ -915,17 +914,17 @@ enum ImagePointType {
           + "CTRL/SHIFT + Right Click = delete currently selected image point</html>");
 
   public static final int SPACE_BETWEEN_NAMES_AND_PUS = 32;
-  private final String m_fileName;
-  private final String m_folderName;
-  private final String m_imageName;
-  private final boolean m_useFolder;
-  private final boolean m_endInPNG;
-  private final boolean m_fillAll;
-  private final boolean m_canUseBottomLeftPoint;
-  private final boolean m_canHaveMultiplePoints;
-  private final boolean m_usesCentersPoint;
-  private final String m_description;
-  private final String m_instructions;
+  private final String fileName;
+  private final String folderName;
+  private final String imageName;
+  private final boolean useFolder;
+  private final boolean endInPNG;
+  private final boolean fillAll;
+  private final boolean canUseBottomLeftPoint;
+  private final boolean canHaveMultiplePoints;
+  private final boolean usesCentersPoint;
+  private final String description;
+  private final String instructions;
 
   protected static ImagePointType[] getTypes() {
     return new ImagePointType[] {decorations, name_place, pu_place, capitols, vc, blockade, convoy, comments,
@@ -936,60 +935,60 @@ enum ImagePointType {
       final boolean endInPNG, final boolean fillAll, final boolean canUseBottomLeftPoint,
       final boolean canHaveMultiplePoints, final boolean usesCentersPoint, final String description,
       final String instructions) {
-    m_fileName = fileName;
-    m_folderName = folderName;
-    m_imageName = imageName;
-    m_useFolder = useFolder;
-    m_endInPNG = endInPNG;
-    m_fillAll = fillAll;
-    m_canUseBottomLeftPoint = canUseBottomLeftPoint;
-    m_canHaveMultiplePoints = canHaveMultiplePoints;
-    m_usesCentersPoint = usesCentersPoint;
-    m_description = description;
-    m_instructions = instructions;
+    this.fileName = fileName;
+    this.folderName = folderName;
+    this.imageName = imageName;
+    this.useFolder = useFolder;
+    this.endInPNG = endInPNG;
+    this.fillAll = fillAll;
+    this.canUseBottomLeftPoint = canUseBottomLeftPoint;
+    this.canHaveMultiplePoints = canHaveMultiplePoints;
+    this.usesCentersPoint = usesCentersPoint;
+    this.description = description;
+    this.instructions = instructions;
   }
 
   public String getFileName() {
-    return m_fileName;
+    return fileName;
   }
 
   public String getFolderName() {
-    return m_folderName;
+    return folderName;
   }
 
   public String getImageName() {
-    return m_imageName;
+    return imageName;
   }
 
   public boolean isUseFolder() {
-    return m_useFolder;
+    return useFolder;
   }
 
   public boolean isEndInPNG() {
-    return m_endInPNG;
+    return endInPNG;
   }
 
   public boolean isFillAll() {
-    return m_fillAll;
+    return fillAll;
   }
 
   public boolean isCanUseBottomLeftPoint() {
-    return m_canUseBottomLeftPoint;
+    return canUseBottomLeftPoint;
   }
 
   public boolean isCanHaveMultiplePoints() {
-    return m_canHaveMultiplePoints;
+    return canHaveMultiplePoints;
   }
 
   public boolean isUsesCentersPoint() {
-    return m_usesCentersPoint;
+    return usesCentersPoint;
   }
 
   public String getDescription() {
-    return m_description;
+    return description;
   }
 
   public String getInstructions() {
-    return m_instructions;
+    return instructions;
   }
 }

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -65,14 +65,14 @@ public class PolygonGrabber extends JFrame {
   private static boolean s_islandMode;
   private final JCheckBoxMenuItem modeItem;
   // the current set of polyongs
-  private List<Polygon> m_current;
+  private List<Polygon> current;
   // holds the map image
   // private Image m_image;
-  private BufferedImage m_bufferedImage;
+  private BufferedImage bufferedImage;
   // maps String -> List of polygons
-  private Map<String, List<Polygon>> m_polygons = new HashMap<>();
+  private Map<String, List<Polygon>> polygons = new HashMap<>();
   // holds the centers for the polygons
-  private Map<String, Point> m_centers;
+  private Map<String, Point> centers;
   private final JLabel location = new JLabel();
   private static File s_mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
@@ -145,7 +145,7 @@ public class PolygonGrabber extends JFrame {
         "File Suggestion", 1) == 0) {
       try {
         System.out.println("Centers : " + file.getPath());
-        m_centers = PointFileReaderWriter.readOneToOne(new FileInputStream(file.getPath()));
+        centers = PointFileReaderWriter.readOneToOne(new FileInputStream(file.getPath()));
       } catch (final IOException ex1) {
         System.out.println("Something wrong with Centers file");
         ex1.printStackTrace();
@@ -156,7 +156,7 @@ public class PolygonGrabber extends JFrame {
         final String centerPath = new FileOpen("Select A Center File", s_mapFolderLocation, ".txt").getPathString();
         if (centerPath != null) {
           System.out.println("Centers : " + centerPath);
-          m_centers = PointFileReaderWriter.readOneToOne(new FileInputStream(centerPath));
+          centers = PointFileReaderWriter.readOneToOne(new FileInputStream(centerPath));
         } else {
           System.out.println("You must specify a centers file.");
           System.out.println("Shutting down.");
@@ -193,9 +193,9 @@ public class PolygonGrabber extends JFrame {
       }
     });
     // set up the image panel size dimensions ...etc
-    imagePanel.setMinimumSize(new Dimension(m_bufferedImage.getWidth(this), m_bufferedImage.getHeight(this)));
-    imagePanel.setPreferredSize(new Dimension(m_bufferedImage.getWidth(this), m_bufferedImage.getHeight(this)));
-    imagePanel.setMaximumSize(new Dimension(m_bufferedImage.getWidth(this), m_bufferedImage.getHeight(this)));
+    imagePanel.setMinimumSize(new Dimension(bufferedImage.getWidth(this), bufferedImage.getHeight(this)));
+    imagePanel.setPreferredSize(new Dimension(bufferedImage.getWidth(this), bufferedImage.getHeight(this)));
+    imagePanel.setMaximumSize(new Dimension(bufferedImage.getWidth(this), bufferedImage.getHeight(this)));
     // set up the layout manager
     this.getContentPane().setLayout(new BorderLayout());
     this.getContentPane().add(new JScrollPane(imagePanel), BorderLayout.CENTER);
@@ -214,15 +214,15 @@ public class PolygonGrabber extends JFrame {
               + "<br>Also, if a territory has more than 1 part (like an island chain), you will need to go back and "
               + "<br>redo the entire territory chain using CTRL + Click in order to capture each part of the territory."
               + "</html>"));
-      m_current = new ArrayList<>();
-      final BufferedImage imageCopy = new BufferedImage(m_bufferedImage.getWidth(null),
-          m_bufferedImage.getHeight(null), BufferedImage.TYPE_INT_ARGB);
+      current = new ArrayList<>();
+      final BufferedImage imageCopy = new BufferedImage(bufferedImage.getWidth(null),
+          bufferedImage.getHeight(null), BufferedImage.TYPE_INT_ARGB);
       final Graphics g = imageCopy.getGraphics();
-      g.drawImage(m_bufferedImage, 0, 0, null);
-      final Iterator<String> territoryNames = m_centers.keySet().iterator();
+      g.drawImage(bufferedImage, 0, 0, null);
+      final Iterator<String> territoryNames = centers.keySet().iterator();
       while (territoryNames.hasNext()) {
         final String territoryName = territoryNames.next();
-        final Point center = m_centers.get(territoryName);
+        final Point center = centers.get(territoryName);
         System.out.println("Detecting Polygon for:" + territoryName);
         final Polygon p = findPolygon(center.x, center.y);
         // test if the poly contains the center point (this often fails when there is an island right above (because
@@ -235,7 +235,7 @@ public class PolygonGrabber extends JFrame {
         // make sure it gets
         // done properly
         boolean hasIslands = false;
-        for (final Point otherCenterPoint : m_centers.values()) {
+        for (final Point otherCenterPoint : centers.values()) {
           if (center.equals(otherCenterPoint)) {
             continue;
           }
@@ -255,7 +255,7 @@ public class PolygonGrabber extends JFrame {
         }
         final List<Polygon> polys = new ArrayList<>();
         polys.add(p);
-        m_polygons.put(territoryName, polys);
+        polygons.put(territoryName, polys);
       }
       g.dispose();
       imageCopy.flush();
@@ -307,8 +307,8 @@ public class PolygonGrabber extends JFrame {
   private void createImage(final String mapName) {
     final Image image = Toolkit.getDefaultToolkit().createImage(mapName);
     Util.ensureImageLoaded(image);
-    m_bufferedImage = new BufferedImage(image.getWidth(null), image.getHeight(null), BufferedImage.TYPE_INT_ARGB);
-    final Graphics g = m_bufferedImage.getGraphics();
+    bufferedImage = new BufferedImage(image.getWidth(null), image.getHeight(null), BufferedImage.TYPE_INT_ARGB);
+    final Graphics g = bufferedImage.getGraphics();
     g.drawImage(image, 0, 0, this);
     g.dispose();
   }
@@ -332,8 +332,8 @@ public class PolygonGrabber extends JFrame {
       @Override
       public void paint(final Graphics g) {
         // super.paint(g);
-        g.drawImage(m_bufferedImage, 0, 0, this);
-        final Iterator<Entry<String, List<Polygon>>> iter = m_polygons.entrySet().iterator();
+        g.drawImage(bufferedImage, 0, 0, this);
+        final Iterator<Entry<String, List<Polygon>>> iter = polygons.entrySet().iterator();
         g.setColor(Color.red);
         while (iter.hasNext()) {
           final Collection<Polygon> polygons = iter.next().getValue();
@@ -354,8 +354,8 @@ public class PolygonGrabber extends JFrame {
           }
         } // while
         g.setColor(Color.red);
-        if (m_current != null) {
-          for (final Polygon item : m_current) {
+        if (current != null) {
+          for (final Polygon item : current) {
             g.fillPolygon(item.xpoints, item.ypoints, item.npoints);
           } // while
         } // if
@@ -376,7 +376,7 @@ public class PolygonGrabber extends JFrame {
         return;
       }
       final FileOutputStream out = new FileOutputStream(polyName);
-      PointFileReaderWriter.writeOneToManyPolygons(out, m_polygons);
+      PointFileReaderWriter.writeOneToManyPolygons(out, polygons);
       out.flush();
       out.close();
       System.out.println("Data written to :" + new File(polyName).getCanonicalPath());
@@ -397,7 +397,7 @@ public class PolygonGrabber extends JFrame {
         return;
       }
       final FileInputStream in = new FileInputStream(polyName);
-      m_polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+      polygons = PointFileReaderWriter.readOneToManyPolygons(in);
       repaint();
     } catch (final FileNotFoundException ex) {
       ClientLogger.logQuietly("file name = " + polyName, ex);
@@ -422,19 +422,19 @@ public class PolygonGrabber extends JFrame {
     if (p == null) {
       return;
     }
-    if (rightMouse && m_current != null) { // right click and list of polys is not empty
+    if (rightMouse && current != null) { // right click and list of polys is not empty
       doneCurrentGroup();
     } else if (pointInCurrentPolygon(point)) { // point clicked is already highlighted
       System.out.println("rejecting");
       return;
     } else if (ctrlDown) {
-      if (m_current == null) {
-        m_current = new ArrayList<>();
+      if (current == null) {
+        current = new ArrayList<>();
       }
-      m_current.add(p);
+      current.add(p);
     } else {
-      m_current = new ArrayList<>();
-      m_current.add(p);
+      current = new ArrayList<>();
+      current.add(p);
     }
     repaint();
   }
@@ -449,10 +449,10 @@ public class PolygonGrabber extends JFrame {
    * @return java.lang.boolean
    */
   private boolean pointInCurrentPolygon(final Point p) {
-    if (m_current == null) {
+    if (current == null) {
       return false;
     }
-    for (final Polygon item : m_current) {
+    for (final Polygon item : current) {
       if (item.contains(p)) {
         return true;
       }
@@ -467,23 +467,23 @@ public class PolygonGrabber extends JFrame {
    */
   private void doneCurrentGroup() throws HeadlessException {
     final JTextField text = new JTextField();
-    final Iterator<Entry<String, Point>> centersiter = m_centers.entrySet().iterator();
+    final Iterator<Entry<String, Point>> centersiter = centers.entrySet().iterator();
     guessCountryName(text, centersiter);
     final int option = JOptionPane.showConfirmDialog(this, text);
     // cancel = 2
     // no = 1
     // yes = 0
     if (option == 0) {
-      if (!m_centers.keySet().contains(text.getText())) {
+      if (!centers.keySet().contains(text.getText())) {
         // not a valid name
         JOptionPane.showMessageDialog(this, "not a valid name");
-        m_current = null;
+        current = null;
         return;
       }
-      m_polygons.put(text.getText(), new ArrayList<>(m_current));
-      m_current = null;
+      polygons.put(text.getText(), new ArrayList<>(current));
+      current = null;
     } else if (option > 0) {
-      m_current = null;
+      current = null;
     } else {
       System.out.println("something very invalid");
     }
@@ -503,7 +503,7 @@ public class PolygonGrabber extends JFrame {
     while (centersiter.hasNext()) {
       final Entry<String, Point> item = centersiter.next();
       final Point p = new Point(item.getValue());
-      for (final Polygon polygon : m_current) {
+      for (final Polygon polygon : current) {
         if (polygon.contains(p)) {
           options.add(item.getKey());
         } // if
@@ -547,7 +547,7 @@ public class PolygonGrabber extends JFrame {
     // with ARGB value of 00,FF,FF,FF to determine if it
     // it black or not.
     // maybe here ?
-    return (m_bufferedImage.getRGB(x, y) & 0x00FFFFFF) == 0;
+    return (bufferedImage.getRGB(x, y) & 0x00FFFFFF) == 0;
   }
 
   private static boolean isBlack(final int x, final int y, final BufferedImage bufferedImage) {
@@ -573,7 +573,7 @@ public class PolygonGrabber extends JFrame {
    * @return java.lang.boolean
    */
   private boolean inBounds(final int x, final int y) {
-    return x >= 0 && x < m_bufferedImage.getWidth(null) && y >= 0 && y < m_bufferedImage.getHeight(null);
+    return x >= 0 && x < bufferedImage.getWidth(null) && y >= 0 && y < bufferedImage.getHeight(null);
   }
 
   private static boolean inBounds(final int x, final int y, final Image image) {
@@ -615,7 +615,7 @@ public class PolygonGrabber extends JFrame {
   }
 
   // used below
-  private final Point m_testPoint = new Point();
+  private final Point testPoint = new Point();
 
   /**
    * java.lang.boolean isOnEdge(java.lang.int, java.awt.Point)
@@ -629,10 +629,10 @@ public class PolygonGrabber extends JFrame {
    * @return java.lang.boolean
    */
   private boolean isOnEdge(final int direction, final Point currentPoint) {
-    m_testPoint.setLocation(currentPoint);
-    move(m_testPoint, direction);
-    return m_testPoint.x == 0 || m_testPoint.y == 0 || m_testPoint.y == m_bufferedImage.getHeight(this)
-        || m_testPoint.x == m_bufferedImage.getWidth(this) || isBlack(m_testPoint);
+    testPoint.setLocation(currentPoint);
+    move(testPoint, direction);
+    return testPoint.x == 0 || testPoint.y == 0 || testPoint.y == bufferedImage.getHeight(this)
+        || testPoint.x == bufferedImage.getWidth(this) || isBlack(testPoint);
   }
 
   private boolean doesPolygonContainAnyBlackInside(final Polygon poly, final BufferedImage imageCopy,
@@ -640,8 +640,8 @@ public class PolygonGrabber extends JFrame {
     // we would like to just test if each point is both black and contained within the polygon, but contains counts the
     // borders,
     // so we have to turn the border edges a different color (then later back to black again) using a copy of the image
-    // final BufferedImage testImage = new BufferedImage(m_bufferedImage.getWidth(null),
-    // m_bufferedImage.getHeight(null),
+    // final BufferedImage testImage = new BufferedImage(bufferedImage.getWidth(null),
+    // bufferedImage.getHeight(null),
     // BufferedImage.TYPE_INT_ARGB);
     imageCopyGraphics.setColor(Color.GREEN);
     imageCopyGraphics.drawPolygon(poly.xpoints, poly.ypoints, poly.npoints);

--- a/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/src/main/java/tools/image/ReliefImageBreaker.java
@@ -38,8 +38,8 @@ import tools.map.making.ImageIoCompletionWatcher;
 public class ReliefImageBreaker {
   private static String location = null;
   private static JFrame observer = new JFrame();
-  private boolean m_seaZoneOnly;
-  private MapData m_mapData;
+  private boolean seaZoneOnly;
+  private MapData mapData;
   private static File s_mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
 
@@ -81,7 +81,7 @@ public class ReliefImageBreaker {
       System.exit(0);
     }
     // ask user wether it is sea zone only or not
-    m_seaZoneOnly = doSeaZone();
+    seaZoneOnly = doSeaZone();
 
     // ask user where the map is
     final String mapDir = getMapDirectory();
@@ -91,18 +91,18 @@ public class ReliefImageBreaker {
       System.exit(0);
     }
     try {
-      m_mapData = new MapData(mapDir);
+      mapData = new MapData(mapDir);
       // files for the map.
     } catch (final NullPointerException npe) {
       System.out.println("Bad data given or missing text files, shutting down");
       System.exit(0);
     }
-    for (final String territoryName : m_mapData.getTerritories()) {
+    for (final String territoryName : mapData.getTerritories()) {
       final boolean seaZone = Util.isTerritoryNameIndicatingWater(territoryName);
-      if (!seaZone && m_seaZoneOnly) {
+      if (!seaZone && seaZoneOnly) {
         continue;
       }
-      if (seaZone && !m_seaZoneOnly) {
+      if (seaZone && !seaZoneOnly) {
         continue;
       }
       processImage(territoryName, map);
@@ -178,11 +178,11 @@ public class ReliefImageBreaker {
   }
 
   private void processImage(final String territory, final Image map) throws IOException {
-    final Rectangle bounds = m_mapData.getBoundingRect(territory);
+    final Rectangle bounds = mapData.getBoundingRect(territory);
     final int width = bounds.width;
     final int height = bounds.height;
     final BufferedImage alphaChannelImage = Util.createImage(bounds.width, bounds.height, true);
-    final Iterator<Polygon> iter = m_mapData.getPolygons(territory).iterator();
+    final Iterator<Polygon> iter = mapData.getPolygons(territory).iterator();
     while (iter.hasNext()) {
       Polygon item = iter.next();
       item = new Polygon(item.xpoints, item.ypoints, item.npoints);
@@ -192,12 +192,12 @@ public class ReliefImageBreaker {
     final GraphicsConfiguration m_localGraphicSystem =
         GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
     final BufferedImage relief = m_localGraphicSystem.createCompatibleImage(width, height,
-        m_seaZoneOnly ? Transparency.BITMASK : Transparency.TRANSLUCENT);
+        seaZoneOnly ? Transparency.BITMASK : Transparency.TRANSLUCENT);
     relief.getGraphics().drawImage(map, 0, 0, width, height, bounds.x, bounds.y, bounds.x + width, bounds.y + height,
         observer);
     blankOutline(alphaChannelImage, relief);
     String outFileName = location + File.separator + territory;
-    if (!m_seaZoneOnly) {
+    if (!seaZoneOnly) {
       outFileName += "_relief.png";
     } else {
       outFileName += ".png";

--- a/src/main/java/tools/image/TileImageBreaker.java
+++ b/src/main/java/tools/image/TileImageBreaker.java
@@ -32,7 +32,7 @@ import tools.map.making.JTextAreaOptionPane;
 public class TileImageBreaker {
   private static String location = null;
   private static JFrame observer = new JFrame();
-  private boolean m_baseMap;
+  private boolean baseMap;
   private static File s_mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
   private static final JTextAreaOptionPane textOptionPane = new JTextAreaOptionPane(null,
@@ -97,7 +97,7 @@ public class TileImageBreaker {
         final GraphicsConfiguration m_localGraphicSystem =
             GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
         final BufferedImage relief = m_localGraphicSystem.createCompatibleImage(TileManager.TILE_SIZE,
-            TileManager.TILE_SIZE, m_baseMap ? Transparency.BITMASK : Transparency.TRANSLUCENT);
+            TileManager.TILE_SIZE, baseMap ? Transparency.BITMASK : Transparency.TRANSLUCENT);
         relief.getGraphics().drawImage(map, 0, 0, TileManager.TILE_SIZE, TileManager.TILE_SIZE, bounds.x, bounds.y,
             bounds.x + TileManager.TILE_SIZE, bounds.y + TileManager.TILE_SIZE, observer);
 

--- a/src/main/java/tools/map/making/ImageIoCompletionWatcher.java
+++ b/src/main/java/tools/map/making/ImageIoCompletionWatcher.java
@@ -9,13 +9,13 @@ import java.util.concurrent.CountDownLatch;
  */
 public class ImageIoCompletionWatcher implements ImageObserver {
   // we countdown when we are done
-  private final CountDownLatch m_countDownLatch = new CountDownLatch(1);
+  private final CountDownLatch countDownLatch = new CountDownLatch(1);
 
   public ImageIoCompletionWatcher() {}
 
   public void waitForCompletion() {
     try {
-      m_countDownLatch.await();
+      countDownLatch.await();
     } catch (final InterruptedException e) {
       // Ignore interrupted exception
     }
@@ -26,7 +26,7 @@ public class ImageIoCompletionWatcher implements ImageObserver {
       final int height) {
     // wait for complete or error/abort
     if (((flags & ALLBITS) != 0) || ((flags & ABORT) != 0)) {
-      m_countDownLatch.countDown();
+      countDownLatch.countDown();
       return false;
     }
     return true;

--- a/src/main/java/tools/map/making/JTextAreaOptionPane.java
+++ b/src/main/java/tools/map/making/JTextAreaOptionPane.java
@@ -20,52 +20,52 @@ import javax.swing.WindowConstants;
  * A text area that can show updates scrolling by.
  */
 public class JTextAreaOptionPane {
-  private final JTextArea m_editor = new JTextArea();
-  private final JFrame m_windowFrame = new JFrame();
-  private final JButton m_okButton = new JButton();
-  private final boolean m_logToSystemOut;
-  private final WeakReference<Window> m_parentComponentReference;
-  private int m_counter;
-  private final CountDownLatch m_countDownLatch;
+  private final JTextArea editor = new JTextArea();
+  private final JFrame windowFrame = new JFrame();
+  private final JButton okButton = new JButton();
+  private final boolean logToSystemOut;
+  private final WeakReference<Window> parentComponentReference;
+  private int counter;
+  private final CountDownLatch countDownLatch;
 
   public JTextAreaOptionPane(final JFrame parentComponent, final String initialEditorText, final String labelText,
       final String title, final Image icon, final int editorSizeX, final int editorSizeY, final boolean logToSystemOut,
       final int latchCount, final CountDownLatch countDownLatch) {
-    m_logToSystemOut = logToSystemOut;
-    m_countDownLatch = countDownLatch;
-    m_counter = latchCount;
-    m_parentComponentReference = new WeakReference<>(parentComponent);
-    m_windowFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+    this.logToSystemOut = logToSystemOut;
+    this.countDownLatch = countDownLatch;
+    counter = latchCount;
+    parentComponentReference = new WeakReference<>(parentComponent);
+    windowFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
     if (icon != null) {
-      m_windowFrame.setIconImage(icon);
+      windowFrame.setIconImage(icon);
     } else if (parentComponent != null && parentComponent.getIconImage() != null) {
-      m_windowFrame.setIconImage(parentComponent.getIconImage());
+      windowFrame.setIconImage(parentComponent.getIconImage());
     }
     final BorderLayout layout = new BorderLayout();
     layout.setHgap(30);
     layout.setVgap(30);
-    m_windowFrame.setLayout(layout);
-    m_windowFrame.setTitle(title);
+    windowFrame.setLayout(layout);
+    windowFrame.setTitle(title);
     final JLabel m_label = new JLabel();
     m_label.setText(labelText);
-    m_okButton.setText("OK");
-    m_okButton.setEnabled(false);
-    m_editor.setEditable(false);
-    // m_editor.setContentType("text/html");
-    m_editor.setText(initialEditorText);
-    if (m_logToSystemOut) {
+    okButton.setText("OK");
+    okButton.setEnabled(false);
+    editor.setEditable(false);
+    // editor.setContentType("text/html");
+    editor.setText(initialEditorText);
+    if (this.logToSystemOut) {
       System.out.println(initialEditorText);
     }
-    m_editor.setCaretPosition(0);
-    m_windowFrame.setPreferredSize(new Dimension(editorSizeX, editorSizeY));
-    m_windowFrame.getContentPane().add(m_label, BorderLayout.NORTH);
-    m_windowFrame.getContentPane().add(new JScrollPane(m_editor), BorderLayout.CENTER);
-    m_windowFrame.getContentPane().add(m_okButton, BorderLayout.SOUTH);
-    m_okButton.addActionListener(new ActionListener() {
+    editor.setCaretPosition(0);
+    windowFrame.setPreferredSize(new Dimension(editorSizeX, editorSizeY));
+    windowFrame.getContentPane().add(m_label, BorderLayout.NORTH);
+    windowFrame.getContentPane().add(new JScrollPane(editor), BorderLayout.CENTER);
+    windowFrame.getContentPane().add(okButton, BorderLayout.SOUTH);
+    okButton.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent e) {
-        if (m_countDownLatch != null) {
-          m_countDownLatch.countDown();
+        if (JTextAreaOptionPane.this.countDownLatch != null) {
+          JTextAreaOptionPane.this.countDownLatch.countDown();
         }
         dispose();
       }
@@ -73,33 +73,33 @@ public class JTextAreaOptionPane {
   }
 
   private void setWidgetActivation() {
-    if (m_counter <= 0) {
-      m_okButton.setEnabled(true);
+    if (counter <= 0) {
+      okButton.setEnabled(true);
     }
   }
 
   public void show() {
-    m_windowFrame.pack();
-    m_windowFrame.setLocationRelativeTo(m_parentComponentReference.get());
-    m_windowFrame.setVisible(true);
+    windowFrame.pack();
+    windowFrame.setLocationRelativeTo(parentComponentReference.get());
+    windowFrame.setVisible(true);
   }
 
   public void dispose() {
-    m_windowFrame.setVisible(false);
-    m_windowFrame.dispose();
+    windowFrame.setVisible(false);
+    windowFrame.dispose();
   }
 
   public void countDown() {
-    m_counter--;
+    counter--;
     setWidgetActivation();
   }
 
   public void append(final String text) {
-    if (m_logToSystemOut) {
+    if (logToSystemOut) {
       System.out.print(text);
     }
-    m_editor.append(text);
-    m_editor.setCaretPosition(m_editor.getText().length());
+    editor.append(text);
+    editor.setCaretPosition(editor.getText().length());
   }
 
   public void appendNewLine(final String text) {

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -58,16 +58,16 @@ public class MapCreator extends JFrame {
   private static int s_unit_width = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static int s_unit_height = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static boolean s_runUtilitiesAsSeperateProcesses = true;
-  final JPanel m_mainPanel;
-  final JPanel m_sidePanel;
-  final JButton m_part1;
-  final JButton m_part2;
-  final JButton m_part3;
-  final JButton m_part4;
-  final JPanel m_panel1 = new JPanel();
-  final JPanel m_panel2 = new JPanel();
-  final JPanel m_panel3 = new JPanel();
-  final JPanel m_panel4 = new JPanel();
+  final JPanel mainPanel;
+  final JPanel sidePanel;
+  final JButton part1;
+  final JButton part2;
+  final JButton part3;
+  final JButton part4;
+  final JPanel panel1 = new JPanel();
+  final JPanel panel2 = new JPanel();
+  final JPanel panel3 = new JPanel();
+  final JPanel panel4 = new JPanel();
 
   public static String[] getProperties() {
     return new String[] {TRIPLEA_MAP_FOLDER, TRIPLEA_UNIT_ZOOM, TRIPLEA_UNIT_WIDTH, TRIPLEA_UNIT_HEIGHT};
@@ -85,34 +85,34 @@ public class MapCreator extends JFrame {
     super("TripleA Map Creator");
     setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
     // components
-    m_mainPanel = new JPanel();
-    m_sidePanel = new JPanel();
-    m_part1 = new JButton("Step 1: Map Properties");
-    m_part2 = new JButton("Step 2: Map Utilities");
-    m_part3 = new JButton("Step 3: Game XML");
-    m_part4 = new JButton("Other: Optional Things");
-    m_sidePanel.setLayout(new BoxLayout(m_sidePanel, BoxLayout.PAGE_AXIS));
-    m_sidePanel.add(Box.createVerticalGlue());
-    m_sidePanel.add(m_part1);
-    m_part1.setAlignmentX(Component.CENTER_ALIGNMENT);
-    m_sidePanel.add(Box.createVerticalGlue());
-    m_sidePanel.add(m_part2);
-    m_part2.setAlignmentX(Component.CENTER_ALIGNMENT);
-    m_sidePanel.add(Box.createVerticalGlue());
-    m_sidePanel.add(m_part3);
-    m_part3.setAlignmentX(Component.CENTER_ALIGNMENT);
-    m_sidePanel.add(Box.createVerticalGlue());
-    m_sidePanel.add(m_part4);
-    m_part4.setAlignmentX(Component.CENTER_ALIGNMENT);
-    m_sidePanel.add(Box.createVerticalGlue());
+    mainPanel = new JPanel();
+    sidePanel = new JPanel();
+    part1 = new JButton("Step 1: Map Properties");
+    part2 = new JButton("Step 2: Map Utilities");
+    part3 = new JButton("Step 3: Game XML");
+    part4 = new JButton("Other: Optional Things");
+    sidePanel.setLayout(new BoxLayout(sidePanel, BoxLayout.PAGE_AXIS));
+    sidePanel.add(Box.createVerticalGlue());
+    sidePanel.add(part1);
+    part1.setAlignmentX(Component.CENTER_ALIGNMENT);
+    sidePanel.add(Box.createVerticalGlue());
+    sidePanel.add(part2);
+    part2.setAlignmentX(Component.CENTER_ALIGNMENT);
+    sidePanel.add(Box.createVerticalGlue());
+    sidePanel.add(part3);
+    part3.setAlignmentX(Component.CENTER_ALIGNMENT);
+    sidePanel.add(Box.createVerticalGlue());
+    sidePanel.add(part4);
+    part4.setAlignmentX(Component.CENTER_ALIGNMENT);
+    sidePanel.add(Box.createVerticalGlue());
     createPart1Panel();
     createPart2Panel();
     createPart3Panel();
     createPart4Panel();
-    m_part1.addActionListener(SwingAction.of("Part 1", e -> setupMainPanel(m_panel1)));
-    m_part2.addActionListener(SwingAction.of("Part 2", e -> setupMainPanel(m_panel2)));
-    m_part3.addActionListener(SwingAction.of("Part 3", e -> setupMainPanel(m_panel3)));
-    m_part4.addActionListener(SwingAction.of("Part 4", e -> setupMainPanel(m_panel4)));
+    part1.addActionListener(SwingAction.of("Part 1", e -> setupMainPanel(panel1)));
+    part2.addActionListener(SwingAction.of("Part 2", e -> setupMainPanel(panel2)));
+    part3.addActionListener(SwingAction.of("Part 3", e -> setupMainPanel(panel3)));
+    part4.addActionListener(SwingAction.of("Part 4", e -> setupMainPanel(panel4)));
     // set up the menu actions
     final Action exitAction = SwingAction.of("Exit", e -> System.exit(0));
     exitAction.putValue(Action.SHORT_DESCRIPTION, "Exit The Program");
@@ -128,15 +128,15 @@ public class MapCreator extends JFrame {
     menuBar.add(fileMenu);
     // set up the layout manager
     this.getContentPane().setLayout(new BorderLayout());
-    this.getContentPane().add(new JScrollPane(m_sidePanel), BorderLayout.WEST);
-    this.getContentPane().add(new JScrollPane(m_mainPanel), BorderLayout.CENTER);
+    this.getContentPane().add(new JScrollPane(sidePanel), BorderLayout.WEST);
+    this.getContentPane().add(new JScrollPane(mainPanel), BorderLayout.CENTER);
     // now set up the main screen
-    setupMainPanel(m_panel1);
+    setupMainPanel(panel1);
   }
 
   private void setupMainPanel(final JPanel panel) {
-    m_mainPanel.removeAll();
-    m_mainPanel.add(panel);
+    mainPanel.removeAll();
+    mainPanel.add(panel);
     setWidgetActivation();
   }
 
@@ -150,16 +150,16 @@ public class MapCreator extends JFrame {
       });
       return;
     }
-    m_mainPanel.validate();
-    m_mainPanel.repaint();
+    mainPanel.validate();
+    mainPanel.repaint();
     this.validate();
     this.repaint();
   }
 
   private void createPart1Panel() {
-    m_panel1.removeAll();
-    m_panel1.setLayout(new BoxLayout(m_panel1, BoxLayout.PAGE_AXIS));
-    m_panel1.add(Box.createVerticalStrut(30));
+    panel1.removeAll();
+    panel1.setLayout(new BoxLayout(panel1, BoxLayout.PAGE_AXIS));
+    panel1.add(Box.createVerticalStrut(30));
     final JTextArea text = new JTextArea(12, 10);
     text.setWrapStyleWord(true);
     text.setLineWrap(true);
@@ -178,9 +178,9 @@ public class MapCreator extends JFrame {
         + "\r\nPut these in the map's root folder. You can now start the map maker by clicking and filling "
         + "in the details below, before moving on to 'Step 2' and running the map utilities.");
     final JScrollPane scrollText = new JScrollPane(text);
-    m_panel1.add(scrollText);
-    m_panel1.add(Box.createVerticalStrut(30));
-    m_panel1.add(new JLabel("Click button open up the readme file on how to make maps:"));
+    panel1.add(scrollText);
+    panel1.add(Box.createVerticalStrut(30));
+    panel1.add(new JLabel("Click button open up the readme file on how to make maps:"));
     final JButton helpButton = new JButton("Start Tutorial  /  Show Help Document");
     helpButton.addActionListener(new ActionListener() {
       @Override
@@ -194,9 +194,9 @@ public class MapCreator extends JFrame {
         }
       }
     });
-    m_panel1.add(helpButton);
-    m_panel1.add(Box.createVerticalStrut(30));
-    m_panel1.add(new JLabel("Click button to select where your map folder is:"));
+    panel1.add(helpButton);
+    panel1.add(Box.createVerticalStrut(30));
+    panel1.add(new JLabel("Click button to select where your map folder is:"));
     final JButton mapFolderButton = new JButton("Select Map Folder");
     mapFolderButton.addActionListener(SwingAction.of("Select Map Folder", e -> {
       final String path = new FileSave("Where is your map's folder?", null, s_mapFolderLocation).getPathString();
@@ -208,10 +208,10 @@ public class MapCreator extends JFrame {
         }
       }
     }));
-    m_panel1.add(mapFolderButton);
-    m_panel1.add(Box.createVerticalStrut(30));
-    m_panel1.add(new JLabel("Set the unit scaling (unit image zoom): "));
-    m_panel1.add(new JLabel("Choose one of: 1.25, 1, 0.875, 0.8333, 0.75, 0.6666, 0.5625, 0.5"));
+    panel1.add(mapFolderButton);
+    panel1.add(Box.createVerticalStrut(30));
+    panel1.add(new JLabel("Set the unit scaling (unit image zoom): "));
+    panel1.add(new JLabel("Choose one of: 1.25, 1, 0.875, 0.8333, 0.75, 0.6666, 0.5625, 0.5"));
     final JTextField unitZoomText = new JTextField("" + s_unit_zoom);
     unitZoomText.setMaximumSize(new Dimension(100, 20));
     unitZoomText.addFocusListener(new FocusListener() {
@@ -229,9 +229,9 @@ public class MapCreator extends JFrame {
         unitZoomText.setText("" + s_unit_zoom);
       }
     });
-    m_panel1.add(unitZoomText);
-    m_panel1.add(Box.createVerticalStrut(30));
-    m_panel1.add(new JLabel("Set the width of the unit images: "));
+    panel1.add(unitZoomText);
+    panel1.add(Box.createVerticalStrut(30));
+    panel1.add(new JLabel("Set the width of the unit images: "));
     final JTextField unitWidthText = new JTextField("" + s_unit_width);
     unitWidthText.setMaximumSize(new Dimension(100, 20));
     unitWidthText.addFocusListener(new FocusListener() {
@@ -249,9 +249,9 @@ public class MapCreator extends JFrame {
         unitWidthText.setText("" + s_unit_width);
       }
     });
-    m_panel1.add(unitWidthText);
-    m_panel1.add(Box.createVerticalStrut(30));
-    m_panel1.add(new JLabel("Set the height of the unit images: "));
+    panel1.add(unitWidthText);
+    panel1.add(Box.createVerticalStrut(30));
+    panel1.add(new JLabel("Set the height of the unit images: "));
     final JTextField unitHeightText = new JTextField("" + s_unit_height);
     unitHeightText.setMaximumSize(new Dimension(100, 20));
     unitHeightText.addFocusListener(new FocusListener() {
@@ -269,12 +269,12 @@ public class MapCreator extends JFrame {
         unitHeightText.setText("" + s_unit_height);
       }
     });
-    m_panel1.add(unitHeightText);
-    m_panel1.add(Box.createVerticalStrut(30));
-    m_panel1
+    panel1.add(unitHeightText);
+    panel1.add(Box.createVerticalStrut(30));
+    panel1
         .add(new JLabel("<html>Here you can set the 'max memory' that utilities like the Polygon Grabber will use.<br>"
             + "This is useful is you have a very large map, or ever get any Java Heap Space errors.</html>"));
-    m_panel1.add(new JLabel("Set the amount of memory to use when running new processes (in megabytes [mb]):"));
+    panel1.add(new JLabel("Set the amount of memory to use when running new processes (in megabytes [mb]):"));
     final JTextField memoryText = new JTextField("" + (s_memory / (1024 * 1024)));
     memoryText.setMaximumSize(new Dimension(100, 20));
     memoryText.addFocusListener(new FocusListener() {
@@ -291,22 +291,22 @@ public class MapCreator extends JFrame {
         memoryText.setText("" + (s_memory / (1024 * 1024)));
       }
     });
-    m_panel1.add(memoryText);
+    panel1.add(memoryText);
     final JCheckBox runTypeBox = new JCheckBox("Run All Utilities as Separate Processes");
     runTypeBox.setSelected(s_runUtilitiesAsSeperateProcesses);
     runTypeBox.addActionListener(SwingAction.of("Run All Utilities as Separate Processes",
         e -> s_runUtilitiesAsSeperateProcesses = runTypeBox.isSelected()));
-    m_panel1.add(runTypeBox);
-    m_panel1.add(Box.createVerticalStrut(30));
-    m_panel1.validate();
+    panel1.add(runTypeBox);
+    panel1.add(Box.createVerticalStrut(30));
+    panel1.validate();
   }
 
   private void createPart2Panel() {
-    m_panel2.removeAll();
-    m_panel2.setLayout(new BoxLayout(m_panel2, BoxLayout.PAGE_AXIS));
-    m_panel2.add(Box.createVerticalStrut(30));
-    m_panel2.add(new JLabel("Map Skin Utilities:"));
-    m_panel2.add(Box.createVerticalStrut(30));
+    panel2.removeAll();
+    panel2.setLayout(new BoxLayout(panel2, BoxLayout.PAGE_AXIS));
+    panel2.add(Box.createVerticalStrut(30));
+    panel2.add(new JLabel("Map Skin Utilities:"));
+    panel2.add(Box.createVerticalStrut(30));
     final JButton mapPropertiesMakerButton = new JButton("Run the Map Properties Maker");
     mapPropertiesMakerButton.addActionListener(SwingAction.of("Run the Map Properties Maker", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -320,8 +320,8 @@ public class MapCreator extends JFrame {
         }).start();
       }
     }));
-    m_panel2.add(mapPropertiesMakerButton);
-    m_panel2.add(Box.createVerticalStrut(30));
+    panel2.add(mapPropertiesMakerButton);
+    panel2.add(Box.createVerticalStrut(30));
     final JButton centerPickerButton = new JButton("Run the Center Picker");
     centerPickerButton.addActionListener(SwingAction.of("Run the Center Picker", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -335,8 +335,8 @@ public class MapCreator extends JFrame {
         }).start();
       }
     }));
-    m_panel2.add(centerPickerButton);
-    m_panel2.add(Box.createVerticalStrut(30));
+    panel2.add(centerPickerButton);
+    panel2.add(Box.createVerticalStrut(30));
     final JButton polygonGrabberButton = new JButton("Run the Polygon Grabber");
     polygonGrabberButton.addActionListener(SwingAction.of("Run the Polygon Grabber", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -351,8 +351,8 @@ public class MapCreator extends JFrame {
       }
 
     }));
-    m_panel2.add(polygonGrabberButton);
-    m_panel2.add(Box.createVerticalStrut(30));
+    panel2.add(polygonGrabberButton);
+    panel2.add(Box.createVerticalStrut(30));
     final JButton autoPlacerButton = new JButton("Run the Automatic Placement Finder");
     autoPlacerButton.addActionListener(SwingAction.of("Run the Automatic Placement Finder", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -367,8 +367,8 @@ public class MapCreator extends JFrame {
       }
 
     }));
-    m_panel2.add(autoPlacerButton);
-    m_panel2.add(Box.createVerticalStrut(30));
+    panel2.add(autoPlacerButton);
+    panel2.add(Box.createVerticalStrut(30));
     final JButton placementPickerButton = new JButton("Run the Placement Picker");
     placementPickerButton.addActionListener(SwingAction.of("Run the Placement Picker", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -382,8 +382,8 @@ public class MapCreator extends JFrame {
         }).start();
       }
     }));
-    m_panel2.add(placementPickerButton);
-    m_panel2.add(Box.createVerticalStrut(30));
+    panel2.add(placementPickerButton);
+    panel2.add(Box.createVerticalStrut(30));
     final JButton tileBreakerButton = new JButton("Run the Tile Image Breaker");
     tileBreakerButton.addActionListener(SwingAction.of("Run the Tile Image Breaker", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -401,8 +401,8 @@ public class MapCreator extends JFrame {
         }).start();
       }
     }));
-    m_panel2.add(tileBreakerButton);
-    m_panel2.add(Box.createVerticalStrut(30));
+    panel2.add(tileBreakerButton);
+    panel2.add(Box.createVerticalStrut(30));
     final JButton decorationPlacerButton = new JButton("Run the Decoration Placer");
     decorationPlacerButton.addActionListener(SwingAction.of("Run the Decoration Placer", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -420,18 +420,18 @@ public class MapCreator extends JFrame {
         }).start();
       }
     }));
-    m_panel2.add(decorationPlacerButton);
-    m_panel2.add(Box.createVerticalStrut(30));
-    m_panel2.validate();
+    panel2.add(decorationPlacerButton);
+    panel2.add(Box.createVerticalStrut(30));
+    panel2.validate();
   }
 
   private void createPart3Panel() {
-    m_panel3.removeAll();
-    m_panel3.setLayout(new BoxLayout(m_panel3, BoxLayout.PAGE_AXIS));
-    m_panel3.add(Box.createVerticalStrut(30));
-    m_panel3.add(new JLabel("Game XML Utilities:"));
-    m_panel3.add(new JLabel("Sorry but for now the only XML creator is Wisconsin's 'Part 2' of his map maker."));
-    m_panel3.add(Box.createVerticalStrut(30));
+    panel3.removeAll();
+    panel3.setLayout(new BoxLayout(panel3, BoxLayout.PAGE_AXIS));
+    panel3.add(Box.createVerticalStrut(30));
+    panel3.add(new JLabel("Game XML Utilities:"));
+    panel3.add(new JLabel("Sorry but for now the only XML creator is Wisconsin's 'Part 2' of his map maker."));
+    panel3.add(Box.createVerticalStrut(30));
     final JButton connectionFinderButton = new JButton("Run the Connection Finder");
     connectionFinderButton.addActionListener(SwingAction.of("Run the Connection Finder", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -449,17 +449,17 @@ public class MapCreator extends JFrame {
         }).start();
       }
     }));
-    m_panel3.add(connectionFinderButton);
-    m_panel3.add(Box.createVerticalStrut(30));
-    m_panel3.validate();
+    panel3.add(connectionFinderButton);
+    panel3.add(Box.createVerticalStrut(30));
+    panel3.validate();
   }
 
   private void createPart4Panel() {
-    m_panel4.removeAll();
-    m_panel4.setLayout(new BoxLayout(m_panel4, BoxLayout.PAGE_AXIS));
-    m_panel4.add(Box.createVerticalStrut(30));
-    m_panel4.add(new JLabel("Other or Optional Utilities:"));
-    m_panel4.add(Box.createVerticalStrut(30));
+    panel4.removeAll();
+    panel4.setLayout(new BoxLayout(panel4, BoxLayout.PAGE_AXIS));
+    panel4.add(Box.createVerticalStrut(30));
+    panel4.add(new JLabel("Other or Optional Utilities:"));
+    panel4.add(Box.createVerticalStrut(30));
     final JButton reliefBreakerButton = new JButton("Run the Relief Image Breaker");
     reliefBreakerButton.addActionListener(SwingAction.of("Run the Relief Image Breaker", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -477,8 +477,8 @@ public class MapCreator extends JFrame {
         }).start();
       }
     }));
-    m_panel4.add(reliefBreakerButton);
-    m_panel4.add(Box.createVerticalStrut(30));
+    panel4.add(reliefBreakerButton);
+    panel4.add(Box.createVerticalStrut(30));
     final JButton imageShrinkerButton = new JButton("Run the Image Shrinker");
     imageShrinkerButton.addActionListener(SwingAction.of("Run the Image Shrinker", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -496,8 +496,8 @@ public class MapCreator extends JFrame {
         }).start();
       }
     }));
-    m_panel4.add(imageShrinkerButton);
-    m_panel4.add(Box.createVerticalStrut(30));
+    panel4.add(imageShrinkerButton);
+    panel4.add(Box.createVerticalStrut(30));
     final JButton tileImageReconstructorButton = new JButton("Run the Tile Image Reconstructor");
     tileImageReconstructorButton.addActionListener(SwingAction.of("Run the Tile Image Reconstructor", e -> {
       if (s_runUtilitiesAsSeperateProcesses) {
@@ -516,9 +516,9 @@ public class MapCreator extends JFrame {
       }
 
     }));
-    m_panel4.add(tileImageReconstructorButton);
-    m_panel4.add(Box.createVerticalStrut(30));
-    m_panel4.validate();
+    panel4.add(tileImageReconstructorButton);
+    panel4.add(Box.createVerticalStrut(30));
+    panel4.validate();
   }
 
   private static void runUtility(final Class<?> javaClass) {

--- a/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -44,36 +44,36 @@ import games.strategy.util.Tuple;
 @SuppressWarnings("unchecked")
 public class MapPropertyWrapper<T> extends AEditableProperty {
   private static final long serialVersionUID = 6406798101396215624L;
-  private IEditableProperty m_property;
+  private IEditableProperty property;
   // private final Class m_clazz;
   // private final T m_defaultValue;
-  private final Method m_setter;
-  private final Method m_getter;
+  private final Method setter;
+  private final Method getter;
 
   public MapPropertyWrapper(final String name, final String description, final T defaultValue, final Method setter,
       final Method getter) {
     super(name, description);
     // m_clazz = clazz;
-    m_setter = setter;
-    m_getter = getter;
+    this.setter = setter;
+    this.getter = getter;
     // m_defaultValue = defaultValue;
     if (defaultValue instanceof Boolean) {
-      m_property = new BooleanProperty(name, description, ((Boolean) defaultValue));
+      property = new BooleanProperty(name, description, ((Boolean) defaultValue));
     } else if (defaultValue instanceof Color) {
-      m_property = new ColorProperty(name, description, ((Color) defaultValue));
+      property = new ColorProperty(name, description, ((Color) defaultValue));
     } else if (defaultValue instanceof File) {
-      m_property = new FileProperty(name, description, ((File) defaultValue));
+      property = new FileProperty(name, description, ((File) defaultValue));
     } else if (defaultValue instanceof String) {
-      m_property = new StringProperty(name, description, ((String) defaultValue));
+      property = new StringProperty(name, description, ((String) defaultValue));
     } else if (defaultValue instanceof Collection || defaultValue instanceof List || defaultValue instanceof Set) {
-      m_property = new CollectionProperty<>(name, description, ((Collection<?>) defaultValue));
+      property = new CollectionProperty<>(name, description, ((Collection<?>) defaultValue));
     } else if (defaultValue instanceof Map || defaultValue instanceof HashMap) {
-      m_property = new MapProperty<>(name, description, ((Map<?, ?>) defaultValue));
+      property = new MapProperty<>(name, description, ((Map<?, ?>) defaultValue));
     } else if (defaultValue instanceof Integer) {
-      m_property =
+      property =
           new NumberProperty(name, description, Integer.MAX_VALUE, Integer.MIN_VALUE, ((Integer) defaultValue));
     } else if (defaultValue instanceof Double) {
-      m_property =
+      property =
           new DoubleProperty(name, description, Double.MAX_VALUE, Double.MIN_VALUE, ((Double) defaultValue), 5);
     } else {
       throw new IllegalArgumentException(
@@ -85,11 +85,11 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
       final Collection<T> possibleValues, final Method setter, final Method getter) {
     super(name, description);
     // m_clazz = clazz;
-    m_setter = setter;
-    m_getter = getter;
+    this.setter = setter;
+    this.getter = getter;
     // m_defaultValue = defaultValue;
     if (defaultValue instanceof Collection) {
-      m_property = new ComboProperty<>(name, description, defaultValue, possibleValues);
+      property = new ComboProperty<>(name, description, defaultValue, possibleValues);
     } else {
       throw new IllegalArgumentException(
           "Cannot instantiate PropertyWrapper with: " + defaultValue.getClass().getCanonicalName());
@@ -100,63 +100,63 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
       final int defaultValue, final Method setter, final Method getter) {
     super(name, description);
     // m_clazz = clazz;
-    m_setter = setter;
-    m_getter = getter;
+    this.setter = setter;
+    this.getter = getter;
     // m_defaultValue = defaultValue;
-    m_property = new NumberProperty(name, description, max, min, defaultValue);
+    property = new NumberProperty(name, description, max, min, defaultValue);
   }
 
   public MapPropertyWrapper(final String name, final String description, final double max, final double min,
       final double defaultValue, final int places, final Method setter, final Method getter) {
     super(name, description);
     // m_clazz = clazz;
-    m_setter = setter;
-    m_getter = getter;
+    this.setter = setter;
+    this.getter = getter;
     // m_defaultValue = defaultValue;
-    m_property = new DoubleProperty(name, description, max, min, defaultValue, places);
+    property = new DoubleProperty(name, description, max, min, defaultValue, places);
   }
 
   public MapPropertyWrapper(final String name, final String description, final File defaultValue,
       final String[] acceptableSuffixes, final Method setter, final Method getter) {
     super(name, description);
     // m_clazz = clazz;
-    m_setter = setter;
-    m_getter = getter;
+    this.setter = setter;
+    this.getter = getter;
     // m_defaultValue = defaultValue;
-    m_property = new FileProperty(name, description, defaultValue, acceptableSuffixes);
+    property = new FileProperty(name, description, defaultValue, acceptableSuffixes);
   }
 
   @Override
   public int getRowsNeeded() {
-    return m_property.getRowsNeeded();
+    return property.getRowsNeeded();
   }
 
   @Override
   public Object getValue() {
-    return m_property.getValue();
+    return property.getValue();
   }
 
   public T getValueT() {
-    return (T) m_property.getValue();
+    return (T) property.getValue();
   }
 
   @Override
   public void setValue(final Object value) throws ClassCastException {
-    m_property.setValue(value);
+    property.setValue(value);
   }
 
   public void setValueT(final T value) {
-    m_property.setValue(value);
+    property.setValue(value);
   }
 
   @Override
   public JComponent getEditorComponent() {
-    return m_property.getEditorComponent();
+    return property.getEditorComponent();
   }
 
   public T getFromObject(final Object object) {
     try {
-      return (T) m_getter.invoke(object);
+      return (T) getter.invoke(object);
     } catch (final IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
       ClientLogger.logQuietly(e);
     }
@@ -167,8 +167,8 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
     final Object value = getValue();
     final Object[] args = {value};
     try {
-      System.out.println(m_setter + "   to   " + value);
-      m_setter.invoke(object, args);
+      System.out.println(setter + "   to   " + value);
+      setter.invoke(object, args);
     } catch (final IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
       ClientLogger.logQuietly(e);
     }
@@ -237,7 +237,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
 
   @Override
   public boolean validate(final Object value) {
-    return m_property.validate(value);
+    return property.validate(value);
   }
 
   public static void main(final String[] args) {

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -62,13 +62,13 @@ public class PlacementPicker extends JFrame {
   private static boolean s_showOverflowMode = false;
   private static boolean s_showIncompleteMode = false;
   private static int s_incompleteNum = 1;
-  private Point m_currentSquare;
-  private Image m_image;
-  private final JLabel m_location = new JLabel();
-  private Map<String, List<Polygon>> m_polygons = new HashMap<>();
-  private Map<String, List<Point>> m_placements;
-  private List<Point> m_currentPlacements;
-  private String m_currentCountry;
+  private Point currentSquare;
+  private Image image;
+  private final JLabel locationLabel = new JLabel();
+  private Map<String, List<Polygon>> polygons = new HashMap<>();
+  private Map<String, List<Point>> placements;
+  private List<Point> currentPlacements;
+  private String currentCountry;
   private static int PLACEWIDTH = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static int PLACEHEIGHT = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static boolean placeDimensionsSet = false;
@@ -268,7 +268,7 @@ public class PlacementPicker extends JFrame {
         "File Suggestion", 1) == 0) {
       try {
         System.out.println("Polygons : " + file.getPath());
-        m_polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(file.getPath()));
+        polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(file.getPath()));
       } catch (final IOException ex1) {
         ex1.printStackTrace();
       }
@@ -278,7 +278,7 @@ public class PlacementPicker extends JFrame {
         final String polyPath = new FileOpen("Select A Polygon File", s_mapFolderLocation, ".txt").getPathString();
         if (polyPath != null) {
           System.out.println("Polygons : " + polyPath);
-          m_polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
+          polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
         } else {
           System.out.println("Polygons file not given. Will run regardless");
         }
@@ -296,8 +296,8 @@ public class PlacementPicker extends JFrame {
     imagePanel.addMouseMotionListener(new MouseMotionAdapter() {
       @Override
       public void mouseMoved(final MouseEvent e) {
-        m_location.setText("x:" + e.getX() + " y:" + e.getY());
-        m_currentSquare = new Point(e.getPoint());
+        locationLabel.setText("x:" + e.getX() + " y:" + e.getY());
+        currentSquare = new Point(e.getPoint());
         repaint();
       }
     });
@@ -313,13 +313,13 @@ public class PlacementPicker extends JFrame {
       }
     });
     // set up the image panel size dimensions ...etc
-    imagePanel.setMinimumSize(new Dimension(m_image.getWidth(this), m_image.getHeight(this)));
-    imagePanel.setPreferredSize(new Dimension(m_image.getWidth(this), m_image.getHeight(this)));
-    imagePanel.setMaximumSize(new Dimension(m_image.getWidth(this), m_image.getHeight(this)));
+    imagePanel.setMinimumSize(new Dimension(image.getWidth(this), image.getHeight(this)));
+    imagePanel.setPreferredSize(new Dimension(image.getWidth(this), image.getHeight(this)));
+    imagePanel.setMaximumSize(new Dimension(image.getWidth(this), image.getHeight(this)));
     // set up the layout manager
     this.getContentPane().setLayout(new BorderLayout());
     this.getContentPane().add(new JScrollPane(imagePanel), BorderLayout.CENTER);
-    this.getContentPane().add(m_location, BorderLayout.SOUTH);
+    this.getContentPane().add(locationLabel, BorderLayout.SOUTH);
     // set up the actions
     final Action openAction = SwingAction.of("Load Placements", e -> loadPlacements());
     openAction.putValue(Action.SHORT_DESCRIPTION, "Load An Existing Placement File");
@@ -397,8 +397,8 @@ public class PlacementPicker extends JFrame {
    *        .lang.String mapName the path of image map
    */
   private void createImage(final String mapName) {
-    m_image = Toolkit.getDefaultToolkit().createImage(mapName);
-    Util.ensureImageLoaded(m_image);
+    image = Toolkit.getDefaultToolkit().createImage(mapName);
+    Util.ensureImageLoaded(image);
   }
 
   /**
@@ -415,12 +415,12 @@ public class PlacementPicker extends JFrame {
       @Override
       public void paint(final Graphics g) {
         // super.paint(g);
-        g.drawImage(m_image, 0, 0, this);
+        g.drawImage(image, 0, 0, this);
         if (s_showAllMode) {
           g.setColor(Color.yellow);
-          for (final Entry<String, List<Point>> entry : m_placements.entrySet()) {
-            if (entry.getKey().equals(m_currentCountry) && m_currentPlacements != null
-                && !m_currentPlacements.isEmpty()) {
+          for (final Entry<String, List<Point>> entry : placements.entrySet()) {
+            if (entry.getKey().equals(currentCountry) && currentPlacements != null
+                && !currentPlacements.isEmpty()) {
               continue;
             }
             final Iterator<Point> pointIter = entry.getValue().iterator();
@@ -437,17 +437,17 @@ public class PlacementPicker extends JFrame {
         }
         if (s_showIncompleteMode) {
           g.setColor(Color.green);
-          final Set<String> territories = new HashSet<>(m_polygons.keySet());
+          final Set<String> territories = new HashSet<>(polygons.keySet());
           final Iterator<String> terrIter = territories.iterator();
           while (terrIter.hasNext()) {
             final String terr = terrIter.next();
-            final List<Point> points = m_placements.get(terr);
+            final List<Point> points = placements.get(terr);
             if (points != null && points.size() >= s_incompleteNum) {
               terrIter.remove();
             }
           }
           for (final String terr : territories) {
-            final List<Polygon> polys = m_polygons.get(terr);
+            final List<Polygon> polys = polygons.get(terr);
             if (polys == null || polys.isEmpty()) {
               continue;
             }
@@ -457,13 +457,13 @@ public class PlacementPicker extends JFrame {
           }
         }
         g.setColor(Color.red);
-        if (m_currentSquare != null) {
-          g.drawRect(m_currentSquare.x, m_currentSquare.y, PLACEWIDTH, PLACEHEIGHT);
+        if (currentSquare != null) {
+          g.drawRect(currentSquare.x, currentSquare.y, PLACEWIDTH, PLACEHEIGHT);
         }
-        if (m_currentPlacements == null) {
+        if (currentPlacements == null) {
           return;
         }
-        final Iterator<Point> pointIter = m_currentPlacements.iterator();
+        final Iterator<Point> pointIter = currentPlacements.iterator();
         while (pointIter.hasNext()) {
           final Point item = pointIter.next();
           g.fillRect(item.x, item.y, PLACEWIDTH, PLACEHEIGHT);
@@ -490,7 +490,7 @@ public class PlacementPicker extends JFrame {
         return;
       }
       final FileOutputStream out = new FileOutputStream(fileName);
-      PointFileReaderWriter.writeOneToMany(out, new HashMap<>(m_placements));
+      PointFileReaderWriter.writeOneToMany(out, new HashMap<>(placements));
       out.flush();
       out.close();
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
@@ -511,7 +511,7 @@ public class PlacementPicker extends JFrame {
         return;
       }
       final FileInputStream in = new FileInputStream(placeName);
-      m_placements = PointFileReaderWriter.readOneToMany(in);
+      placements = PointFileReaderWriter.readOneToMany(in);
       repaint();
     } catch (final HeadlessException | IOException ex) {
       ClientLogger.logQuietly(ex);
@@ -535,31 +535,31 @@ public class PlacementPicker extends JFrame {
    */
   private void mouseEvent(final Point point, final boolean ctrlDown, final boolean rightMouse) {
     if (!rightMouse && !ctrlDown) {
-      m_currentCountry = Util.findTerritoryName(point, m_polygons, "there be dragons");
+      currentCountry = Util.findTerritoryName(point, polygons, "there be dragons");
       // If there isn't an existing array, create one
-      if (m_placements == null || m_placements.get(m_currentCountry) == null) {
-        m_currentPlacements = new ArrayList<>();
+      if (placements == null || placements.get(currentCountry) == null) {
+        currentPlacements = new ArrayList<>();
       } else {
-        m_currentPlacements = new ArrayList<>(m_placements.get(m_currentCountry));
+        currentPlacements = new ArrayList<>(placements.get(currentCountry));
       }
-      JOptionPane.showMessageDialog(this, m_currentCountry);
+      JOptionPane.showMessageDialog(this, currentCountry);
     } else if (!rightMouse && ctrlDown) {
-      if (m_currentPlacements != null) {
-        m_currentPlacements.add(point);
+      if (currentPlacements != null) {
+        currentPlacements.add(point);
       }
     } else if (rightMouse && ctrlDown) {
-      if (m_currentPlacements != null) {
+      if (currentPlacements != null) {
         // If there isn't an existing hashmap, create one
-        if (m_placements == null) {
-          m_placements = new HashMap<>();
+        if (placements == null) {
+          placements = new HashMap<>();
         }
-        m_placements.put(m_currentCountry, m_currentPlacements);
-        m_currentPlacements = new ArrayList<>();
-        System.out.println("done:" + m_currentCountry);
+        placements.put(currentCountry, currentPlacements);
+        currentPlacements = new ArrayList<>();
+        System.out.println("done:" + currentCountry);
       }
     } else if (rightMouse) {
-      if (m_currentPlacements != null && !m_currentPlacements.isEmpty()) {
-        m_currentPlacements.remove(m_currentPlacements.size() - 1);
+      if (currentPlacements != null && !currentPlacements.isEmpty()) {
+        currentPlacements.remove(currentPlacements.size() - 1);
       }
     }
     repaint();


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName rule in tool code.

It's pretty much just removing the `m_` prefix on fields.  In only a few cases was a field renamed to be more descriptive (e.g. `location` -> `locationLabel`).