### PR TITLE
Update Bonus Income By Improving Player Selection UI and Setting Starting Point to 100%

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -910,7 +910,7 @@ public class GameParser {
       }
     }
     data.getPlayerList().forEach(playerId -> data.getProperties().addPlayerProperty(
-        new NumberProperty(Constants.getBonusIncomePercentageFor(playerId), null, 999, 0, 0)));
+        new NumberProperty(Constants.getBonusIncomePercentageFor(playerId), null, 999, 0, 100)));
   }
 
   private void parseEditableProperty(final Element property, final String name, final String defaultValue)

--- a/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -71,9 +71,9 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     final JLabel allianceLabel = new JLabel("Alliance");
     this.add(allianceLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
-    final JLabel bonusLabel = new JLabel("Bonus Income Percentage");
+    final JLabel bonusLabel = new JLabel("Income");
     this.add(bonusLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
+        GridBagConstraints.NONE, new Insets(0, 20, 5, 0), 0, 0));
     for (final PlayerID player : players) {
       final PlayerSelectorRow selector =
           new PlayerSelectorRow(player, reloadSelections, disableable, playersEnablementListing,

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -455,9 +455,9 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     final JLabel allianceLabel = new JLabel("Alliance");
     m_localPlayerPanel.add(allianceLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
-    final JLabel bonusLabel = new JLabel("Bonus Income Percentage");
+    final JLabel bonusLabel = new JLabel("Income");
     m_localPlayerPanel.add(bonusLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
+        GridBagConstraints.NONE, new Insets(0, 20, 5, 0), 0, 0));
     for (final PlayerID player : players) {
       final PlayerSelectorRow selector =
           new PlayerSelectorRow(player, reloadSelections, disableable, playersEnablementListing,

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -25,6 +25,7 @@ class PlayerSelectorRow {
   private final String playerName;
   private final JComboBox<String> playerTypes;
   private JComponent bonusIncomePercentage;
+  private final JLabel bonusIncomePercentageLabel;
   private boolean enabled = true;
   private final JLabel name;
   private final JLabel alliances;
@@ -87,6 +88,7 @@ class PlayerSelectorRow {
       bonusIncomePercentage =
           gameProperties.getPlayerProperty(Constants.getBonusIncomePercentageFor(player)).getEditorComponent();
     }
+    bonusIncomePercentageLabel = new JLabel("%");
 
     setWidgetActivation();
   }
@@ -106,7 +108,10 @@ class PlayerSelectorRow {
     // TODO: remove null check for next incompatible release
     if (bonusIncomePercentage != null) {
       container.add(bonusIncomePercentage, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-          GridBagConstraints.NONE, new Insets(0, 50, 5, 0), 0, 0));
+          GridBagConstraints.NONE, new Insets(0, 20, 5, 0), 0, 0));
+      container.add(bonusIncomePercentageLabel,
+          new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+              GridBagConstraints.NONE, new Insets(0, 5, 5, 5), 0, 0));
     }
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -33,7 +33,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.triplea.util.AiBonusIncomeUtils;
+import games.strategy.triplea.util.BonusIncomeUtils;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
@@ -124,7 +124,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       endTurnReport.append("<br />").append(doNationalObjectivesAndOtherEndTurnEffects(m_bridge));
       final IntegerMap<Resource> income = m_player.getResources().getResourcesCopy();
       income.subtract(leftOverResources);
-      endTurnReport.append("<br />").append(AiBonusIncomeUtils.addAiBonusIncome(income, m_bridge, m_player));
+      endTurnReport.append("<br />").append(BonusIncomeUtils.addBonusIncome(income, m_bridge, m_player));
 
       // now we do upkeep costs, including upkeep cost as a percentage of our entire income for this turn (including
       // NOs)

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -23,7 +23,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.triplea.util.AiBonusIncomeUtils;
+import games.strategy.triplea.util.BonusIncomeUtils;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -169,7 +169,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
 
   private static void initAiStartingBonusIncome(final IDelegateBridge bridge) {
     bridge.getData().getPlayerList().getPlayers().forEach(
-        player -> AiBonusIncomeUtils.addAiBonusIncome(player.getResources().getResourcesCopy(), bridge, player));
+        player -> BonusIncomeUtils.addBonusIncome(player.getResources().getResourcesCopy(), bridge, player));
   }
 
   private static void initDeleteAssetsOfDisabledPlayers(final IDelegateBridge aBridge) {

--- a/src/main/java/games/strategy/triplea/util/AiBonusIncomeUtils.java
+++ b/src/main/java/games/strategy/triplea/util/AiBonusIncomeUtils.java
@@ -20,14 +20,14 @@ public class AiBonusIncomeUtils {
     final StringBuilder sb = new StringBuilder();
     for (final Resource resource : income.keySet()) {
       final int amount = income.getInt(resource);
-      final int bonusPercent = Properties.getBonusIncomePercentage(player, bridge.getData());
-      final int bonusIncome = (int) Math.round(((double) amount * (double) bonusPercent / 100));
+      final int incomePercent = Properties.getBonusIncomePercentage(player, bridge.getData());
+      final int bonusIncome = (int) Math.round(((double) amount * (double) (incomePercent - 100) / 100));
       if (bonusIncome == 0) {
         continue;
       }
       final int total = player.getResources().getQuantity(resource) + bonusIncome;
-      final String message = "Giving " + player.getName() + " " + bonusPercent + "% bonus income of " + bonusIncome
-          + " " + resource.getName() + "; end with " + total + " " + resource.getName();
+      final String message = "Giving " + player.getName() + " " + (incomePercent - 100) + "% bonus income of "
+          + bonusIncome + " " + resource.getName() + "; end with " + total + " " + resource.getName();
       bridge.getHistoryWriter().startEvent(message);
       bridge.addChange(ChangeFactory.changeResourcesChange(player, resource, bonusIncome));
       sb.append(message).append("<br />");

--- a/src/main/java/games/strategy/triplea/util/BonusIncomeUtils.java
+++ b/src/main/java/games/strategy/triplea/util/BonusIncomeUtils.java
@@ -8,14 +8,14 @@ import games.strategy.triplea.Properties;
 import games.strategy.util.IntegerMap;
 
 
-public class AiBonusIncomeUtils {
+public class BonusIncomeUtils {
 
   /**
    * Add AI bonus income based on the player's set percentage for all resources.
    * 
    * @return string that summarizes all the changes
    */
-  public static String addAiBonusIncome(final IntegerMap<Resource> income, final IDelegateBridge bridge,
+  public static String addBonusIncome(final IntegerMap<Resource> income, final IDelegateBridge bridge,
       final PlayerID player) {
     final StringBuilder sb = new StringBuilder();
     for (final Resource resource : income.keySet()) {


### PR DESCRIPTION
Some small updates to bonus income based on feedback: https://forums.triplea-game.org/topic/113/ai-bonus-settings-revamp/50

Functional Changes
- Update player selection UI to be more intuitive and look cleaner
- Update bonus income to have starting point at 100% instead of 0%