### PR TITLE
Add download version for New World Order Lebowski Edition map (#1704)

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -1062,10 +1062,10 @@
     <br>Filesize is huge, at 64mb, so it may take a while to download.  Now comes with relief tiles, thx dagon.
     <br>
     <br>Converted up to TripleA 1.2.x.x by Veqryn
-  version: 1
 - mapName: New World Order Lebowski Edition
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/new_world_order_lebowski_edition/archive/master.zip
+  version: 1
   img: http://tripleamaps.sourceforge.net/images/TripleA_nwo_1939_lebowski_mini.png
   description: |
     <br>


### PR DESCRIPTION
This PR fixes the secondary issue reported in #1704.

The discussion, reproduction steps, and test methodology described in #1705 is the same for this PR.  The only difference is that the `version` attribute wasn't missing so much as it was in the wrong position such that it was being applied to the previous record.  Probably just a merge error.