### PR TITLE
Remove or document unused method parameters in AI code

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -545,6 +545,10 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
 
   /**
    * No need to override this.
+   *
+   * @param endTurnForumPosterDelegate The delegate to end the turn with.
+   * @param data The game data.
+   * @param player The player whose turn is ending.
    */
   protected void endTurn(final IAbstractForumPosterDelegate endTurnForumPosterDelegate, final GameData data,
       final PlayerID player) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
@@ -306,7 +306,7 @@ public class ProAI extends AbstractAI {
       return null;
     }
     calc.setData(getGameData());
-    return retreatAI.retreatQuery(battleID, submerge, battleTerritory, possibleTerritories, message);
+    return retreatAI.retreatQuery(battleID, battleTerritory, possibleTerritories);
   }
 
   @Override
@@ -451,8 +451,7 @@ public class ProAI extends AbstractAI {
     calc.setData(getGameData());
 
     // Calculate battle results
-    final ProBattleResult result =
-        calc.calculateBattleResults(player, unitTerritory, attackers, defenders, new HashSet<>(), true);
+    final ProBattleResult result = calc.calculateBattleResults(unitTerritory, attackers, defenders, new HashSet<>());
     ProLogger.debug(player.getName() + " sub attack TUVSwing=" + result.getTUVSwing());
     return result.getTUVSwing() > 0;
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -316,7 +316,7 @@ public class ProCombatMoveAI {
       for (final ProTerritory patd : territoriesToTryToAttack) {
         final Territory t = patd.getTerritory();
         if (patd.getBattleResult() == null) {
-          patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+          patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
               patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
         }
         ProLogger.trace(patd.getResultString() + " with attackers: " + patd.getUnits());
@@ -424,7 +424,7 @@ public class ProCombatMoveAI {
         // Find max remaining defenders
         final Set<Unit> attackingUnits = new HashSet<>(patd.getMaxUnits());
         attackingUnits.addAll(patd.getMaxAmphibUnits());
-        final ProBattleResult result = calc.estimateAttackBattleResults(player, t, new ArrayList<>(attackingUnits),
+        final ProBattleResult result = calc.estimateAttackBattleResults(t, new ArrayList<>(attackingUnits),
             patd.getMaxEnemyDefenders(player, data), patd.getMaxBombardUnits());
         final List<Unit> remainingUnitsToDefendWith =
             Match.getMatches(result.getAverageAttackersRemaining(), Matches.UnitIsAir.invert());
@@ -432,8 +432,8 @@ public class ProCombatMoveAI {
             + ", MyAttackers=" + attackingUnits.size() + ", RemainingUnits=" + remainingUnitsToDefendWith.size());
 
         // Determine counter attack results to see if I can hold it
-        final ProBattleResult result2 = calc.calculateBattleResults(player, t, patd.getMaxEnemyUnits(),
-            remainingUnitsToDefendWith, enemyAttackOptions.getMax(t).getMaxBombardUnits(), false);
+        final ProBattleResult result2 = calc.calculateBattleResults(t, patd.getMaxEnemyUnits(),
+            remainingUnitsToDefendWith, enemyAttackOptions.getMax(t).getMaxBombardUnits());
         final boolean canHold = (!result2.isHasLandUnitRemaining() && !t.isWater()) || (result2.getTUVSwing() < 0)
             || (result2.getWinPercentage() < ProData.minWinPercentage);
         patd.setCanHold(canHold);
@@ -639,12 +639,11 @@ public class ProCombatMoveAI {
             if (defendMap.get(unloadTerritory) != null) {
               defenders.addAll(defendMap.get(unloadTerritory).getMaxUnits());
             }
-            final ProBattleResult result = calc.calculateBattleResults(player, unloadTerritory,
-                enemyAttackOptions.getMax(unloadTerritory).getMaxUnits(), new ArrayList<>(defenders), new HashSet<>(),
-                false);
-            final ProBattleResult minResult = calc.calculateBattleResults(player, unloadTerritory,
+            final ProBattleResult result = calc.calculateBattleResults(unloadTerritory,
+                enemyAttackOptions.getMax(unloadTerritory).getMaxUnits(), new ArrayList<>(defenders), new HashSet<>());
+            final ProBattleResult minResult = calc.calculateBattleResults(unloadTerritory,
                 enemyAttackOptions.getMax(unloadTerritory).getMaxUnits(),
-                territoryTransportAndBombardMap.get(unloadTerritory), new HashSet<>(), false);
+                territoryTransportAndBombardMap.get(unloadTerritory), new HashSet<>());
             final double minTUVSwing = Math.min(result.getTUVSwing(), minResult.getTUVSwing());
             if (minTUVSwing > 0) {
               totalEnemyTUVSwing += minTUVSwing;
@@ -659,8 +658,8 @@ public class ProCombatMoveAI {
         }
 
         // Determine whether its worth attacking
-        final ProBattleResult result = calc.calculateBattleResults(player, t, patd.getUnits(),
-            patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet(), true);
+        final ProBattleResult result = calc.calculateBattleResults(t, patd.getUnits(),
+            patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet());
         int production = 0;
         int isEnemyCapital = 0;
         final TerritoryAttachment ta = TerritoryAttachment.get(t);
@@ -767,7 +766,7 @@ public class ProCombatMoveAI {
             continue;
           }
           if (patd.getBattleResult() == null) {
-            patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+            patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
                 patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
           }
           final ProBattleResult result = patd.getBattleResult();
@@ -776,7 +775,7 @@ public class ProCombatMoveAI {
             final List<Unit> attackingUnits = patd.getUnits();
             final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player, data);
             final boolean isOverwhelmingWin =
-                ProBattleUtils.checkForOverwhelmingWin(player, t, attackingUnits, defendingUnits);
+                ProBattleUtils.checkForOverwhelmingWin(t, attackingUnits, defendingUnits);
             final boolean hasAA = Match.someMatch(defendingUnits, Matches.UnitIsAAforAnything);
             if (!hasAA && !isOverwhelmingWin) {
               minWinPercentage = result.getWinPercentage();
@@ -805,14 +804,14 @@ public class ProCombatMoveAI {
 
             // Check if I already have enough attack units to win in 2 rounds
             if (patd.getBattleResult() == null) {
-              patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+              patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
                   patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
             }
             final ProBattleResult result = patd.getBattleResult();
             final List<Unit> attackingUnits = patd.getUnits();
             final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player, data);
             final boolean isOverwhelmingWin =
-                ProBattleUtils.checkForOverwhelmingWin(player, t, attackingUnits, defendingUnits);
+                ProBattleUtils.checkForOverwhelmingWin(t, attackingUnits, defendingUnits);
             if (!isOverwhelmingWin && result.getBattleRounds() > 2) {
               minWinTerritory = t;
               break;
@@ -840,13 +839,13 @@ public class ProCombatMoveAI {
         for (final Territory t : sortedUnitAttackOptions.get(unit)) {
           final ProTerritory patd = attackMap.get(t);
           if (attackMap.get(t).getBattleResult() == null) {
-            attackMap.get(t).setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+            attackMap.get(t).setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
                 patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
           }
           final ProBattleResult result = attackMap.get(t).getBattleResult();
           final List<Unit> attackers = new ArrayList<>(patd.getUnits());
           attackers.add(unit);
-          final ProBattleResult result2 = calc.estimateAttackBattleResults(player, t, attackers,
+          final ProBattleResult result2 = calc.estimateAttackBattleResults(t, attackers,
               patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet());
           final double unitValue = ProData.unitValueMap.getInt(unit.getType());
           if ((result2.getTUVSwing() - unitValue / 3) > result.getTUVSwing()) {
@@ -869,7 +868,7 @@ public class ProCombatMoveAI {
 
         // Find battle result
         if (patd.getBattleResult() == null) {
-          patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+          patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
               patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
         }
         final ProBattleResult result = patd.getBattleResult();
@@ -881,15 +880,15 @@ public class ProCombatMoveAI {
             && !ProMatches.territoryIsWaterAndAdjacentToOwnedFactory(player, data).match(t)) {
           List<Unit> remainingUnitsToDefendWith =
               Match.getMatches(result.getAverageAttackersRemaining(), Matches.UnitIsAir.invert());
-          ProBattleResult result2 = calc.calculateBattleResults(player, t, patd.getMaxEnemyUnits(),
-              remainingUnitsToDefendWith, patd.getMaxBombardUnits(), false);
+          ProBattleResult result2 = calc.calculateBattleResults(t, patd.getMaxEnemyUnits(),
+              remainingUnitsToDefendWith, patd.getMaxBombardUnits());
           if (patd.isCanHold() && result2.getTUVSwing() > 0) {
             final List<Unit> unusedUnits = new ArrayList<>(patd.getMaxUnits());
             unusedUnits.addAll(patd.getMaxAmphibUnits());
             unusedUnits.removeAll(usedUnits);
             unusedUnits.addAll(remainingUnitsToDefendWith);
-            final ProBattleResult result3 = calc.calculateBattleResults(player, t, patd.getMaxEnemyUnits(), unusedUnits,
-                patd.getMaxBombardUnits(), false);
+            final ProBattleResult result3 = calc.calculateBattleResults(t, patd.getMaxEnemyUnits(), unusedUnits,
+                patd.getMaxBombardUnits());
             if (result3.getTUVSwing() < result2.getTUVSwing()) {
               result2 = result3;
               remainingUnitsToDefendWith = unusedUnits;
@@ -1005,8 +1004,7 @@ public class ProCombatMoveAI {
     }
 
     // Sort units by number of attack options and cost
-    Map<Unit, Set<Territory>> sortedUnitAttackOptions =
-        ProSortMoveOptionsUtils.sortUnitMoveOptions(player, unitAttackOptions);
+    Map<Unit, Set<Territory>> sortedUnitAttackOptions = ProSortMoveOptionsUtils.sortUnitMoveOptions(unitAttackOptions);
 
     // Try to set at least one destroyer in each sea territory with subs
     for (final Iterator<Unit> it = sortedUnitAttackOptions.keySet().iterator(); it.hasNext();) {
@@ -1072,7 +1070,7 @@ public class ProCombatMoveAI {
         final ProTerritory patd = attackMap.get(t);
         if (!attackMap.get(t).isCurrentlyWins() && attackMap.get(t).isCanHold()) {
           if (attackMap.get(t).getBattleResult() == null) {
-            attackMap.get(t).setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+            attackMap.get(t).setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
                 patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
           }
           final ProBattleResult result = attackMap.get(t).getBattleResult();
@@ -1121,7 +1119,7 @@ public class ProCombatMoveAI {
 
           // Check battle results
           if (patd.getBattleResult() == null) {
-            patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+            patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
                 patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
           }
           final ProBattleResult result = patd.getBattleResult();
@@ -1131,7 +1129,7 @@ public class ProCombatMoveAI {
             final boolean hasNoDefenders =
                 Match.noneMatch(defendingUnits, ProMatches.unitIsEnemyAndNotInfa(player, data));
             final boolean isOverwhelmingWin =
-                ProBattleUtils.checkForOverwhelmingWin(player, t, patd.getUnits(), defendingUnits);
+                ProBattleUtils.checkForOverwhelmingWin(t, patd.getUnits(), defendingUnits);
             final boolean hasAA = Match.someMatch(defendingUnits, Matches.UnitIsAAforAnything);
             if (!hasNoDefenders && !isOverwhelmingWin && (!hasAA || result.getWinPercentage() < minWinPercentage)) {
               minWinPercentage = result.getWinPercentage();
@@ -1179,7 +1177,7 @@ public class ProCombatMoveAI {
             continue;
           }
           if (patd.getBattleResult() == null) {
-            patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+            patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
                 patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
           }
           final ProBattleResult result = patd.getBattleResult();
@@ -1189,7 +1187,7 @@ public class ProCombatMoveAI {
             final boolean hasNoDefenders =
                 Match.noneMatch(defendingUnits, ProMatches.unitIsEnemyAndNotInfa(player, data));
             final boolean isOverwhelmingWin =
-                ProBattleUtils.checkForOverwhelmingWin(player, t, patd.getUnits(), defendingUnits);
+                ProBattleUtils.checkForOverwhelmingWin(t, patd.getUnits(), defendingUnits);
             final boolean hasAA = Match.someMatch(defendingUnits, Matches.UnitIsAAforAnything);
             if (!isAirUnit || (!hasNoDefenders && !isOverwhelmingWin
                 && (!hasAA || result.getWinPercentage() < minWinPercentage))) {
@@ -1239,7 +1237,7 @@ public class ProCombatMoveAI {
           final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player, data);
           if (!patd.isCurrentlyWins() && !TransportTracker.isTransporting(transport) && !defendingUnits.isEmpty()) {
             if (patd.getBattleResult() == null) {
-              patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+              patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
                   patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
             }
             final ProBattleResult result = patd.getBattleResult();
@@ -1288,7 +1286,7 @@ public class ProCombatMoveAI {
         final ProTerritory patd = attackMap.get(t);
         if (!patd.isCurrentlyWins()) {
           if (patd.getBattleResult() == null) {
-            patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+            patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
                 patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
           }
           final ProBattleResult result = patd.getBattleResult();
@@ -1405,7 +1403,7 @@ public class ProCombatMoveAI {
       for (final Territory t : bombardOptions.get(u)) {
         final ProTerritory patd = attackMap.get(t);
         if (patd.getBattleResult() == null) {
-          patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+          patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
               patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
         }
         final ProBattleResult result = patd.getBattleResult();
@@ -1488,7 +1486,7 @@ public class ProCombatMoveAI {
       // Determine counter attack results to see if I can hold it
       final Set<Unit> enemyAttackingUnits = new HashSet<>(enemyAttackOptions.getMax(myCapital).getMaxUnits());
       enemyAttackingUnits.addAll(enemyAttackOptions.getMax(myCapital).getMaxAmphibUnits());
-      final ProBattleResult result = calc.estimateDefendBattleResults(player, myCapital,
+      final ProBattleResult result = calc.estimateDefendBattleResults(myCapital,
           new ArrayList<>(enemyAttackingUnits), defenders, enemyAttackOptions.getMax(myCapital).getMaxBombardUnits());
       ProLogger.trace("Current capital result hasLandUnitRemaining=" + result.isHasLandUnitRemaining() + ", TUVSwing="
           + result.getTUVSwing() + ", defenders=" + defenders.size() + ", attackers=" + enemyAttackingUnits.size());

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -301,8 +301,7 @@ public class ProNonCombatMoveAI {
     final List<Territory> result = new ArrayList<>(territoriesToDefendWithOneUnit);
 
     // Sort units by number of defend options and cost
-    final Map<Unit, Set<Territory>> sortedUnitMoveOptions =
-        ProSortMoveOptionsUtils.sortUnitMoveOptions(player, unitMoveMap);
+    final Map<Unit, Set<Territory>> sortedUnitMoveOptions = ProSortMoveOptionsUtils.sortUnitMoveOptions(unitMoveMap);
 
     // Set unit with the fewest move options in each territory
     for (final Unit unit : sortedUnitMoveOptions.keySet()) {
@@ -362,8 +361,8 @@ public class ProNonCombatMoveAI {
       patd.setMaxEnemyBombardUnits(enemyAttackOptions.getMax(t).getMaxBombardUnits());
       final List<Unit> minDefendingUnitsAndNotAA =
           Match.getMatches(patd.getCantMoveUnits(), Matches.UnitIsAAforAnything.invert());
-      final ProBattleResult minResult = calc.calculateBattleResults(player, t, new ArrayList<>(enemyAttackingUnits),
-          minDefendingUnitsAndNotAA, enemyAttackOptions.getMax(t).getMaxBombardUnits(), false);
+      final ProBattleResult minResult = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits),
+          minDefendingUnitsAndNotAA, enemyAttackOptions.getMax(t).getMaxBombardUnits());
       patd.setMinBattleResult(minResult);
       if (minResult.getTUVSwing() <= 0 && !minDefendingUnitsAndNotAA.isEmpty()) {
         ProLogger.debug("Territory=" + t.getName() + ", CanHold=true" + ", MinDefenders="
@@ -378,8 +377,8 @@ public class ProNonCombatMoveAI {
       defendingUnits.addAll(patd.getMaxAmphibUnits());
       defendingUnits.addAll(patd.getCantMoveUnits());
       final List<Unit> defendingUnitsAndNotAA = Match.getMatches(defendingUnits, Matches.UnitIsAAforAnything.invert());
-      final ProBattleResult result = calc.calculateBattleResults(player, t, new ArrayList<>(enemyAttackingUnits),
-          defendingUnitsAndNotAA, enemyAttackOptions.getMax(t).getMaxBombardUnits(), false);
+      final ProBattleResult result = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits),
+          defendingUnitsAndNotAA, enemyAttackOptions.getMax(t).getMaxBombardUnits());
       int isFactory = 0;
       if (ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
         isFactory = 1;
@@ -606,7 +605,7 @@ public class ProNonCombatMoveAI {
 
       // Sort units by number of defend options and cost
       final Map<Unit, Set<Territory>> sortedUnitMoveOptions =
-          ProSortMoveOptionsUtils.sortUnitMoveOptions(player, unitDefendOptions);
+          ProSortMoveOptionsUtils.sortUnitMoveOptions(unitDefendOptions);
 
       // Set enough units in territories to have at least a chance of winning
       for (final Iterator<Unit> it = sortedUnitMoveOptions.keySet().iterator(); it.hasNext();) {
@@ -648,7 +647,7 @@ public class ProNonCombatMoveAI {
             defendingUnits = moveMap.get(t).getAllDefenders();
           }
           if (moveMap.get(t).getBattleResult() == null) {
-            moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(player, t,
+            moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(t,
                 moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
           }
           final ProBattleResult result = moveMap.get(t).getBattleResult();
@@ -700,7 +699,7 @@ public class ProNonCombatMoveAI {
             defendingUnits = moveMap.get(t).getAllDefenders();
           }
           if (moveMap.get(t).getBattleResult() == null) {
-            moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(player, t,
+            moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(t,
                 moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
           }
           final ProBattleResult result = moveMap.get(t).getBattleResult();
@@ -746,7 +745,7 @@ public class ProNonCombatMoveAI {
             if (!TransportTracker.isTransporting(transport)) {
               final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
               if (moveMap.get(t).getBattleResult() == null) {
-                moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(player, t,
+                moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(t,
                     moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
               }
               final ProBattleResult result = moveMap.get(t).getBattleResult();
@@ -790,7 +789,7 @@ public class ProNonCombatMoveAI {
         for (final Territory t : amphibMoveOptions.get(transport)) {
           final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
           if (moveMap.get(t).getBattleResult() == null) {
-            moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(player, t,
+            moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(t,
                 moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
           }
           final ProBattleResult result = moveMap.get(t).getBattleResult();
@@ -878,8 +877,8 @@ public class ProNonCombatMoveAI {
 
         // Find defense result and hold value based on used defenders TUV
         final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
-        moveMap.get(t).setBattleResult(calc.calculateBattleResults(player, t, moveMap.get(t).getMaxEnemyUnits(),
-            defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits(), false));
+        moveMap.get(t).setBattleResult(calc.calculateBattleResults(t, moveMap.get(t).getMaxEnemyUnits(),
+            defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
         final ProBattleResult result = patd.getBattleResult();
         int isFactory = 0;
         if (ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
@@ -1350,7 +1349,7 @@ public class ProNonCombatMoveAI {
               final List<Unit> defendingUnits =
                   Match.getMatches(moveMap.get(t).getAllDefenders(), Matches.UnitIsNotLand);
               if (moveMap.get(t).getBattleResult() == null) {
-                moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(player, t,
+                moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(t,
                     moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
               }
               final ProBattleResult result = moveMap.get(t).getBattleResult();
@@ -1394,7 +1393,7 @@ public class ProNonCombatMoveAI {
               final List<Unit> defendingUnits =
                   Match.getMatches(moveMap.get(t).getAllDefenders(), Matches.UnitIsNotLand);
               if (moveMap.get(t).getBattleResult() == null) {
-                moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(player, t,
+                moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(t,
                     moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
               }
               final ProBattleResult result = moveMap.get(t).getBattleResult();
@@ -1506,8 +1505,8 @@ public class ProNonCombatMoveAI {
 
         // Find result with temp units
         final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
-        moveMap.get(t).setBattleResult(calc.calculateBattleResults(player, t, moveMap.get(t).getMaxEnemyUnits(),
-            defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits(), false));
+        moveMap.get(t).setBattleResult(calc.calculateBattleResults(t, moveMap.get(t).getMaxEnemyUnits(),
+            defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
         final ProBattleResult result = moveMap.get(t).getBattleResult();
         int isWater = 0;
         if (t.isWater()) {
@@ -1519,8 +1518,8 @@ public class ProNonCombatMoveAI {
         // Find min result without temp units
         final List<Unit> minDefendingUnits = new ArrayList<>(defendingUnits);
         minDefendingUnits.removeAll(moveMap.get(t).getTempUnits());
-        final ProBattleResult minResult = calc.calculateBattleResults(player, t, moveMap.get(t).getMaxEnemyUnits(),
-            minDefendingUnits, moveMap.get(t).getMaxEnemyBombardUnits(), false);
+        final ProBattleResult minResult = calc.calculateBattleResults(t, moveMap.get(t).getMaxEnemyUnits(),
+            minDefendingUnits, moveMap.get(t).getMaxEnemyBombardUnits());
 
         // Check if territory is worth defending with temp units
         if (holdValue > minResult.getTUVSwing()) {
@@ -1753,8 +1752,8 @@ public class ProNonCombatMoveAI {
         final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
         defendingUnits.add(u);
         if (moveMap.get(t).getBattleResult() == null) {
-          moveMap.get(t).setBattleResult(calc.calculateBattleResults(player, t, moveMap.get(t).getMaxEnemyUnits(),
-              defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits(), false));
+          moveMap.get(t).setBattleResult(calc.calculateBattleResults(t, moveMap.get(t).getMaxEnemyUnits(),
+              defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
         }
         final ProBattleResult result = moveMap.get(t).getBattleResult();
         ProLogger.trace(t + ", TUVSwing=" + result.getTUVSwing() + ", win%=" + result.getWinPercentage()
@@ -1766,8 +1765,8 @@ public class ProNonCombatMoveAI {
 
         // Determine if territory can be held with owned units
         final List<Unit> myDefenders = Match.getMatches(defendingUnits, Matches.unitIsOwnedBy(player));
-        final ProBattleResult result2 = calc.calculateBattleResults(player, t, moveMap.get(t).getMaxEnemyUnits(),
-            myDefenders, moveMap.get(t).getMaxEnemyBombardUnits(), false);
+        final ProBattleResult result2 = calc.calculateBattleResults(t, moveMap.get(t).getMaxEnemyUnits(),
+            myDefenders, moveMap.get(t).getMaxEnemyBombardUnits());
         int cantHoldWithoutAllies = 0;
         if (result2.getWinPercentage() >= ProData.minWinPercentage || result2.getTUVSwing() > 0) {
           cantHoldWithoutAllies = 1;
@@ -1872,8 +1871,8 @@ public class ProNonCombatMoveAI {
             // Check if territory is safe after all current moves
             if (moveMap.get(t).getBattleResult() == null) {
               final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
-              moveMap.get(t).setBattleResult(calc.calculateBattleResults(player, t, moveMap.get(t).getMaxEnemyUnits(),
-                  defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits(), false));
+              moveMap.get(t).setBattleResult(calc.calculateBattleResults(t, moveMap.get(t).getMaxEnemyUnits(),
+                  defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
             }
             final ProBattleResult result = moveMap.get(t).getBattleResult();
             if (result.getWinPercentage() >= ProData.minWinPercentage || result.getTUVSwing() > 0) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -344,8 +344,8 @@ public class ProPurchaseAI {
         // Find current battle result
         final Set<Unit> enemyAttackingUnits = new HashSet<>(enemyAttackOptions.getMax(t).getMaxUnits());
         enemyAttackingUnits.addAll(enemyAttackOptions.getMax(t).getMaxAmphibUnits());
-        final ProBattleResult result = calc.calculateBattleResults(player, t, new ArrayList<>(enemyAttackingUnits),
-            placeTerritory.getDefendingUnits(), enemyAttackOptions.getMax(t).getMaxBombardUnits(), false);
+        final ProBattleResult result = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits),
+            placeTerritory.getDefendingUnits(), enemyAttackOptions.getMax(t).getMaxBombardUnits());
         placeTerritory.setMinBattleResult(result);
         double holdValue = 0;
         if (t.isWater()) {
@@ -518,8 +518,8 @@ public class ProPurchaseAI {
           enemyAttackingUnits.addAll(enemyAttackOptions.getMax(t).getMaxAmphibUnits());
           final List<Unit> defenders = new ArrayList<>(placeTerritory.getDefendingUnits());
           defenders.addAll(unitsToPlace);
-          finalResult = calc.calculateBattleResults(player, t, new ArrayList<>(enemyAttackingUnits), defenders,
-              enemyAttackOptions.getMax(t).getMaxBombardUnits(), false);
+          finalResult = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits), defenders,
+              enemyAttackOptions.getMax(t).getMaxBombardUnits());
 
           // Break if it can be held
           if ((!t.equals(ProData.myCapital) && !finalResult.isHasLandUnitRemaining() && finalResult.getTUVSwing() <= 0)
@@ -823,7 +823,7 @@ public class ProPurchaseAI {
         final List<Unit> defenders = t.getUnits().getMatches(Matches.isUnitAllied(player, data));
         final Set<Unit> enemyAttackingUnits = new HashSet<>(enemyAttackOptions.getMax(t).getMaxUnits());
         enemyAttackingUnits.addAll(enemyAttackOptions.getMax(t).getMaxAmphibUnits());
-        final ProBattleResult result = calc.estimateDefendBattleResults(player, t, new ArrayList<>(enemyAttackingUnits),
+        final ProBattleResult result = calc.estimateDefendBattleResults(t, new ArrayList<>(enemyAttackingUnits),
             defenders, enemyAttackOptions.getMax(t).getMaxBombardUnits());
 
         // Check if it can't be held or if it can then that it wasn't conquered this turn
@@ -1055,8 +1055,8 @@ public class ProPurchaseAI {
         final List<Unit> unitsToPlace = new ArrayList<>();
         final List<Unit> initialDefendingUnits = new ArrayList<>(placeTerritory.getDefendingUnits());
         initialDefendingUnits.addAll(ProPurchaseUtils.getPlaceUnits(t, purchaseTerritories));
-        ProBattleResult result = calc.calculateBattleResults(player, t, enemyAttackOptions.getMax(t).getMaxUnits(),
-            initialDefendingUnits, enemyAttackOptions.getMax(t).getMaxBombardUnits(), false);
+        ProBattleResult result = calc.calculateBattleResults(t, enemyAttackOptions.getMax(t).getMaxUnits(),
+            initialDefendingUnits, enemyAttackOptions.getMax(t).getMaxBombardUnits());
         boolean hasOnlyRetreatingSubs =
             Properties.getSubRetreatBeforeBattle(data) && Match.allMatch(initialDefendingUnits, Matches.UnitIsSub)
                 && Match.noneMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsDestroyer);
@@ -1120,7 +1120,7 @@ public class ProPurchaseAI {
             final List<Unit> defendingUnits = new ArrayList<>(placeTerritory.getDefendingUnits());
             defendingUnits.addAll(ProPurchaseUtils.getPlaceUnits(t, purchaseTerritories));
             defendingUnits.addAll(unitsToPlace);
-            result = calc.estimateDefendBattleResults(player, t, enemyAttackOptions.getMax(t).getMaxUnits(),
+            result = calc.estimateDefendBattleResults(t, enemyAttackOptions.getMax(t).getMaxUnits(),
                 defendingUnits, enemyAttackOptions.getMax(t).getMaxBombardUnits());
             hasOnlyRetreatingSubs =
                 Properties.getSubRetreatBeforeBattle(data) && Match.allMatch(defendingUnits, Matches.UnitIsSub)
@@ -1747,8 +1747,8 @@ public class ProPurchaseAI {
         enemyAttackingUnits.addAll(enemyAttackOptions.getMax(t).getMaxAmphibUnits());
         final List<Unit> defenders = new ArrayList<>(placeTerritory.getDefendingUnits());
         defenders.addAll(unitsToPlace);
-        finalResult = calc.calculateBattleResults(player, t, new ArrayList<>(enemyAttackingUnits), defenders,
-            enemyAttackOptions.getMax(t).getMaxBombardUnits(), false);
+        finalResult = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits), defenders,
+            enemyAttackOptions.getMax(t).getMaxBombardUnits());
 
         // Break if it can be held
         if ((!t.equals(ProData.myCapital) && !finalResult.isHasLandUnitRemaining() && finalResult.getTUVSwing() <= 0)

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
@@ -50,8 +50,8 @@ public class ProRetreatAI {
     calc = ai.getCalc();
   }
 
-  public Territory retreatQuery(final GUID battleID, final boolean submerge, final Territory battleTerritory,
-      final Collection<Territory> possibleTerritories, final String message) {
+  public Territory retreatQuery(final GUID battleID, final Territory battleTerritory,
+      final Collection<Territory> possibleTerritories) {
 
     // Get battle data
     final GameData data = ProData.getData();
@@ -65,8 +65,7 @@ public class ProRetreatAI {
     final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
 
     // Calculate battle results
-    final ProBattleResult result =
-        calc.calculateBattleResults(player, battleTerritory, attackers, defenders, new HashSet<>(), isAttacker);
+    final ProBattleResult result = calc.calculateBattleResults(battleTerritory, attackers, defenders, new HashSet<>());
 
     // Determine if it has a factory
     int isFactory = 0;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProScrambleAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProScrambleAI.java
@@ -49,8 +49,7 @@ public class ProScrambleAI {
     final List<Unit> attackers = (List<Unit>) battle.getAttackingUnits();
     final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
     final Set<Unit> bombardingUnits = new HashSet<>(battle.getBombardingUnits());
-    final ProBattleResult minResult =
-        calc.calculateBattleResults(player, scrambleTo, attackers, defenders, bombardingUnits, false);
+    final ProBattleResult minResult = calc.calculateBattleResults(scrambleTo, attackers, defenders, bombardingUnits);
     ProLogger
         .debug(scrambleTo + ", minTUVSwing=" + minResult.getTUVSwing() + ", minWin%=" + minResult.getWinPercentage());
     if (minResult.getTUVSwing() <= 0 && minResult.getWinPercentage() < (100 - ProData.minWinPercentage)) {
@@ -77,8 +76,7 @@ public class ProScrambleAI {
       possibleMaxScramblerMap.put(t, canScrambleAir);
     }
     defenders.addAll(allScramblers);
-    final ProBattleResult maxResult =
-        calc.calculateBattleResults(player, scrambleTo, attackers, defenders, bombardingUnits, false);
+    final ProBattleResult maxResult = calc.calculateBattleResults(scrambleTo, attackers, defenders, bombardingUnits);
     ProLogger
         .debug(scrambleTo + ", maxTUVSwing=" + maxResult.getTUVSwing() + ", maxWin%=" + maxResult.getWinPercentage());
     if (maxResult.getTUVSwing() >= minResult.getTUVSwing()) {
@@ -106,7 +104,7 @@ public class ProScrambleAI {
 
     // Sort units by number of defend options and cost
     final Map<Unit, Set<Territory>> sortedUnitDefendOptions =
-        ProSortMoveOptionsUtils.sortUnitMoveOptions(player, unitDefendOptions);
+        ProSortMoveOptionsUtils.sortUnitMoveOptions(unitDefendOptions);
 
     // Add one scramble unit at a time and check if final result is better than min result
     final List<Unit> unitsToScramble = new ArrayList<>();
@@ -115,7 +113,7 @@ public class ProScrambleAI {
       unitsToScramble.add(u);
       final List<Unit> currentDefenders = (List<Unit>) battle.getDefendingUnits();
       currentDefenders.addAll(unitsToScramble);
-      result = calc.calculateBattleResults(player, scrambleTo, attackers, currentDefenders, bombardingUnits, false);
+      result = calc.calculateBattleResults(scrambleTo, attackers, currentDefenders, bombardingUnits);
       ProLogger.debug(scrambleTo + ", TUVSwing=" + result.getTUVSwing() + ", Win%=" + result.getWinPercentage()
           + ", addedUnit=" + u);
       if (result.getTUVSwing() <= 0 && result.getWinPercentage() < (100 - ProData.minWinPercentage)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -835,7 +835,7 @@ public class ProTerritoryManager {
 
               // Add to transport map
               proTransportData.addTerritories(amphibTerritories, myUnitsToLoadTerritories);
-              proTransportData.addSeaTerritories(seaMoveTerritories, myUnitsToLoadTerritories, data);
+              proTransportData.addSeaTerritories(seaMoveTerritories, myUnitsToLoadTerritories);
             }
           }
           currentTerritories.clear();
@@ -995,14 +995,13 @@ public class ProTerritoryManager {
       if (isIgnoringRelationships) {
         defenders = new ArrayList<>(t.getUnits().getUnits());
       }
-      patd.setMaxBattleResult(
-          calc.estimateAttackBattleResults(player, t, patd.getMaxUnits(), defenders, new HashSet<>()));
+      patd.setMaxBattleResult(calc.estimateAttackBattleResults(t, patd.getMaxUnits(), defenders, new HashSet<>()));
 
       // Add in amphib units if I can't win without them
       if (patd.getMaxBattleResult().getWinPercentage() < ProData.winPercentage && !patd.getMaxAmphibUnits().isEmpty()) {
         final Set<Unit> combinedUnits = new HashSet<>(patd.getMaxUnits());
         combinedUnits.addAll(patd.getMaxAmphibUnits());
-        patd.setMaxBattleResult(calc.estimateAttackBattleResults(player, t, new ArrayList<>(combinedUnits), defenders,
+        patd.setMaxBattleResult(calc.estimateAttackBattleResults(t, new ArrayList<>(combinedUnits), defenders,
             patd.getMaxBombardUnits()));
         patd.setNeedAmphibUnits(true);
       }
@@ -1046,7 +1045,7 @@ public class ProTerritoryManager {
             final Set<Unit> enemyDefendersBeforeStrafe = new HashSet<>(defenders);
             enemyDefendersBeforeStrafe.addAll(additionalEnemyDefenders);
             final ProBattleResult result =
-                calc.estimateAttackBattleResults(alliedPlayer, t, new ArrayList<>(alliedUnits),
+                calc.estimateAttackBattleResults(t, new ArrayList<>(alliedUnits),
                     new ArrayList<>(enemyDefendersBeforeStrafe), alliedAttack.getMaxBombardUnits());
             if (result.getWinPercentage() < ProData.winPercentage) {
               patd.setStrafing(true);
@@ -1054,13 +1053,13 @@ public class ProTerritoryManager {
               // Try to strafe to allow allies to conquer territory
               final Set<Unit> combinedUnits = new HashSet<>(patd.getMaxUnits());
               combinedUnits.addAll(patd.getMaxAmphibUnits());
-              final ProBattleResult strafeResult = calc.callBattleCalculator(player, t, new ArrayList<>(combinedUnits),
+              final ProBattleResult strafeResult = calc.callBattleCalculator(t, new ArrayList<>(combinedUnits),
                   defenders, patd.getMaxBombardUnits(), true);
 
               // Check allied result with strafe
               final Set<Unit> enemyDefendersAfterStrafe = new HashSet<>(strafeResult.getAverageDefendersRemaining());
               enemyDefendersAfterStrafe.addAll(additionalEnemyDefenders);
-              patd.setMaxBattleResult(calc.estimateAttackBattleResults(alliedPlayer, t, new ArrayList<>(alliedUnits),
+              patd.setMaxBattleResult(calc.estimateAttackBattleResults(t, new ArrayList<>(alliedUnits),
                   new ArrayList<>(enemyDefendersAfterStrafe), alliedAttack.getMaxBombardUnits()));
 
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTransport.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTransport.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 
@@ -33,8 +32,7 @@ public class ProTransport {
     }
   }
 
-  public void addSeaTerritories(final Set<Territory> attackTerritories, final Set<Territory> myUnitsToLoadTerritories,
-      final GameData data) {
+  public void addSeaTerritories(final Set<Territory> attackTerritories, final Set<Territory> myUnitsToLoadTerritories) {
     for (final Territory attackTerritory : attackTerritories) {
       if (seaTransportMap.containsKey(attackTerritory)) {
         seaTransportMap.get(attackTerritory).addAll(myUnitsToLoadTerritories);

--- a/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProSimulateTurnUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProSimulateTurnUtils.java
@@ -59,7 +59,7 @@ public class ProSimulateTurnUtils {
         ProLogger.debug("attackers=" + attackers);
         ProLogger.debug("defenders=" + defenders);
         ProLogger.debug("bombardingUnits=" + bombardingUnits);
-        final ProBattleResult result = calc.callBattleCalculator(player, t, attackers, defenders, bombardingUnits);
+        final ProBattleResult result = calc.callBattleCalculator(t, attackers, defenders, bombardingUnits);
         final List<Unit> remainingUnits = result.getAverageAttackersRemaining();
         ProLogger.debug("remainingUnits=" + remainingUnits);
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -34,7 +34,7 @@ public class ProBattleUtils {
   public static final int SHORT_RANGE = 2;
   public static final int MEDIUM_RANGE = 3;
 
-  public static boolean checkForOverwhelmingWin(final PlayerID player, final Territory t,
+  public static boolean checkForOverwhelmingWin(final Territory t,
       final List<Unit> attackingUnits, final List<Unit> defendingUnits) {
     final GameData data = ProData.getData();
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -39,7 +39,7 @@ public class ProOddsCalculator {
     isCanceled = true;
   }
 
-  public ProBattleResult estimateAttackBattleResults(final PlayerID player, final Territory t,
+  public ProBattleResult estimateAttackBattleResults(final Territory t,
       final List<Unit> attackingUnits, final List<Unit> defendingUnits, final Set<Unit> bombardingUnits) {
 
     final ProBattleResult result = checkIfNoAttackersOrDefenders(t, attackingUnits, defendingUnits);
@@ -52,10 +52,10 @@ public class ProOddsCalculator {
     if (strengthDifference < 45) {
       return new ProBattleResult(0, -999, false, new ArrayList<>(), defendingUnits, 1);
     }
-    return callBattleCalculator(player, t, attackingUnits, defendingUnits, bombardingUnits);
+    return callBattleCalculator(t, attackingUnits, defendingUnits, bombardingUnits);
   }
 
-  public ProBattleResult estimateDefendBattleResults(final PlayerID player, final Territory t,
+  public ProBattleResult estimateDefendBattleResults(final Territory t,
       final List<Unit> attackingUnits, final List<Unit> defendingUnits, final Set<Unit> bombardingUnits) {
 
     final ProBattleResult result = checkIfNoAttackersOrDefenders(t, attackingUnits, defendingUnits);
@@ -70,18 +70,17 @@ public class ProOddsCalculator {
       return new ProBattleResult(100 + strengthDifference, 999 + strengthDifference, !isLandAndCanOnlyBeAttackedByAir,
           attackingUnits, new ArrayList<>(), 1);
     }
-    return callBattleCalculator(player, t, attackingUnits, defendingUnits, bombardingUnits);
+    return callBattleCalculator(t, attackingUnits, defendingUnits, bombardingUnits);
   }
 
-  public ProBattleResult calculateBattleResults(final PlayerID player, final Territory t,
-      final List<Unit> attackingUnits, final List<Unit> defendingUnits, final Set<Unit> bombardingUnits,
-      final boolean isAttacker) {
+  public ProBattleResult calculateBattleResults(final Territory t,
+      final List<Unit> attackingUnits, final List<Unit> defendingUnits, final Set<Unit> bombardingUnits) {
 
     final ProBattleResult result = checkIfNoAttackersOrDefenders(t, attackingUnits, defendingUnits);
     if (result != null) {
       return result;
     }
-    return callBattleCalculator(player, t, attackingUnits, defendingUnits, bombardingUnits);
+    return callBattleCalculator(t, attackingUnits, defendingUnits, bombardingUnits);
   }
 
   private static ProBattleResult checkIfNoAttackersOrDefenders(final Territory t, final List<Unit> attackingUnits,
@@ -104,12 +103,12 @@ public class ProOddsCalculator {
   }
 
 
-  public ProBattleResult callBattleCalculator(final PlayerID player, final Territory t, final List<Unit> attackingUnits,
+  public ProBattleResult callBattleCalculator(final Territory t, final List<Unit> attackingUnits,
       final List<Unit> defendingUnits, final Set<Unit> bombardingUnits) {
-    return callBattleCalculator(player, t, attackingUnits, defendingUnits, bombardingUnits, false);
+    return callBattleCalculator(t, attackingUnits, defendingUnits, bombardingUnits, false);
   }
 
-  public ProBattleResult callBattleCalculator(final PlayerID player, final Territory t, final List<Unit> attackingUnits,
+  public ProBattleResult callBattleCalculator(final Territory t, final List<Unit> attackingUnits,
       final List<Unit> defendingUnits, final Set<Unit> bombardingUnits, final boolean retreatWhenOnlyAirLeft) {
     final GameData data = ProData.getData();
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProSortMoveOptionsUtils.java
@@ -25,8 +25,7 @@ import games.strategy.triplea.delegate.UnitBattleComparator;
  */
 public class ProSortMoveOptionsUtils {
 
-  public static Map<Unit, Set<Territory>> sortUnitMoveOptions(final PlayerID player,
-      final Map<Unit, Set<Territory>> unitAttackOptions) {
+  public static Map<Unit, Set<Territory>> sortUnitMoveOptions(final Map<Unit, Set<Territory>> unitAttackOptions) {
 
     final List<Map.Entry<Unit, Set<Territory>>> list = new LinkedList<>(unitAttackOptions.entrySet());
     Collections.sort(list, (o1, o2) -> {
@@ -61,7 +60,7 @@ public class ProSortMoveOptionsUtils {
       for (final Territory t : o1.getValue()) {
         final ProTerritory patd = attackMap.get(t);
         if (patd.getBattleResult() == null) {
-          patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+          patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
               patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
         }
         if (!patd.isCurrentlyWins()) {
@@ -72,7 +71,7 @@ public class ProSortMoveOptionsUtils {
       for (final Territory t : o2.getValue()) {
         final ProTerritory patd = attackMap.get(t);
         if (patd.getBattleResult() == null) {
-          patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+          patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
               patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
         }
         if (!patd.isCurrentlyWins()) {
@@ -110,7 +109,7 @@ public class ProSortMoveOptionsUtils {
       for (final Territory t : o1.getValue()) {
         final ProTerritory patd = attackMap.get(t);
         if (patd.getBattleResult() == null) {
-          patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+          patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
               patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
         }
         if (!patd.isCurrentlyWins()) {
@@ -121,7 +120,7 @@ public class ProSortMoveOptionsUtils {
       for (final Territory t : o2.getValue()) {
         final ProTerritory patd = attackMap.get(t);
         if (patd.getBattleResult() == null) {
-          patd.setBattleResult(calc.estimateAttackBattleResults(player, t, patd.getUnits(),
+          patd.setBattleResult(calc.estimateAttackBattleResults(t, patd.getUnits(),
               patd.getMaxEnemyDefenders(player, data), patd.getBombardTerritoryMap().keySet()));
         }
         if (!patd.isCurrentlyWins()) {

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -88,7 +88,7 @@ public class Utils {
   }
 
   // returns all territories that are water territories (veqryn)
-  public static List<Territory> onlyWaterTerr(final GameData data, final List<Territory> allTerr) {
+  public static List<Territory> onlyWaterTerr(final List<Territory> allTerr) {
     final List<Territory> water = new ArrayList<>(allTerr);
     final Iterator<Territory> wFIter = water.iterator();
     while (wFIter.hasNext()) {
@@ -104,8 +104,7 @@ public class Utils {
    * Return Territories containing any unit depending on unitCondition
    * Differs from findCertainShips because it doesn't require the units be owned.
    */
-  public static List<Territory> findUnitTerr(final GameData data, final PlayerID player,
-      final Match<Unit> unitCondition) {
+  public static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units
     final CompositeMatch<Unit> limitShips = new CompositeMatchAnd<>(unitCondition);
     final List<Territory> shipTerr = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -613,7 +613,7 @@ public class WeakAI extends AbstractAI {
       // next take territories with largest PU value
       return ta2.getProduction() - ta1.getProduction();
     });
-    final List<Territory> isWaterTerr = Utils.onlyWaterTerr(data, enemyOwned);
+    final List<Territory> isWaterTerr = Utils.onlyWaterTerr(enemyOwned);
     enemyOwned.removeAll(isWaterTerr);
     // first find the territories we can just walk into
     for (final Territory enemy : enemyOwned) {
@@ -818,7 +818,7 @@ public class WeakAI extends AbstractAI {
     final CompositeMatch<Unit> ourFactories =
         new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitCanProduceUnits);
     final List<Territory> rfactories =
-        Match.getMatches(Utils.findUnitTerr(data, player, ourFactories), Matches.isTerritoryOwnedBy(player));
+        Match.getMatches(Utils.findUnitTerr(data, ourFactories), Matches.isTerritoryOwnedBy(player));
     // figure out if anything needs to be repaired
     if (player.getRepairFrontier() != null
         && games.strategy.triplea.Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {


### PR DESCRIPTION
This PR removes or documents unused method parameters in AI code.

I did not remove the following two unused method parameters for the reasons described below.  @ron-murhammer, if you have any suggestions for how to correctly handle these occurrences, please let me know, and I'll update the PR.  Otherwise, I'm content to just leave them alone for the time being.

#### `ProPurchaseOption#getTransportEfficiency(GameData)`

The `GameData` parameter is unused but cannot be removed because there is already an overload of this method that takes zero parameters.  One of the two methods needs to be renamed, but it wasn't obvious to me a) which one should be renamed, and b) what an appropriate new name would be.

#### `ProLogger#log(Level, String, Throwable)`

The `Throwable` parameter is unused, but I didn't remove it because I'm inclined to believe _something_ should be done with it.  I don't understand the purpose of `ProLogger` and `ProLogUI` enough to know what is appropriate.  I was hesitant to simply dump a stack trace to `ProLogUI`, so I just left the unused parameter intact.