### PR TITLE
Validate YAML files during build (#1728)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ jdk:
 - oraclejdk8
 install: true
 script:
-## validate yamls before we do anything else
-- ruby -e "require 'yaml';puts YAML.load_file('./triplea_maps.yaml')" > /dev/null || exit 1
-- ruby -e "require 'yaml';puts YAML.load_file('./lobby_server.yaml')" > /dev/null || exit 1
-## run the gradle build
 - ./gradlew --no-daemon check
 after_success:
 - chmod +x ./.travis/update_checkstyle_thresholds && ./.travis/update_checkstyle_thresholds

--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,16 @@ plugins {
     id "de.qaware.seu.as.code.git" version "2.2.0"
 }
 
+apply from: 'gradle/scripts/yaml.gradle'
+
 version = System.getenv("TAGGED_VERSION") ?: ""
 group = 'triplea'
 description = 'TripleA is a free online turn based strategy game and board game engine, similar to such board games as Axis & Allies or Risk.'
 mainClassName = "games.strategy.engine.framework.GameRunner"
+
+ext {
+    schemasDir = file('config/triplea/schemas')
+}
 
 compileJava {
     options.encoding = 'UTF-8'
@@ -34,6 +40,10 @@ targetCompatibility = 1.8
 
 tasks.withType(JavaCompile) {
     options.incremental = true
+}
+
+check {
+    dependsOn 'validateYamls'
 }
 
 checkstyle {
@@ -95,6 +105,13 @@ git {
         directory assetsDirectory
         branch 'master'
         singleBranch true
+    }
+}
+
+task validateYamls(group: 'verification', description: 'Validates YAML files.') {
+    doLast {
+        validateYaml(file('lobby_server.yaml'), file("$schemasDir/lobby_server.json"))
+        validateYaml(file('triplea_maps.yaml'), file("$schemasDir/triplea_maps.json"))
     }
 }
 

--- a/config/triplea/schemas/lobby_server.json
+++ b/config/triplea/schemas/lobby_server.json
@@ -30,7 +30,7 @@
       },
       "message": {
         "description": "The message displayed when a user connects to an available lobby server",
-        "type": "string"
+        "type": ["string", "null"]
       },
       "error_message": {
         "description": "The message displayed when a user connects to an unavailable lobby server",

--- a/config/triplea/schemas/lobby_server.json
+++ b/config/triplea/schemas/lobby_server.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Lobby server set",
+  "description": "A set of lobby servers",
+  "type": "array",
+  "items": {
+    "title": "Lobby server",
+    "description": "A lobby server",
+    "type": "object",
+    "properties": {
+      "version": {
+        "description": "The lobby server engine version",
+        "type": "string",
+        "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$"
+      },
+      "host": {
+        "description": "The lobby server host",
+        "type": "string",
+        "anyOf": [
+          { "format": "host-name" },
+          { "format": "ipv4" },
+          { "format": "ipv6" }
+        ]
+      },
+      "port": {
+        "description": "The TCP port on which the lobby server accepts connections",
+        "type": "number",
+        "minimum": 0,
+        "maximum": 65535
+      },
+      "message": {
+        "description": "The message displayed when a user connects to an available lobby server",
+        "type": "string"
+      },
+      "error_message": {
+        "description": "The message displayed when a user connects to an unavailable lobby server",
+        "type": ["string", "null"]
+      }
+    },
+    "required": ["version", "host", "port", "message", "error_message"],
+    "additionalProperties": false
+  }
+}

--- a/config/triplea/schemas/triplea_maps.json
+++ b/config/triplea/schemas/triplea_maps.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Maps set",
+  "description": "A set of maps",
+  "type": "array",
+  "items": {
+    "title": "Map",
+    "description": "A map",
+    "type": "object",
+    "properties": {
+      "mapName": {
+        "description": "The map name",
+        "type": "string"
+      },
+      "mapCategory": {
+        "description": "The map category",
+        "type": "string",
+        "enum": ["BEST", "GOOD", "DEVELOPMENT", "EXPERIMENTAL"]
+      },
+      "mapType": {
+        "description": "The map type",
+        "type": "string",
+        "enum": ["MAP", "MAP_SKIN", "MAP_TOOL"]
+      },
+      "url": {
+        "description": "The map download URL",
+        "type": "string"
+      },
+      "version": {
+        "description": "The map download version",
+        "type": "number",
+        "minimum": 1
+      },
+      "img": {
+        "description": "The map thumbnail image URL",
+        "type": "string"
+      },
+      "description": {
+        "description": "The map description",
+        "type": "string"
+      }
+    },
+    "required": ["mapName", "url", "version", "description"],
+    "additionalProperties": false
+  }
+}

--- a/gradle/scripts/yaml.gradle
+++ b/gradle/scripts/yaml.gradle
@@ -1,0 +1,29 @@
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.github.fge.jsonschema.main.JsonSchemaFactory
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.8.1'
+        classpath group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.8.8'
+        classpath group: 'com.github.fge', name: 'json-schema-validator', version: '2.2.6'
+    }
+}
+
+ext.validateYaml = { yamlFile, jsonSchemaFile ->
+    def yamlMapper = new ObjectMapper(new YAMLFactory())
+    def yaml = yamlMapper.readTree(yamlFile)
+
+    def jsonMapper = new ObjectMapper()
+    def yamlSchema = jsonMapper.readTree(jsonSchemaFile)
+    def schema = JsonSchemaFactory.byDefault().getJsonSchema(yamlSchema)
+
+    def report = schema.validate(yaml, true)
+    if (!report.success) {
+        throw new GradleException("$yamlFile: $report")
+    }
+}


### PR DESCRIPTION
This PR addresses #1728 by not only validating the syntax of all TripleA YAML files, but it also ensures each file's structure does not deviate from its corresponding schema (defined as part of this PR).

#### Functional changes
None.

#### Refactoring changes
None.

#### Other changes
* A new task (`validateYamls`) was added to the Gradle build which validates the syntax and structure of both `lobby_server.yaml` and `triplea_maps.yaml`.  The task runs as part of the `check` task.
* The existing YAML syntax checks run as part of the Travis build were removed.

#### Other issues for review
* Please review both schemas and ensure their constraints are correct.  Did I miss any constraints?  Are any properties over-constrained?  Are any properties under-constrained?  I'll add some additional comments in a forthcoming review.
* I placed the schemas under `config/triplea/schemas`.  Please suggest a better location, if any.
* I placed the YAML validation code in a separate script under `gradle/scripts/yaml.gradle`.  Please suggest a better location, if any.  (I had considered using `scripts/gradle/*` but didn't want to necessarily address moving the existing files under `scripts` into a subfolder as part of this PR.)  I can merge with `build.gradle` if desired, but I always find the additional imports and `buildscript` changes required for a single task/function to be distracting in the context of the entire build script.

#### Testing
I verified the current `lobby_server.yaml` and `triplea_maps.yaml` obey the schemas defined in this PR.

I verified that introducing a schema violation in either file causes the Gradle build to fail.

#### Notes
You'll notice that I've defined the schemas using JSON Schema and am importing the YAML files as JSON.  This is simply so I could implement a pure-Gradle solution without having to resort to calling out to external tools.  I was not able to find a (maintained) YAML schema validator for the JVM.  As there is a one-to-one correspondence between JSON and YAML, it didn't seem like a problem to validate the JSON representation of the YAML files using a JSON schema.  Please advise if my assumption is incorrect or if there is a YAML schema validator for the JVM that I am not aware of.