### PR TITLE
Fix variable naming violation and simplify loop

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 checkstyleIntegTestMaxWarnings=1
-checkstyleMainMaxWarnings=4400
+checkstyleMainMaxWarnings=4378
 checkstyleTestMaxWarnings=53

--- a/src/main/java/games/strategy/triplea/ui/AbstractForumPosterPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractForumPosterPanel.java
@@ -21,30 +21,20 @@ public abstract class AbstractForumPosterPanel extends ActionPanel {
   protected TripleAFrame m_frame;
   protected ForumPosterComponent m_forumPosterComponent;
 
-  public AbstractForumPosterPanel(final GameData data, final MapPanel map) {
+  AbstractForumPosterPanel(final GameData data, final MapPanel map) {
     super(data, map);
     m_actionLabel = new JLabel();
   }
 
   private int getRound() {
-    int round = 0;
     final Object[] pathFromRoot = getData().getHistory().getLastNode().getPath();
-    final Object[] arr$ = pathFromRoot;
-    final int len$ = arr$.length;
-    int i$ = 0;
-    do {
-      if (i$ >= len$) {
-        break;
-      }
-      final Object pathNode = arr$[i$];
+    for (final Object pathNode : pathFromRoot) {
       final HistoryNode curNode = (HistoryNode) pathNode;
       if (curNode instanceof Round) {
-        round = ((Round) curNode).getRoundNo();
-        break;
+        return ((Round) curNode).getRoundNo();
       }
-      i$++;
-    } while (true);
-    return round;
+    }
+    return 0;
   }
 
   @Override


### PR DESCRIPTION
Primarily fix a variable naming violation where variable names end with a dollar sign. While here, the do/while loop can be converted to a while loop. But once that is done, it is pretty obvious it can be converted to a for loop, and then again to a foreach loop removing both the object cast and index variables.