### PR TITLE
Checkstyle: Fix abbreviation violations in tool code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=4493
+checkstyleMainMaxWarnings=4458
 checkstyleTestMaxWarnings=53

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -558,7 +558,7 @@ public class DecorationPlacer extends JFrame {
               + "(name_place.txt) ?",
           "Points end in .png OR they do not?", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null,
           pointsAreNamesOptions,
-          pointsAreNamesOptions[(s_imagePointType.isEndInPNG() ? 0 : 1)]) == JOptionPane.NO_OPTION);
+          pointsAreNamesOptions[(s_imagePointType.isEndInPng() ? 0 : 1)]) == JOptionPane.NO_OPTION);
       s_createNewImageOnRightClick = false;
       s_staticImageForPlacing = null;
     } else {
@@ -918,7 +918,7 @@ enum ImagePointType {
   private final String folderName;
   private final String imageName;
   private final boolean useFolder;
-  private final boolean endInPNG;
+  private final boolean endInPng;
   private final boolean fillAll;
   private final boolean canUseBottomLeftPoint;
   private final boolean canHaveMultiplePoints;
@@ -932,14 +932,14 @@ enum ImagePointType {
   }
 
   ImagePointType(final String fileName, final String folderName, final String imageName, final boolean useFolder,
-      final boolean endInPNG, final boolean fillAll, final boolean canUseBottomLeftPoint,
+      final boolean endInPng, final boolean fillAll, final boolean canUseBottomLeftPoint,
       final boolean canHaveMultiplePoints, final boolean usesCentersPoint, final String description,
       final String instructions) {
     this.fileName = fileName;
     this.folderName = folderName;
     this.imageName = imageName;
     this.useFolder = useFolder;
-    this.endInPNG = endInPNG;
+    this.endInPng = endInPng;
     this.fillAll = fillAll;
     this.canUseBottomLeftPoint = canUseBottomLeftPoint;
     this.canHaveMultiplePoints = canHaveMultiplePoints;
@@ -964,8 +964,8 @@ enum ImagePointType {
     return useFolder;
   }
 
-  public boolean isEndInPNG() {
-    return endInPNG;
+  public boolean isEndInPng() {
+    return endInPng;
   }
 
   public boolean isFillAll() {

--- a/src/main/java/tools/image/FileOpen.java
+++ b/src/main/java/tools/image/FileOpen.java
@@ -76,8 +76,7 @@ public class FileOpen {
       // get the file
       file = chooser.getSelectedFile();
     } catch (final Exception ex) {
-      final String ERR_MSG_1 = "Warning! Could not load the file!";
-      JOptionPane.showMessageDialog(null, ERR_MSG_1, "Warning!", JOptionPane.WARNING_MESSAGE);
+      JOptionPane.showMessageDialog(null, "Warning! Could not load the file!", "Warning!", JOptionPane.WARNING_MESSAGE);
       file = null;
     }
   } // constructor

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -177,7 +177,7 @@ public class ConnectionFinder {
     try {
       final String fileName = new FileSave("Where To Save connections.txt ? (cancel to print to console)",
           "connections.txt", s_mapFolderLocation).getPathString();
-      final StringBuffer connectionsString = convertToXML(connections);
+      final StringBuffer connectionsString = convertToXml(connections);
       if (fileName == null) {
         System.out.println();
         if (territoryDefinitions != null) {
@@ -234,7 +234,7 @@ public class ConnectionFinder {
    *        a map of connections between Territories
    * @return a StringBuffer containing XML representing these connections
    */
-  private static StringBuffer convertToXML(final Map<String, Collection<String>> connections) {
+  private static StringBuffer convertToXml(final Map<String, Collection<String>> connections) {
     final StringBuffer output = new StringBuffer();
     output.append("<!-- Territory Connections -->\r\n");
     // sort for pretty xml's

--- a/src/main/java/tools/map/making/MapProperties.java
+++ b/src/main/java/tools/map/making/MapProperties.java
@@ -67,8 +67,8 @@ public class MapProperties {
     colorMap.put(Constants.PLAYER_NAME_IMPASSABLE, new Color(0xD8BA7C));
   }
 
-  public Tuple<PropertiesUI, List<MapPropertyWrapper<?>>> propertyWrapperUI(final boolean editable) {
-    return MapPropertyWrapper.createPropertiesUI(this, editable);
+  public Tuple<PropertiesUI, List<MapPropertyWrapper<?>>> propertyWrapperUi(final boolean editable) {
+    return MapPropertyWrapper.createPropertiesUi(this, editable);
   }
 
   public void writePropertiesToObject(final List<MapPropertyWrapper<?>> properties) {

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -217,10 +217,10 @@ public class MapPropertiesMaker extends JFrame {
         GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
     final JButton showMore = new JButton("Show All Options");
     showMore.addActionListener(SwingAction.of("Show All Options", e -> {
-      final Tuple<PropertiesUI, List<MapPropertyWrapper<?>>> propertyWrapperUI =
-          MapPropertiesMaker.s_mapProperties.propertyWrapperUI(true);
-      JOptionPane.showMessageDialog(MapPropertiesMaker.this, propertyWrapperUI.getFirst());
-      s_mapProperties.writePropertiesToObject(propertyWrapperUI.getSecond());
+      final Tuple<PropertiesUI, List<MapPropertyWrapper<?>>> propertyWrapperUi =
+          MapPropertiesMaker.s_mapProperties.propertyWrapperUi(true);
+      JOptionPane.showMessageDialog(MapPropertiesMaker.this, propertyWrapperUi.getFirst());
+      s_mapProperties.writePropertiesToObject(propertyWrapperUi.getSecond());
       MapPropertiesMaker.this.createPlayerColorChooser();
       MapPropertiesMaker.this.validate();
       MapPropertiesMaker.this.repaint();

--- a/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -169,12 +169,12 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
     }
   }
 
-  public static PropertiesUI createPropertiesUI(final List<? extends IEditableProperty> properties,
+  public static PropertiesUI createPropertiesUi(final List<? extends IEditableProperty> properties,
       final boolean editable) {
     return new PropertiesUI(properties, editable);
   }
 
-  static Tuple<PropertiesUI, List<MapPropertyWrapper<?>>> createPropertiesUI(final Object object,
+  static Tuple<PropertiesUI, List<MapPropertyWrapper<?>>> createPropertiesUi(final Object object,
       final boolean editable) {
     final List<MapPropertyWrapper<?>> properties = createProperties(object);
     final PropertiesUI ui = new PropertiesUI(properties, editable);
@@ -189,7 +189,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
   public static void main(final String[] args) {
     final MapProperties mapProperties = new MapProperties();
     final List<MapPropertyWrapper<?>> properties = createProperties(mapProperties);
-    final PropertiesUI ui = createPropertiesUI(properties, true);
+    final PropertiesUI ui = createPropertiesUi(properties, true);
     final JFrame frame = new JFrame();
     frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
     frame.getContentPane().add(ui);

--- a/src/main/java/tools/map/xml/creator/CanalDefinitionsPanel.java
+++ b/src/main/java/tools/map/xml/creator/CanalDefinitionsPanel.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Sets;
 
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
-import tools.map.xml.creator.TerritoryDefinitionDialog.DEFINITION;
+import tools.map.xml.creator.TerritoryDefinitionDialog.Definition;
 
 
 public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
@@ -49,7 +49,7 @@ public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
     mapXmlCreator.setAutoFillAction(SwingAction.of(e -> {
       final int prevCanalCount = MapXmlHelper.getCanalDefinitionsMap().size();
       if (prevCanalCount > 0) {
-        if (JOptionPane.YES_OPTION != MapXmlUIHelper.showYesNoOptionDialog("Auto-Fill Warning",
+        if (JOptionPane.YES_OPTION != MapXmlUiHelper.showYesNoOptionDialog("Auto-Fill Warning",
             "All current canal definitions will be deleted.\rDo you want to continue with Auto-Fill?",
             JOptionPane.WARNING_MESSAGE)) {
           return;
@@ -177,7 +177,7 @@ public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
     }
     final String newTerrName = newTerrNameOptional.get();
 
-    Boolean newTerrIsWater = MapXmlHelper.getTerritoryDefintionsMap().get(newTerrName).get(DEFINITION.IS_WATER);
+    Boolean newTerrIsWater = MapXmlHelper.getTerritoryDefintionsMap().get(newTerrName).get(Definition.IS_WATER);
     if (newTerrIsWater == null) {
       newTerrIsWater = false;
     }
@@ -309,7 +309,7 @@ public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
   private void mouseRightClickedOnImage() {
     if (currentCanalName.isPresent()
         && (selectedLandTerritories.size() < 2 || selectedWaterTerritories.size() < 2)) {
-      if (JOptionPane.YES_OPTION != MapXmlUIHelper.showYesNoOptionDialog("Canal incomplete",
+      if (JOptionPane.YES_OPTION != MapXmlUiHelper.showYesNoOptionDialog("Canal incomplete",
           "Canal '" + currentCanalName + "' is incomplete. A canal needs at least 2 land and 2 water territories.\r"
               + "Do you want to continue to deselect the canal?",
           JOptionPane.WARNING_MESSAGE)) {
@@ -388,14 +388,14 @@ public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
     final Set<String> neighbors = MapXmlHelper.getTerritoryConnectionsMap().get(newTerrName);
     for (final Entry<String, Set<String>> terrConnEntry : MapXmlHelper.getTerritoryConnectionsMap().entrySet()) {
       if (MapXmlHelper.getTerritoryDefintionsMap().get(terrConnEntry.getKey())
-          .get(DEFINITION.IS_WATER) == waterNeighbors
+          .get(Definition.IS_WATER) == waterNeighbors
           && terrConnEntry.getValue().contains(newTerrName)) {
         neighborsByType.add(terrConnEntry.getKey());
       }
     }
     if (neighbors != null) {
       for (final String neighbor : neighbors) {
-        if (MapXmlHelper.getTerritoryDefintionsMap().get(neighbor).get(DEFINITION.IS_WATER) == waterNeighbors) {
+        if (MapXmlHelper.getTerritoryDefintionsMap().get(neighbor).get(Definition.IS_WATER) == waterNeighbors) {
           neighborsByType.add(neighbor);
         }
       }
@@ -434,12 +434,12 @@ public final class CanalDefinitionsPanel extends ImageScrollPanePanel {
       final String terr1 = terrConnEntry.getKey();
       if (terrList.contains(terr1)) {
         for (final String terr2 : terrConnEntry.getValue()) {
-          if (MapXmlHelper.getTerritoryDefintionsMap().get(terr2).get(DEFINITION.IS_WATER) == typeIsWater) {
+          if (MapXmlHelper.getTerritoryDefintionsMap().get(terr2).get(Definition.IS_WATER) == typeIsWater) {
             neighborsMap.get(terr1).add(terr2);
           }
         }
       } else {
-        if (MapXmlHelper.getTerritoryDefintionsMap().get(terr1).get(DEFINITION.IS_WATER) == typeIsWater) {
+        if (MapXmlHelper.getTerritoryDefintionsMap().get(terr1).get(Definition.IS_WATER) == typeIsWater) {
           final SortedSet<String> selectedTerritoriesCopy = new TreeSet<>(terrList);
           selectedTerritoriesCopy.retainAll(terrConnEntry.getValue());
           for (final String terr2 : selectedTerritoriesCopy) {

--- a/src/main/java/tools/map/xml/creator/DynamicRow.java
+++ b/src/main/java/tools/map/xml/creator/DynamicRow.java
@@ -34,7 +34,7 @@ public abstract class DynamicRow {
     this.parentRowPanel = parentRowPanel;
 
     buttonRemovePerRow = new JButton("X");
-    buttonRemovePerRow.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonRemovePerRow.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     final Dimension dimension = new Dimension(25, 20);
     buttonRemovePerRow.setPreferredSize(dimension);
     buttonRemovePerRow.addActionListener(SwingAction.of("Remove Row", e -> {
@@ -50,7 +50,7 @@ public abstract class DynamicRow {
   }
 
   public void addToParentComponent(final JComponent parent, final int rowIndex) {
-    addToParentComponentWithGbc(parent, rowIndex, MapXmlUIHelper.getGbcDefaultTemplateWith(0, rowIndex));
+    addToParentComponentWithGbc(parent, rowIndex, MapXmlUiHelper.getGbcDefaultTemplateWith(0, rowIndex));
   }
 
   public void addToParentComponentWithGbc(final JComponent parent, final int rowIndex,
@@ -69,7 +69,7 @@ public abstract class DynamicRow {
 
     parentRowPanel.removeFinalButtonRow();
 
-    parentRowPanel.addFinalButtonRow(MapXmlUIHelper.getGbcDefaultTemplateWith(0, parentRowPanel.countRows()));
+    parentRowPanel.addFinalButtonRow(MapXmlUiHelper.getGbcDefaultTemplateWith(0, parentRowPanel.countRows()));
   }
 
   private void removeRowByNameAndPushUpFollowingRows(final String currentRowName) {

--- a/src/main/java/tools/map/xml/creator/DynamicRowsPanel.java
+++ b/src/main/java/tools/map/xml/creator/DynamicRowsPanel.java
@@ -126,11 +126,11 @@ public abstract class DynamicRowsPanel {
 
     final int countPlayers = countRows();
     newRow.addToParentComponentWithGbc(ownPanel, countPlayers,
-        MapXmlUIHelper.getGbcDefaultTemplateWith(0, countPlayers));
+        MapXmlUiHelper.getGbcDefaultTemplateWith(0, countPlayers));
     rows.add(newRow);
 
     final int finalButtonGridY = countPlayers + 1;
-    addFinalButtonRow(MapXmlUIHelper.getGbcDefaultTemplateWith(0, finalButtonGridY));
+    addFinalButtonRow(MapXmlUiHelper.getGbcDefaultTemplateWith(0, finalButtonGridY));
   }
 
   protected void addFinalButtonRow(final GridBagConstraints gbcTemplate) {

--- a/src/main/java/tools/map/xml/creator/GameSequencePanel.java
+++ b/src/main/java/tools/map/xml/creator/GameSequencePanel.java
@@ -51,7 +51,7 @@ public class GameSequencePanel extends DynamicRowsPanel {
 
     setOwnPanelLayout();
 
-    final GridBagConstraints gbcDefault = MapXmlUIHelper.getGbcDefaultTemplateWith(0, 0);
+    final GridBagConstraints gbcDefault = MapXmlUiHelper.getGbcDefaultTemplateWith(0, 0);
 
     addLabelsRow(gbcDefault);
 
@@ -64,7 +64,7 @@ public class GameSequencePanel extends DynamicRowsPanel {
 
     addAddSequenceButton();
 
-    addFinalButtonRow(MapXmlUIHelper.getGBCCloneWith(gbcDefault, 0, rowIndex));
+    addFinalButtonRow(MapXmlUiHelper.getGbcCloneWith(gbcDefault, 0, rowIndex));
   }
 
   /**
@@ -80,11 +80,11 @@ public class GameSequencePanel extends DynamicRowsPanel {
 
     final JLabel labelClassName = new JLabel("Class Name");
     labelClassName.setPreferredSize(dimension);
-    getOwnPanel().add(labelClassName, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelSequenceName, 1, 0));
+    getOwnPanel().add(labelClassName, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelSequenceName, 1, 0));
 
     final JLabel labelDisplayName = new JLabel("Display Name");
     labelDisplayName.setPreferredSize(dimension);
-    getOwnPanel().add(labelDisplayName, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelSequenceName, 2, 0));
+    getOwnPanel().add(labelDisplayName, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelSequenceName, 2, 0));
   }
 
   private void addMainInputRow(final GridBagConstraints gbcBase, final int rowIndex,
@@ -93,13 +93,13 @@ public class GameSequencePanel extends DynamicRowsPanel {
     final GameSequenceRow newRow =
         new GameSequenceRow(this, getOwnPanel(), rowEntry.getKey(), defintionValues.get(0),
             defintionValues.get(1));
-    newRow.addToParentComponentWithGbc(getOwnPanel(), rowIndex, MapXmlUIHelper.getGBCCloneWith(gbcBase, 0, rowIndex));
+    newRow.addToParentComponentWithGbc(getOwnPanel(), rowIndex, MapXmlUiHelper.getGbcCloneWith(gbcBase, 0, rowIndex));
     rows.add(newRow);
   }
 
   private void addAddSequenceButton() {
     final JButton buttonAddSequence = new JButton("Add Sequence");
-    buttonAddSequence.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonAddSequence.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonAddSequence.addActionListener(SwingAction.of("Add Sequence", e -> {
       final Optional<String> newSequenceNameOptional =
           Optional.of(JOptionPane.showInputDialog(getOwnPanel(), "Enter a new sequence name:",

--- a/src/main/java/tools/map/xml/creator/GameSequenceRow.java
+++ b/src/main/java/tools/map/xml/creator/GameSequenceRow.java
@@ -34,7 +34,7 @@ class GameSequenceRow extends DynamicRow {
     Dimension dimension = textFieldSequenceName.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_MEDIUM;
     textFieldSequenceName.setPreferredSize(dimension);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldSequenceName, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldSequenceName, () -> {
       final String inputText = textFieldSequenceName.getText().trim();
       if (currentRowName.equals(inputText)) {
         return;
@@ -73,7 +73,7 @@ class GameSequenceRow extends DynamicRow {
     dimension = textFieldClassName.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_LARGE;
     textFieldClassName.setPreferredSize(dimension);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldClassName, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldClassName, () -> {
       final String inputText = textFieldClassName.getText().trim();
       MapXmlHelper.getGamePlaySequenceMap().get(sequenceName).set(0, inputText);
     });
@@ -81,7 +81,7 @@ class GameSequenceRow extends DynamicRow {
     dimension = textFieldDisplayName.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_LARGE;
     textFieldDisplayName.setPreferredSize(dimension);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldDisplayName, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldDisplayName, () -> {
       final String inputText = textFieldDisplayName.getText().trim();
       MapXmlHelper.getGamePlaySequenceMap().get(sequenceName).set(1, inputText);
     });

--- a/src/main/java/tools/map/xml/creator/GameSettingsPanel.java
+++ b/src/main/java/tools/map/xml/creator/GameSettingsPanel.java
@@ -49,23 +49,22 @@ public class GameSettingsPanel extends DynamicRowsPanel {
       + "Damage From Bombing Done To Units Instead Of Territories, AA Territory Restricted, National Objectives, "
       + "Continuous Research";
 
-
-  public static enum SETTING_TYPE {
+  public enum SettingType {
     NORMAL, PER_PLAYER, PER_ALLY
   }
 
-  private static SETTING_TYPE getSettingType(final String setting) {
+  private static SettingType getSettingType(final String setting) {
     if (setting.endsWith(" bid")) {
-      return SETTING_TYPE.PER_PLAYER;
+      return SettingType.PER_PLAYER;
     } else if (setting.endsWith(" Honorable Victory VCs")) {
-      return SETTING_TYPE.PER_ALLY;
+      return SettingType.PER_ALLY;
     } else {
-      return SETTING_TYPE.NORMAL;
+      return SettingType.NORMAL;
     }
   }
 
   public static boolean isBoolean(final String setting) {
-    return (getSettingType(setting).equals(SETTING_TYPE.NORMAL) || setting.equals("MaxFactoriesPerTerritory"));
+    return (getSettingType(setting).equals(SettingType.NORMAL) || setting.equals("MaxFactoriesPerTerritory"));
     // TODO: maybe list is incomplete!
   }
 
@@ -166,7 +165,7 @@ public class GameSettingsPanel extends DynamicRowsPanel {
     // <4> Add Final Button Row
     final JButton buttonAddValue = new JButton("Add Game Setting");
 
-    buttonAddValue.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonAddValue.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonAddValue.addActionListener(SwingAction.of("Add Game Setting", e -> {
       final String suggestedSettingName = (String) JOptionPane.showInputDialog(getOwnPanel(),
           "Which game setting should be added?", "Choose Game Setting", JOptionPane.QUESTION_MESSAGE, null,

--- a/src/main/java/tools/map/xml/creator/GameSettingsRow.java
+++ b/src/main/java/tools/map/xml/creator/GameSettingsRow.java
@@ -176,7 +176,7 @@ class GameSettingsRow extends DynamicRow {
     dimension.width = INPUT_FIELD_SIZE_SMALL;
     textFieldMinNumber.setPreferredSize(dimension);
     textFieldMinNumber.setEnabled(!isBoolean);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldMinNumber, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldMinNumber, () -> {
       final String inputText = textFieldMinNumber.getText().trim();
       try {
         final int newValue = Integer.parseInt(inputText);
@@ -205,7 +205,7 @@ class GameSettingsRow extends DynamicRow {
     dimension.width = INPUT_FIELD_SIZE_SMALL;
     textFieldMaxNumber.setPreferredSize(dimension);
     textFieldMaxNumber.setEnabled(!isBoolean);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldMaxNumber, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldMaxNumber, () -> {
       final String inputText = textFieldMaxNumber.getText().trim();
       try {
         final int newValue = Integer.parseInt(inputText);

--- a/src/main/java/tools/map/xml/creator/MapPropertiesPanel.java
+++ b/src/main/java/tools/map/xml/creator/MapPropertiesPanel.java
@@ -86,31 +86,31 @@ public class MapPropertiesPanel {
     stepActionPanel.add(labelMapNameExample, gridBadConstLabelMapNameExample);
 
     // Map Version
-    stepActionPanel.add(labelMapVersion, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapName, 2, 2));
+    stepActionPanel.add(labelMapVersion, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapName, 2, 2));
 
     textFieldMapVersion.addFocusListener(FocusListenerFocusLost
         .withAction(() -> MapXmlHelper.putXmlStrings("info_@version", textFieldMapVersion.getText())));
     textFieldMapVersion.setMaximumSize(new Dimension(0, 0));
     textFieldMapVersion.setColumns(columns);
-    stepActionPanel.add(textFieldMapVersion, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapName, 1, 2));
+    stepActionPanel.add(textFieldMapVersion, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapName, 1, 2));
 
 
-    stepActionPanel.add(labelMapVersionExample, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapNameExample, 2, 2));
+    stepActionPanel.add(labelMapVersionExample, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapNameExample, 2, 2));
 
     // Resource Name
-    stepActionPanel.add(labelResourceName, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapName, 0, 3));
+    stepActionPanel.add(labelResourceName, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapName, 0, 3));
 
     textFieldResourceName.addFocusListener(FocusListenerFocusLost
         .withAction(() -> MapXmlHelper.addResourceList(0, textFieldResourceName.getText())));
     textFieldResourceName.setMaximumSize(new Dimension(0, 0));
     textFieldResourceName.setColumns(columns);
-    stepActionPanel.add(textFieldResourceName, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapName, 1, 3));
+    stepActionPanel.add(textFieldResourceName, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapName, 1, 3));
 
     stepActionPanel.add(labelResourceNameExample,
-        MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapNameExample, 2, 3));
+        MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapNameExample, 2, 3));
 
     // Map Image File
-    stepActionPanel.add(labelMapImageFile, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapName, 0, 4));
+    stepActionPanel.add(labelMapImageFile, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapName, 0, 4));
 
     textFieldMapImageFile.setEnabled(false);
     textFieldMapImageFile.setMaximumSize(new Dimension(0, 0));
@@ -121,7 +121,7 @@ public class MapPropertiesPanel {
         buttonSelectMapImageFile.doClick();
       }
     });
-    stepActionPanel.add(textFieldMapImageFile, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapName, 1, 4));
+    stepActionPanel.add(textFieldMapImageFile, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapName, 1, 4));
 
     buttonSelectMapImageFile.addActionListener(SwingAction.of("Select Map Image File", e -> {
       selectMapImageFile();
@@ -148,10 +148,10 @@ public class MapPropertiesPanel {
       }
     }));
     stepActionPanel.add(buttonSelectMapImageFile,
-        MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapNameExample, 2, 4));
+        MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapNameExample, 2, 4));
 
     // Map Centers File
-    stepActionPanel.add(labelCentersFile, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapName, 0, 5));
+    stepActionPanel.add(labelCentersFile, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapName, 0, 5));
 
     textFieldCentersFile.setEnabled(false);
     textFieldCentersFile.setMaximumSize(new Dimension(0, 0));
@@ -162,7 +162,7 @@ public class MapPropertiesPanel {
         buttonSelectCentersFile.doClick();
       }
     });
-    stepActionPanel.add(textFieldCentersFile, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapName, 1, 5));
+    stepActionPanel.add(textFieldCentersFile, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapName, 1, 5));
 
     buttonSelectCentersFile.addActionListener(SwingAction.of("Select Centers File", e -> {
       selectCentersFile();
@@ -170,20 +170,20 @@ public class MapPropertiesPanel {
         textFieldWaterFilter.setEnabled(true);
       }
     }));
-    stepActionPanel.add(buttonSelectCentersFile, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapNameExample, 2, 5));
+    stepActionPanel.add(buttonSelectCentersFile, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapNameExample, 2, 5));
 
     // Water Territory Filter
     stepActionPanel.add(labelWaterFilter,
-        MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapName, 0, 6, GridBagConstraints.NORTHWEST));
+        MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapName, 0, 6, GridBagConstraints.NORTHWEST));
 
     textFieldWaterFilter.setEnabled(MapXmlCreator.mapCentersFile != null);
     textFieldWaterFilter.addFocusListener(
         FocusListenerFocusLost.withAction(() -> MapXmlCreator.waterFilterString = textFieldWaterFilter.getText()));
     textFieldWaterFilter.setColumns(columns);
     textFieldWaterFilter.setMaximumSize(textFieldWaterFilter.getPreferredSize());
-    stepActionPanel.add(textFieldWaterFilter, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapName, 1, 6));
+    stepActionPanel.add(textFieldWaterFilter, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapName, 1, 6));
 
-    stepActionPanel.add(labelWaterFilterExample, MapXmlUIHelper.getGBCCloneWith(gridBadConstLabelMapNameExample, 2, 6));
+    stepActionPanel.add(labelWaterFilterExample, MapXmlUiHelper.getGbcCloneWith(gridBadConstLabelMapNameExample, 2, 6));
 
     mapXmlCreator.setAutoFillActionListener(null);
   }

--- a/src/main/java/tools/map/xml/creator/MapXmlCreator.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlCreator.java
@@ -355,7 +355,7 @@ public class MapXmlCreator extends JFrame {
     stepPanel.add(Box.createVerticalStrut(20));
 
     stepTitleLabel = new JLabel("Map Properties");
-    stepTitleLabel.setFont(new Font(MapXmlUIHelper.defaultMapXMLCreatorFontName, Font.BOLD, 12));
+    stepTitleLabel.setFont(new Font(MapXmlUiHelper.defaultMapXMLCreatorFontName, Font.BOLD, 12));
     stepTitleLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
     stepPanel.add(stepTitleLabel);
 
@@ -389,7 +389,7 @@ public class MapXmlCreator extends JFrame {
     // set up the actions
     final Action openAction = SwingAction.of("Load Map XML", e -> {
       final GameStep goToStep;
-      goToStep = MapXmlCreator.loadXML();
+      goToStep = MapXmlCreator.loadXml();
       highestStep = goToStep;
       DynamicRowsPanel.me = Optional.empty();
       SwingUtilities.invokeLater(() -> {
@@ -401,7 +401,7 @@ public class MapXmlCreator extends JFrame {
     final Action saveAction = SwingAction.of(BUTTON_LABEL_SAVE_MAP_XML, e -> {
       stepActionPanel.requestFocus();
       if (!DynamicRowsPanel.me.isPresent() || DynamicRowsPanel.me.get().dataIsConsistent()) {
-        MapXmlCreator.saveXML();
+        MapXmlCreator.saveXml();
       }
     });
     saveAction.putValue(Action.SHORT_DESCRIPTION, "Save the Map XML to File");
@@ -470,7 +470,7 @@ public class MapXmlCreator extends JFrame {
     southRightPanelFlowLayout.setAlignment(FlowLayout.RIGHT);
     southPanel.add(southRightPanel);
 
-    final JButton buttonAvailableChoices = MapXmlUIHelper.createButton("Available Choices", KeyEvent.VK_C);
+    final JButton buttonAvailableChoices = MapXmlUiHelper.createButton("Available Choices", KeyEvent.VK_C);
     buttonAvailableChoices.addActionListener(e -> {
       switch (currentStep) {
 
@@ -621,7 +621,7 @@ public class MapXmlCreator extends JFrame {
   private void createButtonHelp() {
     buttonHelp = new JButton("Help");
     buttonHelp.setMnemonic(KeyEvent.VK_H);
-    buttonHelp.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonHelp.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonHelp.addActionListener(e -> {
       switch (currentStep) {
         case MAP_PROPERTIES:
@@ -809,19 +809,19 @@ public class MapXmlCreator extends JFrame {
   private void addSouthCenterPanelButtons() {
     buttonBack = new JButton("Back");
     buttonBack.setMnemonic(KeyEvent.VK_B);
-    buttonBack.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonBack.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonBack.addActionListener(e -> {
       goToStep(getPrevGameStepTo(currentStep));
       invokeLaterRepaintActionPanel();
     });
     southCenterPanel.add(buttonBack);
 
-    autoFillButton = MapXmlUIHelper.createButton("Auto-Fill", KeyEvent.VK_A);
+    autoFillButton = MapXmlUiHelper.createButton("Auto-Fill", KeyEvent.VK_A);
     autoFillButton.setMinimumSize(new Dimension(50, 23));
     autoFillButton.setMaximumSize(new Dimension(50, 23));
     southCenterPanel.add(autoFillButton);
 
-    nextButton = MapXmlUIHelper.createButton("Next", KeyEvent.VK_N, e -> {
+    nextButton = MapXmlUiHelper.createButton("Next", KeyEvent.VK_N, e -> {
       goToStep(getNextGameStepTo(currentStep));
       invokeLaterRepaintActionPanel();
     });
@@ -892,7 +892,7 @@ public class MapXmlCreator extends JFrame {
   }
 
 
-  private final String stepLabelFontName = MapXmlUIHelper.defaultMapXMLCreatorFontName;
+  private final String stepLabelFontName = MapXmlUiHelper.defaultMapXMLCreatorFontName;
   private final Font stepLabelFontDefault = new Font(stepLabelFontName, Font.PLAIN, 13);
   private final Font stepLabelFontHighlighted = new Font(stepLabelFontName, Font.BOLD, 13);
 
@@ -1064,25 +1064,25 @@ public class MapXmlCreator extends JFrame {
     gridBadConstLabelNotesRow.gridwidth = 3;
     stepActionPanel.add(spTaNotes, gridBadConstLabelNotesRow);
 
-    final GridBagConstraints gridBadConstButtonPreviewHTMLRow = (GridBagConstraints) gridBadConstLabelNotesRow.clone();
-    gridBadConstButtonPreviewHTMLRow.weighty = 0.0;
-    gridBadConstButtonPreviewHTMLRow.insets = new Insets(0, 0, 0, 0);
-    gridBadConstButtonPreviewHTMLRow.gridwidth = 1;
-    gridBadConstButtonPreviewHTMLRow.gridx = 1;
-    gridBadConstButtonPreviewHTMLRow.gridy = 1;
+    final GridBagConstraints gridBadConstButtonPreviewHtmlRow = (GridBagConstraints) gridBadConstLabelNotesRow.clone();
+    gridBadConstButtonPreviewHtmlRow.weighty = 0.0;
+    gridBadConstButtonPreviewHtmlRow.insets = new Insets(0, 0, 0, 0);
+    gridBadConstButtonPreviewHtmlRow.gridwidth = 1;
+    gridBadConstButtonPreviewHtmlRow.gridx = 1;
+    gridBadConstButtonPreviewHtmlRow.gridy = 1;
 
-    final JButton buttonPreviewHTML = new JButton("Preview HTML");
-    buttonPreviewHTML.setPreferredSize(new Dimension(300, 30));
-    buttonPreviewHTML.setAction(SwingAction.of("Preview HTML", e -> showHTML(MapXmlHelper.getNotes(), "HTML Preview")));
-    stepActionPanel.add(buttonPreviewHTML, gridBadConstButtonPreviewHTMLRow);
+    final JButton buttonPreviewHtml = new JButton("Preview HTML");
+    buttonPreviewHtml.setPreferredSize(new Dimension(300, 30));
+    buttonPreviewHtml.setAction(SwingAction.of("Preview HTML", e -> showHtml(MapXmlHelper.getNotes(), "HTML Preview")));
+    stepActionPanel.add(buttonPreviewHtml, gridBadConstButtonPreviewHtmlRow);
 
     final GridBagConstraints gridBadConstLabelCongratsRow =
-        (GridBagConstraints) gridBadConstButtonPreviewHTMLRow.clone();
+        (GridBagConstraints) gridBadConstButtonPreviewHtmlRow.clone();
     gridBadConstLabelCongratsRow.gridy = 2;
     stepActionPanel.add(new JLabel("<html><big>Congratulation!</big></html>"), gridBadConstLabelCongratsRow);
 
     final GridBagConstraints gridBadConstLabelAllCompletedRow =
-        (GridBagConstraints) gridBadConstButtonPreviewHTMLRow.clone();
+        (GridBagConstraints) gridBadConstButtonPreviewHtmlRow.clone();
     gridBadConstLabelAllCompletedRow.gridy = 3;
     stepActionPanel.add(
         new JLabel("<html><nobr>You have completed all the steps for creating the map XML.</nobr></html>"),
@@ -1090,8 +1090,8 @@ public class MapXmlCreator extends JFrame {
 
     final JButton buttonSave = new JButton("Save Entries to XML");
     buttonSave.setPreferredSize(new Dimension(600, 35));
-    buttonSave.setAction(SwingAction.of(BUTTON_LABEL_SAVE_MAP_XML, e -> MapXmlCreator.saveXML()));
-    final GridBagConstraints gridBadConstButtonSaveRow = (GridBagConstraints) gridBadConstButtonPreviewHTMLRow.clone();
+    buttonSave.setAction(SwingAction.of(BUTTON_LABEL_SAVE_MAP_XML, e -> MapXmlCreator.saveXml()));
+    final GridBagConstraints gridBadConstButtonSaveRow = (GridBagConstraints) gridBadConstButtonPreviewHtmlRow.clone();
     gridBadConstButtonSaveRow.insets = new Insets(5, 0, 0, 0);
     gridBadConstButtonSaveRow.gridy = 4;
     stepActionPanel.add(buttonSave, gridBadConstButtonSaveRow);
@@ -1108,7 +1108,7 @@ public class MapXmlCreator extends JFrame {
     stepActionPanel.add(tabbedPane, BorderLayout.CENTER);
   }
 
-  private void showHTML(final String htmlString, final String title) {
+  private void showHtml(final String htmlString, final String title) {
     SwingUtilities.invokeLater(new Runnable() {
       @Override
       public void run() {
@@ -1141,7 +1141,7 @@ public class MapXmlCreator extends JFrame {
     });
   }
 
-  static void saveXML() {
+  static void saveXml() {
     try {
       final String fileName =
           new FileSave("Where to Save the Game XML ?",
@@ -1157,7 +1157,7 @@ public class MapXmlCreator extends JFrame {
       transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
       transformer.setOutputProperty(OutputKeys.INDENT, "yes");
       transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, GameParser.DTD_FILE_NAME);
-      final DOMSource source = new DOMSource(MapXmlHelper.getXMLDocument());
+      final DOMSource source = new DOMSource(MapXmlHelper.getXmlDocument());
       final File newFile = new File(fileName);
       final StreamResult result = new StreamResult(newFile);
 
@@ -1187,30 +1187,30 @@ public class MapXmlCreator extends JFrame {
     getLogger().log(level, msg);
   }
 
-  static GameStep loadXML() {
-    final String gameXMLPath =
-        MapXmlUIHelper.selectFile("Game XML File", MapXmlHelper.getMapXMLFile(), FILE_NAME_ENDING_XML).getPathString();
-    MapXmlCreator.log(Level.INFO, "Load Game XML from " + gameXMLPath);
+  static GameStep loadXml() {
+    final String gameXmlPath =
+        MapXmlUiHelper.selectFile("Game XML File", MapXmlHelper.getMapXmlFile(), FILE_NAME_ENDING_XML).getPathString();
+    MapXmlCreator.log(Level.INFO, "Load Game XML from " + gameXmlPath);
     try {
-      return loadXmlFromFilePath(gameXMLPath);
+      return loadXmlFromFilePath(gameXmlPath);
     } catch (SAXException | IOException | ParserConfigurationException e) {
-      ClientLogger.logError("Failed to load XML File: " + gameXMLPath, e);
-      return loadXML();
+      ClientLogger.logError("Failed to load XML File: " + gameXmlPath, e);
+      return loadXml();
     }
   }
 
-  private static GameStep loadXmlFromFilePath(final String gameXMLPath)
+  private static GameStep loadXmlFromFilePath(final String gameXmlPath)
       throws SAXException, IOException, ParserConfigurationException {
-    final FileInputStream in = new FileInputStream(gameXMLPath);
+    final FileInputStream in = new FileInputStream(gameXmlPath);
 
     // parse using builder to get DOM representation of the XML file
-    final org.w3c.dom.Document dom = new GameParser(gameXMLPath).getDocument(in);
+    final org.w3c.dom.Document dom = new GameParser(gameXmlPath).getDocument(in);
 
-    GameStep goToStep = MapXmlHelper.parseValuesFromXML(dom);
+    GameStep goToStep = MapXmlHelper.parseValuesFromXml(dom);
 
     // set map file, image file and map folder
-    MapXmlHelper.setMapXMLFile(new File(gameXMLPath));
-    File mapFolder = MapXmlHelper.getMapXMLFile().getParentFile();
+    MapXmlHelper.setMapXmlFile(new File(gameXmlPath));
+    File mapFolder = MapXmlHelper.getMapXmlFile().getParentFile();
     if (mapFolder.getName().equals(GameSelectorModel.DEFAULT_GAME_XML_DIRECTORY_NAME)) {
       mapFolder = mapFolder.getParentFile();
     }

--- a/src/main/java/tools/map/xml/creator/MapXmlData.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlData.java
@@ -14,11 +14,11 @@ import games.strategy.util.Triple;
 
 public class MapXmlData {
   private String notes = "";
-  private File mapXMLFile;
+  private File mapXmlFile;
 
   private Map<String, String> xmlStringsMap = Maps.newLinkedHashMap();
   private List<String> resourceList = new ArrayList<>();
-  private Map<String, Map<TerritoryDefinitionDialog.DEFINITION, Boolean>> territoryDefintionsMap =
+  private Map<String, Map<TerritoryDefinitionDialog.Definition, Boolean>> territoryDefintionsMap =
       Maps.newHashMap();
   private Map<String, Set<String>> territoryConnectionsMap = Maps.newHashMap();
   private List<String> playerNames = new ArrayList<>();
@@ -81,12 +81,12 @@ public class MapXmlData {
     this.resourceList = resourceList;
   }
 
-  public Map<String, Map<TerritoryDefinitionDialog.DEFINITION, Boolean>> getTerritoryDefintionsMap() {
+  public Map<String, Map<TerritoryDefinitionDialog.Definition, Boolean>> getTerritoryDefintionsMap() {
     return territoryDefintionsMap;
   }
 
   public void setTerritoryDefintionsMap(
-      final Map<String, Map<TerritoryDefinitionDialog.DEFINITION, Boolean>> territoryDefintionsMap) {
+      final Map<String, Map<TerritoryDefinitionDialog.Definition, Boolean>> territoryDefintionsMap) {
     this.territoryDefintionsMap = territoryDefintionsMap;
   }
 
@@ -218,12 +218,12 @@ public class MapXmlData {
     this.notes = notes;
   }
 
-  public File getMapXMLFile() {
-    return mapXMLFile;
+  public File getMapXmlFile() {
+    return mapXmlFile;
   }
 
-  public void setMapXMLFile(final File mapXMLFile) {
-    this.mapXMLFile = mapXMLFile;
+  public void setMapXmlFile(final File mapXmlFile) {
+    this.mapXmlFile = mapXmlFile;
   }
 
   /**
@@ -252,12 +252,12 @@ public class MapXmlData {
       final Map<String, Set<String>> waterLandTerritoyConnections) {
     for (final Entry<String, Set<String>> terrConn : MapXmlHelper.getTerritoryConnectionsMap().entrySet()) {
       if (MapXmlHelper.getTerritoryDefintionsMap().get(terrConn.getKey())
-          .get(TerritoryDefinitionDialog.DEFINITION.IS_WATER)) {
+          .get(TerritoryDefinitionDialog.Definition.IS_WATER)) {
         // terrConn.Key is water territory, get none-water entries in terrConn.Value
         @SuppressWarnings("unchecked")
         final Set<String> landTerrValue = (Set<String>) terrConn.getValue().stream()
             .filter(terr -> !MapXmlHelper.getTerritoryDefintionsMap().get(terr).get(
-                TerritoryDefinitionDialog.DEFINITION.IS_WATER));
+                TerritoryDefinitionDialog.Definition.IS_WATER));
         if (!landTerrValue.isEmpty()) {
           waterLandTerritoyConnections.put(terrConn.getKey(), landTerrValue);
         }
@@ -266,7 +266,7 @@ public class MapXmlData {
         @SuppressWarnings("unchecked")
         final Set<String> waterTerrValue = (Set<String>) terrConn.getValue().stream()
             .filter(terr -> MapXmlHelper.getTerritoryDefintionsMap().get(terr)
-                .get(TerritoryDefinitionDialog.DEFINITION.IS_WATER));
+                .get(TerritoryDefinitionDialog.Definition.IS_WATER));
         landWaterTerritoyConnections.put(terrConn.getKey(), waterTerrValue);
       }
     }

--- a/src/main/java/tools/map/xml/creator/MapXmlHelper.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlHelper.java
@@ -34,7 +34,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.BattleDelegate;
 import games.strategy.util.Triple;
 import tools.map.xml.creator.MapXmlCreator.GameStep;
-import tools.map.xml.creator.TerritoryDefinitionDialog.DEFINITION;
+import tools.map.xml.creator.TerritoryDefinitionDialog.Definition;
 
 /**
  * This class reads, writes and keeps the Map XML properties.
@@ -155,11 +155,11 @@ public class MapXmlHelper {
     mapXmlData.setResourceList(resourceList);
   }
 
-  public static Map<String, Map<DEFINITION, Boolean>> getTerritoryDefintionsMap() {
+  public static Map<String, Map<Definition, Boolean>> getTerritoryDefintionsMap() {
     return mapXmlData.getTerritoryDefintionsMap();
   }
 
-  public static void setTerritoryDefintions(final Map<String, Map<DEFINITION, Boolean>> territoryDefintions) {
+  public static void setTerritoryDefintions(final Map<String, Map<Definition, Boolean>> territoryDefintions) {
     mapXmlData.setTerritoryDefintionsMap(territoryDefintions);
   }
 
@@ -291,12 +291,12 @@ public class MapXmlHelper {
     mapXmlData.setNotes(notes);
   }
 
-  public static File getMapXMLFile() {
-    return mapXmlData.getMapXMLFile();
+  public static File getMapXmlFile() {
+    return mapXmlData.getMapXmlFile();
   }
 
-  public static void setMapXMLFile(final File mapXMLFile) {
-    MapXmlHelper.mapXmlData.setMapXMLFile(mapXMLFile);
+  public static void setMapXmlFile(final File mapXmlFile) {
+    MapXmlHelper.mapXmlData.setMapXmlFile(mapXmlFile);
   }
 
   static void setMapXmlData(final MapXmlData mapXmlData) {
@@ -317,7 +317,7 @@ public class MapXmlHelper {
     getResourceList().add(index, value);
   }
 
-  static void putTerritoryDefintions(final String key, final HashMap<DEFINITION, Boolean> value) {
+  static void putTerritoryDefintions(final String key, final HashMap<Definition, Boolean> value) {
     getTerritoryDefintionsMap().put(key, value);
   }
 
@@ -456,7 +456,7 @@ public class MapXmlHelper {
   ///////////////////////////////////////////
   // Start of XML parsing methods
   ///////////////////////////////////////////
-  static GameStep parseValuesFromXML(final Document dom) {
+  static GameStep parseValuesFromXml(final Document dom) {
     initializeAll();
 
     final Node mainlastChild = dom.getLastChild();
@@ -701,23 +701,23 @@ public class MapXmlHelper {
           getTerritoyProductionsMap().put(attachmentAttachTo,
               Integer.parseInt(attachmentOptionAttr.get(XML_NODE_NAME_VALUE)));
         } else {
-          Map<DEFINITION, Boolean> terrDefinitions = getTerritoryDefintionsMap().get(attachmentAttachTo);
+          Map<Definition, Boolean> terrDefinitions = getTerritoryDefintionsMap().get(attachmentAttachTo);
           if (terrDefinitions == null) {
             terrDefinitions = Maps.newHashMap();
             getTerritoryDefintionsMap().put(attachmentAttachTo, terrDefinitions);
           }
           switch (TerritoryDefinitionDialog.valueOf(optionNameAttr)) {
             case IS_CAPITAL:
-              terrDefinitions.put(DEFINITION.IS_CAPITAL, true);
+              terrDefinitions.put(Definition.IS_CAPITAL, true);
               break;
             case IS_VICTORY_CITY:
-              terrDefinitions.put(DEFINITION.IS_VICTORY_CITY, true);
+              terrDefinitions.put(Definition.IS_VICTORY_CITY, true);
               break;
             case IS_WATER:
-              terrDefinitions.put(DEFINITION.IS_WATER, true);
+              terrDefinitions.put(Definition.IS_WATER, true);
               break;
             case IMPASSABLE:
-              terrDefinitions.put(DEFINITION.IMPASSABLE, true);
+              terrDefinitions.put(Definition.IMPASSABLE, true);
               break;
           }
         }
@@ -877,7 +877,7 @@ public class MapXmlHelper {
   private static void parseNodeTerritory(final Node mapChildNode) {
     final NamedNodeMap terrAttrNodes = mapChildNode.getAttributes();
     String terrName = null;
-    final HashMap<DEFINITION, Boolean> terrDef = Maps.newHashMap();
+    final HashMap<Definition, Boolean> terrDef = Maps.newHashMap();
     for (int i = 0; i < terrAttrNodes.getLength(); ++i) {
       final Node terrAttrNode = terrAttrNodes.item(i);
       if (terrAttrNode.getNodeName().equals(XML_ATTR_ATTACHMENT_NAME_NAME)) {
@@ -893,7 +893,7 @@ public class MapXmlHelper {
   ///////////////////////////////////////////
   // Start of XML creation methods
   ///////////////////////////////////////////
-  static Document getXMLDocument() throws ParserConfigurationException {
+  static Document getXmlDocument() throws ParserConfigurationException {
     // TODO: break into smaller chunks, consider builder pattern
     final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
     final DocumentBuilder db = dbf.newDocumentBuilder();
@@ -902,7 +902,7 @@ public class MapXmlHelper {
     final Element game = doc.createElement(XML_NODE_NAME_GAME);
     doc.appendChild(game);
 
-    appendFromXMLStrings(doc, game);
+    appendFromXmlStrings(doc, game);
 
     final Element map = doc.createElement(XML_NODE_NAME_MAP);
     game.appendChild(map);
@@ -963,11 +963,11 @@ public class MapXmlHelper {
       propertyList.appendChild(property);
     }
 
-    if (getMapXMLFile() != null) {
+    if (getMapXmlFile() != null) {
       propertyList.appendChild(doc.createComment(" Map Name: also used for map utils when asked "));
       final Element property = doc.createElement(XML_NODE_NAME_PROPERTY);
       property.setAttribute(XML_ATTR_PROPERTY_NAME_NAME, XML_ATTR_VALUE_PROPERTY_NAME_MAP_NAME);
-      final String fileName = getMapXMLFile().getName();
+      final String fileName = getMapXmlFile().getName();
       property.setAttribute(XML_ATTR_PROPERTY_NAME_VALUE, fileName.substring(0, fileName.lastIndexOf(".") - 1));
       property.setAttribute(XML_ATTR_PROPERTY_NAME_EDITABLE, Constants.PROPERTY_FALSE);
       propertyList.appendChild(property);
@@ -1151,9 +1151,9 @@ public class MapXmlHelper {
   }
 
   private static void addAttachmentsFromTerritoryDefinitions(final Map<String, List<String>> territoryAttachments) {
-    for (final Entry<String, Map<DEFINITION, Boolean>> territoryDefinition : getTerritoryDefintionsMap().entrySet()) {
+    for (final Entry<String, Map<Definition, Boolean>> territoryDefinition : getTerritoryDefintionsMap().entrySet()) {
       final String territoryName = territoryDefinition.getKey();
-      for (final Entry<DEFINITION, Boolean> definition : territoryDefinition.getValue().entrySet()) {
+      for (final Entry<Definition, Boolean> definition : territoryDefinition.getValue().entrySet()) {
         if (definition.getValue() == Boolean.TRUE) {
           final ArrayList<String> attachmentOptions = new ArrayList<>();
           attachmentOptions.add(territoryName);
@@ -1171,15 +1171,15 @@ public class MapXmlHelper {
 
   private static boolean appendFromTerritoryDefinitions(final Document doc, final Element map) {
     boolean territoryAttachmentNeeded = false;
-    for (final Entry<String, Map<DEFINITION, Boolean>> entryTerritoryDefinition : getTerritoryDefintionsMap()
+    for (final Entry<String, Map<Definition, Boolean>> entryTerritoryDefinition : getTerritoryDefintionsMap()
         .entrySet()) {
       final Element territory = doc.createElement(XML_NODE_NAME_TERRITORY);
       territory.setAttribute(XML_ATTR_PROPERTY_NAME_NAME, entryTerritoryDefinition.getKey());
-      final Map<DEFINITION, Boolean> territoryDefinition = entryTerritoryDefinition.getValue();
+      final Map<Definition, Boolean> territoryDefinition = entryTerritoryDefinition.getValue();
       final int territoryDefinitionSize = territoryDefinition.size();
-      final Boolean isWater = territoryDefinition.get(DEFINITION.IS_WATER);
+      final Boolean isWater = territoryDefinition.get(Definition.IS_WATER);
       if (isWater != null && isWater) {
-        territory.setAttribute(TerritoryDefinitionDialog.getDefinitionString(DEFINITION.IS_WATER), "true");
+        territory.setAttribute(TerritoryDefinitionDialog.getDefinitionString(Definition.IS_WATER), "true");
         if (territoryDefinitionSize > 1) {
           territoryAttachmentNeeded = true;
         }
@@ -1201,11 +1201,11 @@ public class MapXmlHelper {
     return territoryAttachmentNeeded;
   }
 
-  private static void appendFromXMLStrings(final Document doc, final Element game) {
+  private static void appendFromXmlStrings(final Document doc, final Element game) {
     Element currentElem = null;
     String prevKeyNode = null;
-    for (final Entry<String, String> entryXMLString : getXmlStringsMap().entrySet()) {
-      final String key = entryXMLString.getKey();
+    for (final Entry<String, String> entryXmlString : getXmlStringsMap().entrySet()) {
+      final String key = entryXmlString.getKey();
       final String[] split = key.split("_@");
       if (!split[0].equals(prevKeyNode)) {
         Element parentElem = game;
@@ -1215,7 +1215,7 @@ public class MapXmlHelper {
           parentElem = currentElem;
         }
       }
-      currentElem.setAttribute(split[1], entryXMLString.getValue());
+      currentElem.setAttribute(split[1], entryXmlString.getValue());
       prevKeyNode = split[0];
     }
   }

--- a/src/main/java/tools/map/xml/creator/MapXmlUiHelper.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlUiHelper.java
@@ -16,7 +16,7 @@ import javax.swing.JTextField;
 
 import tools.image.FileOpen;
 
-public class MapXmlUIHelper {
+public class MapXmlUiHelper {
 
   /**
    *
@@ -31,7 +31,7 @@ public class MapXmlUIHelper {
       final String title, final Object message,
       final int messageType)
       throws HeadlessException {
-    return MapXmlUIHelper.showOptionDialog(
+    return showOptionDialog(
         title,
         message,
         JOptionPane.YES_NO_OPTION,
@@ -77,11 +77,11 @@ public class MapXmlUIHelper {
         messageType, null, null, initialValue);
   }
 
-  public static final Font defaultMapXMLCreatorFont = MapXmlUIHelper.getDefaultMapXMLCreatorFont();
-  public static final String defaultMapXMLCreatorFontName = MapXmlUIHelper.getDefaultMapXMLCreatorFontName();
+  public static final Font defaultMapXMLCreatorFont = getDefaultMapXmlCreatorFont();
+  public static final String defaultMapXMLCreatorFontName = getDefaultMapXmlCreatorFontName();
   public static final String preferredMapXMLCreatorFontName = "Tahoma";
 
-  public static Font getDefaultMapXMLCreatorFont() {
+  public static Font getDefaultMapXmlCreatorFont() {
     return defaultMapXMLCreatorFont;
   }
 
@@ -90,7 +90,7 @@ public class MapXmlUIHelper {
    *
    * @return default font name for XML Creator
    */
-  public static String getDefaultMapXMLCreatorFontName() {
+  public static String getDefaultMapXmlCreatorFontName() {
     final String[] availableFontFamilyNames =
         GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
     for (final String fontName : availableFontFamilyNames) {
@@ -109,7 +109,7 @@ public class MapXmlUIHelper {
    * @param actionListener - the ActionListener to be added
    */
   public static JButton createButton(final String buttonText, final int mnemonic, final ActionListener actionListener) {
-    final JButton newButton = MapXmlUIHelper.createButton(buttonText, mnemonic);
+    final JButton newButton = createButton(buttonText, mnemonic);
     newButton.addActionListener(actionListener);
     return newButton;
   }
@@ -135,9 +135,9 @@ public class MapXmlUIHelper {
    * @param anchor anchor value for new GridBagConstraints object
    * @return cloned GridBagConstraints object with provided gridx and gridy values
    */
-  public static GridBagConstraints getGBCCloneWith(final GridBagConstraints gbcToClone, final int gridx,
+  public static GridBagConstraints getGbcCloneWith(final GridBagConstraints gbcToClone, final int gridx,
       final int gridy, final int anchor) {
-    final GridBagConstraints gbcNew = MapXmlUIHelper.getGBCCloneWith(gbcToClone, gridx, gridy);
+    final GridBagConstraints gbcNew = getGbcCloneWith(gbcToClone, gridx, gridy);
     gbcNew.anchor = anchor;
     return gbcNew;
   }
@@ -148,7 +148,7 @@ public class MapXmlUIHelper {
    * @param gridy gridy value for new GridBagConstraints object
    * @return cloned GridBagConstraints object with provided gridx and gridy values
    */
-  public static GridBagConstraints getGBCCloneWith(final GridBagConstraints gbcToClone, final int gridx,
+  public static GridBagConstraints getGbcCloneWith(final GridBagConstraints gbcToClone, final int gridx,
       final int gridy) {
     final GridBagConstraints gbcNew = (GridBagConstraints) gbcToClone.clone();
     gbcNew.gridx = gridx;
@@ -176,7 +176,7 @@ public class MapXmlUIHelper {
    * @return new GridBagConstraints based on gbcTemplate and provided data
    */
   public static GridBagConstraints getGbcDefaultTemplateWith(final int gridx, final int gridy) {
-    return getGBCCloneWith(MapXmlUIHelper.gbcTemplate, gridx, gridy);
+    return getGbcCloneWith(gbcTemplate, gridx, gridy);
   }
 
   /**

--- a/src/main/java/tools/map/xml/creator/PlayerAndAlliancesPanel.java
+++ b/src/main/java/tools/map/xml/creator/PlayerAndAlliancesPanel.java
@@ -95,7 +95,7 @@ public class PlayerAndAlliancesPanel extends DynamicRowsPanel {
     final JButton buttonAddAlliance = new JButton("Add Alliance");
     final JButton buttonRemoveAlliance = new JButton("Remove Alliance");
 
-    buttonAddPlayer.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonAddPlayer.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonAddPlayer.addActionListener(SwingAction.of("Add Player", e -> {
       String newPlayerName = JOptionPane.showInputDialog(getOwnPanel(), "Enter a new player name:",
           "Player" + (MapXmlHelper.getPlayerNames().size() + 1));
@@ -141,7 +141,7 @@ public class PlayerAndAlliancesPanel extends DynamicRowsPanel {
     }));
     addButton(buttonAddPlayer);
 
-    buttonAddAlliance.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonAddAlliance.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonAddAlliance.addActionListener(SwingAction.of("Add Alliance", e -> {
       String newAllianceName = JOptionPane.showInputDialog(getOwnPanel(), "Enter a new alliance name:",
           "Alliance" + (alliances.size() + 1));
@@ -170,7 +170,7 @@ public class PlayerAndAlliancesPanel extends DynamicRowsPanel {
     }));
     addButton(buttonAddAlliance);
 
-    buttonRemoveAlliance.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonRemoveAlliance.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonRemoveAlliance.setEnabled(alliances.size() > 1);
     buttonRemoveAlliance.addActionListener(SwingAction.of("Remove Alliance", e -> {
       final String removeAllianceName = (String) JOptionPane.showInputDialog(getOwnPanel(),

--- a/src/main/java/tools/map/xml/creator/PlayerAndAlliancesRow.java
+++ b/src/main/java/tools/map/xml/creator/PlayerAndAlliancesRow.java
@@ -40,7 +40,7 @@ class PlayerAndAlliancesRow extends DynamicRow {
     Dimension dimension = textFieldPlayerName.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_MEDIUM;
     textFieldPlayerName.setPreferredSize(dimension);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldPlayerName, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldPlayerName, () -> {
       final String inputText = textFieldPlayerName.getText().trim();
       if (currentRowName.equals(inputText)) {
         return;

--- a/src/main/java/tools/map/xml/creator/PlayerSequencePanel.java
+++ b/src/main/java/tools/map/xml/creator/PlayerSequencePanel.java
@@ -105,7 +105,7 @@ public class PlayerSequencePanel extends DynamicRowsPanel {
     // <4> Add Final Button Row
     final JButton buttonAddSequence = new JButton("Add Sequence");
 
-    buttonAddSequence.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonAddSequence.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonAddSequence.addActionListener(SwingAction.of("Add Sequence", e -> {
       String newSequenceName = JOptionPane.showInputDialog(getOwnPanel(), "Enter a new sequence name:",
           "Sequence" + (MapXmlHelper.getPlayerSequenceMap().size() + 1));

--- a/src/main/java/tools/map/xml/creator/PlayerSequenceRow.java
+++ b/src/main/java/tools/map/xml/creator/PlayerSequenceRow.java
@@ -34,7 +34,7 @@ class PlayerSequenceRow extends DynamicRow {
     Dimension dimension = textFieldSequenceName.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_MEDIUM;
     textFieldSequenceName.setPreferredSize(dimension);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldMaxCount, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldMaxCount, () -> {
       final String inputText = textFieldSequenceName.getText().trim();
       if (currentRowName.equals(inputText)) {
         return;
@@ -79,7 +79,7 @@ class PlayerSequenceRow extends DynamicRow {
     dimension = textFieldMaxCount.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_SMALL;
     textFieldMaxCount.setPreferredSize(dimension);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldMaxCount, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldMaxCount, () -> {
       final String inputText = textFieldMaxCount.getText().trim();
       try {
         final int newValue = Integer.parseInt(inputText);

--- a/src/main/java/tools/map/xml/creator/ProductionFrontiersPanel.java
+++ b/src/main/java/tools/map/xml/creator/ProductionFrontiersPanel.java
@@ -100,7 +100,7 @@ public class ProductionFrontiersPanel extends DynamicRowsPanel {
     // <4> Add Final Button Row
     final JButton buttonAddUnit = new JButton("Add Unit");
 
-    buttonAddUnit.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonAddUnit.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonAddUnit.addActionListener(SwingAction.of("Add Unit", e -> {
       final List<String> curr_playersUnitNames = MapXmlHelper.getProductionFrontiersMap().get(playerName);
 

--- a/src/main/java/tools/map/xml/creator/TechnologyDefinitionsPanel.java
+++ b/src/main/java/tools/map/xml/creator/TechnologyDefinitionsPanel.java
@@ -99,7 +99,7 @@ public class TechnologyDefinitionsPanel extends DynamicRowsPanel {
     // <4> Add Final Button Row
     final JButton buttonAddTechnology = new JButton("Add Technology");
 
-    buttonAddTechnology.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonAddTechnology.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonAddTechnology.addActionListener(SwingAction.of("Add Technology", e -> {
       String newTechnologyName = JOptionPane.showInputDialog(getOwnPanel(), "Enter a new technology name:",
           "Technology" + (MapXmlHelper.getTechnologyDefinitionsMap().size() + 1));

--- a/src/main/java/tools/map/xml/creator/TechnologyDefinitionsRow.java
+++ b/src/main/java/tools/map/xml/creator/TechnologyDefinitionsRow.java
@@ -32,7 +32,7 @@ class TechnologyDefinitionsRow extends DynamicRow {
     Dimension dimension = textFieldTechnologyName.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_LARGE;
     textFieldTechnologyName.setPreferredSize(dimension);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldTechnologyName, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldTechnologyName, () -> {
       final String inputText = textFieldTechnologyName.getText().trim();
       final String curr_playerName = (String) comboBoxPlayerName.getSelectedItem();
       if (currentRowName.startsWith(inputText + "_")) {

--- a/src/main/java/tools/map/xml/creator/TerritoryDefinitionDialog.java
+++ b/src/main/java/tools/map/xml/creator/TerritoryDefinitionDialog.java
@@ -20,11 +20,11 @@ import javax.swing.border.EmptyBorder;
 
 
 public class TerritoryDefinitionDialog extends JDialog {
-  public static enum DEFINITION {
+  public static enum Definition {
     IS_WATER, IS_VICTORY_CITY, IMPASSABLE, IS_CAPITAL
   }
 
-  static String getDefinitionString(final DEFINITION def) {
+  static String getDefinitionString(final Definition def) {
     switch (def) {
       case IS_WATER:
         return TERRITORY_DEFINITION_IS_WATER;
@@ -36,22 +36,22 @@ public class TerritoryDefinitionDialog extends JDialog {
         return TERRITORY_DEFINITION_IS_CAPITAL;
       default:
         throw new IllegalArgumentException(
-            "Provided value is not valid for " + DEFINITION.class);
+            "Provided value is not valid for " + Definition.class);
     }
   }
 
-  static DEFINITION valueOf(final String defString) {
+  static Definition valueOf(final String defString) {
     if (defString.equals(TERRITORY_DEFINITION_IS_WATER)) {
-      return DEFINITION.IS_WATER;
+      return Definition.IS_WATER;
     } else if (defString.equals(TERRITORY_DEFINITION_IS_VICTORY_CITY)) {
-      return DEFINITION.IS_VICTORY_CITY;
+      return Definition.IS_VICTORY_CITY;
     } else if (defString.equals(TERRITORY_DEFINITION_IMPASSABLE)) {
-      return DEFINITION.IMPASSABLE;
+      return Definition.IMPASSABLE;
     } else if (defString.equals(TERRITORY_DEFINITION_IS_CAPITAL)) {
-      return DEFINITION.IS_CAPITAL;
+      return Definition.IS_CAPITAL;
     }
     throw new IllegalArgumentException(
-        "'" + defString + "' is not a valid string for " + DEFINITION.class);
+        "'" + defString + "' is not a valid string for " + Definition.class);
   }
 
   private static final long serialVersionUID = -2504102953599720855L;
@@ -60,16 +60,16 @@ public class TerritoryDefinitionDialog extends JDialog {
   public static final String TERRITORY_DEFINITION_IMPASSABLE = "isImpassable"; // typo in engine!!!
   public static final String TERRITORY_DEFINITION_IS_CAPITAL = "capital";
 
-  private final Map<DEFINITION, Boolean> properties;
+  private final Map<Definition, Boolean> properties;
   private final JButton okButton;
 
   TerritoryDefinitionDialog(final MapXmlCreator mapXmlCreator, final String territoryName,
-      final Map<DEFINITION, Boolean> properties) {
+      final Map<Definition, Boolean> properties) {
     this(mapXmlCreator, JOptionPane.getFrameForComponent(null), territoryName, properties);
   }
 
   private TerritoryDefinitionDialog(final MapXmlCreator mapXmlCreator, final Frame parentFrame,
-      final String territoryName, final Map<DEFINITION, Boolean> properties) {
+      final String territoryName, final Map<Definition, Boolean> properties) {
     super(parentFrame, "Edit Territory Definitions of " + territoryName, true);
     this.properties = properties;
     okButton = new JButton("OK");
@@ -113,30 +113,30 @@ public class TerritoryDefinitionDialog extends JDialog {
     buttonsPanel.add(new JLabel(" "));
     // add buttons here:
     final JCheckBox cbIsWater = new JCheckBox("is water territory");
-    final Boolean isWater = properties.get(DEFINITION.IS_WATER);
+    final Boolean isWater = properties.get(Definition.IS_WATER);
     cbIsWater.setSelected((isWater != null ? isWater : false));
-    cbIsWater.addActionListener(e -> properties.put(DEFINITION.IS_WATER, cbIsWater.isSelected()));
+    cbIsWater.addActionListener(e -> properties.put(Definition.IS_WATER, cbIsWater.isSelected()));
     buttonsPanel.add(cbIsWater);
     buttonsPanel.add(new JLabel(" "));
 
     final JCheckBox cbIsVictoryCity = new JCheckBox("is victory city");
-    final Boolean isVictoryCity = properties.get(DEFINITION.IS_VICTORY_CITY);
+    final Boolean isVictoryCity = properties.get(Definition.IS_VICTORY_CITY);
     cbIsVictoryCity.setSelected((isVictoryCity != null ? isVictoryCity : false));
-    cbIsVictoryCity.addActionListener(e -> properties.put(DEFINITION.IS_VICTORY_CITY, cbIsVictoryCity.isSelected()));
+    cbIsVictoryCity.addActionListener(e -> properties.put(Definition.IS_VICTORY_CITY, cbIsVictoryCity.isSelected()));
     buttonsPanel.add(cbIsVictoryCity);
     buttonsPanel.add(new JLabel(" "));
 
     final JCheckBox cbImpassable = new JCheckBox("is impassable");
-    final Boolean impassable = properties.get(DEFINITION.IMPASSABLE);
+    final Boolean impassable = properties.get(Definition.IMPASSABLE);
     cbImpassable.setSelected((impassable != null ? impassable : false));
-    cbImpassable.addActionListener(e -> properties.put(DEFINITION.IMPASSABLE, cbImpassable.isSelected()));
+    cbImpassable.addActionListener(e -> properties.put(Definition.IMPASSABLE, cbImpassable.isSelected()));
     buttonsPanel.add(cbImpassable);
     buttonsPanel.add(new JLabel(" "));
 
     final JCheckBox cbIsCapital = new JCheckBox("is capital");
-    final Boolean isCapital = properties.get(DEFINITION.IS_CAPITAL);
+    final Boolean isCapital = properties.get(Definition.IS_CAPITAL);
     cbIsCapital.setSelected((isCapital != null ? isCapital : false));
-    cbIsCapital.addActionListener(e -> properties.put(DEFINITION.IS_CAPITAL, cbIsCapital.isSelected()));
+    cbIsCapital.addActionListener(e -> properties.put(Definition.IS_CAPITAL, cbIsCapital.isSelected()));
     buttonsPanel.add(cbIsCapital);
 
     buttonsPanel.add(Box.createGlue());

--- a/src/main/java/tools/map/xml/creator/TerritoryDefinitionsPanel.java
+++ b/src/main/java/tools/map/xml/creator/TerritoryDefinitionsPanel.java
@@ -31,7 +31,7 @@ class TerritoryDefinitionsPanel extends ImageScrollPanePanel {
   @Override
   protected void paintCenterSpecifics(final Graphics g, final String centerName, final FontMetrics fontMetrics,
       final Point item, final int textStartX) {
-    final Map<TerritoryDefinitionDialog.DEFINITION, Boolean> territoryDefinition =
+    final Map<TerritoryDefinitionDialog.Definition, Boolean> territoryDefinition =
         MapXmlHelper.getTerritoryDefintionsMap().get(centerName);
     if (territoryDefinition != null) {
       final int y_value = item.y + 10;
@@ -40,7 +40,7 @@ class TerritoryDefinitionsPanel extends ImageScrollPanePanel {
       final FontMetrics fm = g.getFontMetrics();
       int h = fm.getAscent();
       final int oneCharacterWidthSpace = 17;
-      for (final Entry<TerritoryDefinitionDialog.DEFINITION, Boolean> definitionEntry : territoryDefinition
+      for (final Entry<TerritoryDefinitionDialog.Definition, Boolean> definitionEntry : territoryDefinition
           .entrySet()) {
         if (definitionEntry.getValue()) {
           final int x_value = textStartX + oneCharacterWidthSpace * definitionCount;
@@ -62,7 +62,7 @@ class TerritoryDefinitionsPanel extends ImageScrollPanePanel {
               g.setColor(Color.green);
               break;
             default:
-              throw new IllegalStateException("No valid value for " + TerritoryDefinitionDialog.DEFINITION.class);
+              throw new IllegalStateException("No valid value for " + TerritoryDefinitionDialog.Definition.class);
           }
           g.fillOval(x_value, y_value, 16, 16);
           g.setColor(Color.red);
@@ -81,16 +81,16 @@ class TerritoryDefinitionsPanel extends ImageScrollPanePanel {
   protected void paintPreparation(final Map<String, Point> centers) {
     if (!MapXmlCreator.waterFilterString.isEmpty() && MapXmlHelper.getTerritoryDefintionsMap().isEmpty()) {
       for (final String centerName : centers.keySet()) {
-        final HashMap<TerritoryDefinitionDialog.DEFINITION, Boolean> territoyDefintion =
+        final HashMap<TerritoryDefinitionDialog.Definition, Boolean> territoyDefintion =
             Maps.newHashMap();
         if (centerName.startsWith(MapXmlCreator.waterFilterString)) {
-          territoyDefintion.put(TerritoryDefinitionDialog.DEFINITION.IS_WATER, true);
+          territoyDefintion.put(TerritoryDefinitionDialog.Definition.IS_WATER, true);
         }
         MapXmlHelper.putTerritoryDefintions(centerName, territoyDefintion);
       }
     } else {
       for (final String centerName : centers.keySet()) {
-        final HashMap<TerritoryDefinitionDialog.DEFINITION, Boolean> territoyDefintion =
+        final HashMap<TerritoryDefinitionDialog.Definition, Boolean> territoyDefintion =
             Maps.newHashMap();
         MapXmlHelper.putTerritoryDefintions(centerName, territoyDefintion);
       }
@@ -122,7 +122,7 @@ class TerritoryDefinitionsPanel extends ImageScrollPanePanel {
       centers.put(territoryNameNew, centers.get(territoryName));
     } else {
       SwingUtilities.invokeLater(() -> {
-        Map<TerritoryDefinitionDialog.DEFINITION, Boolean> territoyDefintions =
+        Map<TerritoryDefinitionDialog.Definition, Boolean> territoyDefintions =
             MapXmlHelper.getTerritoryDefintionsMap().get(territoryName);
         if (territoyDefintions == null) {
           territoyDefintions = Maps.newHashMap();

--- a/src/main/java/tools/map/xml/creator/UnitDefinitionsPanel.java
+++ b/src/main/java/tools/map/xml/creator/UnitDefinitionsPanel.java
@@ -90,7 +90,7 @@ public class UnitDefinitionsPanel extends DynamicRowsPanel {
     // <4> Add Final Button Row
     final JButton buttonAddUnit = new JButton("Add Unit");
 
-    buttonAddUnit.setFont(MapXmlUIHelper.defaultMapXMLCreatorFont);
+    buttonAddUnit.setFont(MapXmlUiHelper.defaultMapXMLCreatorFont);
     buttonAddUnit.addActionListener(SwingAction.of("Add Unit", e -> {
       String newUnitName = JOptionPane.showInputDialog(getOwnPanel(), "Enter a new unit name:",
           "Unit" + (MapXmlHelper.getUnitDefinitionsMap().size() + 1));

--- a/src/main/java/tools/map/xml/creator/UnitDefinitionsRow.java
+++ b/src/main/java/tools/map/xml/creator/UnitDefinitionsRow.java
@@ -29,7 +29,7 @@ class UnitDefinitionsRow extends DynamicRow {
     Dimension dimension = textFieldUnitName.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_MEDIUM;
     textFieldUnitName.setPreferredSize(dimension);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldUnitName, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldUnitName, () -> {
       final String inputText = textFieldUnitName.getText().trim();
       if (currentRowName.equals(inputText)) {
         return;
@@ -66,7 +66,7 @@ class UnitDefinitionsRow extends DynamicRow {
     dimension = textFieldBuyCost.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_SMALL;
     textFieldBuyCost.setPreferredSize(dimension);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldBuyCost, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldBuyCost, () -> {
       final String inputText = textFieldBuyCost.getText().trim();
       try {
         final int newValue = Integer.parseInt(inputText);
@@ -82,7 +82,7 @@ class UnitDefinitionsRow extends DynamicRow {
     dimension = textFieldBuyQuantity.getPreferredSize();
     dimension.width = INPUT_FIELD_SIZE_SMALL;
     textFieldBuyQuantity.setPreferredSize(dimension);
-    MapXmlUIHelper.addNewFocusListenerForTextField(textFieldBuyQuantity, () -> {
+    MapXmlUiHelper.addNewFocusListenerForTextField(textFieldBuyQuantity, () -> {
       final String inputText = textFieldBuyQuantity.getText().trim();
       try {
         final int newValue = Integer.parseInt(inputText);

--- a/src/test/java/tools/map/xml/creator/DynamicRowTest.java
+++ b/src/test/java/tools/map/xml/creator/DynamicRowTest.java
@@ -12,7 +12,7 @@ public class DynamicRowTest {
   public void testGetGbcDefaultTemplateWith() {
     final int gridx = 2;
     final int gridy = 3;
-    final GridBagConstraints gbcTemplate = MapXmlUIHelper.getGbcDefaultTemplateWith(gridx, gridy);
+    final GridBagConstraints gbcTemplate = MapXmlUiHelper.getGbcDefaultTemplateWith(gridx, gridy);
     assertEquals(gbcTemplate.gridx, gridx);
     assertEquals(gbcTemplate.gridy, gridy);
   }

--- a/src/test/java/tools/map/xml/creator/MapXmlHelperTest.java
+++ b/src/test/java/tools/map/xml/creator/MapXmlHelperTest.java
@@ -19,7 +19,7 @@ public final class MapXmlHelperTest {
     final String notes = "lorum<br/>ipsum";
     initMapXmlData().setNotes(notes);
 
-    final Document document = MapXmlHelper.getXMLDocument();
+    final Document document = MapXmlHelper.getXmlDocument();
 
     final NodeList nodes = selectNodes(document, "//property[@name=\"notes\"]/value/child::node()");
     assertThat(nodes.getLength(), is(1));


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in tool code.

For the most part, I did **not** expand abbreviations where they caused a violation; I simply converted them using the abbreviation naming convention established in #1659.  Please advise if any should be expanded.

Examples of fixes in this PR:

* `GBC` --> `Gbc` (i.e. `GridBagConstraints`)
* `HTML` --> `Html`
* `PNG` --> `Png`
* `UI` --> `Ui`
* `XML` --> `Xml`