### PR TITLE
Move Bonus Income Percentage to Player Instead of Settings UI

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -909,7 +909,7 @@ public class GameParser {
         }
       }
     }
-    data.getPlayerList().forEach(playerId -> data.getProperties().addEditableProperty(
+    data.getPlayerList().forEach(playerId -> data.getProperties().addPlayerProperty(
         new NumberProperty(Constants.getBonusIncomePercentageFor(playerId), null, 999, 0, 0)));
   }
 

--- a/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -11,7 +11,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
@@ -42,7 +41,7 @@ public class GameProperties extends GameDataComponent {
   // added.
   private final List<String> ordering = new ArrayList<>();
 
-  private final Map<String, IEditableProperty> playerProperties = new LinkedHashMap<>();
+  private final Map<String, IEditableProperty> playerProperties = new HashMap<>();
 
   /**
    * Creates a new instance of GameProperties.
@@ -139,11 +138,6 @@ public class GameProperties extends GameDataComponent {
     playerProperties.put(property.getName(), property);
   }
 
-  /**
-   * Return list of player properties in the order they were added.
-   *
-   * @return a list of IEditableProperty
-   */
   public IEditableProperty getPlayerProperty(final String name) {
     return playerProperties.get(name);
   }

--- a/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -11,6 +11,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
@@ -40,6 +41,8 @@ public class GameProperties extends GameDataComponent {
   // This list is used to keep track of order properties were
   // added.
   private final List<String> ordering = new ArrayList<>();
+
+  private final Map<String, IEditableProperty> playerProperties = new LinkedHashMap<>();
 
   /**
    * Creates a new instance of GameProperties.
@@ -80,6 +83,9 @@ public class GameProperties extends GameDataComponent {
   public Object get(final String key) {
     if (editableProperties.containsKey(key)) {
       return editableProperties.get(key).getValue();
+    }
+    if (playerProperties.containsKey(key)) {
+      return playerProperties.get(key).getValue();
     }
     return constantProperties.get(key);
   }
@@ -127,6 +133,19 @@ public class GameProperties extends GameDataComponent {
       }
     }
     return properties;
+  }
+
+  public void addPlayerProperty(final IEditableProperty property) {
+    playerProperties.put(property.getName(), property);
+  }
+
+  /**
+   * Return list of player properties in the order they were added.
+   *
+   * @return a list of IEditableProperty
+   */
+  public IEditableProperty getPlayerProperty(final String name) {
+    return playerProperties.get(name);
   }
 
   public static void toOutputStream(final OutputStream sink, final List<IEditableProperty> editableProperties)

--- a/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.framework.startup.ui;
 
-import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -54,33 +53,31 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     final HashMap<String, Boolean> playersEnablementListing = data.getPlayerList().getPlayersEnabledListing();
     final Map<String, String> reloadSelections = PlayerID.currentPlayers(data);
     final String[] playerTypes = data.getGameLoader().getServerPlayerTypes();
-    final String[] playerNames = data.getPlayerList().getNames();
+    final List<PlayerID> players = data.getPlayerList().getPlayers();
     // if the xml was created correctly, this list will be in turn order. we want to keep it that way.
     int gridx = 0;
     int gridy = 0;
     if (!disableable.isEmpty() || playersEnablementListing.containsValue(Boolean.FALSE)) {
       final JLabel enableLabel = new JLabel("Use");
-      enableLabel.setForeground(Color.black);
       this.add(enableLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
           GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     }
     final JLabel nameLabel = new JLabel("Name");
-    nameLabel.setForeground(Color.black);
     this.add(nameLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     final JLabel typeLabel = new JLabel("Type");
-    typeLabel.setForeground(Color.black);
     this.add(typeLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     final JLabel allianceLabel = new JLabel("Alliance");
-    allianceLabel.setForeground(Color.black);
     this.add(allianceLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
-    for (final String playerName : playerNames) {
+    final JLabel bonusLabel = new JLabel("Bonus Income Percentage");
+    this.add(bonusLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
+    for (final PlayerID player : players) {
       final PlayerComboBoxSelector selector =
-          new PlayerComboBoxSelector(playerName, reloadSelections, disableable, playersEnablementListing,
-              data.getAllianceTracker().getAlliancesPlayerIsIn(data.getPlayerList().getPlayerID(playerName)),
-              playerTypes, this);
+          new PlayerComboBoxSelector(player, reloadSelections, disableable, playersEnablementListing,
+              data.getAllianceTracker().getAlliancesPlayerIsIn(player), playerTypes, this, data.getProperties());
       m_playerTypes.add(selector);
       selector.layout(++gridy, this);
     }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -1,14 +1,10 @@
 package games.strategy.engine.framework.startup.ui;
 
 import java.awt.Color;
-import java.awt.Container;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -16,8 +12,6 @@ import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
@@ -35,7 +29,7 @@ import games.strategy.engine.random.PlainRandomSource;
 public class LocalSetupPanel extends SetupPanel implements Observer {
   private static final long serialVersionUID = 2284030734590389060L;
   private final GameSelectorModel m_gameSelectorModel;
-  private final List<LocalPlayerComboBoxSelector> m_playerTypes = new ArrayList<>();
+  private final List<PlayerComboBoxSelector> m_playerTypes = new ArrayList<>();
 
   public LocalSetupPanel(final GameSelectorModel model) {
     m_gameSelectorModel = model;
@@ -83,8 +77,8 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     this.add(allianceLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
     for (final String playerName : playerNames) {
-      final LocalPlayerComboBoxSelector selector =
-          new LocalPlayerComboBoxSelector(playerName, reloadSelections, disableable, playersEnablementListing,
+      final PlayerComboBoxSelector selector =
+          new PlayerComboBoxSelector(playerName, reloadSelections, disableable, playersEnablementListing,
               data.getAllianceTracker().getAlliancesPlayerIsIn(data.getPlayerList().getPlayerID(playerName)),
               playerTypes, this);
       m_playerTypes.add(selector);
@@ -113,7 +107,7 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
       return false;
     }
     // make sure at least 1 player is enabled
-    for (final LocalPlayerComboBoxSelector player : m_playerTypes) {
+    for (final PlayerComboBoxSelector player : m_playerTypes) {
       if (player.isPlayerEnabled()) {
         return true;
       }
@@ -151,7 +145,7 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     final IRandomSource randomSource = new PlainRandomSource();
     final Map<String, String> playerTypes = new HashMap<>();
     final Map<String, Boolean> playersEnabled = new HashMap<>();
-    for (final LocalPlayerComboBoxSelector player : m_playerTypes) {
+    for (final PlayerComboBoxSelector player : m_playerTypes) {
       playerTypes.put(player.getPlayerName(), player.getPlayerType());
       playersEnabled.put(player.getPlayerName(), player.isPlayerEnabled());
     }
@@ -163,100 +157,4 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     final LocalLauncher launcher = new LocalLauncher(m_gameSelectorModel, randomSource, pl);
     return launcher;
   }
-}
-
-
-class LocalPlayerComboBoxSelector {
-  private final JCheckBox m_enabledCheckBox;
-  private final String m_playerName;
-  private final JComboBox<String> m_playerTypes;
-  private boolean m_enabled = true;
-  private final JLabel m_name;
-  private final JLabel m_alliances;
-  private final Collection<String> m_disableable;
-  private final String[] m_types;
-  private final SetupPanel m_parent;
-
-  LocalPlayerComboBoxSelector(final String playerName, final Map<String, String> reloadSelections,
-      final Collection<String> disableable, final HashMap<String, Boolean> playersEnablementListing,
-      final Collection<String> playerAlliances, final String[] types, final SetupPanel parent) {
-    m_playerName = playerName;
-    m_name = new JLabel(m_playerName + ":");
-    m_enabledCheckBox = new JCheckBox();
-    final ActionListener m_disablePlayerActionListener = new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent e) {
-        if (m_enabledCheckBox.isSelected()) {
-          m_enabled = true;
-          // the 1st in the list should be human
-          m_playerTypes.setSelectedItem(m_types[0]);
-        } else {
-          m_enabled = false;
-          // the 2nd in the list should be Weak AI
-          m_playerTypes.setSelectedItem(m_types[Math.max(0, Math.min(m_types.length - 1, 1))]);
-        }
-        setWidgetActivation();
-      }
-    };
-    m_enabledCheckBox.addActionListener(m_disablePlayerActionListener);
-    m_enabledCheckBox.setSelected(playersEnablementListing.get(playerName));
-    m_enabledCheckBox.setEnabled(disableable.contains(playerName));
-    m_disableable = disableable;
-    m_parent = parent;
-    m_types = types;
-    m_playerTypes = new JComboBox<>(types);
-    String previousSelection = reloadSelections.get(playerName);
-    if (previousSelection.equalsIgnoreCase("Client")) {
-      previousSelection = types[0];
-    }
-    if (!(previousSelection.equals("no_one")) && Arrays.asList(types).contains(previousSelection)) {
-      m_playerTypes.setSelectedItem(previousSelection);
-    } else if (m_playerName.startsWith("Neutral") || playerName.startsWith("AI")) {
-      // the 4th in the list should be Pro AI (Hard AI)
-      m_playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 3))]);
-    }
-    // we do not set the default for the combobox because the default is the top item, which in this case is human
-    String m_playerAlliances;
-    if (playerAlliances.contains(playerName)) {
-      m_playerAlliances = "";
-    } else {
-      m_playerAlliances = playerAlliances.toString();
-    }
-    m_alliances = new JLabel(m_playerAlliances);
-    setWidgetActivation();
-  }
-
-  public void layout(final int row, final Container container) {
-    int gridx = 0;
-    if (!m_disableable.isEmpty()) {
-      container.add(m_enabledCheckBox, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-          GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    }
-    container.add(m_name, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    container.add(m_playerTypes, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    container.add(m_alliances, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
-  }
-
-  public String getPlayerName() {
-    return m_playerName;
-  }
-
-  public String getPlayerType() {
-    return (String) m_playerTypes.getSelectedItem();
-  }
-
-  public boolean isPlayerEnabled() {
-    return m_enabledCheckBox.isSelected();
-  }
-
-  private void setWidgetActivation() {
-    m_name.setEnabled(m_enabled);
-    m_alliances.setEnabled(m_enabled);
-    m_enabledCheckBox.setEnabled(m_disableable.contains(m_playerName));
-    m_parent.notifyObservers();
-  }
-
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -28,7 +28,7 @@ import games.strategy.engine.random.PlainRandomSource;
 public class LocalSetupPanel extends SetupPanel implements Observer {
   private static final long serialVersionUID = 2284030734590389060L;
   private final GameSelectorModel m_gameSelectorModel;
-  private final List<PlayerComboBoxSelector> m_playerTypes = new ArrayList<>();
+  private final List<PlayerSelectorRow> m_playerTypes = new ArrayList<>();
 
   public LocalSetupPanel(final GameSelectorModel model) {
     m_gameSelectorModel = model;
@@ -75,8 +75,8 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     this.add(bonusLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     for (final PlayerID player : players) {
-      final PlayerComboBoxSelector selector =
-          new PlayerComboBoxSelector(player, reloadSelections, disableable, playersEnablementListing,
+      final PlayerSelectorRow selector =
+          new PlayerSelectorRow(player, reloadSelections, disableable, playersEnablementListing,
               data.getAllianceTracker().getAlliancesPlayerIsIn(player), playerTypes, this, data.getProperties());
       m_playerTypes.add(selector);
       selector.layout(++gridy, this);
@@ -104,7 +104,7 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
       return false;
     }
     // make sure at least 1 player is enabled
-    for (final PlayerComboBoxSelector player : m_playerTypes) {
+    for (final PlayerSelectorRow player : m_playerTypes) {
       if (player.isPlayerEnabled()) {
         return true;
       }
@@ -142,7 +142,7 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     final IRandomSource randomSource = new PlainRandomSource();
     final Map<String, String> playerTypes = new HashMap<>();
     final Map<String, Boolean> playersEnabled = new HashMap<>();
-    for (final PlayerComboBoxSelector player : m_playerTypes) {
+    for (final PlayerSelectorRow player : m_playerTypes) {
       playerTypes.put(player.getPlayerName(), player.getPlayerType());
       playersEnabled.put(player.getPlayerName(), player.isPlayerEnabled());
     }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.framework.startup.ui;
 
-import java.awt.Color;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -438,33 +437,31 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     final HashMap<String, Boolean> playersEnablementListing = data.getPlayerList().getPlayersEnabledListing();
     final Map<String, String> reloadSelections = PlayerID.currentPlayers(data);
     final String[] playerTypes = data.getGameLoader().getServerPlayerTypes();
-    final String[] playerNames = data.getPlayerList().getNames();
+    final List<PlayerID> players = data.getPlayerList().getPlayers();
     // if the xml was created correctly, this list will be in turn order. we want to keep it that way.
     int gridx = 0;
     int gridy = 0;
     if (!disableable.isEmpty() || playersEnablementListing.containsValue(Boolean.FALSE)) {
       final JLabel enableLabel = new JLabel("Use");
-      enableLabel.setForeground(Color.black);
       m_localPlayerPanel.add(enableLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
           GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     }
     final JLabel nameLabel = new JLabel("Name");
-    nameLabel.setForeground(Color.black);
     m_localPlayerPanel.add(nameLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     final JLabel typeLabel = new JLabel("Type");
-    typeLabel.setForeground(Color.black);
     m_localPlayerPanel.add(typeLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     final JLabel allianceLabel = new JLabel("Alliance");
-    allianceLabel.setForeground(Color.black);
     m_localPlayerPanel.add(allianceLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
-    for (final String playerName : playerNames) {
+    final JLabel bonusLabel = new JLabel("Bonus Income Percentage");
+    m_localPlayerPanel.add(bonusLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
+    for (final PlayerID player : players) {
       final PlayerComboBoxSelector selector =
-          new PlayerComboBoxSelector(playerName, reloadSelections, disableable, playersEnablementListing,
-              data.getAllianceTracker().getAlliancesPlayerIsIn(data.getPlayerList().getPlayerID(playerName)),
-              playerTypes, parent);
+          new PlayerComboBoxSelector(player, reloadSelections, disableable, playersEnablementListing,
+              data.getAllianceTracker().getAlliancesPlayerIsIn(player), playerTypes, parent, data.getProperties());
       m_playerTypes.add(selector);
       selector.layout(++gridy, m_localPlayerPanel);
     }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -70,7 +70,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   private final SelectAndViewEditor m_forumPosterEditor;
   private final SelectAndViewEditor m_emailSenderEditor;
   private final SelectAndViewEditor m_webPosterEditor;
-  private final List<PlayerComboBoxSelector> m_playerTypes = new ArrayList<>();
+  private final List<PlayerSelectorRow> m_playerTypes = new ArrayList<>();
   private final JPanel m_localPlayerPanel = new JPanel();
   private final JButton m_localPlayerSelection = new JButton("Select Local Players and AI's");
 
@@ -308,7 +308,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
       return false;
     }
     // make sure at least 1 player is enabled
-    for (final PlayerComboBoxSelector player : m_playerTypes) {
+    for (final PlayerSelectorRow player : m_playerTypes) {
       if (player.isPlayerEnabled()) {
         return true;
       }
@@ -401,7 +401,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     final PBEMDiceRoller randomSource = new PBEMDiceRoller((IRemoteDiceServer) m_diceServerEditor.getBean(), gameUUID);
     final Map<String, String> playerTypes = new HashMap<>();
     final Map<String, Boolean> playersEnabled = new HashMap<>();
-    for (final PlayerComboBoxSelector player : m_playerTypes) {
+    for (final PlayerSelectorRow player : m_playerTypes) {
       playerTypes.put(player.getPlayerName(), player.getPlayerType());
       playersEnabled.put(player.getPlayerName(), player.isPlayerEnabled());
     }
@@ -459,8 +459,8 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     m_localPlayerPanel.add(bonusLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     for (final PlayerID player : players) {
-      final PlayerComboBoxSelector selector =
-          new PlayerComboBoxSelector(player, reloadSelections, disableable, playersEnablementListing,
+      final PlayerSelectorRow selector =
+          new PlayerSelectorRow(player, reloadSelections, disableable, playersEnablementListing,
               data.getAllianceTracker().getAlliancesPlayerIsIn(player), playerTypes, parent, data.getProperties());
       m_playerTypes.add(selector);
       selector.layout(++gridy, m_localPlayerPanel);

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -573,16 +573,14 @@ class PBEMLocalPlayerComboBoxSelector {
     m_parent.notifyObservers();
   }
 
-  /**
-   * A cache for serialized beans that should be stored locally.
-   * This is used to store settings which are not game related, and should therefore not go into the options cache
-   * This is often used by editors to remember previous values
-   */
-
 }
 
 
-/** A bean cache used by PBEMSetupPanel. */
+/**
+ * A cache for serialized beans that should be stored locally.
+ * This is used to store settings which are not game related, and should therefore not go into the options cache
+ * This is often used by editors to remember previous values
+ */
 enum LocalBeanCache {
   INSTANCE;
   private final File m_file;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -1,12 +1,9 @@
 package games.strategy.engine.framework.startup.ui;
 
 import java.awt.Color;
-import java.awt.Container;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
@@ -17,7 +14,6 @@ import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -26,8 +22,6 @@ import java.util.Observable;
 import java.util.Observer;
 
 import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -77,7 +71,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
   private final SelectAndViewEditor m_forumPosterEditor;
   private final SelectAndViewEditor m_emailSenderEditor;
   private final SelectAndViewEditor m_webPosterEditor;
-  private final List<PBEMLocalPlayerComboBoxSelector> m_playerTypes = new ArrayList<>();
+  private final List<PlayerComboBoxSelector> m_playerTypes = new ArrayList<>();
   private final JPanel m_localPlayerPanel = new JPanel();
   private final JButton m_localPlayerSelection = new JButton("Select Local Players and AI's");
 
@@ -315,7 +309,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
       return false;
     }
     // make sure at least 1 player is enabled
-    for (final PBEMLocalPlayerComboBoxSelector player : m_playerTypes) {
+    for (final PlayerComboBoxSelector player : m_playerTypes) {
       if (player.isPlayerEnabled()) {
         return true;
       }
@@ -408,7 +402,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     final PBEMDiceRoller randomSource = new PBEMDiceRoller((IRemoteDiceServer) m_diceServerEditor.getBean(), gameUUID);
     final Map<String, String> playerTypes = new HashMap<>();
     final Map<String, Boolean> playersEnabled = new HashMap<>();
-    for (final PBEMLocalPlayerComboBoxSelector player : m_playerTypes) {
+    for (final PlayerComboBoxSelector player : m_playerTypes) {
       playerTypes.put(player.getPlayerName(), player.getPlayerType());
       playersEnabled.put(player.getPlayerName(), player.isPlayerEnabled());
     }
@@ -467,8 +461,8 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     m_localPlayerPanel.add(allianceLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
     for (final String playerName : playerNames) {
-      final PBEMLocalPlayerComboBoxSelector selector =
-          new PBEMLocalPlayerComboBoxSelector(playerName, reloadSelections, disableable, playersEnablementListing,
+      final PlayerComboBoxSelector selector =
+          new PlayerComboBoxSelector(playerName, reloadSelections, disableable, playersEnablementListing,
               data.getAllianceTracker().getAlliancesPlayerIsIn(data.getPlayerList().getPlayerID(playerName)),
               playerTypes, parent);
       m_playerTypes.add(selector);
@@ -477,102 +471,6 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     m_localPlayerPanel.validate();
     m_localPlayerPanel.invalidate();
   }
-}
-
-
-class PBEMLocalPlayerComboBoxSelector {
-  private final JCheckBox m_enabledCheckBox;
-  private final String m_playerName;
-  private final JComboBox<String> m_playerTypes;
-  private boolean m_enabled = true;
-  private final JLabel m_name;
-  private final JLabel m_alliances;
-  private final Collection<String> m_disableable;
-  private final String[] m_types;
-  private final SetupPanel m_parent;
-
-  PBEMLocalPlayerComboBoxSelector(final String playerName, final Map<String, String> reloadSelections,
-      final Collection<String> disableable, final HashMap<String, Boolean> playersEnablementListing,
-      final Collection<String> playerAlliances, final String[] types, final SetupPanel parent) {
-    m_playerName = playerName;
-    m_name = new JLabel(m_playerName + ":");
-    m_enabledCheckBox = new JCheckBox();
-    final ActionListener m_disablePlayerActionListener = new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent e) {
-        if (m_enabledCheckBox.isSelected()) {
-          m_enabled = true;
-          // the 1st in the list should be human
-          m_playerTypes.setSelectedItem(m_types[0]);
-        } else {
-          m_enabled = false;
-          // the 2nd in the list should be Weak AI
-          m_playerTypes.setSelectedItem(m_types[Math.max(0, Math.min(m_types.length - 1, 1))]);
-        }
-        setWidgetActivation();
-      }
-    };
-    m_enabledCheckBox.addActionListener(m_disablePlayerActionListener);
-    m_enabledCheckBox.setSelected(playersEnablementListing.get(playerName));
-    m_enabledCheckBox.setEnabled(disableable.contains(playerName));
-    m_disableable = disableable;
-    m_parent = parent;
-    m_types = types;
-    m_playerTypes = new JComboBox<>(types);
-    String previousSelection = reloadSelections.get(playerName);
-    if (previousSelection.equalsIgnoreCase("Client")) {
-      previousSelection = types[0];
-    }
-    if (!(previousSelection.equals("no_one")) && Arrays.asList(types).contains(previousSelection)) {
-      m_playerTypes.setSelectedItem(previousSelection);
-    } else if (m_playerName.startsWith("Neutral") || playerName.startsWith("AI")) {
-      // the 4th in the list should be Pro AI (Hard AI)
-      m_playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 3))]);
-    }
-    // we do not set the default for the combobox because the default is the top item, which in this case is human
-    String m_playerAlliances;
-    if (playerAlliances.contains(playerName)) {
-      m_playerAlliances = "";
-    } else {
-      m_playerAlliances = playerAlliances.toString();
-    }
-    m_alliances = new JLabel(m_playerAlliances);
-    setWidgetActivation();
-  }
-
-  public void layout(final int row, final Container container) {
-    int gridx = 0;
-    if (!m_disableable.isEmpty()) {
-      container.add(m_enabledCheckBox, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-          GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    }
-    container.add(m_name, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    container.add(m_playerTypes, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    container.add(m_alliances, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
-  }
-
-  public String getPlayerName() {
-    return m_playerName;
-  }
-
-  public String getPlayerType() {
-    return (String) m_playerTypes.getSelectedItem();
-  }
-
-  public boolean isPlayerEnabled() {
-    return m_enabledCheckBox.isSelected();
-  }
-
-  private void setWidgetActivation() {
-    m_name.setEnabled(m_enabled);
-    m_alliances.setEnabled(m_enabled);
-    m_enabledCheckBox.setEnabled(m_disableable.contains(m_playerName));
-    m_parent.notifyObservers();
-  }
-
 }
 
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerComboBoxSelector.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerComboBoxSelector.java
@@ -16,96 +16,98 @@ import javax.swing.JLabel;
 
 class PlayerComboBoxSelector {
 
-  private final JCheckBox m_enabledCheckBox;
-  private final String m_playerName;
-  private final JComboBox<String> m_playerTypes;
-  private boolean m_enabled = true;
-  private final JLabel m_name;
-  private final JLabel m_alliances;
-  private final Collection<String> m_disableable;
-  private final String[] m_types;
-  private final SetupPanel m_parent;
+  private final JCheckBox enabledCheckBox;
+  private final String playerName;
+  private final JComboBox<String> playerTypes;
+  private boolean enabled = true;
+  private final JLabel name;
+  private final JLabel alliances;
+  private final Collection<String> disableable;
+  private final SetupPanel parent;
 
   PlayerComboBoxSelector(final String playerName, final Map<String, String> reloadSelections,
       final Collection<String> disableable, final HashMap<String, Boolean> playersEnablementListing,
       final Collection<String> playerAlliances, final String[] types, final SetupPanel parent) {
-    m_playerName = playerName;
-    m_name = new JLabel(m_playerName + ":");
-    m_enabledCheckBox = new JCheckBox();
+    this.playerName = playerName;
+    this.disableable = disableable;
+    this.parent = parent;
+    name = new JLabel(playerName + ":");
+
+    enabledCheckBox = new JCheckBox();
     final ActionListener m_disablePlayerActionListener = new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent e) {
-        if (m_enabledCheckBox.isSelected()) {
-          m_enabled = true;
+        if (enabledCheckBox.isSelected()) {
+          enabled = true;
           // the 1st in the list should be human
-          m_playerTypes.setSelectedItem(m_types[0]);
+          playerTypes.setSelectedItem(types[0]);
         } else {
-          m_enabled = false;
+          enabled = false;
           // the 2nd in the list should be Weak AI
-          m_playerTypes.setSelectedItem(m_types[Math.max(0, Math.min(m_types.length - 1, 1))]);
+          playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 1))]);
         }
         setWidgetActivation();
       }
     };
-    m_enabledCheckBox.addActionListener(m_disablePlayerActionListener);
-    m_enabledCheckBox.setSelected(playersEnablementListing.get(playerName));
-    m_enabledCheckBox.setEnabled(disableable.contains(playerName));
-    m_disableable = disableable;
-    m_parent = parent;
-    m_types = types;
-    m_playerTypes = new JComboBox<>(types);
+    enabledCheckBox.addActionListener(m_disablePlayerActionListener);
+    enabledCheckBox.setSelected(playersEnablementListing.get(playerName));
+    enabledCheckBox.setEnabled(disableable.contains(playerName));
+
+    playerTypes = new JComboBox<>(types);
     String previousSelection = reloadSelections.get(playerName);
     if (previousSelection.equalsIgnoreCase("Client")) {
       previousSelection = types[0];
     }
     if (!(previousSelection.equals("no_one")) && Arrays.asList(types).contains(previousSelection)) {
-      m_playerTypes.setSelectedItem(previousSelection);
-    } else if (m_playerName.startsWith("Neutral") || playerName.startsWith("AI")) {
+      playerTypes.setSelectedItem(previousSelection);
+    } else if (playerName.startsWith("Neutral") || playerName.startsWith("AI")) {
       // the 4th in the list should be Pro AI (Hard AI)
-      m_playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 3))]);
+      playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 3))]);
     }
-    // we do not set the default for the combobox because the default is the top item, which in this case is human
-    String m_playerAlliances;
+
+    // we do not set the default for the combo box because the default is the top item, which in this case is human
+    String alliancesLabelText;
     if (playerAlliances.contains(playerName)) {
-      m_playerAlliances = "";
+      alliancesLabelText = "";
     } else {
-      m_playerAlliances = playerAlliances.toString();
+      alliancesLabelText = playerAlliances.toString();
     }
-    m_alliances = new JLabel(m_playerAlliances);
+    alliances = new JLabel(alliancesLabelText);
+
     setWidgetActivation();
   }
 
-  public void layout(final int row, final Container container) {
+  void layout(final int row, final Container container) {
     int gridx = 0;
-    if (!m_disableable.isEmpty()) {
-      container.add(m_enabledCheckBox, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+    if (!disableable.isEmpty()) {
+      container.add(enabledCheckBox, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
           GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     }
-    container.add(m_name, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+    container.add(name, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    container.add(m_playerTypes, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+    container.add(playerTypes, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    container.add(m_alliances, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+    container.add(alliances, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
   }
 
-  public String getPlayerName() {
-    return m_playerName;
+  String getPlayerName() {
+    return playerName;
   }
 
-  public String getPlayerType() {
-    return (String) m_playerTypes.getSelectedItem();
+  String getPlayerType() {
+    return (String) playerTypes.getSelectedItem();
   }
 
-  public boolean isPlayerEnabled() {
-    return m_enabledCheckBox.isSelected();
+  boolean isPlayerEnabled() {
+    return enabledCheckBox.isSelected();
   }
 
   private void setWidgetActivation() {
-    m_name.setEnabled(m_enabled);
-    m_alliances.setEnabled(m_enabled);
-    m_enabledCheckBox.setEnabled(m_disableable.contains(m_playerName));
-    m_parent.notifyObservers();
+    name.setEnabled(enabled);
+    alliances.setEnabled(enabled);
+    enabledCheckBox.setEnabled(disableable.contains(playerName));
+    parent.notifyObservers();
   }
 
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerComboBoxSelector.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerComboBoxSelector.java
@@ -1,0 +1,111 @@
+package games.strategy.engine.framework.startup.ui;
+
+import java.awt.Container;
+import java.awt.GridBagConstraints;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+
+class PlayerComboBoxSelector {
+
+  private final JCheckBox m_enabledCheckBox;
+  private final String m_playerName;
+  private final JComboBox<String> m_playerTypes;
+  private boolean m_enabled = true;
+  private final JLabel m_name;
+  private final JLabel m_alliances;
+  private final Collection<String> m_disableable;
+  private final String[] m_types;
+  private final SetupPanel m_parent;
+
+  PlayerComboBoxSelector(final String playerName, final Map<String, String> reloadSelections,
+      final Collection<String> disableable, final HashMap<String, Boolean> playersEnablementListing,
+      final Collection<String> playerAlliances, final String[] types, final SetupPanel parent) {
+    m_playerName = playerName;
+    m_name = new JLabel(m_playerName + ":");
+    m_enabledCheckBox = new JCheckBox();
+    final ActionListener m_disablePlayerActionListener = new ActionListener() {
+      @Override
+      public void actionPerformed(final ActionEvent e) {
+        if (m_enabledCheckBox.isSelected()) {
+          m_enabled = true;
+          // the 1st in the list should be human
+          m_playerTypes.setSelectedItem(m_types[0]);
+        } else {
+          m_enabled = false;
+          // the 2nd in the list should be Weak AI
+          m_playerTypes.setSelectedItem(m_types[Math.max(0, Math.min(m_types.length - 1, 1))]);
+        }
+        setWidgetActivation();
+      }
+    };
+    m_enabledCheckBox.addActionListener(m_disablePlayerActionListener);
+    m_enabledCheckBox.setSelected(playersEnablementListing.get(playerName));
+    m_enabledCheckBox.setEnabled(disableable.contains(playerName));
+    m_disableable = disableable;
+    m_parent = parent;
+    m_types = types;
+    m_playerTypes = new JComboBox<>(types);
+    String previousSelection = reloadSelections.get(playerName);
+    if (previousSelection.equalsIgnoreCase("Client")) {
+      previousSelection = types[0];
+    }
+    if (!(previousSelection.equals("no_one")) && Arrays.asList(types).contains(previousSelection)) {
+      m_playerTypes.setSelectedItem(previousSelection);
+    } else if (m_playerName.startsWith("Neutral") || playerName.startsWith("AI")) {
+      // the 4th in the list should be Pro AI (Hard AI)
+      m_playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 3))]);
+    }
+    // we do not set the default for the combobox because the default is the top item, which in this case is human
+    String m_playerAlliances;
+    if (playerAlliances.contains(playerName)) {
+      m_playerAlliances = "";
+    } else {
+      m_playerAlliances = playerAlliances.toString();
+    }
+    m_alliances = new JLabel(m_playerAlliances);
+    setWidgetActivation();
+  }
+
+  public void layout(final int row, final Container container) {
+    int gridx = 0;
+    if (!m_disableable.isEmpty()) {
+      container.add(m_enabledCheckBox, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+          GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
+    }
+    container.add(m_name, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
+    container.add(m_playerTypes, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
+    container.add(m_alliances, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
+  }
+
+  public String getPlayerName() {
+    return m_playerName;
+  }
+
+  public String getPlayerType() {
+    return (String) m_playerTypes.getSelectedItem();
+  }
+
+  public boolean isPlayerEnabled() {
+    return m_enabledCheckBox.isSelected();
+  }
+
+  private void setWidgetActivation() {
+    m_name.setEnabled(m_enabled);
+    m_alliances.setEnabled(m_enabled);
+    m_enabledCheckBox.setEnabled(m_disableable.contains(m_playerName));
+    m_parent.notifyObservers();
+  }
+
+}

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerComboBoxSelector.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerComboBoxSelector.java
@@ -12,25 +12,36 @@ import java.util.Map;
 
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
+
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.properties.GameProperties;
+import games.strategy.triplea.Constants;
 
 class PlayerComboBoxSelector {
 
   private final JCheckBox enabledCheckBox;
+  private final PlayerID player;
   private final String playerName;
   private final JComboBox<String> playerTypes;
+  private final JComponent bonusIncomePercentage;
   private boolean enabled = true;
   private final JLabel name;
   private final JLabel alliances;
   private final Collection<String> disableable;
   private final SetupPanel parent;
+  private final GameProperties gameProperties;
 
-  PlayerComboBoxSelector(final String playerName, final Map<String, String> reloadSelections,
+  PlayerComboBoxSelector(final PlayerID player, final Map<String, String> reloadSelections,
       final Collection<String> disableable, final HashMap<String, Boolean> playersEnablementListing,
-      final Collection<String> playerAlliances, final String[] types, final SetupPanel parent) {
-    this.playerName = playerName;
+      final Collection<String> playerAlliances, final String[] types, final SetupPanel parent,
+      final GameProperties gameProperties) {
+    this.player = player;
     this.disableable = disableable;
     this.parent = parent;
+    this.gameProperties = gameProperties;
+    playerName = player.getName();
     name = new JLabel(playerName + ":");
 
     enabledCheckBox = new JCheckBox();
@@ -74,6 +85,9 @@ class PlayerComboBoxSelector {
     }
     alliances = new JLabel(alliancesLabelText);
 
+    bonusIncomePercentage =
+        gameProperties.getPlayerProperty(Constants.getBonusIncomePercentageFor(player)).getEditorComponent();
+
     setWidgetActivation();
   }
 
@@ -89,6 +103,8 @@ class PlayerComboBoxSelector {
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     container.add(alliances, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
+    container.add(bonusIncomePercentage, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 50, 5, 0), 0, 0));
   }
 
   String getPlayerName() {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -19,10 +19,9 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
 
-class PlayerComboBoxSelector {
+class PlayerSelectorRow {
 
   private final JCheckBox enabledCheckBox;
-  private final PlayerID player;
   private final String playerName;
   private final JComboBox<String> playerTypes;
   private final JComponent bonusIncomePercentage;
@@ -31,16 +30,13 @@ class PlayerComboBoxSelector {
   private final JLabel alliances;
   private final Collection<String> disableable;
   private final SetupPanel parent;
-  private final GameProperties gameProperties;
 
-  PlayerComboBoxSelector(final PlayerID player, final Map<String, String> reloadSelections,
+  PlayerSelectorRow(final PlayerID player, final Map<String, String> reloadSelections,
       final Collection<String> disableable, final HashMap<String, Boolean> playersEnablementListing,
       final Collection<String> playerAlliances, final String[] types, final SetupPanel parent,
       final GameProperties gameProperties) {
-    this.player = player;
     this.disableable = disableable;
     this.parent = parent;
-    this.gameProperties = gameProperties;
     playerName = player.getName();
     name = new JLabel(playerName + ":");
 


### PR DESCRIPTION
Third installment of AI bonus changes. Significant refactoring of the player UI (local and PBEM/PBF) to consolidate some of the logic. Potentially easier to review commit by commit.

Functional Changes
- Bonus income percentage now display on player UI rather than settings UI
- Local and PBEM/PBF player UI updated to display labels and better positioning of fields