### PR TITLE
Add additional conditions for when to prompt for place factory selection

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -34,6 +34,7 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.ui.SwingComponents;
 import games.strategy.util.CompositeMatch;
 import games.strategy.util.CompositeMatchAnd;
+import games.strategy.util.CompositeMatchOr;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.Tuple;
@@ -217,7 +218,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
 
       // Get next producer territory
       Territory producer = producers.get(0);
-      if (producers.size() > 1) {
+      final boolean isCarrierLeftAndCanMoveExistingFightersToCarrier =
+          Match.someMatch(unitsLeftToPlace, Matches.UnitIsCarrier) && canMoveExistingFightersToNewCarriers()
+              && !Properties.getLHTRCarrierProductionRules(getData());
+      final boolean areAllRemainingSeaOrConstructionUnits =
+          m_player.getUnits().allMatch(new CompositeMatchOr<Unit>(Matches.UnitIsSea, Matches.UnitIsConstruction));
+      if (producers.size() > 1
+          && (isCarrierLeftAndCanMoveExistingFightersToCarrier || !areAllRemainingSeaOrConstructionUnits)) {
         producer = getRemotePlayer().selectProducerTerritoryForUnits(producers, at);
         if (producer == null) {
           break;


### PR DESCRIPTION
This is a usability change so input welcome. The recent change to allow users to select which factory to use for sea placement when multiple are available can be annoying when it isn't really necessary. So let's limit prompting only when its needed.

Functional Changes
- Only prompt for selection if user is currently placing a carrier and playing with rule to move existing fighters to new carrier OR there are units other than sea or construction units to place (land or air)

I'd recommend testing on some different maps and different situations. This should allow 'power users' who are used to setting all air/land units before sea to avoid this old problem to limit when they get prompted.