### PR TITLE
Ai fix planes without carrier capacity purchase bug

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -116,13 +117,16 @@ public class ProPurchaseUtils {
     return purchaseOptions;
   }
 
-  public static ProPurchaseOption randomizePurchaseOption(final Map<ProPurchaseOption, Double> purchaseEfficiencies,
-      final String type) {
+  public static Optional<ProPurchaseOption> randomizePurchaseOption(
+      final Map<ProPurchaseOption, Double> purchaseEfficiencies, final String type) {
 
     ProLogger.trace("Select purchase option for " + type);
     double totalEfficiency = 0;
     for (final Double efficiency : purchaseEfficiencies.values()) {
       totalEfficiency += efficiency;
+    }
+    if (totalEfficiency == 0) {
+      return Optional.empty();
     }
     final Map<ProPurchaseOption, Double> purchasePercentages = new LinkedHashMap<>();
     double upperBound = 0.0;
@@ -136,10 +140,10 @@ public class ProPurchaseUtils {
     ProLogger.trace("Random number: " + randomNumber);
     for (final ProPurchaseOption ppo : purchasePercentages.keySet()) {
       if (randomNumber <= purchasePercentages.get(ppo)) {
-        return ppo;
+        return Optional.of(ppo);
       }
     }
-    return purchasePercentages.keySet().iterator().next();
+    return Optional.of(purchasePercentages.keySet().iterator().next());
   }
 
   public static List<Unit> findMaxPurchaseDefenders(final PlayerID player, final Territory t,


### PR DESCRIPTION
Fixes this reported bug: https://forums.triplea-game.org/topic/73/iron-war-official-thread/85

For AI sea zones purchases, if it can't afford any sea units but can afford air units, it will buy air units even if there isn't carrier space. It actually realizes there isn't enough carrier room but there is a bug that even though all air units have a 0% chance of being purchased it still selects one of them randomly! Essentially, this is just a rare edge case that has to do with not handling when only air units are available to purchase based on resources in a SZ and none of them have carrier space. This pretty much never happens on 99% of maps since they have cheap sea units like subs or destroyers that would always be available.