### PR TITLE
Checkstyle: Fix missing Javadoc violations indirectly (part 4)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=4928
+checkstyleMainMaxWarnings=4821
 checkstyleTestMaxWarnings=135

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProMyMoveOptions.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProMyMoveOptions.java
@@ -18,7 +18,7 @@ public class ProMyMoveOptions {
   private final List<ProTransport> transportList;
   private final Map<Unit, Set<Territory>> bomberMoveMap;
 
-  public ProMyMoveOptions() {
+  ProMyMoveOptions() {
     territoryMap = new HashMap<>();
     unitMoveMap = new HashMap<>();
     transportMoveMap = new HashMap<>();
@@ -27,7 +27,7 @@ public class ProMyMoveOptions {
     bomberMoveMap = new HashMap<>();
   }
 
-  public ProMyMoveOptions(final ProMyMoveOptions myMoveOptions) {
+  ProMyMoveOptions(final ProMyMoveOptions myMoveOptions) {
     this();
     for (final Territory t : myMoveOptions.territoryMap.keySet()) {
       territoryMap.put(t, new ProTerritory(myMoveOptions.territoryMap.get(t)));

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
@@ -36,7 +36,7 @@ public class ProOtherMoveOptions {
     return maxMoveMap.get(t);
   }
 
-  public List<ProTerritory> getAll(final Territory t) {
+  List<ProTerritory> getAll(final Territory t) {
     final List<ProTerritory> result = moveMaps.get(t);
     if (result != null) {
       return result;

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPlaceTerritory.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPlaceTerritory.java
@@ -15,7 +15,7 @@ public class ProPlaceTerritory {
   private List<Unit> placeUnits;
   private boolean canHold;
 
-  public ProPlaceTerritory(final Territory territory) {
+  ProPlaceTerritory(final Territory territory) {
     this.territory = territory;
     defendingUnits = new ArrayList<>();
     minBattleResult = new ProBattleResult();

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOption.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOption.java
@@ -56,7 +56,7 @@ public class ProPurchaseOption {
   private boolean isAttackSupport;
   private boolean isDefenseSupport;
 
-  public ProPurchaseOption(final ProductionRule productionRule, final UnitType unitType, final PlayerID player,
+  ProPurchaseOption(final ProductionRule productionRule, final UnitType unitType, final PlayerID player,
       final GameData data) {
     this.productionRule = productionRule;
     this.unitType = unitType;

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
@@ -147,7 +147,7 @@ public class ProPurchaseOptionMap {
     return new ArrayList<>(landOptions);
   }
 
-  public List<ProPurchaseOption> getSeaOptions() {
+  private List<ProPurchaseOption> getSeaOptions() {
     final Set<ProPurchaseOption> seaOptions = new HashSet<>();
     seaOptions.addAll(seaDefenseOptions);
     seaOptions.addAll(seaTransportOptions);

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritory.java
@@ -90,7 +90,7 @@ public class ProTerritory {
     maxScrambleUnits = new ArrayList<>();
   }
 
-  public ProTerritory(final ProTerritory patd) {
+  ProTerritory(final ProTerritory patd) {
     this.territory = patd.getTerritory();
     maxUnits = new ArrayList<>(patd.getMaxUnits());
     units = new ArrayList<>(patd.getUnits());
@@ -402,7 +402,7 @@ public class ProTerritory {
     return bombardOptionsMap;
   }
 
-  public void addBombardOptionsMap(final Unit unit, final Territory t) {
+  void addBombardOptionsMap(final Unit unit, final Territory t) {
     if (bombardOptionsMap.containsKey(unit)) {
       bombardOptionsMap.get(unit).add(t);
     } else {

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTransport.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTransport.java
@@ -14,13 +14,13 @@ public class ProTransport {
   private Map<Territory, Set<Territory>> transportMap;
   private Map<Territory, Set<Territory>> seaTransportMap;
 
-  public ProTransport(final Unit transport) {
+  ProTransport(final Unit transport) {
     this.transport = transport;
     transportMap = new HashMap<>();
     seaTransportMap = new HashMap<>();
   }
 
-  public void addTerritories(final Set<Territory> attackTerritories, final Set<Territory> myUnitsToLoadTerritories) {
+  void addTerritories(final Set<Territory> attackTerritories, final Set<Territory> myUnitsToLoadTerritories) {
     for (final Territory attackTerritory : attackTerritories) {
       if (transportMap.containsKey(attackTerritory)) {
         transportMap.get(attackTerritory).addAll(myUnitsToLoadTerritories);
@@ -32,7 +32,7 @@ public class ProTransport {
     }
   }
 
-  public void addSeaTerritories(final Set<Territory> attackTerritories, final Set<Territory> myUnitsToLoadTerritories) {
+  void addSeaTerritories(final Set<Territory> attackTerritories, final Set<Territory> myUnitsToLoadTerritories) {
     for (final Territory attackTerritory : attackTerritories) {
       if (seaTransportMap.containsKey(attackTerritory)) {
         seaTransportMap.get(attackTerritory).addAll(myUnitsToLoadTerritories);

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
@@ -24,7 +24,7 @@ public class ProLogSettings implements Serializable {
   private static ProLogSettings s_lastSettings = null;
   private static String PROGRAM_SETTINGS = "Program Settings";
 
-  public static ProLogSettings loadSettings() {
+  static ProLogSettings loadSettings() {
     if (s_lastSettings == null) {
       ProLogSettings result = new ProLogSettings();
       try {
@@ -45,7 +45,7 @@ public class ProLogSettings implements Serializable {
     }
   }
 
-  public static void saveSettings(final ProLogSettings settings) {
+  static void saveSettings(final ProLogSettings settings) {
     s_lastSettings = settings;
     try (final ByteArrayOutputStream pool = new ByteArrayOutputStream(10000);
         ObjectOutputStream outputStream = new ObjectOutputStream(pool);) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogUI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogUI.java
@@ -35,7 +35,7 @@ public class ProLogUI {
     s_settingsWindow.setVisible(true);
   }
 
-  public static void notifyAILogMessage(final Level level, final String message) {
+  static void notifyAILogMessage(final Level level, final String message) {
     if (s_settingsWindow == null) {
       return;
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogWindow.java
@@ -19,16 +19,16 @@ import games.strategy.ui.SwingAction;
 /**
  * GUI class used to display logging window and logging settings.
  */
-public class ProLogWindow extends javax.swing.JDialog {
+class ProLogWindow extends javax.swing.JDialog {
   private static final long serialVersionUID = -5989598624017028122L;
 
   /** Creates new form ProLogWindow. */
-  public ProLogWindow(final TripleAFrame frame) {
+  ProLogWindow(final TripleAFrame frame) {
     super(frame);
     initComponents();
   }
 
-  public void clear() {
+  void clear() {
     this.dispose();
     v_tabPaneMain = null;
     v_logHolderTabbedPane = null;
@@ -252,7 +252,7 @@ public class ProLogWindow extends javax.swing.JDialog {
     v_limitLogHistoryToSpinner.setValue(settings.LimitLogHistoryTo);
   }
 
-  public ProLogSettings createSettings() {
+  ProLogSettings createSettings() {
     final ProLogSettings settings = new ProLogSettings();
     settings.EnableAILogging = v_enableAILogging.isSelected();
     if (v_logDepth.getSelectedIndex() == 0) {
@@ -356,7 +356,7 @@ public class ProLogWindow extends javax.swing.JDialog {
 
   private JTextArea currentLogTextArea = null;
 
-  public void addMessage(final Level level, final String message) {
+  void addMessage(final Level level, final String message) {
     try {
       if (currentLogTextArea == null) {
         currentLogTextArea = v_aiOutputLogArea;
@@ -367,7 +367,7 @@ public class ProLogWindow extends javax.swing.JDialog {
     }
   }
 
-  public void notifyNewRound(final int roundNumber, final String name) {
+  void notifyNewRound(final int roundNumber, final String name) {
     SwingAction.invokeAndWait(() -> {
       final JPanel newPanel = new JPanel();
       final JScrollPane newScrollPane = new JScrollPane();

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -333,7 +333,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Territory> territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(final PlayerID player,
+  static Match<Territory> territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(final PlayerID player,
       final List<PlayerID> players, final List<Territory> territoriesThatCantBeHeld) {
     return new Match<Territory>() {
       @Override
@@ -448,8 +448,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Territory> territoryIsAlliedLandAndHasNoEnemyNeighbors(final PlayerID player,
-      final GameData data) {
+  static Match<Territory> territoryIsAlliedLandAndHasNoEnemyNeighbors(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -605,7 +604,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Unit> unitCanBeMovedAndIsOwned(final PlayerID player) {
+  private static Match<Unit> unitCanBeMovedAndIsOwned(final PlayerID player) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -754,7 +753,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Unit> unitIsAlliedAir(final PlayerID player, final GameData data) {
+  static Match<Unit> unitIsAlliedAir(final PlayerID player, final GameData data) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -806,7 +805,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Unit> unitIsEnemyNotNeutral(final PlayerID player, final GameData data) {
+  static Match<Unit> unitIsEnemyNotNeutral(final PlayerID player, final GameData data) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -828,7 +827,7 @@ public class ProMatches {
     };
   }
 
-  public static Match<Unit> unitIsOwnedAir(final PlayerID player) {
+  static Match<Unit> unitIsOwnedAir(final PlayerID player) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -54,7 +54,7 @@ public class ProPurchaseUtils {
     return result;
   }
 
-  public static boolean canTerritoryUsePurchaseOption(final PlayerID player, final ProPurchaseOption ppo,
+  private static boolean canTerritoryUsePurchaseOption(final PlayerID player, final ProPurchaseOption ppo,
       final Territory t) {
     if (ppo == null) {
       return false;
@@ -218,7 +218,7 @@ public class ProPurchaseUtils {
     return purchaseTerritories;
   }
 
-  public static int getUnitProduction(final Territory territory, final GameData data, final PlayerID player) {
+  private static int getUnitProduction(final Territory territory, final GameData data, final PlayerID player) {
 
     final CompositeMatchAnd<Unit> factoryMatch = new CompositeMatchAnd<>(
         Matches.UnitIsOwnedAndIsFactoryOrCanProduceUnits(player), Matches.unitIsBeingTransported().invert());

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
@@ -39,17 +39,6 @@ public class ProTransportUtils {
     return maxMovement;
   }
 
-  public static int findNumUnitsThatCanBeTransported(final PlayerID player, final Territory t) {
-    final GameData data = ProData.getData();
-    int numUnitsToLoad = 0;
-    final Set<Territory> neighbors = data.getMap().getNeighbors(t, Matches.TerritoryIsLand);
-    for (final Territory neighbor : neighbors) {
-      numUnitsToLoad +=
-          Match.getMatches(neighbor.getUnits().getUnits(), ProMatches.unitIsOwnedTransportableUnit(player)).size();
-    }
-    return numUnitsToLoad;
-  }
-
   public static List<Unit> getUnitsToTransportThatCantMoveToHigherValue(final PlayerID player, final Unit transport,
       final Set<Territory> territoriesToLoadFrom, final List<Unit> unitsToIgnore,
       final Map<Territory, ProTerritory> moveMap, final Map<Unit, Set<Territory>> unitMoveMap, final double value) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -95,7 +95,7 @@ public class ProUtils {
     return true;
   }
 
-  public static List<PlayerID> getEnemyPlayers(final PlayerID player) {
+  private static List<PlayerID> getEnemyPlayers(final PlayerID player) {
     final GameData data = ProData.getData();
     final List<PlayerID> enemyPlayers = new ArrayList<>();
     for (final PlayerID players : data.getPlayerList().getPlayers()) {
@@ -106,7 +106,7 @@ public class ProUtils {
     return enemyPlayers;
   }
 
-  public static List<PlayerID> getAlliedPlayers(final PlayerID player) {
+  private static List<PlayerID> getAlliedPlayers(final PlayerID player) {
     final GameData data = ProData.getData();
     final List<PlayerID> alliedPlayers = new ArrayList<>();
     for (final PlayerID players : data.getPlayerList().getPlayers()) {

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -18,11 +18,11 @@ import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.CompositeMatchOr;
 import games.strategy.util.Match;
 
-public class Utils {
+class Utils {
   /**
    * All the territories that border one of our territories.
    */
-  public static List<Territory> getNeighboringEnemyLandTerritories(final GameData data, final PlayerID player) {
+  static List<Territory> getNeighboringEnemyLandTerritories(final GameData data, final PlayerID player) {
     final ArrayList<Territory> rVal = new ArrayList<>();
     for (final Territory t : data.getMap()) {
       if (Matches.isTerritoryEnemy(player, data).match(t) && !t.getOwner().isNull()) {
@@ -34,7 +34,7 @@ public class Utils {
     return rVal;
   }
 
-  public static List<Unit> getUnitsUpToStrength(final double maxStrength, final Collection<Unit> units,
+  static List<Unit> getUnitsUpToStrength(final double maxStrength, final Collection<Unit> units,
       final boolean sea) {
     if (AIUtils.strength(units, true, sea) < maxStrength) {
       return new ArrayList<>(units);
@@ -49,7 +49,7 @@ public class Utils {
     return rVal;
   }
 
-  public static float getStrengthOfPotentialAttackers(final Territory location, final GameData data) {
+  static float getStrengthOfPotentialAttackers(final Territory location, final GameData data) {
     float strength = 0;
     for (final Territory t : data.getMap().getNeighbors(location,
         location.isWater() ? Matches.TerritoryIsWater : Matches.TerritoryIsLand)) {
@@ -59,7 +59,7 @@ public class Utils {
     return strength;
   }
 
-  public static Route findNearest(final Territory start, final Match<Territory> endCondition,
+  static Route findNearest(final Territory start, final Match<Territory> endCondition,
       final Match<Territory> routeCondition, final GameData data) {
     Route shortestRoute = null;
     for (final Territory t : data.getMap().getTerritories()) {
@@ -76,7 +76,7 @@ public class Utils {
     return shortestRoute;
   }
 
-  public static boolean hasLandRouteToEnemyOwnedCapitol(final Territory t, final PlayerID us, final GameData data) {
+  static boolean hasLandRouteToEnemyOwnedCapitol(final Territory t, final PlayerID us, final GameData data) {
     for (final PlayerID player : Match.getMatches(data.getPlayerList().getPlayers(), Matches.isAtWar(us, data))) {
       for (final Territory capital : TerritoryAttachment.getAllCurrentlyOwnedCapitals(player, data)) {
         if (data.getMap().getDistance(t, capital, Matches.TerritoryIsLand) != -1) {
@@ -88,7 +88,7 @@ public class Utils {
   }
 
   // returns all territories that are water territories (veqryn)
-  public static List<Territory> onlyWaterTerr(final List<Territory> allTerr) {
+  static List<Territory> onlyWaterTerr(final List<Territory> allTerr) {
     final List<Territory> water = new ArrayList<>(allTerr);
     final Iterator<Territory> wFIter = water.iterator();
     while (wFIter.hasNext()) {
@@ -104,7 +104,7 @@ public class Utils {
    * Return Territories containing any unit depending on unitCondition
    * Differs from findCertainShips because it doesn't require the units be owned.
    */
-  public static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
+  static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units
     final CompositeMatch<Unit> limitShips = new CompositeMatchAnd<>(unitCondition);
     final List<Territory> shipTerr = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -205,7 +205,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     return m_gameProperty;
   }
 
-  public boolean getGamePropertyState(final GameData data) {
+  boolean getGamePropertyState(final GameData data) {
     if (m_gameProperty == null) {
       return false;
     }

--- a/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -42,16 +42,6 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   // set "actionAccept" to "UK" so UK can accept this action to go through.
   protected ArrayList<PlayerID> m_actionAccept = new ArrayList<>();
 
-  public static Match<AbstractUserActionAttachment> isSatisfiedMatch(
-      final HashMap<ICondition, Boolean> testedConditions) {
-    return new Match<AbstractUserActionAttachment>() {
-      @Override
-      public boolean match(final AbstractUserActionAttachment value) {
-        return value.isSatisfied(testedConditions);
-      }
-    };
-  }
-
   /**
    * @return true if there is no condition to this action or if the condition is satisfied.
    */

--- a/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -63,7 +63,7 @@ public class CanalAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static CanalAttachment get(final Territory t, final String nameOfAttachment) {
+  static CanalAttachment get(final Territory t, final String nameOfAttachment) {
     final CanalAttachment rVal = (CanalAttachment) t.getAttachment(nameOfAttachment);
     if (rVal == null) {
       throw new IllegalStateException(

--- a/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -32,7 +32,7 @@ public class PlayerAttachment extends DefaultAttachment {
     return p.getPlayerAttachment();
   }
 
-  public static PlayerAttachment get(final PlayerID p, final String nameOfAttachment) {
+  static PlayerAttachment get(final PlayerID p, final String nameOfAttachment) {
     final PlayerAttachment rVal = p.getPlayerAttachment(); // (PlayerAttachment) p.getAttachment(nameOfAttachment);
     if (rVal == null) {
       throw new IllegalStateException("No player attachment for:" + p.getName() + " with name:" + nameOfAttachment);

--- a/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -55,7 +55,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static RelationshipTypeAttachment get(final RelationshipType pr, final String nameOfAttachment) {
+  static RelationshipTypeAttachment get(final RelationshipType pr, final String nameOfAttachment) {
     final RelationshipTypeAttachment rVal = (RelationshipTypeAttachment) pr.getAttachment(nameOfAttachment);
     if (rVal == null) {
       throw new IllegalStateException("No relationshipType attachment for:" + pr.getName());

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -888,7 +888,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   // Static Methods for interpreting data in attachments
-  public static int getAttackBonus(final UnitType ut, final PlayerID player, final GameData data) {
+  static int getAttackBonus(final UnitType ut, final PlayerID player, final GameData data) {
     int rVal = 0;
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
@@ -899,7 +899,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static int getDefenseBonus(final UnitType ut, final PlayerID player, final GameData data) {
+  static int getDefenseBonus(final UnitType ut, final PlayerID player, final GameData data) {
     int rVal = 0;
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
@@ -910,7 +910,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static int getMovementBonus(final UnitType ut, final PlayerID player, final GameData data) {
+  static int getMovementBonus(final UnitType ut, final PlayerID player, final GameData data) {
     int rVal = 0;
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
@@ -921,7 +921,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static int getRadarBonus(final UnitType ut, final PlayerID player, final GameData data) {
+  static int getRadarBonus(final UnitType ut, final PlayerID player, final GameData data) {
     int rVal = 0;
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
@@ -932,7 +932,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static int getAirAttackBonus(final UnitType ut, final PlayerID player, final GameData data) {
+  static int getAirAttackBonus(final UnitType ut, final PlayerID player, final GameData data) {
     int rVal = 0;
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
@@ -943,7 +943,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static int getAirDefenseBonus(final UnitType ut, final PlayerID player, final GameData data) {
+  static int getAirDefenseBonus(final UnitType ut, final PlayerID player, final GameData data) {
     int rVal = 0;
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
@@ -1181,7 +1181,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static int getAttackRollsBonus(final UnitType ut, final PlayerID player, final GameData data) {
+  static int getAttackRollsBonus(final UnitType ut, final PlayerID player, final GameData data) {
     int rVal = 0;
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
@@ -1192,7 +1192,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static int getDefenseRollsBonus(final UnitType ut, final PlayerID player, final GameData data) {
+  static int getDefenseRollsBonus(final UnitType ut, final PlayerID player, final GameData data) {
     int rVal = 0;
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);

--- a/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -30,7 +30,7 @@ public class TechAttachment extends DefaultAttachment {
     return attachment;
   }
 
-  public static TechAttachment get(final PlayerID id, final String nameOfAttachment) {
+  static TechAttachment get(final PlayerID id, final String nameOfAttachment) {
     if (!nameOfAttachment.equals(Constants.TECH_ATTACHMENT_NAME)) {
       throw new IllegalStateException(
           "TechAttachment may not yet get attachments not named:" + Constants.TECH_ATTACHMENT_NAME);

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -137,7 +137,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     return (TerritoryAttachment) t.getAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
   }
 
-  public static TerritoryAttachment get(final Territory t, final String nameOfAttachment) {
+  static TerritoryAttachment get(final Territory t, final String nameOfAttachment) {
     final TerritoryAttachment rVal = (TerritoryAttachment) t.getAttachment(nameOfAttachment);
     if (rVal == null && !t.isWater()) {
       throw new IllegalStateException("No territory attachment for:" + t.getName() + " with name:" + nameOfAttachment);

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -45,7 +45,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static TerritoryEffectAttachment get(final TerritoryEffect te, final String nameOfAttachment) {
+  static TerritoryEffectAttachment get(final TerritoryEffect te, final String nameOfAttachment) {
     final TerritoryEffectAttachment rVal = (TerritoryEffectAttachment) te.getAttachment(nameOfAttachment);
     if (rVal == null) {
       throw new IllegalStateException(

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -189,7 +189,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     return collectTestsForAllTriggers(toFirePossible, aBridge, null, null);
   }
 
-  public static HashMap<ICondition, Boolean> collectTestsForAllTriggers(final HashSet<TriggerAttachment> toFirePossible,
+  static HashMap<ICondition, Boolean> collectTestsForAllTriggers(final HashSet<TriggerAttachment> toFirePossible,
       final IDelegateBridge aBridge, final HashSet<ICondition> allConditionsNeededSoFar,
       final HashMap<ICondition, Boolean> allConditionsTestedSoFar) {
     final HashSet<ICondition> allConditionsNeeded = AbstractConditionsAttachment

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -56,7 +56,7 @@ public class UnitAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public static UnitAttachment get(final UnitType type, final String nameOfAttachment) {
+  static UnitAttachment get(final UnitType type, final String nameOfAttachment) {
     final UnitAttachment rVal = (UnitAttachment) type.getAttachment(nameOfAttachment);
     if (rVal == null) {
       throw new IllegalStateException(
@@ -2277,16 +2277,6 @@ public class UnitAttachment extends DefaultAttachment {
     m_typeAA = "AA";
   }
 
-  public static Set<String> getAllOfTypeAAs(final Collection<Unit> aaUnits, final Collection<Unit> targets,
-      final Match<Unit> typeOfAA, final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed) {
-    final Set<String> rVal = new HashSet<>();
-    for (final Unit u : Match.getMatches(aaUnits,
-        Matches.UnitIsAAthatCanHitTheseUnits(targets, typeOfAA, airborneTechTargetsAllowed))) {
-      rVal.add(UnitAttachment.get(u.getType()).getTypeAA());
-    }
-    return rVal;
-  }
-
   public static List<String> getAllOfTypeAAs(final Collection<Unit> aaUnitsAlreadyVerified) {
     final Set<String> aaSet = new HashSet<>();
     for (final Unit u : aaUnitsAlreadyVerified) {
@@ -2706,7 +2696,7 @@ public class UnitAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public Collection<Territory> getListedTerritories(final String[] list) throws GameParseException {
+  private Collection<Territory> getListedTerritories(final String[] list) throws GameParseException {
     final List<Territory> rVal = new ArrayList<>();
     for (final String name : list) {
       // Validate all territories exist

--- a/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -67,7 +67,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     return supports;
   }
 
-  public static UnitSupportAttachment get(final UnitType u, final String nameOfAttachment) {
+  static UnitSupportAttachment get(final UnitType u, final String nameOfAttachment) {
     final UnitSupportAttachment rVal = (UnitSupportAttachment) u.getAttachment(nameOfAttachment);
     if (rVal == null) {
       throw new IllegalStateException("No unit type attachment for:" + u.getName() + " with name:" + nameOfAttachment);
@@ -341,7 +341,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
    * in the case that supportable units are declared before any artillery
    */
   @InternalDoNotExport
-  public static void addRule(final UnitType type, final GameData data, final boolean first) throws GameParseException {
+  static void addRule(final UnitType type, final GameData data, final boolean first) throws GameParseException {
     final String attachmentName =
         (first ? Constants.SUPPORT_RULE_NAME_OLD_TEMP_FIRST : Constants.SUPPORT_RULE_NAME_OLD) + type.getName();
     final UnitSupportAttachment rule = new UnitSupportAttachment(attachmentName, type, data);
@@ -396,7 +396,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   @InternalDoNotExport
-  public static void setOldSupportCount(final UnitType type, final GameData data, final String count) {
+  static void setOldSupportCount(final UnitType type, final GameData data, final String count) {
     for (final UnitSupportAttachment rule : get(data)) {
       if (rule.getBonusType().equals(Constants.OLD_ART_RULE_NAME) && rule.getAttachedTo() == type) {
         rule.setNumber(count);
@@ -405,7 +405,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   }
 
   @InternalDoNotExport
-  public static void addTarget(final UnitType type, final GameData data) throws GameParseException {
+  static void addTarget(final UnitType type, final GameData data) throws GameParseException {
     final Iterator<UnitSupportAttachment> iter = get(data).iterator();
     boolean first = true;
     while (iter.hasNext()) {

--- a/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -47,7 +47,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
     return returnList;
   }
 
-  public static UserActionAttachment get(final PlayerID player, final String nameOfAttachment) {
+  static UserActionAttachment get(final PlayerID player, final String nameOfAttachment) {
     final UserActionAttachment rVal = (UserActionAttachment) player.getAttachment(nameOfAttachment);
     if (rVal == null) {
       throw new IllegalStateException(

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1350,7 +1350,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     return unitsAllowed;
   }
 
-  public int howManyOfConstructionUnit(final Unit unit, final IntegerMap<String> constructionsMap) {
+  int howManyOfConstructionUnit(final Unit unit, final IntegerMap<String> constructionsMap) {
     final UnitAttachment ua = UnitAttachment.get(unit.getUnitType());
     if (/* !ua.getIsFactory() && */(!ua.getIsConstruction() || ua.getConstructionsPerTerrPerTypePerTurn() < 1
         || ua.getMaxConstructionsPerTypePerTerr() < 1)) {
@@ -1401,7 +1401,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     };
   }
 
-  public boolean getCanAllUnitsWithRequiresUnitsBePlacedCorrectly(final Collection<Unit> units, final Territory to) {
+  private boolean getCanAllUnitsWithRequiresUnitsBePlacedCorrectly(final Collection<Unit> units, final Territory to) {
     if (!isUnitPlacementRestrictions() || !Match.someMatch(units, Matches.UnitRequiresUnitsOnCreation)) {
       return true;
     }
@@ -1534,7 +1534,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     return unitsAtStartOfTurnInTO;
   }
 
-  public Collection<Unit> unitsPlacedInTerritorySoFar(final Territory to) {
+  private Collection<Unit> unitsPlacedInTerritorySoFar(final Territory to) {
     if (to == null) {
       return new ArrayList<>();
     }

--- a/src/main/java/games/strategy/triplea/delegate/AbstractUndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractUndoableMove.java
@@ -52,7 +52,7 @@ public abstract class AbstractUndoableMove implements Serializable {
     return m_units.contains(unit);
   }
 
-  public final void undo(final IDelegateBridge delegateBridge) {
+  final void undo(final IDelegateBridge delegateBridge) {
     // undo any changes to the game data
     delegateBridge.getHistoryWriter().startEvent(
         delegateBridge.getPlayerID().getName() + " undo move " + (getIndex() + 1) + ".", getDescriptionObject());

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -51,7 +51,7 @@ public class AirBattle extends AbstractBattle {
   // -1 would mean forever until one side is eliminated. (default is 1 round)
   protected final int m_maxRounds;
 
-  public AirBattle(final Territory battleSite, final boolean bombingRaid, final GameData data, final PlayerID attacker,
+  AirBattle(final Territory battleSite, final boolean bombingRaid, final GameData data, final PlayerID attacker,
       final BattleTracker battleTracker) {
     super(battleSite, attacker, battleTracker, bombingRaid, (bombingRaid ? BattleType.AIR_RAID : BattleType.AIR_BATTLE),
         data);
@@ -115,7 +115,7 @@ public class AirBattle extends AbstractBattle {
     return;
   }
 
-  public boolean shouldFightAirBattle() {
+  private boolean shouldFightAirBattle() {
     if (m_isBombingRun) {
       return Match.someMatch(m_attackingUnits, Matches.UnitIsStrategicBomber) && !m_defendingUnits.isEmpty();
     } else {
@@ -262,7 +262,7 @@ public class AirBattle extends AbstractBattle {
     return steps;
   }
 
-  public List<String> determineStepStrings(final boolean showFirstRun, final IDelegateBridge bridge) {
+  private List<String> determineStepStrings(final boolean showFirstRun, final IDelegateBridge bridge) {
     final List<String> steps = new ArrayList<>();
     if (showFirstRun) {
       steps.add(AIR_BATTLE);
@@ -391,7 +391,7 @@ public class AirBattle extends AbstractBattle {
     m_battleTracker.removeBattle(AirBattle.this);
   }
 
-  public void finishBattleAndRemoveFromTrackerHeadless(final IDelegateBridge bridge) {
+  void finishBattleAndRemoveFromTrackerHeadless(final IDelegateBridge bridge) {
     makeBattle(bridge);
     m_whoWon = WhoWon.ATTACKER;
     m_battleResultDescription = BattleRecord.BattleResultDescription.NO_BATTLE;
@@ -649,7 +649,7 @@ public class AirBattle extends AbstractBattle {
     };
   }
 
-  public static Match<Unit> attackingGroundSeaBattleEscorts(final PlayerID attacker, final GameData data) {
+  static Match<Unit> attackingGroundSeaBattleEscorts(final PlayerID attacker, final GameData data) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -689,7 +689,7 @@ public class AirBattle extends AbstractBattle {
     };
   }
 
-  public static boolean territoryCouldPossiblyHaveAirBattleDefenders(final Territory territory, final PlayerID attacker,
+  static boolean territoryCouldPossiblyHaveAirBattleDefenders(final Territory territory, final PlayerID attacker,
       final GameData data, final boolean bombing) {
     final boolean canScrambleToAirBattle = games.strategy.triplea.Properties.getCanScrambleIntoAirBattles(data);
     final Match<Unit> defendingAirMatch = bombing ? defendingBombingRaidInterceptors(attacker, data)
@@ -712,7 +712,7 @@ public class AirBattle extends AbstractBattle {
             Matches.territoryHasUnitsThatMatch(defendingAirMatch));
   }
 
-  public static int getAirBattleRolls(final Collection<Unit> units, final boolean defending) {
+  static int getAirBattleRolls(final Collection<Unit> units, final boolean defending) {
     int rolls = 0;
     for (final Unit u : units) {
       rolls += getAirBattleRolls(u, defending);
@@ -720,7 +720,7 @@ public class AirBattle extends AbstractBattle {
     return rolls;
   }
 
-  public static int getAirBattleRolls(final Unit unit, final boolean defending) {
+  static int getAirBattleRolls(final Unit unit, final boolean defending) {
     if (defending) {
       if (!unitHasAirDefenseGreaterThanZero().match(unit)) {
         return 0;

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -38,7 +38,7 @@ public class AirMovementValidator {
   // any owned air units that are in sea zones without carriers. these would be air units that have already been moved
   // this turn, and
   // therefore would need pickup.
-  public static MoveValidationResult validateAirCanLand(final GameData data, final Collection<Unit> units,
+  static MoveValidationResult validateAirCanLand(final GameData data, final Collection<Unit> units,
       final Route route, final PlayerID player, final MoveValidationResult result) {
     // First check if we even need to check
     if (getEditMode(data) || // Edit Mode, no need to check
@@ -706,7 +706,7 @@ public class AirMovementValidator {
     return 0;
   }
 
-  public static int carrierCost(final Collection<Unit> units) {
+  static int carrierCost(final Collection<Unit> units) {
     int sum = 0;
     for (final Unit unit : units) {
       sum += carrierCost(unit);
@@ -714,7 +714,7 @@ public class AirMovementValidator {
     return sum;
   }
 
-  public static int carrierCost(final Unit unit) {
+  private static int carrierCost(final Unit unit) {
     if (Matches.UnitCanLandOnCarrier.match(unit)) {
       return UnitAttachment.get(unit.getType()).getCarrierCost();
     }

--- a/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -35,7 +35,7 @@ public class AirThatCantLandUtil {
     return games.strategy.triplea.Properties.getLandExistingFightersOnNewCarriers(data);
   }
 
-  public Collection<Territory> getTerritoriesWhereAirCantLand(final PlayerID player) {
+  Collection<Territory> getTerritoriesWhereAirCantLand(final PlayerID player) {
     final GameData data = m_bridge.getData();
     final Collection<Territory> cantLand = new ArrayList<>();
     final Iterator<Territory> territories = data.getMap().getTerritories().iterator();
@@ -52,7 +52,7 @@ public class AirThatCantLandUtil {
     return cantLand;
   }
 
-  public void removeAirThatCantLand(final PlayerID player, final boolean spareAirInSeaZonesBesideFactories) {
+  void removeAirThatCantLand(final PlayerID player, final boolean spareAirInSeaZonesBesideFactories) {
     final GameData data = m_bridge.getData();
     final GameMap map = data.getMap();
     final Iterator<Territory> territories = getTerritoriesWhereAirCantLand(player).iterator();

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -66,7 +66,7 @@ public class BattleCalculator {
   // can tell what dice is for who
   // we also want to sort by movement, so casualties will be choosen as the
   // units with least movement
-  public static void sortPreBattle(final List<Unit> units) {
+  static void sortPreBattle(final List<Unit> units) {
     final Comparator<Unit> comparator = (u1, u2) -> {
       if (u1.getUnitType().equals(u2.getUnitType())) {
         return UnitComparator.getLowestToHighestMovementComparator().compare(u1, u2);
@@ -89,7 +89,7 @@ public class BattleCalculator {
     return rVal;
   }
 
-  public static int getTotalHitpointsLeft(final Unit unit) {
+  private static int getTotalHitpointsLeft(final Unit unit) {
     if (unit == null) {
       return 0;
     }
@@ -1228,7 +1228,7 @@ public class BattleCalculator {
     return false;
   }
 
-  public static int getRolls(final Collection<Unit> units, final PlayerID id,
+  private static int getRolls(final Collection<Unit> units, final PlayerID id,
       final boolean defend, final boolean bombing, final Set<List<UnitSupportAttachment>> supportRulesFriendly,
       final IntegerMap<UnitSupportAttachment> supportLeftFriendlyCopy,
       final Set<List<UnitSupportAttachment>> supportRulesEnemy,
@@ -1243,14 +1243,14 @@ public class BattleCalculator {
     return count;
   }
 
-  public static int getRolls(final Collection<Unit> units, final PlayerID id, final boolean defend,
+  static int getRolls(final Collection<Unit> units, final PlayerID id, final boolean defend,
       final boolean bombing, final Collection<TerritoryEffect> territoryEffects) {
     return getRolls(units, id, defend, bombing, new HashSet<>(),
         new IntegerMap<>(), new HashSet<>(),
         new IntegerMap<>(), territoryEffects);
   }
 
-  public static int getRolls(final Unit unit, final PlayerID id, final boolean defend,
+  private static int getRolls(final Unit unit, final PlayerID id, final boolean defend,
       final boolean bombing, final Set<List<UnitSupportAttachment>> supportRulesFriendly,
       final IntegerMap<UnitSupportAttachment> supportLeftFriendlyCopy,
       final Set<List<UnitSupportAttachment>> supportRulesEnemy,
@@ -1289,7 +1289,7 @@ public class BattleCalculator {
     return rolls;
   }
 
-  public static int getRolls(final Unit unit, final PlayerID id, final boolean defend,
+  static int getRolls(final Unit unit, final PlayerID id, final boolean defend,
       final boolean bombing, final Collection<TerritoryEffect> territoryEffects) {
     return getRolls(unit, id, defend, bombing, new HashSet<>(),
         new IntegerMap<>(), new HashSet<>(),

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -180,7 +180,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     return true;
   }
 
-  public static void doInitialize(final BattleTracker battleTracker, final IDelegateBridge aBridge) {
+  static void doInitialize(final BattleTracker battleTracker, final IDelegateBridge aBridge) {
     setupUnitsInSameTerritoryBattles(battleTracker, aBridge);
     setupTerritoriesAbandonedToTheEnemy(battleTracker, aBridge);
     // these are "blitzed" and "conquered" territories without a fight, without a pending
@@ -189,7 +189,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     resetMaxScrambleCount(aBridge);
   }
 
-  public static void clearEmptyAirBattleAttacks(final BattleTracker battleTracker, final IDelegateBridge aBridge) {
+  private static void clearEmptyAirBattleAttacks(final BattleTracker battleTracker, final IDelegateBridge aBridge) {
     // these are air battle and air raids where there is no defender, probably because no
     // air is in range to defend
     battleTracker.clearEmptyAirBattleAttacks(aBridge);
@@ -1448,7 +1448,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     markDamaged(damagedMap, bridge, true);
   }
 
-  public static void markDamaged(final IntegerMap<Unit> damagedMap, final IDelegateBridge bridge,
+  private static void markDamaged(final IntegerMap<Unit> damagedMap, final IDelegateBridge bridge,
       final boolean addPreviousHits) {
     final Set<Unit> units = new HashSet<>(damagedMap.keySet());
     if (addPreviousHits) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -149,7 +149,7 @@ public class BattleTracker implements java.io.Serializable {
         Tuple.of(oldRelation, newRelation)));
   }
 
-  public boolean didAllThesePlayersJustGoToWarThisTurn(final PlayerID p1, final Collection<Unit> enemyUnits,
+  boolean didAllThesePlayersJustGoToWarThisTurn(final PlayerID p1, final Collection<Unit> enemyUnits,
       final GameData data) {
     final Set<PlayerID> enemies = new HashSet<>();
     for (final Unit u : Match.getMatches(enemyUnits, Matches.unitIsEnemyOf(data, p1))) {
@@ -163,7 +163,7 @@ public class BattleTracker implements java.io.Serializable {
     return true;
   }
 
-  public boolean didThesePlayersJustGoToWarThisTurn(final PlayerID p1, final PlayerID p2) {
+  private boolean didThesePlayersJustGoToWarThisTurn(final PlayerID p1, final PlayerID p2) {
     // check all relationship changes that are p1 and p2, to make sure that oldRelation is not war,
     // and newRelation is war
     for (final Tuple<Tuple<PlayerID, PlayerID>, Tuple<RelationshipType, RelationshipType>> t : m_relationshipChangesThisTurn) {
@@ -199,7 +199,7 @@ public class BattleTracker implements java.io.Serializable {
     }
   }
 
-  public void clearEmptyAirBattleAttacks(final IDelegateBridge bridge) {
+  void clearEmptyAirBattleAttacks(final IDelegateBridge bridge) {
     for (final IBattle battle : new ArrayList<>(m_pendingBattles)) {
       if (AirBattle.class.isAssignableFrom(battle.getClass())) {
         final AirBattle airBattle = (AirBattle) battle;
@@ -211,7 +211,7 @@ public class BattleTracker implements java.io.Serializable {
     }
   }
 
-  public void undoBattle(final Route route, final Collection<Unit> units, final PlayerID player,
+  void undoBattle(final Route route, final Collection<Unit> units, final PlayerID player,
       final IDelegateBridge bridge) {
     for (final IBattle battle : new ArrayList<>(m_pendingBattles)) {
       if (battle.getTerritory().equals(route.getEnd())) {
@@ -919,7 +919,7 @@ public class BattleTracker implements java.io.Serializable {
     return null;
   }
 
-  public Collection<IBattle> getPendingBattles(final Territory t, final BattleType type) {
+  Collection<IBattle> getPendingBattles(final Territory t, final BattleType type) {
     final Collection<IBattle> battles = new HashSet<>();
     for (final IBattle battle : m_pendingBattles) {
       if (battle.getTerritory().equals(t) && (type == null || type.equals(battle.getBattleType()))) {
@@ -957,7 +957,7 @@ public class BattleTracker implements java.io.Serializable {
     return battles;
   }
 
-  public BattleListing getPendingBattleSites() {
+  BattleListing getPendingBattleSites() {
     final Map<BattleType, Collection<Territory>> battles = new HashMap<>();
     final Collection<IBattle> pending = new HashSet<>(m_pendingBattles);
     for (final IBattle battle : pending) {
@@ -1061,7 +1061,7 @@ public class BattleTracker implements java.io.Serializable {
     m_relationshipChangesThisTurn.clear();
   }
 
-  public void addToDefendingAirThatCanNotLand(final Collection<Unit> units, final Territory szTerritoryTheyAreIn) {
+  void addToDefendingAirThatCanNotLand(final Collection<Unit> units, final Territory szTerritoryTheyAreIn) {
     Collection<Unit> current = m_defendingAirThatCanNotLand.get(szTerritoryTheyAreIn);
     if (current == null) {
       current = new ArrayList<>();
@@ -1081,14 +1081,14 @@ public class BattleTracker implements java.io.Serializable {
     }
   }
 
-  public BattleRecords getBattleRecords() {
+  BattleRecords getBattleRecords() {
     if (m_battleRecords == null) {
       m_battleRecords = new BattleRecords();
     }
     return m_battleRecords;
   }
 
-  public void sendBattleRecordsToGameData(final IDelegateBridge aBridge) {
+  void sendBattleRecordsToGameData(final IDelegateBridge aBridge) {
     if (m_battleRecords != null && !m_battleRecords.isEmpty()) {
       aBridge.getHistoryWriter().startEvent("Recording Battle Statistics");
       aBridge.addChange(ChangeFactory.addBattleRecords(m_battleRecords, aBridge.getData()));

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -90,7 +90,7 @@ public class DiceRoll implements Externalizable {
     return Tuple.of(highestAttack, chosenDiceSize);
   }
 
-  public static int getTotalAAattacks(final Collection<Unit> defendingEnemyAA,
+  static int getTotalAAattacks(final Collection<Unit> defendingEnemyAA,
       final Collection<Unit> validAttackingUnitsForThisRoll) {
     if (defendingEnemyAA.isEmpty() || validAttackingUnitsForThisRoll.isEmpty()) {
       return 0;
@@ -113,7 +113,7 @@ public class DiceRoll implements Externalizable {
     return totalAAattacksNormal + totalAAattacksSurplus;
   }
 
-  public static DiceRoll rollAA(final Collection<Unit> validAttackingUnitsForThisRoll,
+  static DiceRoll rollAA(final Collection<Unit> validAttackingUnitsForThisRoll,
       final Collection<Unit> defendingAAForThisRoll, final IDelegateBridge bridge, final Territory location,
       final boolean defending) {
     {
@@ -838,7 +838,7 @@ public class DiceRoll implements Externalizable {
     }
   }
 
-  public static DiceRoll airBattle(final List<Unit> unitsList, final boolean defending, final PlayerID player,
+  static DiceRoll airBattle(final List<Unit> unitsList, final boolean defending, final PlayerID player,
       final IDelegateBridge bridge, final String annotation) {
     {
       final Set<Unit> duplicatesCheckSet1 = new HashSet<>(unitsList);
@@ -1049,18 +1049,7 @@ public class DiceRoll implements Externalizable {
     return ra.getNegateDominatingFirstRoundAttack();
   }
 
-  public static boolean isAmphibious(final Collection<Unit> m_units) {
-    final Iterator<Unit> unitIter = m_units.iterator();
-    while (unitIter.hasNext()) {
-      final TripleAUnit checkedUnit = (TripleAUnit) unitIter.next();
-      if (checkedUnit.getWasAmphibious()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  public static String getAnnotation(final List<Unit> units, final PlayerID player, final IBattle battle) {
+  static String getAnnotation(final List<Unit> units, final PlayerID player, final IBattle battle) {
     final StringBuilder buffer = new StringBuilder(80);
     buffer.append(player.getName()).append(" roll dice for ").append(MyFormatter.unitsToTextNoOwner(units));
     if (battle != null) {

--- a/src/main/java/games/strategy/triplea/delegate/Die.java
+++ b/src/main/java/games/strategy/triplea/delegate/Die.java
@@ -20,7 +20,7 @@ public class Die implements java.io.Serializable {
     this(value, -1, DieType.MISS);
   }
 
-  public Die(final int value, final int rolledAt, final DieType type) {
+  Die(final int value, final int rolledAt, final DieType type) {
     m_type = type;
     m_value = value;
     m_rolledAt = rolledAt;


### PR DESCRIPTION
This PR fixes violations of the Checkstyle JavadocMethod rule.

The violations were fixed indirectly by either:

1. reducing the accessibility of the method from public to non-public if it was not used outside its package, or
1. removing the method if it was unused.

I purposefully avoided applying this technique to any method that may possibly be accessed via reflection (e.g. serialization and game XML parsing).  Please scrutinize the changes for any I may have mistakenly made that could break reflection as used by TripleA.  I ran through the [compatibility tests](http://www.triplea-game.org/dev_docs/dev/testing) and did not observe any problems.

Due to the large number of violations that can be fixed using this technique, the fixes are being split over multiple PRs to keep the review size reasonable.