### PR TITLE
Delete temporary files created by tests

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
@@ -12,6 +12,7 @@ import javax.swing.JProgressBar;
 import javax.swing.SwingUtilities;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.util.ThreadUtil;
 
 /**
@@ -63,7 +64,7 @@ public class DownloadCoordinator {
     for (final Map.Entry<DownloadFile, Runnable> download : downloadMap.entrySet()) {
       if (download.getKey().isWaiting()) {
         new Thread(download.getValue()).start();
-        download.getKey().startAsyncDownload();
+        download.getKey().startAsyncDownload(ClientFileSystemHelper.createTempFile());
         break;
       }
     }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -9,7 +9,6 @@ import java.util.function.Consumer;
 import com.google.common.io.Files;
 
 import games.strategy.debug.ClientLogger;
-import games.strategy.engine.ClientFileSystemHelper;
 
 /**
  * Keeps track of the state for a file download from a URL.
@@ -49,8 +48,12 @@ class DownloadFile {
     this.downloadCompletedListeners = new ArrayList<>();
   }
 
-  void startAsyncDownload() {
-    final File fileToDownloadTo = ClientFileSystemHelper.createTempFile();
+  /**
+   * @param fileToDownloadTo The intermediate file to which the download is saved; must not be {@code null}. If the
+   *        download is successful, this file will be moved to the install location. If the download is cancelled, this
+   *        file <strong>WILL NOT</strong> be deleted.
+   */
+  void startAsyncDownload(final File fileToDownloadTo) {
     final FileSizeWatcher watcher = new FileSizeWatcher(fileToDownloadTo, progressUpdateListener);
     addDownloadCompletedListener(() -> watcher.stop());
     state = DownloadState.DOWNLOADING;

--- a/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
@@ -3,7 +3,9 @@ package games.strategy.engine.framework.map.download;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -12,18 +14,20 @@ import games.strategy.engine.framework.map.download.DownloadFile.DownloadState;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FileDownloadTest {
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Mock
   private DownloadFileDescription mockDownload;
 
   @Test
-  public void testBasicStartCancel() {
+  public void testBasicStartCancel() throws Exception {
     final DownloadFile testObj = new DownloadFile(mockDownload, e -> {
     }, () -> {
     });
     assertThat(testObj.getDownloadState(), is(DownloadState.NOT_STARTED));
 
-    testObj.startAsyncDownload();
+    testObj.startAsyncDownload(temporaryFolder.newFile());
     assertThat(testObj.getDownloadState(), is(DownloadState.DOWNLOADING));
 
     testObj.cancelDownload();

--- a/src/test/java/games/strategy/engine/framework/map/download/FileSystemStrategyTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/FileSystemStrategyTest.java
@@ -7,11 +7,12 @@ import java.io.File;
 import java.util.Optional;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import com.google.common.io.Files;
 
-import games.strategy.test.TestUtil;
 import games.strategy.util.Version;
 
 /**
@@ -20,6 +21,8 @@ import games.strategy.util.Version;
  * fast, so one day we should just read the versions directly from the map zip files.
  */
 public class FileSystemStrategyTest {
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   private FileSystemAccessStrategy testObj;
 
@@ -29,8 +32,8 @@ public class FileSystemStrategyTest {
   public void setUp() throws Exception {
     testObj = new FileSystemAccessStrategy();
     final String text = DownloadFileProperties.VERSION_PROPERTY + " = 1.2";
-    mapFile = TestUtil.createTempFile("");
-    final File propFile = new File(mapFile.getAbsolutePath() + ".properties");
+    mapFile = temporaryFolder.newFile();
+    final File propFile = temporaryFolder.newFile(mapFile.getName() + ".properties");
     Files.write(text.getBytes(), propFile);
   }
 


### PR DESCRIPTION
I happened to look in the `/tmp` folder of my dev machine, which I haven't rebooted in about a month.  I was surprised to find several thousand files which appeared to be created by TripleA.  I tracked the origin of these files to two test fixtures: `FileDownloadTest` and `FileSystemStrategyTest`.  This PR ensures that temporary files created by tests are properly deleted to avoid cluttering the file system.

The fix for `FileSystemStrategyTest` is straightforward.

The fix for `FileDownloadTest` required a bit more thought.  Currently, the `DownloadFile` class does not delete the temporary file if the download is cancelled.  I didn't want to mess with the logic in `DownloadFile#createDownloadThread()`, so I simply added another level of indirection and now require the caller of `DownloadFile#startAsyncDownload()` to specify the intermediate file where the download is saved before it is copied to the install location.  This allows the test to keep a reference to this file and delete it when the test is complete.

As an alternative, I did consider simply having two overloads for `DownloadFile#startAsyncDownload()`: a one-parameter version as presented in this PR, and a zero-parameter version as previously existed that would just call the one-parameter version with `ClientFileSystemHelper#createTempFile()` as before.  That would avoid changes to `DownloadCoordinator`.  Please advise if that solution is preferable.