### PR TITLE
Checkstyle: Fix abbreviation violations in test code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 checkstyleMainMaxWarnings=4493
-checkstyleTestMaxWarnings=134
+checkstyleTestMaxWarnings=53

--- a/src/test/java/games/strategy/engine/EngineVersionTest.java
+++ b/src/test/java/games/strategy/engine/EngineVersionTest.java
@@ -18,8 +18,8 @@ public class EngineVersionTest {
 
   @Test
   public void testVersionParsingStopsAtFourNumbers() {
-    final String EXPECTED_OUTPUT = "1.2.3.4";
-    String input = EXPECTED_OUTPUT + ".5";
+    final String expectedOutput = "1.2.3.4";
+    String input = expectedOutput + ".5";
 
 
     EngineVersion testObj = createTestObj(input);
@@ -28,7 +28,7 @@ public class EngineVersionTest {
             + "return '1.2.3.4'",
         testObj.getVersion(), is(new Version(1, 2, 3, 4)));
 
-    input = EXPECTED_OUTPUT;
+    input = expectedOutput;
     testObj = createTestObj(input);
     assertThat(
         "We wrote to property file version:'1.2.3.4', and expect to get the same value back when reading from property "

--- a/src/test/java/games/strategy/engine/data/ITestDelegateBridge.java
+++ b/src/test/java/games/strategy/engine/data/ITestDelegateBridge.java
@@ -14,7 +14,7 @@ public interface ITestDelegateBridge extends IDelegateBridge {
    * Changing the player has the effect of commiting the current transaction.
    * Player is initialized to the player specified in the xml data.
    */
-  void setPlayerID(PlayerID playerId);
+  void setPlayerId(PlayerID playerId);
 
   void setStepName(String name);
 

--- a/src/test/java/games/strategy/engine/data/SerializationTest.java
+++ b/src/test/java/games/strategy/engine/data/SerializationTest.java
@@ -40,11 +40,11 @@ public class SerializationTest {
   }
 
   @Test
-  public void testWritePlayerID() throws Exception {
+  public void testWritePlayerId() throws Exception {
     final PlayerID id = gameDataSource.getPlayerList().getPlayerID("chretian");
-    final PlayerID readID = (PlayerID) serialize(id);
-    final PlayerID localID = gameDataSink.getPlayerList().getPlayerID("chretian");
-    assertTrue(localID != readID);
+    final PlayerID readId = (PlayerID) serialize(id);
+    final PlayerID localId = gameDataSink.getPlayerList().getPlayerID("chretian");
+    assertTrue(localId != readId);
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
+++ b/src/test/java/games/strategy/engine/data/TestDelegateBridge.java
@@ -85,7 +85,7 @@ public class TestDelegateBridge implements ITestDelegateBridge {
    * Player is initialized to the player specified in the xml data.
    */
   @Override
-  public void setPlayerID(final PlayerID playerId) {
+  public void setPlayerId(final PlayerID playerId) {
     this.playerId = playerId;
   }
 

--- a/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
+++ b/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
@@ -28,9 +28,9 @@ public class UnitCollectionTest {
   private UnitType unitTypeOne;
   private UnitType unitTypeTwo;
   @Mock
-  private final PlayerID defaultPlayerID = Mockito.spy(new PlayerID("Default Player", true, false, null));
+  private final PlayerID defaultPlayerId = Mockito.spy(new PlayerID("Default Player", true, false, null));
   @Mock
-  private PlayerID otherPlayerID;
+  private PlayerID otherPlayerId;
   private UnitCollection unitCollection;
 
   private Unit unitDefaultPlayer1;
@@ -75,24 +75,24 @@ public class UnitCollectionTest {
         ++defaultPlayerNotifyChangedCounter;
         return null;
       }
-    }).when(defaultPlayerID).notifyChanged();
+    }).when(defaultPlayerId).notifyChanged();
 
-    unitCollection = new UnitCollection(defaultPlayerID, mockGameData);
+    unitCollection = new UnitCollection(defaultPlayerId, mockGameData);
 
-    unitDefaultPlayer1 = new Unit(unitTypeOne, defaultPlayerID, mockGameData);
-    unitDefaultPlayer2 = new Unit(unitTypeTwo, defaultPlayerID, mockGameData);
-    unitDefaultPlayer3 = new Unit(unitTypeTwo, defaultPlayerID, mockGameData);
+    unitDefaultPlayer1 = new Unit(unitTypeOne, defaultPlayerId, mockGameData);
+    unitDefaultPlayer2 = new Unit(unitTypeTwo, defaultPlayerId, mockGameData);
+    unitDefaultPlayer3 = new Unit(unitTypeTwo, defaultPlayerId, mockGameData);
     unitCountDefaultPlayerUnitTypeOne = getDefaultPlayerUnitsOfUnitTypeOne().size();
     unitCountDefaultPlayerUnitTypeTwo = getDefaultPlayerUnitsOfUnitTypeTwo().size();
     unitCountDefaultPlayer = unitCountDefaultPlayerUnitTypeOne + unitCountDefaultPlayerUnitTypeTwo;
 
-    unitOtherPlayer1 = new Unit(unitTypeOne, otherPlayerID, mockGameData);
-    unitOtherPlayer2 = new Unit(unitTypeOne, otherPlayerID, mockGameData);
-    unitOtherPlayer3 = new Unit(unitTypeOne, otherPlayerID, mockGameData);
-    unitOtherPlayer4 = new Unit(unitTypeTwo, otherPlayerID, mockGameData);
-    unitOtherPlayer5 = new Unit(unitTypeTwo, otherPlayerID, mockGameData);
-    unitOtherPlayer6 = new Unit(unitTypeTwo, otherPlayerID, mockGameData);
-    unitOtherPlayer7 = new Unit(unitTypeTwo, otherPlayerID, mockGameData);
+    unitOtherPlayer1 = new Unit(unitTypeOne, otherPlayerId, mockGameData);
+    unitOtherPlayer2 = new Unit(unitTypeOne, otherPlayerId, mockGameData);
+    unitOtherPlayer3 = new Unit(unitTypeOne, otherPlayerId, mockGameData);
+    unitOtherPlayer4 = new Unit(unitTypeTwo, otherPlayerId, mockGameData);
+    unitOtherPlayer5 = new Unit(unitTypeTwo, otherPlayerId, mockGameData);
+    unitOtherPlayer6 = new Unit(unitTypeTwo, otherPlayerId, mockGameData);
+    unitOtherPlayer7 = new Unit(unitTypeTwo, otherPlayerId, mockGameData);
 
     unitCountOtherPlayerUnitTypeOne = getOtherPlayerUnitsOfUnitTypeOne().size();
     unitCountOtherPlayerUnitTypeTwo = getOtherPlayerUnitsOfUnitTypeTwo().size();
@@ -134,14 +134,14 @@ public class UnitCollectionTest {
 
   @Test
   public void unitCollection() {
-    assertThat(unitCollection.getHolder(), is(equalTo(defaultPlayerID)));
+    assertThat(unitCollection.getHolder(), is(equalTo(defaultPlayerId)));
     assertThat(unitCollection.getData(), is(equalTo(mockGameData)));
   }
 
   @Test
   public void addUnit() {
     final int notifyChangedCountBefore = getDefaultPlayerNotifyChangedCounter();
-    final Unit unitDefaultPlayer = new Unit(unitTypeOne, defaultPlayerID, mockGameData);
+    final Unit unitDefaultPlayer = new Unit(unitTypeOne, defaultPlayerId, mockGameData);
     unitCollection.addUnit(unitDefaultPlayer);
 
     assertThat(unitCollection.getUnitCount(), is(equalTo(1)));
@@ -165,7 +165,7 @@ public class UnitCollectionTest {
   public void addAllUnitsFromUnitCollection() {
     final int notifyChangedCountBefore = getDefaultPlayerNotifyChangedCounter();
     final Collection<Unit> unitsOfOtherPlayerOfUnitTypeOne = getOtherPlayerUnitsOfUnitTypeOne();
-    final UnitCollection unitCollectionTwo = new UnitCollection(otherPlayerID, mockGameData);
+    final UnitCollection unitCollectionTwo = new UnitCollection(otherPlayerId, mockGameData);
     unitCollectionTwo.addAllUnits(unitsOfOtherPlayerOfUnitTypeOne);
     unitCollection.addAllUnits(unitCollectionTwo);
 
@@ -248,45 +248,45 @@ public class UnitCollectionTest {
   }
 
   @Test
-  public void getUnitCountByUnitTypeAndPlayerID() {
-    assertThat(unitCollection.getUnitCount(unitTypeOne, defaultPlayerID), is(equalTo(0)));
-    assertThat(unitCollection.getUnitCount(unitTypeTwo, defaultPlayerID), is(equalTo(0)));
-    assertThat(unitCollection.getUnitCount(unitTypeOne, otherPlayerID), is(equalTo(0)));
-    assertThat(unitCollection.getUnitCount(unitTypeTwo, otherPlayerID), is(equalTo(0)));
+  public void getUnitCountByUnitTypeAndPlayerId() {
+    assertThat(unitCollection.getUnitCount(unitTypeOne, defaultPlayerId), is(equalTo(0)));
+    assertThat(unitCollection.getUnitCount(unitTypeTwo, defaultPlayerId), is(equalTo(0)));
+    assertThat(unitCollection.getUnitCount(unitTypeOne, otherPlayerId), is(equalTo(0)));
+    assertThat(unitCollection.getUnitCount(unitTypeTwo, otherPlayerId), is(equalTo(0)));
 
     final UnitCollection allDefaultPlayerUnitCollection = addAllDefaultPlayerUnitsToUnitCollection(unitCollection);
-    assertThat(allDefaultPlayerUnitCollection.getUnitCount(unitTypeOne, defaultPlayerID),
+    assertThat(allDefaultPlayerUnitCollection.getUnitCount(unitTypeOne, defaultPlayerId),
         is(equalTo(unitCountDefaultPlayerUnitTypeOne)));
-    assertThat(allDefaultPlayerUnitCollection.getUnitCount(unitTypeTwo, defaultPlayerID),
+    assertThat(allDefaultPlayerUnitCollection.getUnitCount(unitTypeTwo, defaultPlayerId),
         is(equalTo(unitCountDefaultPlayerUnitTypeTwo)));
-    assertThat(allDefaultPlayerUnitCollection.getUnitCount(unitTypeOne, otherPlayerID), is(equalTo(0)));
-    assertThat(allDefaultPlayerUnitCollection.getUnitCount(unitTypeTwo, otherPlayerID), is(equalTo(0)));
+    assertThat(allDefaultPlayerUnitCollection.getUnitCount(unitTypeOne, otherPlayerId), is(equalTo(0)));
+    assertThat(allDefaultPlayerUnitCollection.getUnitCount(unitTypeTwo, otherPlayerId), is(equalTo(0)));
 
     final UnitCollection allPlayersUnitCollection =
         addAllOtherPlayerUnitsToUnitCollection(allDefaultPlayerUnitCollection);
-    assertThat(allPlayersUnitCollection.getUnitCount(unitTypeOne, defaultPlayerID),
+    assertThat(allPlayersUnitCollection.getUnitCount(unitTypeOne, defaultPlayerId),
         is(equalTo(unitCountDefaultPlayerUnitTypeOne)));
-    assertThat(allPlayersUnitCollection.getUnitCount(unitTypeTwo, defaultPlayerID),
+    assertThat(allPlayersUnitCollection.getUnitCount(unitTypeTwo, defaultPlayerId),
         is(equalTo(unitCountDefaultPlayerUnitTypeTwo)));
-    assertThat(allPlayersUnitCollection.getUnitCount(unitTypeOne, otherPlayerID),
+    assertThat(allPlayersUnitCollection.getUnitCount(unitTypeOne, otherPlayerId),
         is(equalTo(unitCountOtherPlayerUnitTypeOne)));
-    assertThat(allPlayersUnitCollection.getUnitCount(unitTypeTwo, otherPlayerID),
+    assertThat(allPlayersUnitCollection.getUnitCount(unitTypeTwo, otherPlayerId),
         is(equalTo(unitCountOtherPlayerUnitTypeTwo)));
   }
 
   @Test
-  public void getUnitCountByPlayerID() {
-    assertThat(unitCollection.getUnitCount(defaultPlayerID), is(equalTo(0)));
-    assertThat(unitCollection.getUnitCount(otherPlayerID), is(equalTo(0)));
+  public void getUnitCountByPlayerId() {
+    assertThat(unitCollection.getUnitCount(defaultPlayerId), is(equalTo(0)));
+    assertThat(unitCollection.getUnitCount(otherPlayerId), is(equalTo(0)));
 
     final UnitCollection allDefaultPlayerUnitCollection = addAllDefaultPlayerUnitsToUnitCollection(unitCollection);
-    assertThat(allDefaultPlayerUnitCollection.getUnitCount(defaultPlayerID), is(equalTo(unitCountDefaultPlayer)));
-    assertThat(allDefaultPlayerUnitCollection.getUnitCount(otherPlayerID), is(equalTo(0)));
+    assertThat(allDefaultPlayerUnitCollection.getUnitCount(defaultPlayerId), is(equalTo(unitCountDefaultPlayer)));
+    assertThat(allDefaultPlayerUnitCollection.getUnitCount(otherPlayerId), is(equalTo(0)));
 
     final UnitCollection allPlayersUnitCollection =
         addAllOtherPlayerUnitsToUnitCollection(allDefaultPlayerUnitCollection);
-    assertThat(allPlayersUnitCollection.getUnitCount(defaultPlayerID), is(equalTo(unitCountDefaultPlayer)));
-    assertThat(allPlayersUnitCollection.getUnitCount(otherPlayerID), is(equalTo(unitCountOtherPlayer)));
+    assertThat(allPlayersUnitCollection.getUnitCount(defaultPlayerId), is(equalTo(unitCountDefaultPlayer)));
+    assertThat(allPlayersUnitCollection.getUnitCount(otherPlayerId), is(equalTo(unitCountOtherPlayer)));
   }
 
   @Test
@@ -315,15 +315,15 @@ public class UnitCollectionTest {
   }
 
   @Test
-  public void getUnitsByTypeWithPlayerID() {
+  public void getUnitsByTypeWithPlayerId() {
     final UnitCollection allDefaultPlayerUnitCollection = addAllDefaultPlayerUnitsToUnitCollection(unitCollection);
     final IntegerMap<UnitType> unitsByTypeOnlyDefaultPlayer =
-        allDefaultPlayerUnitCollection.getUnitsByType(defaultPlayerID);
+        allDefaultPlayerUnitCollection.getUnitsByType(defaultPlayerId);
     assertThat(unitsByTypeOnlyDefaultPlayer.getInt(unitTypeOne), is(equalTo(unitCountDefaultPlayerUnitTypeOne)));
     assertThat(unitsByTypeOnlyDefaultPlayer.getInt(unitTypeTwo), is(equalTo(unitCountDefaultPlayerUnitTypeTwo)));
     final UnitCollection allPlayersUnitCollection =
         addAllOtherPlayerUnitsToUnitCollection(allDefaultPlayerUnitCollection);
-    final IntegerMap<UnitType> unitsByTypeBothPlayers = allPlayersUnitCollection.getUnitsByType(defaultPlayerID);
+    final IntegerMap<UnitType> unitsByTypeBothPlayers = allPlayersUnitCollection.getUnitsByType(defaultPlayerId);
     assertThat(unitsByTypeBothPlayers.getInt(unitTypeOne), is(equalTo(unitCountDefaultPlayerUnitTypeOne)));
     assertThat(unitsByTypeBothPlayers.getInt(unitTypeTwo), is(equalTo(unitCountDefaultPlayerUnitTypeTwo)));
   }
@@ -378,8 +378,8 @@ public class UnitCollectionTest {
   public void getPlayerUnitCounts() {
     final UnitCollection allPlayerUnitCollection = addAllPlayerUnitsToUnitCollection(unitCollection);
     final IntegerMap<PlayerID> playerUnitCounts = allPlayerUnitCollection.getPlayerUnitCounts();
-    assertThat(playerUnitCounts.getInt(defaultPlayerID), is(equalTo(unitCountDefaultPlayer)));
-    assertThat(playerUnitCounts.getInt(otherPlayerID), is(equalTo(unitCountOtherPlayer)));
+    assertThat(playerUnitCounts.getInt(defaultPlayerId), is(equalTo(unitCountDefaultPlayer)));
+    assertThat(playerUnitCounts.getInt(otherPlayerId), is(equalTo(unitCountOtherPlayer)));
   }
 
   @Test
@@ -393,7 +393,7 @@ public class UnitCollectionTest {
 
   @Test
   public void getHolder() {
-    assertThat(unitCollection.getHolder(), is(equalTo(defaultPlayerID)));
+    assertThat(unitCollection.getHolder(), is(equalTo(defaultPlayerId)));
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -13,7 +13,7 @@ import games.strategy.engine.data.GameData;
 public class GameDataManagerTest {
 
   @Test
-  public void testLoadStoreKeepsGamUUID() throws IOException {
+  public void testLoadStoreKeepsGameUuid() throws IOException {
     final GameData data = new GameData();
     final GameDataManager m = new GameDataManager();
     final ByteArrayOutputStream sink = new ByteArrayOutputStream();

--- a/src/test/java/games/strategy/engine/lobby/server/userDB/BadWordControllerTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/userDB/BadWordControllerTest.java
@@ -10,7 +10,7 @@ import games.strategy.util.Util;
 public class BadWordControllerTest {
 
   @Test
-  public void testCRUD() {
+  public void testCrud() {
     final BadWordController controller = new BadWordController();
     final String word = Util.createUniqueTimeStamp();
     controller.addBadWord(word);

--- a/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
+++ b/src/test/java/games/strategy/engine/message/unifiedmessenger/RemoteMessengerTest.java
@@ -172,13 +172,13 @@ public class RemoteMessengerTest {
       server.setAcceptNewConnections(true);
       final String mac = MacFinder.getHashedMacAddress();
       client = new ClientMessenger("localhost", serverPort, "client", mac);
-      final UnifiedMessenger serverUM = new UnifiedMessenger(server);
-      unifiedMessengerHub = serverUM.getHub();
-      final RemoteMessenger serverRM = new RemoteMessenger(serverUM);
-      final RemoteMessenger clientRM = new RemoteMessenger(new UnifiedMessenger(client));
+      final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(server);
+      unifiedMessengerHub = serverUnifiedMessenger.getHub();
+      final RemoteMessenger serverRemoteMessenger = new RemoteMessenger(serverUnifiedMessenger);
+      final RemoteMessenger clientRemoteMessenger = new RemoteMessenger(new UnifiedMessenger(client));
       // register it on the server
       final TestRemote testRemote = new TestRemote();
-      serverRM.registerRemote(testRemote, test);
+      serverRemoteMessenger.registerRemote(testRemote, test);
       // since the registration must go over a socket
       // and through a couple threads, wait for the
       // client to get it
@@ -188,7 +188,7 @@ public class RemoteMessengerTest {
         ThreadUtil.sleep(50);
       }
       // call it on the client
-      final int rVal = ((ITestRemote) clientRM.getRemote(test)).increment(1);
+      final int rVal = ((ITestRemote) clientRemoteMessenger.getRemote(test)).increment(1);
       assertEquals(2, rVal);
       assertEquals(testRemote.getLastSenderNode(), client.getLocalNode());
     } finally {
@@ -215,14 +215,14 @@ public class RemoteMessengerTest {
       server.setAcceptNewConnections(true);
       final String mac = MacFinder.getHashedMacAddress();
       client = new ClientMessenger("localhost", serverPort, "client", mac);
-      final RemoteMessenger serverRM = new RemoteMessenger(new UnifiedMessenger(server));
+      final RemoteMessenger serverRemoteMessenger = new RemoteMessenger(new UnifiedMessenger(server));
       final TestRemote testRemote = new TestRemote();
-      serverRM.registerRemote(testRemote, test);
-      final RemoteMessenger clientRM = new RemoteMessenger(new UnifiedMessenger(client));
+      serverRemoteMessenger.registerRemote(testRemote, test);
+      final RemoteMessenger clientRemoteMessenger = new RemoteMessenger(new UnifiedMessenger(client));
       // call it on the client
       // should be no need to wait since the constructor should not
       // reutrn until the initial state of the messenger is good
-      final int rVal = ((ITestRemote) clientRM.getRemote(test)).increment(1);
+      final int rVal = ((ITestRemote) clientRemoteMessenger.getRemote(test)).increment(1);
       assertEquals(2, rVal);
       assertEquals(testRemote.getLastSenderNode(), client.getLocalNode());
     } finally {
@@ -242,14 +242,14 @@ public class RemoteMessengerTest {
       server.setAcceptNewConnections(true);
       final String mac = MacFinder.getHashedMacAddress();
       client = new ClientMessenger("localhost", serverPort, "client", mac);
-      final UnifiedMessenger serverUM = new UnifiedMessenger(server);
-      final RemoteMessenger clientRM = new RemoteMessenger(new UnifiedMessenger(client));
-      clientRM.registerRemote(new TestRemote(), test);
-      serverUM.getHub().waitForNodesToImplement(test.getName());
-      assertTrue(serverUM.getHub().hasImplementors(test.getName()));
+      final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(server);
+      final RemoteMessenger clientRemoteMessenger = new RemoteMessenger(new UnifiedMessenger(client));
+      clientRemoteMessenger.registerRemote(new TestRemote(), test);
+      serverUnifiedMessenger.getHub().waitForNodesToImplement(test.getName());
+      assertTrue(serverUnifiedMessenger.getHub().hasImplementors(test.getName()));
       client.shutDown();
       ThreadUtil.sleep(200);
-      assertTrue(!serverUM.getHub().hasImplementors(test.getName()));
+      assertTrue(!serverUnifiedMessenger.getHub().hasImplementors(test.getName()));
     } finally {
       shutdownServerAndClient(server, client);
     }
@@ -267,9 +267,9 @@ public class RemoteMessengerTest {
       server.setAcceptNewConnections(true);
       final String mac = MacFinder.getHashedMacAddress();
       client = new ClientMessenger("localhost", serverPort, "client", mac);
-      final UnifiedMessenger serverUM = new UnifiedMessenger(server);
-      final RemoteMessenger serverRM = new RemoteMessenger(serverUM);
-      final RemoteMessenger clientRM = new RemoteMessenger(new UnifiedMessenger(client));
+      final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(server);
+      final RemoteMessenger serverRemoteMessenger = new RemoteMessenger(serverUnifiedMessenger);
+      final RemoteMessenger clientRemoteMessenger = new RemoteMessenger(new UnifiedMessenger(client));
       final Object lock = new Object();
       final AtomicBoolean started = new AtomicBoolean(false);
       final IFoo foo = new IFoo() {
@@ -285,15 +285,15 @@ public class RemoteMessengerTest {
           }
         }
       };
-      clientRM.registerRemote(foo, test);
-      serverUM.getHub().waitForNodesToImplement(test.getName());
-      assertTrue(serverUM.getHub().hasImplementors(test.getName()));
+      clientRemoteMessenger.registerRemote(foo, test);
+      serverUnifiedMessenger.getHub().waitForNodesToImplement(test.getName());
+      assertTrue(serverUnifiedMessenger.getHub().hasImplementors(test.getName()));
       final AtomicReference<ConnectionLostException> rme = new AtomicReference<>(null);
       final Runnable r = new Runnable() {
         @Override
         public void run() {
           try {
-            final IFoo remoteFoo = (IFoo) serverRM.getRemote(test);
+            final IFoo remoteFoo = (IFoo) serverRemoteMessenger.getRemote(test);
             remoteFoo.foo();
           } catch (final ConnectionLostException e) {
             rme.set(e);

--- a/src/test/java/games/strategy/engine/vault/VaultTest.java
+++ b/src/test/java/games/strategy/engine/vault/VaultTest.java
@@ -45,10 +45,10 @@ public class VaultTest {
     serverMessenger.setAcceptNewConnections(true);
     final String mac = MacFinder.getHashedMacAddress();
     clientMessenger = new ClientMessenger("localhost", SERVER_PORT, "client1", mac);
-    final UnifiedMessenger serverUM = new UnifiedMessenger(serverMessenger);
-    final UnifiedMessenger clientUM = new UnifiedMessenger(clientMessenger);
-    serverVault = new Vault(new ChannelMessenger(serverUM));
-    clientVault = new Vault(new ChannelMessenger(clientUM));
+    final UnifiedMessenger serverUnifiedMessenger = new UnifiedMessenger(serverMessenger);
+    final UnifiedMessenger clientUnifiedMessenger = new UnifiedMessenger(clientMessenger);
+    serverVault = new Vault(new ChannelMessenger(serverUnifiedMessenger));
+    clientVault = new Vault(new ChannelMessenger(clientUnifiedMessenger));
     Thread.yield();
   }
 

--- a/src/test/java/games/strategy/test/TestUtil.java
+++ b/src/test/java/games/strategy/test/TestUtil.java
@@ -31,8 +31,8 @@ public class TestUtil {
   public static int getUniquePort() {
     // store/get from SystemProperties
     // to get around junit reloading
-    final String KEY = "triplea.test.port";
-    String prop = System.getProperties().getProperty(KEY);
+    final String key = "triplea.test.port";
+    String prop = System.getProperties().getProperty(key);
     if (prop == null) {
       // start off with something fairly random, between 12000 - 14000
       prop = Integer.toString(12000 + (int) (Math.random() % 2000));
@@ -42,7 +42,7 @@ public class TestUtil {
     if (val > 15000) {
       val = 12000;
     }
-    System.getProperties().put(KEY, "" + val);
+    System.getProperties().put(key, "" + val);
     return val;
   }
 

--- a/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -6,7 +6,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.fighter;
 import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
 import static games.strategy.triplea.delegate.GameDataTestUtil.getDelegateBridge;
 import static games.strategy.triplea.delegate.GameDataTestUtil.makeGameLowLuck;
-import static games.strategy.triplea.delegate.GameDataTestUtil.setSelectAACasualties;
+import static games.strategy.triplea.delegate.GameDataTestUtil.setSelectAntiAirCasualties;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -46,57 +46,59 @@ public class BattleCalculatorTest {
   }
 
   @Test
-  public void testAACasualtiesLowLuck() {
+  public void testAntiAirCasualtiesLowLuck() {
     final GameData data = bridge.getData();
     makeGameLowLuck(data);
-    setSelectAACasualties(data, false);
+    setSelectAntiAirCasualties(data, false);
     final DiceRoll roll = new DiceRoll(new int[] {0}, 1, 1, false);
     final Collection<Unit> planes = bomber(data).create(5, british(data));
-    final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAntiAir =
+        territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir,
+        defendingAntiAir, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 1);
     assertEquals(1, randomSource.getTotalRolled());
   }
 
   @Test
-  public void testAACasualtiesLowLuckDifferentMovementLetf() {
+  public void testAntiAirCasualtiesLowLuckDifferentMovementLetf() {
     final GameData data = bridge.getData();
     makeGameLowLuck(data);
-    setSelectAACasualties(data, false);
+    setSelectAntiAirCasualties(data, false);
     final DiceRoll roll = new DiceRoll(new int[] {0}, 1, 1, false);
     final List<Unit> planes = bomber(data).create(5, british(data));
-    final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAntiAir =
+        territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
     TripleAUnit.get(planes.get(0)).setAlreadyMoved(1);
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir,
+        defendingAntiAir, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 1);
   }
 
   @Test
-  public void testAACasualtiesLowLuckMixed() {
+  public void testAntiAirCasualtiesLowLuckMixed() {
     final GameData data = bridge.getData();
     makeGameLowLuck(data);
-    setSelectAACasualties(data, false);
+    setSelectAntiAirCasualties(data, false);
     // 6 bombers and 6 fighters
     final Collection<Unit> planes = bomber(data).create(6, british(data));
     planes.addAll(fighter(data).create(6, british(data)));
-    final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAntiAir =
+        territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // don't allow rolling, 6 of each is deterministic
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
-        DiceRoll
-            .rollAA(
-                Match.getMatches(planes,
-                    Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, bridge, territory("Germany", data), true);
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+        DiceRoll.rollAA(
+            Match.getMatches(planes,
+                Matches.unitIsOfTypes(
+                    UnitAttachment.get(defendingAntiAir.iterator().next().getType()).getTargetsAA(data))),
+            defendingAntiAir, bridge, territory("Germany", data), true);
+    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir,
+        defendingAntiAir, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // should be 1 fighter and 1 bomber
     assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);
@@ -104,27 +106,27 @@ public class BattleCalculatorTest {
   }
 
   @Test
-  public void testAACasualtiesLowLuckMixedMultipleDiceRolled() {
+  public void testAntiAirCasualtiesLowLuckMixedMultipleDiceRolled() {
     final GameData data = bridge.getData();
     makeGameLowLuck(data);
-    setSelectAACasualties(data, false);
+    setSelectAntiAirCasualties(data, false);
     // 5 bombers and 5 fighters
     final Collection<Unit> planes = bomber(data).create(5, british(data));
     planes.addAll(fighter(data).create(5, british(data)));
-    final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAntiAir =
+        territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // should roll once, a hit
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, 1, 1, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
     final DiceRoll roll =
-        DiceRoll
-            .rollAA(
-                Match.getMatches(planes,
-                    Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, bridge, territory("Germany", data), true);
+        DiceRoll.rollAA(
+            Match.getMatches(planes,
+                Matches.unitIsOfTypes(
+                    UnitAttachment.get(defendingAntiAir.iterator().next().getType()).getTargetsAA(data))),
+            defendingAntiAir, bridge, territory("Germany", data), true);
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir,
+        defendingAntiAir, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // two extra rolls to pick which units are hit
     assertEquals(3, randomSource.getTotalRolled());
@@ -134,14 +136,15 @@ public class BattleCalculatorTest {
   }
 
   @Test
-  public void testAACasualtiesLowLuckMixedWithChooseAACasualties() {
+  public void testAntiAirCasualtiesLowLuckMixedWithChooseAntiAirCasualties() {
     final GameData data = bridge.getData();
     makeGameLowLuck(data);
-    setSelectAACasualties(data, true);
+    setSelectAntiAirCasualties(data, true);
     // 6 bombers and 6 fighters
     final Collection<Unit> planes = bomber(data).create(6, british(data));
     planes.addAll(fighter(data).create(6, british(data)));
-    final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAntiAir =
+        territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     when(dummyPlayer.selectCasualties(any(), any(), anyInt(), any(), any(), any(), any(), any(), any(), anyBoolean(),
         any(),
         any(), any(), any(), anyBoolean())).thenAnswer(new Answer<CasualtyDetails>() {
@@ -158,15 +161,14 @@ public class BattleCalculatorTest {
     // don't allow rolling, 6 of each is deterministic
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
-        DiceRoll
-            .rollAA(
-                Match.getMatches(planes,
-                    Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, bridge, territory("Germany", data), true);
+        DiceRoll.rollAA(
+            Match.getMatches(planes,
+                Matches.unitIsOfTypes(
+                    UnitAttachment.get(defendingAntiAir.iterator().next().getType()).getTargetsAA(data))),
+            defendingAntiAir, bridge, territory("Germany", data), true);
     final Collection<Unit> casualties =
-        BattleCalculator.getAACasualties(false, planes, planes, defendingAA, defendingAA, roll, bridge, germans(data),
-            british(data), null, territory("Germany", data), null, false, null).getKilled();
+        BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir, defendingAntiAir, roll, bridge,
+            germans(data), british(data), null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // we selected all bombers
     assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 2);
@@ -174,14 +176,15 @@ public class BattleCalculatorTest {
   }
 
   @Test
-  public void testAACasualtiesLowLuckMixedWithChooseAACasualtiesRoll() {
+  public void testAntiAirCasualtiesLowLuckMixedWithChooseAntiAirCasualtiesRoll() {
     final GameData data = bridge.getData();
     makeGameLowLuck(data);
-    setSelectAACasualties(data, true);
+    setSelectAntiAirCasualties(data, true);
     // 7 bombers and 7 fighters
     final Collection<Unit> planes = bomber(data).create(7, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
-    final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAntiAir =
+        territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     when(dummyPlayer.selectCasualties(any(), any(), anyInt(), any(), any(), any(), any(), any(), any(), anyBoolean(),
         any(), any(), any(), any(), anyBoolean())).thenAnswer(new Answer<CasualtyDetails>() {
           @Override
@@ -196,15 +199,14 @@ public class BattleCalculatorTest {
     // only 1 roll, a hit
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
-        DiceRoll
-            .rollAA(
-                Match.getMatches(planes,
-                    Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, bridge, territory("Germany", data), true);
+        DiceRoll.rollAA(
+            Match.getMatches(planes,
+                Matches.unitIsOfTypes(
+                    UnitAttachment.get(defendingAntiAir.iterator().next().getType()).getTargetsAA(data))),
+            defendingAntiAir, bridge, territory("Germany", data), true);
     final Collection<Unit> casualties =
-        BattleCalculator.getAACasualties(false, planes, planes, defendingAA, defendingAA, roll, bridge, germans(data),
-            british(data), null, territory("Germany", data), null, false, null).getKilled();
+        BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir, defendingAntiAir, roll, bridge,
+            germans(data), british(data), null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // we selected all bombers
     assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 3);
@@ -212,29 +214,29 @@ public class BattleCalculatorTest {
   }
 
   @Test
-  public void testAACasualtiesLowLuckMixedWithRolling() {
+  public void testAntiAirCasualtiesLowLuckMixedWithRolling() {
     final GameData data = bridge.getData();
     makeGameLowLuck(data);
-    setSelectAACasualties(data, false);
+    setSelectAntiAirCasualties(data, false);
     // 7 bombers and 7 fighters
     // 2 extra units, roll once
     final Collection<Unit> planes = bomber(data).create(7, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
-    final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAntiAir =
+        territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // one roll, a hit
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0});
     bridge.setRandomSource(randomSource);
     final DiceRoll roll =
-        DiceRoll
-            .rollAA(
-                Match.getMatches(planes,
-                    Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, bridge, territory("Germany", data), true);
+        DiceRoll.rollAA(
+            Match.getMatches(planes,
+                Matches.unitIsOfTypes(
+                    UnitAttachment.get(defendingAntiAir.iterator().next().getType()).getTargetsAA(data))),
+            defendingAntiAir, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir,
+        defendingAntiAir, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // a second roll for choosing which unit
     assertEquals(2, randomSource.getTotalRolled());
@@ -244,30 +246,30 @@ public class BattleCalculatorTest {
   }
 
   @Test
-  public void testAACasualtiesLowLuckMixedWithRollingMiss() {
+  public void testAntiAirCasualtiesLowLuckMixedWithRollingMiss() {
     final GameData data = bridge.getData();
     makeGameLowLuck(data);
-    setSelectAACasualties(data, false);
+    setSelectAntiAirCasualties(data, false);
     // 7 bombers and 7 fighters
     // 2 extra units, roll once
     final Collection<Unit> planes = bomber(data).create(7, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
-    final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAntiAir =
+        territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // one roll, a miss
     final ScriptedRandomSource randomSource =
         new ScriptedRandomSource(new int[] {2, 0, 0, 0, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
     final DiceRoll roll =
-        DiceRoll
-            .rollAA(
-                Match.getMatches(planes,
-                    Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, bridge, territory("Germany", data), true);
+        DiceRoll.rollAA(
+            Match.getMatches(planes,
+                Matches.unitIsOfTypes(
+                    UnitAttachment.get(defendingAntiAir.iterator().next().getType()).getTargetsAA(data))),
+            defendingAntiAir, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir,
+        defendingAntiAir, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     assertEquals(4, randomSource.getTotalRolled());
     // should be 1 fighter and 1 bomber
@@ -276,28 +278,28 @@ public class BattleCalculatorTest {
   }
 
   @Test
-  public void testAACasualtiesLowLuckMixedWithRollingForBombers() {
+  public void testAntiAirCasualtiesLowLuckMixedWithRollingForBombers() {
     final GameData data = bridge.getData();
     makeGameLowLuck(data);
-    setSelectAACasualties(data, false);
+    setSelectAntiAirCasualties(data, false);
     // 6 bombers, 7 fighters
     final Collection<Unit> planes = bomber(data).create(6, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
-    final Collection<Unit> defendingAA = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAntiAir =
+        territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // 1 roll for the extra fighter
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
     final DiceRoll roll =
-        DiceRoll
-            .rollAA(
-                Match.getMatches(planes,
-                    Matches
-                        .unitIsOfTypes(UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(data))),
-                defendingAA, bridge, territory("Germany", data), true);
+        DiceRoll.rollAA(
+            Match.getMatches(planes,
+                Matches.unitIsOfTypes(
+                    UnitAttachment.get(defendingAntiAir.iterator().next().getType()).getTargetsAA(data))),
+            defendingAntiAir, bridge, territory("Germany", data), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
+    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir,
+        defendingAntiAir, roll, bridge, null, null, null, territory("Germany", data), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // should be 2 fighters and 1 bombers
     assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);

--- a/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -219,7 +219,7 @@ public class DiceRollTest {
   }
 
   @Test
-  public void testAA() {
+  public void testAntiAir() {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final PlayerID russians = GameDataTestUtil.russians(gameData);
     final PlayerID germans = GameDataTestUtil.germans(gameData);
@@ -240,7 +240,7 @@ public class DiceRollTest {
   }
 
   @Test
-  public void testAALowLuck() {
+  public void testAntiAirLowLuck() {
     GameDataTestUtil.makeGameLowLuck(gameData);
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final PlayerID russians = GameDataTestUtil.russians(gameData);
@@ -288,7 +288,7 @@ public class DiceRollTest {
   }
 
   @Test
-  public void testAALowLuckDifferentMovement() {
+  public void testAntiAirLowLuckDifferentMovement() {
     GameDataTestUtil.makeGameLowLuck(gameData);
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
     final PlayerID russians = GameDataTestUtil.russians(gameData);
@@ -314,7 +314,7 @@ public class DiceRollTest {
   }
 
   @Test
-  public void testAALowLuckWithRadar() throws Exception {
+  public void testAntiAirLowLuckWithRadar() throws Exception {
     gameData = TestMapGameData.WW2V3_1941.getGameData();
     GameDataTestUtil.makeGameLowLuck(gameData);
     final Territory finnland = gameData.getMap().getTerritory("Finland");
@@ -397,7 +397,7 @@ public class DiceRollTest {
   }
 
   @Test
-  public void testLHTRBomberDefend() {
+  public void testLhtrBomberDefend() {
     final PlayerID british = GameDataTestUtil.british(gameData);
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, true);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
@@ -413,7 +413,7 @@ public class DiceRollTest {
   }
 
   @Test
-  public void testHeavyBombersLHTR() {
+  public void testHeavyBombersLhtr() {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
@@ -432,7 +432,7 @@ public class DiceRollTest {
   }
 
   @Test
-  public void testHeavyBombersLHTR2() {
+  public void testHeavyBombersLhtr2() {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);
@@ -450,7 +450,7 @@ public class DiceRollTest {
   }
 
   @Test
-  public void testHeavyBombersDefendLHTR() {
+  public void testHeavyBombersDefendLhtr() {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge testDelegateBridge = getDelegateBridge(british);

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -221,7 +221,7 @@ public class GameDataTestUtil {
     return indexOfType;
   }
 
-  public static void setSelectAACasualties(final GameData data, final boolean val) {
+  public static void setSelectAntiAirCasualties(final GameData data, final boolean val) {
     for (final IEditableProperty property : data.getProperties().getEditableProperties()) {
       if (property.getName().equals(Constants.CHOOSE_AA)) {
         ((BooleanProperty) property).setValue(val);

--- a/src/test/java/games/strategy/triplea/delegate/LHTRTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LHTRTest.java
@@ -97,7 +97,7 @@ public class LHTRTest {
   }
 
   @Test
-  public void testAAGunsDontFireNonCombat() {
+  public void testAntiAirGunsDontFireNonCombat() {
     final MoveDelegate delegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     delegate.initialize("MoveDelegate", "MoveDelegate");
     final PlayerID germans = GameDataTestUtil.germans(gameData);
@@ -149,7 +149,7 @@ public class LHTRTest {
   }
 
   @Test
-  public void testLHTRBombingRaid() {
+  public void testLhtrBombingRaid() {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final Territory uk = gameData.getMap().getTerritory("United Kingdom");
     final PlayerID germans = GameDataTestUtil.germans(gameData);
@@ -186,7 +186,7 @@ public class LHTRTest {
   }
 
   @Test
-  public void testLHTRBombingRaid2Bombers() {
+  public void testLhtrBombingRaid2Bombers() {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final Territory uk = gameData.getMap().getTerritory("United Kingdom");
     final PlayerID germans = GameDataTestUtil.germans(gameData);

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -530,7 +530,7 @@ public class MoveDelegateTest extends DelegateTest {
   public void testLoadUnloadLoadMoveTransports() {
     bridge = super.getDelegateBridge(japanese);
     bridge.setStepName("japaneseCombatMove");
-    bridge.setPlayerID(japanese);
+    bridge.setPlayerId(japanese);
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
     // Set up the test
@@ -1245,9 +1245,9 @@ public class MoveDelegateTest extends DelegateTest {
   }
 
   @Test
-  public void testAACantMoveToConquered() {
+  public void testAntiAirCantMoveToConquered() {
     bridge.setStepName("japaneseCombatMove");
-    bridge.setPlayerID(japanese);
+    bridge.setPlayerId(japanese);
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
     final Route route = new Route();

--- a/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -124,16 +124,16 @@ public class PacificTest extends DelegateTest {
     bridge.setStepName("japaneseEndTurn");
     bridge.setStepName("japaneseBattle");
     // Defending US infantry hit on a 2 (0 base)
-    final List<Unit> infantryUS = infantry.create(1, americans);
+    final List<Unit> infantryUs = infantry.create(1, americans);
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(queensland);
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     DiceRoll roll =
-        DiceRoll.rollDice(infantryUS, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
+        DiceRoll.rollDice(infantryUs, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
     assertEquals(1, roll.getHits());
     // Defending US marines hit on a 2 (0 base)
-    final List<Unit> marineUS = marine.create(1, americans);
+    final List<Unit> marineUs = marine.create(1, americans);
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
-    roll = DiceRoll.rollDice(marineUS, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
+    roll = DiceRoll.rollDice(marineUs, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
     assertEquals(1, roll.getHits());
     // Chinese units
     // Defending Chinese infantry hit on a 2 (0 base)
@@ -152,16 +152,16 @@ public class PacificTest extends DelegateTest {
     }
     // >>> After patch normal to-hits will miss <<<
     // Defending US infantry miss on a 2 (0 base)
-    final List<Unit> infantryUS = infantry.create(1, americans);
+    final List<Unit> infantryUs = infantry.create(1, americans);
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(queensland);
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
     DiceRoll roll =
-        DiceRoll.rollDice(infantryUS, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
+        DiceRoll.rollDice(infantryUs, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
     assertEquals(0, roll.getHits());
     // Defending US marines miss on a 2 (0 base)
-    final List<Unit> marineUS = marine.create(1, americans);
+    final List<Unit> marineUs = marine.create(1, americans);
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {1}));
-    roll = DiceRoll.rollDice(marineUS, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
+    roll = DiceRoll.rollDice(marineUs, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
     assertEquals(0, roll.getHits());
     // Chinese units
     // Defending Chinese infantry still hit on a 2 (0 base)
@@ -173,11 +173,11 @@ public class PacificTest extends DelegateTest {
     // Defending US infantry hit on a 1 (0 base)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0}));
     roll =
-        DiceRoll.rollDice(infantryUS, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
+        DiceRoll.rollDice(infantryUs, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
     assertEquals(1, roll.getHits());
     // Defending US marines hit on a 1 (0 base)
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {0}));
-    roll = DiceRoll.rollDice(marineUS, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
+    roll = DiceRoll.rollDice(marineUs, true, americans, bridge, new MockBattle(queensland), "", territoryEffects, null);
     assertEquals(1, roll.getHits());
     // Chinese units
     // Defending Chinese infantry still hit on a 2 (0 base)

--- a/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -123,7 +123,7 @@ public class PlaceDelegateTest extends DelegateTest {
   }
 
   @Test
-  public void testCantPlaceAAWhenOneAlreadyThere() {
+  public void testCantPlaceAntiAirWhenOneAlreadyThere() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(aaGun, 1);
     final String response = delegate.canUnitsBePlaced(uk, getUnits(map, british), british);
@@ -131,7 +131,7 @@ public class PlaceDelegateTest extends DelegateTest {
   }
 
   @Test
-  public void testCantPlaceTwoAA() {
+  public void testCantPlaceTwoAntiAir() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(aaGun, 2);
     final String response = delegate.canUnitsBePlaced(westCanada, getUnits(map, british), british);

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -583,10 +583,10 @@ public class RevisedTest {
     // make sure the transport was unloaded
     assertTrue(moveDelegate.getMovesMade().get(1).wasTransportUnloaded(transport));
     // try to unload the other infantry somewhere else, an error occurs
-    final Route sz5ToEE = new Route();
-    sz5ToEE.setStart(sz5);
-    sz5ToEE.add(eastEurope);
-    error = moveDelegate.move(infantry.subList(1, 2), sz5ToEE);
+    final Route sz5ToEastEurope = new Route();
+    sz5ToEastEurope.setStart(sz5);
+    sz5ToEastEurope.add(eastEurope);
+    error = moveDelegate.move(infantry.subList(1, 2), sz5ToEastEurope);
     assertNotNull(error, error);
     assertTrue(error.startsWith(MoveValidator.TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_TO));
     // end the round
@@ -601,7 +601,7 @@ public class RevisedTest {
     // a new round, the move should work
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    error = moveDelegate.move(infantry.subList(1, 2), sz5ToEE);
+    error = moveDelegate.move(infantry.subList(1, 2), sz5ToEastEurope);
     assertNull(error);
   }
 
@@ -741,7 +741,7 @@ public class RevisedTest {
   }
 
   @Test
-  public void testAAOwnership() {
+  public void testAntiAirOwnership() {
     // Set up players
     // PlayerID british = GameDataTestUtil.british(gameData);
     final PlayerID japanese = GameDataTestUtil.japanese(gameData);
@@ -1088,7 +1088,7 @@ public class RevisedTest {
   }
 
   @Test
-  public void testAttackSubsAndBBOnDestroyerAndSubs() {
+  public void testAttackSubsAndBattleshipOnDestroyerAndSubs() {
     final String defender = "Germans";
     final String attacker = "British";
     final Territory attacked = territory("31 Sea Zone", gameData);
@@ -1187,7 +1187,7 @@ public class RevisedTest {
   }
 
   @Test
-  public void testAttackSubsAndDestroyerOnBBAndSubs() {
+  public void testAttackSubsAndDestroyerOnBatleshipAndSubs() {
     final String defender = "Germans";
     final String attacker = "British";
     final Territory attacked = territory("31 Sea Zone", gameData);

--- a/src/test/java/games/strategy/triplea/delegate/StratBombTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/StratBombTest.java
@@ -41,7 +41,7 @@ public class StratBombTest {
 
 
   @Test
-  public void testBombingRaidInvidualAA() {
+  public void testBombingRaidInvidualAntiAir() {
     final Territory wgermany = gameData.getMap().getTerritory("Western Germany");
     final Territory uk = gameData.getMap().getTerritory("United Kingdom");
     final PlayerID british = GameDataTestUtil.british(gameData);

--- a/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
@@ -213,7 +213,7 @@ public class VictoryTest {
   }
 
   @Test
-  public void testPUOnlyResourcesToPurchase() {
+  public void testPuOnlyResourcesToPurchase() {
     testBridge.setStepName("italianPurchase");
     purchaseDelegate.setDelegateBridgeAndPlayer(testBridge);
     purchaseDelegate.start();
@@ -228,7 +228,7 @@ public class VictoryTest {
   }
 
   @Test
-  public void testNoPUResourcesToPurchase() {
+  public void testNoPuResourcesToPurchase() {
     testBridge.setStepName("italianPurchase");
     purchaseDelegate.setDelegateBridgeAndPlayer(testBridge);
     purchaseDelegate.start();

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -133,7 +133,7 @@ public class WW2V3_41_Test {
   }
 
   @Test
-  public void testAACasualtiesLowLuckMixedRadar() {
+  public void testAntiAirCasualtiesLowLuckMixedRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
     final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge m_bridge = getDelegateBridge(british);
@@ -143,19 +143,18 @@ public class WW2V3_41_Test {
     // 3 bombers and 3 fighters
     final Collection<Unit> planes = bomber(gameData).create(3, british(gameData));
     planes.addAll(fighter(gameData).create(3, british(gameData)));
-    final Collection<Unit> defendingAA =
+    final Collection<Unit> defendingAntiAir =
         territory("Germany", gameData).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // don't allow rolling, 6 of each is deterministic
     m_bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
-    final DiceRoll roll =
-        DiceRoll
-            .rollAA(
-                Match.getMatches(planes,
-                    Matches.unitIsOfTypes(
-                        UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(gameData))),
-                defendingAA, m_bridge, territory("Germany", gameData), true);
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
+    final DiceRoll roll = DiceRoll.rollAA(
+        Match.getMatches(planes,
+            Matches.unitIsOfTypes(
+                UnitAttachment.get(defendingAntiAir.iterator().next().getType()).getTargetsAA(gameData))),
+        defendingAntiAir, m_bridge, territory("Germany", gameData), true);
+    final Collection<Unit> casualties =
+        BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir, defendingAntiAir, roll, m_bridge,
+            null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     // should be 1 fighter and 1 bomber
     assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 1);
@@ -163,7 +162,7 @@ public class WW2V3_41_Test {
   }
 
   @Test
-  public void testAACasualtiesLowLuckMixedWithRollingRadar() {
+  public void testAntiAirCasualtiesLowLuckMixedWithRollingRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
     final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge m_bridge = getDelegateBridge(british);
@@ -173,23 +172,22 @@ public class WW2V3_41_Test {
     // 4 bombers and 4 fighters
     final Collection<Unit> planes = bomber(gameData).create(4, british(gameData));
     planes.addAll(fighter(gameData).create(4, british(gameData)));
-    final Collection<Unit> defendingAA =
+    final Collection<Unit> defendingAntiAir =
         territory("Germany", gameData).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // 1 roll, a hit
     // then a dice to select the casualty
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, 1});
     m_bridge.setRandomSource(randomSource);
-    final DiceRoll roll =
-        DiceRoll
-            .rollAA(
-                Match.getMatches(planes,
-                    Matches.unitIsOfTypes(
-                        UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(gameData))),
-                defendingAA, m_bridge, territory("Germany", gameData), true);
+    final DiceRoll roll = DiceRoll.rollAA(
+        Match.getMatches(planes,
+            Matches.unitIsOfTypes(
+                UnitAttachment.get(defendingAntiAir.iterator().next().getType()).getTargetsAA(gameData))),
+        defendingAntiAir, m_bridge, territory("Germany", gameData), true);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
+    final Collection<Unit> casualties =
+        BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir, defendingAntiAir, roll, m_bridge,
+            null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 3);
     // should be 1 fighter and 2 bombers
     assertEquals(Match.countMatches(casualties, Matches.UnitIsStrategicBomber), 2);
@@ -197,7 +195,7 @@ public class WW2V3_41_Test {
   }
 
   @Test
-  public void testAACasualtiesLowLuckMixedWithRollingMissRadar() {
+  public void testAntiAirCasualtiesLowLuckMixedWithRollingMissRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
     final PlayerID british = GameDataTestUtil.british(gameData);
     final ITestDelegateBridge m_bridge = getDelegateBridge(british);
@@ -207,25 +205,24 @@ public class WW2V3_41_Test {
     // 4 bombers and 4 fighters
     final Collection<Unit> planes = bomber(gameData).create(4, british(gameData));
     planes.addAll(fighter(gameData).create(4, british(gameData)));
-    final Collection<Unit> defendingAA =
+    final Collection<Unit> defendingAntiAir =
         territory("Germany", gameData).getUnits().getMatches(Matches.UnitIsAAforAnything);
     // 1 roll, a miss
     // then a dice to select the casualty
     final ScriptedRandomSource randomSource =
         new ScriptedRandomSource(new int[] {5, 0, 0, 0, ScriptedRandomSource.ERROR});
     m_bridge.setRandomSource(randomSource);
-    final DiceRoll roll =
-        DiceRoll
-            .rollAA(
-                Match.getMatches(planes,
-                    Matches.unitIsOfTypes(
-                        UnitAttachment.get(defendingAA.iterator().next().getType()).getTargetsAA(gameData))),
-                defendingAA, m_bridge, territory("Germany", gameData), true);
+    final DiceRoll roll = DiceRoll.rollAA(
+        Match.getMatches(planes,
+            Matches.unitIsOfTypes(
+                UnitAttachment.get(defendingAntiAir.iterator().next().getType()).getTargetsAA(gameData))),
+        defendingAntiAir, m_bridge, territory("Germany", gameData), true);
     assertEquals(roll.getHits(), 2);
     // make sure we rolled once
     assertEquals(1, randomSource.getTotalRolled());
-    final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAA,
-        defendingAA, roll, m_bridge, null, null, null, territory("Germany", gameData), null, false, null).getKilled();
+    final Collection<Unit> casualties =
+        BattleCalculator.getAACasualties(false, planes, planes, defendingAntiAir, defendingAntiAir, roll, m_bridge,
+            null, null, null, territory("Germany", gameData), null, false, null).getKilled();
     assertEquals(casualties.size(), 2);
     assertEquals(4, randomSource.getTotalRolled());
     // should be 1 fighter and 2 bombers
@@ -419,7 +416,7 @@ public class WW2V3_41_Test {
   }
 
   @Test
-  public void testCantBlitzFactoryOrAA() {
+  public void testCantBlitzFactoryOrAntiAir() {
     // Set up territories
     final Territory poland = territory("Poland", gameData);
     final Territory eastPoland = territory("East Poland", gameData);
@@ -456,7 +453,7 @@ public class WW2V3_41_Test {
   }
 
   @Test
-  public void testMultipleAAInTerritory() {
+  public void testMultipleAntiAirInTerritory() {
     // Set up territories
     final Territory poland = territory("Poland", gameData);
     // Add a russian factory
@@ -504,7 +501,7 @@ public class WW2V3_41_Test {
     final PlayerID germans = GameDataTestUtil.germans(gameData);
     final PlaceDelegate placeDelegate = placeDelegate(gameData);
     delegateBridge.setStepName("Place");
-    delegateBridge.setPlayerID(germans);
+    delegateBridge.setPlayerId(germans);
     placeDelegate.setDelegateBridgeAndPlayer(getDelegateBridge(germans(gameData)));
     placeDelegate.start();
     addTo(germans(gameData), aaGun(gameData).create(1, germans(gameData)), gameData);
@@ -616,7 +613,7 @@ public class WW2V3_41_Test {
     // Set up the move delegate
     final PlaceDelegate placeDelegate = placeDelegate(gameData);
     delegateBridge.setStepName("Place");
-    delegateBridge.setPlayerID(british);
+    delegateBridge.setPlayerId(british);
     placeDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     placeDelegate.start();
     // Add the factory
@@ -642,7 +639,7 @@ public class WW2V3_41_Test {
     // Set up game
     final PlayerID chinese = GameDataTestUtil.chinese(gameData);
     final ITestDelegateBridge delegateBridge = getDelegateBridge(chinese(gameData));
-    delegateBridge.setPlayerID(chinese);
+    delegateBridge.setPlayerId(chinese);
     delegateBridge.setStepName("CombatMove");
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
@@ -705,7 +702,7 @@ public class WW2V3_41_Test {
   }
 
   @Test
-  public void testPlaceInOccupiedSZ() {
+  public void testPlaceInOccupiedSeaZone() {
     // Set up game
     final PlayerID germans = GameDataTestUtil.germans(gameData);
     final ITestDelegateBridge delegateBridge = getDelegateBridge(british(gameData));
@@ -718,7 +715,7 @@ public class WW2V3_41_Test {
     // Set up the move delegate
     final PlaceDelegate placeDelegate = placeDelegate(gameData);
     delegateBridge.setStepName("Place");
-    delegateBridge.setPlayerID(germans);
+    delegateBridge.setPlayerId(germans);
     placeDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     placeDelegate.start();
     // Add the transport

--- a/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
+++ b/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
@@ -29,24 +29,25 @@ public final class EventThreadJOptionPaneTest {
   private final CountDownLatchHandler latchHandler = new CountDownLatchHandler(true);
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldRunSupplierOnEDTWhenNotCalledFromEDT() throws Exception {
+  public void testInvokeAndWaitWithSupplier_ShouldRunSupplierOnEventDispatchThreadWhenNotCalledFromEventDispatchThread()
+      throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
-    final AtomicBoolean runOnEDT = new AtomicBoolean(false);
+    final AtomicBoolean runOnEventDispatchThread = new AtomicBoolean(false);
 
     new Thread(() -> {
       EventThreadJOptionPane.invokeAndWait(latchHandler, () -> {
-        runOnEDT.set(SwingUtilities.isEventDispatchThread());
+        runOnEventDispatchThread.set(SwingUtilities.isEventDispatchThread());
         return Optional.empty();
       });
       latch.countDown();
     }).start();
     latch.await();
 
-    assertThat(runOnEDT.get(), is(true));
+    assertThat(runOnEventDispatchThread.get(), is(true));
   }
 
   @Test
-  public void testInvokeAndWaitWithSupplier_ShouldNotDeadlockWhenCalledFromEDT() throws Exception {
+  public void testInvokeAndWaitWithSupplier_ShouldNotDeadlockWhenCalledFromEventDispatchThread() throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicBoolean run = new AtomicBoolean(false);
 


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in test code.

For the most part, I expanded abbreviations where they caused a violation.  For example:

* `ID` --> `Id`
* `AA` --> `AntiAir`
* `SZ` --> `SeaZone`
* `EDT` --> `EventDispatchThread`

I did **not** expand the following abbreviations; I simply converted them using the abbreviation naming convention established in #1659.  Please advise if they should be expanded.

* `LHTR` --> `Lhtr` (would expand to `LarryHarrisTournamentRules`) [4 occurrences]
* `PU` --> `Pu` (would expand to `ProductionUnit`) [2 occurrences]