### PR TITLE
Remove unused parameters from ProMatches methods

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -202,7 +202,7 @@ public class ProCombatMoveAI {
           !data.getMap().getNeighbors(t, Matches.territoryIs(ProData.myCapital)).isEmpty();
       final int isNotNeutralAdjacentToMyCapital =
           (isAdjacentToMyCapital && ProMatches.territoryIsEnemyNotNeutralLand(player, data).match(t)) ? 1 : 0;
-      final int isFactory = ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t) ? 1 : 0;
+      final int isFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t) ? 1 : 0;
       final int isFFA = ProUtils.isFFA(data, player) ? 1 : 0;
 
       // Determine production value and if it is an enemy capital
@@ -401,7 +401,7 @@ public class ProCombatMoveAI {
 
       // Add strategic value for factories
       int isFactory = 0;
-      if (ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t)) {
+      if (ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
         isFactory = 1;
       }
 
@@ -911,7 +911,7 @@ public class ProCombatMoveAI {
         final int isLand = !t.isWater() ? 1 : 0;
         final int isCanHold = canHold ? 1 : 0;
         final int isCantHoldAmphib = !canHold && !patd.getAmphibAttackMap().isEmpty() ? 1 : 0;
-        final int isFactory = ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t) ? 1 : 0;
+        final int isFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t) ? 1 : 0;
         final int isFFA = ProUtils.isFFA(data, player) ? 1 : 0;
         final int production = TerritoryAttachment.getProduction(t);
         double capitalValue = 0;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -293,7 +293,7 @@ public class ProNonCombatMoveAI {
           Match.someMatch(moveMap.get(t).getCantMoveUnits(), ProMatches.unitIsAlliedLandAndNotInfra(player, data));
       if (!t.isWater() && !hasAlliedLandUnits
           && ProMatches
-              .territoryHasNeighborOwnedByAndHasLandUnit(data, player, ProUtils.getPotentialEnemyPlayers(player))
+              .territoryHasNeighborOwnedByAndHasLandUnit(data, ProUtils.getPotentialEnemyPlayers(player))
               .match(t)) {
         territoriesToDefendWithOneUnit.add(t);
       }
@@ -381,7 +381,7 @@ public class ProNonCombatMoveAI {
       final ProBattleResult result = calc.calculateBattleResults(player, t, new ArrayList<>(enemyAttackingUnits),
           defendingUnitsAndNotAA, enemyAttackOptions.getMax(t).getMaxBombardUnits(), false);
       int isFactory = 0;
-      if (ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t)) {
+      if (ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
         isFactory = 1;
       }
       int isMyCapital = 0;
@@ -430,7 +430,7 @@ public class ProNonCombatMoveAI {
 
       // Determine if it has a factory
       int isFactory = 0;
-      if (ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t)
+      if (ProMatches.territoryHasInfraFactoryAndIsLand().match(t)
           || (factoryMoveMap != null && factoryMoveMap.containsKey(t))) {
         isFactory = 1;
       }
@@ -490,7 +490,7 @@ public class ProNonCombatMoveAI {
     for (final Iterator<ProTerritory> it = prioritizedTerritories.iterator(); it.hasNext();) {
       final ProTerritory patd = it.next();
       final Territory t = patd.getTerritory();
-      final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t);
+      final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t);
       final ProBattleResult minResult = patd.getMinBattleResult();
       final int cantMoveUnitValue = BattleCalculator.getTUV(moveMap.get(t).getCantMoveUnits(), ProData.unitValueMap);
       final boolean isLandAndCanOnlyBeAttackedByAir =
@@ -501,7 +501,7 @@ public class ProNonCombatMoveAI {
           minResult.getTUVSwing() <= 0 && minResult.getWinPercentage() < (100 - ProData.winPercentage);
       final boolean isNotFactoryAndHasNoEnemyNeighbors = !t.isWater() && !hasFactory
           && !ProMatches
-              .territoryHasNeighborOwnedByAndHasLandUnit(data, player, ProUtils.getPotentialEnemyPlayers(player))
+              .territoryHasNeighborOwnedByAndHasLandUnit(data, ProUtils.getPotentialEnemyPlayers(player))
               .match(t);
       final boolean isNotFactoryAndOnlyAmphib = !t.isWater() && !hasFactory
           && Match.noneMatch(moveMap.get(t).getMaxUnits(), Matches.UnitIsLand) && cantMoveUnitValue < 5;
@@ -652,7 +652,7 @@ public class ProNonCombatMoveAI {
                 moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
           }
           final ProBattleResult result = moveMap.get(t).getBattleResult();
-          final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t);
+          final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t);
           if (result.getWinPercentage() > maxWinPercentage
               && ((t.equals(ProData.myCapital) && result.getWinPercentage() > (100 - ProData.winPercentage))
                   || (hasFactory && result.getWinPercentage() > (100 - ProData.minWinPercentage))
@@ -691,7 +691,7 @@ public class ProNonCombatMoveAI {
             }
           }
           if (!t.isWater() && !t.getOwner().equals(player) && Matches.UnitIsAir.match(unit)
-              && !ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t)) {
+              && !ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
             continue; // skip moving air units to allied land without a factory
           }
           List<Unit> defendingUnits = Match.getMatches(moveMap.get(t).getAllDefenders(),
@@ -704,7 +704,7 @@ public class ProNonCombatMoveAI {
                 moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
           }
           final ProBattleResult result = moveMap.get(t).getBattleResult();
-          final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t);
+          final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t);
           if (result.getWinPercentage() > maxWinPercentage
               && ((t.equals(ProData.myCapital) && result.getWinPercentage() > (100 - ProData.winPercentage))
                   || (hasFactory && result.getWinPercentage() > (100 - ProData.minWinPercentage))
@@ -794,7 +794,7 @@ public class ProNonCombatMoveAI {
                 moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
           }
           final ProBattleResult result = moveMap.get(t).getBattleResult();
-          final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t);
+          final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t);
           if ((t.equals(ProData.myCapital) && result.getWinPercentage() > (100 - ProData.winPercentage))
               || (hasFactory && result.getWinPercentage() > (100 - ProData.minWinPercentage))
               || result.getTUVSwing() > 0) {
@@ -882,7 +882,7 @@ public class ProNonCombatMoveAI {
             defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits(), false));
         final ProBattleResult result = patd.getBattleResult();
         int isFactory = 0;
-        if (ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t)) {
+        if (ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
           isFactory = 1;
         }
         int isMyCapital = 0;
@@ -905,7 +905,7 @@ public class ProNonCombatMoveAI {
         // Find strategic value
         boolean hasHigherStrategicValue = true;
         if (!t.isWater() && !t.equals(ProData.myCapital)
-            && !ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t)) {
+            && !ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
           double totalValue = 0.0;
           final List<Unit> nonAirDefenders = Match.getMatches(moveMap.get(t).getTempUnits(), Matches.UnitIsNotAir);
           for (final Unit u : nonAirDefenders) {
@@ -1789,7 +1789,7 @@ public class ProNonCombatMoveAI {
             Match.countMatches(possibleMoveTerritories, ProMatches.territoryIsEnemyNotNeutralLand(player, data));
 
         // Check if number of attack territories and value are max
-        final int isntFactory = ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t) ? 0 : 1;
+        final int isntFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t) ? 0 : 1;
         final int hasOwnedCarrier =
             Match.someMatch(moveMap.get(t).getAllDefenders(), ProMatches.UnitIsOwnedCarrier(player)) ? 1 : 0;
         final double airValue = (200.0 * numSeaAttackTerritories + 100 * numLandAttackTerritories
@@ -1929,7 +1929,7 @@ public class ProNonCombatMoveAI {
 
       // Only check AA units whose territory can't be held and don't have factories
       if (Matches.UnitIsAAforAnything.match(u) && !moveMap.get(currentTerritory).isCanHold()
-          && !ProMatches.territoryHasInfraFactoryAndIsLand(player).match(currentTerritory)) {
+          && !ProMatches.territoryHasInfraFactoryAndIsLand().match(currentTerritory)) {
         Territory maxValueTerritory = null;
         double maxValue = 0;
         for (final Territory t : infraUnitMoveMap.get(u)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -565,7 +565,7 @@ public class ProPurchaseAI {
           final boolean hasEnemyNeighbors =
               !data.getMap().getNeighbors(t, ProMatches.territoryIsEnemyLand(player, data)).isEmpty();
           final Set<Territory> nearbyLandTerritories =
-              data.getMap().getNeighbors(t, 9, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, false));
+              data.getMap().getNeighbors(t, 9, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
           final int numNearbyEnemyTerritories = Match.countMatches(nearbyLandTerritories,
               Matches.isTerritoryOwnedBy(ProUtils.getPotentialEnemyPlayers(player)));
           final boolean hasLocalLandSuperiority =
@@ -1188,7 +1188,7 @@ public class ProPurchaseAI {
       }
       for (final Territory nearbySeaTerritory : nearbyAlliedSeaTerritories) {
         myUnitsInSeaTerritories
-            .addAll(nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsOwnedNotLand(player, data)));
+            .addAll(nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsOwnedNotLand(player)));
         myUnitsInSeaTerritories.addAll(ProPurchaseUtils.getPlaceUnits(nearbySeaTerritory, purchaseTerritories));
       }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
@@ -70,7 +70,7 @@ public class ProRetreatAI {
 
     // Determine if it has a factory
     int isFactory = 0;
-    if (ProMatches.territoryHasInfraFactoryAndIsLand(player).match(battleTerritory)) {
+    if (ProMatches.territoryHasInfraFactoryAndIsLand().match(battleTerritory)) {
       isFactory = 1;
     }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -546,7 +546,7 @@ public class ProTerritoryManager {
             ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, myLandUnit));
         if (isIgnoringRelationships) {
           possibleMoveTerritories = data.getMap().getNeighbors(myUnitTerritory, range,
-              ProMatches.territoryCanPotentiallyMoveSpecificLandUnit(player, data, isCombatMove, myLandUnit));
+              ProMatches.territoryCanPotentiallyMoveSpecificLandUnit(player, data, myLandUnit));
         }
         possibleMoveTerritories.add(myUnitTerritory);
         final Set<Territory> potentialTerritories =
@@ -660,7 +660,7 @@ public class ProTerritoryManager {
             ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove));
         if (isIgnoringRelationships) {
           possibleMoveTerritories = data.getMap().getNeighbors(myUnitTerritory, range,
-              ProMatches.territoryCanPotentiallyMoveAirUnits(player, data, isCombatMove));
+              ProMatches.territoryCanPotentiallyMoveAirUnits(player, data));
         }
         possibleMoveTerritories.add(myUnitTerritory);
         final Set<Territory> potentialTerritories =
@@ -741,7 +741,7 @@ public class ProTerritoryManager {
           ProMatches.territoryCanMoveLandUnits(player, data, isCombatMove), moveAmphibToTerritoryMatch);
       if (isIgnoringRelationships) {
         unloadAmphibTerritoryMatch = new CompositeMatchAnd<>(
-            ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, isCombatMove), moveAmphibToTerritoryMatch);
+            ProMatches.territoryCanPotentiallyMoveLandUnits(player, data), moveAmphibToTerritoryMatch);
       }
 
       // Check each transport unit individually since they can have different ranges
@@ -1011,7 +1011,7 @@ public class ProTerritoryManager {
       boolean isEnemyCapitalOrFactory = false;
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
       if (!t.getOwner().isNull()
-          && ((ta != null && ta.isCapital()) || ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t))) {
+          && ((ta != null && ta.isCapital()) || ProMatches.territoryHasInfraFactoryAndIsLand().match(t))) {
         isEnemyCapitalOrFactory = true;
       }
       if (patd.getMaxBattleResult().getWinPercentage() < ProData.minWinPercentage && isEnemyCapitalOrFactory

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -230,8 +230,7 @@ public class ProBattleUtils {
       }
     }
     for (final Territory nearbySeaTerritory : nearbyAlliedSeaTerritories) {
-      myUnitsInSeaTerritories
-          .addAll(nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsOwnedNotLand(player, data)));
+      myUnitsInSeaTerritories.addAll(nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsOwnedNotLand(player)));
       myUnitsInSeaTerritories.addAll(ProPurchaseUtils.getPlaceUnits(nearbySeaTerritory, purchaseTerritories));
       alliedUnitsInSeaTerritories
           .addAll(nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsAlliedNotOwned(player, data)));

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -51,8 +51,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Territory> territoryCanPotentiallyMoveAirUnits(final PlayerID player, final GameData data,
-      final boolean isCombatMove) {
+  public static Match<Territory> territoryCanPotentiallyMoveAirUnits(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -92,7 +91,7 @@ public class ProMatches {
   }
 
   public static Match<Territory> territoryCanPotentiallyMoveSpecificLandUnit(final PlayerID player, final GameData data,
-      final boolean isCombatMove, final Unit u) {
+      final Unit u) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -118,8 +117,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Territory> territoryCanPotentiallyMoveLandUnits(final PlayerID player, final GameData data,
-      final boolean isCombatMove) {
+  public static Match<Territory> territoryCanPotentiallyMoveLandUnits(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -311,7 +309,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Territory> territoryHasInfraFactoryAndIsLand(final PlayerID player) {
+  public static Match<Territory> territoryHasInfraFactoryAndIsLand() {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -329,14 +327,14 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> match =
-            new CompositeMatchAnd<>(territoryHasInfraFactoryAndIsLand(player), Matches.isTerritoryEnemy(player, data));
+            new CompositeMatchAnd<>(territoryHasInfraFactoryAndIsLand(), Matches.isTerritoryEnemy(player, data));
         return match.match(t);
       }
     };
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(final PlayerID player,
-      final GameData data, final List<PlayerID> players, final List<Territory> territoriesThatCantBeHeld) {
+      final List<PlayerID> players, final List<Territory> territoriesThatCantBeHeld) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -345,7 +343,7 @@ public class ProMatches {
         final Match<Territory> enemyOrOwnedCantBeHeld =
             new CompositeMatchOr<>(Matches.isTerritoryOwnedBy(players), ownedAndCantBeHeld);
         final Match<Territory> match =
-            new CompositeMatchAnd<>(territoryHasInfraFactoryAndIsLand(player), enemyOrOwnedCantBeHeld);
+            new CompositeMatchAnd<>(territoryHasInfraFactoryAndIsLand(), enemyOrOwnedCantBeHeld);
         return match.match(t);
       }
     };
@@ -437,7 +435,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Territory> territoryHasNeighborOwnedByAndHasLandUnit(final GameData data, final PlayerID player,
+  public static Match<Territory> territoryHasNeighborOwnedByAndHasLandUnit(final GameData data,
       final List<PlayerID> players) {
     return new Match<Territory>() {
       @Override
@@ -873,7 +871,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Unit> unitIsOwnedNotLand(final PlayerID player, final GameData data) {
+  public static Match<Unit> unitIsOwnedNotLand(final PlayerID player) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -937,7 +935,7 @@ public class ProMatches {
    *        territory we are testing for required units
    * @return whether the territory contains one of the required combos of units
    */
-  public static Match<Unit> unitWhichRequiresUnitsHasRequiredUnits(final PlayerID player, final Territory t) {
+  public static Match<Unit> unitWhichRequiresUnitsHasRequiredUnits(final Territory t) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unitWhichRequiresUnits) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -142,7 +142,7 @@ public class ProTerritoryValueUtils {
     for (final Territory t : data.getMap().getTerritories()) {
       if (!t.isWater()) {
         final int landMassSize = 1 + data.getMap()
-            .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true)).size();
+            .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data)).size();
         if (landMassSize > maxLandMassSize) {
           maxLandMassSize = landMassSize;
         }
@@ -162,7 +162,7 @@ public class ProTerritoryValueUtils {
     final List<Territory> allTerritories = data.getMap().getTerritories();
     enemyCapitalsAndFactories.addAll(
         Match.getMatches(allTerritories, ProMatches.territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(player,
-            data, ProUtils.getPotentialEnemyPlayers(player), territoriesThatCantBeHeld)));
+            ProUtils.getPotentialEnemyPlayers(player), territoriesThatCantBeHeld)));
     final int numPotentialEnemyTerritories =
         Match.countMatches(allTerritories, Matches.isTerritoryOwnedBy(ProUtils.getPotentialEnemyPlayers(player)));
     if (enemyCapitalsAndFactories.size() * 2 >= numPotentialEnemyTerritories) {
@@ -177,7 +177,7 @@ public class ProTerritoryValueUtils {
 
       // Get factory production if factory
       int factoryProduction = 0;
-      if (ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t)) {
+      if (ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
         factoryProduction = TerritoryAttachment.getProduction(t);
       }
 
@@ -191,7 +191,7 @@ public class ProTerritoryValueUtils {
       // Calculate value
       final int isNeutral = t.getOwner().isNull() ? 1 : 0;
       final int landMassSize = 1 + data.getMap()
-          .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true)).size();
+          .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data)).size();
       final double value = Math.sqrt(factoryProduction + Math.sqrt(playerProduction)) * 32 / (1 + 3 * isNeutral)
           * landMassSize / maxLandMassSize;
       enemyCapitalsAndFactoriesMap.put(t, value);
@@ -215,7 +215,7 @@ public class ProTerritoryValueUtils {
         findNearbyEnemyCapitalsAndFactories(t, enemyCapitalsAndFactoriesMap);
     for (final Territory enemyCapitalOrFactory : nearbyEnemyCapitalsAndFactories) {
       final int distance = data.getMap().getDistance(t, enemyCapitalOrFactory,
-          ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
+          ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
       if (distance > 0) {
         values.add(enemyCapitalsAndFactoriesMap.get(enemyCapitalOrFactory) / Math.pow(2, distance));
       }
@@ -229,13 +229,13 @@ public class ProTerritoryValueUtils {
     // Determine value based on nearby territory production
     double nearbyEnemyValue = 0;
     final Set<Territory> nearbyTerritories =
-        data.getMap().getNeighbors(t, 2, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
+        data.getMap().getNeighbors(t, 2, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
     final List<Territory> nearbyEnemyTerritories = Match.getMatches(nearbyTerritories,
         ProMatches.territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
     nearbyEnemyTerritories.removeAll(territoriesToAttack);
     for (final Territory nearbyEnemyTerritory : nearbyEnemyTerritories) {
       final int distance = data.getMap().getDistance(t, nearbyEnemyTerritory,
-          ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
+          ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
       if (distance > 0) {
         double value = TerritoryAttachment.getProduction(nearbyEnemyTerritory);
         if (nearbyEnemyTerritory.getOwner().isNull()) {
@@ -249,9 +249,9 @@ public class ProTerritoryValueUtils {
       }
     }
     final int landMassSize = 1
-        + data.getMap().getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true)).size();
+        + data.getMap().getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data)).size();
     double value = nearbyEnemyValue * landMassSize / maxLandMassSize + capitalOrFactoryValue;
-    if (ProMatches.territoryHasInfraFactoryAndIsLand(player).match(t)) {
+    if (ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
       value *= 1.1; // prefer territories with factories
     }
 
@@ -292,7 +292,7 @@ public class ProTerritoryValueUtils {
     double nearbyLandValue = 0;
     final Set<Territory> nearbyTerritories = data.getMap().getNeighbors(t, 3);
     final List<Territory> nearbyLandTerritories =
-        Match.getMatches(nearbyTerritories, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, false));
+        Match.getMatches(nearbyTerritories, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
     nearbyLandTerritories.removeAll(territoriesToAttack);
     for (final Territory nearbyLandTerritory : nearbyLandTerritories) {
       final Route route = data.getMap().getRoute_IgnoreEnd(t, nearbyLandTerritory,

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -168,13 +168,13 @@ public class ProUtils {
   public static int getClosestEnemyLandTerritoryDistance(final GameData data, final PlayerID player,
       final Territory t) {
     final Set<Territory> landTerritories =
-        data.getMap().getNeighbors(t, 9, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
+        data.getMap().getNeighbors(t, 9, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
     final List<Territory> enemyLandTerritories =
         Match.getMatches(landTerritories, Matches.isTerritoryOwnedBy(getPotentialEnemyPlayers(player)));
     int minDistance = 10;
     for (final Territory enemyLandTerritory : enemyLandTerritories) {
       final int distance = data.getMap().getDistance(t, enemyLandTerritory,
-          ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
+          ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
       if (distance < minDistance) {
         minDistance = distance;
       }
@@ -189,7 +189,7 @@ public class ProUtils {
   public static int getClosestEnemyOrNeutralLandTerritoryDistance(final GameData data, final PlayerID player,
       final Territory t, final Map<Territory, Double> territoryValueMap) {
     final Set<Territory> landTerritories =
-        data.getMap().getNeighbors(t, 9, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
+        data.getMap().getNeighbors(t, 9, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
     final List<Territory> enemyLandTerritories =
         Match.getMatches(landTerritories, Matches.isTerritoryOwnedBy(getEnemyPlayers(player)));
     int minDistance = 10;
@@ -198,7 +198,7 @@ public class ProUtils {
         continue;
       }
       int distance = data.getMap().getDistance(t, enemyLandTerritory,
-          ProMatches.territoryCanPotentiallyMoveLandUnits(player, data, true));
+          ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
       if (enemyLandTerritory.getOwner().isNull()) {
         distance++;
       }


### PR DESCRIPTION
This PR removes unused parameters from methods in the `ProMatches` class.