### PR TITLE
Remove empty skipped tests

### DIFF
--- a/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
@@ -17,7 +17,6 @@ import java.util.Observer;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -249,27 +248,5 @@ public class GameSelectorModelTest {
   public void testGetGameVersion() {
     this.testObjectSetMockGameData();
     assertThat(testObj.getGameVersion(), is(fakeGameVersion));
-  }
-
-  @Ignore
-  @Test
-  public void testLoadFromInputStream() {
-    // testObj.load(InputStream, string fileName);
-    // TODO
-  }
-
-
-  @Ignore
-  @Test
-  public void testLoadFromFile() {
-    // testObj.load(File, Component);
-    // TODO
-  }
-
-  @Ignore
-  @Test
-  public void testLoadDefaultGame() {
-    // testObj.loadDefaultGame(Component);
-    // TODO
   }
 }


### PR DESCRIPTION
These skipped tests offer no value.  The comments don't describe any methodology that would be useful to someone implementing these tests in the future.  They simply call out that the corresponding methods have no test coverage, which can be inferred from a coverage report.