### PR TITLE
Checkstyle: Update thresholds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=4997
-checkstyleTestMaxWarnings=136
+checkstyleMainMaxWarnings=4985
+checkstyleTestMaxWarnings=135


### PR DESCRIPTION
As discussed in #1700, the script that automatically updates the Checkstyle thresholds after each build is failing, and the Checkstyle thresholds have since diverged from the actual violation counts.  This PR simply resets the thresholds to the current violation counts on `master`.