### PR TITLE
Add setProduction(Integer) method to handle game history

### DIFF
--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -292,9 +292,9 @@ public class TerritoryAttachment extends DefaultAttachment {
 
 
   /**
-   * setProduction (or just "production" in a map xml) sets both the m_production AND the m_unitProduction of a
-   * territory to be equal to the
-   * String value passed.
+   * Sets production and unitProduction (or just "production" in a map xml)
+   * of a territory to be equal to the string value passed. This method is
+   * used when parsing game XML since it passes string values.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setProduction(final String value) {
@@ -303,6 +303,11 @@ public class TerritoryAttachment extends DefaultAttachment {
     m_unitProduction = m_production;
   }
 
+  /**
+   * Sets production and unitProduction (or just "production" in a map xml)
+   * of a territory to be equal to the Integer value passed. This method is
+   * used when working with game history since it passes Integer values.
+   */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setProduction(final Integer value) {
     m_production = value;

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -25,8 +25,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 9102862080104655281L;
 
   public static boolean doWeHaveEnoughCapitalsToProduce(final PlayerID player, final GameData data) {
-    final List<Territory> capitalsListOriginal =
-        new ArrayList<>(TerritoryAttachment.getAllCapitals(player, data));
+    final List<Territory> capitalsListOriginal = new ArrayList<>(TerritoryAttachment.getAllCapitals(player, data));
     final List<Territory> capitalsListOwned =
         new ArrayList<>(TerritoryAttachment.getAllCurrentlyOwnedCapitals(player, data));
     final PlayerAttachment pa = PlayerAttachment.get(player);
@@ -300,6 +299,13 @@ public class TerritoryAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setProduction(final String value) {
     m_production = getInt(value);
+    // do NOT remove. unitProduction should always default to production
+    m_unitProduction = m_production;
+  }
+
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  public void setProduction(final Integer value) {
+    m_production = value;
     // do NOT remove. unitProduction should always default to production
     m_unitProduction = m_production;
   }


### PR DESCRIPTION
This fixes the issue in #1743.

When clicking to previous rounds in game history, the engine calls to revert territory production changes with Integer rather than String so there needs to be a method called by reflection to handle it (this pattern exists in many other attachments).