### PR TITLE
Checkstyle: Update thresholds [High Priority]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=4595
-checkstyleTestMaxWarnings=135
+checkstyleMainMaxWarnings=4596
+checkstyleTestMaxWarnings=134


### PR DESCRIPTION
This PR updates the Checkstyle thresholds for `master`.

The build broke when #1774 was merged.  I suspect there was a net increase in Checkstyle violations when some other recent PRs were merged (#1773, #1777).  The net increase was permitted by the build system because of the bug reported in #1700 because the thresholds have drifted since they were last manually reset (about a week ago).

@ron-murhammer @DanVanAtta Please merge ASAP to get the build green again.

@DanVanAtta Please look at the possibly-revoked token described in #1700 so we can get that script working again and avoid the drift in the Checkstyle thresholds.