### PR TITLE
Checkstyle: Fix missing Javadoc violations indirectly (part 5)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=4821
+checkstyleMainMaxWarnings=4709
 checkstyleTestMaxWarnings=135

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -23,7 +23,7 @@ import games.strategy.util.Triple;
 /**
  * Provides some static methods for validating game edits.
  */
-public class EditValidator {
+class EditValidator {
   private static String validateTerritoryBasic(final GameData data, final Territory territory) {
     final String result = null;
     /*
@@ -49,8 +49,7 @@ public class EditValidator {
     return result;
   }
 
-  public static String validateChangeTerritoryOwner(final GameData data, final Territory territory,
-      final PlayerID player) {
+  static String validateChangeTerritoryOwner(final GameData data, final Territory territory, final PlayerID player) {
     String result = null;
     if (Matches.TerritoryIsWater.match(territory) && territory.getOwner().equals(PlayerID.NULL_PLAYERID)
         && TerritoryAttachment.get(territory) == null) {
@@ -62,7 +61,7 @@ public class EditValidator {
     return result;
   }
 
-  public static String validateAddUnits(final GameData data, final Territory territory, final Collection<Unit> units) {
+  static String validateAddUnits(final GameData data, final Territory territory, final Collection<Unit> units) {
     String result = null;
     if (units.isEmpty()) {
       return "No units selected";
@@ -128,8 +127,7 @@ public class EditValidator {
     return result;
   }
 
-  public static String validateRemoveUnits(final GameData data, final Territory territory,
-      final Collection<Unit> units) {
+  static String validateRemoveUnits(final GameData data, final Territory territory, final Collection<Unit> units) {
     String result = null;
     if (units.isEmpty()) {
       return "No units selected";
@@ -160,8 +158,7 @@ public class EditValidator {
     return result;
   }
 
-  public static String validateAddTech(final GameData data, final Collection<TechAdvance> techs,
-      final PlayerID player) {
+  static String validateAddTech(final GameData data, final Collection<TechAdvance> techs, final PlayerID player) {
     final String result = null;
     if (techs == null) {
       return "No tech selected";
@@ -186,8 +183,7 @@ public class EditValidator {
     return result;
   }
 
-  public static String validateRemoveTech(final GameData data, final Collection<TechAdvance> techs,
-      final PlayerID player) {
+  static String validateRemoveTech(final GameData data, final Collection<TechAdvance> techs, final PlayerID player) {
     final String result = null;
     if (techs == null) {
       return "No tech selected";
@@ -215,7 +211,7 @@ public class EditValidator {
     return result;
   }
 
-  public static String validateChangeHitDamage(final GameData data, final IntegerMap<Unit> unitDamageMap,
+  static String validateChangeHitDamage(final GameData data, final IntegerMap<Unit> unitDamageMap,
       final Territory territory) {
     String result = null;
     if (unitDamageMap == null || unitDamageMap.isEmpty()) {
@@ -246,7 +242,7 @@ public class EditValidator {
     return result;
   }
 
-  public static String validateChangeBombingDamage(final GameData data, final IntegerMap<Unit> unitDamageMap,
+  static String validateChangeBombingDamage(final GameData data, final IntegerMap<Unit> unitDamageMap,
       final Territory territory) {
     String result = null;
     if (unitDamageMap == null || unitDamageMap.isEmpty()) {
@@ -279,7 +275,7 @@ public class EditValidator {
     return result;
   }
 
-  public static String validateChangePoliticalRelationships(final GameData data,
+  static String validateChangePoliticalRelationships(final GameData data,
       final Collection<Triple<PlayerID, PlayerID, RelationshipType>> relationshipChanges) {
     final String result = null;
     if (relationshipChanges == null || relationshipChanges.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -349,7 +349,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     return games.strategy.triplea.Properties.getTriggeredVictory(getData());
   }
 
-  public int getProduction(final PlayerID id) {
+  private int getProduction(final PlayerID id) {
     int sum = 0;
     final Iterator<Territory> territories = getData().getMap().iterator();
     while (territories.hasNext()) {

--- a/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
+++ b/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
@@ -31,7 +31,7 @@ public class ExecutionStack implements Serializable {
   private IExecutable m_current;
   private final Stack<IExecutable> m_stack = new Stack<>();
 
-  public void execute(final IDelegateBridge bridge) {
+  void execute(final IDelegateBridge bridge) {
     // we were interrupted before, resume where we left off
     if (m_current != null) {
       m_stack.push(m_current);
@@ -43,7 +43,7 @@ public class ExecutionStack implements Serializable {
     m_current = null;
   }
 
-  public void push(final Collection<IExecutable> executables) {
+  void push(final Collection<IExecutable> executables) {
     for (final IExecutable ex : executables) {
       push(ex);
     }

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -48,7 +48,7 @@ public class Fire implements IExecutable {
   private final boolean m_isAmphibious;
   private final Collection<Unit> m_amphibiousLandAttackers;
 
-  public Fire(final Collection<Unit> attackableUnits, final MustFightBattle.ReturnFire canReturnFire,
+  Fire(final Collection<Unit> attackableUnits, final MustFightBattle.ReturnFire canReturnFire,
       final PlayerID firingPlayer, final PlayerID hitPlayer, final Collection<Unit> firingUnits, final String stepName,
       final String text, final MustFightBattle battle, final boolean defending,
       final Map<Unit, Collection<Unit>> dependentUnits, final ExecutionStack stack, final boolean headless,

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -218,24 +218,11 @@ public class Matches {
   };
   public static final Match<Unit> unitHasNotMoved = new InverseMatch<>(unitHasMoved);
 
-  public static Match<Unit> unitCanAttack(final PlayerID id) {
+  static Match<Unit> unitCanAttack(final PlayerID id) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unit) {
         final UnitAttachment ua = UnitAttachment.get(unit.getType());
-        if (ua.getMovement(id) <= 0) {
-          return false;
-        }
-        return ua.getAttack(id) > 0;
-      }
-    };
-  }
-
-  public static Match<UnitType> unitTypeCanAttack(final PlayerID id) {
-    return new Match<UnitType>() {
-      @Override
-      public boolean match(final UnitType uT) {
-        final UnitAttachment ua = UnitAttachment.get(uT);
         if (ua.getMovement(id) <= 0) {
           return false;
         }
@@ -334,7 +321,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitCanBeGivenByTerritoryTo(final PlayerID player) {
+  static Match<Unit> UnitCanBeGivenByTerritoryTo(final PlayerID player) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit o) {
@@ -345,7 +332,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitCanBeCapturedOnEnteringToInThisTerritory(final PlayerID player, final Territory terr,
+  static Match<Unit> UnitCanBeCapturedOnEnteringToInThisTerritory(final PlayerID player, final Territory terr,
       final GameData data) {
     return new Match<Unit>() {
       @Override
@@ -379,7 +366,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitDestroyedWhenCapturedByOrFrom(final PlayerID playerBY) {
+  static Match<Unit> UnitDestroyedWhenCapturedByOrFrom(final PlayerID playerBY) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit o) {
@@ -447,7 +434,7 @@ public class Matches {
     }
   };
 
-  public static Match<Unit> UnitIsAtMaxDamageOrNotCanBeDamaged(final Territory t) {
+  static Match<Unit> UnitIsAtMaxDamageOrNotCanBeDamaged(final Territory t) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unit) {
@@ -465,7 +452,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitIsLegalBombingTargetBy(final Unit bomberOrRocket) {
+  static Match<Unit> UnitIsLegalBombingTargetBy(final Unit bomberOrRocket) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unit) {
@@ -633,7 +620,7 @@ public class Matches {
     }
   };
 
-  public static Match<Unit> UnitIsNotInfrastructureAndNotCapturedOnEntering(final PlayerID player,
+  static Match<Unit> UnitIsNotInfrastructureAndNotCapturedOnEntering(final PlayerID player,
       final Territory terr, final GameData data) {
     return new Match<Unit>() {
       @Override
@@ -695,7 +682,7 @@ public class Matches {
     }
   };
 
-  public static Match<Territory> TerritoryHasOwnedCarrier(final PlayerID player) {
+  static Match<Territory> TerritoryHasOwnedCarrier(final PlayerID player) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -902,7 +889,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitIsAAofTypeAA(final String typeAA) {
+  static Match<Unit> UnitIsAAofTypeAA(final String typeAA) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit obj) {
@@ -952,7 +939,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitIsAAthatCanFire(final Collection<Unit> unitsMovingOrAttacking,
+  static Match<Unit> UnitIsAAthatCanFire(final Collection<Unit> unitsMovingOrAttacking,
       final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed, final PlayerID playerMovingOrAttacking,
       final Match<Unit> typeOfAA, final int battleRoundNumber, final boolean defending, final GameData data) {
     return new CompositeMatchAnd<>(Matches.enemyUnit(playerMovingOrAttacking, data),
@@ -1243,17 +1230,6 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryHasValidLandRouteTo(final GameData data, final Territory goTerr) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final CompositeMatch<Territory> validLandRoute =
-            new CompositeMatchAnd<>(Matches.TerritoryIsLand, Matches.TerritoryIsNotImpassable);
-        return data.getMap().getRoute(t, goTerr, validLandRoute) != null;
-      }
-    };
-  }
-
   public static Match<Territory> territoryIsInList(final Collection<Territory> list) {
     return new Match<Territory>() {
       @Override
@@ -1349,7 +1325,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryHasOwnedAtBeginningOfTurnIsFactoryOrCanProduceUnitsNeighbor(
+  static Match<Territory> territoryHasOwnedAtBeginningOfTurnIsFactoryOrCanProduceUnitsNeighbor(
       final GameData data, final PlayerID player) {
     return new Match<Territory>() {
       @Override
@@ -1425,8 +1401,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryHasAlliedIsFactoryOrCanProduceUnits(final GameData data,
-      final PlayerID player) {
+  static Match<Territory> territoryHasAlliedIsFactoryOrCanProduceUnits(final GameData data, final PlayerID player) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -1454,7 +1429,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryIsEmptyOfCombatUnits(final GameData data, final PlayerID player) {
+  static Match<Territory> territoryIsEmptyOfCombatUnits(final GameData data, final PlayerID player) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -1492,7 +1467,7 @@ public class Matches {
   };
   public static final Match<Territory> TerritoryIsNotImpassable = new InverseMatch<>(TerritoryIsImpassable);
 
-  public static Match<Territory> seaCanMoveOver(final PlayerID player, final GameData data) {
+  static Match<Territory> seaCanMoveOver(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -1504,7 +1479,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> airCanFlyOver(final PlayerID player, final GameData data,
+  static Match<Territory> airCanFlyOver(final PlayerID player, final GameData data,
       final boolean areNeutralsPassableByAir) {
     return new Match<Territory>() {
       @Override
@@ -1543,7 +1518,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> TerritoryIsImpassableToLandUnits(final PlayerID player, final GameData data) {
+  private static Match<Territory> TerritoryIsImpassableToLandUnits(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -1772,16 +1747,6 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> unitHasDefenseThatIsMoreThanOrEqualTo(final int minDefense) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit unit) {
-        final UnitAttachment ua = UnitAttachment.get(unit.getType());
-        return ua.getDefense(unit.getOwner()) >= minDefense;
-      }
-    };
-  }
-
   public static Match<Unit> unitIsTransporting() {
     return new Match<Unit>() {
       @Override
@@ -1876,7 +1841,7 @@ public class Matches {
     return comp;
   }
 
-  public static Match<Unit> unitIsInTerritory(final Territory territory) {
+  static Match<Unit> unitIsInTerritory(final Territory territory) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit o) {
@@ -2123,15 +2088,6 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryHasNoAlliedUnits(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        return !t.getUnits().someMatch(alliedUnit(player, data));
-      }
-    };
-  }
-
   public static Match<Territory> territoryHasAlliedUnits(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
@@ -2141,7 +2097,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryHasNonSubmergedEnemyUnits(final PlayerID player, final GameData data) {
+  static Match<Territory> territoryHasNonSubmergedEnemyUnits(final PlayerID player, final GameData data) {
     final CompositeMatch<Unit> match = new CompositeMatchAnd<>();
     match.add(enemyUnit(player, data));
     match.add(UnitIsSubmerged.invert());
@@ -2167,15 +2123,6 @@ public class Matches {
       @Override
       public boolean match(final Territory t) {
         return t.getUnits().someMatch(new CompositeMatchAnd<>(enemyUnit(player, data), UnitIsSea));
-      }
-    };
-  }
-
-  public static Match<Territory> territoryHasEnemyBlitzUnits(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        return t.getUnits().someMatch(enemyUnit(player, data)) && t.getUnits().someMatch(Matches.UnitCanBlitz);
       }
     };
   }
@@ -2215,18 +2162,6 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryHasOwnedTransportingUnits(final PlayerID player) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final CompositeMatch<Unit> match = new CompositeMatchAnd<>();
-        match.add(unitIsOwnedBy(player));
-        match.add(transportIsTransporting());
-        return t.getUnits().someMatch(match);
-      }
-    };
-  }
-
   public static Match<Unit> transportCannotUnload(final Territory territory) {
     return new Match<Unit>() {
       @Override
@@ -2251,7 +2186,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> transportIsTransporting() {
+  static Match<Unit> transportIsTransporting() {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit transport) {
@@ -2353,7 +2288,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryWasFoughOver(final BattleTracker tracker) {
+  static Match<Territory> territoryWasFoughOver(final BattleTracker tracker) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -2378,7 +2313,7 @@ public class Matches {
     }
   };
 
-  public static Match<Unit> unitOwnerHasImprovedArtillerySupportTech() {
+  static Match<Unit> unitOwnerHasImprovedArtillerySupportTech() {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -2432,7 +2367,7 @@ public class Matches {
     }
   };
 
-  public static Match<Unit> UnitCanRepairThisUnit(final Unit damagedUnit) {
+  static Match<Unit> UnitCanRepairThisUnit(final Unit damagedUnit) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unitCanRepair) {
@@ -2508,7 +2443,7 @@ public class Matches {
     }
   };
 
-  public static Match<Unit> UnitCanGiveBonusMovementToThisUnit(final Unit unitWhichWillGetBonus) {
+  static Match<Unit> UnitCanGiveBonusMovementToThisUnit(final Unit unitWhichWillGetBonus) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unitCanGiveBonusMovement) {
@@ -2645,8 +2580,7 @@ public class Matches {
     }
   };
 
-  public static Match<Unit> UnitWhichConsumesUnitsHasRequiredUnits(
-      final Collection<Unit> unitsInTerritoryAtStartOfTurn) {
+  static Match<Unit> UnitWhichConsumesUnitsHasRequiredUnits(final Collection<Unit> unitsInTerritoryAtStartOfTurn) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unitWhichRequiresUnits) {
@@ -2963,26 +2897,6 @@ public class Matches {
     };
   }
 
-  public static Match<PlayerID> isNeutral(final PlayerID player, final GameData data) {
-    return new Match<PlayerID>() {
-      @Override
-      public boolean match(final PlayerID player2) {
-        return Matches.RelationshipTypeIsNeutral
-            .match(data.getRelationshipTracker().getRelationshipType(player, player2));
-      }
-    };
-  }
-
-  public static Match<PlayerID> isNeutralWithAnyOfThesePlayers(final Collection<PlayerID> players,
-      final GameData data) {
-    return new Match<PlayerID>() {
-      @Override
-      public boolean match(final PlayerID player2) {
-        return data.getRelationshipTracker().isNeutralWithAnyOfThesePlayers(player2, players);
-      }
-    };
-  }
-
   public static Match<Unit> UnitIsOwnedAndIsFactoryOrCanProduceUnits(final PlayerID player) {
     return new Match<Unit>() {
       @Override
@@ -3017,7 +2931,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitHasWhenCombatDamagedEffect() {
+  private static Match<Unit> UnitHasWhenCombatDamagedEffect() {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -3026,7 +2940,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitHasWhenCombatDamagedEffect(final String filterForEffect) {
+  static Match<Unit> UnitHasWhenCombatDamagedEffect(final String filterForEffect) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -3053,7 +2967,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> TerritoryHasWhenCapturedByGoesTo() {
+  static Match<Territory> TerritoryHasWhenCapturedByGoesTo() {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -3066,7 +2980,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitWhenCapturedChangesIntoDifferentUnitType() {
+  static Match<Unit> UnitWhenCapturedChangesIntoDifferentUnitType() {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -3129,7 +3043,7 @@ public class Matches {
     };
   }
 
-  public static Match<PlayerID> isAlliedAndAlliancesCanChainTogether(final PlayerID player, final GameData data) {
+  static Match<PlayerID> isAlliedAndAlliancesCanChainTogether(final PlayerID player, final GameData data) {
     return new Match<PlayerID>() {
       @Override
       public boolean match(final PlayerID player2) {
@@ -3238,7 +3152,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryAllowsRocketsCanFlyOver(final PlayerID player, final GameData data) {
+  static Match<Territory> territoryAllowsRocketsCanFlyOver(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -3283,7 +3197,7 @@ public class Matches {
     }
   };
 
-  public static Match<Territory> territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(
+  static Match<Territory> territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(
       final PlayerID attacker) {
     return new Match<Territory>() {
       @Override
@@ -3303,8 +3217,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryOwnerRelationshipTypeCanMoveIntoDuringCombatMove(
-      final PlayerID movingPlayer) {
+  static Match<Territory> territoryOwnerRelationshipTypeCanMoveIntoDuringCombatMove(final PlayerID movingPlayer) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -278,7 +278,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
   }
 
-  public static Change getResetUnitStateChange(final GameData data) {
+  static Change getResetUnitStateChange(final GameData data) {
     final CompositeChange change = new CompositeChange();
     for (final Unit u : data.getUnits()) {
       final TripleAUnit taUnit = TripleAUnit.get(u);
@@ -395,7 +395,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     return change;
   }
 
-  public static void repairMultipleHitPointUnits(final IDelegateBridge aBridge, final PlayerID player) {
+  static void repairMultipleHitPointUnits(final IDelegateBridge aBridge, final PlayerID player) {
     final GameData data = aBridge.getData();
     final boolean repairOnlyOwn =
         games.strategy.triplea.Properties.getBattleshipsRepairAtBeginningOfRound(aBridge.getData());
@@ -568,7 +568,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     return null;
   }
 
-  public static Collection<Territory> getEmptyNeutral(final Route route) {
+  static Collection<Territory> getEmptyNeutral(final Route route) {
     final Match<Territory> emptyNeutral =
         new CompositeMatchAnd<>(Matches.TerritoryIsEmpty, Matches.TerritoryIsNeutralButNotWater);
     final Collection<Territory> neutral = route.getMatches(emptyNeutral);

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1412,7 +1412,7 @@ public class MoveValidator {
     return carrierMustMoveWith(units, start.getUnits().getUnits(), data, player);
   }
 
-  public static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units,
+  static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units,
       final Collection<Unit> startUnits, final GameData data, final PlayerID player) {
     // we want to get all air units that are owned by our allies
     // but not us that can land on a carrier
@@ -1453,7 +1453,7 @@ public class MoveValidator {
     return mapping;
   }
 
-  public static Collection<Unit> getCanCarry(final Unit carrier, final Collection<Unit> selectFrom,
+  private static Collection<Unit> getCanCarry(final Unit carrier, final Collection<Unit> selectFrom,
       final PlayerID playerWhoIsDoingTheMovement, final GameData data) {
     final UnitAttachment ua = UnitAttachment.get(carrier.getUnitType());
     final Collection<Unit> canCarry = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -271,7 +271,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return change;
   }
 
-  public void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
+  void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
     for (final Unit holder : dependencies.keySet()) {
       final Collection<Unit> transporting = dependencies.get(holder);
       if (m_dependentUnits.get(holder) != null) {
@@ -286,7 +286,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return m_attacker.getName() + " attack " + m_defender.getName() + " in " + m_battleSite.getName();
   }
 
-  public void updateDefendingAAUnits() {
+  private void updateDefendingAAUnits() {
     final Collection<Unit> canFire = new ArrayList<>(m_defendingUnits.size() + m_defendingWaitingToDie.size());
     canFire.addAll(m_defendingUnits);
     canFire.addAll(m_defendingWaitingToDie);
@@ -300,7 +300,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     Collections.reverse(m_defendingAAtypes);
   }
 
-  public void updateOffensiveAAUnits() {
+  private void updateOffensiveAAUnits() {
     final Collection<Unit> canFire = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
     canFire.addAll(m_attackingUnits);
     canFire.addAll(m_attackingWaitingToDie);
@@ -478,7 +478,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     m_attackingUnits.removeAll(Match.getMatches(m_attackingUnits, airNotInTerritory));
   }
 
-  public List<String> determineStepStrings(final boolean showFirstRun, final IDelegateBridge bridge) {
+  List<String> determineStepStrings(final boolean showFirstRun, final IDelegateBridge bridge) {
     final List<String> steps = new ArrayList<>();
     if (canFireOffensiveAA()) {
       for (final String typeAA : UnitAttachment.getAllOfTypeAAs(m_offensiveAA)) {
@@ -1573,7 +1573,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return change;
   }
 
-  public void reLoadTransports(final Collection<Unit> units, final CompositeChange change) {
+  void reLoadTransports(final Collection<Unit> units, final CompositeChange change) {
     final Collection<Unit> transports = Match.getMatches(units, Matches.UnitCanTransport);
     // Put units back on their transports
     for (final Unit transport : transports) {
@@ -2401,7 +2401,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   // Figure out what units a transport is transported and has unloaded
-  public Collection<Unit> getTransportDependents(final Collection<Unit> targets, final GameData data) {
+  private Collection<Unit> getTransportDependents(final Collection<Unit> targets, final GameData data) {
     if (m_headless) {
       return Collections.emptyList();
     }
@@ -2637,7 +2637,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     m_battleTracker.addToDefendingAirThatCanNotLand(m_defendingAir, m_battleSite);
   }
 
-  public static CompositeChange clearTransportedByForAlliedAirOnCarrier(final Collection<Unit> attackingUnits,
+  static CompositeChange clearTransportedByForAlliedAirOnCarrier(final Collection<Unit> attackingUnits,
       final Territory battleSite, final PlayerID attacker, final GameData data) {
     final CompositeChange change = new CompositeChange();
     // Clear the transported_by for successfully won battles where there was an allied air unit held as cargo by an
@@ -2702,7 +2702,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   // In an amphibious assault, sort on who is unloading from xports first
   // This will allow the marines with higher scores to get killed last
-  public void sortAmphib(final List<Unit> units, final GameData data) {
+  private void sortAmphib(final List<Unit> units, final GameData data) {
     final Comparator<Unit> decreasingMovement = UnitComparator.getLowestToHighestMovementComparator();
     final Comparator<Unit> comparator = (u1, u2) -> {
       int amphibComp = 0;

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -161,7 +161,7 @@ public class NonFightingBattle extends DependentBattle {
     }
   }
 
-  public void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
+  void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
     for (final Unit holder : dependencies.keySet()) {
       final Collection<Unit> transporting = dependencies.get(holder);
       if (m_dependentUnits.get(holder) != null) {

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -516,7 +516,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     }
   }
 
-  public static void chainAlliancesTogether(final IDelegateBridge aBridge) {
+  static void chainAlliancesTogether(final IDelegateBridge aBridge) {
     final GameData data = aBridge.getData();
     if (!games.strategy.triplea.Properties.getAlliancesCanChainTogether(data)) {
       return;
@@ -581,7 +581,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     }
   }
 
-  public static void givesBackOriginalTerritories(final IDelegateBridge aBridge) {
+  private static void givesBackOriginalTerritories(final IDelegateBridge aBridge) {
     final GameData data = aBridge.getData();
     final CompositeChange change = new CompositeChange();
     final Collection<PlayerID> players = data.getPlayerList().getPlayers();

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -225,7 +225,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         Matches.isTerritoryOwnedBy(PlayerID.NULL_PLAYERID), Matches.TerritoryIsEmpty);
   }
 
-  public Match<PlayerID> getPlayerCanPickMatch() {
+  private Match<PlayerID> getPlayerCanPickMatch() {
     return new Match<PlayerID>() {
       @Override
       public boolean match(final PlayerID player) {

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -72,7 +72,7 @@ public class RocketsFireHelper {
 
   public RocketsFireHelper() {}
 
-  public void fireRockets(final IDelegateBridge bridge, final PlayerID player) {
+  void fireRockets(final IDelegateBridge bridge, final PlayerID player) {
     final GameData data = bridge.getData();
     final Set<Territory> rocketTerritories = getTerritoriesWithRockets(data, player);
     if (rocketTerritories.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -163,7 +163,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     return null;
   }
 
-  public static MoveValidationResult validateMove(final Collection<Unit> units, final Route route,
+  static MoveValidationResult validateMove(final Collection<Unit> units, final Route route,
       final PlayerID player, final Collection<Unit> transportsToLoad, final Map<Unit, Collection<Unit>> newDependents,
       final boolean isNonCombat, final List<UndoableMove> undoableMoves, final GameData data) {
     final MoveValidationResult result = new MoveValidationResult();

--- a/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -182,7 +182,7 @@ public abstract class TechAdvance extends NamedAttachable {
     return ta;
   }
 
-  public static TechAdvance findAdvance(final String propertyString, final GameData data, final PlayerID player) {
+  static TechAdvance findAdvance(final String propertyString, final GameData data, final PlayerID player) {
     for (final TechAdvance t : getTechAdvances(data, player)) {
       if (t.getProperty().equals(propertyString)) {
         return t;

--- a/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -73,7 +73,7 @@ public class TechTracker implements java.io.Serializable {
     advance.perform(player, bridge);
   }
 
-  public static synchronized void removeAdvance(final PlayerID player, final IDelegateBridge bridge,
+  static synchronized void removeAdvance(final PlayerID player, final IDelegateBridge bridge,
       final TechAdvance advance) {
     Change attachmentChange;
     if (advance instanceof GenericTechAdvance) {

--- a/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
@@ -25,7 +25,7 @@ public class TerritoryEffectHelper {
     }
   }
 
-  public static int getTerritoryCombatBonus(final UnitType type, final Collection<TerritoryEffect> effects,
+  static int getTerritoryCombatBonus(final UnitType type, final Collection<TerritoryEffect> effects,
       final boolean defending) {
     if (type == null || effects == null || effects.isEmpty()) {
       return 0;
@@ -75,7 +75,7 @@ public class TerritoryEffectHelper {
     return rVal;
   }
 
-  public static Set<UnitType> getUnitTypesForUnitsNotAllowedIntoTerritory(final Collection<Territory> steps) {
+  static Set<UnitType> getUnitTypesForUnitsNotAllowedIntoTerritory(final Collection<Territory> steps) {
     final Set<UnitType> rVal = new HashSet<>();
     for (final Territory location : steps) {
       rVal.addAll(getUnitTypesForUnitsNotAllowedIntoTerritory(location));

--- a/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -120,7 +120,7 @@ public class TransportTracker {
     return ((TripleAUnit) unit).getTransportedBy();
   }
 
-  public static Change unloadTransportChange(final TripleAUnit unit, final Territory territory, final PlayerID id,
+  static Change unloadTransportChange(final TripleAUnit unit, final Territory territory, final PlayerID id,
       final boolean dependentBattle) {
     final CompositeChange change = new CompositeChange();
     final TripleAUnit transport = (TripleAUnit) transportedBy(unit);
@@ -150,7 +150,7 @@ public class TransportTracker {
     return change;
   }
 
-  public static Change unloadAirTransportChange(final TripleAUnit unit, final Territory territory, final PlayerID id,
+  static Change unloadAirTransportChange(final TripleAUnit unit, final Territory territory, final PlayerID id,
       final boolean dependentBattle) {
     final CompositeChange change = new CompositeChange();
     final TripleAUnit transport = (TripleAUnit) transportedBy(unit);
@@ -184,7 +184,7 @@ public class TransportTracker {
     return change;
   }
 
-  public static Change loadTransportChange(final TripleAUnit transport, final Unit unit) {
+  static Change loadTransportChange(final TripleAUnit transport, final Unit unit) {
     assertTransport(transport);
     final CompositeChange change = new CompositeChange();
     // clear the loaded by
@@ -216,7 +216,7 @@ public class TransportTracker {
     return capacity - used - unloaded;
   }
 
-  public static Collection<Unit> getUnitsLoadedOnAlliedTransportsThisTurn(final Collection<Unit> units) {
+  static Collection<Unit> getUnitsLoadedOnAlliedTransportsThisTurn(final Collection<Unit> units) {
     final Collection<Unit> rVal = new ArrayList<>();
     for (final Unit u : units) {
       // a unit loaded onto an allied transport
@@ -236,7 +236,7 @@ public class TransportTracker {
     return rVal;
   }
 
-  public static boolean hasTransportUnloadedInPreviousPhase(final Unit transport) {
+  static boolean hasTransportUnloadedInPreviousPhase(final Unit transport) {
     final Collection<Unit> unloaded = ((TripleAUnit) transport).getUnloaded();
     // See if transport has unloaded anywhere yet
     for (final Unit u : unloaded) {
@@ -262,7 +262,7 @@ public class TransportTracker {
   // multiple territories in a given turn.
   // In WW2V1 a transport can unload to multiple territories in
   // non-combat phase, provided they are both adjacent to the sea zone.
-  public static boolean isTransportUnloadRestrictedToAnotherTerritory(final Unit transport, final Territory territory) {
+  static boolean isTransportUnloadRestrictedToAnotherTerritory(final Unit transport, final Territory territory) {
     final Collection<Unit> unloaded = ((TripleAUnit) transport).getUnloaded();
     if (unloaded.isEmpty()) {
       return false;
@@ -292,7 +292,7 @@ public class TransportTracker {
   // However, we only need to call this method to determine why we can't
   // unload an additional unit. Since transports only hold up to two units,
   // we only need to return one territory, not multiple territories.
-  public static Territory getTerritoryTransportHasUnloadedTo(final Unit transport) {
+  static Territory getTerritoryTransportHasUnloadedTo(final Unit transport) {
     final Collection<Unit> unloaded = ((TripleAUnit) transport).getUnloaded();
     if (unloaded.isEmpty()) {
       return null;
@@ -302,7 +302,7 @@ public class TransportTracker {
   }
 
   // If a transport has been in combat, it cannot load AND unload in non-combat
-  public static boolean isTransportUnloadRestrictedInNonCombat(final Unit transport) {
+  static boolean isTransportUnloadRestrictedInNonCombat(final Unit transport) {
     final TripleAUnit taUnit = (TripleAUnit) transport;
     return GameStepPropertiesHelper.isNonCombatMove(transport.getData(), true) && taUnit.getWasInCombat()
         && taUnit.getWasLoadedAfterCombat();

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -56,7 +56,7 @@ public class UndoableMove extends AbstractUndoableMove {
     return m_reasonCantUndo == null && m_dependOnMe.isEmpty();
   }
 
-  public String getReasonCantUndo() {
+  String getReasonCantUndo() {
     if (m_reasonCantUndo != null) {
       return m_reasonCantUndo;
     } else if (!m_dependOnMe.isEmpty()) {
@@ -184,13 +184,6 @@ public class UndoableMove extends AbstractUndoableMove {
         m_iDependOn.add(other);
         other.m_dependOnMe.add(this);
       }
-    }
-  }
-
-  // for use with airborne moving
-  public void addDependency(final List<UndoableMove> undoableMoves) {
-    for (final UndoableMove other : undoableMoves) {
-      addDependency(other);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
@@ -14,7 +14,7 @@ import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
 public class UnitComparator {
-  public static Comparator<Unit> getLowestToHighestMovementComparator() {
+  static Comparator<Unit> getLowestToHighestMovementComparator() {
     return (u1, u2) -> {
       final int left1 = TripleAUnit.get(u1).getMovementLeft();
       final int left2 = TripleAUnit.get(u2).getMovementLeft();
@@ -247,7 +247,7 @@ public class UnitComparator {
     };
   }
 
-  public static Comparator<Unit> getDecreasingAttackComparator(final PlayerID player) {
+  static Comparator<Unit> getDecreasingAttackComparator(final PlayerID player) {
     return (u1, u2) -> {
       final UnitAttachment ua1 = UnitAttachment.get(u1.getType());
       final UnitAttachment ua2 = UnitAttachment.get(u2.getType());

--- a/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
@@ -22,7 +22,7 @@ public class UnitsThatCantFightUtil {
   }
 
   // TODO Used to notify of kamikazi attacks
-  public Collection<Territory> getTerritoriesWhereUnitsCantFight(final PlayerID player) {
+  Collection<Territory> getTerritoriesWhereUnitsCantFight(final PlayerID player) {
     final CompositeMatch<Unit> enemyAttackUnits = new CompositeMatchAnd<>();
     enemyAttackUnits.add(Matches.enemyUnit(player, m_data));
     enemyAttackUnits.add(Matches.unitCanAttack(player));

--- a/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -60,7 +60,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
     return !getValidActions().isEmpty();
   }
 
-  public HashMap<ICondition, Boolean> getTestedConditions() {
+  private HashMap<ICondition, Boolean> getTestedConditions() {
     final HashSet<ICondition> allConditionsNeeded = AbstractConditionsAttachment.getAllConditionsRecursive(
         new HashSet<>(UserActionAttachment.getUserActionAttachments(m_player)), null);
     return AbstractConditionsAttachment.testAllConditionsRecursive(allConditionsNeeded, null, m_bridge);

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleListing.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleListing.java
@@ -32,14 +32,6 @@ public class BattleListing implements Serializable {
     return m_battles;
   }
 
-  public Set<Territory> getAllBattleTerritories() {
-    final Set<Territory> territories = new HashSet<>();
-    for (final Entry<BattleType, Collection<Territory>> entry : m_battles.entrySet()) {
-      territories.addAll(entry.getValue());
-    }
-    return territories;
-  }
-
   public Set<Territory> getNormalBattlesIncludingAirBattles() {
     final Set<Territory> territories = new HashSet<>();
     for (final Entry<BattleType, Collection<Territory>> entry : m_battles.entrySet()) {
@@ -54,16 +46,6 @@ public class BattleListing implements Serializable {
     final Set<Territory> territories = new HashSet<>();
     for (final Entry<BattleType, Collection<Territory>> entry : m_battles.entrySet()) {
       if (entry.getKey().isBombingRun()) {
-        territories.addAll(entry.getValue());
-      }
-    }
-    return territories;
-  }
-
-  public Set<Territory> getAirBattles() {
-    final Set<Territory> territories = new HashSet<>();
-    for (final Entry<BattleType, Collection<Territory>> entry : m_battles.entrySet()) {
-      if (entry.getKey().isAirPreBattleOrPreRaid()) {
         territories.addAll(entry.getValue());
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/MoveDescription.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/MoveDescription.java
@@ -31,14 +31,6 @@ public class MoveDescription extends AbstractMoveDescription {
     }
   }
 
-  public MoveDescription(final Collection<Unit> units, final Route route,
-      final Collection<Unit> transportsThatCanBeLoaded) {
-    super(units);
-    m_route = route;
-    m_transportsThatCanBeLoaded = transportsThatCanBeLoaded;
-    m_dependentUnits = null;
-  }
-
   public MoveDescription(final Collection<Unit> units, final Route route) {
     super(units);
     m_route = route;

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/MoveValidationResult.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/MoveValidationResult.java
@@ -4,9 +4,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import games.strategy.engine.data.Unit;
 
@@ -23,21 +21,6 @@ public class MoveValidationResult implements Serializable, Comparable<MoveValida
     m_disallowedUnitsList = new ArrayList<>();
     m_unresolvedUnitWarnings = new ArrayList<>();
     m_unresolvedUnitsList = new ArrayList<>();
-  }
-
-  public MoveValidationResult(final MoveValidationResult toCopy) {
-    this();
-    for (final String warning : toCopy.getDisallowedUnitWarnings()) {
-      for (final Unit unit : toCopy.getDisallowedUnits(warning)) {
-        addDisallowedUnit(warning, unit);
-      }
-    }
-    for (final String warning : toCopy.getUnresolvedUnitWarnings()) {
-      for (final Unit unit : toCopy.getUnresolvedUnits(warning)) {
-        addUnresolvedUnit(warning, unit);
-      }
-    }
-    setError(toCopy.getError());
   }
 
   public void addDisallowedUnit(final String warning, final Unit unit) {
@@ -89,34 +72,6 @@ public class MoveValidationResult implements Serializable, Comparable<MoveValida
 
   public String getError() {
     return m_error;
-  }
-
-  public Collection<Unit> getDisallowedUnits() {
-    final Set<Unit> allDisallowedUnits = new LinkedHashSet<>();
-    for (final Collection<Unit> unitList : m_disallowedUnitsList) {
-      for (final Unit unit : unitList) {
-        allDisallowedUnits.add(unit);
-      }
-    }
-    return allDisallowedUnits;
-  }
-
-  public Collection<Unit> getUnresolvedUnits() {
-    final Set<Unit> allUnresolvedUnits = new LinkedHashSet<>();
-    for (final Collection<Unit> unitList : m_unresolvedUnitsList) {
-      for (final Unit unit : unitList) {
-        allUnresolvedUnits.add(unit);
-      }
-    }
-    return allUnresolvedUnits;
-  }
-
-  public Collection<Unit> getDisallowedUnits(final String warning) {
-    final int index = m_disallowedUnitWarnings.indexOf(warning);
-    if (index == -1) {
-      return Collections.emptyList();
-    }
-    return new ArrayList<>(m_disallowedUnitsList.get(index));
   }
 
   public Collection<Unit> getUnresolvedUnits(final String warning) {

--- a/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -102,7 +102,7 @@ public class DiceImageFactory {
     }
   }
 
-  public Image getDieImage(final int i, final Die.DieType type) {
+  private Image getDieImage(final int i, final Die.DieType type) {
     if (i <= 0) {
       throw new IllegalArgumentException("die must be greater than 0, not:" + i);
     }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
@@ -65,7 +65,7 @@ public class AggregateResults implements Serializable {
     return results == null ? new ArrayList<>() : results.getRemainingDefendingUnits();
   }
 
-  public double getAverageAttackingUnitsLeft() {
+  double getAverageAttackingUnitsLeft() {
     if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
@@ -109,7 +109,7 @@ public class AggregateResults implements Serializable {
     return defenderLost - attackerLost;
   }
 
-  public double getAverageAttackingUnitsLeftWhenAttackerWon() {
+  double getAverageAttackingUnitsLeftWhenAttackerWon() {
     if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
@@ -127,7 +127,7 @@ public class AggregateResults implements Serializable {
     return count / total;
   }
 
-  public double getAverageDefendingUnitsLeft() {
+  double getAverageDefendingUnitsLeft() {
     if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
@@ -138,7 +138,7 @@ public class AggregateResults implements Serializable {
     return count / m_results.size();
   }
 
-  public double getAverageDefendingUnitsLeftWhenDefenderWon() {
+  double getAverageDefendingUnitsLeftWhenDefenderWon() {
     if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
@@ -169,7 +169,7 @@ public class AggregateResults implements Serializable {
     return count / m_results.size();
   }
 
-  public double getDefenderWinPercent() {
+  double getDefenderWinPercent() {
     if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
@@ -197,7 +197,7 @@ public class AggregateResults implements Serializable {
     return count / m_results.size();
   }
 
-  public double getDrawPercent() {
+  double getDrawPercent() {
     if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -86,7 +86,7 @@ public class OddsCalculator implements IOddsCalculator, Callable<AggregateResult
     this(data, false);
   }
 
-  public OddsCalculator(final GameData data, final boolean dataHasAlreadyBeenCloned) {
+  OddsCalculator(final GameData data, final boolean dataHasAlreadyBeenCloned) {
     m_data = data == null ? null : (dataHasAlreadyBeenCloned ? data : GameDataUtils.cloneGameData(data, false));
     if (data != null) {
       m_isDataSet = true;
@@ -275,7 +275,7 @@ public class OddsCalculator implements IOddsCalculator, Callable<AggregateResult
     return rVal;
   }
 
-  public static boolean isValidOrderOfLoss(final String orderOfLoss, final GameData data) {
+  static boolean isValidOrderOfLoss(final String orderOfLoss, final GameData data) {
     if (orderOfLoss == null || orderOfLoss.trim().length() == 0) {
       return true;
     }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -79,7 +79,7 @@ import games.strategy.util.IntegerMap;
 import games.strategy.util.ListenerList;
 import games.strategy.util.Match;
 
-public class OddsCalculatorPanel extends JPanel {
+class OddsCalculatorPanel extends JPanel {
   private static final long serialVersionUID = -3559687618320469183L;
   private static final String NO_EFFECTS = "*None*";
   private final Window m_parent;
@@ -129,7 +129,7 @@ public class OddsCalculatorPanel extends JPanel {
   private JList<String> m_territoryEffectsJList;
   private final WidgetChangedListener m_listenerPlayerUnitsPanel = () -> setWidgetActivation();
 
-  public OddsCalculatorPanel(final GameData data, final IUIContext context, final Territory location,
+  OddsCalculatorPanel(final GameData data, final IUIContext context, final Territory location,
       final Window parent) {
     m_data = data;
     m_context = context;
@@ -188,7 +188,7 @@ public class OddsCalculatorPanel extends JPanel {
     revalidate();
   }
 
-  public void shutdown() {
+  void shutdown() {
     try {
       // use this if not using a static calc, so that we gc the calc and shutdown all threads.
       // must be shutdown, as it has a thread pool per each instance.
@@ -465,12 +465,12 @@ public class OddsCalculatorPanel extends JPanel {
     }
   }
 
-  public String formatPercentage(final double percentage) {
+  String formatPercentage(final double percentage) {
     final NumberFormat format = new DecimalFormat("%");
     return format.format(percentage);
   }
 
-  public String formatValue(final double value) {
+  String formatValue(final double value) {
     final NumberFormat format = new DecimalFormat("#0.##");
     return format.format(value);
   }
@@ -758,7 +758,7 @@ public class OddsCalculatorPanel extends JPanel {
     m_time.setText(blank);
   }
 
-  public void setWidgetActivation() {
+  void setWidgetActivation() {
     m_keepOneAttackingLandUnitCheckBox.setEnabled(m_landBattleCheckBox.isSelected());
     m_amphibiousCheckBox.setEnabled(m_landBattleCheckBox.isSelected());
     final boolean isLand = isLand();
@@ -815,7 +815,7 @@ public class OddsCalculatorPanel extends JPanel {
     }
   }
 
-  public void selectCalculateButton() {
+  void selectCalculateButton() {
     m_calculateButton.requestFocus();
   }
 


### PR DESCRIPTION
This PR fixes violations of the Checkstyle JavadocMethod rule.

The violations were fixed indirectly by either:

1. reducing the accessibility of the method from public to non-public if it was not used outside its package, or
1. removing the method if it was unused.

I purposefully avoided applying this technique to any method that may possibly be accessed via reflection (e.g. serialization and game XML parsing).  Please scrutinize the changes for any I may have mistakenly made that could break reflection as used by TripleA.  I ran through the [compatibility tests](http://www.triplea-game.org/dev_docs/dev/testing) and did not observe any problems.

Due to the large number of violations that can be fixed using this technique, the fixes are being split over multiple PRs to keep the review size reasonable.