### PR TITLE
Checkstyle: Fix missing Javadoc violations indirectly (part 1)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=5125
-checkstyleTestMaxWarnings=139
+checkstyleMainMaxWarnings=5059
+checkstyleTestMaxWarnings=136

--- a/src/main/java/games/strategy/debug/ClientLogger.java
+++ b/src/main/java/games/strategy/debug/ClientLogger.java
@@ -1,7 +1,6 @@
 package games.strategy.debug;
 
 import java.io.PrintStream;
-import java.util.Set;
 
 public class ClientLogger {
   private static final PrintStream developerOutputStream = System.out;
@@ -35,12 +34,5 @@ public class ClientLogger {
   public static void logError(final String msg, final Throwable e) {
     logError(msg);
     logError(e);
-  }
-
-  public static void logError(final String msg, final Set<Exception> exceptions) {
-    logError(msg);
-    for (final Exception e : exceptions) {
-      logError(e);
-    }
   }
 }

--- a/src/main/java/games/strategy/debug/GenericConsole.java
+++ b/src/main/java/games/strategy/debug/GenericConsole.java
@@ -70,7 +70,7 @@ public abstract class GenericConsole extends JFrame {
   /**
    * Displays standard error to the console.
    */
-  public void displayStandardError() {
+  protected void displayStandardError() {
     final SynchedByteArrayOutputStream out = new SynchedByteArrayOutputStream(System.err);
     final ThreadReader reader = new ThreadReader(out, m_text, true, getConsoleInstance());
     final Thread thread = new Thread(reader, "Console std err reader");
@@ -80,7 +80,7 @@ public abstract class GenericConsole extends JFrame {
     System.setErr(print);
   }
 
-  public void displayStandardOutput() {
+  protected void displayStandardOutput() {
     final SynchedByteArrayOutputStream out = new SynchedByteArrayOutputStream(System.out);
     final ThreadReader reader = new ThreadReader(out, m_text, false, getConsoleInstance());
     final Thread thread = new Thread(reader, "Console std out reader");

--- a/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -41,8 +41,7 @@ public final class ClientFileSystemHelper {
     return getRootRelativeToClassFile(fileName);
   }
 
-
-  public static String getGameRunnerFileLocation(final String runnerClassName) {
+  private static String getGameRunnerFileLocation(final String runnerClassName) {
     final URL url = GameRunner.class.getResource(runnerClassName);
     String fileName = url.getFile();
 

--- a/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/src/main/java/games/strategy/engine/chat/Chat.java
@@ -75,7 +75,7 @@ public class Chat {
     return rVal;
   }
 
-  public String getNotesForNode(final INode node) {
+  String getNotesForNode(final INode node) {
     final LinkedHashSet<String> notes = notesMap.get(node);
     if (notes == null) {
       return null;
@@ -184,7 +184,7 @@ public class Chat {
     }
   }
 
-  public void sendSlap(final String playerName) {
+  void sendSlap(final String playerName) {
     final IChatChannel remote = (IChatChannel) messengers.getChannelMessenger()
         .getChannelBroadcastor(new RemoteName(chatChannelName, IChatChannel.class));
     remote.slapOccured(playerName);
@@ -214,7 +214,7 @@ public class Chat {
     }
   }
 
-  public void setIgnored(final INode node, final boolean isIgnored) {
+  void setIgnored(final INode node, final boolean isIgnored) {
     if (isIgnored) {
       ignoreList.add(node.getName());
     } else {

--- a/src/main/java/games/strategy/engine/chat/ChatFloodControl.java
+++ b/src/main/java/games/strategy/engine/chat/ChatFloodControl.java
@@ -8,7 +8,7 @@ import java.util.Map;
  * sends more than "N" messages will be filtered until the next time window begins.
  *
  */
-public class ChatFloodControl {
+class ChatFloodControl {
   private static final int ONE_MINUTE = 60 * 1000;
   static final int EVENTS_PER_WINDOW = 20;
   static final int WINDOW = ONE_MINUTE;
@@ -16,7 +16,7 @@ public class ChatFloodControl {
   private final Map<String, Integer> messageCount = new HashMap<>();
   private long clearTime;
 
-  public ChatFloodControl() {
+  ChatFloodControl() {
     this(System.currentTimeMillis());
   }
 
@@ -24,7 +24,7 @@ public class ChatFloodControl {
     clearTime = initialClearTime;
   }
 
-  public boolean allow(final String from, final long now) {
+  boolean allow(final String from, final long now) {
     synchronized (lock) {
       // reset the window
       if (now > clearTime) {

--- a/src/main/java/games/strategy/engine/chat/ChatIgnoreList.java
+++ b/src/main/java/games/strategy/engine/chat/ChatIgnoreList.java
@@ -8,12 +8,12 @@ import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
-public class ChatIgnoreList {
+class ChatIgnoreList {
   private static final Logger log = Logger.getLogger(ChatIgnoreList.class.getName());
   private final Object lock = new Object();
   private final Set<String> ignore = new HashSet<>();
 
-  public ChatIgnoreList() {
+  ChatIgnoreList() {
     final Preferences prefs = getPrefNode();
     try {
       Collections.addAll(ignore, prefs.keys());
@@ -22,7 +22,7 @@ public class ChatIgnoreList {
     }
   }
 
-  public void add(final String name) {
+  void add(final String name) {
     synchronized (lock) {
       ignore.add(name);
       final Preferences prefs = getPrefNode();
@@ -35,11 +35,11 @@ public class ChatIgnoreList {
     }
   }
 
-  protected static Preferences getPrefNode() {
+  static Preferences getPrefNode() {
     return Preferences.userNodeForPackage(ChatIgnoreList.class);
   }
 
-  public void remove(final String name) {
+  void remove(final String name) {
     synchronized (lock) {
       ignore.remove(name);
       final Preferences prefs = getPrefNode();
@@ -52,7 +52,7 @@ public class ChatIgnoreList {
     }
   }
 
-  public boolean shouldIgnore(final String name) {
+  boolean shouldIgnore(final String name) {
     synchronized (lock) {
       return ignore.contains(name);
     }

--- a/src/main/java/games/strategy/engine/chat/ChatMessage.java
+++ b/src/main/java/games/strategy/engine/chat/ChatMessage.java
@@ -1,26 +1,25 @@
 package games.strategy.engine.chat;
 
-
-public class ChatMessage {
+class ChatMessage {
   private final String message;
   private final String from;
   private final boolean isMyMessage;
 
-  public ChatMessage(final String message, final String from, final boolean isMyMessage) {
+  ChatMessage(final String message, final String from, final boolean isMyMessage) {
     this.message = message;
     this.from = from;
     this.isMyMessage = isMyMessage;
   }
 
-  public String getFrom() {
+  String getFrom() {
     return from;
   }
 
-  public boolean isMyMessage() {
+  boolean isMyMessage() {
     return isMyMessage;
   }
 
-  public String getMessage() {
+  String getMessage() {
     return message;
   }
 }

--- a/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -82,7 +82,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
     return text.getText();
   }
 
-  public void shutDown() {
+  void shutDown() {
     if (chat != null) {
       chat.removeChatListener(this);
       cleanupKeyMap();
@@ -92,7 +92,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
     this.removeAll();
   }
 
-  public void setChat(final Chat chat) {
+  void setChat(final Chat chat) {
     if (!SwingUtilities.isEventDispatchThread()) {
       SwingAction.invokeAndWait(() -> setChat(chat));
       return;

--- a/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -78,7 +78,7 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
     hiddenPlayers.add(name);
   }
 
-  public void shutDown() {
+  void shutDown() {
     if (chat != null) {
       chat.removeChatListener(this);
       chat.getStatusManager().removeStatusListener(statusListener);

--- a/src/main/java/games/strategy/engine/chat/StatusController.java
+++ b/src/main/java/games/strategy/engine/chat/StatusController.java
@@ -9,12 +9,12 @@ import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
 
-public class StatusController implements IStatusController {
+class StatusController implements IStatusController {
   private final Object mutex = new Object();
   private final Map<INode, String> status = new HashMap<>();
   private final Messengers messengers;
 
-  public StatusController(final Messengers messengers) {
+  StatusController(final Messengers messengers) {
     this.messengers = messengers;
     ((IServerMessenger) this.messengers.getMessenger()).addConnectionChangeListener(new IConnectionChangeListener() {
       @Override
@@ -27,7 +27,7 @@ public class StatusController implements IStatusController {
     });
   }
 
-  protected void connectionRemoved(final INode to) {
+  private void connectionRemoved(final INode to) {
     synchronized (mutex) {
       status.remove(to);
     }

--- a/src/main/java/games/strategy/engine/chat/StatusManager.java
+++ b/src/main/java/games/strategy/engine/chat/StatusManager.java
@@ -59,7 +59,7 @@ public class StatusManager {
     }
   }
 
-  public void setStatus(final String status) {
+  void setStatus(final String status) {
     final IStatusController controller =
         (IStatusController) messengers.getRemoteMessenger().getRemote(IStatusController.STATUS_CONTROLLER);
     controller.setStatus(status);

--- a/src/main/java/games/strategy/engine/data/AllianceTracker.java
+++ b/src/main/java/games/strategy/engine/data/AllianceTracker.java
@@ -101,8 +101,7 @@ public class AllianceTracker implements Serializable {
     }
   }
 
-
-  public Set<PlayerID> getAllies(final PlayerID currentPlayer) {
+  Set<PlayerID> getAllies(final PlayerID currentPlayer) {
     final Set<PlayerID> allies = new HashSet<>();
     // for each of the player alliances, add each player from that alliance to the total alliance list
     alliances.get(currentPlayer).forEach(alliance -> allies.addAll(getPlayersInAlliance(alliance)));

--- a/src/main/java/games/strategy/engine/data/BattleRecordsList.java
+++ b/src/main/java/games/strategy/engine/data/BattleRecordsList.java
@@ -44,7 +44,7 @@ public class BattleRecordsList extends GameDataComponent {
     return battleRecords.get(getData().getSequence().getRound());
   }
 
-  public BattleRecords getCurrentRoundCopy() {
+  private BattleRecords getCurrentRoundCopy() {
     final BattleRecords current = battleRecords.get(getData().getSequence().getRound());
     if (current == null) {
       return new BattleRecords();

--- a/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -46,7 +46,7 @@ public class CompositeRouteFinder {
     return result;
   }
 
-  public Route findRoute(final Territory start, final Territory end) {
+  Route findRoute(final Territory start, final Territory end) {
     final HashSet<Territory> allMatchingTers =
         ToHashSet(Match.getMatches(m_map.getTerritories(), new CompositeMatchOr<>(m_matches.keySet())));
     final HashMap<Territory, Integer> terScoreMap = CreateScoreMap();

--- a/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/src/main/java/games/strategy/engine/data/GameMap.java
@@ -9,7 +9,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import games.strategy.triplea.delegate.Matches;
@@ -42,26 +41,11 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     m_gridDimensions = gridDimensions;
   }
 
-  public int getXDimension() {
-    if (m_gridDimensions == null || m_gridDimensions.length < 1) {
-      return 0;
-    }
-    return m_gridDimensions[0];
-  }
-
-  public int getYDimension() {
-    if (m_gridDimensions == null || m_gridDimensions.length < 2) {
-      return 0;
-    }
-    return m_gridDimensions[1];
-  }
-
   public Territory getTerritoryFromCoordinates(final int... coordinate) {
     return getTerritoryFromCoordinates(true, coordinate);
   }
 
-  // public Territory getTerritoryFromCoordinates(int xCoordinate, int yCoordinate)
-  public Territory getTerritoryFromCoordinates(final boolean allowNull, final int... coordinate) {
+  private Territory getTerritoryFromCoordinates(final boolean allowNull, final int... coordinate) {
     if (m_gridDimensions == null) {
       if (allowNull) {
         return null;
@@ -149,7 +133,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     return 0;
   };
 
-  public boolean isCoordinateValid(final int... coordinate) {
+  boolean isCoordinateValid(final int... coordinate) {
     if (coordinate.length != m_gridDimensions.length) {
       return false;
     }
@@ -168,29 +152,6 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     m_territories.add(t1);
     m_connections.put(t1, Collections.emptySet());
     m_territoryLookup.put(t1.getName(), t1);
-  }
-
-  public void removeTerritory(final Territory t1) {
-    if (!m_territories.contains(t1)) {
-      throw new IllegalArgumentException("Map does not contain " + t1.getName());
-    }
-    m_territories.remove(t1);
-    m_connections.remove(t1);
-    m_territoryLookup.remove(t1.getName());
-    // remove territory from other connections
-    final Map<Territory, Set<Territory>> tempConnections = new HashMap<>();
-    for (final Entry<Territory, Set<Territory>> entry : m_connections.entrySet()) {
-      if (entry.getValue().contains(t1)) {
-        final Set<Territory> current = entry.getValue();
-        final Set<Territory> modified = new HashSet<>(current);
-        modified.remove(t1);
-        tempConnections.put(entry.getKey(), modified);
-      }
-    }
-    // preserve unmodifiable nature
-    for (final Entry<Territory, Set<Territory>> entry : tempConnections.entrySet()) {
-      m_connections.put(entry.getKey(), Collections.unmodifiableSet(entry.getValue()));
-    }
   }
 
   /**

--- a/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
+++ b/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
@@ -45,7 +45,7 @@ public class GameObjectStreamData implements Externalizable {
     }
   }
 
-  public Named getReference(final GameData data) {
+  Named getReference(final GameData data) {
     if (data == null) {
       throw new IllegalArgumentException("Data cant be null");
     }

--- a/src/main/java/games/strategy/engine/data/RelationshipInterpreter.java
+++ b/src/main/java/games/strategy/engine/data/RelationshipInterpreter.java
@@ -101,17 +101,6 @@ public class RelationshipInterpreter extends GameDataComponent {
     return false;
   }
 
-  public Set<PlayerID> getNeutralities(final PlayerID p1) {
-    final Set<PlayerID> neutrals = new HashSet<>();
-    for (final PlayerID player : getData().getPlayerList().getPlayers()) {
-      if (Matches.RelationshipTypeIsNeutral.match(getRelationshipType(p1, player))) {
-        neutrals.add(player);
-      }
-    }
-    neutrals.remove(p1);
-    return neutrals;
-  }
-
   public boolean canMoveLandUnitsOverOwnedLand(final PlayerID p1, final PlayerID p2) {
     return Matches.RelationshipTypeCanMoveLandUnitsOverOwnedLand.match(getRelationshipType(p1, p2));
   }

--- a/src/main/java/games/strategy/engine/data/RepairFrontier.java
+++ b/src/main/java/games/strategy/engine/data/RepairFrontier.java
@@ -22,19 +22,11 @@ public class RepairFrontier extends DefaultNamed implements Iterable<RepairRule>
     super(name, data);
   }
 
-  public void addRule(final RepairRule rule) {
+  void addRule(final RepairRule rule) {
     if (m_rules.contains(rule)) {
       throw new IllegalStateException("Rule already added:" + rule);
     }
     m_rules.add(rule);
-    m_cachedRules = null;
-  }
-
-  public void removeRule(final RepairRule rule) {
-    if (!m_rules.contains(rule)) {
-      throw new IllegalStateException("Rule not present:" + rule);
-    }
-    m_rules.remove(rule);
     m_cachedRules = null;
   }
 

--- a/src/main/java/games/strategy/engine/data/ResourceCollection.java
+++ b/src/main/java/games/strategy/engine/data/ResourceCollection.java
@@ -121,15 +121,9 @@ public class ResourceCollection extends GameDataComponent {
     subtract(resourceCollection.m_resources);
   }
 
-  public void subtract(final IntegerMap<Resource> cost) {
+  private void subtract(final IntegerMap<Resource> cost) {
     for (final Resource resource : cost.keySet()) {
       removeResource(resource, cost.getInt(resource));
-    }
-  }
-
-  public void subtract(final IntegerMap<Resource> cost, final int quantity) {
-    for (int i = 0; i < quantity; i++) {
-      subtract(cost);
     }
   }
 
@@ -190,7 +184,8 @@ public class ResourceCollection extends GameDataComponent {
     return toString(m_resources, getData(), ", ");
   }
 
-  public static String toString(final IntegerMap<Resource> resources, final GameData data, final String lineSeparator) {
+  private static String toString(final IntegerMap<Resource> resources, final GameData data,
+      final String lineSeparator) {
     if (resources == null || resources.isEmpty() || resources.allValuesEqual(0)) {
       return "nothing";
     }

--- a/src/main/java/games/strategy/engine/data/Route.java
+++ b/src/main/java/games/strategy/engine/data/Route.java
@@ -436,7 +436,7 @@ public class Route implements Serializable, Iterable<Territory> {
     return movementLeft;
   }
 
-  public ResourceCollection getMovementFuelCostCharge(final Unit unit, final GameData data) {
+  private ResourceCollection getMovementFuelCostCharge(final Unit unit, final GameData data) {
     final ResourceCollection col = new ResourceCollection(data);
     if (Matches.unitIsBeingTransported().match(unit)) {
       return col;

--- a/src/main/java/games/strategy/engine/data/RouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/RouteFinder.java
@@ -12,18 +12,18 @@ import games.strategy.util.Match;
 
 // TODO this class doesn't take movementcost into account... typically the shortest route is the fastest route, but not
 // always...
-public class RouteFinder {
+class RouteFinder {
   private final GameMap m_map;
   private final Match<Territory> m_condition;
   private final Map<Territory, Territory> m_previous;
 
-  public RouteFinder(final GameMap map, final Match<Territory> condition) {
+  RouteFinder(final GameMap map, final Match<Territory> condition) {
     m_map = map;
     m_condition = condition;
     m_previous = new HashMap<>();
   }
 
-  public Route findRoute(final Territory start, final Territory end) {
+  Route findRoute(final Territory start, final Territory end) {
     final Set<Territory> startSet = m_map.getNeighbors(start, m_condition);
     for (final Territory t : startSet) {
       m_previous.put(t, start);

--- a/src/main/java/games/strategy/engine/data/TechnologyFrontierList.java
+++ b/src/main/java/games/strategy/engine/data/TechnologyFrontierList.java
@@ -18,12 +18,6 @@ public class TechnologyFrontierList extends GameDataComponent {
     m_technologyFrontiers.add(tf);
   }
 
-  public void addTechnologyFrontier(final List<TechnologyFrontier> tfs) {
-    for (final TechnologyFrontier tf : tfs) {
-      m_technologyFrontiers.add(tf);
-    }
-  }
-
   public int size() {
     return m_technologyFrontiers.size();
   }

--- a/src/main/java/games/strategy/engine/data/Territory.java
+++ b/src/main/java/games/strategy/engine/data/Territory.java
@@ -6,6 +6,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   private PlayerID m_owner = PlayerID.NULL_PLAYERID;
   private final UnitCollection m_units;
   // In a grid-based game, stores the coordinate of the Territory
+  @SuppressWarnings("unused")
   private final int[] m_coordinate;
 
   public Territory(final String name, final GameData data) {
@@ -88,34 +89,5 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   @Override
   public String getType() {
     return UnitHolder.TERRITORY;
-  }
-
-  public boolean matchesCoordinates(final int... coordinate) {
-    if (coordinate.length != m_coordinate.length) {
-      return false;
-    } else {
-      for (int i = 0; i < coordinate.length; i++) {
-        if (coordinate[i] != m_coordinate[i]) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-  public int getX() {
-    try {
-      return m_coordinate[0];
-    } catch (final ArrayIndexOutOfBoundsException e) {
-      throw new RuntimeException("Territory " + this.getName() + " doesn't have a defined x coordinate");
-    }
-  }
-
-  public int getY() {
-    try {
-      return m_coordinate[1];
-    } catch (final ArrayIndexOutOfBoundsException e) {
-      throw new RuntimeException("Territory " + this.getName() + " doesn't have a defined y coordinate");
-    }
   }
 }

--- a/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -56,7 +56,7 @@ public class UnitCollection extends GameDataComponent implements Iterable<Unit> 
     return m_units.size();
   }
 
-  public int getUnitCount(final UnitType type) {
+  int getUnitCount(final UnitType type) {
     int count = 0;
     final Iterator<Unit> iterator = m_units.iterator();
     while (iterator.hasNext()) {
@@ -79,7 +79,7 @@ public class UnitCollection extends GameDataComponent implements Iterable<Unit> 
     return count;
   }
 
-  public int getUnitCount(final PlayerID owner) {
+  int getUnitCount(final PlayerID owner) {
     int count = 0;
     final Iterator<Unit> iterator = m_units.iterator();
     while (iterator.hasNext()) {

--- a/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/src/main/java/games/strategy/engine/data/UnitType.java
@@ -36,7 +36,7 @@ public class UnitType extends NamedAttachable {
     return create(quantity, owner, isTemp, 0, 0);
   }
 
-  public List<Unit> create(final int quantity, final PlayerID owner, final boolean isTemp, final int hitsTaken,
+  List<Unit> create(final int quantity, final PlayerID owner, final boolean isTemp, final int hitsTaken,
       final int bombingUnitDamage) {
     final List<Unit> collection = new ArrayList<>();
     for (int i = 0; i < quantity; i++) {

--- a/src/main/java/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
@@ -14,7 +14,7 @@ public class ObjectPropertyChange extends Change {
   private final Object m_newValue;
   private final Object m_oldValue;
 
-  public ObjectPropertyChange(final Object object, final String property, final Object newValue) {
+  ObjectPropertyChange(final Object object, final String property, final Object newValue) {
     m_object = object;
     m_property = property.intern();
     m_newValue = newValue;
@@ -22,7 +22,7 @@ public class ObjectPropertyChange extends Change {
     m_oldValue = PropertyUtil.getPropertyFieldObject(property, object);
   }
 
-  public ObjectPropertyChange(final Object object, final String property, final Object newValue,
+  private ObjectPropertyChange(final Object object, final String property, final Object newValue,
       final Object oldValue) {
     m_object = object;
     // prevent multiple copies of the property names being held in the game

--- a/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -31,7 +31,7 @@ public class ComboProperty<T> extends AEditableProperty {
   }
 
   @SuppressWarnings("unchecked")
-  public ComboProperty(final String name, final String description, final T defaultValue,
+  private ComboProperty(final String name, final String description, final T defaultValue,
       final Collection<T> possibleValues, final boolean allowNone) {
     super(name, description);
     if (!allowNone && !possibleValues.contains(defaultValue) && defaultValue == null) {

--- a/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -108,14 +108,6 @@ public class GameProperties extends GameDataComponent {
     return (String) value;
   }
 
-  public Object get(final String key, final Object defaultValue) {
-    final Object value = get(key);
-    if (value == null) {
-      return defaultValue;
-    }
-    return value;
-  }
-
   public void addEditableProperty(final IEditableProperty property) {
     // add to the editable properties
     editableProperties.put(property.getName(), property);

--- a/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -42,7 +42,7 @@ public abstract class AbstractGame implements IGame {
   protected boolean m_firstRun = true;
   protected final ListenerList<GameStepListener> m_gameStepListeners = new ListenerList<>();
 
-  public AbstractGame(final GameData data, final Set<IGamePlayer> gamePlayers,
+  protected AbstractGame(final GameData data, final Set<IGamePlayer> gamePlayers,
       final Map<String, INode> remotePlayerMapping, final Messengers messengers) {
     m_data = data;
     m_messenger = messengers.getMessenger();

--- a/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
+++ b/src/main/java/games/strategy/engine/framework/EngineVersionProperties.java
@@ -22,7 +22,7 @@ import games.strategy.engine.ClientContext;
 import games.strategy.net.OpenFileUtility;
 import games.strategy.util.Version;
 
-public class EngineVersionProperties {
+class EngineVersionProperties {
   private final Version latestVersionOut;
   private final String link;
   private final String linkAlt;
@@ -42,7 +42,7 @@ public class EngineVersionProperties {
     changelogLink = props.getProperty("CHANGELOG", "http://triplea-game.github.io/release_notes/");
   }
 
-  public static EngineVersionProperties contactServerForEngineVersionProperties() {
+  static EngineVersionProperties contactServerForEngineVersionProperties() {
     // sourceforge sometimes takes a long while to return results
     // so run a couple requests in parallel, starting with delays to try and get a response quickly
     final AtomicReference<EngineVersionProperties> ref = new AtomicReference<>();
@@ -80,19 +80,19 @@ public class EngineVersionProperties {
     return props;
   }
 
-  public Version getLatestVersionOut() {
+  Version getLatestVersionOut() {
     return latestVersionOut;
   }
 
-  public String getLinkToDownloadLatestVersion() {
+  String getLinkToDownloadLatestVersion() {
     return link;
   }
 
-  public String getLinkAltToDownloadLatestVersion() {
+  String getLinkAltToDownloadLatestVersion() {
     return linkAlt;
   }
 
-  public String getChangeLogLink() {
+  String getChangeLogLink() {
     return changelogLink;
   }
 
@@ -122,7 +122,7 @@ public class EngineVersionProperties {
     return text.toString();
   }
 
-  public Component getOutOfDateComponent() {
+  Component getOutOfDateComponent() {
     final JPanel panel = new JPanel(new BorderLayout());
     final JEditorPane intro = new JEditorPane("text/html", getOutOfDateMessage());
     intro.setEditable(false);

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -218,8 +218,7 @@ public class GameDataManager {
     saveGame(sink, data, true);
   }
 
-  public void saveGame(final OutputStream sink, final GameData data, final boolean saveDelegateInfo)
-      throws IOException {
+  void saveGame(final OutputStream sink, final GameData data, final boolean saveDelegateInfo) throws IOException {
     // write internally first in case of error
     final ByteArrayOutputStream bytes = new ByteArrayOutputStream(25000);
     final ObjectOutputStream outStream = new ObjectOutputStream(bytes);

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -345,7 +345,7 @@ public class GameRunner {
     return arg.substring(index + 1);
   }
 
-  public static void setupLogging(GameMode gameMode) {
+  private static void setupLogging(GameMode gameMode) {
     if (gameMode == GameMode.SWING_CLIENT) {
       Toolkit.getDefaultToolkit().getSystemEventQueue().push(new EventQueue() {
         @Override
@@ -565,7 +565,7 @@ public class GameRunner {
     startGame(System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY), null, maxMemory);
   }
 
-  public static void startGame(final String savegamePath, final String classpath, final Long maxMemory) {
+  static void startGame(final String savegamePath, final String classpath, final Long maxMemory) {
     final List<String> commands = new ArrayList<>();
     if (maxMemory != null && maxMemory > (32 * 1024 * 1024)) {
       ProcessRunnerUtil.populateBasicJavaArgs(commands, classpath, maxMemory);
@@ -686,7 +686,7 @@ public class GameRunner {
     ProcessRunnerUtil.exec(commands);
   }
 
-  public static String findOldJar(final Version oldVersionNeeded, final boolean ignoreMicro) throws IOException {
+  static String findOldJar(final Version oldVersionNeeded, final boolean ignoreMicro) throws IOException {
     if (ClientContext.engineVersion().getVersion().equals(oldVersionNeeded, ignoreMicro)) {
       return System.getProperty("java.class.path");
     }

--- a/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -33,7 +33,7 @@ public class ProcessRunnerUtil {
     populateBasicJavaArgs(commands, System.getProperty("java.class.path"), maxMemory);
   }
 
-  public static void populateBasicJavaArgs(final List<String> commands, final String newClasspath) {
+  static void populateBasicJavaArgs(final List<String> commands, final String newClasspath) {
     // for whatever reason, .maxMemory() returns a value about 12% smaller than the real Xmx value, so we are going to
     // add 64m to that to
     // compensate

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -393,7 +393,7 @@ public class ServerGame extends AbstractGame {
     }
   }
 
-  public void saveGame(final OutputStream out) throws IOException {
+  private void saveGame(final OutputStream out) throws IOException {
     try {
       if (!m_delegateExecutionManager.blockDelegateExecution(6000)) {
         throw new IOException("Could not lock delegate execution");

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessConsoleController.java
@@ -24,20 +24,20 @@ import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 
-public class HeadlessConsoleController {
+class HeadlessConsoleController {
 
   private final HeadlessGameServer server;
   private final PrintStream out;
   private final BufferedReader in;
   private boolean m_chatMode = false;
 
-  public HeadlessConsoleController(final HeadlessGameServer server, final InputStream in, final PrintStream out) {
+  HeadlessConsoleController(final HeadlessGameServer server, final InputStream in, final PrintStream out) {
     this.out = checkNotNull(out);
     this.in = new BufferedReader(new InputStreamReader(checkNotNull(in)));
     this.server = checkNotNull(server);
   }
 
-  protected void process(final String command) {
+  void process(final String command) {
     if (command.equals("")) {
       return;
     }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -391,7 +391,7 @@ public class HeadlessGameServer {
     return m_shutDown;
   }
 
-  public HeadlessGameServer() {
+  private HeadlessGameServer() {
     super();
     if (s_instance != null) {
       throw new IllegalStateException("Instance already exists");
@@ -478,7 +478,7 @@ public class HeadlessGameServer {
     }
   }
 
-  public static String[] getProperties() {
+  private static String[] getProperties() {
     return new String[] {GameRunner.TRIPLEA_GAME_PROPERTY, GameRunner.TRIPLEA_GAME_HOST_CONSOLE_PROPERTY,
         GameRunner.TRIPLEA_SERVER_PROPERTY, GameRunner.TRIPLEA_PORT_PROPERTY,
         GameRunner.TRIPLEA_NAME_PROPERTY, GameRunner.LOBBY_HOST, LobbyServer.TRIPLEA_LOBBY_PORT_PROPERTY,
@@ -488,7 +488,7 @@ public class HeadlessGameServer {
         GameRunner.MAP_FOLDER};
   }
 
-  public String getStatus() {
+  String getStatus() {
     String message = "Server Start Date: " + m_startDate;
     final ServerGame game = getIGame();
     if (game != null) {
@@ -516,7 +516,7 @@ public class HeadlessGameServer {
     System.out.println(sb.toString());
   }
 
-  public synchronized void shutdown() {
+  synchronized void shutdown() {
     m_shutDown = true;
     printThreadDumpsAndStatus();
     try {
@@ -559,7 +559,7 @@ public class HeadlessGameServer {
     System.out.println("Shutdown Script Finished.");
   }
 
-  public void waitForUsersHeadless() {
+  private void waitForUsersHeadless() {
     setServerGame(null);
 
     final Runnable r = () -> {

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServerConsole.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServerConsole.java
@@ -10,26 +10,26 @@ import games.strategy.util.ThreadUtil;
 /**
  * Terminal line console.
  */
-public class HeadlessGameServerConsole {
-  protected static final int LOOP_SLEEP_MS = 20;
+class HeadlessGameServerConsole {
+  static final int LOOP_SLEEP_MS = 20;
 
   private final PrintStream out;
   private final BufferedReader in;
   private final HeadlessConsoleController commandController;
   private boolean shutdown = false;
 
-  public HeadlessGameServerConsole(final HeadlessGameServer server, final InputStream in, final PrintStream out) {
+  HeadlessGameServerConsole(final HeadlessGameServer server, final InputStream in, final PrintStream out) {
     this(new BufferedReader(new InputStreamReader(in)), out, new HeadlessConsoleController(server, in, out));
   }
 
-  protected HeadlessGameServerConsole(final BufferedReader in, final PrintStream out,
+  HeadlessGameServerConsole(final BufferedReader in, final PrintStream out,
       final HeadlessConsoleController commandController) {
     this.out = out;
     this.in = in;
     this.commandController = commandController;
   }
 
-  public void start() {
+  void start() {
     final Thread t = new Thread(() -> printEvalLoop(), "Headless console eval print loop");
     t.setDaemon(true);
     t.start();
@@ -55,7 +55,7 @@ public class HeadlessGameServerConsole {
     }
   }
 
-  protected void shutdown() {
+  void shutdown() {
     this.shutdown = true;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -31,7 +31,7 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
   private final GameSelectorModel m_gameSelectorModel;
   private final InGameLobbyWatcherWrapper m_lobbyWatcher = new InGameLobbyWatcherWrapper();
 
-  public HeadlessServerSetup(final ServerModel model, final GameSelectorModel gameSelectorModel) {
+  HeadlessServerSetup(final ServerModel model, final GameSelectorModel gameSelectorModel) {
     m_model = model;
     m_gameSelectorModel = gameSelectorModel;
     m_model.setRemoteModelListener(this);
@@ -41,7 +41,7 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     internalPlayerListChanged();
   }
 
-  public void createLobbyWatcher() {
+  void createLobbyWatcher() {
     if (m_lobbyWatcher != null) {
       m_lobbyWatcher.setInGameLobbyWatcher(InGameLobbyWatcher.newInGameLobbyWatcher(m_model.getMessenger(), null,
           m_lobbyWatcher.getInGameLobbyWatcher()));
@@ -49,7 +49,7 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     }
   }
 
-  public synchronized void repostLobbyWatcher(final IGame iGame) {
+  synchronized void repostLobbyWatcher(final IGame iGame) {
     if (iGame != null) {
       return;
     }
@@ -63,7 +63,7 @@ public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
     createLobbyWatcher();
   }
 
-  public void shutDownLobbyWatcher() {
+  void shutDownLobbyWatcher() {
     if (m_lobbyWatcher != null) {
       m_lobbyWatcher.shutDown();
     }

--- a/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -41,7 +41,7 @@ public class AirThatCantLandUtilTest {
     return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
-  public static String fight(final BattleDelegate battle, final Territory territory, final boolean bombing) {
+  private static String fight(final BattleDelegate battle, final Territory territory, final boolean bombing) {
     for (final Entry<BattleType, Collection<Territory>> entry : battle.getBattles().getBattles().entrySet()) {
       if (entry.getKey().isBombingRun() == bombing) {
         if (entry.getValue().contains(territory)) {

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -53,7 +53,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import org.junit.Before;
@@ -77,7 +76,6 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.triplea.delegate.IBattle.BattleType;
 import games.strategy.triplea.delegate.dataObjects.CasualtyDetails;
 import games.strategy.triplea.delegate.dataObjects.CasualtyList;
 import games.strategy.triplea.delegate.dataObjects.PlaceableUnits;
@@ -110,18 +108,6 @@ public class RevisedTest {
 
   private ITestDelegateBridge getDelegateBridge(final PlayerID player) {
     return GameDataTestUtil.getDelegateBridge(player, gameData);
-  }
-
-  public static String fight(final BattleDelegate battle, final Territory territory, final boolean bombing) {
-    for (final Entry<BattleType, Collection<Territory>> entry : battle.getBattles().getBattles().entrySet()) {
-      if (entry.getKey().isBombingRun() == bombing) {
-        if (entry.getValue().contains(territory)) {
-          return battle.fightBattle(territory, bombing, entry.getKey());
-        }
-      }
-    }
-    throw new IllegalStateException(
-        "Could not find " + (bombing ? "bombing" : "normal") + " battle in: " + territory.getName());
   }
 
   @Test

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -123,7 +123,7 @@ public class WW2V3_41_Test {
     return GameDataTestUtil.getDelegateBridge(player, gameData);
   }
 
-  public static String fight(final BattleDelegate battle, final Territory territory) {
+  private static String fight(final BattleDelegate battle, final Territory territory) {
     for (final Entry<BattleType, Collection<Territory>> entry : battle.getBattles().getBattles().entrySet()) {
       if (!entry.getKey().isBombingRun() && entry.getValue().contains(territory)) {
         return battle.fightBattle(territory, false, entry.getKey());


### PR DESCRIPTION
This PR fixes violations of the Checkstyle JavadocMethod rule.

The violations were fixed indirectly by either:

1. reducing the accessibility of the method from public to non-public if it was not used outside its package, or
1. removing the method if it was unused.

I purposefully avoided applying this technique to any method that may possibly be accessed via reflection (e.g. serialization and game XML parsing).  Please scrutinize the changes for any I may have mistakenly made that could break reflection as used by TripleA.

Due to the large number of violations that can be fixed using this technique, the fixes are being split over multiple PRs to keep the review size reasonable.