### PR TITLE
Checkstyle: Fix missing Javadoc violations indirectly (part 3)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=4979
+checkstyleMainMaxWarnings=4926
 checkstyleTestMaxWarnings=135

--- a/src/main/java/games/strategy/engine/message/InvocationInProgress.java
+++ b/src/main/java/games/strategy/engine/message/InvocationInProgress.java
@@ -6,26 +6,26 @@ import games.strategy.net.INode;
 /**
  * We are waiting for the results of a remote invocation.
  */
-public class InvocationInProgress {
+class InvocationInProgress {
   private final INode m_waitingOn;
   private final HubInvoke m_methodCall;
   private final INode m_caller;
   private RemoteMethodCallResults m_results;
 
-  public InvocationInProgress(final INode waitingOn, final HubInvoke methodCalls, final INode methodCallsFrom) {
+  InvocationInProgress(final INode waitingOn, final HubInvoke methodCalls, final INode methodCallsFrom) {
     m_waitingOn = waitingOn;
     m_methodCall = methodCalls;
     m_caller = methodCallsFrom;
   }
 
-  public boolean isWaitingOn(final INode node) {
+  boolean isWaitingOn(final INode node) {
     return m_waitingOn.equals(node);
   }
 
   /**
    * @return true if there are no more results to process.
    */
-  public boolean process(final HubInvocationResults hubresults, final INode from) {
+  boolean process(final HubInvocationResults hubresults, final INode from) {
     if (hubresults.results == null) {
       throw new IllegalStateException("No results");
     }
@@ -36,23 +36,23 @@ public class InvocationInProgress {
     return true;
   }
 
-  public HubInvoke getMethodCall() {
+  HubInvoke getMethodCall() {
     return m_methodCall;
   }
 
-  public INode getCaller() {
+  INode getCaller() {
     return m_caller;
   }
 
-  public RemoteMethodCallResults getResults() {
+  RemoteMethodCallResults getResults() {
     return m_results;
   }
 
-  public GUID getMethodCallID() {
+  GUID getMethodCallID() {
     return m_methodCall.methodCallID;
   }
 
-  public boolean shouldSendResults() {
+  boolean shouldSendResults() {
     return m_methodCall.needReturnValues;
   }
 }

--- a/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
+++ b/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
@@ -8,10 +8,10 @@ import java.util.logging.Logger;
 
 import games.strategy.util.Tuple;
 
-public class RemoteInterfaceHelper {
+class RemoteInterfaceHelper {
   private static final Logger s_logger = Logger.getLogger(RemoteInterfaceHelper.class.getName());
 
-  public static int getNumber(final String methodName, final Class<?>[] argTypes, final Class<?> remoteInterface) {
+  static int getNumber(final String methodName, final Class<?>[] argTypes, final Class<?> remoteInterface) {
     final Method[] methods = remoteInterface.getMethods();
     Arrays.sort(methods, methodComparator);
     if (s_logger.isLoggable(Level.FINEST)) {
@@ -40,7 +40,7 @@ public class RemoteInterfaceHelper {
     throw new IllegalStateException("Method not found");
   }
 
-  public static Tuple<String, Class<?>[]> getMethodInfo(final int methodNumber, final Class<?> remoteInterface) {
+  static Tuple<String, Class<?>[]> getMethodInfo(final int methodNumber, final Class<?> remoteInterface) {
     final Method[] methods = remoteInterface.getMethods();
     Arrays.sort(methods, methodComparator);
     if (s_logger.isLoggable(Level.FINEST)) {

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.message.unifiedmessenger;
 
-import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
@@ -323,16 +322,6 @@ public class UnifiedMessenger {
         m_results.put(methodID, results.results);
         m_pendingInvocations.remove(methodID).countDown();
       }
-    }
-  }
-
-  public void dumpState(final PrintStream stream) {
-    synchronized (m_endPointMutex) {
-      stream.println("Local Endpoints:" + m_localEndPoints);
-    }
-    synchronized (m_endPointMutex) {
-      stream.println("Remote nodes with implementors:" + m_results);
-      stream.println("Remote nodes with implementors:" + m_pendingInvocations);
     }
   }
 

--- a/src/main/java/games/strategy/engine/pbem/GmailEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/GmailEmailSender.java
@@ -8,7 +8,7 @@ import games.strategy.triplea.help.HelpSupport;
 public class GmailEmailSender extends GenericEmailSender {
   private static final long serialVersionUID = 3511375113962472063L;
 
-  public GmailEmailSender() {
+  GmailEmailSender() {
     setHost("smtp.gmail.com");
     setPort(587);
     setEncryption(Encryption.TLS);

--- a/src/main/java/games/strategy/engine/pbem/HotmailEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/HotmailEmailSender.java
@@ -11,7 +11,7 @@ import games.strategy.triplea.help.HelpSupport;
 public class HotmailEmailSender extends GenericEmailSender {
   private static final long serialVersionUID = 3511375113962472063L;
 
-  public HotmailEmailSender() {
+  HotmailEmailSender() {
     setHost("smtp.live.com");
     setPort(587);
     setEncryption(Encryption.TLS);

--- a/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
+++ b/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
@@ -32,7 +32,7 @@ public class CryptoRandomSource implements IRandomSource {
     return val & 0xff;
   }
 
-  public static int[] bytesToInts(final byte[] bytes) {
+  static int[] bytesToInts(final byte[] bytes) {
     final int[] rVal = new int[bytes.length / 4];
     for (int i = 0; i < rVal.length; i++) {
       rVal[i] = byteToIntUnsigned(bytes[4 * i]) + (byteToIntUnsigned(bytes[4 * i + 1]) << 8)
@@ -41,7 +41,7 @@ public class CryptoRandomSource implements IRandomSource {
     return rVal;
   }
 
-  public static int[] xor(final int[] val1, final int[] val2, final int max) {
+  static int[] xor(final int[] val1, final int[] val2, final int max) {
     if (val1.length != val2.length) {
       throw new IllegalArgumentException("Arrays not of same length");
     }

--- a/src/main/java/games/strategy/engine/random/DiceStatistic.java
+++ b/src/main/java/games/strategy/engine/random/DiceStatistic.java
@@ -8,7 +8,7 @@ public class DiceStatistic implements java.io.Serializable {
   private final double m_stdDeviation;
   private final double m_variance;
 
-  public DiceStatistic(final double average, final int total, final double median, final double stdDeviation,
+  DiceStatistic(final double average, final int total, final double median, final double stdDeviation,
       final double variance) {
     m_average = average;
     m_total = total;

--- a/src/main/java/games/strategy/engine/random/RandomStatsDetails.java
+++ b/src/main/java/games/strategy/engine/random/RandomStatsDetails.java
@@ -25,7 +25,7 @@ public class RandomStatsDetails implements Serializable {
   private final DiceStatistic m_totalStats;
   private final Map<PlayerID, DiceStatistic> m_playerStats = new HashMap<>();
 
-  public RandomStatsDetails(final Map<PlayerID, IntegerMap<Integer>> randomStats, final int diceSides) {
+  RandomStatsDetails(final Map<PlayerID, IntegerMap<Integer>> randomStats, final int diceSides) {
     m_data = randomStats;
     m_totalMap = new IntegerMap<>();
     for (final Entry<PlayerID, IntegerMap<Integer>> entry : m_data.entrySet()) {
@@ -139,7 +139,7 @@ public class RandomStatsDetails implements Serializable {
     return sb.toString();
   }
 
-  public static String getAllStatsString(final RandomStatsDetails details, final String indentation) {
+  static String getAllStatsString(final RandomStatsDetails details, final String indentation) {
     if (details.getTotalStats().getTotal() <= 0) {
       return "";
     }
@@ -187,7 +187,7 @@ public class RandomStatsDetails implements Serializable {
     return panel;
   }
 
-  public static JPanel getAllStats(final RandomStatsDetails details) {
+  static JPanel getAllStats(final RandomStatsDetails details) {
     final Insets insets = new Insets(2, 2, 2, 2);
     final JPanel panel = new JPanel();
     panel.setLayout(new GridBagLayout());

--- a/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/src/main/java/games/strategy/net/ServerMessenger.java
@@ -198,7 +198,7 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
   // which can be very slow
   private final List<String> m_liveMutedUsernames = new ArrayList<>();
 
-  public boolean IsUsernameMuted(final String username) {
+  private boolean IsUsernameMuted(final String username) {
     synchronized (m_cachedListLock) {
       return m_liveMutedUsernames.contains(username);
     }
@@ -223,7 +223,7 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
 
   private final List<String> m_liveMutedMacAddresses = new ArrayList<>();
 
-  public boolean IsMacMuted(final String mac) {
+  private boolean IsMacMuted(final String mac) {
     synchronized (m_cachedListLock) {
       return m_liveMutedMacAddresses.contains(mac);
     }

--- a/src/main/java/games/strategy/net/UniversalPlugAndPlayHelper.java
+++ b/src/main/java/games/strategy/net/UniversalPlugAndPlayHelper.java
@@ -2,14 +2,10 @@ package games.strategy.net;
 
 import java.awt.Component;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.net.SocketException;
-import java.net.SocketTimeoutException;
 import java.util.Enumeration;
 
 import javax.swing.JOptionPane;
@@ -55,7 +51,7 @@ public class UniversalPlugAndPlayHelper {
     return worked;
   }
 
-  public String attemptAddingPortForwarding(final JTextArea textArea) {
+  private String attemptAddingPortForwarding(final JTextArea textArea) {
     System.out.println("Starting Universal Plug and Play (UPnP) add port forward map script.");
     textArea.append("Starting Universal Plug and Play (UPnP) add port forward map script.\r\n");
     final String localError = findLocalInetAddress();
@@ -76,59 +72,6 @@ public class UniversalPlugAndPlayHelper {
       return addPortError;
     }
     textArea.append("Port Forwarding map added successfully.\r\n");
-    return null;
-  }
-
-  public String testConnection() {
-    System.out.println("Waiting for a connection");
-    final int internalPort = port;
-    boolean connection = false;
-    // boolean bytes = false;
-    try (ServerSocket ss = new ServerSocket(internalPort)) {
-      ss.setSoTimeout(5000);
-      try {
-        final Socket s = ss.accept();
-        connection = true;
-        final InputStream in = s.getInputStream();
-        while (in.available() > 0) {
-          System.out.println("byte : " + in.read());
-          // bytes = true;
-        }
-      } catch (final SocketTimeoutException stoe) {
-        System.out.println("Connection Test Timed Out. Port Forward may still work anyway.");
-        return "Connection Test Timed Out. Port Forward may still work anyway.";
-      }
-    } catch (final IOException e) {
-      System.out.println("Connection Test Timed Out. Port Forward may still work anyway. \r\n " + e.getMessage());
-      return "Connection Test Timed Out. Port Forward may still work anyway. \r\n " + e.getMessage();
-    }
-
-    if (!connection) {
-      System.out.println("Connection Test Timed Out. Port Forward may still work anyway.");
-      return "Connection Test Timed Out. Port Forward may still work anyway.";
-    }
-    System.out.println("Connection made!");
-    return null;
-  }
-
-  public String removePortForwardUPNP() {
-    System.out.println("Attempting to remove Port Forwarding");
-    final int externalPort = port;
-    boolean removed = false;
-    try {
-      removed = m_device.deletePortMapping(null, externalPort, "TCP");
-    } catch (final IOException e) {
-      System.out.println("Failed to remove port mapping! \r\n " + e.getMessage());
-      return "Failed to remove port mapping! \r\n " + e.getMessage();
-    } catch (final UPNPResponseException e) {
-      System.out.println("Failed to remove port mapping! \r\n " + e.getMessage());
-      return "Failed to remove port mapping! \r\n " + e.getMessage();
-    }
-    if (!removed) {
-      System.out.println("Failed to remove port mapping!");
-      return "Failed to remove port mapping!";
-    }
-    System.out.println("Success. Port Forwarding map removed.");
     return null;
   }
 

--- a/src/main/java/games/strategy/net/nio/Decoder.java
+++ b/src/main/java/games/strategy/net/nio/Decoder.java
@@ -25,7 +25,7 @@ import games.strategy.net.nio.QuarantineConversation.ACTION;
 /**
  * A thread to Decode messages from a reader.
  */
-public class Decoder {
+class Decoder {
   private static final Logger logger = Logger.getLogger(Decoder.class.getName());
   private final NIOReader reader;
   private volatile boolean running = true;
@@ -40,7 +40,7 @@ public class Decoder {
       new ConcurrentHashMap<>();
   private final Thread thread;
 
-  public Decoder(final NIOSocket nioSocket, final NIOReader reader, final IErrorReporter reporter,
+  Decoder(final NIOSocket nioSocket, final NIOReader reader, final IErrorReporter reporter,
       final IObjectStreamFactory objectStreamFactory, final String threadSuffix) {
     this.reader = reader;
     errorReporter = reporter;
@@ -50,7 +50,7 @@ public class Decoder {
     thread.start();
   }
 
-  public void shutDown() {
+  void shutDown() {
     running = false;
     thread.interrupt();
   }
@@ -189,7 +189,7 @@ public class Decoder {
    * writing of the full identifiers, and simply write a single
    * byte to show the type.
    */
-  public static byte getType(final Object msg) {
+  static byte getType(final Object msg) {
     if (msg instanceof HubInvoke) {
       return 1;
     } else if (msg instanceof SpokeInvoke) {
@@ -202,11 +202,11 @@ public class Decoder {
     return Byte.MAX_VALUE;
   }
 
-  public void add(final SocketChannel channel, final QuarantineConversation conversation) {
+  void add(final SocketChannel channel, final QuarantineConversation conversation) {
     quarantine.put(channel, conversation);
   }
 
-  public void closed(final SocketChannel channel) {
+  void closed(final SocketChannel channel) {
     // remove if it exists
     final QuarantineConversation conversation = quarantine.remove(channel);
     if (conversation != null) {

--- a/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/src/main/java/games/strategy/net/nio/Encoder.java
@@ -14,19 +14,19 @@ import games.strategy.net.Node;
 /**
  * Encodes data to be written by a writer.
  */
-public class Encoder {
+class Encoder {
   private static final Logger s_logger = Logger.getLogger(Encoder.class.getName());
   private final NIOWriter m_writer;
   private final IObjectStreamFactory m_objectStreamFactory;
   private final NIOSocket m_nioSocket;
 
-  public Encoder(final NIOSocket nioSocket, final NIOWriter writer, final IObjectStreamFactory objectStreamFactory) {
+  Encoder(final NIOSocket nioSocket, final NIOWriter writer, final IObjectStreamFactory objectStreamFactory) {
     m_nioSocket = nioSocket;
     m_writer = writer;
     m_objectStreamFactory = objectStreamFactory;
   }
 
-  public void write(final SocketChannel to, final MessageHeader header) {
+  void write(final SocketChannel to, final MessageHeader header) {
     if (s_logger.isLoggable(Level.FINEST)) {
       s_logger.log(Level.FINEST, "Encoding msg:" + header + " to:" + to);
     }

--- a/src/main/java/games/strategy/net/nio/NIOReader.java
+++ b/src/main/java/games/strategy/net/nio/NIOReader.java
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
  * Data is read in packets, and placed in the output queye.<br>
  * Packets are placed in the output queue in order they are read from the socket.
  */
-public class NIOReader {
+class NIOReader {
   private static final Logger logger = Logger.getLogger(NIOReader.class.getName());
   private final LinkedBlockingQueue<SocketReadData> outputQueue = new LinkedBlockingQueue<>();
   private volatile boolean running = true;
@@ -34,7 +34,7 @@ public class NIOReader {
   private final List<SocketChannel> socketsToAdd = new ArrayList<>();
   private long totalBytes;
 
-  public NIOReader(final IErrorReporter reporter, final String threadSuffix) {
+  NIOReader(final IErrorReporter reporter, final String threadSuffix) {
     errorReporter = reporter;
     try {
       selector = Selector.open();
@@ -46,7 +46,7 @@ public class NIOReader {
     t.start();
   }
 
-  public void shutDown() {
+  void shutDown() {
     running = false;
     try {
       selector.close();
@@ -55,7 +55,7 @@ public class NIOReader {
     }
   }
 
-  public void add(final SocketChannel channel) {
+  void add(final SocketChannel channel) {
     synchronized (socketsToAddMutex) {
       socketsToAdd.add(channel);
       selector.wakeup();
@@ -165,11 +165,11 @@ public class NIOReader {
     return packet;
   }
 
-  public SocketReadData take() throws InterruptedException {
+  SocketReadData take() throws InterruptedException {
     return outputQueue.take();
   }
 
-  public void closed(final SocketChannel channel) {
+  void closed(final SocketChannel channel) {
     reading.remove(channel);
   }
 }

--- a/src/main/java/games/strategy/net/nio/NIOWriter.java
+++ b/src/main/java/games/strategy/net/nio/NIOWriter.java
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
  * Data is written in packets that are enqued on our buffer.
  * Packets are sent to the sockets in the order that they are received.
  */
-public class NIOWriter {
+class NIOWriter {
   private static final Logger s_logger = Logger.getLogger(NIOWriter.class.getName());
   private final Selector m_selector;
   private final IErrorReporter m_errorReporter;
@@ -35,7 +35,7 @@ public class NIOWriter {
   private long m_totalBytes = 0;
   private volatile boolean m_running = true;
 
-  public NIOWriter(final IErrorReporter reporter, final String threadSuffix) {
+  NIOWriter(final IErrorReporter reporter, final String threadSuffix) {
     m_errorReporter = reporter;
     try {
       m_selector = Selector.open();
@@ -47,7 +47,7 @@ public class NIOWriter {
     t.start();
   }
 
-  public void shutDown() {
+  void shutDown() {
     m_running = false;
     try {
       m_selector.close();
@@ -150,7 +150,7 @@ public class NIOWriter {
   /**
    * Remove the data for this channel.
    */
-  public void closed(final SocketChannel channel) {
+  void closed(final SocketChannel channel) {
     removeAll(channel);
   }
 
@@ -188,7 +188,7 @@ public class NIOWriter {
     }
   }
 
-  public void enque(final SocketWriteData data, final SocketChannel channel) {
+  void enque(final SocketWriteData data, final SocketChannel channel) {
     synchronized (m_mutex) {
       if (!m_running) {
         return;

--- a/src/main/java/games/strategy/net/nio/SocketWriteData.java
+++ b/src/main/java/games/strategy/net/nio/SocketWriteData.java
@@ -18,7 +18,7 @@ import java.util.logging.Logger;
  * The packet is written over the network as 32 bits indicating the size in bytes, then the data itself.
  * </p>
  */
-public class SocketWriteData {
+class SocketWriteData {
   private static final Logger s_logger = Logger.getLogger(SocketWriteData.class.getName());
   private static final AtomicInteger s_counter = new AtomicInteger();
   private final ByteBuffer m_size;
@@ -27,7 +27,7 @@ public class SocketWriteData {
   // how many times we called write before we finished writing ourselves
   private int m_writeCalls = 0;
 
-  public SocketWriteData(final byte[] data, int count) {
+  SocketWriteData(final byte[] data, int count) {
     m_content = ByteBuffer.allocate(count);
     m_content.put(data, 0, count);
     m_size = ByteBuffer.allocate(4);
@@ -40,18 +40,18 @@ public class SocketWriteData {
     m_content.flip();
   }
 
-  public int size() {
+  int size() {
     return m_size.capacity() + m_content.capacity();
   }
 
-  public int getWriteCalls() {
+  int getWriteCalls() {
     return m_writeCalls;
   }
 
   /**
    * @return true if the write has written the entire message.
    */
-  public boolean write(final SocketChannel channel) throws IOException {
+  boolean write(final SocketChannel channel) throws IOException {
     m_writeCalls++;
     if (m_size.hasRemaining()) {
       final int count = channel.write(m_size);

--- a/src/main/java/games/strategy/performance/PerfTimer.java
+++ b/src/main/java/games/strategy/performance/PerfTimer.java
@@ -7,7 +7,7 @@ import java.util.prefs.Preferences;
  * Provides a high level API to the game engine for performance measurements.
  * This class handles the library details and sends output to 'PerformanceConsole.java'
  */
-public class PerfTimer implements Closeable {
+class PerfTimer implements Closeable {
 
   private static final String LOG_PERFORMANCE_KEY = "logPerformance";
   private static final PerfTimer DISABLED_TIMER = new PerfTimer("disabled");
@@ -15,7 +15,7 @@ public class PerfTimer implements Closeable {
   private static boolean enabled;
 
   private final long startMillis;
-  public final String title;
+  final String title;
 
   static {
     enabled = isEnabled();
@@ -38,7 +38,7 @@ public class PerfTimer implements Closeable {
     processResult(stopTimer(), this);
   }
 
-  public static void setEnabled(final boolean isEnabled) {
+  static void setEnabled(final boolean isEnabled) {
     if (enabled != isEnabled) {
       enabled = isEnabled;
       PerformanceConsole.getInstance().setVisible(enabled);
@@ -51,12 +51,12 @@ public class PerfTimer implements Closeable {
     prefs.put(LOG_PERFORMANCE_KEY, Boolean.valueOf(enabled).toString());
   }
 
-  public static boolean isEnabled() {
+  static boolean isEnabled() {
     final Preferences prefs = Preferences.userNodeForPackage(EnablePerformanceLoggingCheckBox.class);
     return prefs.getBoolean(LOG_PERFORMANCE_KEY, false);
   }
 
-  public static PerfTimer startTimer(final String title) {
+  static PerfTimer startTimer(final String title) {
     return enabled ? new PerfTimer(title) : DISABLED_TIMER;
   }
 

--- a/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -125,7 +125,7 @@ public class ClipPlayer {
   private final ResourceLoader resourceLoader;
   private static ClipPlayer clipPlayer;
 
-  public static synchronized ClipPlayer getInstance() {
+  static synchronized ClipPlayer getInstance() {
     if (clipPlayer == null) {
       clipPlayer = new ClipPlayer(ResourceLoader.getGameEngineAssetLoader());
     }

--- a/src/main/java/games/strategy/sound/SoundOptions.java
+++ b/src/main/java/games/strategy/sound/SoundOptions.java
@@ -37,7 +37,7 @@ public final class SoundOptions {
     parentPanel.add(soundOptions);
   }
 
-  public SoundOptions(final JComponent parent) {
+  private SoundOptions(final JComponent parent) {
     clipPlayer = ClipPlayer.getInstance();
     final String ok = "OK";
     final String cancel = "Cancel";

--- a/src/main/java/games/strategy/sound/SoundPath.java
+++ b/src/main/java/games/strategy/sound/SoundPath.java
@@ -82,7 +82,7 @@ public class SoundPath {
     return getAllSoundOptionsWithDescription().keySet();
   }
 
-  public static Map<String, String> getAllSoundOptionsWithDescription() {
+  private static Map<String, String> getAllSoundOptionsWithDescription() {
     final Map<String, String> soundOptions = new HashMap<>();
 
     soundOptions.put(SoundPath.CLIP_CHAT_MESSAGE, "Chat Messaging");
@@ -140,7 +140,7 @@ public class SoundPath {
     return soundOptions;
   }
 
-  public static List<IEditableProperty> getSoundOptions() {
+  static List<IEditableProperty> getSoundOptions() {
     final List<IEditableProperty> soundBoxes = new ArrayList<>();
     getAllSoundOptionsWithDescription().forEach(
         (path, description) -> soundBoxes.add(new SoundOptionCheckBox(path, description)));

--- a/src/main/java/games/strategy/sound/SoundProperties.java
+++ b/src/main/java/games/strategy/sound/SoundProperties.java
@@ -13,7 +13,7 @@ import games.strategy.util.UrlStreams;
 /**
  * sounds.properties file helper class
  */
-public class SoundProperties {
+class SoundProperties {
   // Filename
   private static final String PROPERTY_FILE = "sounds.properties";
   static final String PROPERTY_DEFAULT_FOLDER = "Sound.Default.Folder";
@@ -24,7 +24,7 @@ public class SoundProperties {
   private static long timestamp = 0;
   private final Properties m_properties = new Properties();
 
-  protected SoundProperties(final ResourceLoader loader) {
+  SoundProperties(final ResourceLoader loader) {
     final URL url = loader.getResource(PROPERTY_FILE);
     if (url != null) {
       final Optional<InputStream> inputStream = UrlStreams.openStream(url);
@@ -38,7 +38,7 @@ public class SoundProperties {
     }
   }
 
-  public static SoundProperties getInstance(final ResourceLoader loader) {
+  static SoundProperties getInstance(final ResourceLoader loader) {
     // cache properties for 1 second
     if (s_op == null || Calendar.getInstance().getTimeInMillis() > timestamp + 1000) {
       s_op = new SoundProperties(loader);
@@ -47,14 +47,14 @@ public class SoundProperties {
     return s_op;
   }
 
-  public String getDefaultEraFolder() {
+  String getDefaultEraFolder() {
     return getProperty(PROPERTY_DEFAULT_FOLDER, DEFAULT_ERA_FOLDER);
   }
 
   /**
    * @return The string property, or null if not found.
    */
-  public String getProperty(final String key) {
+  String getProperty(final String key) {
     return m_properties.getProperty(key);
   }
 

--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -328,14 +328,6 @@ public class TripleAUnit extends Unit {
     return getTransporting();
   }
 
-  public Unit getDependentOf() {
-    if (m_transportedBy != null) {
-      return m_transportedBy;
-    }
-    // TODO: add support for carriers as well
-    return null;
-  }
-
   public boolean getWasAmphibious() {
     return m_wasAmphibious;
   }
@@ -406,17 +398,6 @@ public class TripleAUnit extends Unit {
   public int getHowMuchCanThisUnitBeRepaired(final Unit u, final Territory t) {
     return Math.max(0,
         (this.getHowMuchDamageCanThisUnitTakeTotal(u, t) - this.getHowMuchMoreDamageCanThisUnitTake(u, t)));
-  }
-
-  public int getHowMuchShouldUnitBeRepairedToNotBeDisabled(final Unit u, final Territory t) {
-    final UnitAttachment ua = UnitAttachment.get(u.getType());
-    final int maxOperationalDamage = ua.getMaxOperationalDamage();
-    if (maxOperationalDamage < 0) {
-      return 0;
-    }
-    final TripleAUnit taUnit = (TripleAUnit) u;
-    final int currentDamage = taUnit.getUnitDamage();
-    return Math.max(0, currentDamage - maxOperationalDamage);
   }
 
   public static int getProductionPotentialOfTerritory(final Collection<Unit> unitsAtStartOfStepInTerritory,

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -131,7 +131,7 @@ public class AIUtils {
     return -1;
   }
 
-  public static List<Unit> interleaveCarriersAndPlanes(final List<Unit> units, final int planesThatDontNeedToLand) {
+  static List<Unit> interleaveCarriersAndPlanes(final List<Unit> units, final int planesThatDontNeedToLand) {
     if (!(Match.someMatch(units, Matches.UnitIsCarrier) && Match.someMatch(units, Matches.UnitCanLandOnCarrier))) {
       return units;
     }

--- a/src/main/java/games/strategy/triplea/ai/fastAI/AggregateEstimate.java
+++ b/src/main/java/games/strategy/triplea/ai/fastAI/AggregateEstimate.java
@@ -21,7 +21,7 @@ public class AggregateEstimate extends AggregateResults {
   private final List<Unit> remainingAttackingUnits;
   private final List<Unit> remainingDefendingUnits;
 
-  public AggregateEstimate(final int battleRoundsFought, final double winPercentage,
+  AggregateEstimate(final int battleRoundsFought, final double winPercentage,
       final List<Unit> remainingAttackingUnits, final List<Unit> remainingDefendingUnits) {
     super(1);
     this.battleRoundsFought = battleRoundsFought;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProBidAI.java
@@ -45,13 +45,13 @@ import games.strategy.util.Match;
 /**
  * Pro bid AI.
  */
-public class ProBidAI {
+class ProBidAI {
 
   private static final int PURCHASE_LOOP_MAX_TIME_MILLIS = 150 * 1000;
 
   private GameData data;
 
-  public void bid(int PUsToSpend, final IPurchaseDelegate purchaseDelegate, final GameData data,
+  void bid(int PUsToSpend, final IPurchaseDelegate purchaseDelegate, final GameData data,
       final PlayerID player) {
     ProLogger.info("Starting bid purchase phase");
 
@@ -367,7 +367,7 @@ public class ProBidAI {
   }
 
   // TODO: Rewrite this as its from the old AI
-  public void bidPlace(final IAbstractPlaceDelegate placeDelegate, final GameData data, final PlayerID player) {
+  void bidPlace(final IAbstractPlaceDelegate placeDelegate, final GameData data, final PlayerID player) {
     ProLogger.info("Starting bid place phase");
     // if we have purchased a factory, it will be a priority for placing units
     // should place most expensive on it

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -45,7 +45,7 @@ import games.strategy.util.Match;
 /**
  * Pro combat move AI.
  */
-public class ProCombatMoveAI {
+class ProCombatMoveAI {
 
   private static final int MIN_BOMBING_SCORE = 4; // Avoid bombing low production factories with AA
 
@@ -57,12 +57,12 @@ public class ProCombatMoveAI {
   private boolean isDefensive;
   private boolean isBombing;
 
-  public ProCombatMoveAI(final ProAI ai) {
+  ProCombatMoveAI(final ProAI ai) {
     this.ai = ai;
     calc = ai.getCalc();
   }
 
-  public Map<Territory, ProTerritory> doCombatMove(final IMoveDelegate moveDel) {
+  Map<Territory, ProTerritory> doCombatMove(final IMoveDelegate moveDel) {
     ProLogger.info("Starting combat move phase");
 
     // Current data at the start of combat move
@@ -148,7 +148,7 @@ public class ProCombatMoveAI {
     return territoryManager.getAttackOptions().getTerritoryMap();
   }
 
-  public void doMove(final Map<Territory, ProTerritory> attackMap, final IMoveDelegate moveDel, final GameData data,
+  void doMove(final Map<Territory, ProTerritory> attackMap, final IMoveDelegate moveDel, final GameData data,
       final PlayerID player) {
     this.data = data;
     this.player = player;
@@ -177,7 +177,7 @@ public class ProCombatMoveAI {
     isBombing = false;
   }
 
-  public boolean isBombing() {
+  boolean isBombing() {
     return isBombing;
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -52,7 +52,7 @@ import games.strategy.util.Match;
 /**
  * Pro non-combat move AI.
  */
-public class ProNonCombatMoveAI {
+class ProNonCombatMoveAI {
 
   private final ProOddsCalculator calc;
   private GameData data;
@@ -60,15 +60,15 @@ public class ProNonCombatMoveAI {
   private Map<Unit, Territory> unitTerritoryMap;
   private ProTerritoryManager territoryManager;
 
-  public ProNonCombatMoveAI(final ProAI ai) {
+  ProNonCombatMoveAI(final ProAI ai) {
     calc = ai.getCalc();
   }
 
-  public Map<Territory, ProTerritory> simulateNonCombatMove(final IMoveDelegate moveDel) {
+  Map<Territory, ProTerritory> simulateNonCombatMove(final IMoveDelegate moveDel) {
     return doNonCombatMove(null, null, moveDel);
   }
 
-  public Map<Territory, ProTerritory> doNonCombatMove(Map<Territory, ProTerritory> factoryMoveMap,
+  Map<Territory, ProTerritory> doNonCombatMove(Map<Territory, ProTerritory> factoryMoveMap,
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories, final IMoveDelegate moveDel) {
     ProLogger.info("Starting non-combat move phase");
 
@@ -167,7 +167,7 @@ public class ProNonCombatMoveAI {
     return factoryMoveMap;
   }
 
-  public void doMove(final Map<Territory, ProTerritory> moveMap, final IMoveDelegate moveDel, final GameData data,
+  void doMove(final Map<Territory, ProTerritory> moveMap, final IMoveDelegate moveDel, final GameData data,
       final PlayerID player) {
 
     this.data = data;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
@@ -27,15 +27,15 @@ import games.strategy.util.Match;
 /**
  * Pro politics AI.
  */
-public class ProPoliticsAI {
+class ProPoliticsAI {
 
   private final ProOddsCalculator calc;
 
-  public ProPoliticsAI(final ProAI ai) {
+  ProPoliticsAI(final ProAI ai) {
     calc = ai.getCalc();
   }
 
-  public List<PoliticalActionAttachment> politicalActions() {
+  List<PoliticalActionAttachment> politicalActions() {
 
     final GameData data = ProData.getData();
     final PlayerID player = ProData.getPlayer();
@@ -168,7 +168,7 @@ public class ProPoliticsAI {
     return results;
   }
 
-  public void doActions(final List<PoliticalActionAttachment> actions) {
+  void doActions(final List<PoliticalActionAttachment> actions) {
     final GameData data = ProData.getData();
     final PoliticsDelegate politicsDelegate = DelegateFinder.politicsDelegate(data);
     for (final PoliticalActionAttachment action : actions) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -52,7 +52,7 @@ import games.strategy.util.Match;
 /**
  * Pro purchase AI.
  */
-public class ProPurchaseAI {
+class ProPurchaseAI {
 
   private final ProOddsCalculator calc;
   private GameData data;
@@ -61,11 +61,11 @@ public class ProPurchaseAI {
   private ProResourceTracker resourceTracker;
   private ProTerritoryManager territoryManager;
 
-  public ProPurchaseAI(final ProAI ai) {
+  ProPurchaseAI(final ProAI ai) {
     calc = ai.getCalc();
   }
 
-  public int repair(int PUsRemaining, final IPurchaseDelegate purchaseDelegate, final GameData data,
+  int repair(int PUsRemaining, final IPurchaseDelegate purchaseDelegate, final GameData data,
       final PlayerID player) {
 
     ProLogger.info("Repairing factories with PUsRemaining=" + PUsRemaining);
@@ -120,7 +120,7 @@ public class ProPurchaseAI {
     return PUsRemaining;
   }
 
-  public Map<Territory, ProPurchaseTerritory> purchase(final IPurchaseDelegate purchaseDelegate,
+  Map<Territory, ProPurchaseTerritory> purchase(final IPurchaseDelegate purchaseDelegate,
       final GameData startOfTurnData) {
 
     // Current data fields
@@ -212,7 +212,7 @@ public class ProPurchaseAI {
     return purchaseTerritories;
   }
 
-  public void place(final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
+  void place(final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
       final IAbstractPlaceDelegate placeDelegate) {
     ProLogger.info("Starting place phase");
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
@@ -42,15 +42,15 @@ import games.strategy.util.Match;
  * 2. attacker submerges sub at start or end of battle
  * 3. defender submerges (or moves if Classic rules) sub at start or end of battle
  */
-public class ProRetreatAI {
+class ProRetreatAI {
 
   private final ProOddsCalculator calc;
 
-  public ProRetreatAI(final ProAI ai) {
+  ProRetreatAI(final ProAI ai) {
     calc = ai.getCalc();
   }
 
-  public Territory retreatQuery(final GUID battleID, final Territory battleTerritory,
+  Territory retreatQuery(final GUID battleID, final Territory battleTerritory,
       final Collection<Territory> possibleTerritories) {
 
     // Get battle data

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProScrambleAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProScrambleAI.java
@@ -28,15 +28,15 @@ import games.strategy.util.Tuple;
 /**
  * Pro scramble AI.
  */
-public class ProScrambleAI {
+class ProScrambleAI {
 
   private final ProOddsCalculator calc;
 
-  public ProScrambleAI(final ProAI ai) {
+  ProScrambleAI(final ProAI ai) {
     calc = ai.getCalc();
   }
 
-  public HashMap<Territory, Collection<Unit>> scrambleUnitsQuery(final Territory scrambleTo,
+  HashMap<Territory, Collection<Unit>> scrambleUnitsQuery(final Territory scrambleTo,
       final Map<Territory, Tuple<Collection<Unit>, Collection<Unit>>> possibleScramblers) {
 
     // Get battle data

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -37,9 +37,9 @@ import games.strategy.util.Match;
 /**
  * Pro tech AI.
  */
-public final class ProTechAI {
+final class ProTechAI {
 
-  public static void tech(final ITechDelegate techDelegate, final GameData data, final PlayerID player) {
+  static void tech(final ITechDelegate techDelegate, final GameData data, final PlayerID player) {
     if (!games.strategy.triplea.Properties.getWW2V3TechModel(data)) {
       return;
     }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle JavadocMethod rule.

The violations were fixed indirectly by either:

1. reducing the accessibility of the method from public to non-public if it was not used outside its package, or
1. removing the method if it was unused.

I purposefully avoided applying this technique to any method that may possibly be accessed via reflection (e.g. serialization and game XML parsing).  Please scrutinize the changes for any I may have mistakenly made that could break reflection as used by TripleA.  I ran through the [compatibility tests](http://www.triplea-game.org/dev_docs/dev/testing) and did not observe any problems.

Due to the large number of violations that can be fixed using this technique, the fixes are being split over multiple PRs to keep the review size reasonable.