### PR TITLE
Checkstyle: Fix abbreviation violations in local variables (part 3)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 checkstyleIntegTestMaxWarnings=1
-checkstyleMainMaxWarnings=4303
+checkstyleMainMaxWarnings=4254
 checkstyleTestMaxWarnings=54

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -807,16 +807,16 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     // check for battle stats
     if (objectiveMet && m_destroyedTUV != null) {
       final String[] s = m_destroyedTUV.split(":");
-      final int requiredDestroyedTUV = getInt(s[0]);
-      if (requiredDestroyedTUV >= 0) {
+      final int requiredDestroyedTuv = getInt(s[0]);
+      if (requiredDestroyedTuv >= 0) {
         final boolean justCurrentRound = s[1].equals("currentRound");
-        final int destroyedTUVforThisRoundSoFar = BattleRecordsList.getTUVdamageCausedByPlayer(playerAttachedTo,
+        final int destroyedTuvForThisRoundSoFar = BattleRecordsList.getTUVdamageCausedByPlayer(playerAttachedTo,
             data.getBattleRecordsList(), 0, data.getSequence().getRound(), justCurrentRound, false);
-        if (requiredDestroyedTUV > destroyedTUVforThisRoundSoFar) {
+        if (requiredDestroyedTuv > destroyedTuvForThisRoundSoFar) {
           objectiveMet = false;
         }
         if (getCountEach()) {
-          m_eachMultiple = destroyedTUVforThisRoundSoFar;
+          m_eachMultiple = destroyedTuvForThisRoundSoFar;
         }
       }
     }

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1165,9 +1165,9 @@ public class TechAbilityAttachment extends DefaultAttachment {
     for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, data)) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
       if (taa != null) {
-        final HashMap<String, HashSet<UnitType>> mapAA = taa.getAirborneTargettedByAA();
-        if (mapAA != null && !mapAA.isEmpty()) {
-          for (final Entry<String, HashSet<UnitType>> entry : mapAA.entrySet()) {
+        final HashMap<String, HashSet<UnitType>> mapAntiAir = taa.getAirborneTargettedByAA();
+        if (mapAntiAir != null && !mapAntiAir.isEmpty()) {
+          for (final Entry<String, HashSet<UnitType>> entry : mapAntiAir.entrySet()) {
             HashSet<UnitType> current = rVal.get(entry.getKey());
             if (current == null) {
               current = new HashSet<>();
@@ -1252,9 +1252,9 @@ public class TechAbilityAttachment extends DefaultAttachment {
         } else if (propertyString.equals(TechAdvance.TECH_PROPERTY_AA_RADAR)) {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
-          final List<UnitType> allAA =
+          final List<UnitType> allAntiAir =
               Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeIsAAforAnything);
-          for (final UnitType aa : allAA) {
+          for (final UnitType aa : allAntiAir) {
             taa.setRadarBonus("1:" + aa.getName());
           }
         } else if (propertyString.equals(TechAdvance.TECH_PROPERTY_SUPER_SUBS)) {
@@ -1319,14 +1319,14 @@ public class TechAbilityAttachment extends DefaultAttachment {
           final List<UnitType> allBombers =
               Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeIsStrategicBomber);
           final int heavyBomberDiceRollsTotal = games.strategy.triplea.Properties.getHeavyBomberDiceRolls(data);
-          final boolean heavyBombersLHTR = games.strategy.triplea.Properties.getLHTR_Heavy_Bombers(data);
+          final boolean heavyBombersLhtr = games.strategy.triplea.Properties.getLHTR_Heavy_Bombers(data);
           for (final UnitType bomber : allBombers) {
             // TODO: The bomber dice rolls get set when the xml is parsed.
             // we subtract the base rolls to get the bonus
             final int heavyBomberDiceRollsBonus =
                 heavyBomberDiceRollsTotal - UnitAttachment.get(bomber).getAttackRolls(PlayerID.NULL_PLAYERID);
             taa.setAttackRollsBonus(heavyBomberDiceRollsBonus + ":" + bomber.getName());
-            if (heavyBombersLHTR) {
+            if (heavyBombersLhtr) {
               // TODO: this all happens WHEN the xml is parsed. Which means if the user changes the game options, this
               // does not get changed.
               // (meaning, turning on LHTR bombers will not result in this bonus damage, etc. It would have to start on,

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -644,9 +644,9 @@ public class TerritoryAttachment extends DefaultAttachment {
     return rVal;
   }
 
-  public String toStringForInfo(final boolean useHTML, final boolean includeAttachedToName) {
+  public String toStringForInfo(final boolean useHtml, final boolean includeAttachedToName) {
     final StringBuilder sb = new StringBuilder("");
-    final String br = (useHTML ? "<br>" : ", ");
+    final String br = (useHtml ? "<br>" : ", ");
     final Territory t = (Territory) this.getAttachedTo();
     if (t == null) {
       return sb.toString();
@@ -732,7 +732,7 @@ public class TerritoryAttachment extends DefaultAttachment {
         sb.append(br);
       }
       if (m_resources != null) {
-        if (useHTML) {
+        if (useHtml) {
           sb.append("&nbsp;&nbsp;&nbsp;&nbsp;")
               .append((m_resources.toStringForHTML()).replaceAll("<br>", "<br>&nbsp;&nbsp;&nbsp;&nbsp;"));
         } else {

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2418,11 +2418,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
           }
           aBridge.addChange(
               ChangeFactory.changeResourcesChange(aPlayer, data.getResourceList().getResource(t.getResource()), toAdd));
-          final String PUMessage = MyFormatter.attachmentNameToText(t.getName()) + ": " + aPlayer.getName()
+          final String puMessage = MyFormatter.attachmentNameToText(t.getName()) + ": " + aPlayer.getName()
               + " met a national objective for an additional " + t.getResourceCount() + " " + t.getResource()
               + "; end with " + total + " " + t.getResource();
-          aBridge.getHistoryWriter().startEvent(PUMessage);
-          strbuf.append(PUMessage).append(" <br />");
+          aBridge.getHistoryWriter().startEvent(puMessage);
+          strbuf.append(puMessage).append(" <br />");
         }
       }
     }

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2828,7 +2828,7 @@ public class UnitAttachment extends DefaultAttachment {
         + (m_placementLimit != null ? m_placementLimit.toString() : "null");
   }
 
-  public String toStringShortAndOnlyImportantDifferences(final PlayerID player, final boolean useHTML,
+  public String toStringShortAndOnlyImportantDifferences(final PlayerID player, final boolean useHtml,
       final boolean includeAttachedToName) {
     // displays everything in a very short form, in English rather than as xml stuff
     // shows all except for: m_constructionType, m_constructionsPerTerrPerTypePerTurn, m_maxConstructionsPerTypePerTerr,
@@ -2942,7 +2942,7 @@ public class UnitAttachment extends DefaultAttachment {
       }
     }
     // line break
-    if (useHTML) {
+    if (useHtml) {
       stats.append("<br /> &nbsp;&nbsp;&nbsp;&nbsp; ");
     }
     if (getIsInfrastructure()) {
@@ -3100,7 +3100,7 @@ public class UnitAttachment extends DefaultAttachment {
       stats.append("when hit this unit loses certain abilities, ");
     }
     // line break
-    if (useHTML) {
+    if (useHtml) {
       stats.append("<br /> &nbsp;&nbsp;&nbsp;&nbsp; ");
     }
     if (getMaxBuiltPerPlayer() > -1) {

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -98,14 +98,14 @@ class AAInMoveUtil implements Serializable {
   }
 
   Collection<Territory> getTerritoriesWhereAAWillFire(final Route route, final Collection<Unit> units) {
-    final boolean alwaysOnAA = isAlwaysONAAEnabled();
+    final boolean alwaysOnAntiAir = isAlwaysONAAEnabled();
     // Just the attacked territory will have AA firing
-    if (!alwaysOnAA && isAATerritoryRestricted()) {
+    if (!alwaysOnAntiAir && isAATerritoryRestricted()) {
       return Collections.emptyList();
     }
     final GameData data = getData();
     // No AA in nonCombat unless 'Always on AA'
-    if (GameStepPropertiesHelper.isNonCombatMove(data, false) && !alwaysOnAA) {
+    if (GameStepPropertiesHelper.isNonCombatMove(data, false) && !alwaysOnAntiAir) {
       return Collections.emptyList();
     }
     // can't rely on m_player being the unit owner in Edit Mode
@@ -116,18 +116,18 @@ class AAInMoveUtil implements Serializable {
     // don't iterate over the end
     // that will be a battle
     // and handled else where in this tangled mess
-    final Match<Unit> hasAA = Matches.UnitIsAAthatCanFire(units, airborneTechTargetsAllowed, movingPlayer,
+    final Match<Unit> hasAntiAir = Matches.UnitIsAAthatCanFire(units, airborneTechTargetsAllowed, movingPlayer,
         Matches.UnitIsAAforFlyOverOnly, 1, true, data);
     // AA guns in transports shouldn't be able to fire
-    final List<Territory> territoriesWhereAAWillFire = new ArrayList<>();
+    final List<Territory> territoriesWhereAntiAirWillFire = new ArrayList<>();
     for (final Territory current : route.getMiddleSteps()) {
-      if (current.getUnits().someMatch(hasAA)) {
-        territoriesWhereAAWillFire.add(current);
+      if (current.getUnits().someMatch(hasAntiAir)) {
+        territoriesWhereAntiAirWillFire.add(current);
       }
     }
     if (games.strategy.triplea.Properties.getForceAAattacksForLastStepOfFlyOver(data)) {
-      if (route.getEnd().getUnits().someMatch(hasAA)) {
-        territoriesWhereAAWillFire.add(route.getEnd());
+      if (route.getEnd().getUnits().someMatch(hasAntiAir)) {
+        territoriesWhereAntiAirWillFire.add(route.getEnd());
       }
     } else {
       // Since we are not firing on the last step, check the start as well, to prevent the user from moving to and from
@@ -138,11 +138,11 @@ class AAInMoveUtil implements Serializable {
       // battle.
       // TODO: there is a bug in which if you move an air unit to a battle site in the middle of non combat, it wont
       // fire
-      if (route.getStart().getUnits().someMatch(hasAA) && !getBattleTracker().wasBattleFought(route.getStart())) {
-        territoriesWhereAAWillFire.add(route.getStart());
+      if (route.getStart().getUnits().someMatch(hasAntiAir) && !getBattleTracker().wasBattleFought(route.getStart())) {
+        territoriesWhereAntiAirWillFire.add(route.getStart());
       }
     }
-    return territoriesWhereAAWillFire;
+    return territoriesWhereAntiAirWillFire;
   }
 
   private BattleTracker getBattleTracker() {
@@ -173,24 +173,25 @@ class AAInMoveUtil implements Serializable {
     final PlayerID movingPlayer = movingPlayer(units);
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(movingPlayer, getData());
-    final List<Unit> defendingAA = territory.getUnits().getMatches(Matches.UnitIsAAthatCanFire(units,
+    final List<Unit> defendingAntiAir = territory.getUnits().getMatches(Matches.UnitIsAAthatCanFire(units,
         airborneTechTargetsAllowed, movingPlayer, Matches.UnitIsAAforFlyOverOnly, 1, true, getData()));
     // comes ordered alphabetically already
-    final List<String> AAtypes = UnitAttachment.getAllOfTypeAAs(defendingAA);
+    final List<String> AAtypes = UnitAttachment.getAllOfTypeAAs(defendingAntiAir);
     // stacks are backwards
     Collections.reverse(AAtypes);
-    for (final String currentTypeAA : AAtypes) {
-      final Collection<Unit> currentPossibleAA = Match.getMatches(defendingAA, Matches.UnitIsAAofTypeAA(currentTypeAA));
-      final Set<UnitType> targetUnitTypesForThisTypeAA =
-          UnitAttachment.get(currentPossibleAA.iterator().next().getType()).getTargetsAA(getData());
-      final Set<UnitType> airborneTypesTargettedToo = airborneTechTargetsAllowed.get(currentTypeAA);
+    for (final String currentTypeAntiAir : AAtypes) {
+      final Collection<Unit> currentPossibleAntiAir =
+          Match.getMatches(defendingAntiAir, Matches.UnitIsAAofTypeAA(currentTypeAntiAir));
+      final Set<UnitType> targetUnitTypesForThisTypeAntiAir =
+          UnitAttachment.get(currentPossibleAntiAir.iterator().next().getType()).getTargetsAA(getData());
+      final Set<UnitType> airborneTypesTargettedToo = airborneTechTargetsAllowed.get(currentTypeAntiAir);
       final Collection<Unit> validTargetedUnitsForThisRoll =
-          Match.getMatches(units, new CompositeMatchOr<>(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAA),
+          Match.getMatches(units, new CompositeMatchOr<>(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAntiAir),
               new CompositeMatchAnd<Unit>(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
       // once we fire the AA guns, we can't undo
       // otherwise you could keep undoing and redoing
       // until you got the roll you wanted
-      currentMove.setCantUndo("Move cannot be undone after " + currentTypeAA + " has fired.");
+      currentMove.setCantUndo("Move cannot be undone after " + currentTypeAntiAir + " has fired.");
       final DiceRoll[] dice = new DiceRoll[1];
       final IExecutable rollDice = new IExecutable() {
         private static final long serialVersionUID = 4714364489659654758L;
@@ -200,7 +201,7 @@ class AAInMoveUtil implements Serializable {
           // get rid of units already killed, so we don't target them twice
           validTargetedUnitsForThisRoll.removeAll(m_casualties);
           if (!validTargetedUnitsForThisRoll.isEmpty()) {
-            dice[0] = DiceRoll.rollAA(validTargetedUnitsForThisRoll, currentPossibleAA, m_bridge, territory, true);
+            dice[0] = DiceRoll.rollAA(validTargetedUnitsForThisRoll, currentPossibleAntiAir, m_bridge, territory, true);
           }
         }
       };
@@ -212,27 +213,27 @@ class AAInMoveUtil implements Serializable {
           if (!validTargetedUnitsForThisRoll.isEmpty()) {
             final int hitCount = dice[0].getHits();
             if (hitCount == 0) {
-              if (currentTypeAA.equals("AA")) {
+              if (currentTypeAntiAir.equals("AA")) {
                 m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_MISS,
-                    findDefender(currentPossibleAA, territory));
+                    findDefender(currentPossibleAntiAir, territory));
               } else {
                 m_bridge.getSoundChannelBroadcaster().playSoundForAll(
-                    SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAA.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
-                    findDefender(currentPossibleAA, territory));
+                    SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAntiAir.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
+                    findDefender(currentPossibleAntiAir, territory));
               }
-              getRemotePlayer().reportMessage("No " + currentTypeAA + " hits in " + territory.getName(),
-                  "No " + currentTypeAA + " hits in " + territory.getName());
+              getRemotePlayer().reportMessage("No " + currentTypeAntiAir + " hits in " + territory.getName(),
+                  "No " + currentTypeAntiAir + " hits in " + territory.getName());
             } else {
-              if (currentTypeAA.equals("AA")) {
+              if (currentTypeAntiAir.equals("AA")) {
                 m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT,
-                    findDefender(currentPossibleAA, territory));
+                    findDefender(currentPossibleAntiAir, territory));
               } else {
                 m_bridge.getSoundChannelBroadcaster().playSoundForAll(
-                    SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAA.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
-                    findDefender(currentPossibleAA, territory));
+                    SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAntiAir.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
+                    findDefender(currentPossibleAntiAir, territory));
               }
-              selectCasualties(dice[0], units, validTargetedUnitsForThisRoll, currentPossibleAA, defendingAA, territory,
-                  currentTypeAA);
+              selectCasualties(dice[0], units, validTargetedUnitsForThisRoll, currentPossibleAntiAir, defendingAntiAir,
+                  territory, currentTypeAntiAir);
             }
           }
         }
@@ -266,13 +267,13 @@ class AAInMoveUtil implements Serializable {
    * that the iterator will move through them.
    */
   private void selectCasualties(final DiceRoll dice, final Collection<Unit> allFriendlyUnits,
-      final Collection<Unit> validTargetedUnitsForThisRoll, final Collection<Unit> defendingAA,
-      final Collection<Unit> allEnemyUnits, final Territory territory, final String currentTypeAA) {
+      final Collection<Unit> validTargetedUnitsForThisRoll, final Collection<Unit> defendingAntiAir,
+      final Collection<Unit> allEnemyUnits, final Territory territory, final String currentTypeAntiAir) {
     final CasualtyDetails casualties = BattleCalculator.getAACasualties(false, validTargetedUnitsForThisRoll,
-        allFriendlyUnits, defendingAA, allEnemyUnits, dice, m_bridge, territory.getOwner(), m_player, null, territory,
-        TerritoryEffectHelper.getEffects(territory), false, new ArrayList<>());
-    getRemotePlayer().reportMessage(casualties.size() + " " + currentTypeAA + " hits in " + territory.getName(),
-        casualties.size() + " " + currentTypeAA + " hits in " + territory.getName());
+        allFriendlyUnits, defendingAntiAir, allEnemyUnits, dice, m_bridge, territory.getOwner(), m_player, null,
+        territory, TerritoryEffectHelper.getEffects(territory), false, new ArrayList<>());
+    getRemotePlayer().reportMessage(casualties.size() + " " + currentTypeAntiAir + " hits in " + territory.getName(),
+        casualties.size() + " " + currentTypeAntiAir + " hits in " + territory.getName());
     BattleDelegate.markDamaged(new ArrayList<>(casualties.getDamaged()), m_bridge);
     m_bridge.getHistoryWriter().addChildToEvent(
         MyFormatter.unitsToTextNoOwner(casualties.getKilled()) + " lost in " + territory.getName(),

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -114,11 +114,11 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       final Change change = ChangeFactory.changeResourcesChange(m_player, PUs, toAdd);
       m_bridge.addChange(change);
       if (data.getProperties().get(Constants.PACIFIC_THEATER, false) && pa != null) {
-        final Change changeVP = (ChangeFactory.attachmentPropertyChange(pa,
+        final Change changeVp = (ChangeFactory.attachmentPropertyChange(pa,
             (pa.getVps() + (toAdd / 10) + (pa.getCaptureVps() / 10)), "vps"));
-        final Change changeCapVP = ChangeFactory.attachmentPropertyChange(pa, "0", "captureVps");
-        final CompositeChange ccVP = new CompositeChange(changeVP, changeCapVP);
-        m_bridge.addChange(ccVP);
+        final Change changeCaptureVp = ChangeFactory.attachmentPropertyChange(pa, "0", "captureVps");
+        final CompositeChange ccVp = new CompositeChange(changeVp, changeCaptureVp);
+        m_bridge.addChange(ccVp);
       }
       endTurnReport.append("<br />").append(addOtherResources(m_bridge));
       endTurnReport.append("<br />").append(doNationalObjectivesAndOtherEndTurnEffects(m_bridge));
@@ -129,7 +129,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       // now we do upkeep costs, including upkeep cost as a percentage of our entire income for this turn (including
       // NOs)
       final int currentPUs = m_player.getResources().getQuantity(PUs);
-      final float gainedPUS = Math.max(0, currentPUs - leftOverPUs);
+      final float gainedPus = Math.max(0, currentPUs - leftOverPUs);
       int relationshipUpkeepCostFlat = 0;
       int relationshipUpkeepCostPercentage = 0;
       int relationshipUpkeepTotalCost = 0;
@@ -143,7 +143,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       }
       relationshipUpkeepCostPercentage = Math.min(100, relationshipUpkeepCostPercentage);
       if (relationshipUpkeepCostPercentage != 0) {
-        relationshipUpkeepTotalCost += Math.round(gainedPUS * (relationshipUpkeepCostPercentage) / 100f);
+        relationshipUpkeepTotalCost += Math.round(gainedPus * (relationshipUpkeepCostPercentage) / 100f);
       }
       if (relationshipUpkeepCostFlat != 0) {
         relationshipUpkeepTotalCost += relationshipUpkeepCostFlat;

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -875,7 +875,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     // if water, remove land. if land, remove water.
     units.removeAll(Match.getMatches(units, water ? Matches.UnitIsLand : Matches.UnitIsSea));
     final Collection<Unit> placeableUnits = new ArrayList<>();
-    final Collection<Unit> unitsAtStartOfTurnInTO = unitsAtStartOfStepInTerritory(to);
+    final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
     final Collection<Unit> allProducedUnits = unitsPlacedInTerritorySoFar(to);
     final boolean isBid = GameStepPropertiesHelper.isBid(getData());
     final boolean wasFactoryThereAtStart =
@@ -918,7 +918,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (Match.someMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
       final Collection<Unit> unitsWhichConsume = Match.getMatches(placeableUnits, Matches.UnitConsumesUnitsOnCreation);
       for (final Unit unit : unitsWhichConsume) {
-        if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO).invert().match(unit)) {
+        if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
           placeableUnits.remove(unit);
         }
       }
@@ -968,11 +968,11 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   protected boolean canWeConsumeUnits(final Collection<Unit> units, final Territory to, final boolean actuallyDoIt,
       final CompositeChange change) {
     boolean weCanConsume = true;
-    final Collection<Unit> unitsAtStartOfTurnInTO = unitsAtStartOfStepInTerritory(to);
+    final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
     final Collection<Unit> removedUnits = new ArrayList<>();
     final Collection<Unit> unitsWhichConsume = Match.getMatches(units, Matches.UnitConsumesUnitsOnCreation);
     for (final Unit unit : unitsWhichConsume) {
-      if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO).invert().match(unit)) {
+      if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
         weCanConsume = false;
       }
       if (!weCanConsume) {
@@ -990,8 +990,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
             Matches.unitIsOwnedBy(unit.getOwner()), Matches.unitIsOfType(ut),
             Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.UnitHasNotTakenAnyDamage, Matches.UnitIsNotDisabled);
         final Collection<Unit> unitsBeingRemoved =
-            Match.getNMatches(unitsAtStartOfTurnInTO, requiredNumber, unitIsOwnedByAndOfTypeAndNotDamaged);
-        unitsAtStartOfTurnInTO.removeAll(unitsBeingRemoved);
+            Match.getNMatches(unitsAtStartOfTurnInTo, requiredNumber, unitIsOwnedByAndOfTypeAndNotDamaged);
+        unitsAtStartOfTurnInTo.removeAll(unitsBeingRemoved);
         // if we should actually do it, not just test, then add to bridge
         if (actuallyDoIt && change != null) {
           final Change remove = ChangeFactory.removeUnits(to, unitsBeingRemoved);
@@ -1246,8 +1246,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         || !Match.someMatch(units, Matches.UnitIsConstruction)) {
       return new IntegerMap<>();
     }
-    final Collection<Unit> unitsAtStartOfTurnInTO = unitsAtStartOfStepInTerritory(to);
-    final Collection<Unit> unitsInTO = to.getUnits().getUnits();
+    final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
+    final Collection<Unit> unitsInTo = to.getUnits().getUnits();
     final Collection<Unit> unitsPlacedAlready = getAlreadyProduced(to);
     // build an integer map of each unit we have in our list of held units, as well as integer maps for maximum units
     // and units per turn
@@ -1282,7 +1282,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       }
       // remove any units that require other units to be consumed on creation (veqryn)
       if (Matches.UnitConsumesUnitsOnCreation.match(currentUnit)
-          && Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO).invert().match(currentUnit)) {
+          && Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(currentUnit)) {
         continue;
       }
       unitMapHeld.add(ua.getConstructionType(), 1);
@@ -1299,16 +1299,16 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final boolean wasFactoryThereAtStart =
         wasOwnedUnitThatCanProduceUnitsOrIsFactoryInTerritoryAtStartOfStep(to, player);
     // build an integer map of each construction unit in the territory
-    final IntegerMap<String> unitMapTO = new IntegerMap<>();
-    if (Match.someMatch(unitsInTO, Matches.UnitIsConstruction)) {
-      for (final Unit currentUnit : Match.getMatches(unitsInTO, Matches.UnitIsConstruction)) {
+    final IntegerMap<String> unitMapTo = new IntegerMap<>();
+    if (Match.someMatch(unitsInTo, Matches.UnitIsConstruction)) {
+      for (final Unit currentUnit : Match.getMatches(unitsInTo, Matches.UnitIsConstruction)) {
         final UnitAttachment ua = UnitAttachment.get(currentUnit.getUnitType());
         /*
          * if (Matches.UnitIsFactory.match(currentUnit) && !ua.getIsConstruction())
          * unitMapTO.add("factory", 1);
          * else
          */
-        unitMapTO.add(ua.getConstructionType(), 1);
+        unitMapTo.add(ua.getConstructionType(), 1);
       }
       // account for units already in the territory, based on max
       final Iterator<String> mapString = unitMapHeld.keySet().iterator();
@@ -1326,7 +1326,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
               (unlimitedConstructions ? 10000 : 0));
         }
         unitMapHeld.put(constructionType,
-            Math.max(0, Math.min(unitMax - unitMapTO.getInt(constructionType), unitMapHeld.getInt(constructionType))));
+            Math.max(0, Math.min(unitMax - unitMapTo.getInt(constructionType), unitMapHeld.getInt(constructionType))));
       }
     }
     // deal with already placed units
@@ -1523,26 +1523,26 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (to == null) {
       return new ArrayList<>();
     }
-    final Collection<Unit> unitsInTO = to.getUnits().getUnits();
+    final Collection<Unit> unitsInTo = to.getUnits().getUnits();
     final Collection<Unit> unitsPlacedAlready = getAlreadyProduced(to);
     if (Matches.TerritoryIsWater.match(to)) {
       for (final Territory current : getAllProducers(to, m_player, null, true)) {
         unitsPlacedAlready.addAll(getAlreadyProduced(current));
       }
     }
-    final Collection<Unit> unitsAtStartOfTurnInTO = new ArrayList<>(unitsInTO);
-    unitsAtStartOfTurnInTO.removeAll(unitsPlacedAlready);
-    return unitsAtStartOfTurnInTO;
+    final Collection<Unit> unitsAtStartOfTurnInTo = new ArrayList<>(unitsInTo);
+    unitsAtStartOfTurnInTo.removeAll(unitsPlacedAlready);
+    return unitsAtStartOfTurnInTo;
   }
 
   private Collection<Unit> unitsPlacedInTerritorySoFar(final Territory to) {
     if (to == null) {
       return new ArrayList<>();
     }
-    final Collection<Unit> unitsInTO = to.getUnits().getUnits();
+    final Collection<Unit> unitsInTo = to.getUnits().getUnits();
     final Collection<Unit> unitsAtStartOfStep = unitsAtStartOfStepInTerritory(to);
-    unitsInTO.removeAll(unitsAtStartOfStep);
-    return unitsInTO;
+    unitsInTo.removeAll(unitsAtStartOfStep);
+    return unitsInTo;
   }
 
   /**
@@ -1554,7 +1554,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
    */
   public boolean wasOwnedUnitThatCanProduceUnitsOrIsFactoryInTerritoryAtStartOfStep(final Territory to,
       final PlayerID player) {
-    final Collection<Unit> unitsAtStartOfTurnInTO = unitsAtStartOfStepInTerritory(to);
+    final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
     final CompositeMatchAnd<Unit> factoryMatch = new CompositeMatchAnd<>(
         Matches.UnitIsOwnedAndIsFactoryOrCanProduceUnits(player), Matches.unitIsBeingTransported().invert());
     // land factories in water can't produce, and sea factories in land can't produce. air can produce like land if in
@@ -1565,7 +1565,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     } else {
       factoryMatch.add(Matches.UnitIsSea.invert());
     }
-    return Match.countMatches(unitsAtStartOfTurnInTO, factoryMatch) > 0;
+    return Match.countMatches(unitsAtStartOfTurnInTo, factoryMatch) > 0;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -749,13 +749,13 @@ public class AirBattle extends AbstractBattle {
     removeFromDependents(killed, bridge, dependentBattles, false);
   }
 
-  private static void notifyCasualties(final GUID battleID, final IDelegateBridge bridge, final String stepName,
+  private static void notifyCasualties(final GUID battleId, final IDelegateBridge bridge, final String stepName,
       final DiceRoll dice, final PlayerID hitPlayer, final PlayerID firingPlayer, final CasualtyDetails details) {
-    getDisplay(bridge).casualtyNotification(battleID, stepName, dice, hitPlayer, details.getKilled(),
+    getDisplay(bridge).casualtyNotification(battleId, stepName, dice, hitPlayer, details.getKilled(),
         details.getDamaged(), Collections.emptyMap());
     final Runnable r = () -> {
       try {
-        getRemote(firingPlayer, bridge).confirmEnemyCasualties(battleID, "Press space to continue", hitPlayer);
+        getRemote(firingPlayer, bridge).confirmEnemyCasualties(battleId, "Press space to continue", hitPlayer);
       } catch (final Exception e) {
         ClientLogger.logQuietly(e);
       }
@@ -763,7 +763,7 @@ public class AirBattle extends AbstractBattle {
     // execute in a seperate thread to allow either player to click continue first.
     final Thread t = new Thread(r, "Click to continue waiter");
     t.start();
-    getRemote(hitPlayer, bridge).confirmOwnCasualties(battleID, "Press space to continue");
+    getRemote(hitPlayer, bridge).confirmOwnCasualties(battleId, "Press space to continue");
     try {
       bridge.leaveDelegateExecution();
       t.join();

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -101,34 +101,37 @@ public class BattleCalculator {
    * Choose plane casualties according to specified rules.
    */
   public static CasualtyDetails getAACasualties(final boolean defending, final Collection<Unit> planes,
-      final Collection<Unit> allFriendlyUnits, final Collection<Unit> defendingAA, final Collection<Unit> allEnemyUnits,
+      final Collection<Unit> allFriendlyUnits, final Collection<Unit> defendingAntiAir,
+      final Collection<Unit> allEnemyUnits,
       final DiceRoll dice, final IDelegateBridge bridge, final PlayerID firingPlayer, final PlayerID hitPlayer,
-      final GUID battleID, final Territory terr, final Collection<TerritoryEffect> territoryEffects,
+      final GUID battleId, final Territory terr, final Collection<TerritoryEffect> territoryEffects,
       final boolean amphibious, final Collection<Unit> amphibiousLandAttackers) {
     if (planes.isEmpty()) {
       return new CasualtyDetails();
     }
     final GameData data = bridge.getData();
     final boolean allowMultipleHitsPerUnit =
-        Match.allMatch(defendingAA, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
+        Match.allMatch(defendingAntiAir, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
     if (isChooseAA(data)) {
       final String text = "Select " + dice.getHits() + " casualties from aa fire in " + terr.getName();
       return selectCasualties(null, hitPlayer, planes, allFriendlyUnits, firingPlayer, allEnemyUnits, amphibious,
-          amphibiousLandAttackers, terr, territoryEffects, bridge, text, dice, defending, battleID, false,
+          amphibiousLandAttackers, terr, territoryEffects, bridge, text, dice, defending, battleId, false,
           dice.getHits(), allowMultipleHitsPerUnit);
     } else {
       if (Properties.getLow_Luck(data) || Properties.getLL_AA_ONLY(data)) {
-        return getLowLuckAACasualties(defending, planes, defendingAA, dice, bridge, allowMultipleHitsPerUnit);
+        return getLowLuckAACasualties(defending, planes, defendingAntiAir, dice, bridge, allowMultipleHitsPerUnit);
       } else {
         // priority goes: choose -> individually -> random
         // if none are set, we roll individually
         if (isRollAAIndividually(data)) {
-          return IndividuallyFiredAACasualties(defending, planes, defendingAA, dice, bridge, allowMultipleHitsPerUnit);
+          return IndividuallyFiredAACasualties(defending, planes, defendingAntiAir, dice, bridge,
+              allowMultipleHitsPerUnit);
         }
         if (isRandomAACasualties(data)) {
           return RandomAACasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
         }
-        return IndividuallyFiredAACasualties(defending, planes, defendingAA, dice, bridge, allowMultipleHitsPerUnit);
+        return IndividuallyFiredAACasualties(defending, planes, defendingAntiAir, dice, bridge,
+            allowMultipleHitsPerUnit);
       }
     }
   }
@@ -162,7 +165,7 @@ public class BattleCalculator {
   }
 
   private static CasualtyDetails getLowLuckAACasualties(final boolean defending, final Collection<Unit> planes,
-      final Collection<Unit> defendingAA, final DiceRoll dice, final IDelegateBridge bridge,
+      final Collection<Unit> defendingAntiAir, final DiceRoll dice, final IDelegateBridge bridge,
       final boolean allowMultipleHitsPerUnit) {
     {
       final Set<Unit> duplicatesCheckSet1 = new HashSet<>(planes);
@@ -170,10 +173,10 @@ public class BattleCalculator {
         throw new IllegalStateException(
             "Duplicate Units Detected: Original List:" + planes + "  HashSet:" + duplicatesCheckSet1);
       }
-      final Set<Unit> duplicatesCheckSet2 = new HashSet<>(defendingAA);
-      if (defendingAA.size() != duplicatesCheckSet2.size()) {
+      final Set<Unit> duplicatesCheckSet2 = new HashSet<>(defendingAntiAir);
+      if (defendingAntiAir.size() != duplicatesCheckSet2.size()) {
         throw new IllegalStateException(
-            "Duplicate Units Detected: Original List:" + defendingAA + "  HashSet:" + duplicatesCheckSet2);
+            "Duplicate Units Detected: Original List:" + defendingAntiAir + "  HashSet:" + duplicatesCheckSet2);
       }
     }
     int hitsLeft = dice.getHits();
@@ -184,15 +187,15 @@ public class BattleCalculator {
     final CasualtyDetails finalCasualtyDetails = new CasualtyDetails();
     final GameData data = bridge.getData();
     final Tuple<Integer, Integer> attackThenDiceSides =
-        DiceRoll.getAAattackAndMaxDiceSides(defendingAA, data, !defending);
+        DiceRoll.getAAattackAndMaxDiceSides(defendingAntiAir, data, !defending);
     final int highestAttack = attackThenDiceSides.getFirst();
     if (highestAttack < 1) {
       return new CasualtyDetails();
     }
     final int chosenDiceSize = attackThenDiceSides.getSecond();
     final Triple<Integer, Integer, Boolean> triple =
-        DiceRoll.getTotalAAPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(null, null, !defending, defendingAA,
-            planes, data, false);
+        DiceRoll.getTotalAAPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(null, null, !defending,
+            defendingAntiAir, planes, data, false);
     // final int totalPower = triple.getFirst();
     final boolean allSameAttackPower = triple.getThird();
     // multiple HP units need to be counted multiple times:
@@ -348,7 +351,7 @@ public class BattleCalculator {
     }
     final CasualtyDetails finalCasualtyDetails = new CasualtyDetails();
     // normal behavior is instant kill, which means planes.size()
-    final int planeHP = (allowMultipleHitsPerUnit ? getTotalHitpointsLeft(planes) : planes.size());
+    final int planeHitPoints = (allowMultipleHitsPerUnit ? getTotalHitpointsLeft(planes) : planes.size());
     final List<Unit> planesList = new ArrayList<>();
     for (final Unit plane : planes) {
       final int hpLeft =
@@ -361,10 +364,10 @@ public class BattleCalculator {
       }
     }
     // We need to choose which planes die randomly
-    if (hitsLeft < planeHP) {
+    if (hitsLeft < planeHitPoints) {
       // roll all at once to prevent frequent random calls, important for pbem games
-      final int[] hitRandom =
-          bridge.getRandom(planeHP, hitsLeft, null, DiceType.ENGINE, "Deciding which planes should die due to AA fire");
+      final int[] hitRandom = bridge.getRandom(planeHitPoints, hitsLeft, null, DiceType.ENGINE,
+          "Deciding which planes should die due to AA fire");
       int pos = 0;
       for (final int element : hitRandom) {
         pos += element;
@@ -392,26 +395,26 @@ public class BattleCalculator {
    * Choose plane casualties based on individual AA shots at each aircraft.
    */
   private static CasualtyDetails IndividuallyFiredAACasualties(final boolean defending, final Collection<Unit> planes,
-      final Collection<Unit> defendingAA, final DiceRoll dice, final IDelegateBridge bridge,
+      final Collection<Unit> defendingAntiAir, final DiceRoll dice, final IDelegateBridge bridge,
       final boolean allowMultipleHitsPerUnit) {
     // if we have aa guns that are not infinite, then we need to randomly decide the aa casualties since there are not
     // enough rolls to have
     // a single roll for each aircraft, or too many rolls
     // normal behavior is instant kill, which means planes.size()
-    final int planeHP = (allowMultipleHitsPerUnit ? getTotalHitpointsLeft(planes) : planes.size());
+    final int planeHitPoints = (allowMultipleHitsPerUnit ? getTotalHitpointsLeft(planes) : planes.size());
 
-    if (DiceRoll.getTotalAAattacks(defendingAA, planes) != planeHP) {
+    if (DiceRoll.getTotalAAattacks(defendingAntiAir, planes) != planeHitPoints) {
       return RandomAACasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }
     final Triple<Integer, Integer, Boolean> triple =
-        DiceRoll.getTotalAAPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(null, null, !defending, defendingAA,
-            planes, bridge.getData(), false);
+        DiceRoll.getTotalAAPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(null, null, !defending,
+            defendingAntiAir, planes, bridge.getData(), false);
     final boolean allSameAttackPower = triple.getThird();
     if (!allSameAttackPower) {
       return RandomAACasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }
     final Tuple<Integer, Integer> attackThenDiceSides =
-        DiceRoll.getAAattackAndMaxDiceSides(defendingAA, bridge.getData(), !defending);
+        DiceRoll.getAAattackAndMaxDiceSides(defendingAntiAir, bridge.getData(), !defending);
     final int highestAttack = attackThenDiceSides.getFirst();
     // int chosenDiceSize = attackThenDiceSides[1];
     final CasualtyDetails finalCasualtyDetails = new CasualtyDetails();
@@ -428,10 +431,10 @@ public class BattleCalculator {
       }
     }
     // We need to choose which planes die based on their position in the list and the individual AA rolls
-    if (hits > planeHP) {
+    if (hits > planeHitPoints) {
       throw new IllegalStateException("Cannot have more hits than number of die rolls");
     }
-    if (hits < planeHP) {
+    if (hits < planeHitPoints) {
       final List<Die> rolls = dice.getRolls(highestAttack);
       for (int i = 0; i < rolls.size(); i++) {
         final Die die = rolls.get(i);
@@ -458,14 +461,14 @@ public class BattleCalculator {
   }
 
   /**
-   * @param battleID
+   * @param battleId
    *        may be null if we are not in a battle (eg, if this is an aa fire due to moving).
    */
   public static CasualtyDetails selectCasualties(final String step, final PlayerID player,
       final Collection<Unit> targetsToPickFrom, final Collection<Unit> friendlyUnits, final PlayerID enemyPlayer,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
       final Territory battlesite, final Collection<TerritoryEffect> territoryEffects, final IDelegateBridge bridge,
-      final String text, final DiceRoll dice, final boolean defending, final GUID battleID, final boolean headLess,
+      final String text, final DiceRoll dice, final boolean defending, final GUID battleId, final boolean headLess,
       final int extraHits, final boolean allowMultipleHitsPerUnit) {
     if (targetsToPickFrom.isEmpty()) {
       return new CasualtyDetails();
@@ -490,7 +493,7 @@ public class BattleCalculator {
     if (isEditMode && !headLess) {
       final CasualtyDetails editSelection = tripleaPlayer.selectCasualties(targetsToPickFrom, dependents, 0, text, dice,
           player, friendlyUnits, enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, new CasualtyList(),
-          battleID, battlesite, allowMultipleHitsPerUnit);
+          battleId, battlesite, allowMultipleHitsPerUnit);
       List<Unit> killed = editSelection.getKilled();
       // if partial retreat is possible, kill amphibious units first
       if (isPartialAmphibiousRetreat(data)) {
@@ -536,7 +539,7 @@ public class BattleCalculator {
     } else {
       casualtySelection = tripleaPlayer.selectCasualties(sortedTargetsToPickFrom, dependents, hitsRemaining, text, dice,
           player, friendlyUnits, enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, defaultCasualties,
-          battleID, battlesite, allowMultipleHitsPerUnit);
+          battleId, battlesite, allowMultipleHitsPerUnit);
     }
     List<Unit> killed = casualtySelection.getKilled();
     // if partial retreat is possible, kill amphibious units first
@@ -573,7 +576,7 @@ public class BattleCalculator {
             + casualtySelection.toString());
       }
       return selectCasualties(step, player, sortedTargetsToPickFrom, friendlyUnits, enemyPlayer, enemyUnits, amphibious,
-          amphibiousLandAttackers, battlesite, territoryEffects, bridge, text, dice, defending, battleID, headLess,
+          amphibiousLandAttackers, battlesite, territoryEffects, bridge, text, dice, defending, battleId, headLess,
           extraHits, allowMultipleHitsPerUnit);
     }
     // check we have enough of each type
@@ -584,7 +587,7 @@ public class BattleCalculator {
             + MyFormatter.unitsToTextNoOwner(sortedTargetsToPickFrom) + ", for " + casualtySelection.toString());
       }
       return selectCasualties(step, player, sortedTargetsToPickFrom, friendlyUnits, enemyPlayer, enemyUnits, amphibious,
-          amphibiousLandAttackers, battlesite, territoryEffects, bridge, text, dice, defending, battleID, headLess,
+          amphibiousLandAttackers, battlesite, territoryEffects, bridge, text, dice, defending, battleId, headLess,
           extraHits, allowMultipleHitsPerUnit);
     }
     return casualtySelection;
@@ -654,8 +657,8 @@ public class BattleCalculator {
           return Tuple.of(defaultCasualtySelection, sorted);
         }
         final UnitAttachment ua = UnitAttachment.get(unit.getType());
-        final int extraHP = Math.min((hits - numSelectedCasualties), (ua.getHitPoints() - (1 + unit.getHits())));
-        for (int i = 0; i < extraHP; i++) {
+        final int extraHitPoints = Math.min((hits - numSelectedCasualties), (ua.getHitPoints() - (1 + unit.getHits())));
+        for (int i = 0; i < extraHitPoints; i++) {
           numSelectedCasualties++;
           defaultCasualtySelection.addToDamaged(unit);
         }
@@ -919,10 +922,10 @@ public class BattleCalculator {
    * @return a map of unit types to PU cost
    */
   public static IntegerMap<UnitType> getCostsForTUV(final PlayerID player, final GameData data) {
-    final Resource PUS;
+    final Resource pus;
     data.acquireReadLock();
     try {
-      PUS = data.getResourceList().getResource(Constants.PUS);
+      pus = data.getResourceList().getResource(Constants.PUS);
     } finally {
       data.releaseReadLock();
     }
@@ -933,7 +936,7 @@ public class BattleCalculator {
       return getCostsForTuvForAllPlayersMergedAndAveraged(data);
     }
     for (final ProductionRule rule : frontier.getRules()) {
-      final int costPerGroup = rule.getCosts().getInt(PUS);
+      final int costPerGroup = rule.getCosts().getInt(pus);
       final NamedAttachable resourceOrUnit = rule.getResults().keySet().iterator().next();
       if (!(resourceOrUnit instanceof UnitType)) {
         continue;
@@ -968,10 +971,10 @@ public class BattleCalculator {
      * 0)
      * return s_costsForTuvForAllPlayersMergedAndAveraged;
      */
-    final Resource PUS;
+    final Resource pus;
     data.acquireReadLock();
     try {
-      PUS = data.getResourceList().getResource(Constants.PUS);
+      pus = data.getResourceList().getResource(Constants.PUS);
     } finally {
       data.releaseReadLock();
     }
@@ -985,7 +988,7 @@ public class BattleCalculator {
       }
       final UnitType ut = (UnitType) resourceOrUnit;
       final int numberProduced = rule.getResults().getInt(ut);
-      final int costPerGroup = rule.getCosts().getInt(PUS);
+      final int costPerGroup = rule.getCosts().getInt(pus);
       // we round up the cost
       final int roundedCostPerSingle = (int) Math.ceil((double) costPerGroup / (double) numberProduced);
       if (differentCosts.containsKey(ut)) {
@@ -1087,15 +1090,15 @@ public class BattleCalculator {
   private static Map<UnitType, ResourceCollection> getResourceCostsForTUVForAllPlayersMergedAndAveraged(
       final GameData data) {
     final Map<UnitType, ResourceCollection> average = new HashMap<>();
-    final Resource PUS;
+    final Resource pus;
     data.acquireReadLock();
     try {
-      PUS = data.getResourceList().getResource(Constants.PUS);
+      pus = data.getResourceList().getResource(Constants.PUS);
     } finally {
       data.releaseReadLock();
     }
     final IntegerMap<Resource> defaultMap = new IntegerMap<>();
-    defaultMap.put(PUS, 1);
+    defaultMap.put(pus, 1);
     final ResourceCollection defaultResources = new ResourceCollection(data, defaultMap);
     final Map<UnitType, List<ResourceCollection>> backups = new HashMap<>();
     final Map<UnitType, ResourceCollection> backupAveraged = new HashMap<>();

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -635,7 +635,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final boolean fromIslandOnly = games.strategy.triplea.Properties.getScramble_From_Island_Only(data);
     final boolean toSeaOnly = games.strategy.triplea.Properties.getScramble_To_Sea_Only(data);
     final boolean toAnyAmphibious = games.strategy.triplea.Properties.getScrambleToAnyAmphibiousAssault(data);
-    final boolean toSBR = games.strategy.triplea.Properties.getCanScrambleIntoAirBattles(data);
+    final boolean toSbr = games.strategy.triplea.Properties.getCanScrambleIntoAirBattles(data);
     int maxScrambleDistance = 0;
     final Iterator<UnitType> utIter = data.getUnitTypeList().iterator();
     while (utIter.hasNext()) {
@@ -657,7 +657,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final HashMap<Territory, HashSet<Territory>> scrambleTerrs = new HashMap<>();
     final Set<Territory> territoriesWithBattles =
         m_battleTracker.getPendingBattleSites().getNormalBattlesIncludingAirBattles();
-    if (toSBR) {
+    if (toSbr) {
       territoriesWithBattles
           .addAll(m_battleTracker.getPendingBattleSites().getStrategicBombingRaidsIncludingAirBattles());
     }
@@ -866,17 +866,17 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             // after that is applied, we have to make a map of all dependencies
             final Map<Territory, Map<Unit, Collection<Unit>>> dependencies =
                 new HashMap<>();
-            final Map<Unit, Collection<Unit>> dependenciesForMFB =
+            final Map<Unit, Collection<Unit>> dependenciesForMfb =
                 TransportTracker.transporting(attackingUnits, attackingUnits);
             for (final Unit transport : Match.getMatches(attackingUnits, Matches.UnitIsTransport)) {
               // however, the map we add to the newly created battle, cannot hold any units that are NOT in this
               // territory.
               // BUT it must still hold all transports
-              if (!dependenciesForMFB.containsKey(transport)) {
-                dependenciesForMFB.put(transport, new ArrayList<>());
+              if (!dependenciesForMfb.containsKey(transport)) {
+                dependenciesForMfb.put(transport, new ArrayList<>());
               }
             }
-            dependencies.put(to, dependenciesForMFB);
+            dependencies.put(to, dependenciesForMfb);
             for (final Territory t : neighborsLand) {
               // All other maps, must hold only the transported units that in their territory
               final Collection<Unit> allNeighborUnits =

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -547,23 +547,23 @@ public class BattleTracker implements java.io.Serializable {
     if (territory.getOwner().isNull() && !territory.isWater()
         && games.strategy.triplea.Properties.getNeutralCharge(data) >= 0) {
       final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-      final int PUChargeIdeal = -games.strategy.triplea.Properties.getNeutralCharge(data);
-      final int PUChargeReal = Math.min(0, Math.max(PUChargeIdeal, -id.getResources().getQuantity(PUs)));
-      final Change neutralFee = ChangeFactory.changeResourcesChange(id, PUs, PUChargeReal);
+      final int puChargeIdeal = -games.strategy.triplea.Properties.getNeutralCharge(data);
+      final int puChargeReal = Math.min(0, Math.max(puChargeIdeal, -id.getResources().getQuantity(PUs)));
+      final Change neutralFee = ChangeFactory.changeResourcesChange(id, PUs, puChargeReal);
       bridge.addChange(neutralFee);
       if (changeTracker != null) {
         changeTracker.addChange(neutralFee);
       }
-      if (PUChargeIdeal == PUChargeReal) {
-        bridge.getHistoryWriter().addChildToEvent(id.getName() + " loses " + -PUChargeReal + " "
-            + MyFormatter.pluralize("PU", -PUChargeReal) + " for violating " + territory.getName() + "s neutrality.");
+      if (puChargeIdeal == puChargeReal) {
+        bridge.getHistoryWriter().addChildToEvent(id.getName() + " loses " + -puChargeReal + " "
+            + MyFormatter.pluralize("PU", -puChargeReal) + " for violating " + territory.getName() + "s neutrality.");
       } else {
         System.out.println("Player, " + id.getName() + " attacks a Neutral territory, and should have had to pay "
-            + PUChargeIdeal + ", but did not have enough PUs to pay! This is a bug.");
+            + puChargeIdeal + ", but did not have enough PUs to pay! This is a bug.");
         bridge.getHistoryWriter()
-            .addChildToEvent(id.getName() + " loses " + -PUChargeReal + " " + MyFormatter.pluralize("PU", -PUChargeReal)
+            .addChildToEvent(id.getName() + " loses " + -puChargeReal + " " + MyFormatter.pluralize("PU", -puChargeReal)
                 + " for violating " + territory.getName() + "s neutrality.  Correct amount to charge is: "
-                + PUChargeIdeal + ".  Player should not have been able to make this attack!");
+                + puChargeIdeal + ".  Player should not have been able to make this attack!");
       }
     }
     // if its a capital we take the money
@@ -583,32 +583,32 @@ public class BattleTracker implements java.io.Serializable {
             .addChildToEvent(id.getName() + " captures one of " + whoseCapital.getName() + " capitals");
       } else if (whoseCapital.equals(territory.getOwner())) {
         final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-        final int capturedPUCount = whoseCapital.getResources().getQuantity(PUs);
+        final int capturedPuCount = whoseCapital.getResources().getQuantity(PUs);
         if (pa != null) {
           if (isPacificTheater(data)) {
-            final Change changeVP =
-                ChangeFactory.attachmentPropertyChange(pa, (capturedPUCount + pa.getCaptureVps()), "captureVps");
-            bridge.addChange(changeVP);
+            final Change changeVp =
+                ChangeFactory.attachmentPropertyChange(pa, (capturedPuCount + pa.getCaptureVps()), "captureVps");
+            bridge.addChange(changeVp);
             if (changeTracker != null) {
-              changeTracker.addChange(changeVP);
+              changeTracker.addChange(changeVp);
             }
           }
         }
-        final Change remove = ChangeFactory.changeResourcesChange(whoseCapital, PUs, -capturedPUCount);
+        final Change remove = ChangeFactory.changeResourcesChange(whoseCapital, PUs, -capturedPuCount);
         bridge.addChange(remove);
         if (paWhoseCapital != null && paWhoseCapital.getDestroysPUs()) {
-          bridge.getHistoryWriter().addChildToEvent(id.getName() + " destroys " + capturedPUCount
-              + MyFormatter.pluralize("PU", capturedPUCount) + " while taking " + whoseCapital.getName() + " capital");
+          bridge.getHistoryWriter().addChildToEvent(id.getName() + " destroys " + capturedPuCount
+              + MyFormatter.pluralize("PU", capturedPuCount) + " while taking " + whoseCapital.getName() + " capital");
           if (changeTracker != null) {
             changeTracker.addChange(remove);
           }
         } else {
-          bridge.getHistoryWriter().addChildToEvent(id.getName() + " captures " + capturedPUCount
-              + MyFormatter.pluralize("PU", capturedPUCount) + " while taking " + whoseCapital.getName() + " capital");
+          bridge.getHistoryWriter().addChildToEvent(id.getName() + " captures " + capturedPuCount
+              + MyFormatter.pluralize("PU", capturedPuCount) + " while taking " + whoseCapital.getName() + " capital");
           if (changeTracker != null) {
             changeTracker.addChange(remove);
           }
-          final Change add = ChangeFactory.changeResourcesChange(id, PUs, capturedPUCount);
+          final Change add = ChangeFactory.changeResourcesChange(id, PUs, capturedPuCount);
           bridge.addChange(add);
           if (changeTracker != null) {
             changeTracker.addChange(add);

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -113,7 +113,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
   @Override
   protected Collection<Unit> getUnitsToBePlacedLand(final Territory to, final Collection<Unit> units,
       final PlayerID player) {
-    final Collection<Unit> unitsAtStartOfTurnInTO = unitsAtStartOfStepInTerritory(to);
+    final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
     final Collection<Unit> placeableUnits = new ArrayList<>();
     final CompositeMatch<Unit> groundUnits =
         // we add factories and constructions later
@@ -142,7 +142,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     if (Match.someMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
       final Collection<Unit> unitsWhichConsume = Match.getMatches(placeableUnits, Matches.UnitConsumesUnitsOnCreation);
       for (final Unit unit : unitsWhichConsume) {
-        if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTO).invert().match(unit)) {
+        if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
           placeableUnits.remove(unit);
         }
       }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in local variables.

For the most part, I did **not** expand abbreviations where they caused a violation; I simply converted them using the abbreviation naming convention established in #1659.  Please advise if any should be expanded.

The abbreviations that were expanded included:

* `AA` --> `AntiAir`
* `HP` --> `HitPoints`

I wasn't sure if `MFB` was an abbreviation for "amphibious battle".  If so, please advise if that abbreviation should be expanded, as well.

Due to the large number of violations that fall under this category, the fixes are being split over multiple PRs to keep the review size reasonable.