### PR TITLE
Upgrade install4j Gradle plugin to 6.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,10 @@
-buildscript {
-    repositories {
-        maven { url 'http://maven.ej-technologies.com/repository' }
-    }
-    dependencies {
-        classpath group: 'com.install4j', name: 'gradle-plugin', version: '6.0.4'
-    }
-}
-
 plugins {
     id 'java'
     id 'application'
     id 'checkstyle'
     id 'com.github.ben-manes.versions' version '0.12.0'
     id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id 'com.install4j.gradle' version '6.1.2'
     id "de.qaware.seu.as.code.git" version "2.2.0"
 }
 
@@ -161,8 +153,6 @@ task lobbyServer(type: Zip, group: 'release', dependsOn: renameShadowJar) {
 }
 
 task generateZipReleases(group: 'release', dependsOn: [allPlatform, lobbyServer]) {}
-
-apply plugin: 'install4j'
 
 task copyJRE(type: Copy, dependsOn: [updateAssets]) {
     from "${assetsDirectory}/install4j/windows-x86-1.8.0_66.tar.gz"


### PR DESCRIPTION
This PR upgrades the install4j Gradle plugin to version 6.1.2 to match the version of install4j we use to build the installers.

#### Functional changes
None.

#### Refactoring changes
None.

#### Other changes
* Upgrade install4j Gradle plugin to version 6.1.2.
* Use the Gradle 2+ plugin mechanism to register the install4j plugin (the install4j plugin has been available on `plugins.gradle.org` since version 6.1).

#### Other issues for review
None.

#### Testing
I built the installers using `./gradlew clean release`.  I then ran the Unix installer and verified I could start a new local game from the installed image.  Finally, I verified running the uninstaller worked as expected.