### PR TITLE
Checkstyle: Enforce threshold for integration test code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,24 +34,6 @@ tasks.withType(JavaCompile) {
     options.incremental = true
 }
 
-check {
-    dependsOn 'validateYamls'
-}
-
-checkstyle {
-    toolVersion = "7.6.1"
-}
-
-checkstyleMain {
-    maxWarnings = checkstyleMainMaxWarnings.toInteger()
-    source sourceSets.main.output.resourcesDir
-}
-
-checkstyleTest {
-    maxWarnings = checkstyleTestMaxWarnings.toInteger()
-    source sourceSets.test.output.resourcesDir
-}
-
 jar {
     manifest {
         attributes 'Main-Class': mainClassName, 'TripleA-Version': version
@@ -118,9 +100,6 @@ task integTest(type: Test) {
 
     mustRunAfter tasks.test
 }
-
-check.dependsOn integTest
-
 
 def assetsDirectory = file("${buildDir}/assets")
 git {
@@ -222,4 +201,27 @@ gradle.taskGraph.whenReady { graph ->
             it.project.install4j.installDir = file(project.install4jHomeDir)
         }
     })
+}
+
+check {
+    dependsOn 'integTest', 'validateYamls'
+}
+
+checkstyle {
+    toolVersion = "7.6.1"
+}
+
+checkstyleIntegTest {
+    maxWarnings = checkstyleIntegTestMaxWarnings.toInteger()
+    source sourceSets.integTest.output.resourcesDir
+}
+
+checkstyleMain {
+    maxWarnings = checkstyleMainMaxWarnings.toInteger()
+    source sourceSets.main.output.resourcesDir
+}
+
+checkstyleTest {
+    maxWarnings = checkstyleTestMaxWarnings.toInteger()
+    source sourceSets.test.output.resourcesDir
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
+checkstyleIntegTestMaxWarnings=1
 checkstyleMainMaxWarnings=4400
 checkstyleTestMaxWarnings=53


### PR DESCRIPTION
I didn't catch this during the review of #1773: I forgot to point out that by adding a new source set, we needed to also enforce a corresponding Checkstyle threshold.  This PR does that and sets the initial threshold to the current violation count on `master`.

I also refactored the script a bit to move all `check`-related task configuration to the bottom of the script to ensure all tasks have been defined (Gradle requires a task to be defined before you can reference it).  Otherwise, the task configurations get distributed around the file in a non-intuitive manner.