### PR TITLE
Add all attacking units at battle site for retreat consideration

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -1416,7 +1416,13 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (availableTerritories.isEmpty() && !(submerge || canDefendingSubsSubmergeOrRetreat)) {
       return;
     }
+
+    // If attacker then add all owned units at battle site as some might have been removed from battle (infra)
     Collection<Unit> units = defender ? m_defendingUnits : m_attackingUnits;
+    if (!defender) {
+      units = new HashSet<Unit>(units);
+      units.addAll(m_battleSite.getUnits().getMatches(Matches.unitIsOwnedBy(m_attacker)));
+    }
     if (subs) {
       units = Match.getMatches(units, Matches.UnitIsSub);
     } else if (planes) {


### PR DESCRIPTION
Fixes #442.

Need to consider units such as infra that were removed from fighting in the battle when retreating.