### PR TITLE
Remove uneccessary censoring

### DIFF
--- a/.travis/push_maps_yaml
+++ b/.travis/push_maps_yaml
@@ -7,7 +7,7 @@ git config --global user.email "tripleabuilderbot@gmail.com"
 git config --global user.name "tripleabuilderbot"
 
 ## clone the website repo, suppress any output
-git clone --quiet https://${PUSH_TO_WEBSITE_TOKEN}@github.com/triplea-game/triplea-game.github.io.git website 2>&1 > /dev/null
+git clone --quiet https://${PUSH_TO_WEBSITE_TOKEN}@github.com/triplea-game/triplea-game.github.io.git website
 
 #Split the yaml file into multiple files
 ./.travis/yaml_splitter ./triplea_maps.yaml ./website/_maps/
@@ -17,7 +17,7 @@ cd website
 if ! git diff-index --quiet HEAD --; then
   git add _maps/*
   git commit -m "Bot: update map files after game engine build $TAGGED_VERSION"
-  git push -fq origin master 2>&1 > /dev/null
+  git push -fq origin master
 fi
 
 cd ..

--- a/.travis/push_tag
+++ b/.travis/push_tag
@@ -26,8 +26,7 @@ configGithub() {
 deleteExistingTag() {
   echo "Attempting to delete tag $TAGGED_VERSION, this is so we will recreate the release if this build is being re-run."
   ## sed is to mask out access token in case the https url is printed 
-  git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --delete "refs/tags/$TAGGED_VERSION" \
-     | sed 's|https://.*github|https://[secure]@github|'
+  git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --delete "refs/tags/$TAGGED_VERSION"
 
   echo "Done doing tag deletes, ignore any errors immediately above if there are any for failing to delete non-existent tags"
 } 
@@ -49,7 +48,7 @@ createTag() {
 pushTag() {
   echo "Pushing tag: $TAGGED_VERSION to github to trigger releases deployment"
 
-  git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags 2>&1 | sed 's|https://.*github|https://[secure]@github|'
+  git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags
 }
 
 main

--- a/.travis/update_checkstyle_thresholds
+++ b/.travis/update_checkstyle_thresholds
@@ -83,8 +83,7 @@ update_remote_thresholds() {
       -X PUT \
       --header "Accept: application/vnd.github.v3+json" \
       --data "$update_request" \
-      "https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@api.github.com/repos/$TRAVIS_REPO_SLUG/contents/$GRADLE_PROPERTIES" \
-    2>&1 | sed -r 's|https://[^@]+@|https://[secure]@|'
+      "https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@api.github.com/repos/$TRAVIS_REPO_SLUG/contents/$GRADLE_PROPERTIES"
 }
 
 main


### PR DESCRIPTION
@DanVanAtta @ron-murhammer I did some testing: It's absolutely impossible to intentionally leak secret env variables via the buildscript. Travis is censoring the log on its own!

I created an empty travis script just containing `echo $SECRET_TOKEN` and what was printed? `[secret]`