### PR TITLE
Update AI Bonus Properties 2

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -910,7 +910,7 @@ public class GameParser {
       }
     }
     data.getPlayerList().forEach(playerId -> data.getProperties().addEditableProperty(
-        new NumberProperty(Constants.getBonusIncomePercentageFor(playerId), null, 1000, -100, 0)));
+        new NumberProperty(Constants.getBonusIncomePercentageFor(playerId), null, 999, 0, 0)));
   }
 
   private void parseEditableProperty(final Element property, final String name, final String defaultValue)

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -23,6 +23,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.util.AiBonusIncomeUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -86,6 +87,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
     initOriginalOwner(aBridge);
     initTech(aBridge);
     initSkipUnusedBids(aBridge.getData());
+    initAiStartingBonusIncome(aBridge);
     initDeleteAssetsOfDisabledPlayers(aBridge);
     initTransportedLandUnits(aBridge);
     resetUnitState(aBridge);
@@ -163,6 +165,11 @@ public class InitializationDelegate extends BaseTripleADelegate {
         }
       }
     }
+  }
+
+  private static void initAiStartingBonusIncome(final IDelegateBridge bridge) {
+    bridge.getData().getPlayerList().getPlayers().forEach(
+        player -> AiBonusIncomeUtils.addAiBonusIncome(player.getResources().getResourcesCopy(), bridge, player));
   }
 
   private static void initDeleteAssetsOfDisabledPlayers(final IDelegateBridge aBridge) {

--- a/src/main/java/games/strategy/triplea/util/AiBonusIncomeUtils.java
+++ b/src/main/java/games/strategy/triplea/util/AiBonusIncomeUtils.java
@@ -1,0 +1,38 @@
+package games.strategy.triplea.util;
+
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.Properties;
+import games.strategy.util.IntegerMap;
+
+
+public class AiBonusIncomeUtils {
+
+  /**
+   * Add AI bonus income based on the player's set percentage for all resources.
+   * 
+   * @return string that summarizes all the changes
+   */
+  public static String addAiBonusIncome(final IntegerMap<Resource> income, final IDelegateBridge bridge,
+      final PlayerID player) {
+    final StringBuilder sb = new StringBuilder();
+    for (final Resource resource : income.keySet()) {
+      final int amount = income.getInt(resource);
+      final int bonusPercent = Properties.getBonusIncomePercentage(player, bridge.getData());
+      final int bonusIncome = (int) Math.round(((double) amount * (double) bonusPercent / 100));
+      if (bonusIncome == 0) {
+        continue;
+      }
+      final int total = player.getResources().getQuantity(resource) + bonusIncome;
+      final String message = "Giving " + player.getName() + " " + bonusPercent + "% bonus income of " + bonusIncome
+          + " " + resource.getName() + "; end with " + total + " " + resource.getName();
+      bridge.getHistoryWriter().startEvent(message);
+      bridge.addChange(ChangeFactory.changeResourcesChange(player, resource, bonusIncome));
+      sb.append(message).append("<br />");
+    }
+    return sb.toString();
+  }
+
+}


### PR DESCRIPTION
Next update for AI bonus parameters.

Changes:
- Bonus income now works for all resources
- Starting resources are increased by bonus as well
- Updated wording of bonus in history and end turn report
- Adjust bonus income range to only be positive (0-999)

Recommend testing on maps with multiple resources such as Iron War.