### PR TITLE
Enforce no duplicate keys in YAML files

### DIFF
--- a/gradle/scripts/yaml.gradle
+++ b/gradle/scripts/yaml.gradle
@@ -1,6 +1,8 @@
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.github.fge.jsonschema.main.JsonSchemaFactory
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
 
 buildscript {
     repositories {
@@ -11,10 +13,24 @@ buildscript {
         classpath group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.8.1'
         classpath group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.8.8'
         classpath group: 'com.github.fge', name: 'json-schema-validator', version: '2.2.6'
+        classpath group: 'org.yaml', name: 'snakeyaml', version: '1.18'
     }
 }
 
-ext.validateYaml = { yamlFile, jsonSchemaFile ->
+// Temporary until SnakeYAML defaults to no duplicate keys per YAML 1.2 spec
+// https://bitbucket.org/asomov/snakeyaml/issues/337/option-to-disallow-duplicate-keys
+def validateHasNoDuplicateKeys(yamlFile) {
+    def loaderOptions = new LoaderOptions()
+    loaderOptions.setAllowDuplicateKeys(false)
+    def yaml = new Yaml(loaderOptions)
+    try {
+        yamlFile.withInputStream { yaml.load(it) }
+    } catch (Exception e) {
+        throw new GradleException("$yamlFile: ${e.message}", e)
+    }
+}
+
+def validateSchema(yamlFile, jsonSchemaFile) {
     def yamlMapper = new ObjectMapper(new YAMLFactory())
     def yaml = yamlMapper.readTree(yamlFile)
 
@@ -26,4 +42,9 @@ ext.validateYaml = { yamlFile, jsonSchemaFile ->
     if (!report.success) {
         throw new GradleException("$yamlFile: $report")
     }
+}
+
+ext.validateYaml = { yamlFile, jsonSchemaFile ->
+    validateHasNoDuplicateKeys(yamlFile)
+    validateSchema(yamlFile, jsonSchemaFile)
 }

--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -454,7 +454,6 @@
     <br>c.) General tips:
     <br>Refer to game notes.
     <br>
-  version: 1
 - mapName: Ultimate World
   mapCategory: GOOD
   url: https://github.com/triplea-maps/ultimate_world/archive/master.zip
@@ -1550,7 +1549,6 @@
     <br>
     <br>by humbabba
     <br>
-  version: 1
 - mapName: Empire
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/empire/archive/master.zip
@@ -1610,7 +1608,6 @@
     <br>and simply unpack those into your new Elemental_Forces folder from above. Delete
     <br>Elemental_Forces.zip when ready.
     <br>
-  version: 1
 - mapName: Game of Thrones
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/game_of_thrones/archive/master.zip
@@ -1677,7 +1674,7 @@
 - mapName: Zombieland
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/zombieland/archive/master.zip
-  version: 1
+  version: 2
   img: http://tripleamaps.sourceforge.net/images/TripleA_zombieland_mini.png
   description: |
     <br>Created by Pulicat
@@ -1687,7 +1684,6 @@
     <br>
     <br>abandoned
     <br>
-  version: 2
 - mapName: Hex Globe10
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/hex_globe10/archive/master.zip


### PR DESCRIPTION
This PR is a follow-up to #1731 and in response to @DanVanAtta [noting](https://github.com/triplea-game/triplea-game.github.io/pull/186#discussion_r118395657) that `triplea_maps.yaml` contains duplicate keys for some maps.

SnakeYAML (the parser used by the Jackson YAML converter) defaults to allowing duplicate keys because the YAML 1.1 spec is not clear on this issue [\[1\]](https://bitbucket.org/asomov/snakeyaml/issues/337/option-to-disallow-duplicate-keys).  When a duplicate key is present in a record, SnakeYAML silently overwrites any previous value for that key.  However, this option can be overridden to raise an error when a duplicate key is detected.

Unfortunately, the Jackson YAML converter does not provide a mechanism to pass this configuration option to the SnakeYAML parser.  Therefore, I had to add a second phase to the YAML validation task that uses SnakeYAML directly to parse each file with the allow duplicate key option disabled.

According to the SnakeYAML docs for `LoaderOptions#setAllowDuplicateKeys()`, the YAML 1.2 spec makes it clear that no duplicate keys are allowed.  It is expected that a future major revision of SnakeYAML will change the default behavior to disallow duplicate keys.

This PR also updates `triplea_maps.yaml` to remove all duplicate keys.