### PR TITLE
Checkstyle: Fix abbreviation violations in local variables (part 1)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-checkstyleMainMaxWarnings=4458
+checkstyleMainMaxWarnings=4400
 checkstyleTestMaxWarnings=53

--- a/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -265,7 +265,7 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
       extra = extra + notes;
     }
     String status = chat.getStatusManager().getStatus(node);
-    final StringBuilder statusSB = new StringBuilder("");
+    final StringBuilder sb = new StringBuilder("");
     if (status != null && status.length() > 0) {
       if (status.length() > 25) {
         status = status.substring(0, 25);
@@ -275,9 +275,9 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
         if (c >= '\u0300' && c <= '\u036F') { // skip combining characters
           continue;
         }
-        statusSB.append(c);
+        sb.append(c);
       }
-      extra = extra + " (" + statusSB.toString() + ")";
+      extra = extra + " (" + sb.toString() + ")";
     }
     if (extra.length() == 0) {
       return node.getName();

--- a/src/main/java/games/strategy/engine/data/PlayerManager.java
+++ b/src/main/java/games/strategy/engine/data/PlayerManager.java
@@ -103,9 +103,9 @@ public class PlayerManager {
     for (final String player : m_playerMapping.keySet()) {
       if (!m_playerMapping.get(player).equals(localNode)) {
         any = player;
-        final PlayerID remotePlayerID = data.getPlayerList().getPlayerID(player);
-        if (!data.getRelationshipTracker().isAllied(local, remotePlayerID)) {
-          return remotePlayerID;
+        final PlayerID remotePlayerId = data.getPlayerList().getPlayerID(player);
+        if (!data.getRelationshipTracker().isAllied(local, remotePlayerId)) {
+          return remotePlayerId;
         }
       }
     }

--- a/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
+++ b/src/main/java/games/strategy/engine/delegate/DelegateExecutionManager.java
@@ -53,11 +53,11 @@ public class DelegateExecutionManager {
    * </p>
    *
    * <p>
-   * If timeToWaitMS is > 0, we will give up trying to block delegate execution after timeTiWaitMS has elapsed.
+   * If timeToWaitMs is > 0, we will give up trying to block delegate execution after timeToWaitMs has elapsed.
    * </p>
    */
-  public boolean blockDelegateExecution(final int timeToWaitMS) throws InterruptedException {
-    final boolean rVal = m_readWriteLock.writeLock().tryLock(timeToWaitMS, TimeUnit.MILLISECONDS);
+  public boolean blockDelegateExecution(final int timeToWaitMs) throws InterruptedException {
+    final boolean rVal = m_readWriteLock.writeLock().tryLock(timeToWaitMs, TimeUnit.MILLISECONDS);
     if (!rVal) {
       if (sm_logger.isLoggable(Level.FINE)) {
         sm_logger.fine("Could not block delegate execution. Read Lock count: " + m_readWriteLock.getReadLockCount()

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -686,14 +686,14 @@ public class GameRunner {
   }
 
   // newClassPath can be null
-  private static void joinGame(final int port, final String hostAddressIP, final String newClassPath,
+  private static void joinGame(final int port, final String hostAddressIp, final String newClassPath,
       final Messengers messengers) {
     final List<String> commands = new ArrayList<>();
     ProcessRunnerUtil.populateBasicJavaArgs(commands, newClassPath);
     final String prefix = "-D";
     commands.add(prefix + TRIPLEA_CLIENT_PROPERTY + "=true");
     commands.add(prefix + TRIPLEA_PORT_PROPERTY + "=" + port);
-    commands.add(prefix + TRIPLEA_HOST_PROPERTY + "=" + hostAddressIP);
+    commands.add(prefix + TRIPLEA_HOST_PROPERTY + "=" + hostAddressIp);
     commands.add(prefix + TRIPLEA_NAME_PROPERTY + "=" + messengers.getMessenger().getLocalNode().getName());
     commands.add(GameRunner.class.getName());
     ProcessRunnerUtil.exec(commands);

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -502,24 +502,24 @@ public class ServerGame extends AbstractGame {
   }
 
   private void waitForPlayerToFinishStep() {
-    final PlayerID playerID = getCurrentStep().getPlayerID();
+    final PlayerID playerId = getCurrentStep().getPlayerID();
     // no player specified for the given step
-    if (playerID == null) {
+    if (playerId == null) {
       return;
     }
     if (!getCurrentStep().getDelegate().delegateCurrentlyRequiresUserInput()) {
       return;
     }
-    final IGamePlayer player = m_gamePlayers.get(playerID);
+    final IGamePlayer player = m_gamePlayers.get(playerId);
     if (player != null) {
       // a local player
       player.start(getCurrentStep().getName());
     } else {
       // a remote player
-      final INode destination = m_playerManager.getNode(playerID.getName());
+      final INode destination = m_playerManager.getNode(playerId.getName());
       final IGameStepAdvancer advancer =
           (IGameStepAdvancer) m_remoteMessenger.getRemote(ClientGame.getRemoteStepAdvancerName(destination));
-      advancer.startPlayerStep(getCurrentStep().getName(), playerID);
+      advancer.startPlayerStep(getCurrentStep().getName(), playerId);
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/map/download/FeedbackDialog.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FeedbackDialog.java
@@ -23,8 +23,8 @@ public final class FeedbackDialog {
     final Optional<DownloadFileDescription> mapSelection = findFirstSelectedMap(selectedValuesList, maps);
 
     if (mapSelection.isPresent()) {
-      final String feedbackURL = mapSelection.get().getFeedbackUrl();
-      SwingComponents.newOpenUrlConfirmationDialog(feedbackURL);
+      final String feedbackUrl = mapSelection.get().getFeedbackUrl();
+      SwingComponents.newOpenUrlConfirmationDialog(feedbackUrl);
     } else {
       SwingComponents.newMessageDialog("To open the map feedback from in your web browser, please first select a map "
           + "title, and then click the feedback button again.");

--- a/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -111,10 +111,10 @@ class FileSystemAccessStrategy {
 
   private static String formatMapList(final List<DownloadFileDescription> mapList,
       final Function<DownloadFileDescription, String> outputFunction) {
-    final int MAX_MAPS_TO_LIST = 6;
+    final int maxMapsToList = 6;
     final StringBuilder sb = new StringBuilder("<ul>");
     for (int i = 0; i < mapList.size(); i++) {
-      if (i > MAX_MAPS_TO_LIST) {
+      if (i > maxMapsToList) {
         sb.append("<li>...</li>");
         break;
       } else {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -282,19 +282,19 @@ public class GameSelectorModel extends Observable {
     }
     NewGameChooserEntry selectedGame = null;
     // just in case flush doesn't work, we still force it again here
-    final String userPreferredDefaultGameURI =
+    final String userPreferredDefaultGameUri =
         (forceFactoryDefault ? DEFAULT_GAME_URI : prefs.get(DEFAULT_GAME_URI_PREF, DEFAULT_GAME_URI));
     // we don't want to load a game file by default that is not within the map folders we can load. (ie: if a previous
     // version of triplea
     // was using running a game within its root folder, we shouldn't open it)
     final String user = ClientFileSystemHelper.getUserRootFolder().toURI().toString();
-    if (!forceFactoryDefault && userPreferredDefaultGameURI != null && userPreferredDefaultGameURI.length() > 0
-        && userPreferredDefaultGameURI.contains(user)) {
+    if (!forceFactoryDefault && userPreferredDefaultGameUri != null && userPreferredDefaultGameUri.length() > 0
+        && userPreferredDefaultGameUri.contains(user)) {
       // if the user has a preferred URI, then we load it, and don't bother parsing or doing anything with the whole
       // game model list
       try {
-        final URI defaultURI = new URI(userPreferredDefaultGameURI);
-        selectedGame = new NewGameChooserEntry(defaultURI);
+        final URI defaultUri = new URI(userPreferredDefaultGameUri);
+        selectedGame = new NewGameChooserEntry(defaultUri);
       } catch (final Exception e) {
         selectedGame = selectByName(ui, forceFactoryDefault);
         if (selectedGame == null) {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -255,8 +255,8 @@ class EnginePreferences extends JDialog {
       final Properties systemIni = GameRunner.getSystemIni();
       final int currentSetting = Memory.getMaxMemoryFromSystemIniFileInMB(systemIni);
       final boolean useDefault = Memory.useDefaultMaxMemory(systemIni) || currentSetting <= 0;
-      final int currentMaxMemoryInMB = (int) (Memory.getMaxMemoryInBytes() / (1024 * 1024));
-      final IntTextField newMaxMemory = new IntTextField(0, (1024 * 3), currentMaxMemoryInMB, 5);
+      final int currentMaxMemoryInMb = (int) (Memory.getMaxMemoryInBytes() / (1024 * 1024));
+      final IntTextField newMaxMemory = new IntTextField(0, (1024 * 3), currentMaxMemoryInMb, 5);
       final JRadioButton noneButton = new JRadioButton("Use Default", useDefault);
       final JRadioButton userButton = new JRadioButton("Use These User Settings:", !useDefault);
       final ButtonGroup bgroup = new ButtonGroup();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -404,8 +404,8 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     LocalBeanCache.INSTANCE.storeSerializable(server.getDisplayName(), server);
     LocalBeanCache.INSTANCE.writeToDisk();
     // create local launcher
-    final String gameUUID = (String) m_gameSelectorModel.getGameData().getProperties().get(GameData.GAME_UUID);
-    final PBEMDiceRoller randomSource = new PBEMDiceRoller((IRemoteDiceServer) m_diceServerEditor.getBean(), gameUUID);
+    final String gameUuid = (String) m_gameSelectorModel.getGameData().getProperties().get(GameData.GAME_UUID);
+    final PBEMDiceRoller randomSource = new PBEMDiceRoller((IRemoteDiceServer) m_diceServerEditor.getBean(), gameUuid);
     final Map<String, String> playerTypes = new HashMap<>();
     final Map<String, Boolean> playersEnabled = new HashMap<>();
     for (final PBEMLocalPlayerComboBoxSelector player : m_playerTypes) {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
@@ -173,8 +173,8 @@ public class MicroWebPosterEditor extends EditorPanel {
       window.setVisible(false);
       window.dispose();
     });
-    final JButton btnOK = new JButton("Initialize");
-    btnOK.addActionListener(e -> {
+    final JButton btnOk = new JButton("Initialize");
+    btnOk.addActionListener(e -> {
       window.setVisible(false);
       window.dispose();
       final StringBuilder sb = new StringBuilder();
@@ -203,7 +203,7 @@ public class MicroWebPosterEditor extends EditorPanel {
             "Error", JOptionPane.INFORMATION_MESSAGE);
       }
     });
-    window.getContentPane().add(btnOK, new GridBagConstraints(0, m_parties.length + 1, 1, 1, 0, 0,
+    window.getContentPane().add(btnOk, new GridBagConstraints(0, m_parties.length + 1, 1, 1, 0, 0,
         GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(30, 20, 20, 10), 0, 0));
     window.getContentPane().add(btnClose, new GridBagConstraints(1, m_parties.length + 1, 1, 1, 0, 0,
         GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(30, 10, 20, 20), 0, 0));

--- a/src/main/java/games/strategy/engine/framework/system/Memory.java
+++ b/src/main/java/games/strategy/engine/framework/system/Memory.java
@@ -89,11 +89,11 @@ public class Memory {
     return maxMemorySet;
   }
 
-  public static Properties setMaxMemoryInMB(final int maxMemoryInMB) {
-    System.out.println("Setting max memory for TripleA to: " + maxMemoryInMB + "m");
+  public static Properties setMaxMemoryInMB(final int maxMemoryInMb) {
+    System.out.println("Setting max memory for TripleA to: " + maxMemoryInMb + "m");
     final Properties prop = new Properties();
     prop.put(TRIPLEA_MEMORY_USE_DEFAULT, "false");
-    prop.put(TRIPLEA_MEMORY_XMX, "" + maxMemoryInMB);
+    prop.put(TRIPLEA_MEMORY_XMX, "" + maxMemoryInMb);
     return prop;
   }
 

--- a/src/main/java/games/strategy/engine/history/Step.java
+++ b/src/main/java/games/strategy/engine/history/Step.java
@@ -43,11 +43,11 @@ class StepHistorySerializer implements SerializationWriter {
   private final PlayerID m_playerID;
   private final String m_displayName;
 
-  public StepHistorySerializer(final String stepName, final String delegateName, final PlayerID playerID,
+  public StepHistorySerializer(final String stepName, final String delegateName, final PlayerID playerId,
       final String displayName) {
     m_stepName = stepName;
     m_delegateName = delegateName;
-    m_playerID = playerID;
+    m_playerID = playerId;
     m_displayName = displayName;
   }
 

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -118,16 +118,16 @@ public class LobbyFrame extends JFrame {
       controller.boot(clickedOn);
     }));
     rVal.add(SwingAction.of("Ban Player", e -> {
-      final int resultBT = JOptionPane.showOptionDialog(LobbyFrame.this,
+      final int resultBanType = JOptionPane.showOptionDialog(LobbyFrame.this,
           "<html>Select the type of ban: <br>"
               + "Please consult other admins before banning longer than 1 day. <br>"
               + "And please remember to report this ban.</html>",
           "Select Ban Type", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null,
           banOrMuteOptions.toArray(), banOrMuteOptions.toArray()[banOrMuteOptions.size() - 1]);
-      if (resultBT < 0) {
+      if (resultBanType < 0) {
         return;
       }
-      final String selectedBanType = (String) banOrMuteOptions.toArray()[resultBT];
+      final String selectedBanType = (String) banOrMuteOptions.toArray()[resultBanType];
       if (selectedBanType.equals("Cancel")) {
         return;
       }
@@ -140,13 +140,13 @@ public class LobbyFrame extends JFrame {
       timeUnits.add("Year");
       timeUnits.add("Forever");
       timeUnits.add("Cancel");
-      final int resultTU = JOptionPane.showOptionDialog(LobbyFrame.this, "Select the unit of measurement: ",
+      final int resultTimespanUnit = JOptionPane.showOptionDialog(LobbyFrame.this, "Select the unit of measurement: ",
           "Select Timespan Unit", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null,
           timeUnits.toArray(), timeUnits.toArray()[timeUnits.size() - 1]);
-      if (resultTU < 0) {
+      if (resultTimespanUnit < 0) {
         return;
       }
-      final String selectedTimeUnit = (String) timeUnits.toArray()[resultTU];
+      final String selectedTimeUnit = (String) timeUnits.toArray()[resultTimespanUnit];
       if (selectedTimeUnit.equalsIgnoreCase("Cancel")) {
         return;
       }
@@ -161,12 +161,12 @@ public class LobbyFrame extends JFrame {
         controller.boot(clickedOn);
         return;
       }
-      final String resultLOT = JOptionPane.showInputDialog(LobbyFrame.this,
+      final String resultLengthOfTime = JOptionPane.showInputDialog(LobbyFrame.this,
           "Now please enter the length of time to ban the player: (In " + selectedTimeUnit + "s) ", 1);
-      if (resultLOT == null) {
+      if (resultLengthOfTime == null) {
         return;
       }
-      final long result2 = Long.parseLong(resultLOT);
+      final long result2 = Long.parseLong(resultLengthOfTime);
       if (result2 < 0) {
         return;
       }
@@ -197,14 +197,14 @@ public class LobbyFrame extends JFrame {
 
 
     rVal.add(SwingAction.of("Mute Player", e -> {
-      final int resultMT = JOptionPane.showOptionDialog(LobbyFrame.this,
+      final int resultMuteType = JOptionPane.showOptionDialog(LobbyFrame.this,
           "<html>Select the type of mute: <br>Please consult other admins before muting longer than 1 day.</html>",
           "Select Mute Type", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null,
           banOrMuteOptions.toArray(), banOrMuteOptions.toArray()[banOrMuteOptions.size() - 1]);
-      if (resultMT < 0) {
+      if (resultMuteType < 0) {
         return;
       }
-      final String selectedMuteType = (String) banOrMuteOptions.toArray()[resultMT];
+      final String selectedMuteType = (String) banOrMuteOptions.toArray()[resultMuteType];
       if (selectedMuteType.equals("Cancel")) {
         return;
       }
@@ -217,13 +217,13 @@ public class LobbyFrame extends JFrame {
       timeUnits.add("Year");
       timeUnits.add("Forever");
       timeUnits.add("Cancel");
-      final int resultTU = JOptionPane.showOptionDialog(LobbyFrame.this, "Select the unit of measurement: ",
+      final int resultTimespanUnit = JOptionPane.showOptionDialog(LobbyFrame.this, "Select the unit of measurement: ",
           "Select Timespan Unit", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null,
           timeUnits.toArray(), timeUnits.toArray()[timeUnits.size() - 1]);
-      if (resultTU < 0) {
+      if (resultTimespanUnit < 0) {
         return;
       }
-      final String selectedTimeUnit = (String) timeUnits.toArray()[resultTU];
+      final String selectedTimeUnit = (String) timeUnits.toArray()[resultTimespanUnit];
       if (selectedTimeUnit.equals("Cancel")) {
         return;
       }
@@ -236,12 +236,12 @@ public class LobbyFrame extends JFrame {
         }
         return;
       }
-      final String resultLOT = JOptionPane.showInputDialog(LobbyFrame.this,
+      final String resultLengthOfTime = JOptionPane.showInputDialog(LobbyFrame.this,
           "Now please enter the length of time to mute the player: (In " + selectedTimeUnit + "s) ", 1);
-      if (resultLOT == null) {
+      if (resultLengthOfTime == null) {
         return;
       }
-      final long result2 = Long.parseLong(resultLOT);
+      final long result2 = Long.parseLong(resultLengthOfTime);
       if (result2 < 0) {
         return;
       }
@@ -280,11 +280,11 @@ public class LobbyFrame extends JFrame {
         if (value == null) {
           return;
         }
-        final long resultML = Long.parseLong(value.toString());
-        if (resultML < 0) {
+        final long resultMuteLengthInMinutes = Long.parseLong(value.toString());
+        if (resultMuteLengthInMinutes < 0) {
           return;
         }
-        final long ticks = resultML * 1000 * 60;
+        final long ticks = resultMuteLengthInMinutes * 1000 * 60;
         final long expire = System.currentTimeMillis() + ticks;
         controller.muteUsername(clickedOn, new Date(expire));
         controller.muteMac(clickedOn, new Date(expire));

--- a/src/main/java/games/strategy/engine/lobby/server/ILobbyGameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ILobbyGameController.java
@@ -10,9 +10,9 @@ public interface ILobbyGameController extends IRemote {
   RemoteName GAME_CONTROLLER_REMOTE = new RemoteName(
       "games.strategy.engine.lobby.server.IGameController.GAME_CONTROLLER_REMOTE", ILobbyGameController.class);
 
-  void postGame(GUID gameID, GameDescription description);
+  void postGame(GUID gameId, GameDescription description);
 
-  void updateGame(GUID gameID, GameDescription description);
+  void updateGame(GUID gameId, GameDescription description);
 
   Map<GUID, GameDescription> listGames();
 
@@ -25,5 +25,5 @@ public interface ILobbyGameController extends IRemote {
    * This method may only be called by the node that is hosting this game.
    * </p>
    */
-  String testGame(GUID gameID);
+  String testGame(GUID gameId);
 }

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
@@ -58,14 +58,14 @@ class LobbyGameController implements ILobbyGameController {
   }
 
   @Override
-  public void postGame(final GUID gameID, final GameDescription description) {
+  public void postGame(final GUID gameId, final GameDescription description) {
     final INode from = MessageContext.getSender();
     assertCorrectHost(description, from);
     s_logger.info("Game added:" + description);
     synchronized (m_mutex) {
-      m_allGames.put(gameID, description);
+      m_allGames.put(gameId, description);
     }
-    m_broadcaster.gameUpdated(gameID, description);
+    m_broadcaster.gameUpdated(gameId, description);
   }
 
   private static void assertCorrectHost(final GameDescription description, final INode from) {
@@ -76,14 +76,14 @@ class LobbyGameController implements ILobbyGameController {
   }
 
   @Override
-  public void updateGame(final GUID gameID, final GameDescription description) {
+  public void updateGame(final GUID gameId, final GameDescription description) {
     final INode from = MessageContext.getSender();
     assertCorrectHost(description, from);
     if (s_logger.isLoggable(Level.FINE)) {
       s_logger.fine("Game updated:" + description);
     }
     synchronized (m_mutex) {
-      final GameDescription oldDescription = m_allGames.get(gameID);
+      final GameDescription oldDescription = m_allGames.get(gameId);
       // out of order updates
       // ignore, we already have the latest
       if (oldDescription.getVersion() > description.getVersion()) {
@@ -92,9 +92,9 @@ class LobbyGameController implements ILobbyGameController {
       if (!oldDescription.getHostedBy().equals(description.getHostedBy())) {
         throw new IllegalStateException("Game modified by wrong host");
       }
-      m_allGames.put(gameID, description);
+      m_allGames.put(gameId, description);
     }
-    m_broadcaster.gameUpdated(gameID, description);
+    m_broadcaster.gameUpdated(gameId, description);
   }
 
   @Override
@@ -110,10 +110,10 @@ class LobbyGameController implements ILobbyGameController {
   }
 
   @Override
-  public String testGame(final GUID gameID) {
+  public String testGame(final GUID gameId) {
     GameDescription description;
     synchronized (m_mutex) {
-      description = m_allGames.get(gameID);
+      description = m_allGames.get(gameId);
     }
     if (description == null) {
       return "No such game found";

--- a/src/main/java/games/strategy/engine/message/HubInvocationResults.java
+++ b/src/main/java/games/strategy/engine/message/HubInvocationResults.java
@@ -10,7 +10,7 @@ public class HubInvocationResults extends InvocationResults {
     super();
   }
 
-  public HubInvocationResults(final RemoteMethodCallResults results, final GUID methodCallID) {
-    super(results, methodCallID);
+  public HubInvocationResults(final RemoteMethodCallResults results, final GUID methodCallId) {
+    super(results, methodCallId);
   }
 }

--- a/src/main/java/games/strategy/engine/message/HubInvoke.java
+++ b/src/main/java/games/strategy/engine/message/HubInvoke.java
@@ -10,7 +10,7 @@ public class HubInvoke extends Invoke {
     super();
   }
 
-  public HubInvoke(final GUID methodCallID, final boolean needReturnValues, final RemoteMethodCall call) {
-    super(methodCallID, needReturnValues, call);
+  public HubInvoke(final GUID methodCallId, final boolean needReturnValues, final RemoteMethodCall call) {
+    super(methodCallId, needReturnValues, call);
   }
 }

--- a/src/main/java/games/strategy/engine/message/SpokeInvocationResults.java
+++ b/src/main/java/games/strategy/engine/message/SpokeInvocationResults.java
@@ -10,7 +10,7 @@ public class SpokeInvocationResults extends InvocationResults {
     super();
   }
 
-  public SpokeInvocationResults(final RemoteMethodCallResults results, final GUID methodCallID) {
-    super(results, methodCallID);
+  public SpokeInvocationResults(final RemoteMethodCallResults results, final GUID methodCallId) {
+    super(results, methodCallId);
   }
 }

--- a/src/main/java/games/strategy/engine/message/SpokeInvoke.java
+++ b/src/main/java/games/strategy/engine/message/SpokeInvoke.java
@@ -17,9 +17,9 @@ public class SpokeInvoke extends Invoke {
     super();
   }
 
-  public SpokeInvoke(final GUID methodCallID, final boolean needReturnValues, final RemoteMethodCall call,
+  public SpokeInvoke(final GUID methodCallId, final boolean needReturnValues, final RemoteMethodCall call,
       final INode invoker) {
-    super(methodCallID, needReturnValues, call);
+    super(methodCallId, needReturnValues, call);
     m_invoker = invoker;
   }
 

--- a/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -101,21 +101,21 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
   }
 
   private void results(final HubInvocationResults results, final INode from) {
-    final GUID methodID = results.methodCallID;
-    final InvocationInProgress invocationInProgress = invocations.get(methodID);
+    final GUID methodId = results.methodCallID;
+    final InvocationInProgress invocationInProgress = invocations.get(methodId);
     final boolean done = invocationInProgress.process(results, from);
     if (done) {
-      invocations.remove(methodID);
+      invocations.remove(methodId);
       if (invocationInProgress.shouldSendResults()) {
-        sendResultsToCaller(methodID, invocationInProgress);
+        sendResultsToCaller(methodId, invocationInProgress);
       }
     }
   }
 
-  private void sendResultsToCaller(final GUID methodID, final InvocationInProgress invocationInProgress) {
+  private void sendResultsToCaller(final GUID methodId, final InvocationInProgress invocationInProgress) {
     final RemoteMethodCallResults result = invocationInProgress.getResults();
     final INode caller = invocationInProgress.getCaller();
-    final SpokeInvocationResults spokeResults = new SpokeInvocationResults(result, methodID);
+    final SpokeInvocationResults spokeResults = new SpokeInvocationResults(result, methodId);
     send(spokeResults, caller);
   }
 

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/InvocationResults.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/InvocationResults.java
@@ -16,15 +16,15 @@ public abstract class InvocationResults implements Externalizable {
 
   public InvocationResults() {}
 
-  public InvocationResults(final RemoteMethodCallResults results, final GUID methodCallID) {
+  public InvocationResults(final RemoteMethodCallResults results, final GUID methodCallId) {
     if (results == null) {
       throw new IllegalArgumentException("Null results");
     }
-    if (methodCallID == null) {
+    if (methodCallId == null) {
       throw new IllegalArgumentException("Null id");
     }
     this.results = results;
-    this.methodCallID = methodCallID;
+    this.methodCallID = methodCallId;
   }
 
   @Override

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/Invoke.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/Invoke.java
@@ -23,14 +23,14 @@ public abstract class Invoke implements Externalizable {
         + methodCallID;
   }
 
-  public Invoke(final GUID methodCallID, final boolean needReturnValues, final RemoteMethodCall call) {
-    if (needReturnValues && methodCallID == null) {
+  public Invoke(final GUID methodCallId, final boolean needReturnValues, final RemoteMethodCall call) {
+    if (needReturnValues && methodCallId == null) {
       throw new IllegalArgumentException("Cant have no id and need return values");
     }
-    if (!needReturnValues && methodCallID != null) {
+    if (!needReturnValues && methodCallId != null) {
       throw new IllegalArgumentException("Cant have id and not need return values");
     }
-    this.methodCallID = methodCallID;
+    this.methodCallID = methodCallId;
     this.needReturnValues = needReturnValues;
     this.call = call;
   }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -109,13 +109,13 @@ public class UnifiedMessenger {
   }
 
   private RemoteMethodCallResults invokeAndWaitRemote(final RemoteMethodCall remoteCall) {
-    final GUID methodCallID = new GUID();
+    final GUID methodCallId = new GUID();
     final CountDownLatch latch = new CountDownLatch(1);
     synchronized (m_pendingLock) {
-      m_pendingInvocations.put(methodCallID, latch);
+      m_pendingInvocations.put(methodCallId, latch);
     }
     // invoke remotely
-    final Invoke invoke = new HubInvoke(methodCallID, true, remoteCall);
+    final Invoke invoke = new HubInvoke(methodCallId, true, remoteCall);
     send(invoke, m_messenger.getServerNode());
 
     try {
@@ -125,11 +125,11 @@ public class UnifiedMessenger {
     }
 
     synchronized (m_pendingLock) {
-      final RemoteMethodCallResults results = m_results.remove(methodCallID);
+      final RemoteMethodCallResults results = m_results.remove(methodCallId);
       if (results == null) {
         throw new IllegalStateException(
             "No results from remote call. Method returned:" + remoteCall.getMethodName() + " for remote name:"
-                + remoteCall.getRemoteName() + " with id:" + methodCallID);
+                + remoteCall.getRemoteName() + " with id:" + methodCallId);
       }
       return results;
     }
@@ -229,12 +229,12 @@ public class UnifiedMessenger {
   /**
    * Wait for the messenger to know about the given endpoint.
    */
-  public void waitForLocalImplement(final String endPointName, long timeoutMS) {
+  public void waitForLocalImplement(final String endPointName, long timeoutMs) {
     // dont use Long.MAX_VALUE since that will overflow
-    if (timeoutMS <= 0) {
-      timeoutMS = Integer.MAX_VALUE;
+    if (timeoutMs <= 0) {
+      timeoutMs = Integer.MAX_VALUE;
     }
-    final long endTime = timeoutMS + System.currentTimeMillis();
+    final long endTime = timeoutMs + System.currentTimeMillis();
     while (System.currentTimeMillis() < endTime && !hasLocalEndPoint(endPointName)) {
       ThreadUtil.sleep(50);
     }
@@ -314,13 +314,13 @@ public class UnifiedMessenger {
       // maybe an attempt to spoof a message
       assertIsServer(from);
       final SpokeInvocationResults results = (SpokeInvocationResults) msg;
-      final GUID methodID = results.methodCallID;
+      final GUID methodId = results.methodCallID;
       // both of these should already be populated
       // this list should be a synchronized list so we can do the add
       // all
       synchronized (m_pendingLock) {
-        m_results.put(methodID, results.results);
-        m_pendingInvocations.remove(methodID).countDown();
+        m_results.put(methodId, results.results);
+        m_pendingInvocations.remove(methodId).countDown();
       }
     }
   }

--- a/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
+++ b/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
@@ -67,8 +67,8 @@ public class PBEMMessagePoster implements Serializable {
     final IForumPoster forumPoster = (IForumPoster) gameData.getProperties().get(FORUM_POSTER_PROP_NAME);
     final IEmailSender emailSender = (IEmailSender) gameData.getProperties().get(EMAIL_SENDER_PROP_NAME);
     final IWebPoster webPoster = (IWebPoster) gameData.getProperties().get(WEB_POSTER_PROP_NAME);
-    final boolean isPBEM = gameData.getProperties().get(PBEM_GAME_PROP_NAME, false);
-    return (isPBEM && (forumPoster != null || emailSender != null || webPoster != null));
+    final boolean isPbem = gameData.getProperties().get(PBEM_GAME_PROP_NAME, false);
+    return (isPbem && (forumPoster != null || emailSender != null || webPoster != null));
   }
 
   public IForumPoster getForumPoster() {
@@ -221,10 +221,10 @@ public class PBEMMessagePoster implements Serializable {
   }
 
   public static void postTurn(final String title, final HistoryLog historyLog, final boolean includeSaveGame,
-      final PBEMMessagePoster posterPBEM, final IAbstractForumPosterDelegate postingDelegate,
+      final PBEMMessagePoster posterPbem, final IAbstractForumPosterDelegate postingDelegate,
       final MainGameFrame mainGameFrame, final JComponent postButton) {
     String message = "";
-    final IForumPoster turnSummaryMsgr = posterPBEM.getForumPoster();
+    final IForumPoster turnSummaryMsgr = posterPbem.getForumPoster();
     final StringBuilder sb = new StringBuilder();
     if (turnSummaryMsgr != null) {
       sb.append(message).append("Post ").append(title).append(" ");
@@ -233,11 +233,11 @@ public class PBEMMessagePoster implements Serializable {
       }
       sb.append("to ").append(turnSummaryMsgr.getDisplayName()).append("?\n");
     }
-    final IEmailSender emailSender = posterPBEM.getEmailSender();
+    final IEmailSender emailSender = posterPbem.getEmailSender();
     if (emailSender != null) {
       sb.append("Send email to ").append(emailSender.getToAddress()).append("?\n");
     }
-    final IWebPoster webPoster = posterPBEM.getWebPoster();
+    final IWebPoster webPoster = posterPbem.getWebPoster();
     if (webPoster != null) {
       sb.append("Send game state of '").append(webPoster.getGameName()).append("' to ").append(webPoster.getHost())
           .append("?\n");
@@ -260,21 +260,21 @@ public class PBEMMessagePoster implements Serializable {
           saveGameFile = File.createTempFile("triplea", ".tsvg");
           if (saveGameFile != null) {
             mainGameFrame.getGame().saveGame(saveGameFile);
-            posterPBEM.setSaveGame(saveGameFile);
+            posterPbem.setSaveGame(saveGameFile);
           }
         } catch (final Exception e) {
           postOk = false;
           ClientLogger.logQuietly(e);
         }
-        posterPBEM.setTurnSummary(historyLog.toString());
+        posterPbem.setTurnSummary(historyLog.toString());
         try {
           // forward the poster to the delegate which invokes post() on the poster
           if (postingDelegate != null) {
-            if (!postingDelegate.postTurnSummary(posterPBEM, title, includeSaveGame)) {
+            if (!postingDelegate.postTurnSummary(posterPbem, title, includeSaveGame)) {
               postOk = false;
             }
           } else {
-            if (!posterPBEM.post(null, title, includeSaveGame)) {
+            if (!posterPbem.post(null, title, includeSaveGame)) {
               postOk = false;
             }
           }
@@ -286,9 +286,9 @@ public class PBEMMessagePoster implements Serializable {
           postingDelegate.setHasPostedTurnSummary(postOk);
         }
         final StringBuilder sb1 = new StringBuilder();
-        if (posterPBEM.getForumPoster() != null) {
-          final String saveGameRef = posterPBEM.getSaveGameRef();
-          final String turnSummaryRef = posterPBEM.getTurnSummaryRef();
+        if (posterPbem.getForumPoster() != null) {
+          final String saveGameRef = posterPbem.getSaveGameRef();
+          final String turnSummaryRef = posterPbem.getTurnSummaryRef();
           if (saveGameRef != null) {
             sb1.append("\nSave Game : ").append(saveGameRef);
           }
@@ -296,11 +296,11 @@ public class PBEMMessagePoster implements Serializable {
             sb1.append("\nSummary Text: ").append(turnSummaryRef);
           }
         }
-        if (posterPBEM.getEmailSender() != null) {
-          sb1.append("\nEmails: ").append(posterPBEM.getEmailSendStatus());
+        if (posterPbem.getEmailSender() != null) {
+          sb1.append("\nEmails: ").append(posterPbem.getEmailSendStatus());
         }
-        if (posterPBEM.getWebPoster() != null) {
-          sb1.append("\nWeb Site Post: ").append(posterPBEM.getWebPostStatus());
+        if (posterPbem.getWebPoster() != null) {
+          sb1.append("\nWeb Site Post: ").append(posterPbem.getWebPostStatus());
         }
         historyLog.getWriter().println(sb1.toString());
         if (historyLog.isVisible()) {

--- a/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
@@ -43,14 +43,14 @@ public class TripleAForumPoster extends AbstractForumPoster {
     username = new BasicNameValuePair("username", getUsername());
     password = new BasicNameValuePair("password", getPassword());
     try (CloseableHttpClient client = HttpClients.custom().disableCookieManagement().build()) {
-      int userID = getUserId(client);
-      String token = getToken(client, userID);
+      int userId = getUserId(client);
+      String token = getToken(client, userId);
       try {
         post(client, token, "### " + title + "\n" + summary);
         m_turnSummaryRef = "Sucessfully posted!";
         return true;
       } finally {
-        deleteToken(client, userID, token);
+        deleteToken(client, userId, token);
       }
     } catch (Exception e) {
       ClientLogger.logQuietly(e);
@@ -89,9 +89,9 @@ public class TripleAForumPoster extends AbstractForumPoster {
     }
   }
 
-  private static void deleteToken(CloseableHttpClient client, int userID, String token)
+  private static void deleteToken(CloseableHttpClient client, int userId, String token)
       throws ClientProtocolException, IOException {
-    HttpDelete httpDelete = new HttpDelete(tripleAForumURL + "/api/v1/users/" + userID + "/tokens/" + token);
+    HttpDelete httpDelete = new HttpDelete(tripleAForumURL + "/api/v1/users/" + userId + "/tokens/" + token);
     addTokenHeader(httpDelete, token);
     client.execute(httpDelete);
   }
@@ -120,8 +120,8 @@ public class TripleAForumPoster extends AbstractForumPoster {
     post.setEntity(new UrlEncodedFormEntity(entity, StandardCharsets.UTF_8));
     HttpProxy.addProxy(post);
     try (CloseableHttpResponse response = client.execute(post)) {
-      String rawJSON = Util.getStringFromInputStream(response.getEntity().getContent());
-      return new JSONObject(rawJSON);
+      String rawJson = Util.getStringFromInputStream(response.getEntity().getContent());
+      return new JSONObject(rawJson);
     }
   }
 
@@ -130,8 +130,8 @@ public class TripleAForumPoster extends AbstractForumPoster {
     post.setEntity(new UrlEncodedFormEntity(Arrays.asList(password), StandardCharsets.UTF_8));
     HttpProxy.addProxy(post);
     try (CloseableHttpResponse response = client.execute(post)) {
-      String rawJSON = Util.getStringFromInputStream(response.getEntity().getContent());
-      JSONObject jsonObject = new JSONObject(rawJSON);
+      String rawJson = Util.getStringFromInputStream(response.getEntity().getContent());
+      JSONObject jsonObject = new JSONObject(rawJson);
       if (jsonObject.has("code")) {
         String code = jsonObject.getString("code");
         if (code.equalsIgnoreCase("ok")) {
@@ -139,7 +139,7 @@ public class TripleAForumPoster extends AbstractForumPoster {
         }
         throw new Exception("Failed to retrieve Token. Code: " + code + " Message: " + jsonObject.getString("message"));
       }
-      throw new Exception("Failed to retrieve Token, server did not return correct JSON: " + rawJSON);
+      throw new Exception("Failed to retrieve Token, server did not return correct JSON: " + rawJson);
     }
   }
 

--- a/src/main/java/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
@@ -100,7 +100,7 @@ public class TripleAWarClubForumPoster extends AbstractForumPoster {
       final String s_forumId = "20";
       final String url = WAR_CLUB_FORUM_URL + "/reply.php?forum=" + s_forumId + "&topic_id="
           + URLEncoder.encode(m_topicId, StandardCharsets.UTF_8.name());
-      String XOOPS_TOKEN_REQUEST;
+      String xoopsTokenRequest;
       HttpGet httpGet = new HttpGet(url);
       HttpProxy.addProxy(httpGet);
       try (CloseableHttpResponse response = client.execute(httpGet, httpContext)) {
@@ -113,7 +113,7 @@ public class TripleAWarClubForumPoster extends AbstractForumPoster {
         if (!m.matches()) {
           throw new Exception("Unable to find 'XOOPS_TOKEN_REQUEST' form field on reply page");
         }
-        XOOPS_TOKEN_REQUEST = m.group(1);
+        xoopsTokenRequest = m.group(1);
       }
 
       MultipartEntityBuilder builder = MultipartEntityBuilder.create()
@@ -121,7 +121,7 @@ public class TripleAWarClubForumPoster extends AbstractForumPoster {
           .addTextBody("message", summary)
           .addTextBody("forum", s_forumId)
           .addTextBody("topic_id", m_topicId)
-          .addTextBody("XOOPS_TOKEN_REQUEST", XOOPS_TOKEN_REQUEST)
+          .addTextBody("XOOPS_TOKEN_REQUEST", xoopsTokenRequest)
           .addTextBody("xoops_upload_file[]", "userfile")
           .addTextBody("contents_submit", "Submit")
           .addTextBody("doxcode", "1")

--- a/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
+++ b/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
@@ -84,11 +84,11 @@ public class CryptoRandomSource implements IRandomSource {
     // generate numbers locally, and put them in the vault
     final int[] localRandom = m_plainRandom.getRandom(max, count, annotation);
     // lock it so the client knows that its there, but cant read it
-    final VaultID localID = vault.lock(intsToBytes(localRandom));
+    final VaultID localId = vault.lock(intsToBytes(localRandom));
     // ask the remote to generate numbers
     final IRemoteRandom remote =
         (IRemoteRandom) (m_game.getRemoteMessenger().getRemote(ServerGame.getRemoteRandomName(m_remotePlayer)));
-    final Object clientRandom = remote.generate(max, count, annotation, localID);
+    final Object clientRandom = remote.generate(max, count, annotation, localId);
     if (!(clientRandom instanceof int[])) {
       // Let the error be thrown
       System.out.println("Client remote random generated: " + clientRandom + ".  Asked for: " + count + "x" + max
@@ -96,7 +96,7 @@ public class CryptoRandomSource implements IRandomSource {
     }
     final int[] remoteNumbers = (int[]) clientRandom;
     // unlock ours, tell the client he can verify
-    vault.unlock(localID);
+    vault.unlock(localId);
     remote.verifyNumbers();
     // finally, we join the two together to get the real value
     return xor(localRandom, remoteNumbers, max);

--- a/src/main/java/games/strategy/engine/random/IRemoteDiceServer.java
+++ b/src/main/java/games/strategy/engine/random/IRemoteDiceServer.java
@@ -9,7 +9,7 @@ public interface IRemoteDiceServer extends IBean {
   /**
    * Post a request to the dice server, and return the resulting html page as a string.
    */
-  String postRequest(int max, int numDice, String subjectMessage, String gameID, String gameUUID)
+  String postRequest(int max, int numDice, String subjectMessage, String gameId, String gameUuid)
       throws IOException;
 
   /**

--- a/src/main/java/games/strategy/engine/random/IRemoteRandom.java
+++ b/src/main/java/games/strategy/engine/random/IRemoteRandom.java
@@ -7,11 +7,11 @@ public interface IRemoteRandom extends IRemote {
   /**
    * Generate a random number, and lock it in the vault.
    *
-   * @param serverVaultID
+   * @param serverVaultId
    *        - the vaultID where the server has stored his numbers
    * @return the vault id for which we have locked the data
    */
-  int[] generate(int max, int count, String annotation, VaultID serverVaultID);
+  int[] generate(int max, int count, String annotation, VaultID serverVaultId);
 
   /**
    * unlock the random number last generated.

--- a/src/main/java/games/strategy/engine/random/InternalDiceServer.java
+++ b/src/main/java/games/strategy/engine/random/InternalDiceServer.java
@@ -33,8 +33,8 @@ public class InternalDiceServer implements IRemoteDiceServer {
   }
 
   @Override
-  public String postRequest(final int max, final int numDice, final String subjectMessage, final String gameID,
-      final String gameUUID) throws IOException {
+  public String postRequest(final int max, final int numDice, final String subjectMessage, final String gameId,
+      final String gameUuid) throws IOException {
     // the interface is rather stupid, you have to return a string here, which is then passed back in getDice()
     final int[] ints = _randomSource.getRandom(max, numDice, "Internal Dice Server");
     final StringBuilder sb = new StringBuilder();

--- a/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
@@ -42,9 +42,9 @@ public class PBEMDiceRoller implements IRandomSource {
     s_focusWindow = w;
   }
 
-  public PBEMDiceRoller(final IRemoteDiceServer diceServer, final String gameUUID) {
+  public PBEMDiceRoller(final IRemoteDiceServer diceServer, final String gameUuid) {
     m_remoteDiceServer = diceServer;
-    m_gameUUID = gameUUID;
+    m_gameUUID = gameUuid;
   }
 
   /**
@@ -129,11 +129,11 @@ class HttpDiceRollerDialog extends JDialog {
    *        the subject for the email the dice roller will send (if it sends emails)
    * @param diceServer
    *        the dice server implementation
-   * @param gameUUID
+   * @param gameUuid
    *        the TripleA game UUID or null
    */
   public HttpDiceRollerDialog(final Frame owner, final int sides, final int count, final String subjectMessage,
-      final IRemoteDiceServer diceServer, final String gameUUID) {
+      final IRemoteDiceServer diceServer, final String gameUuid) {
     super(owner, "Dice roller", true);
     m_owner = owner;
     m_sides = sides;
@@ -141,7 +141,7 @@ class HttpDiceRollerDialog extends JDialog {
     m_subjectMessage = subjectMessage;
     m_gameID = diceServer.getGameId() == null ? "" : diceServer.getGameId();
     m_diceServer = diceServer;
-    m_gameUUID = gameUUID;
+    m_gameUUID = gameUuid;
     setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
     m_exitButton.addActionListener(e -> System.exit(-1));
     m_exitButton.setEnabled(false);

--- a/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -120,12 +120,12 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
   }
 
   @Override
-  public String postRequest(final int max, final int numDice, final String subjectMessage, String gameID,
-      final String gameUUID) throws IOException {
-    if (gameID.trim().length() == 0) {
-      gameID = "TripleA";
+  public String postRequest(final int max, final int numDice, final String subjectMessage, String gameId,
+      final String gameUuid) throws IOException {
+    if (gameId.trim().length() == 0) {
+      gameId = "TripleA";
     }
-    String message = gameID + ":" + subjectMessage;
+    String message = gameId + ":" + subjectMessage;
     final int maxLength = Integer.valueOf(m_props.getProperty("message.maxlength"));
     if (message.length() > maxLength) {
       message = message.substring(0, maxLength - 1);
@@ -146,7 +146,7 @@ public class PropertiesDiceRoller implements IRemoteDiceServer {
       httpPost.addHeader("User-Agent", "triplea/" + ClientContext.engineVersion());
       // this is to allow a dice server to allow the user to request the emails for the game
       // rather than sending out email for each roll
-      httpPost.addHeader("X-Triplea-Game-UUID", gameUUID);
+      httpPost.addHeader("X-Triplea-Game-UUID", gameUuid);
       final String host = m_props.getProperty("host");
       final int port = Integer.parseInt(m_props.getProperty("port", "80"));
       final HttpHost hostConfig = new HttpHost(host, port);

--- a/src/main/java/games/strategy/engine/random/RemoteRandom.java
+++ b/src/main/java/games/strategy/engine/random/RemoteRandom.java
@@ -38,7 +38,7 @@ public class RemoteRandom implements IRemoteRandom {
   }
 
   @Override
-  public int[] generate(final int max, final int count, final String annotation, final VaultID remoteVaultID)
+  public int[] generate(final int max, final int count, final String annotation, final VaultID remoteVaultId)
       throws IllegalStateException {
     if (m_waitingForUnlock) {
       throw new IllegalStateException("Being asked to generate random numbers, but we havent finished last generation. "
@@ -52,14 +52,14 @@ public class RemoteRandom implements IRemoteRandom {
     if (m_remoteVaultID != null) {
       m_game.getVault().release(m_remoteVaultID);
     }
-    m_remoteVaultID = remoteVaultID;
+    m_remoteVaultID = remoteVaultId;
     m_annotation = annotation;
     m_max = max;
     m_localNumbers = m_plainRandom.getRandom(max, count, annotation);
-    m_game.getVault().waitForID(remoteVaultID, 15000);
-    if (!m_game.getVault().knowsAbout(remoteVaultID)) {
+    m_game.getVault().waitForID(remoteVaultId, 15000);
+    if (!m_game.getVault().knowsAbout(remoteVaultId)) {
       throw new IllegalStateException(
-          "Vault id not known, have:" + m_game.getVault().knownIds() + " looking for:" + remoteVaultID);
+          "Vault id not known, have:" + m_game.getVault().knownIds() + " looking for:" + remoteVaultId);
     }
     return m_localNumbers;
   }

--- a/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/src/main/java/games/strategy/engine/vault/Vault.java
@@ -300,11 +300,11 @@ public class Vault {
    * Waits until we know about a given vault id.
    * waits for at most timeout milliseconds
    */
-  public void waitForID(final VaultID id, final long timeoutMS) {
-    if (timeoutMS <= 0) {
+  public void waitForID(final VaultID id, final long timeoutMs) {
+    if (timeoutMs <= 0) {
       throw new IllegalArgumentException("Must suppply positive timeout argument");
     }
-    final long endTime = timeoutMS + System.currentTimeMillis();
+    final long endTime = timeoutMs + System.currentTimeMillis();
     while (System.currentTimeMillis() < endTime && !knowsAbout(id)) {
       synchronized (m_waitForLock) {
         if (knowsAbout(id)) {


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in local variables.

For the most part, I did **not** expand abbreviations where they caused a violation; I simply converted them using the abbreviation naming convention established in #1659.  Please advise if any should be expanded.

The abbreviations that were expanded included:

* `BT` --> `BanType`
* `LOT` --> `LengthOfTime`
* `ML` --> `MuteLength`
* `MT` --> `MuteType`
* `TU` --> `TimespanUnit`

Due to the large number of violations that fall under this category, the fixes are being split over multiple PRs to keep the review size reasonable.