### PR TITLE
Fix broken capability to share war bond income with allies (#1767)

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -52,8 +52,8 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     return games.strategy.triplea.Properties.getGiveUnitsByTerritory(getData());
   }
 
-  public boolean canPlayerCollectIncome(final PlayerID player, final GameData data) {
-    return TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(m_player, getData());
+  private static boolean canPlayerCollectIncome(final PlayerID player, final GameData data) {
+    return TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, data);
   }
 
   /**


### PR DESCRIPTION
This PR addresses the primary issue raised in #1767.

I did not address the second issue discussed [here](https://github.com/triplea-game/triplea/issues/1767#issuecomment-304760791).  There didn't seem to be a valid use case for multiple War Bonds tech attachments, and no map that uses War Bonds has more than a single attachment.  It wasn't clear if multiple War Bonds tech attachments in the XML should just be treated as an error.  Please advise if a new issue should be opened to appropriately deal with that problem.

#### Functional changes
* The `AbstractEndTurnDelegate#canPlayerCollectIncome()` method was modified to no longer ignore its arguments.  This appears to have been broken in 2f024b0.

#### Functional issues for review
None.

#### Refactoring changes
* Changed `AbstractEndTurnDelegate#canPlayerCollectIncome()` to be `private static` as it is not used outside its enclosing class and it does not reference instance state.

#### Refactoring issues for review
None.

#### Testing
Performed as documented [here](https://github.com/triplea-game/triplea/issues/1767#issuecomment-304964734).