### PR TITLE
Handle redirects when getting download length (#1697)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     compile files('lib/AppleJavaExtensions-1.6.jar')
     compile files('lib/upnp.jar')
 
+    testCompile 'eu.codearte.catch-exception:catch-exception:2.0.0-ALPHA-1'
     testCompile 'org.apache.derby:derby:10.10.1.1'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.mockito:mockito-core:2.7.22'

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework.map.download;
 
 import java.io.File;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -60,9 +59,9 @@ final class DownloadFile {
   private Thread createDownloadThread(final File fileToDownloadTo) {
     return new Thread(() -> {
       if (state != DownloadState.CANCELLED) {
-        final URL url = downloadDescription.newURL();
+        final String url = downloadDescription.getUrl();
         try {
-          DownloadUtils.downloadFile(url, fileToDownloadTo);
+          DownloadUtils.downloadToFile(url, fileToDownloadTo);
         } catch (final Exception e) {
           ClientLogger.logError("Failed to download: " + url, e);
         }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework.map.download;
 
 import java.io.File;
-import java.net.URL;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -82,13 +81,6 @@ class DownloadFileDescription {
 
   MapCategory getMapCategory() {
     return mapCategory;
-  }
-
-  URL newURL() {
-    if (url == null) {
-      return null;
-    }
-    return DownloadUtils.toURL(url);
   }
 
   boolean isMap() {

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -342,11 +342,8 @@ public class DownloadMapsWindow extends JFrame {
 
     final Optional<Long> mapSize;
     if (action == MapAction.INSTALL) {
-      if (map.newURL() == null) {
-        mapSize = Optional.empty();
-      } else {
-        mapSize = DownloadUtils.getDownloadLength(map.newURL());
-      }
+      final String mapUrl = map.getUrl();
+      mapSize = (mapUrl != null) ? DownloadUtils.getDownloadLength(mapUrl) : Optional.empty();
     } else {
       mapSize = Optional.of(map.getInstallLocation().length());
     }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -306,6 +306,10 @@ public class DownloadMapsWindow extends JFrame {
       final JList<String> gamesList, final List<DownloadFileDescription> maps, final MapAction action,
       final JLabel mapSizeLabelToUpdate) {
     return e -> {
+      if (e.getValueIsAdjusting()) {
+        return;
+      }
+
       final int index = gamesList.getSelectedIndex();
 
       final boolean somethingIsSelected = index >= 0;

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -306,24 +306,22 @@ public class DownloadMapsWindow extends JFrame {
       final JList<String> gamesList, final List<DownloadFileDescription> maps, final MapAction action,
       final JLabel mapSizeLabelToUpdate) {
     return e -> {
-      if (e.getValueIsAdjusting()) {
-        return;
-      }
+      if (!e.getValueIsAdjusting()) {
+        final int index = gamesList.getSelectedIndex();
 
-      final int index = gamesList.getSelectedIndex();
+        final boolean somethingIsSelected = index >= 0;
+        if (somethingIsSelected) {
+          final String mapName = gamesList.getModel().getElementAt(index);
 
-      final boolean somethingIsSelected = index >= 0;
-      if (somethingIsSelected) {
-        final String mapName = gamesList.getModel().getElementAt(index);
-
-        // find the map description by map name and update the map download detail panel
-        final Optional<DownloadFileDescription> map =
-            maps.stream().filter(mapDescription -> mapDescription.getMapName().equals(mapName)).findFirst();
-        if (map.isPresent()) {
-          final String text = map.get().toHtmlString();
-          descriptionPanel.setText(text);
-          descriptionPanel.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
-          updateMapUrlAndSizeLabel(map.get(), action, mapSizeLabelToUpdate);
+          // find the map description by map name and update the map download detail panel
+          final Optional<DownloadFileDescription> map =
+              maps.stream().filter(mapDescription -> mapDescription.getMapName().equals(mapName)).findFirst();
+          if (map.isPresent()) {
+            final String text = map.get().toHtmlString();
+            descriptionPanel.setText(text);
+            descriptionPanel.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
+            updateMapUrlAndSizeLabel(map.get(), action, mapSizeLabelToUpdate);
+          }
         }
       }
     };

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -340,7 +340,7 @@ public class DownloadMapsWindow extends JFrame {
     final String doubleSpace = "&nbsp;&nbsp;";
 
     final StringBuilder sb = new StringBuilder();
-    sb.append("<html>" + map.getMapName() + doubleSpace + " v" + map.getVersion());
+    sb.append("<html>").append(map.getMapName()).append(doubleSpace).append(" v").append(map.getVersion());
 
     final Optional<Long> mapSize;
     if (action == MapAction.INSTALL) {
@@ -349,11 +349,9 @@ public class DownloadMapsWindow extends JFrame {
     } else {
       mapSize = Optional.of(map.getInstallLocation().length());
     }
-    mapSize.ifPresent(size -> {
-      sb.append(doubleSpace + " (" + createSizeLabel(size) + ")");
-    });
+    mapSize.ifPresent(size -> sb.append(doubleSpace).append(" (").append(createSizeLabel(size)).append(")"));
 
-    sb.append("<br/>");
+    sb.append("<br>");
 
     if (action == MapAction.INSTALL) {
       sb.append(map.getUrl());

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -335,35 +335,36 @@ public class DownloadMapsWindow extends JFrame {
   }
 
   private static String createLabelText(final MapAction action, final DownloadFileDescription map) {
-    final String DOUBLE_SPACE = "&nbsp;&nbsp;";
+    final String doubleSpace = "&nbsp;&nbsp;";
 
-    final long mapSize;
-    String labelText = "<html>" + map.getMapName() + DOUBLE_SPACE + " v" + map.getVersion();
+    final StringBuilder sb = new StringBuilder();
+    sb.append("<html>" + map.getMapName() + doubleSpace + " v" + map.getVersion());
 
+    final Optional<Long> mapSize;
     if (action == MapAction.INSTALL) {
       if (map.newURL() == null) {
-        mapSize = 0L;
+        mapSize = Optional.empty();
       } else {
-        mapSize = DownloadUtils.getDownloadLength(map.newURL()).orElse(-1);
+        mapSize = DownloadUtils.getDownloadLength(map.newURL());
       }
     } else {
-      mapSize = map.getInstallLocation().length();
+      mapSize = Optional.of(map.getInstallLocation().length());
     }
+    mapSize.ifPresent(size -> {
+      sb.append(doubleSpace + " (" + createSizeLabel(size) + ")");
+    });
 
-    if (mapSize > 0) {
-      labelText += DOUBLE_SPACE + " (" + createSizeLabel(mapSize) + ")";
-    }
-
-    labelText += "<br/>";
+    sb.append("<br/>");
 
     if (action == MapAction.INSTALL) {
-      labelText += map.getUrl();
+      sb.append(map.getUrl());
     } else {
-      labelText += map.getInstallLocation().getAbsolutePath();
+      sb.append(map.getInstallLocation().getAbsolutePath());
     }
 
-    labelText += "</html>";
-    return labelText;
+    sb.append("</html>");
+
+    return sb.toString();
   }
 
   private static String createSizeLabel(final long bytes) {

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -40,7 +40,7 @@ class DownloadRunnable {
     try {
       File tempFile = ClientFileSystemHelper.createTempFile();
       tempFile.deleteOnExit();
-      DownloadUtils.downloadFile(urlString, tempFile);
+      DownloadUtils.downloadToFile(urlString, tempFile);
       byte[] contents = Files.readAllBytes(tempFile.toPath());
       return DownloadFileParser.parse(new ByteArrayInputStream(contents));
     } catch (IOException e) {

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -99,7 +99,7 @@ public final class DownloadUtils {
 
   private static CloseableHttpClient newHttpClient() {
     return HttpClients.custom()
-        .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+        .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.IGNORE_COOKIES).build())
         .build();
   }
 

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -28,27 +28,27 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.system.HttpProxy;
 
 public final class DownloadUtils {
-  private static final Map<URL, Long> downloadLengthCache = new HashMap<>();
+  private static final Map<String, Long> downloadLengthCache = new HashMap<>();
 
   private DownloadUtils() {}
 
-  static Optional<Long> getDownloadLength(final URL url) {
-    if (!downloadLengthCache.containsKey(url)) {
-      final Optional<Long> length = getDownloadLengthWithoutCache(url);
+  static Optional<Long> getDownloadLength(final String uri) {
+    if (!downloadLengthCache.containsKey(uri)) {
+      final Optional<Long> length = getDownloadLengthWithoutCache(uri);
       if (length.isPresent()) {
-        downloadLengthCache.put(url, length.get());
+        downloadLengthCache.put(uri, length.get());
       } else {
         return Optional.empty();
       }
     }
-    return Optional.of(downloadLengthCache.get(url));
+    return Optional.of(downloadLengthCache.get(uri));
   }
 
-  private static Optional<Long> getDownloadLengthWithoutCache(final URL url) {
+  private static Optional<Long> getDownloadLengthWithoutCache(final String uri) {
     try (final CloseableHttpClient client = newHttpClient()) {
-      return getLengthOfResourceAt(url.toString(), client);
+      return getLengthOfResourceAt(uri, client);
     } catch (final IOException e) {
-      ClientLogger.logQuietly(String.format("failed to get download length for '%s'", url), e);
+      ClientLogger.logQuietly(String.format("failed to get download length for '%s'", uri), e);
       return Optional.empty();
     }
   }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -28,13 +28,13 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.system.HttpProxy;
 
 public final class DownloadUtils {
-  private static Map<URL, Integer> downloadLengthCache = new HashMap<>();
+  private static final Map<URL, Long> downloadLengthCache = new HashMap<>();
 
   private DownloadUtils() {}
 
-  static Optional<Integer> getDownloadLength(URL url) {
+  static Optional<Long> getDownloadLength(final URL url) {
     if (!downloadLengthCache.containsKey(url)) {
-      Optional<Integer> length = getDownloadLengthWithoutCache(url);
+      final Optional<Long> length = getDownloadLengthWithoutCache(url);
       if (length.isPresent()) {
         downloadLengthCache.put(url, length.get());
       } else {
@@ -44,7 +44,7 @@ public final class DownloadUtils {
     return Optional.of(downloadLengthCache.get(url));
   }
 
-  private static Optional<Integer> getDownloadLengthWithoutCache(final URL url) {
+  private static Optional<Long> getDownloadLengthWithoutCache(final URL url) {
     try (final CloseableHttpClient client = newHttpClient()) {
       return getLengthOfResourceAt(url.toString(), client);
     } catch (final IOException e) {
@@ -70,7 +70,7 @@ public final class DownloadUtils {
    * @throws IOException If an error occurs while attempting to get the resource length.
    */
   @VisibleForTesting
-  static Optional<Integer> getLengthOfResourceAt(
+  static Optional<Long> getLengthOfResourceAt(
       final String uri,
       final CloseableHttpClient client) throws IOException {
     try (final CloseableHttpResponse response = client.execute(newHttpGetRequest(uri))) {
@@ -85,11 +85,7 @@ public final class DownloadUtils {
       }
 
       final long length = entity.getContentLength();
-      if (length > Integer.MAX_VALUE) {
-        throw new IOException("content length exceeds Integer.MAX_VALUE");
-      }
-
-      return (length >= 0L) ? Optional.of((int) length) : Optional.empty();
+      return (length >= 0L) ? Optional.of(length) : Optional.empty();
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/map/download/FileSizeWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FileSizeWatcher.java
@@ -10,13 +10,12 @@ import games.strategy.util.ThreadUtil;
  * the file is polled in a new thread for its file size which is then passed to the
  * consumer.
  */
-class FileSizeWatcher {
-
+final class FileSizeWatcher {
   private final File fileToWatch;
-  private final Consumer<Integer> progressListener;
-  private boolean stop = false;
+  private final Consumer<Long> progressListener;
+  private volatile boolean stop = false;
 
-  FileSizeWatcher(final File fileToWatch, final Consumer<Integer> progressListener) {
+  FileSizeWatcher(final File fileToWatch, final Consumer<Long> progressListener) {
     this.fileToWatch = fileToWatch;
     this.progressListener = progressListener;
     (new Thread(createRunner())).start();
@@ -29,7 +28,7 @@ class FileSizeWatcher {
   private Runnable createRunner() {
     return () -> {
       while (!stop) {
-        progressListener.accept((int) fileToWatch.length());
+        progressListener.accept(fileToWatch.length());
         if (!ThreadUtil.sleep(50)) {
           break;
         }

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
@@ -1,0 +1,55 @@
+package games.strategy.engine.framework.map.download;
+
+import java.net.URL;
+import java.util.Optional;
+
+import javax.swing.JProgressBar;
+import javax.swing.SwingUtilities;
+
+/**
+ * A listener of map download progress events that updates the associated controls in the UI.
+ *
+ * <p>
+ * Instances of this class are thread safe.
+ * </p>
+ */
+final class MapDownloadProgressListener {
+  private static final int MIN_PROGRESS_VALUE = 0;
+
+  private static final int MAX_PROGRESS_VALUE = 100;
+
+  private final JProgressBar progressBar;
+
+  private volatile Optional<Long> downloadLength = Optional.empty();
+
+  MapDownloadProgressListener(final JProgressBar progressBar) {
+    this.progressBar = progressBar;
+  }
+
+  void downloadStarted(final URL url) {
+    SwingUtilities.invokeLater(() -> {
+      progressBar.setMinimum(MIN_PROGRESS_VALUE);
+      progressBar.setMaximum(MAX_PROGRESS_VALUE);
+      progressBar.setIndeterminate(true);
+      progressBar.setStringPainted(false);
+    });
+
+    downloadLength = DownloadUtils.getDownloadLength(url);
+  }
+
+  void downloadUpdated(final long currentLength) {
+    downloadLength.ifPresent(totalLength -> SwingUtilities.invokeLater(() -> {
+      progressBar.setIndeterminate(false);
+      progressBar.setValue((int) (currentLength * MAX_PROGRESS_VALUE / totalLength));
+      progressBar.setStringPainted(true);
+    }));
+  }
+
+  void downloadCompleted() {
+    SwingUtilities.invokeLater(() -> {
+      progressBar.setIndeterminate(false);
+      progressBar.setValue(MAX_PROGRESS_VALUE);
+      progressBar.setStringPainted(true);
+    });
+  }
+}

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
@@ -40,11 +40,13 @@ final class MapDownloadProgressListener {
   }
 
   void downloadUpdated(final long currentLength) {
-    downloadLength.ifPresent(totalLength -> SwingUtilities.invokeLater(() -> {
-      progressBar.setIndeterminate(false);
-      progressBar.setValue((int) (currentLength * MAX_PROGRESS_VALUE / totalLength));
-      progressBar.setStringPainted(true);
-    }));
+    if (currentLength > 0) {
+      downloadLength.ifPresent(totalLength -> SwingUtilities.invokeLater(() -> {
+        progressBar.setIndeterminate(false);
+        progressBar.setValue((int) (currentLength * MAX_PROGRESS_VALUE / totalLength));
+        progressBar.setStringPainted(true);
+      }));
+    }
   }
 
   void downloadCompleted() {

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.framework.map.download;
 
-import java.net.URL;
 import java.util.Optional;
 
 import javax.swing.JProgressBar;
@@ -26,7 +25,7 @@ final class MapDownloadProgressListener {
     this.progressBar = progressBar;
   }
 
-  void downloadStarted(final URL url) {
+  void downloadStarted(final String uri) {
     SwingUtilities.invokeLater(() -> {
       progressBar.setMinimum(MIN_PROGRESS_VALUE);
       progressBar.setMaximum(MAX_PROGRESS_VALUE);
@@ -34,7 +33,7 @@ final class MapDownloadProgressListener {
       progressBar.setStringPainted(false);
     });
 
-    downloadLength = DownloadUtils.getDownloadLength(url);
+    downloadLength = DownloadUtils.getDownloadLength(uri);
   }
 
   void downloadUpdated(final long currentLength) {

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
@@ -19,13 +19,16 @@ final class MapDownloadProgressListener {
 
   private final JProgressBar progressBar;
 
+  private final String uri;
+
   private volatile Optional<Long> downloadLength = Optional.empty();
 
-  MapDownloadProgressListener(final JProgressBar progressBar) {
+  MapDownloadProgressListener(final String uri, final JProgressBar progressBar) {
     this.progressBar = progressBar;
+    this.uri = uri;
   }
 
-  void downloadStarted(final String uri) {
+  void downloadStarted() {
     SwingUtilities.invokeLater(() -> {
       progressBar.setMinimum(MIN_PROGRESS_VALUE);
       progressBar.setMaximum(MAX_PROGRESS_VALUE);

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -93,10 +93,11 @@ final class MapDownloadProgressPanel extends JPanel {
         continue;
       }
 
-      final MapDownloadProgressListener progressListener = new MapDownloadProgressListener(progressBars.get(download));
+      final MapDownloadProgressListener progressListener =
+          new MapDownloadProgressListener(download.getUrl(), progressBars.get(download));
       downloadCoordinator.accept(
           download,
-          () -> progressListener.downloadStarted(download.getUrl()),
+          progressListener::downloadStarted,
           progressListener::downloadUpdated,
           progressListener::downloadCompleted);
     }

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -4,13 +4,11 @@ import java.awt.GridLayout;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
-import javax.swing.SwingUtilities;
 
 import com.google.common.collect.Maps;
 
@@ -72,9 +70,7 @@ final class MapDownloadProgressPanel extends JPanel {
       // space at the end of the label so the text does not end right at the progress bar
       labels.put(download, new JLabel(download.getMapName() + "  "));
       final JProgressBar progressBar = new JProgressBar();
-      progressBar.setStringPainted(true);
       progressBar.setToolTipText("Installing to: " + download.getInstallLocation().getAbsolutePath());
-
       progressBars.put(download, progressBar);
     }
 
@@ -96,13 +92,13 @@ final class MapDownloadProgressPanel extends JPanel {
       if (download.getMapName().isEmpty()) {
         continue;
       }
-      final JProgressBar progressBar = progressBars.get(download);
-      final Consumer<Integer> progressListener = s -> SwingUtilities.invokeLater(() -> progressBar.setValue(s));
-      final Runnable completionListener =
-          () -> SwingUtilities.invokeLater(() -> progressBar.setValue(progressBar.getMaximum()));
 
-
-      downloadCoordinator.accept(download, progressListener, completionListener, progressBar);
+      final MapDownloadProgressListener progressListener = new MapDownloadProgressListener(progressBars.get(download));
+      downloadCoordinator.accept(
+          download,
+          () -> progressListener.downloadStarted(download.newURL()),
+          progressListener::downloadUpdated,
+          progressListener::downloadCompleted);
     }
   }
 }

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -96,7 +96,7 @@ final class MapDownloadProgressPanel extends JPanel {
       final MapDownloadProgressListener progressListener = new MapDownloadProgressListener(progressBars.get(download));
       downloadCoordinator.accept(
           download,
-          () -> progressListener.downloadStarted(download.newURL()),
+          () -> progressListener.downloadStarted(download.getUrl()),
           progressListener::downloadUpdated,
           progressListener::downloadCompleted);
     }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -198,7 +198,7 @@ public class MetaSetupPanel extends SetupPanel {
     final File file = ClientFileSystemHelper.createTempFile();
     try {
       try {
-        DownloadUtils.downloadFile(lobbyPropsUrl, file);
+        DownloadUtils.downloadToFile(lobbyPropsUrl, file);
       } catch (final IOException e) {
         ClientLogger.logQuietly(
             String.format(

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsDownloadToFileTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsDownloadToFileTest.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
@@ -28,8 +29,6 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import com.google.common.io.Files;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class DownloadUtilsDownloadToFileTest {
@@ -85,7 +84,7 @@ public final class DownloadUtilsDownloadToFileTest {
   }
 
   private byte[] fileContent() throws Exception {
-    return Files.toByteArray(file);
+    return Files.readAllBytes(file.toPath());
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsDownloadToFileTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsDownloadToFileTest.java
@@ -1,0 +1,112 @@
+package games.strategy.engine.framework.map.download;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.io.Files;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class DownloadUtilsDownloadToFileTest {
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Mock
+  private CloseableHttpClient client;
+
+  @Mock
+  private HttpEntity entity;
+
+  private File file;
+
+  private FileOutputStream os;
+
+  @Mock
+  private CloseableHttpResponse response;
+
+  @Mock
+  private StatusLine statusLine;
+
+  /**
+   * Sets up the test fixture.
+   */
+  @Before
+  public void setUp() throws Exception {
+    file = temporaryFolder.newFile();
+    os = new FileOutputStream(file);
+
+    when(client.execute(any())).thenReturn(response);
+    when(response.getEntity()).thenReturn(entity);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+  }
+
+  @Test
+  public void shouldCopyEntityToFileWhenHappyPath() throws Exception {
+    final byte[] bytes = givenEntityContentIs(new byte[] {42, 43, 44, 45});
+
+    downloadToFile();
+
+    assertThat(fileContent(), is(bytes));
+  }
+
+  private byte[] givenEntityContentIs(final byte[] bytes) throws Exception {
+    when(entity.getContent()).thenReturn(new ByteArrayInputStream(bytes));
+    return bytes;
+  }
+
+  private void downloadToFile() throws Exception {
+    DownloadUtils.downloadToFile("some://uri", os, client);
+  }
+
+  private byte[] fileContent() throws Exception {
+    return Files.toByteArray(file);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenStatusCodeIsNotOk() {
+    when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_NOT_FOUND);
+
+    catchException(() -> downloadToFile());
+
+    assertThat(caughtException(), allOf(
+        is(instanceOf(IOException.class)),
+        hasMessageThat(containsString("status code"))));
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenEntityIsAbsent() {
+    when(response.getEntity()).thenReturn(null);
+
+    catchException(() -> downloadToFile());
+
+    assertThat(caughtException(), allOf(
+        is(instanceOf(IOException.class)),
+        hasMessageThat(containsString("entity is missing"))));
+  }
+}

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsGetDownloadLengthFromCacheTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsGetDownloadLengthFromCacheTest.java
@@ -1,0 +1,72 @@
+package games.strategy.engine.framework.map.download;
+
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import games.strategy.engine.framework.map.download.DownloadUtils.DownloadLengthSupplier;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class DownloadUtilsGetDownloadLengthFromCacheTest {
+  private static final String URI = "some://uri";
+
+  @Mock
+  private DownloadLengthSupplier downloadLengthSupplier;
+
+  @Before
+  public void setUp() {
+    DownloadUtils.downloadLengthsByUri.clear();
+  }
+
+  @After
+  public void tearDown() {
+    DownloadUtils.downloadLengthsByUri.clear();
+  }
+
+  @Test
+  public void shouldUseSupplierWhenUriAbsentFromCache() {
+    when(downloadLengthSupplier.get(URI)).thenReturn(Optional.of(42L));
+
+    final Optional<Long> downloadLength = getDownloadLengthFromCache();
+
+    assertThat(downloadLength, is(Optional.of(42L)));
+    verify(downloadLengthSupplier).get(URI);
+  }
+
+  private Optional<Long> getDownloadLengthFromCache() {
+    return DownloadUtils.getDownloadLengthFromCache(URI, downloadLengthSupplier);
+  }
+
+  @Test
+  public void shouldUseCacheWhenUriPresentInCache() {
+    DownloadUtils.downloadLengthsByUri.put(URI, 42L);
+
+    final Optional<Long> downloadLength = getDownloadLengthFromCache();
+
+    assertThat(downloadLength, is(Optional.of(42L)));
+    verify(downloadLengthSupplier, never()).get(any());
+  }
+
+  @Test
+  public void shouldNotUpdateCacheWhenSupplierProvidesEmptyValue() {
+    when(downloadLengthSupplier.get(URI)).thenReturn(Optional.empty());
+
+    final Optional<Long> downloadLength = getDownloadLengthFromCache();
+
+    assertThat(downloadLength, is(Optional.empty()));
+    assertThat(DownloadUtils.downloadLengthsByUri, is(anEmptyMap()));
+  }
+}

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsGetDownloadLengthFromHostTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsGetDownloadLengthFromHostTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public final class DownloadUtilsGetDownloadLengthTest {
+public final class DownloadUtilsGetDownloadLengthFromHostTest {
   @Mock
   private CloseableHttpClient client;
 
@@ -52,23 +52,23 @@ public final class DownloadUtilsGetDownloadLengthTest {
   }
 
   @Test
-  public void getLengthOfResourceAt_ShouldReturnLengthWhenContentLengthHeaderIsPresent() throws Exception {
+  public void shouldReturnLengthWhenContentLengthHeaderIsPresent() throws Exception {
     when(contentLengthHeader.getValue()).thenReturn("42");
 
-    final Optional<Long> length = getLengthOfResourceAt();
+    final Optional<Long> length = getDownloadLengthFromHost();
 
     assertThat(length, is(Optional.of(42L)));
   }
 
-  private Optional<Long> getLengthOfResourceAt() throws Exception {
-    return DownloadUtils.getLengthOfResourceAt("some://uri", client);
+  private Optional<Long> getDownloadLengthFromHost() throws Exception {
+    return DownloadUtils.getDownloadLengthFromHost("some://uri", client);
   }
 
   @Test
-  public void getLengthOfResourceAt_ShouldThrowExceptionWhenStatusCodeIsNotOk() {
+  public void shouldThrowExceptionWhenStatusCodeIsNotOk() {
     when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_NOT_FOUND);
 
-    catchException(() -> getLengthOfResourceAt());
+    catchException(() -> getDownloadLengthFromHost());
 
     assertThat(caughtException(), allOf(
         is(instanceOf(IOException.class)),
@@ -76,19 +76,19 @@ public final class DownloadUtilsGetDownloadLengthTest {
   }
 
   @Test
-  public void getLengthOfResourceAt_ShouldReturnEmptyWhenContentLengthHeaderIsAbsent() throws Exception {
+  public void shouldReturnEmptyWhenContentLengthHeaderIsAbsent() throws Exception {
     when(response.getFirstHeader(HttpHeaders.CONTENT_LENGTH)).thenReturn(null);
 
-    final Optional<Long> length = getLengthOfResourceAt();
+    final Optional<Long> length = getDownloadLengthFromHost();
 
     assertThat(length, is(Optional.empty()));
   }
 
   @Test
-  public void getLengthOfResourceAt_ShouldThrowExceptionWhenContentLengthHeaderValueIsAbsent() throws Exception {
+  public void shouldThrowExceptionWhenContentLengthHeaderValueIsAbsent() throws Exception {
     when(contentLengthHeader.getValue()).thenReturn(null);
 
-    catchException(() -> getLengthOfResourceAt());
+    catchException(() -> getDownloadLengthFromHost());
 
     assertThat(caughtException(), allOf(
         is(instanceOf(IOException.class)),
@@ -96,10 +96,10 @@ public final class DownloadUtilsGetDownloadLengthTest {
   }
 
   @Test
-  public void getLengthOfResourceAt_ShouldThrowExceptionWhenContentLengthHeaderValueIsNotNumber() throws Exception {
+  public void shouldThrowExceptionWhenContentLengthHeaderValueIsNotNumber() throws Exception {
     when(contentLengthHeader.getValue()).thenReturn("value");
 
-    catchException(() -> getLengthOfResourceAt());
+    catchException(() -> getDownloadLengthFromHost());
 
     assertThat(caughtException(), is(instanceOf(IOException.class)));
     assertThat(caughtException().getCause(), is(instanceOf(NumberFormatException.class)));

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsGetDownloadLengthTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsGetDownloadLengthTest.java
@@ -1,0 +1,116 @@
+package games.strategy.engine.framework.map.download;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class DownloadUtilsGetDownloadLengthTest {
+  @Mock
+  private CloseableHttpClient client;
+
+  @Mock
+  private HttpEntity entity;
+
+  @Mock
+  private CloseableHttpResponse response;
+
+  @Mock
+  private StatusLine statusLine;
+
+  /**
+   * Sets up the test fixture.
+   */
+  @Before
+  public void setUp() throws Exception {
+    when(client.execute(any())).thenReturn(response);
+    when(response.getEntity()).thenReturn(entity);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+  }
+
+  @Test
+  public void getLengthOfResourceAt_ShouldReturnLengthWhenLengthIsPositive() throws Exception {
+    when(entity.getContentLength()).thenReturn(42L);
+
+    final Optional<Integer> length = getLengthOfResourceAt();
+
+    assertThat(length, is(Optional.of(42)));
+  }
+
+  private Optional<Integer> getLengthOfResourceAt() throws Exception {
+    return DownloadUtils.getLengthOfResourceAt("some://uri", client);
+  }
+
+  @Test
+  public void getLengthOfResourceAt_ShouldReturnLengthWhenLengthIsZero() throws Exception {
+    when(entity.getContentLength()).thenReturn(0L);
+
+    final Optional<Integer> length = getLengthOfResourceAt();
+
+    assertThat(length, is(Optional.of(0)));
+  }
+
+  @Test
+  public void getLengthOfResourceAt_ShouldThrowExceptionWhenStatusCodeIsNotOk() {
+    when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_NOT_FOUND);
+
+    catchException(() -> getLengthOfResourceAt());
+
+    assertThat(caughtException(), allOf(
+        is(instanceOf(IOException.class)),
+        hasMessageThat(containsString("status code"))));
+  }
+
+  @Test
+  public void getLengthOfResourceAt_ShouldThrowExceptionWhenEntityIsAbsent() {
+    when(response.getEntity()).thenReturn(null);
+
+    catchException(() -> getLengthOfResourceAt());
+
+    assertThat(caughtException(), allOf(
+        is(instanceOf(IOException.class)),
+        hasMessageThat(containsString("entity"))));
+  }
+
+  @Test
+  public void getLengthOfResourceAt_ShouldReturnEmptyWhenLengthIsUnknown() throws Exception {
+    when(entity.getContentLength()).thenReturn(-1L);
+
+    final Optional<Integer> length = getLengthOfResourceAt();
+
+    assertThat(length, is(Optional.empty()));
+  }
+
+  @Test
+  public void getLengthOfResourceAt_ShouldThrowExceptionWhenLengthIsGreaterThanMaximum() {
+    when(entity.getContentLength()).thenReturn(Integer.MAX_VALUE + 1L);
+
+    catchException(() -> getLengthOfResourceAt());
+
+    assertThat(caughtException(), allOf(
+        is(instanceOf(IOException.class)),
+        hasMessageThat(containsString("content length"))));
+  }
+}

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsGetDownloadLengthTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsGetDownloadLengthTest.java
@@ -54,12 +54,12 @@ public final class DownloadUtilsGetDownloadLengthTest {
   public void getLengthOfResourceAt_ShouldReturnLengthWhenLengthIsPositive() throws Exception {
     when(entity.getContentLength()).thenReturn(42L);
 
-    final Optional<Integer> length = getLengthOfResourceAt();
+    final Optional<Long> length = getLengthOfResourceAt();
 
-    assertThat(length, is(Optional.of(42)));
+    assertThat(length, is(Optional.of(42L)));
   }
 
-  private Optional<Integer> getLengthOfResourceAt() throws Exception {
+  private Optional<Long> getLengthOfResourceAt() throws Exception {
     return DownloadUtils.getLengthOfResourceAt("some://uri", client);
   }
 
@@ -67,9 +67,9 @@ public final class DownloadUtilsGetDownloadLengthTest {
   public void getLengthOfResourceAt_ShouldReturnLengthWhenLengthIsZero() throws Exception {
     when(entity.getContentLength()).thenReturn(0L);
 
-    final Optional<Integer> length = getLengthOfResourceAt();
+    final Optional<Long> length = getLengthOfResourceAt();
 
-    assertThat(length, is(Optional.of(0)));
+    assertThat(length, is(Optional.of(0L)));
   }
 
   @Test
@@ -98,19 +98,8 @@ public final class DownloadUtilsGetDownloadLengthTest {
   public void getLengthOfResourceAt_ShouldReturnEmptyWhenLengthIsUnknown() throws Exception {
     when(entity.getContentLength()).thenReturn(-1L);
 
-    final Optional<Integer> length = getLengthOfResourceAt();
+    final Optional<Long> length = getLengthOfResourceAt();
 
     assertThat(length, is(Optional.empty()));
-  }
-
-  @Test
-  public void getLengthOfResourceAt_ShouldThrowExceptionWhenLengthIsGreaterThanMaximum() {
-    when(entity.getContentLength()).thenReturn(Integer.MAX_VALUE + 1L);
-
-    catchException(() -> getLengthOfResourceAt());
-
-    assertThat(caughtException(), allOf(
-        is(instanceOf(IOException.class)),
-        hasMessageThat(containsString("content length"))));
   }
 }


### PR DESCRIPTION
This PR addresses the lack of support for HTTP redirects when getting a download's length as described in #1697.

This PR probably could have been a one-line fix (see the original issue description).  However, I agreed with @RoiEXLab's [advice](https://github.com/triplea-game/triplea/pull/1695#issuecomment-300465349) and felt that using the Apache HTTP client instead of `HttpURLConnection` was probably a better choice going forward.  This led me to consider other functional and refactoring issues, and I kept pulling at the thread until the PR arrived in this state. 😃  I have no problem if the team thinks this PR is too big and wants me to go back to the one-liner.

There's a lot of changes here, so I'll submit a review calling out the necessary bits in more detail.

#### Functional changes
* Replaced the `HttpURLConnection`-based implementation of **all** methods in `DownloadUtils` with one based on the Apache HTTP client.  This includes the `downloadFile()` method (since renamed), as well as the `getDownloadLength()` method, which is the target of the original issue.
* Model the download length as a `Long` instead of an `Integer` to match the underlying APIs.  This seemingly simple change is actually responsible for a good portion of the modified lines in this PR as mapping the `Long` range of the download length to the `Integer` range of the progress bar required a fundamental change in how the progress bar range was defined.
* Ensure the download length cache is thread safe, as `getDownloadLength()` is being called on multiple threads.
* Use a HEAD request instead of a GET request when getting the download length.
* Prevent the download length from being requested multiple times when a new item is selected in the UI.
* Display an indeterminate progress bar until a) the total length is known and b) the first byte is received when downloading a file (instead of leaving it at "0%" during that period, which can be for the entire download if the host does not provide download length for some reason).

#### Functional issues for review
* As stated above, it may have been overkill to replace the `downloadFile()` implementation with the Apache HTTP client because it currently is not exhibiting any known problems and already supports redirects.
* The indeterminate progress bar may not be everyone's cup of tea.  About 10-15% of the time during my testing, GitHub would not provide a `Content-Length` header (it would switch to chunked transfer encoding), and thus my progress bar would sit at 0% for the entire download and then jump to 100% when complete.  The indeterminate animation at least provides a visual cue to the user that "something" is happening.
* @RoiEXLab, I'd appreciate any general feedback you may have on my usage of the Apache HTTP client library.  Please call out anything that may not be idiomatic.

#### Refactoring changes
* I reduced method and type accessibility, where appropriate, to the minimum required for several types that I changed.
* I removed any members in the classes I touched that were no longer used.
* I switched all `DownloadUtils` URI parameters from `URL` to `String`.  We already store URIs as strings internally, and the Apache HTTP client API seems to prefer strings (or `URI`s which would have required yet another transformation).  This allowed the removal of a few adapter methods that simply convert `String` to `URL`.
* I renamed the `DownloadUtils#downloadFile()` method to `downloadToFile()`.

#### Refactoring issues for review
None.

#### Other changes
* I added the [catch-exception](https://github.com/Codearte/catch-exception/tree/2.x) library to the `testCompile` classpath to make it easier to test for expected exceptions.  I've been using it for about a year as it's much more elegant than the JUnit try/catch idiom (amid the well-known issues of false positives with `@Test(expected=...)` and the `ExpectedException` rule).

#### Other issues for review
* Please advise if the addition of catch-exception to the project is undesirable, and I'll swap it out for one of the native JUnit solutions.

#### Testing
I manually tested the UI to ensure download lengths were properly displayed and that downloads (including concurrent downloads) weren't broken in general (I tested the majority of maps, skins, and tools among all categories).  I specifically ensured the SourceForge maps that were redirected now had their download lengths displayed correctly and no errors were reported on the console.

As I noted above, I observed during my testing that about 10-15% of the time GitHub did not include a `Content-Length` header in the response (because it chose to use chunked transfer encoding).  This results in the inability to display meaningful progress information as the total length is unknown.  I do not believe this is a regression because I have seen this behavior (progress jumping from 0% to 100%) in previous releases.

There was one additional issue I encountered during testing that I cannot explain.  Very rarely (less than 5%), GET and HEAD requests to SourceForge fail due to an SSL/TLS handshake error:

```
failed to get download length for 'http://downloads.sourceforge.net/project/tripleamaps/developer%20resources/map%20makers/Map_Making_Tutorial_Map.zip'
javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:192)
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:154)
	at sun.security.ssl.SSLSocketImpl.recvAlert(SSLSocketImpl.java:2023)
	<. . . snip . . .>
	at games.strategy.engine.framework.map.download.DownloadMapsWindow.createLabelText(DownloadMapsWindow.java:307)
	at games.strategy.engine.framework.map.download.DownloadMapsWindow.lambda$11(DownloadMapsWindow.java:291)
	at java.lang.Thread.run(Thread.java:745)
```

There is no visible consequence for the end user (this condition is treated as if the download length is simply not available).  However, the above exception is logged quietly.  I don't remember ever seeing this problem in the legacy `HttpURLConnection` implementation.  Because it happens so rarely, I'm guessing it only occurs when SourceForge redirects to a particular mirror that may have an expired or otherwise invalid certificate.  If that's the case, then my guess is the default `HttpURLConnection` SSL/TLS configuration is more forgiving of invalid certificates than the default Apache HTTP client implementation.

If the team feels the rare possibility of the presence of this exception in the log (even quietly) is unacceptable, I'll try to track down the root cause of the problem.

Otherwise, I'd appreciate someone else testing this PR to ensure the Download Maps window is behaving acceptably, especially from another machine with different network characteristics than mine.