### PR TITLE
Add Integration test task to Gradle 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,14 @@ jar {
 repositories {
     jcenter()
 }
+
+sourceSets {
+    integTest {
+        java.srcDir 'src/integ_test/java'
+        resources.srcDir 'src/integ_test/resources'
+    }
+}
+
 dependencies {
     compile 'com.github.insubstantial:substance:7.3'
     compile 'com.google.guava:guava:19.0'
@@ -90,6 +98,16 @@ dependencies {
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.mockito:mockito-core:2.7.22'
     testCompile 'junit:junit:4.12'
+
+    integTestCompile sourceSets.main.output
+    integTestCompile sourceSets.test.output
+
+    integTestCompile configurations.compile
+    integTestCompile configurations.testCompile
+
+    integTestRuntime configurations.runtime
+    integTestRuntime configurations.testRuntime
+
 }
 
 test {
@@ -97,6 +115,25 @@ test {
         exceptionFormat = 'full'
     }
 }
+
+task integTest(type: Test) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = 'Runs the integration tests.'
+
+    testClassesDir = sourceSets.integTest.output.classesDir
+    classpath = sourceSets.integTest.runtimeClasspath
+
+    binResultsDir = file("$buildDir/integration-test-results/binary/integTest")
+
+    reports {
+        html.destination = "$buildDir/reports/integration-test"
+        junitXml.destination = "$buildDir/integration-test-results"
+    }
+
+    mustRunAfter tasks.test
+}
+
+check.dependsOn integTest
 
 
 def assetsDirectory = file("${buildDir}/assets")

--- a/build.gradle
+++ b/build.gradle
@@ -74,10 +74,14 @@ sourceSets {
     integTest {
         java.srcDir 'src/integ_test/java'
         resources.srcDir 'src/integ_test/resources'
+
+        compileClasspath = sourceSets.main.output + sourceSets.test.output + configurations.testRuntime
+        runtimeClasspath = output + compileClasspath
     }
 }
 
 dependencies {
+    compile group: 'postgresql', name: 'postgresql', version: '9.1-901-1.jdbc4'
     compile 'com.github.insubstantial:substance:7.3'
     compile 'com.google.guava:guava:19.0'
     compile 'com.googlecode.soundlibs:jlayer:1.0.1-2'
@@ -98,16 +102,6 @@ dependencies {
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
     testCompile 'org.mockito:mockito-core:2.7.22'
     testCompile 'junit:junit:4.12'
-
-    integTestCompile sourceSets.main.output
-    integTestCompile sourceSets.test.output
-
-    integTestCompile configurations.compile
-    integTestCompile configurations.testCompile
-
-    integTestRuntime configurations.runtime
-    integTestRuntime configurations.testRuntime
-
 }
 
 test {
@@ -123,11 +117,11 @@ task integTest(type: Test) {
     testClassesDir = sourceSets.integTest.output.classesDir
     classpath = sourceSets.integTest.runtimeClasspath
 
-    binResultsDir = file("$buildDir/integration-test-results/binary/integTest")
+    binResultsDir = file("$buildDir/integration_test_results/binary/integTest")
 
     reports {
-        html.destination = "$buildDir/reports/integration-test"
-        junitXml.destination = "$buildDir/integration-test-results"
+        reports.html.destination = file("${reports.html.destination}/$name")
+        reports.junitXml.destination = file("${reports.junitXml.destination}/$name")
     }
 
     mustRunAfter tasks.test

--- a/src/integ_test/java/games/strategy/engine/lobby/server/userDB/DbUserControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/userDB/DbUserControllerIntegrationTest.java
@@ -13,7 +13,7 @@ import games.strategy.util.MD5Crypt;
 import games.strategy.util.ThreadUtil;
 import games.strategy.util.Util;
 
-public class DbUserControllerTest {
+public class DbUserControllerIntegrationTest {
 
   @Test
   public void testCreate() throws Exception {


### PR DESCRIPTION
Related to: https://github.com/triplea-game/triplea/issues/1758 (Derby DB migration - Integration testing without Derby). This PR adds build infrastructure to let us run integration  #tests.

New gradle task to run just  the integration tests can be run with:
```
./gradlew integTest
```
 Integration tests are also run as part of `./gradlew check`, which is what travis runs.

On this branch  DbUserControllerTest was moved and renamed as a proof of concept and as a starting point for next iteration that will add a secondary DB. Since DbUserControllerTest accesses a live DB, and will soon access another one, it is a good example of something to run as an integration test.