### PR TITLE
Select air units to be moved to carrier

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -196,7 +196,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   @Override
-  public String placeUnits(final Collection<Unit> units, final Territory at, BidMode bidMode) {
+  public String placeUnits(final Collection<Unit> units, final Territory at, final BidMode bidMode) {
     if (units == null || units.isEmpty()) {
       return null;
     }
@@ -509,12 +509,6 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       return null;
     }
     final List<Unit> fighters = producer.getUnits().getMatches(ownedFighters);
-    while (fighters.size() > 0 && AirMovementValidator.carrierCost(fighters) > capacity) {
-      fighters.remove(0);
-    }
-    if (fighters.size() == 0) {
-      return null;
-    }
     final Collection<Unit> movedFighters = getRemotePlayer().getNumberOfFightersToMoveToNewCarrier(fighters, producer);
     if (movedFighters == null || movedFighters.isEmpty()) {
       return null;
@@ -1591,12 +1585,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
   /**
    * The rule is that new fighters can be produced on new carriers. This does
-   * not allow for fighters to be produced on old carriers.
+   * not allow for fighters to be produced on old carriers. THIS ISN'T CORRECT.
    */
   protected String validateNewAirCanLandOnCarriers(final Territory to, final Collection<Unit> units) {
     final int cost = AirMovementValidator.carrierCost(units);
     int capacity = AirMovementValidator.carrierCapacity(units, to);
     capacity += AirMovementValidator.carrierCapacity(to.getUnits().getUnits(), to);
+    // TODO: This method considers existing carriers but not existing air units
     if (cost > capacity) {
       return "Not enough new carriers to land all the fighters";
     }


### PR DESCRIPTION
Addresses #1751 

Problem:
On maps where the setting "Produce fighters on carriers=true", users couldn't select which fighters to move. This causes an issue on any maps where there are more than one type of air unit that can land on carriers.

Functional Changes:
- Update user prompt to use UnitChooser which allows the select of which type of units instead of just the number of units

Known Issues:
- There are a number of scenarios that allow the users to place too many air units of carriers and this isn't caught until the end of placement as the engine doesn't do a good job of validating during each unit placement if carrierCost <= carrierCapacity (not quite this simple due to various carrier production rules):
"Produce fighters on carriers"
"Produce new fighters on old carriers"
"Move existing fighters to new carriers"
"Land existing fighters on new carriers"