### PR TITLE
Checkstyle: Fix recent regressions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=4997
-checkstyleTestMaxWarnings=136
+checkstyleMainMaxWarnings=4979
+checkstyleTestMaxWarnings=135

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -434,7 +434,7 @@ public class ServerGame extends AbstractGame {
     }
     if (autoSaveThisDelegate && !currentStep.getName().endsWith("Move")) {
       final String typeName = currentDelegate.getClass().getTypeName();
-      final String phaseName = typeName.substring(typeName.lastIndexOf('.')+1).replaceFirst("Delegate$","");
+      final String phaseName = typeName.substring(typeName.lastIndexOf('.') + 1).replaceFirst("Delegate$", "");
       autoSave("autosaveAfter" + phaseName.substring(0,1).toUpperCase() + phaseName.substring(1) + ".tsvg");
     }
   }

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -51,7 +51,6 @@ import games.strategy.engine.random.RandomStats;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
 import games.strategy.triplea.TripleAPlayer;
-import games.strategy.triplea.delegate.MoveDelegate;
 
 /**
  * Represents a running game.

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/DbUser.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/DbUser.java
@@ -10,7 +10,7 @@ public class DbUser {
   private final Date joined;
 
   /**
-   * All-arg value object constructor
+   * All-arg value object constructor.
    */
   public DbUser(final String name, final String email, final boolean isAdmin, final Date lastLogin, final Date joined) {
     this.name = name;

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/UserDao.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/UserDao.java
@@ -19,7 +19,7 @@ public interface UserDao {
   }
 
   /**
-   * @return null if user name is valid, otherwise returns an error message
+   * @return null if user name is valid, otherwise returns an error message.
    */
   static String validateUserName(String userName) {
     // is this a valid user?

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/UserDaoPrimarySecondary.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/UserDaoPrimarySecondary.java
@@ -3,10 +3,11 @@ package games.strategy.engine.lobby.server.userDB;
 /**
  * Allows for configuration flagging of multiple UserDao instances.
  *
- *
+ * <p>
  * to exist side by side, one in
  * primary mode, and zero or many in secondary mode. This config is intended for writes
  * to go to the primary and all secondarys, and reads to come from primary.
+ * </p>
  */
 public interface UserDaoPrimarySecondary extends UserDao {
   /**


### PR DESCRIPTION
As discussed in #1700, the script that automatically updates the Checkstyle thresholds after each build is failing, and the Checkstyle thresholds have since diverged from the actual violation counts.  This has allowed some regressions to be introduced recently.

This PR fixes those regressions and resets the thresholds to the current violation counts on `master`.