### PR TITLE
Travis push_tag script improvements and delete tag fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ jdk:
 addons:
   apt:
     packages:
+      # python for map file splitter
       - python3
       - python3-yaml
+      # cowsay output formatter, for better readability
+      - cowsay
 install: true
 after_success: ./.travis/update_checkstyle_thresholds
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ addons:
       # python for map file splitter
       - python3
       - python3-yaml
-      # cowsay output formatter, for better readability
-      - cowsay
 install: true
 after_success: ./.travis/update_checkstyle_thresholds
 before_deploy:

--- a/.travis/push_tag
+++ b/.travis/push_tag
@@ -28,7 +28,6 @@ deleteExistingTag() {
   ## sed is to mask out access token in case the https url is printed 
   git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --delete "refs/tags/$TAGGED_VERSION" \
      | sed 's|https://.*github|https://[secure]@github|'
-  git tag -d "$TAGGED_VERSION"
 
   echo "Done doing tag deletes, ignore any errors immediately above if there are any for failing to delete non-existent tags"
 } 
@@ -37,7 +36,7 @@ deleteExistingTag() {
 
 createTag() {
   echo -n "Tagging current branch .. "
-  git tag "$TAGGED_VERSION" -a -m "$TAGGED_VERSION"
+  git tag "$TAGGED_VERSION" -a -f -m "$TAGGED_VERSION"
   result=$?
   if [ "$result" == 0 ]; then
     echo "Success - created tag: $TAGGED_VERSION"

--- a/.travis/push_tag
+++ b/.travis/push_tag
@@ -52,8 +52,6 @@ pushTag() {
 
   git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags 2>&1 | sed 's|https://.*github|https://[secure]@github|'
   result=$?
-  # install cowsay result formatter, for better readability
-  sudo aptitude -y install cowsay
 
   if [ "$result" == 0 ]; then
     echo "Successfully pushed tag $TAGGED_VERSION to github!" | cowsay

--- a/.travis/push_tag
+++ b/.travis/push_tag
@@ -26,7 +26,7 @@ configGithub() {
 deleteExistingTag() {
   echo "Attempting to delete tag $TAGGED_VERSION, this is so we will recreate the release if this build is being re-run."
   ## sed is to mask out access token in case the https url is printed 
-  git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea ":refs/tags/$TAGGED_VERSION" \
+  git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --delete "refs/tags/$TAGGED_VERSION" \
      | sed 's|https://.*github|https://[secure]@github|'
   git tag -d "$TAGGED_VERSION"
 
@@ -51,14 +51,6 @@ pushTag() {
   echo "Pushing tag: $TAGGED_VERSION to github to trigger releases deployment"
 
   git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags 2>&1 | sed 's|https://.*github|https://[secure]@github|'
-  result=$?
-
-  if [ "$result" == 0 ]; then
-    echo "Successfully pushed tag $TAGGED_VERSION to github!" | cowsay
-  else
-    echo "FAILED to push tag $TAGGED_VERSION to github!" | cowsay -d
-    exit 1
-  fi
 }
 
 main

--- a/.travis/push_tag
+++ b/.travis/push_tag
@@ -1,13 +1,66 @@
 #!/bin/bash
 
-echo "Configure Git and PUSH A TAG - this trigger and execute the deploy section of this same build file, in the same travis linux container (skip_cleanup setting below is important)"
-git config --global user.email "tripleabuilderbot@gmail.com"
-git config --global user.name "tripleabuilderbot"
+#
+# This script pushes a tag to github, that creates a github release and triggers a travis release build
+# which then builds the release artifacts and deploys them to the github release.
+#
+# Note, the tag itself is also considered a branch and trigger an extraneous branch build in travis.
+#
 
-echo "Delete previous tag if it exists, this way we can restart builds and regenerate artifacts in case anything goes wrong"
-git tag -d "$TAGGED_VERSION"
-git push origin ":refs/tags/$TAGGED_VERSION"
+set -u
 
-echo "Push a tag to trigger github releases deployment"
-git tag $TAGGED_VERSION -a -m "$TAGGED_VERSION"
-git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags 2>&1 | sed 's|https://.*github|https://[secure]@github|'
+main() {
+  configGithub
+  deleteExistingTag
+  createTag
+  pushTag
+}
+
+configGithub() {
+  echo "Configure Git and PUSH A TAG - this trigger and execute the deploy section of this same build file, in the same travis linux container (skip_cleanup setting below is important)"
+  git config --global user.email "tripleabuilderbot@gmail.com"
+  git config --global user.name "tripleabuilderbot"
+}
+
+
+deleteExistingTag() {
+  echo "Attempting to delete tag $TAGGED_VERSION, this is so we will recreate the release if this build is being re-run."
+  ## sed is to mask out access token in case the https url is printed 
+  git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea ":refs/tags/$TAGGED_VERSION" \
+     | sed 's|https://.*github|https://[secure]@github|'
+  git tag -d "$TAGGED_VERSION"
+
+  echo "Done doing tag deletes, ignore any errors immediately above if there are any for failing to delete non-existent tags"
+} 
+
+
+
+createTag() {
+  echo -n "Tagging current branch .. "
+  git tag "$TAGGED_VERSION" -a -m "$TAGGED_VERSION"
+  result=$?
+  if [ "$result" == 0 ]; then
+    echo "Success - created tag: $TAGGED_VERSION"
+  else 
+    echo "Failed - did not create tag: $TAGGED_VERSION"
+    exit 1
+  fi
+}
+
+pushTag() {
+  echo "Pushing tag: $TAGGED_VERSION to github to trigger releases deployment"
+
+  git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags 2>&1 | sed 's|https://.*github|https://[secure]@github|'
+  result=$?
+  # install cowsay result formatter, for better readability
+  sudo aptitude -y install cowsay
+
+  if [ "$result" == 0 ]; then
+    echo "Successfully pushed tag $TAGGED_VERSION to github!" | cowsay
+  else
+    echo "FAILED to push tag $TAGGED_VERSION to github!" | cowsay -d
+    exit 1
+  fi
+}
+
+main


### PR DESCRIPTION
- The delete tag in push_tags was broken and was generating an authentication failure message. This should be fixed by instead using an https url with access token defined in it.
- Break script up into functions and add a main function to define overall flow
- Check result output from tag creation and push, report more explicitly when those fail.

Related to: https://github.com/triplea-game/triplea/issues/1586#issuecomment-306363274
