### PR TITLE
Minor line ordering edit to README to test travis config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Lobby Game Bot Hosting
 ======================
 - Please see: https://github.com/triplea-game/lobby#run-hosted-bots
 
-Development and Map Making
-==========================
+Development
+===========
+- Accepted feature requests: https://github.com/triplea-game/triplea/wiki/Feature-Back-Log
 - Full project documentation, including 'how to get started guides' are at: http://www.triplea-game.org/dev_docs/
 - Broken map list: https://github.com/triplea-game/triplea/wiki/Broken-Maps
-- Accepted feature requests: https://github.com/triplea-game/triplea/wiki/Feature-Back-Log


### PR DESCRIPTION
Minor, re-order lines. This is mostly to test travis configuration
 (we may want to drop the 'broken map list' from the readme main page. It is not in quite the right context, the broken map wiki page is a tracking document for maps that are broken and dropped from download.)