### PR TITLE
Checkstyle: Fix abbreviation violations in local variables (part 2)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 checkstyleIntegTestMaxWarnings=1
-checkstyleMainMaxWarnings=4373
+checkstyleMainMaxWarnings=4308
 checkstyleTestMaxWarnings=53

--- a/src/main/java/games/strategy/net/MacFinder.java
+++ b/src/main/java/games/strategy/net/MacFinder.java
@@ -39,9 +39,9 @@ public class MacFinder {
     // First, try to get the mac address of the local host network interface
     try {
       final InetAddress address = InetAddress.getLocalHost();
-      final NetworkInterface localHostNI = NetworkInterface.getByInetAddress(address);
-      if (localHostNI != null) {
-        final byte[] rawMac = localHostNI.getHardwareAddress();
+      final NetworkInterface localHostNetworkInterface = NetworkInterface.getByInetAddress(address);
+      if (localHostNetworkInterface != null) {
+        final byte[] rawMac = localHostNetworkInterface.getHardwareAddress();
         final String mac = convertMacBytesToString(rawMac);
         if (isMacValid(mac)) {
           return mac;

--- a/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -354,34 +354,34 @@ public class ClipPlayer {
   }
 
   /**
-   * @param resourceAndPathURL
+   * @param resourceAndPathUrl
    *        (URL uses '/', not File.separator or '\')
    */
-  protected List<URL> findClipFiles(final String resourceAndPathURL) {
+  protected List<URL> findClipFiles(final String resourceAndPathUrl) {
     final List<URL> availableSounds = new ArrayList<>();
-    final URL thisSoundURL = resourceLoader.getResource(resourceAndPathURL);
-    if (thisSoundURL == null) {
+    final URL thisSoundUrl = resourceLoader.getResource(resourceAndPathUrl);
+    if (thisSoundUrl == null) {
       return availableSounds;
     }
-    URI thisSoundURI;
+    URI thisSoundUri;
     File thisSoundFile;
     // we are checking to see if this is a file, to see if it is a directory, or a sound, or a zipped directory, or a
     // zipped sound. There
     // might be a better way to do this...
     try {
-      thisSoundURI = thisSoundURL.toURI();
+      thisSoundUri = thisSoundUrl.toURI();
       try {
-        thisSoundFile = new File(thisSoundURI);
+        thisSoundFile = new File(thisSoundUri);
       } catch (final Exception e) {
         try {
-          thisSoundFile = new File(thisSoundURI.getPath());
+          thisSoundFile = new File(thisSoundUri.getPath());
         } catch (final Exception e3) {
-          thisSoundFile = new File(thisSoundURL.getPath());
+          thisSoundFile = new File(thisSoundUrl.getPath());
         }
       }
     } catch (final URISyntaxException e1) {
       try {
-        thisSoundFile = new File(thisSoundURL.getPath());
+        thisSoundFile = new File(thisSoundUrl.getPath());
       } catch (final Exception e4) {
         thisSoundFile = null;
       }
@@ -392,7 +392,7 @@ public class ClipPlayer {
     if (thisSoundFile == null || !thisSoundFile.exists()) {
       // final long startTime = System.currentTimeMillis();
       // we are probably using zipped sounds. there might be a better way to do this...
-      final String soundFilePath = thisSoundURL.getPath();
+      final String soundFilePath = thisSoundUrl.getPath();
       if (soundFilePath != null && soundFilePath.length() > 5 && soundFilePath.contains(".zip!")) {
         // so the URL with a zip or jar in it, will start with "file:", and unfortunately when you make a file and test
         // if it exists, if it
@@ -419,13 +419,13 @@ public class ClipPlayer {
                 final Enumeration<? extends ZipEntry> zipEnumeration = zf.entries();
                 while (zipEnumeration.hasMoreElements()) {
                   final ZipEntry zipElement = zipEnumeration.nextElement();
-                  if (isZippedMp3(zipElement, resourceAndPathURL)) {
+                  if (isZippedMp3(zipElement, resourceAndPathUrl)) {
                     try {
-                      final URL zipSoundURL = resourceLoader.getResource(zipElement.getName());
-                      if (zipSoundURL == null) {
+                      final URL zipSoundUrl = resourceLoader.getResource(zipElement.getName());
+                      if (zipSoundUrl == null) {
                         continue;
                       }
-                      availableSounds.add(zipSoundURL);
+                      availableSounds.add(zipSoundUrl);
                     } catch (final Exception e) {
                       ClientLogger.logQuietly(e);
                     }
@@ -445,15 +445,15 @@ public class ClipPlayer {
         if (!(isSoundFileNamed(thisSoundFile))) {
           return availableSounds;
         }
-        availableSounds.add(thisSoundURL);
+        availableSounds.add(thisSoundUrl);
       }
     }
     if (thisSoundFile.isDirectory()) {
       for (final File soundFile : thisSoundFile.listFiles()) {
         if (isSoundFileNamed(soundFile)) {
           try {
-            final URL individualSoundURL = soundFile.toURI().toURL();
-            availableSounds.add(individualSoundURL);
+            final URL individualSoundUrl = soundFile.toURI().toURL();
+            availableSounds.add(individualSoundUrl);
           } catch (final MalformedURLException e) {
             String msg = "Error " + e.getMessage() + " with sound file: " + soundFile.getPath();
             ClientLogger.logQuietly(msg, e);
@@ -464,13 +464,13 @@ public class ClipPlayer {
       if (!isSoundFileNamed(thisSoundFile)) {
         return availableSounds;
       }
-      availableSounds.add(thisSoundURL);
+      availableSounds.add(thisSoundUrl);
     }
     return availableSounds;
   }
 
-  private static boolean isZippedMp3(ZipEntry zipElement, String resourceAndPathURL) {
-    return zipElement != null && zipElement.getName() != null && zipElement.getName().contains(resourceAndPathURL)
+  private static boolean isZippedMp3(ZipEntry zipElement, String resourceAndPathUrl) {
+    return zipElement != null && zipElement.getName() != null && zipElement.getName().contains(resourceAndPathUrl)
         && (zipElement.getName().endsWith(MP3_SUFFIX));
   }
 

--- a/src/main/java/games/strategy/sound/DefaultSoundChannel.java
+++ b/src/main/java/games/strategy/sound/DefaultSoundChannel.java
@@ -19,8 +19,8 @@ public class DefaultSoundChannel implements ISound {
 
 
   @Override
-  public void playSoundForAll(final String clipName, final PlayerID playerID) {
-    ClipPlayer.play(clipName, playerID);
+  public void playSoundForAll(final String clipName, final PlayerID playerId) {
+    ClipPlayer.play(clipName, playerId);
   }
 
   @Override

--- a/src/main/java/games/strategy/sound/HeadlessSoundChannel.java
+++ b/src/main/java/games/strategy/sound/HeadlessSoundChannel.java
@@ -7,7 +7,7 @@ import games.strategy.engine.data.PlayerID;
 public class HeadlessSoundChannel implements ISound {
 
   @Override
-  public void playSoundForAll(final String clipName, final PlayerID playerID) {}
+  public void playSoundForAll(final String clipName, final PlayerID playerId) {}
 
   @Override
   public void playSoundToPlayers(final String clipName, final Collection<PlayerID> playersToSendTo,

--- a/src/main/java/games/strategy/sound/ISound.java
+++ b/src/main/java/games/strategy/sound/ISound.java
@@ -19,11 +19,11 @@ public interface ISound extends IChannelSubscribor {
    *
    * @param clipName
    *        The name of the sound clip to play, found in SoundPath.java
-   * @param playerID
+   * @param playerId
    *        The player who's sound we want to play (ie: russians infantry might make different sounds from german
    *        infantry, etc). Can be null.
    */
-  void playSoundForAll(final String clipName, final PlayerID playerID);
+  void playSoundForAll(final String clipName, final PlayerID playerId);
 
 
   /**

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -131,11 +131,11 @@ public class ResourceLoader implements Closeable {
     rVal.add(match.get().getAbsolutePath());
     // find dependencies
     try (final URLClassLoader url = new URLClassLoader(new URL[] {match.get().toURI().toURL()})) {
-      final URL dependencesURL = url.getResource("dependencies.txt");
-      if (dependencesURL != null) {
+      final URL dependencesUrl = url.getResource("dependencies.txt");
+      if (dependencesUrl != null) {
         final java.util.Properties dependenciesFile = new java.util.Properties();
 
-        final Optional<InputStream> inputStream = UrlStreams.openStream(dependencesURL);
+        final Optional<InputStream> inputStream = UrlStreams.openStream(dependencesUrl);
         if (inputStream.isPresent()) {
           try (final InputStream stream = inputStream.get()) {
             dependenciesFile.load(stream);

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -561,10 +561,10 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
       final PlayerID hit, final Collection<Unit> friendlyUnits, final PlayerID enemyPlayer,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
-      final CasualtyList defaultCasualties, final GUID battleID, final Territory battlesite,
+      final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
       final boolean allowMultipleHitsPerUnit) {
     return ui.getBattlePanel().getCasualties(selectFrom, dependents, count, message, dice, hit, defaultCasualties,
-        battleID, allowMultipleHitsPerUnit);
+        battleId, allowMultipleHitsPerUnit);
   }
 
   @Override
@@ -665,9 +665,9 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
   }
 
   @Override
-  public Territory retreatQuery(final GUID battleID, final boolean submerge, final Territory battleTerritory,
+  public Territory retreatQuery(final GUID battleId, final boolean submerge, final Territory battleTerritory,
       final Collection<Territory> possibleTerritories, final String message) {
-    return ui.getBattlePanel().getRetreat(battleID, message, possibleTerritories, submerge);
+    return ui.getBattlePanel().getRetreat(battleId, message, possibleTerritories, submerge);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -124,7 +124,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
       final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
       final PlayerID hit, final Collection<Unit> friendlyUnits, final PlayerID enemyPlayer,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
-      final CasualtyList defaultCasualties, final GUID battleID, final Territory battlesite,
+      final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
       final boolean allowMultipleHitsPerUnit) {
     if (defaultCasualties.size() != count) {
       throw new IllegalStateException("Select Casualties showing different numbers for number of hits to take vs total "
@@ -188,7 +188,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
   }
 
   @Override
-  public Territory retreatQuery(final GUID battleID, final boolean submerge, final Territory battleTerritory,
+  public Territory retreatQuery(final GUID battleId, final boolean submerge, final Territory battleTerritory,
       final Collection<Territory> possibleTerritories, final String message) {
     return null;
   }
@@ -609,26 +609,25 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
         int i = 0;
         // should we use bridge's random source here?
         final double random = Math.random();
-        int MAX_WAR_ACTIONS_PER_TURN =
-            (random < .5 ? 0 : (random < .9 ? 1 : (random < .99 ? 2 : (int) numPlayers / 2)));
-        if ((MAX_WAR_ACTIONS_PER_TURN > 0)
+        int maxWarActionsPerTurn = (random < .5 ? 0 : (random < .9 ? 1 : (random < .99 ? 2 : (int) numPlayers / 2)));
+        if ((maxWarActionsPerTurn > 0)
             && (Match.countMatches(data.getRelationshipTracker().getRelationships(id), Matches.RelationshipIsAtWar))
                 / numPlayers < 0.4) {
           if (Math.random() < .9) {
-            MAX_WAR_ACTIONS_PER_TURN = 0;
+            maxWarActionsPerTurn = 0;
           } else {
-            MAX_WAR_ACTIONS_PER_TURN = 1;
+            maxWarActionsPerTurn = 1;
           }
         }
         final Iterator<PoliticalActionAttachment> actionWarIter = actionChoicesTowardsWar.iterator();
-        while (actionWarIter.hasNext() && MAX_WAR_ACTIONS_PER_TURN > 0) {
+        while (actionWarIter.hasNext() && maxWarActionsPerTurn > 0) {
           final PoliticalActionAttachment action = actionWarIter.next();
           if (!Matches.AbstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())
               .match(action)) {
             continue;
           }
           i++;
-          if (i > MAX_WAR_ACTIONS_PER_TURN) {
+          if (i > maxWarActionsPerTurn) {
             break;
           }
           iPoliticsDelegate.attemptAction(action);
@@ -642,10 +641,10 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
         int i = 0;
         // should we use bridge's random source here?
         final double random = Math.random();
-        final int MAX_OTHER_ACTIONS_PER_TURN =
+        final int maxOtherActionsPerTurn =
             (random < .3 ? 0 : (random < .6 ? 1 : (random < .9 ? 2 : (random < .99 ? 3 : (int) numPlayers))));
         final Iterator<PoliticalActionAttachment> actionOtherIter = actionChoicesOther.iterator();
-        while (actionOtherIter.hasNext() && MAX_OTHER_ACTIONS_PER_TURN > 0) {
+        while (actionOtherIter.hasNext() && maxOtherActionsPerTurn > 0) {
           final PoliticalActionAttachment action = actionOtherIter.next();
           if (!Matches.AbstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())
               .match(action)) {
@@ -655,7 +654,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
             continue;
           }
           i++;
-          if (i > MAX_OTHER_ACTIONS_PER_TURN) {
+          if (i > maxOtherActionsPerTurn) {
             break;
           }
           iPoliticsDelegate.attemptAction(action);

--- a/src/main/java/games/strategy/triplea/ai/fastAI/AggregateEstimate.java
+++ b/src/main/java/games/strategy/triplea/ai/fastAI/AggregateEstimate.java
@@ -41,23 +41,23 @@ public class AggregateEstimate extends AggregateResults {
   }
 
   @Override
-  public Tuple<Double, Double> getAverageTUVofUnitsLeftOver(final IntegerMap<UnitType> attackerCostsForTUV,
-      final IntegerMap<UnitType> defenderCostsForTUV) {
-    final double attackerTUV = BattleCalculator.getTUV(remainingAttackingUnits, attackerCostsForTUV);
-    final double defenderTUV = BattleCalculator.getTUV(remainingDefendingUnits, defenderCostsForTUV);
-    return Tuple.of(attackerTUV, defenderTUV);
+  public Tuple<Double, Double> getAverageTUVofUnitsLeftOver(final IntegerMap<UnitType> attackerCostsForTuv,
+      final IntegerMap<UnitType> defenderCostsForTuv) {
+    final double attackerTuv = BattleCalculator.getTUV(remainingAttackingUnits, attackerCostsForTuv);
+    final double defenderTuv = BattleCalculator.getTUV(remainingDefendingUnits, defenderCostsForTuv);
+    return Tuple.of(attackerTuv, defenderTuv);
   }
 
   @Override
   public double getAverageTUVswing(final PlayerID attacker, final Collection<Unit> attackers, final PlayerID defender,
       final Collection<Unit> defenders, final GameData data) {
-    final IntegerMap<UnitType> attackerCostsForTUV = BattleCalculator.getCostsForTUV(attacker, data);
-    final IntegerMap<UnitType> defenderCostsForTUV = BattleCalculator.getCostsForTUV(defender, data);
-    final int attackerTotalTUV = BattleCalculator.getTUV(attackers, attackerCostsForTUV);
-    final int defenderTotalTUV = BattleCalculator.getTUV(defenders, defenderCostsForTUV);
-    final Tuple<Double, Double> average = getAverageTUVofUnitsLeftOver(attackerCostsForTUV, defenderCostsForTUV);
-    final double attackerLost = attackerTotalTUV - average.getFirst();
-    final double defenderLost = defenderTotalTUV - average.getSecond();
+    final IntegerMap<UnitType> attackerCostsForTuv = BattleCalculator.getCostsForTUV(attacker, data);
+    final IntegerMap<UnitType> defenderCostsForTuv = BattleCalculator.getCostsForTUV(defender, data);
+    final int attackerTotalTuv = BattleCalculator.getTUV(attackers, attackerCostsForTuv);
+    final int defenderTotalTuv = BattleCalculator.getTUV(defenders, defenderCostsForTuv);
+    final Tuple<Double, Double> average = getAverageTUVofUnitsLeftOver(attackerCostsForTuv, defenderCostsForTuv);
+    final double attackerLost = attackerTotalTuv - average.getFirst();
+    final double defenderLost = defenderTotalTuv - average.getSecond();
     return defenderLost - attackerLost;
   }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
@@ -272,7 +272,7 @@ public class ProAI extends AbstractAI {
   }
 
   @Override
-  public Territory retreatQuery(final GUID battleID, final boolean submerge, final Territory battleTerritory,
+  public Territory retreatQuery(final GUID battleId, final boolean submerge, final Territory battleTerritory,
       final Collection<Territory> possibleTerritories, final String message) {
     initializeData();
 
@@ -280,7 +280,7 @@ public class ProAI extends AbstractAI {
     final GameData data = getGameData();
     final PlayerID player = getPlayerID();
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
-    final IBattle battle = delegate.getBattleTracker().getPendingBattle(battleID);
+    final IBattle battle = delegate.getBattleTracker().getPendingBattle(battleId);
 
     // If battle is null or amphibious then don't retreat
     if (battle == null || battleTerritory == null || battle.isAmphibious()) {
@@ -301,7 +301,7 @@ public class ProAI extends AbstractAI {
       return null;
     }
     calc.setData(getGameData());
-    return retreatAI.retreatQuery(battleID, battleTerritory, possibleTerritories);
+    return retreatAI.retreatQuery(battleId, battleTerritory, possibleTerritories);
   }
 
   @Override
@@ -321,7 +321,7 @@ public class ProAI extends AbstractAI {
       final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
       final PlayerID hit, final Collection<Unit> friendlyUnits, final PlayerID enemyPlayer,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
-      final CasualtyList defaultCasualties, final GUID battleID, final Territory battlesite,
+      final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
       final boolean allowMultipleHitsPerUnit) {
     initializeData();
 
@@ -345,7 +345,7 @@ public class ProAI extends AbstractAI {
       final GameData data = getGameData();
       final PlayerID player = getPlayerID();
       final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
-      final IBattle battle = delegate.getBattleTracker().getPendingBattle(battleID);
+      final IBattle battle = delegate.getBattleTracker().getPendingBattle(battleId);
 
       // If defender and could lose battle then don't consider unit cost as just trying to survive
       boolean needToCheck = true;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -629,7 +629,7 @@ class ProCombatMoveAI {
         }
 
         // Determine counter attack results for each transport territory
-        double totalEnemyTuvSwing = 0.0;
+        double enemyTuvSwing = 0.0;
         for (final Territory unloadTerritory : territoryTransportAndBombardMap.keySet()) {
           if (enemyAttackOptions.getMax(unloadTerritory) != null) {
             final List<Unit> enemyAttackers = enemyAttackOptions.getMax(unloadTerritory).getMaxUnits();
@@ -646,7 +646,7 @@ class ProCombatMoveAI {
                 territoryTransportAndBombardMap.get(unloadTerritory), new HashSet<>());
             final double minTuvSwing = Math.min(result.getTUVSwing(), minResult.getTUVSwing());
             if (minTuvSwing > 0) {
-              totalEnemyTuvSwing += minTuvSwing;
+              enemyTuvSwing += minTuvSwing;
             }
             ProLogger.trace(unloadTerritory + ", EnemyAttackers=" + enemyAttackers.size() + ", MaxDefenders="
                 + defenders.size() + ", MaxEnemyTUVSwing=" + result.getTUVSwing() + ", MinDefenders="
@@ -670,15 +670,15 @@ class ProCombatMoveAI {
           }
         }
         final double attackValue = result.getTUVSwing() + production * (1 + 3 * isEnemyCapital);
-        if (!patd.isStrafing() && (0.75 * totalEnemyTuvSwing) > attackValue) {
-          ProLogger.debug("Removing amphib territory: " + patd.getTerritory() + ", totalEnemyTUVSwing="
-              + totalEnemyTuvSwing + ", attackValue=" + attackValue);
+        if (!patd.isStrafing() && (0.75 * enemyTuvSwing) > attackValue) {
+          ProLogger.debug("Removing amphib territory: " + patd.getTerritory() + ", enemyTUVSwing="
+              + enemyTuvSwing + ", attackValue=" + attackValue);
           attackMap.get(t).getUnits().clear();
           attackMap.get(t).getAmphibAttackMap().clear();
           attackMap.get(t).getBombardTerritoryMap().clear();
         } else {
-          ProLogger.debug("Keeping amphib territory: " + patd.getTerritory() + ", totalEnemyTUVSwing="
-              + totalEnemyTuvSwing + ", attackValue=" + attackValue);
+          ProLogger.debug("Keeping amphib territory: " + patd.getTerritory() + ", enemyTUVSwing="
+              + enemyTuvSwing + ", attackValue=" + attackValue);
         }
       }
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProData.java
@@ -41,17 +41,17 @@ public class ProData {
   public static ProPurchaseOptionMap purchaseOptions = null;
   public static double minCostPerHitPoint = Double.MAX_VALUE;
 
-  public static void initialize(final ProAI proAI) {
-    hiddenInitialize(proAI, proAI.getGameData(), proAI.getPlayerID(), false);
+  public static void initialize(final ProAI proAi) {
+    hiddenInitialize(proAi, proAi.getGameData(), proAi.getPlayerID(), false);
   }
 
-  public static void initializeSimulation(final ProAI proAI, final GameData data, final PlayerID player) {
-    hiddenInitialize(proAI, data, player, true);
+  public static void initializeSimulation(final ProAI proAi, final GameData data, final PlayerID player) {
+    hiddenInitialize(proAi, data, player, true);
   }
 
-  private static void hiddenInitialize(final ProAI proAI, final GameData data, final PlayerID player,
+  private static void hiddenInitialize(final ProAI proAi, final GameData data, final PlayerID player,
       final boolean isSimulation) {
-    ProData.proAI = proAI;
+    ProData.proAI = proAi;
     ProData.data = data;
     ProData.player = player;
     ProData.isSimulation = isSimulation;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -359,14 +359,14 @@ class ProNonCombatMoveAI {
       enemyAttackingUnits.addAll(enemyAttackOptions.getMax(t).getMaxAmphibUnits());
       patd.setMaxEnemyUnits(new ArrayList<>(enemyAttackingUnits));
       patd.setMaxEnemyBombardUnits(enemyAttackOptions.getMax(t).getMaxBombardUnits());
-      final List<Unit> minDefendingUnitsAndNotAA =
+      final List<Unit> minDefendingUnitsAndNotAntiAir =
           Match.getMatches(patd.getCantMoveUnits(), Matches.UnitIsAAforAnything.invert());
       final ProBattleResult minResult = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits),
-          minDefendingUnitsAndNotAA, enemyAttackOptions.getMax(t).getMaxBombardUnits());
+          minDefendingUnitsAndNotAntiAir, enemyAttackOptions.getMax(t).getMaxBombardUnits());
       patd.setMinBattleResult(minResult);
-      if (minResult.getTUVSwing() <= 0 && !minDefendingUnitsAndNotAA.isEmpty()) {
+      if (minResult.getTUVSwing() <= 0 && !minDefendingUnitsAndNotAntiAir.isEmpty()) {
         ProLogger.debug("Territory=" + t.getName() + ", CanHold=true" + ", MinDefenders="
-            + minDefendingUnitsAndNotAA.size() + ", EnemyAttackers=" + enemyAttackingUnits.size() + ", win%="
+            + minDefendingUnitsAndNotAntiAir.size() + ", EnemyAttackers=" + enemyAttackingUnits.size() + ", win%="
             + minResult.getWinPercentage() + ", EnemyTUVSwing=" + minResult.getTUVSwing() + ", hasLandUnitRemaining="
             + minResult.isHasLandUnitRemaining());
         continue;
@@ -376,9 +376,10 @@ class ProNonCombatMoveAI {
       final Set<Unit> defendingUnits = new HashSet<>(patd.getMaxUnits());
       defendingUnits.addAll(patd.getMaxAmphibUnits());
       defendingUnits.addAll(patd.getCantMoveUnits());
-      final List<Unit> defendingUnitsAndNotAA = Match.getMatches(defendingUnits, Matches.UnitIsAAforAnything.invert());
+      final List<Unit> defendingUnitsAndNotAntiAir =
+          Match.getMatches(defendingUnits, Matches.UnitIsAAforAnything.invert());
       final ProBattleResult result = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits),
-          defendingUnitsAndNotAA, enemyAttackOptions.getMax(t).getMaxBombardUnits());
+          defendingUnitsAndNotAntiAir, enemyAttackOptions.getMax(t).getMaxBombardUnits());
       int isFactory = 0;
       if (ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
         isFactory = 1;
@@ -387,14 +388,15 @@ class ProNonCombatMoveAI {
       if (t.equals(ProData.myCapital)) {
         isMyCapital = 1;
       }
-      final List<Unit> extraUnits = new ArrayList<>(defendingUnitsAndNotAA);
-      extraUnits.removeAll(minDefendingUnitsAndNotAA);
+      final List<Unit> extraUnits = new ArrayList<>(defendingUnitsAndNotAntiAir);
+      extraUnits.removeAll(minDefendingUnitsAndNotAntiAir);
       final double extraUnitValue = BattleCalculator.getTUV(extraUnits, ProData.unitValueMap);
       final double holdValue = extraUnitValue / 8 * (1 + 0.5 * isFactory) * (1 + 2 * isMyCapital);
-      if (minDefendingUnitsAndNotAA.size() != defendingUnitsAndNotAA.size()
+      if (minDefendingUnitsAndNotAntiAir.size() != defendingUnitsAndNotAntiAir.size()
           && (result.getTUVSwing() - holdValue) < minResult.getTUVSwing()) {
         ProLogger
-            .debug("Territory=" + t.getName() + ", CanHold=true" + ", MaxDefenders=" + defendingUnitsAndNotAA.size()
+            .debug("Territory=" + t.getName() + ", CanHold=true"
+                + ", MaxDefenders=" + defendingUnitsAndNotAntiAir.size()
                 + ", EnemyAttackers=" + enemyAttackingUnits.size() + ", minTUVSwing=" + minResult.getTUVSwing()
                 + ", win%=" + result.getWinPercentage() + ", EnemyTUVSwing=" + result.getTUVSwing()
                 + ", hasLandUnitRemaining=" + result.isHasLandUnitRemaining() + ", holdValue=" + holdValue);
@@ -403,7 +405,7 @@ class ProNonCombatMoveAI {
 
       // Can't hold territory
       patd.setCanHold(false);
-      ProLogger.debug("Can't hold Territory=" + t.getName() + ", MaxDefenders=" + defendingUnitsAndNotAA.size()
+      ProLogger.debug("Can't hold Territory=" + t.getName() + ", MaxDefenders=" + defendingUnitsAndNotAntiAir.size()
           + ", EnemyAttackers=" + enemyAttackingUnits.size() + ", minTUVSwing=" + minResult.getTUVSwing() + ", win%="
           + result.getWinPercentage() + ", EnemyTUVSwing=" + result.getTUVSwing() + ", hasLandUnitRemaining="
           + result.isHasLandUnitRemaining() + ", holdValue=" + holdValue);
@@ -506,13 +508,13 @@ class ProNonCombatMoveAI {
           && Match.noneMatch(moveMap.get(t).getMaxUnits(), Matches.UnitIsLand) && cantMoveUnitValue < 5;
       if (!patd.isCanHold() || patd.getValue() <= 0 || isLandAndCanOnlyBeAttackedByAir || isNotFactoryAndShouldHold
           || canAlreadyBeHeld || isNotFactoryAndHasNoEnemyNeighbors || isNotFactoryAndOnlyAmphib) {
-        final double TUVSwing = minResult.getTUVSwing();
+        final double tuvSwing = minResult.getTUVSwing();
         final boolean hasRemainingLandUnit = minResult.isHasLandUnitRemaining();
         ProLogger.debug("Removing territory=" + t.getName() + ", value=" + patd.getValue() + ", CanHold="
             + patd.isCanHold() + ", isLandAndCanOnlyBeAttackedByAir=" + isLandAndCanOnlyBeAttackedByAir
             + ", isNotFactoryAndShouldHold=" + isNotFactoryAndShouldHold + ", canAlreadyBeHeld=" + canAlreadyBeHeld
             + ", isNotFactoryAndHasNoEnemyNeighbors=" + isNotFactoryAndHasNoEnemyNeighbors
-            + ", isNotFactoryAndOnlyAmphib=" + isNotFactoryAndOnlyAmphib + ", TUVSwing=" + TUVSwing
+            + ", isNotFactoryAndOnlyAmphib=" + isNotFactoryAndOnlyAmphib + ", tuvSwing=" + tuvSwing
             + ", hasRemainingLandUnit=" + hasRemainingLandUnit + ", maxEnemyUnits=" + patd.getMaxEnemyUnits().size());
         it.remove();
       }
@@ -1948,9 +1950,9 @@ class ProNonCombatMoveAI {
           // Find value and try to move to territory that doesn't already have AA
           final List<Unit> units = new ArrayList<>(moveMap.get(t).getCantMoveUnits());
           units.addAll(moveMap.get(t).getUnits());
-          final boolean hasAA = Match.someMatch(units, Matches.UnitIsAAforAnything);
+          final boolean hasAntiAir = Match.someMatch(units, Matches.UnitIsAAforAnything);
           double value = moveMap.get(t).getValue();
-          if (hasAA) {
+          if (hasAntiAir) {
             value *= 0.01;
           }
           ProLogger.trace(t.getName() + " has value=" + value);

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
@@ -144,10 +144,10 @@ class ProPoliticsAI {
         Collections.shuffle(actionChoicesOther);
         int i = 0;
         final double random = Math.random();
-        final int MAX_OTHER_ACTIONS_PER_TURN =
+        final int maxOtherActionsPerTurn =
             (random < .3 ? 0 : (random < .6 ? 1 : (random < .9 ? 2 : (random < .99 ? 3 : (int) numPlayers))));
         final Iterator<PoliticalActionAttachment> actionOtherIter = actionChoicesOther.iterator();
-        while (actionOtherIter.hasNext() && MAX_OTHER_ACTIONS_PER_TURN > 0) {
+        while (actionOtherIter.hasNext() && maxOtherActionsPerTurn > 0) {
           final PoliticalActionAttachment action = actionOtherIter.next();
           if (!Matches.AbstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())
               .match(action)) {
@@ -157,7 +157,7 @@ class ProPoliticsAI {
             continue;
           }
           i++;
-          if (i > MAX_OTHER_ACTIONS_PER_TURN) {
+          if (i > maxOtherActionsPerTurn) {
             break;
           }
           results.add(action);

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -716,10 +716,10 @@ class ProPurchaseAI {
       final boolean enemyCanBomb =
           Match.someMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsStrategicBomber);
       final boolean territoryCanBeBombed = t.getUnits().someMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
-      final boolean hasAABombingDefense = t.getUnits().someMatch(Matches.UnitIsAAforBombingThisUnitOnly);
+      final boolean hasAntiAirBombingDefense = t.getUnits().someMatch(Matches.UnitIsAAforBombingThisUnitOnly);
       ProLogger.debug(t + ", enemyCanBomb=" + enemyCanBomb + ", territoryCanBeBombed=" + territoryCanBeBombed
-          + ", hasAABombingDefense=" + hasAABombingDefense);
-      if (!enemyCanBomb || !territoryCanBeBombed || hasAABombingDefense) {
+          + ", hasAABombingDefense=" + hasAntiAirBombingDefense);
+      if (!enemyCanBomb || !territoryCanBeBombed || hasAntiAirBombingDefense) {
         continue;
       }
 
@@ -733,27 +733,28 @@ class ProPurchaseAI {
       }
 
       // Determine most cost efficient units that can be produced in this territory
-      ProPurchaseOption bestAAOption = null;
+      ProPurchaseOption bestAntiAirOption = null;
       int minCost = Integer.MAX_VALUE;
       for (final ProPurchaseOption ppo : purchaseOptionsForTerritory) {
-        final boolean isAAForBombing = Matches.UnitTypeIsAAforBombingThisUnitOnly.match(ppo.getUnitType());
-        if (isAAForBombing && ppo.getCost() < minCost
+        final boolean isAntiAirForBombing = Matches.UnitTypeIsAAforBombingThisUnitOnly.match(ppo.getUnitType());
+        if (isAntiAirForBombing && ppo.getCost() < minCost
             && !Matches.UnitTypeConsumesUnitsOnCreation.match(ppo.getUnitType())) {
-          bestAAOption = ppo;
+          bestAntiAirOption = ppo;
           minCost = ppo.getCost();
         }
       }
 
       // Check if there aren't any available units
-      if (bestAAOption == null) {
+      if (bestAntiAirOption == null) {
         continue;
       }
-      ProLogger.trace("Best AA unit: " + bestAAOption.getUnitType().getName());
+      ProLogger.trace("Best AA unit: " + bestAntiAirOption.getUnitType().getName());
 
       // Create new temp units
-      resourceTracker.purchase(bestAAOption);
-      remainingUnitProduction -= bestAAOption.getQuantity();
-      final List<Unit> unitsToPlace = bestAAOption.getUnitType().create(bestAAOption.getQuantity(), player, true);
+      resourceTracker.purchase(bestAntiAirOption);
+      remainingUnitProduction -= bestAntiAirOption.getQuantity();
+      final List<Unit> unitsToPlace =
+          bestAntiAirOption.getUnitType().create(bestAntiAirOption.getQuantity(), player, true);
       placeTerritory.getPlaceUnits().addAll(unitsToPlace);
       ProLogger.trace(t + ", placedUnits=" + unitsToPlace);
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProRetreatAI.java
@@ -50,14 +50,14 @@ class ProRetreatAI {
     calc = ai.getCalc();
   }
 
-  Territory retreatQuery(final GUID battleID, final Territory battleTerritory,
+  Territory retreatQuery(final GUID battleId, final Territory battleTerritory,
       final Collection<Territory> possibleTerritories) {
 
     // Get battle data
     final GameData data = ProData.getData();
     final PlayerID player = ProData.getPlayer();
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
-    final IBattle battle = delegate.getBattleTracker().getPendingBattle(battleID);
+    final IBattle battle = delegate.getBattleTracker().getPendingBattle(battleId);
 
     // Get units and determine if attacker
     final boolean isAttacker = player.equals(battle.getAttacker());

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -90,9 +90,9 @@ final class ProTechAI {
   private static float getStrengthOfPotentialAttackers(final Territory location, final GameData data,
       final PlayerID player, final boolean tFirst, final boolean ignoreOnlyPlanes, final List<Territory> ignoreTerr) {
     PlayerID ePlayer = null;
-    final List<PlayerID> qID = getEnemyPlayers(data, player);
+    final List<PlayerID> enemyPlayers = getEnemyPlayers(data, player);
     final HashMap<PlayerID, Float> ePAttackMap = new HashMap<>();
-    final Iterator<PlayerID> playerIter = qID.iterator();
+    final Iterator<PlayerID> playerIter = enemyPlayers.iterator();
     if (location == null) {
       return -1000.0F;
     }
@@ -271,13 +271,13 @@ final class ProTechAI {
       ePAttackMap.put(ePlayer, strength);
     }
     float maxStrength = 0.0F;
-    for (final PlayerID xP : qID) {
+    for (final PlayerID xP : enemyPlayers) {
       if (ePAttackMap.get(xP) > maxStrength) {
         ePlayer = xP;
         maxStrength = ePAttackMap.get(xP);
       }
     }
-    for (final PlayerID xP : qID) {
+    for (final PlayerID xP : enemyPlayers) {
       if (ePlayer != xP) {
         // give 40% of other players...this is will affect a lot of decisions by AI
         maxStrength += ePAttackMap.get(xP) * 0.40F;

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProBattleResult.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProBattleResult.java
@@ -23,11 +23,11 @@ public class ProBattleResult {
     battleRounds = 0;
   }
 
-  public ProBattleResult(final double winPercentage, final double TUVSwing, final boolean hasLandUnitRemaining,
+  public ProBattleResult(final double winPercentage, final double tuvSwing, final boolean hasLandUnitRemaining,
       final List<Unit> averageAttackersRemaining, final List<Unit> averageDefendersRemaining,
       final double battleRounds) {
     this.winPercentage = winPercentage;
-    this.TUVSwing = TUVSwing;
+    this.TUVSwing = tuvSwing;
     this.hasLandUnitRemaining = hasLandUnitRemaining;
     this.averageAttackersRemaining = averageAttackersRemaining;
     this.averageDefendersRemaining = averageDefendersRemaining;

--- a/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProDummyDelegateBridge.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/simulate/ProDummyDelegateBridge.java
@@ -31,8 +31,8 @@ public class ProDummyDelegateBridge implements IDelegateBridge {
   private final CompositeChange m_allChanges = new CompositeChange();
   private MustFightBattle m_battle = null;
 
-  public ProDummyDelegateBridge(final ProAI proAI, final PlayerID player, final GameData data) {
-    m_proAI = proAI;
+  public ProDummyDelegateBridge(final ProAI proAi, final PlayerID player, final GameData data) {
+    m_proAI = proAi;
     m_data = data;
     m_player = player;
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -84,9 +84,9 @@ public class ProBattleUtils {
     if (Properties.getTransportCasualtiesRestricted(data)) {
       unitsThatCanFight = Match.getMatches(unitsThatCanFight, Matches.UnitIsTransportButNotCombatTransport.invert());
     }
-    final int myHP = BattleCalculator.getTotalHitpointsLeft(unitsThatCanFight);
+    final int myHitPoints = BattleCalculator.getTotalHitpointsLeft(unitsThatCanFight);
     final double myPower = estimatePower(t, myUnits, enemyUnits, attacking);
-    return (2 * myHP) + myPower;
+    return (2 * myHitPoints) + myPower;
   }
 
   private static double estimatePower(final Territory t, final List<Unit> myUnits, final List<Unit> enemyUnits,

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -139,28 +139,28 @@ public class ProOddsCalculator {
         Match.getMatches(attackingUnits, Matches.UnitCanBeInBattle(true, !t.isWater(), 1, false, true, true));
     final List<Unit> mainCombatDefenders =
         Match.getMatches(defendingUnits, Matches.UnitCanBeInBattle(false, !t.isWater(), 1, false, true, true));
-    double TUVswing = results.getAverageTUVswing(attacker, mainCombatAttackers, defender, mainCombatDefenders, data);
+    double tuvSwing = results.getAverageTUVswing(attacker, mainCombatAttackers, defender, mainCombatDefenders, data);
     if (Matches.TerritoryIsNeutralButNotWater.match(t)) { // Set TUV swing for neutrals
       final double attackingUnitValue = BattleCalculator.getTUV(mainCombatAttackers, ProData.unitValueMap);
       final double remainingUnitValue =
           results.getAverageTUVofUnitsLeftOver(ProData.unitValueMap, ProData.unitValueMap).getFirst();
-      TUVswing = remainingUnitValue - attackingUnitValue;
+      tuvSwing = remainingUnitValue - attackingUnitValue;
     }
     final List<Unit> defendingTransportedUnits = Match.getMatches(defendingUnits, Matches.unitIsBeingTransported());
     if (t.isWater() && !defendingTransportedUnits.isEmpty()) { // Add TUV swing for transported units
       final double transportedUnitValue = BattleCalculator.getTUV(defendingTransportedUnits, ProData.unitValueMap);
-      TUVswing += transportedUnitValue * winPercentage / 100;
+      tuvSwing += transportedUnitValue * winPercentage / 100;
     }
 
     // Create battle result object
     final List<Territory> tList = new ArrayList<>();
     tList.add(t);
     if (Match.allMatch(tList, Matches.TerritoryIsLand)) {
-      return new ProBattleResult(winPercentage, TUVswing,
+      return new ProBattleResult(winPercentage, tuvSwing,
           Match.someMatch(averageAttackersRemaining, Matches.UnitIsLand), averageAttackersRemaining,
           averageDefendersRemaining, results.getAverageBattleRoundsFought());
     } else {
-      return new ProBattleResult(winPercentage, TUVswing, !averageAttackersRemaining.isEmpty(),
+      return new ProBattleResult(winPercentage, tuvSwing, !averageAttackersRemaining.isEmpty(),
           averageAttackersRemaining, averageDefendersRemaining, results.getAverageBattleRoundsFought());
     }
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -35,8 +35,8 @@ public class ProTerritoryValueUtils {
           ProBattleUtils.estimateStrength(t, new ArrayList<>(t.getUnits().getUnits()), new ArrayList<>(), false);
 
       // Estimate TUV swing as number of casualties * cost
-      final double TUVSwing = -(strength / 8) * ProData.minCostPerHitPoint;
-      value += TUVSwing;
+      final double tuvSwing = -(strength / 8) * ProData.minCostPerHitPoint;
+      value += tuvSwing;
     }
 
     return value;

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -809,8 +809,8 @@ public class WeakAI extends AbstractAI {
       defUnitsAtAmpibRoute = amphibRoute.getEnd().getUnits().getUnitCount();
     }
     final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-    final int totPu = player.getResources().getQuantity(PUs);
-    int leftToSpend = totPu;
+    final int totalPu = player.getResources().getQuantity(PUs);
+    int leftToSpend = totalPu;
     final Territory capitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
     final List<ProductionRule> rules = player.getProductionFrontier().getRules();
     final IntegerMap<ProductionRule> purchase = new IntegerMap<>();
@@ -863,7 +863,7 @@ public class WeakAI extends AbstractAI {
       //
       // if capitol is super safe, we don't have to do this. and if capitol is under siege, we should repair enough to
       // place all our units here
-      int maxUnits = (totPu - 1) / minimumUnitPrice;
+      int maxUnits = (totalPu - 1) / minimumUnitPrice;
       if ((capProduction <= maxUnits / 2 || rfactories.isEmpty()) && capUnit != null) {
         for (final RepairRule rrule : rrules) {
           if (!capUnit.getUnitType().equals(rrule.getResults().keySet().iterator().next())) {

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -535,7 +535,7 @@ public class WeakAI extends AbstractAI {
     final Match<Territory> routeCondition = new CompositeMatchAnd<>(
         Matches.territoryHasEnemyAAforCombatOnly(player, data).invert(), Matches.TerritoryIsImpassable.invert());
     for (final Territory t : delegateRemote.getTerritoriesWhereAirCantLand()) {
-      final Route noAARoute = Utils.findNearest(t, canLand, routeCondition, data);
+      final Route noAntiAirRoute = Utils.findNearest(t, canLand, routeCondition, data);
       final Route aaRoute = Utils.findNearest(t, canLand, Matches.TerritoryIsImpassable.invert(), data);
       final Collection<Unit> airToLand =
           t.getUnits().getMatches(new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.unitIsOwnedBy(player)));
@@ -544,7 +544,7 @@ public class WeakAI extends AbstractAI {
       // simply move first over no aa, then with aa
       // one (but hopefully not both) will be rejected
       moveUnits.add(airToLand);
-      moveRoutes.add(noAARoute);
+      moveRoutes.add(noAntiAirRoute);
       moveUnits.add(airToLand);
       moveRoutes.add(aaRoute);
     }
@@ -809,8 +809,8 @@ public class WeakAI extends AbstractAI {
       defUnitsAtAmpibRoute = amphibRoute.getEnd().getUnits().getUnitCount();
     }
     final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-    final int totPU = player.getResources().getQuantity(PUs);
-    int leftToSpend = totPU;
+    final int totPu = player.getResources().getQuantity(PUs);
+    int leftToSpend = totPu;
     final Territory capitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
     final List<ProductionRule> rules = player.getProductionFrontier().getRules();
     final IntegerMap<ProductionRule> purchase = new IntegerMap<>();
@@ -863,7 +863,7 @@ public class WeakAI extends AbstractAI {
       //
       // if capitol is super safe, we don't have to do this. and if capitol is under siege, we should repair enough to
       // place all our units here
-      int maxUnits = (totPU - 1) / minimumUnitPrice;
+      int maxUnits = (totPu - 1) / minimumUnitPrice;
       if ((capProduction <= maxUnits / 2 || rfactories.isEmpty()) && capUnit != null) {
         for (final RepairRule rrule : rrules) {
           if (!capUnit.getUnitType().equals(rrule.getResults().keySet().iterator().next())) {


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in local variables.

For the most part, I did **not** expand abbreviations where they caused a violation; I simply converted them using the abbreviation naming convention established in #1659.  Please advise if any should be expanded.

The abbreviations that were expanded included:

* `AA` --> `AntiAir`
* `HP` --> `HitPoints`
* `NI` --> `NetworkInterface`

Due to the large number of violations that fall under this category, the fixes are being split over multiple PRs to keep the review size reasonable.