### PR TITLE
Revert buggy checkstyle change

### DIFF
--- a/src/main/java/games/strategy/engine/pbem/GmailEmailSender.java
+++ b/src/main/java/games/strategy/engine/pbem/GmailEmailSender.java
@@ -8,7 +8,7 @@ import games.strategy.triplea.help.HelpSupport;
 public class GmailEmailSender extends GenericEmailSender {
   private static final long serialVersionUID = 3511375113962472063L;
 
-  GmailEmailSender() {
+  public GmailEmailSender() {
     setHost("smtp.gmail.com");
     setPort(587);
     setEncryption(Encryption.TLS);


### PR DESCRIPTION
Change caused failure as soon as you click "Start PBEM .." button

triplea.engine.version.bin:1.9
java.lang.RuntimeException: Bean of type class games.strategy.engine.pbem.GmailEmailSender doesn't have public default constructor, error: Class games.strategy.engine.framework.startup.ui.PBEMSetupPanel can not access a member of class games.strategy.engine.pbem.GmailEmailSender with modifiers ""
	at games.strategy.engine.framework.startup.ui.PBEMSetupPanel.findCachedOrCreateNew(PBEMSetupPanel.java:281)
	at games.strategy.engine.framework.startup.ui.PBEMSetupPanel.loadEmailSender(PBEMSetupPanel.java:250)
	at games.strategy.engine.framework.startup.ui.PBEMSetupPanel.loadAll(PBEMSetupPanel.java:162)
	at games.strategy.engine.framework.startup.ui.PBEMSetupPanel.<init>(PBEMSetupPanel.java:100)
	at games.strategy.engine.framework.startup.mc.SetupPanelModel.showPBEM(SetupPanelModel.java:41)
	at games.strategy.engine.framework.startup.ui.MetaSetupPanel.lambda$setupListeners$1(MetaSetupPanel.java:119)
	at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
	at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
	at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
	at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
	at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:252)
	at org.pushingpixels.substance.internal.utils.RolloverButtonListener.mouseReleased(RolloverButtonListener.java:124)
	at java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:290)
	at java.awt.Component.processMouseEvent(Component.java:6533)
	at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
	at java.awt.Component.processEvent(Component.java:6298)
	at java.awt.Container.processEvent(Container.java:2236)
	at java.awt.Component.dispatchEventImpl(Component.java:4889)
	at java.awt.Container.dispatchEventImpl(Container.java:2294)
	at java.awt.Component.dispatchEvent(Component.java:4711)
	at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4888)
	at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4525)
	at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4466)
	at java.awt.Container.dispatchEventImpl(Container.java:2280)
	at java.awt.Window.dispatchEventImpl(Window.java:2746)
	at java.awt.Component.dispatchEvent(Component.java:4711)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:90)
	at java.awt.EventQueue$4.run(EventQueue.java:731)
	at java.awt.EventQueue$4.run(EventQueue.java:729)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
	at games.strategy.engine.framework.GameRunner$1.dispatchEvent(GameRunner.java:367)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
java.lang.RuntimeException: Bean of type class games.strategy.engine.pbem.GmailEmailSender doesn't have public default constructor, error: Class games.strategy.engine.framework.startup.ui.PBEMSetupPanel can not access a member of class games.strategy.engine.pbem.GmailEmailSender with modifiers ""
	at games.strategy.engine.framework.startup.ui.PBEMSetupPanel.findCachedOrCreateNew(PBEMSetupPanel.java:281)
	at games.strategy.engine.framework.startup.ui.PBEMSetupPanel.loadEmailSender(PBEMSetupPanel.java:250)
	at games.strategy.engine.framework.startup.ui.PBEMSetupPanel.loadAll(PBEMSetupPanel.java:162)
	at games.strategy.engine.framework.startup.ui.PBEMSetupPanel.<init>(PBEMSetupPanel.java:100)
	at games.strategy.engine.framework.startup.mc.SetupPanelModel.showPBEM(SetupPanelModel.java:41)
	at games.strategy.engine.framework.startup.ui.MetaSetupPanel.lambda$setupListeners$1(MetaSetupPanel.java:119)
	at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
	at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
	at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
	at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
	at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:252)
	at org.pushingpixels.substance.internal.utils.RolloverButtonListener.mouseReleased(RolloverButtonListener.java:124)
	at java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:290)
	at java.awt.Component.processMouseEvent(Component.java:6533)
	at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
	at java.awt.Component.processEvent(Component.java:6298)
	at java.awt.Container.processEvent(Container.java:2236)
	at java.awt.Component.dispatchEventImpl(Component.java:4889)
	at java.awt.Container.dispatchEventImpl(Container.java:2294)
	at java.awt.Component.dispatchEvent(Component.java:4711)
	at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4888)
	at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4525)
	at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4466)
	at java.awt.Container.dispatchEventImpl(Container.java:2280)
	at java.awt.Window.dispatchEventImpl(Window.java:2746)
	at java.awt.Component.dispatchEvent(Component.java:4711)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:90)
	at java.awt.EventQueue$4.run(EventQueue.java:731)
	at java.awt.EventQueue$4.run(EventQueue.java:729)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
	at games.strategy.engine.framework.GameRunner$1.dispatchEvent(GameRunner.java:367)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
