### PR TITLE
Checkstyle: Fix missing Javadoc violations indirectly (part 2)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=5059
+checkstyleMainMaxWarnings=4997
 checkstyleTestMaxWarnings=136

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -18,9 +18,9 @@ import games.strategy.engine.ClientFileSystemHelper;
  *
  * @see MapDownloadStrategy
  */
-public class DownloadFile {
+class DownloadFile {
 
-  public enum DownloadState {
+  enum DownloadState {
     NOT_STARTED, DOWNLOADING, CANCELLED, DONE
   }
 
@@ -37,19 +37,19 @@ public class DownloadFile {
    * @param progressUpdateListener Called periodically while download progress is made.
    * @param completionListener Called when the File download is complete.
    */
-  public DownloadFile(final DownloadFileDescription download, final Consumer<Integer> progressUpdateListener,
+  DownloadFile(final DownloadFileDescription download, final Consumer<Integer> progressUpdateListener,
       final Runnable completionListener) {
     this(download, progressUpdateListener);
     this.addDownloadCompletedListener(completionListener);
   }
 
-  protected DownloadFile(final DownloadFileDescription download, final Consumer<Integer> progressUpdateListener) {
+  DownloadFile(final DownloadFileDescription download, final Consumer<Integer> progressUpdateListener) {
     this.downloadDescription = download;
     this.progressUpdateListener = progressUpdateListener;
     this.downloadCompletedListeners = new ArrayList<>();
   }
 
-  public void startAsyncDownload() {
+  void startAsyncDownload() {
     final File fileToDownloadTo = ClientFileSystemHelper.createTempFile();
     final FileSizeWatcher watcher = new FileSizeWatcher(fileToDownloadTo, progressUpdateListener);
     addDownloadCompletedListener(() -> watcher.stop());
@@ -95,29 +95,29 @@ public class DownloadFile {
 
   }
 
-  protected DownloadState getDownloadState() {
+  DownloadState getDownloadState() {
     return state;
   }
 
-  public void cancelDownload() {
+  void cancelDownload() {
     if (!isDone()) {
       state = DownloadState.CANCELLED;
     }
   }
 
-  public boolean isDone() {
+  boolean isDone() {
     return state == DownloadState.CANCELLED || state == DownloadState.DONE;
   }
 
-  public boolean isInProgress() {
+  boolean isInProgress() {
     return state == DownloadState.DOWNLOADING;
   }
 
-  public boolean isWaiting() {
+  boolean isWaiting() {
     return state == DownloadState.NOT_STARTED;
   }
 
-  public void addDownloadCompletedListener(final Runnable listener) {
+  void addDownloadCompletedListener(final Runnable listener) {
     downloadCompletedListeners.add(listener);
   }
 }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -13,7 +13,7 @@ import games.strategy.util.Version;
  * This class represents the essential data for downloading a TripleA map. Where to get it, where to install it,
  * version, etc..
  */
-public class DownloadFileDescription {
+class DownloadFileDescription {
   private final String url;
   private final String description;
   private final String mapName;
@@ -23,12 +23,12 @@ public class DownloadFileDescription {
   private final String img;
 
 
-  public enum DownloadType {
+  enum DownloadType {
     MAP, MAP_SKIN, MAP_TOOL
   }
 
 
-  public enum MapCategory {
+  enum MapCategory {
     BEST("High Quality"),
     GOOD("Good Quality"),
     DEVELOPMENT("In Development"),
@@ -48,12 +48,12 @@ public class DownloadFileDescription {
 
   }
 
-  public DownloadFileDescription(final String url, final String description, final String mapName,
+  DownloadFileDescription(final String url, final String description, final String mapName,
       final Version version, final DownloadType downloadType, final MapCategory mapCategory) {
     this(url,description, mapName, version, downloadType, mapCategory, "");
   }
 
-  public DownloadFileDescription(final String url, final String description, final String mapName,
+  DownloadFileDescription(final String url, final String description, final String mapName,
       final Version version, final DownloadType downloadType, final MapCategory mapCategory, final String img) {
     this.url = url;
     this.description = description;
@@ -64,49 +64,49 @@ public class DownloadFileDescription {
     this.img = img;
   }
 
-  public String getUrl() {
+  String getUrl() {
     return url;
   }
 
-  public String getDescription() {
+  String getDescription() {
     return description;
   }
 
-  public String getMapName() {
+  String getMapName() {
     return mapName;
   }
 
-  public Version getVersion() {
+  Version getVersion() {
     return version;
   }
 
-  public MapCategory getMapCategory() {
+  MapCategory getMapCategory() {
     return mapCategory;
   }
 
-  public URL newURL() {
+  URL newURL() {
     if (url == null) {
       return null;
     }
     return DownloadUtils.toURL(url);
   }
 
-  public boolean isMap() {
+  boolean isMap() {
     return downloadType == DownloadType.MAP;
   }
 
-  public boolean isMapSkin() {
+  boolean isMapSkin() {
     return downloadType == DownloadType.MAP_SKIN;
   }
 
-  public boolean isMapTool() {
+  boolean isMapTool() {
     return downloadType == DownloadType.MAP_TOOL;
   }
 
   /**
    * @return Name of the zip file.
    */
-  public String getMapZipFileName() {
+  String getMapZipFileName() {
     if (url != null && url.contains("/")) {
       return url.substring(url.lastIndexOf('/') + 1, url.length());
     } else {
@@ -115,7 +115,7 @@ public class DownloadFileDescription {
   }
 
   /** Translates the stored URL into a github new issue link. */
-  public String getFeedbackUrl() {
+  String getFeedbackUrl() {
     if (url.contains("github.com") && url.contains("/releases/")) {
       return url.substring(0, url.indexOf("/releases/")) + "/issues/new";
     } else {
@@ -124,7 +124,7 @@ public class DownloadFileDescription {
   }
 
   /** File reference for where to install the file. */
-  public File getInstallLocation() {
+  File getInstallLocation() {
     String masterSuffix = (getMapZipFileName().toLowerCase().endsWith("master.zip")) ? "-master" : "";
     String normalizedMapName = getMapName().toLowerCase().replace(' ', '_') + masterSuffix + ".zip";
     return new File(ClientFileSystemHelper.getUserMapsFolder() + File.separator + normalizedMapName);
@@ -135,7 +135,7 @@ public class DownloadFileDescription {
     return MoreObjects.toStringHelper(this).addValue(url).addValue(mapName).addValue(version).toString();
   }
 
-  public String toHtmlString() {
+  String toHtmlString() {
     String text = "<h1>" + getMapName() + "</h1>\n";
     if (!img.isEmpty()) {
       text += "<img src='" + img + "' />\n";

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
@@ -12,11 +12,11 @@ import games.strategy.engine.ClientContext;
 import games.strategy.util.Version;
 
 /** Properties file used to know which map versions have been installed. */
-public class DownloadFileProperties {
-  protected static final String VERSION_PROPERTY = "map.version";
+class DownloadFileProperties {
+  static final String VERSION_PROPERTY = "map.version";
   private final Properties props = new Properties();
 
-  public static DownloadFileProperties loadForZip(final File zipFile) {
+  static DownloadFileProperties loadForZip(final File zipFile) {
     if (!fromZip(zipFile).exists()) {
       return new DownloadFileProperties();
     }
@@ -29,7 +29,7 @@ public class DownloadFileProperties {
     return rVal;
   }
 
-  public static void saveForZip(final File zipFile, final DownloadFileProperties props) {
+  static void saveForZip(final File zipFile, final DownloadFileProperties props) {
     try (final FileOutputStream fos = new FileOutputStream(fromZip(zipFile))) {
       props.props.store(fos, null);
     } catch (final IOException e) {
@@ -37,13 +37,13 @@ public class DownloadFileProperties {
     }
   }
 
-  public DownloadFileProperties() {}
+  DownloadFileProperties() {}
 
   private static File fromZip(final File zipFile) {
     return new File(zipFile.getAbsolutePath() + ".properties");
   }
 
-  public Version getVersion() {
+  Version getVersion() {
     if (!props.containsKey(VERSION_PROPERTY)) {
       return null;
     }
@@ -56,7 +56,7 @@ public class DownloadFileProperties {
     }
   }
 
-  public void setFrom(final DownloadFileDescription selected) {
+  void setFrom(final DownloadFileDescription selected) {
     setVersion(selected.getVersion());
     props.setProperty("map.url", selected.getUrl());
     props.setProperty("download.time", new Date().toString());

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -54,7 +54,7 @@ public class DownloadUtils {
     }
   }
 
-  public static URL toURL(String url) {
+  static URL toURL(String url) {
     try {
       return new URL(url);
     } catch (MalformedURLException e) {
@@ -62,7 +62,7 @@ public class DownloadUtils {
     }
   }
 
-  public static void downloadFile(URL url, File targetFile) throws IOException {
+  static void downloadFile(URL url, File targetFile) throws IOException {
     FileOutputStream fos = new FileOutputStream(targetFile);
     url = getUrlFollowingRedirects(url);
     ReadableByteChannel rbc = Channels.newChannel(url.openStream());

--- a/src/main/java/games/strategy/engine/framework/map/download/FileSizeWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FileSizeWatcher.java
@@ -10,19 +10,19 @@ import games.strategy.util.ThreadUtil;
  * the file is polled in a new thread for its file size which is then passed to the
  * consumer.
  */
-public class FileSizeWatcher {
+class FileSizeWatcher {
 
   private final File fileToWatch;
   private final Consumer<Integer> progressListener;
   private boolean stop = false;
 
-  public FileSizeWatcher(final File fileToWatch, final Consumer<Integer> progressListener) {
+  FileSizeWatcher(final File fileToWatch, final Consumer<Integer> progressListener) {
     this.fileToWatch = fileToWatch;
     this.progressListener = progressListener;
     (new Thread(createRunner())).start();
   }
 
-  public void stop() {
+  void stop() {
     stop = true;
   }
 

--- a/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -15,11 +15,11 @@ import games.strategy.ui.SwingComponents;
 import games.strategy.util.ThreadUtil;
 import games.strategy.util.Version;
 
-public class FileSystemAccessStrategy {
+class FileSystemAccessStrategy {
 
-  public FileSystemAccessStrategy() {}
+  FileSystemAccessStrategy() {}
 
-  public Optional<Version> getMapVersion(final String mapName) {
+  Optional<Version> getMapVersion(final String mapName) {
     final File potentialFile = new File(mapName);
 
     if (!potentialFile.exists()) {
@@ -34,7 +34,7 @@ public class FileSystemAccessStrategy {
     }
   }
 
-  public static void remove(final List<DownloadFileDescription> toRemove, final DefaultListModel<String> listModel) {
+  static void remove(final List<DownloadFileDescription> toRemove, final DefaultListModel<String> listModel) {
     SwingComponents.promptUser("Remove Maps?",
         "<html>Will remove " + toRemove.size() + " maps, are you sure? <br/>"
             + formatMapList(toRemove, map -> map.getMapName()) + "</html>",

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
@@ -6,13 +6,13 @@ import java.util.Optional;
 
 import games.strategy.util.Version;
 
-public class MapDownloadList {
+class MapDownloadList {
 
   private final List<DownloadFileDescription> available = new ArrayList<>();
   private final List<DownloadFileDescription> installed = new ArrayList<>();
   private final List<DownloadFileDescription> outOfDate = new ArrayList<>();
 
-  public MapDownloadList(final List<DownloadFileDescription> downloads, final FileSystemAccessStrategy strategy) {
+  MapDownloadList(final List<DownloadFileDescription> downloads, final FileSystemAccessStrategy strategy) {
     for (final DownloadFileDescription download : downloads) {
       if (download == null) {
         return;
@@ -30,15 +30,15 @@ public class MapDownloadList {
     }
   }
 
-  public List<DownloadFileDescription> getAvailable() {
+  List<DownloadFileDescription> getAvailable() {
     return available;
   }
 
-  public List<DownloadFileDescription> getInstalled() {
+  List<DownloadFileDescription> getInstalled() {
     return installed;
   }
 
-  public List<DownloadFileDescription> getOutOfDate() {
+  List<DownloadFileDescription> getOutOfDate() {
     return outOfDate;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressPanel.java
@@ -18,7 +18,7 @@ import games.strategy.ui.SwingComponents;
 
 
 /** A small non-modal window that holds the progress bars for the current and pending map downloads. */
-public final class MapDownloadProgressPanel extends JPanel {
+final class MapDownloadProgressPanel extends JPanel {
 
   private static final long serialVersionUID = -7288639737337542689L;
 
@@ -35,19 +35,15 @@ public final class MapDownloadProgressPanel extends JPanel {
   private final Map<DownloadFileDescription, JLabel> labels = Maps.newHashMap();
   private final Map<DownloadFileDescription, JProgressBar> progressBars = Maps.newHashMap();
 
-
-
-  public MapDownloadProgressPanel(final JFrame parent) {
+  MapDownloadProgressPanel(final JFrame parent) {
     downloadCoordinator = new DownloadCoordinator();
   }
 
-
-  public void cancel() {
+  void cancel() {
     downloadCoordinator.cancelDownloads();
   }
 
-
-  public void download(List<DownloadFileDescription> newDownloads) {
+  void download(List<DownloadFileDescription> newDownloads) {
     final List<DownloadFileDescription> brandNewDownloads = new ArrayList<>();
     for (final DownloadFileDescription download : newDownloads) {
       if (!downloadList.contains(download) && !download.getMapName().isEmpty()) {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -128,7 +128,7 @@ public class ClientModel implements IMessengerErrorListener {
     return props;
   }
 
-  public boolean createClientMessenger(Component ui) {
+  boolean createClientMessenger(Component ui) {
     m_gameDataOnStartup = m_gameSelectorModel.getGameData();
     m_gameSelectorModel.setCanSelect(false);
     ui = JOptionPane.getFrameForComponent(ui);
@@ -196,7 +196,7 @@ public class ClientModel implements IMessengerErrorListener {
     return (IServerStartupRemote) m_remoteMessenger.getRemote(ServerModel.SERVER_REMOTE_NAME);
   }
 
-  public List<String> getAvailableServerGames() {
+  List<String> getAvailableServerGames() {
     final Set<String> games = getServerStartup().getAvailableGames();
     if (games == null) {
       return new ArrayList<>();
@@ -423,7 +423,7 @@ public class ClientModel implements IMessengerErrorListener {
     return m_chatPanel;
   }
 
-  public boolean getIsServerHeadlessTest() {
+  boolean getIsServerHeadlessTest() {
     final IServerStartupRemote serverRemote = getServerStartup();
     if (serverRemote != null) {
       m_hostIsHeadlessBot = serverRemote.getIsServerHeadless();

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -163,7 +163,7 @@ public class GameSelectorModel extends Observable {
     return m_data;
   }
 
-  public void setCanSelect(final boolean aBool) {
+  void setCanSelect(final boolean aBool) {
     synchronized (this) {
       m_canSelect = aBool;
     }
@@ -174,7 +174,7 @@ public class GameSelectorModel extends Observable {
     return m_canSelect;
   }
 
-  public void setIsHostHeadlessBot(final boolean aBool) {
+  void setIsHostHeadlessBot(final boolean aBool) {
     synchronized (this) {
       m_isHostHeadlessBot = aBool;
     }
@@ -185,7 +185,7 @@ public class GameSelectorModel extends Observable {
     return m_isHostHeadlessBot;
   }
 
-  public void setClientModelForHostBots(final ClientModel clientModel) {
+  void setClientModelForHostBots(final ClientModel clientModel) {
     synchronized (this) {
       m_clientModelForHostBots = clientModel;
     }
@@ -229,7 +229,7 @@ public class GameSelectorModel extends Observable {
     return m_gameVersion;
   }
 
-  public void setGameData(final GameData data) {
+  void setGameData(final GameData data) {
     synchronized (this) {
       if (data == null) {
         m_gameName = m_gameRound = m_gameVersion = "-";

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -603,7 +603,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     return chatPanel;
   }
 
-  public void disallowRemoveConnections() {
+  private void disallowRemoveConnections() {
     while (removeConnectionsLatch != null && removeConnectionsLatch.getCount() > 0) {
       removeConnectionsLatch.countDown();
     }
@@ -617,7 +617,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
     removeConnectionsLatch = null;
   }
 
-  public Map<String, String> getLocalPlayerTypes() {
+  private Map<String, String> getLocalPlayerTypes() {
     final Map<String, String> localPlayerMappings = new HashMap<>();
     if (data == null) {
       return localPlayerMappings;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -50,7 +50,7 @@ import tools.map.xml.creator.MapXmlCreator;
 /**
  * Class for holding various engine related options and preferences.
  */
-public class EnginePreferences extends JDialog {
+class EnginePreferences extends JDialog {
   private static final long serialVersionUID = 5071190543005064757L;
   private final Frame m_parentFrame;
   private JButton m_okButton;
@@ -368,7 +368,7 @@ public class EnginePreferences extends JDialog {
 
   private void setWidgetActivation() {}
 
-  public static void showEnginePreferences(final JComponent parent) {
+  static void showEnginePreferences(final JComponent parent) {
     final Frame parentFrame = JOptionPane.getFrameForComponent(parent);
     final EnginePreferences enginePrefs = new EnginePreferences(parentFrame);
     enginePrefs.pack();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -60,7 +60,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
   private final IGamePropertiesCache m_gamePropertiesCache = new FileBackedGamePropertiesCache();
   private final Map<String, Object> m_originalPropertiesMap = new HashMap<>();
 
-  public GameSelectorPanel(final GameSelectorModel model) {
+  GameSelectorPanel(final GameSelectorModel model) {
     m_model = model;
     m_model.addObserver(this);
     final GameData data = model.getGameData();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -130,7 +130,7 @@ public class InGameLobbyWatcher {
     return name;
   }
 
-  public void setGame(final IGame game) {
+  void setGame(final IGame game) {
     if (m_game != null) {
       m_game.removeGameStepListener(m_gameStepListener);
     }
@@ -158,7 +158,7 @@ public class InGameLobbyWatcher {
     }
   }
 
-  public InGameLobbyWatcher(final IMessenger messenger, final IRemoteMessenger remoteMessenger,
+  InGameLobbyWatcher(final IMessenger messenger, final IRemoteMessenger remoteMessenger,
       final IServerMessenger serverMessenger, final JComponent parent, final InGameLobbyWatcher oldWatcher) {
     m_messenger = messenger;
     m_remoteMessenger = remoteMessenger;
@@ -261,7 +261,7 @@ public class InGameLobbyWatcher {
     new Thread(r).start();
   }
 
-  public void setGameSelectorModel(final GameSelectorModel model) {
+  void setGameSelectorModel(final GameSelectorModel model) {
     cleanUpGameModelListener();
     if (model != null) {
       m_gameSelectorModel = model;
@@ -294,7 +294,7 @@ public class InGameLobbyWatcher {
     }
   }
 
-  public void shutDown() {
+  void shutDown() {
     m_shutdown = true;
     m_messenger.removeErrorListener(m_messengerErrorListener);
     m_messenger.shutDown();
@@ -309,7 +309,7 @@ public class InGameLobbyWatcher {
     return !m_shutdown;
   }
 
-  public void setGameStatus(final GameDescription.GameStatus status, final IGame game) {
+  void setGameStatus(final GameDescription.GameStatus status, final IGame game) {
     synchronized (m_mutex) {
       m_gameDescription.setStatus(status);
       if (game == null) {
@@ -330,14 +330,14 @@ public class InGameLobbyWatcher {
     return m_gameDescription;
   }
 
-  public void setGameComments(final String comments) {
+  void setGameComments(final String comments) {
     synchronized (m_mutex) {
       m_gameDescription.setComment(comments);
       postUpdate();
     }
   }
 
-  public void setPassworded(final boolean passworded) {
+  void setPassworded(final boolean passworded) {
     synchronized (m_mutex) {
       m_gameDescription.setPassworded(passworded);
       postUpdate();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherWrapper.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherWrapper.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework.startup.ui;
 
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
-import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.lobby.server.GameDescription.GameStatus;
 
 public class InGameLobbyWatcherWrapper {
@@ -30,12 +29,6 @@ public class InGameLobbyWatcherWrapper {
     return lobbyWatcher == null ? "" : lobbyWatcher.getComments();
   }
 
-  public void setGame(final IGame game) {
-    if (lobbyWatcher != null) {
-      lobbyWatcher.setGame(game);
-    }
-  }
-
   public void setGameComments(final String comments) {
     if (lobbyWatcher != null) {
       lobbyWatcher.setGameComments(comments);
@@ -58,12 +51,5 @@ public class InGameLobbyWatcherWrapper {
     if (lobbyWatcher != null) {
       lobbyWatcher.setPassworded(passworded);
     }
-  }
-
-  public GameDescription getGameDescription() {
-    if (lobbyWatcher != null) {
-      return lobbyWatcher.getGameDescription();
-    }
-    return null;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -146,15 +146,6 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     layoutComponents();
   }
 
-  public String getPlayerType(final String playerName) {
-    for (final LocalPlayerComboBoxSelector item : m_playerTypes) {
-      if (item.getPlayerName().equals(playerName)) {
-        return item.getPlayerType();
-      }
-    }
-    throw new IllegalStateException("No player found:" + playerName);
-  }
-
   @Override
   public ILauncher getLauncher() {
     final IRandomSource randomSource = new PlainRandomSource();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/MainPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/MainPanel.java
@@ -34,7 +34,7 @@ import games.strategy.engine.framework.startup.mc.SetupPanelModel;
  * until a new game has been started (TODO: check if the lobby
  * uses mainpanel at all)
  */
-public class MainPanel extends JPanel implements Observer {
+class MainPanel extends JPanel implements Observer {
   private static final long serialVersionUID = -5548760379892913464L;
   private static final Dimension initialSize = new Dimension(800, 620);
 
@@ -49,7 +49,7 @@ public class MainPanel extends JPanel implements Observer {
 
   private boolean isChatShowing;
 
-  public MainPanel(final SetupPanelModel typePanelModel) {
+  MainPanel(final SetupPanelModel typePanelModel) {
     gameTypePanelModel = typePanelModel;
     final GameSelectorModel gameSelectorModel = typePanelModel.getGameSelectorModel();
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -431,15 +431,6 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     }
   }
 
-  public String getPlayerType(final String playerName) {
-    for (final PBEMLocalPlayerComboBoxSelector item : m_playerTypes) {
-      if (item.getPlayerName().equals(playerName)) {
-        return item.getPlayerType();
-      }
-    }
-    throw new IllegalStateException("No player found:" + playerName);
-  }
-
   private void layoutPlayerPanel(final SetupPanel parent) {
     final GameData data = m_gameSelectorModel.getGameData();
     m_localPlayerPanel.removeAll();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -71,7 +71,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     internalPlayerListChanged();
   }
 
-  public void createLobbyWatcher() {
+  void createLobbyWatcher() {
     if (m_lobbyWatcher != null) {
       m_lobbyWatcher.setInGameLobbyWatcher(InGameLobbyWatcher.newInGameLobbyWatcher(m_model.getMessenger(), this,
           m_lobbyWatcher.getInGameLobbyWatcher()));
@@ -93,7 +93,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     createLobbyWatcher();
   }
 
-  public void shutDownLobbyWatcher() {
+  void shutDownLobbyWatcher() {
     if (m_lobbyWatcher != null) {
       m_lobbyWatcher.shutDown();
     }

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -25,8 +25,7 @@ public class NewGameChooserEntry {
   private boolean gameDataFullyLoaded = false;
   private final String gameNameAndMapNameProperty;
 
-
-  public static Comparator<NewGameChooserEntry> getComparator() {
+  static Comparator<NewGameChooserEntry> getComparator() {
     return new Comparator<NewGameChooserEntry>() {
       @Override
       public int compare(final NewGameChooserEntry o1, final NewGameChooserEntry o2) {

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooserModel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooserModel.java
@@ -39,8 +39,7 @@ public class NewGameChooserModel extends DefaultListModel<NewGameChooserEntry> {
     SUCCESS, ERROR
   }
 
-
-  public NewGameChooserModel() {
+  NewGameChooserModel() {
     final Set<NewGameChooserEntry> parsedMapSet = parseMapFiles();
 
     final List<NewGameChooserEntry> entries = new ArrayList<>(parsedMapSet);

--- a/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -60,7 +60,7 @@ public class SaveGameFileChooser extends JFileChooser {
     return s_instance;
   }
 
-  public SaveGameFileChooser() {
+  private SaveGameFileChooser() {
     super();
     setFileFilter(m_gameDataFileFilter);
     ensureMapsFolderExists();

--- a/src/main/java/games/strategy/engine/framework/ui/background/WaitPanel.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/WaitPanel.java
@@ -7,10 +7,10 @@ import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.border.EmptyBorder;
 
-public class WaitPanel extends JPanel {
+class WaitPanel extends JPanel {
   private static final long serialVersionUID = -8625021554802312498L;
 
-  public WaitPanel(final String waitMessage) {
+  WaitPanel(final String waitMessage) {
     setLayout(new BorderLayout());
     final JLabel label = new JLabel(waitMessage);
     label.setBorder(new EmptyBorder(10, 10, 10, 10));

--- a/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
@@ -29,16 +29,16 @@ import games.strategy.engine.lobby.server.userDB.DBUserController;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
 
-public class LoginPanel extends JPanel {
+class LoginPanel extends JPanel {
   private static final long serialVersionUID = -1115199161238394717L;
   private static final Logger s_logger = Logger.getLogger(LoginPanel.class.getName());
 
-  public static enum ReturnValue {
+  static enum ReturnValue {
     CANCEL, LOGON, CREATE_ACCOUNT
   }
 
-  public static final String LAST_LOGIN_NAME_PREF = "LAST_LOGIN_NAME_PREF";
-  public static final String ANONYMOUS_LOGIN_PREF = "ANONYMOUS_LOGIN_PREF";
+  static final String LAST_LOGIN_NAME_PREF = "LAST_LOGIN_NAME_PREF";
+  static final String ANONYMOUS_LOGIN_PREF = "ANONYMOUS_LOGIN_PREF";
   private JDialog m_dialog;
   private JPasswordField m_password;
   private JTextField m_userName;
@@ -48,7 +48,7 @@ public class LoginPanel extends JPanel {
   private JButton m_logon;
   private JButton m_cancel;
 
-  public LoginPanel() {
+  LoginPanel() {
     createComponents();
     layoutComponents();
     setupListeners();
@@ -142,7 +142,7 @@ public class LoginPanel extends JPanel {
     m_dialog.setVisible(false);
   }
 
-  public static void storePrefs(final String userName, final boolean anonymous) {
+  static void storePrefs(final String userName, final boolean anonymous) {
     final Preferences prefs = Preferences.userNodeForPackage(LoginPanel.class);
     prefs.put(LAST_LOGIN_NAME_PREF, userName);
     prefs.putBoolean(ANONYMOUS_LOGIN_PREF, anonymous);
@@ -164,19 +164,19 @@ public class LoginPanel extends JPanel {
     }
   }
 
-  public boolean isAnonymous() {
+  boolean isAnonymous() {
     return m_anonymous.isSelected();
   }
 
-  public String getUserName() {
+  String getUserName() {
     return m_userName.getText();
   }
 
-  public String getPassword() {
+  String getPassword() {
     return new String(m_password.getPassword());
   }
 
-  public ReturnValue show(final Window parent) {
+  ReturnValue show(final Window parent) {
     m_dialog = new JDialog(JOptionPane.getFrameForComponent(parent), "Login", true);
     m_dialog.getContentPane().add(this);
     m_dialog.pack();

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -38,7 +38,7 @@ import games.strategy.net.Node;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.MD5Crypt;
 
-public class LobbyGamePanel extends JPanel {
+class LobbyGamePanel extends JPanel {
   private static final long serialVersionUID = -2576314388949606337L;
   private JButton m_hostGame;
   private JButton m_joinGame;
@@ -48,7 +48,7 @@ public class LobbyGamePanel extends JPanel {
   private JTable m_gameTable;
   private TableSorter m_tableSorter;
 
-  public LobbyGamePanel(final Messengers messengers) {
+  LobbyGamePanel(final Messengers messengers) {
     m_messengers = messengers;
     createComponents();
     layoutComponents();
@@ -123,7 +123,7 @@ public class LobbyGamePanel extends JPanel {
     add(toolBar, BorderLayout.SOUTH);
   }
 
-  public boolean isAdmin() {
+  boolean isAdmin() {
     return ((IModeratorController) m_messengers.getRemoteMessenger()
         .getRemote(AbstractModeratorController.getModeratorControllerName())).isAdmin();
   }

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTable.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTable.java
@@ -12,14 +12,14 @@ import javax.swing.table.TableModel;
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.net.GUID;
 
-public class LobbyGameTable extends JTable {
+class LobbyGameTable extends JTable {
   private static final long serialVersionUID = 8632519876114231003L;
   private GUID m_selectedGame;
   private boolean inTableChange = false;
   private final Font m_defaultFont = UIManager.getDefaults().getFont("Table.font");
   private final Font m_italicFont = new Font(m_defaultFont.getFamily(), Font.ITALIC, m_defaultFont.getSize());
 
-  public LobbyGameTable(final TableModel model) {
+  LobbyGameTable(final TableModel model) {
     super(model);
     getSelectionModel().addListSelectionListener(e -> {
       if (!inTableChange) {

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -18,7 +18,7 @@ import games.strategy.net.GUID;
 import games.strategy.net.IMessenger;
 import games.strategy.util.Tuple;
 
-public class LobbyGameTableModel extends AbstractTableModel {
+class LobbyGameTableModel extends AbstractTableModel {
   private static final long serialVersionUID = 6399458368730633993L;
 
   enum Column {
@@ -31,7 +31,7 @@ public class LobbyGameTableModel extends AbstractTableModel {
   private final List<Tuple<GUID, GameDescription>> gameList;
   private final ILobbyGameBroadcaster lobbyGameBroadcaster;
 
-  public LobbyGameTableModel(final IMessenger messenger, final IChannelMessenger channelMessenger,
+  LobbyGameTableModel(final IMessenger messenger, final IChannelMessenger channelMessenger,
       final IRemoteMessenger remoteMessenger) {
 
     gameList = new ArrayList<>();
@@ -90,7 +90,7 @@ public class LobbyGameTableModel extends AbstractTableModel {
     return lobbyGameBroadcaster;
   }
 
-  public GameDescription get(final int i) {
+  GameDescription get(final int i) {
     return gameList.get(i).getSecond();
   }
 
@@ -130,7 +130,7 @@ public class LobbyGameTableModel extends AbstractTableModel {
     return Column.values()[column].toString();
   }
 
-  public int getColumnIndex(final Column column) {
+  int getColumnIndex(final Column column) {
     return column.ordinal();
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
@@ -19,13 +19,13 @@ import games.strategy.net.IMessenger;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 
-public class LobbyGameController implements ILobbyGameController {
+class LobbyGameController implements ILobbyGameController {
   private static final Logger s_logger = Logger.getLogger(LobbyGameController.class.getName());
   private final Object m_mutex = new Object();
   private final Map<GUID, GameDescription> m_allGames = new HashMap<>();
   private final ILobbyGameBroadcaster m_broadcaster;
 
-  public LobbyGameController(final ILobbyGameBroadcaster broadcaster, final IMessenger messenger) {
+  LobbyGameController(final ILobbyGameBroadcaster broadcaster, final IMessenger messenger) {
     m_broadcaster = broadcaster;
     final IMessenger m_messenger = messenger;
     ((IServerMessenger) m_messenger).addConnectionChangeListener(new IConnectionChangeListener() {
@@ -105,7 +105,7 @@ public class LobbyGameController implements ILobbyGameController {
     }
   }
 
-  public void register(final IRemoteMessenger remote) {
+  void register(final IRemoteMessenger remote) {
     remote.registerRemote(this, GAME_CONTROLLER_REMOTE);
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/BadWordController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/BadWordController.java
@@ -38,7 +38,7 @@ public class BadWordController {
     }
   }
 
-  public void removeBannedWord(final String word) {
+  void removeBannedWord(final String word) {
     s_logger.fine("Removing banned word:" + word);
     final Connection con = Database.getConnection();
     try {

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/BannedMacController.java
@@ -62,7 +62,7 @@ public class BannedMacController {
     }
   }
 
-  public void removeBannedMac(final String mac) {
+  private void removeBannedMac(final String mac) {
     s_logger.fine("Removing banned mac:" + mac);
     final Connection con = Database.getConnection();
     try {

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/BannedUsernameController.java
@@ -63,7 +63,7 @@ public class BannedUsernameController {
     }
   }
 
-  public void removeBannedUsername(final String username) {
+  private void removeBannedUsername(final String username) {
     s_logger.fine("Removing banned username:" + username);
     final Connection con = Database.getConnection();
     try {

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
@@ -219,7 +219,7 @@ public class Database {
     return props;
   }
 
-  public static void backup() {
+  static void backup() {
     final String backupDirName =
         "backup_at_" + new SimpleDateFormat("yyyy_MM_dd__kk_mm_ss").format(new java.util.Date());
     final File backupRootDir = getBackupDir();

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/DbUtil.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/DbUtil.java
@@ -5,10 +5,10 @@ import java.sql.SQLException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class DbUtil {
+class DbUtil {
   private static final Logger s_logger = Logger.getLogger(DbUtil.class.getName());
 
-  public static void closeConnection(final Connection con) {
+  static void closeConnection(final Connection con) {
     try {
       con.close();
     } catch (final SQLException e) {

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/MutedMacController.java
@@ -5,9 +5,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -62,7 +60,7 @@ public class MutedMacController {
     }
   }
 
-  public void removeMutedMac(final String mac) {
+  private void removeMutedMac(final String mac) {
     s_logger.fine("Removing muted mac:" + mac);
     final Connection con = Database.getConnection();
     try {
@@ -123,40 +121,5 @@ public class MutedMacController {
       result = -1;
     }
     return result;
-  }
-
-  public List<String> getMacsThatAreStillMuted(final List<String> macs) {
-    final List<String> results = new ArrayList<>();
-    final String sql = "select mac, mute_till from muted_macs where mac = ?";
-    final Connection con = Database.getConnection();
-    try {
-      for (final String mac : macs) {
-        boolean found = false;
-        boolean expired = false;
-        final PreparedStatement ps = con.prepareStatement(sql);
-        ps.setString(1, mac);
-        final ResultSet rs = ps.executeQuery();
-        found = rs.next();
-        // If the mute has expired, allow the mac
-        if (found) {
-          final Timestamp muteTill = rs.getTimestamp(2);
-          if (muteTill != null && muteTill.getTime() < System.currentTimeMillis()) {
-            s_logger.fine("Mute expired for: " + mac);
-            expired = true;
-          }
-        }
-        rs.close();
-        ps.close();
-        if (found && !expired) {
-          results.add(mac);
-        }
-      }
-    } catch (final SQLException sqle) {
-      s_logger.info("Error testing whether macs were muted: " + macs);
-      throw new IllegalStateException(sqle.getMessage());
-    } finally {
-      DbUtil.closeConnection(con);
-    }
-    return results;
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/MutedUsernameController.java
@@ -5,9 +5,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -63,7 +61,7 @@ public class MutedUsernameController {
     }
   }
 
-  public void removeMutedUsername(final String username) {
+  private void removeMutedUsername(final String username) {
     s_logger.fine("Removing muted username:" + username);
     final Connection con = Database.getConnection();
     try {
@@ -124,40 +122,5 @@ public class MutedUsernameController {
       result = -1;
     }
     return result;
-  }
-
-  public List<String> getUsernamesThatAreStillMuted(final List<String> usernames) {
-    final List<String> results = new ArrayList<>();
-    final String sql = "select username, mute_till from muted_usernames where username = ?";
-    final Connection con = Database.getConnection();
-    try {
-      for (final String username : usernames) {
-        boolean found = false;
-        boolean expired = false;
-        final PreparedStatement ps = con.prepareStatement(sql);
-        ps.setString(1, username);
-        final ResultSet rs = ps.executeQuery();
-        found = rs.next();
-        // If the mute has expired, allow the username
-        if (found) {
-          final Timestamp muteTill = rs.getTimestamp(2);
-          if (muteTill != null && muteTill.getTime() < System.currentTimeMillis()) {
-            s_logger.fine("Mute expired for: " + username);
-            expired = true;
-          }
-        }
-        rs.close();
-        ps.close();
-        if (found && !expired) {
-          results.add(username);
-        }
-      }
-    } catch (final SQLException sqle) {
-      s_logger.info("Error testing whether usernames were muted: " + usernames);
-      throw new IllegalStateException(sqle.getMessage());
-    } finally {
-      DbUtil.closeConnection(con);
-    }
-    return results;
   }
 }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle JavadocMethod rule.

The violations were fixed indirectly by either:

1. reducing the accessibility of the method from public to non-public if it was not used outside its package, or
1. removing the method if it was unused.

I purposefully avoided applying this technique to any method that may possibly be accessed via reflection (e.g. serialization and game XML parsing).  Please scrutinize the changes for any I may have mistakenly made that could break reflection as used by TripleA.

Due to the large number of violations that can be fixed using this technique, the fixes are being split over multiple PRs to keep the review size reasonable.

⚠️ Some changes in this PR **may** conflict with #1730 depending on its final state.  If #1730 looks like it will be merged relatively quickly, please merge it before this one, as the conflicts will be easier to fix on this branch.