### PR TITLE
Revamp AI Bonus Properties

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -910,7 +910,7 @@ public class GameParser {
       }
     }
     data.getPlayerList().forEach(playerId -> data.getProperties().addEditableProperty(
-        new NumberProperty(playerId.getName() + Constants.BONUS_INCOME_PERCENTAGE, null, 1000, -100, 0)));
+        new NumberProperty(Constants.getBonusIncomePercentageFor(playerId), null, 1000, -100, 0)));
   }
 
   private void parseEditableProperty(final Element property, final String name, final String defaultValue)

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -442,7 +442,7 @@ public class GameParser {
     try {
       final Class<?> instanceClass = Class.forName(className);
       instance = instanceClass.newInstance();
-    // a lot can go wrong, the following list is just a subset of potential pitfalls
+      // a lot can go wrong, the following list is just a subset of potential pitfalls
     } catch (final ClassNotFoundException cnfe) {
       throw new GameParseException(mapName, "Class <" + className + "> could not be found.");
     } catch (final InstantiationException ie) {
@@ -983,9 +983,9 @@ public class GameParser {
       final Element current = iterator.next();
       // load the class
       final String className = current.getAttribute("javaClass");
-      XmlGameElementMapper elementMapper = new XmlGameElementMapper();
+      final XmlGameElementMapper elementMapper = new XmlGameElementMapper();
 
-      IDelegate delegate = elementMapper.getDelegate(className).orElseThrow(
+      final IDelegate delegate = elementMapper.getDelegate(className).orElseThrow(
           () -> new GameParseException(mapName, "Class <" + className + "> is not a delegate."));
       final String name = current.getAttribute("name");
       String displayName = current.getAttribute("display");
@@ -1249,7 +1249,7 @@ public class GameParser {
       final Attachable attachable = findAttachment(current, current.getAttribute("type"));
       final String name = current.getAttribute("name");
       final List<Element> options = getChildren("option", current);
-      IAttachment attachment = new XmlGameElementMapper().getAttachment(className, name, attachable, data)
+      final IAttachment attachment = new XmlGameElementMapper().getAttachment(className, name, attachable, data)
           .orElseThrow(
               () -> new GameParseException(mapName, "Attachment of type " + className + " could not be instantiated"));
       attachable.addAttachment(name, attachment);

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -41,7 +41,6 @@ import games.strategy.engine.data.properties.NumberProperty;
 import games.strategy.engine.data.properties.StringProperty;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.framework.IGameLoader;
-import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -909,23 +908,8 @@ public class GameParser {
         }
       }
     }
-    // add properties for all triplea related maps here:
-    if (!runningList.contains(Constants.AI_BONUS_INCOME_FLAT_RATE)) {
-      data.getProperties()
-          .addEditableProperty(new NumberProperty(Constants.AI_BONUS_INCOME_FLAT_RATE, null, 40, -20, 0));
-    }
-    if (!runningList.contains(Constants.AI_BONUS_INCOME_PERCENTAGE)) {
-      data.getProperties()
-          .addEditableProperty(new NumberProperty(Constants.AI_BONUS_INCOME_PERCENTAGE, null, 200, -100, 0));
-    }
-    if (!runningList.contains(Constants.AI_BONUS_ATTACK)) {
-      data.getProperties()
-          .addEditableProperty(new NumberProperty(Constants.AI_BONUS_ATTACK, null, data.getDiceSides(), 0, 0));
-    }
-    if (!runningList.contains(Constants.AI_BONUS_DEFENSE)) {
-      data.getProperties()
-          .addEditableProperty(new NumberProperty(Constants.AI_BONUS_DEFENSE, null, data.getDiceSides(), 0, 0));
-    }
+    data.getPlayerList().forEach(playerId -> data.getProperties()
+        .addEditableProperty(new NumberProperty(playerId.getName() + " Bonus Income Percentage", null, 1000, -100, 0)));
   }
 
   private void parseEditableProperty(final Element property, final String name, final String defaultValue)

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -41,6 +41,7 @@ import games.strategy.engine.data.properties.NumberProperty;
 import games.strategy.engine.data.properties.StringProperty;
 import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.framework.IGameLoader;
+import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -908,8 +909,8 @@ public class GameParser {
         }
       }
     }
-    data.getPlayerList().forEach(playerId -> data.getProperties()
-        .addEditableProperty(new NumberProperty(playerId.getName() + " Bonus Income Percentage", null, 1000, -100, 0)));
+    data.getPlayerList().forEach(playerId -> data.getProperties().addEditableProperty(
+        new NumberProperty(playerId.getName() + Constants.BONUS_INCOME_PERCENTAGE, null, 1000, -100, 0)));
   }
 
   private void parseEditableProperty(final Element property, final String name, final String defaultValue)

--- a/src/main/java/games/strategy/triplea/Constants.java
+++ b/src/main/java/games/strategy/triplea/Constants.java
@@ -192,10 +192,7 @@ public interface Constants {
       "Damage From Bombing Done To Units Instead Of Territories";
   String NEUTRAL_FLYOVER_ALLOWED = "Neutral Flyover Allowed";
   String UNITS_CAN_BE_CHANGED_ON_CAPTURE = "Units Can Be Changed On Capture";
-  String AI_BONUS_INCOME_PERCENTAGE = "AI Bonus Income Percentage";
-  String AI_BONUS_INCOME_FLAT_RATE = "AI Bonus Income Flat Rate";
-  String AI_BONUS_ATTACK = "AI Bonus Attack";
-  String AI_BONUS_DEFENSE = "AI Bonus Defense";
+  String BONUS_INCOME_PERCENTAGE = " Bonus Income Percentage";
   String RELATIONSHIPS_LAST_EXTRA_ROUNDS = "Relationships Last Extra Rounds";
   String ALLIANCES_CAN_CHAIN_TOGETHER = "Alliances Can Chain Together";
   String RAIDS_MAY_BE_PRECEEDED_BY_AIR_BATTLES = "Raids May Be Preceeded By Air Battles";

--- a/src/main/java/games/strategy/triplea/Constants.java
+++ b/src/main/java/games/strategy/triplea/Constants.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea;
 
+import games.strategy.engine.data.PlayerID;
+
 /**
  * Constants used throughout the game.
  */
@@ -192,7 +194,6 @@ public interface Constants {
       "Damage From Bombing Done To Units Instead Of Territories";
   String NEUTRAL_FLYOVER_ALLOWED = "Neutral Flyover Allowed";
   String UNITS_CAN_BE_CHANGED_ON_CAPTURE = "Units Can Be Changed On Capture";
-  String BONUS_INCOME_PERCENTAGE = " Bonus Income Percentage";
   String RELATIONSHIPS_LAST_EXTRA_ROUNDS = "Relationships Last Extra Rounds";
   String ALLIANCES_CAN_CHAIN_TOGETHER = "Alliances Can Chain Together";
   String RAIDS_MAY_BE_PRECEEDED_BY_AIR_BATTLES = "Raids May Be Preceeded By Air Battles";
@@ -254,4 +255,9 @@ public interface Constants {
 
   String CONFIRM_DEFENSIVE_ROLLS = "confirm_defensive_rolls";
   String CONSTRUCTION_TYPE_FACTORY = "factory";
+
+  public static String getBonusIncomePercentageFor(final PlayerID playerId) {
+    return playerId.getName() + " Bonus Income Percentage";
+  }
+
 }

--- a/src/main/java/games/strategy/triplea/Properties.java
+++ b/src/main/java/games/strategy/triplea/Properties.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
 
 /**
  * Provides typed access to the properties of GameData.
@@ -533,20 +534,8 @@ public class Properties implements Constants {
     return data.getProperties().get(USE_POLITICS, false);
   }
 
-  public static int getAIBonusIncomePercentage(final GameData data) {
-    return data.getProperties().get(AI_BONUS_INCOME_PERCENTAGE, 0);
-  }
-
-  public static int getAIBonusIncomeFlatRate(final GameData data) {
-    return data.getProperties().get(AI_BONUS_INCOME_FLAT_RATE, 0);
-  }
-
-  public static int getAIBonusAttack(final GameData data) {
-    return data.getProperties().get(AI_BONUS_ATTACK, 0);
-  }
-
-  public static int getAIBonusDefense(final GameData data) {
-    return data.getProperties().get(AI_BONUS_DEFENSE, 0);
+  public static int getBonusIncomePercentage(final PlayerID playerId, final GameData data) {
+    return data.getProperties().get(playerId.getName() + BONUS_INCOME_PERCENTAGE, 0);
   }
 
   public static int getRelationshipsLastExtraRounds(final GameData data) {

--- a/src/main/java/games/strategy/triplea/Properties.java
+++ b/src/main/java/games/strategy/triplea/Properties.java
@@ -535,7 +535,7 @@ public class Properties implements Constants {
   }
 
   public static int getBonusIncomePercentage(final PlayerID playerId, final GameData data) {
-    return data.getProperties().get(playerId.getName() + BONUS_INCOME_PERCENTAGE, 0);
+    return data.getProperties().get(Constants.getBonusIncomePercentageFor(playerId), 0);
   }
 
   public static int getRelationshipsLastExtraRounds(final GameData data) {

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1406,11 +1406,8 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getAttack(final PlayerID player) {
-    int attackValue =
+    final int attackValue =
         m_attack + TechAbilityAttachment.getAttackBonus((UnitType) this.getAttachedTo(), player, getData());
-    if (attackValue > 0 && player.isAI()) {
-      attackValue += games.strategy.triplea.Properties.getAIBonusAttack(getData());
-    }
     return Math.min(getData().getDiceSides(), Math.max(0, attackValue));
   }
 
@@ -1457,9 +1454,6 @@ public class UnitAttachment extends DefaultAttachment {
     if (defenseValue > 0 && m_isSub && TechTracker.hasSuperSubs(player)) {
       final int bonus = games.strategy.triplea.Properties.getSuper_Sub_Defense_Bonus(getData());
       defenseValue += bonus;
-    }
-    if (defenseValue > 0 && player.isAI()) {
-      defenseValue += games.strategy.triplea.Properties.getAIBonusDefense(getData());
     }
     return Math.min(getData().getDiceSides(), Math.max(0, defenseValue));
   }

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -26,9 +26,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.message.IRemote;
-import games.strategy.triplea.Constants;
 import games.strategy.triplea.MapSupport;
-import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
 import games.strategy.triplea.attachments.ICondition;
@@ -90,7 +88,6 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
           TriggerAttachment.triggerPurchase(toFireTestedAndSatisfied, m_bridge, null, null, true, true, true, true);
         }
       }
-      giveBonusIncome();
       m_needToInitialize = false;
     }
   }
@@ -386,25 +383,6 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
     return returnString.toString();
   }
 
-  private void giveBonusIncome() {
-    // TODO and other resources?
-    final int currentPUs = m_player.getResources().getQuantity(Constants.PUS);
-    if (currentPUs <= 0) {
-      return;
-    }
-    final int bonusPercent = Properties.getBonusIncomePercentage(m_player, getData());
-    int toGive = (int) Math.round(((double) currentPUs * (double) bonusPercent / 100));
-    if (toGive + currentPUs < 0) {
-      toGive = currentPUs * -1;
-    }
-    if (toGive == 0) {
-      return;
-    }
-    m_bridge.getHistoryWriter()
-        .startEvent("Giving player bonus income modifier of " + toGive + MyFormatter.pluralize(" PU", toGive));
-    m_bridge.addChange(
-        ChangeFactory.changeResourcesChange(m_player, getData().getResourceList().getResource(Constants.PUS), toGive));
-  }
 }
 
 

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -28,6 +28,7 @@ import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.message.IRemote;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.MapSupport;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
 import games.strategy.triplea.attachments.ICondition;
@@ -89,7 +90,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
           TriggerAttachment.triggerPurchase(toFireTestedAndSatisfied, m_bridge, null, null, true, true, true, true);
         }
       }
-      giveBonusIncomeToAI();
+      giveBonusIncome();
       m_needToInitialize = false;
     }
   }
@@ -385,24 +386,14 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
     return returnString.toString();
   }
 
-  private void giveBonusIncomeToAI() {
+  private void giveBonusIncome() {
     // TODO and other resources?
-    if (!m_player.isAI()) {
-      return;
-    }
     final int currentPUs = m_player.getResources().getQuantity(Constants.PUS);
     if (currentPUs <= 0) {
       return;
     }
-    int toGive = 0;
-    final int bonusPercent = games.strategy.triplea.Properties.getAIBonusIncomePercentage(getData());
-    if (bonusPercent != 0) {
-      toGive += (int) Math.round(((double) currentPUs * (double) bonusPercent / 100));
-      if (toGive == 0 && bonusPercent > 0 && currentPUs > 0) {
-        toGive += 1;
-      }
-    }
-    toGive += games.strategy.triplea.Properties.getAIBonusIncomeFlatRate(getData());
+    final int bonusPercent = Properties.getBonusIncomePercentage(m_player, getData());
+    int toGive = (int) Math.round(((double) currentPUs * (double) bonusPercent / 100));
     if (toGive + currentPUs < 0) {
       toGive = currentPUs * -1;
     }
@@ -410,7 +401,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
       return;
     }
     m_bridge.getHistoryWriter()
-        .startEvent("Giving AI player bonus income modifier of " + toGive + MyFormatter.pluralize(" PU", toGive));
+        .startEvent("Giving player bonus income modifier of " + toGive + MyFormatter.pluralize(" PU", toGive));
     m_bridge.addChange(
         ChangeFactory.changeResourcesChange(m_player, getData().getResourceList().getResource(Constants.PUS), toGive));
   }


### PR DESCRIPTION
Revamp AI Bonus properties based on this thread: https://forums.triplea-game.org/topic/113/ai-bonus-settings-revamp

Main changes:
- Remove 4 old AI Bonus properties
- Add new Bonus Income Percentage for each nation (not same bonus for all AI)
- Add bonus income during end turn phase instead of purchase phase (so you aren't multiplying saved income from the previous round)

Old:
![capture](https://cloud.githubusercontent.com/assets/1427689/26387560/478fa4ce-4014-11e7-93fc-5b140a5912d1.PNG)

New:
![capture2](https://cloud.githubusercontent.com/assets/1427689/26387566/4ee5705a-4014-11e7-864e-767f5add8075.PNG)
