### PR TITLE
Encapsulate game data file extension logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ sourceSets {
 }
 
 dependencies {
+    compile group: 'commons-io', name: 'commons-io', version: '2.5'
     compile group: 'postgresql', name: 'postgresql', version: '9.1-901-1.jdbc4'
     compile 'com.github.insubstantial:substance:7.3'
     compile 'com.google.guava:guava:19.0'

--- a/src/main/java/games/strategy/engine/framework/GameDataFileUtils.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataFileUtils.java
@@ -1,0 +1,91 @@
+package games.strategy.engine.framework;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.apache.commons.io.IOCase;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * A collection of utilities for working with game data files.
+ */
+public final class GameDataFileUtils {
+  private static final String EXTENSION = ".tsvg";
+
+  private static final String LEGACY_EXTENSION = ".svg";
+
+  /**
+   * Macs download a game data file as "tsvg.gz", so that extension must be used when evaluating candidate game data
+   * files.
+   */
+  private static final String MAC_OS_ALTERNATIVE_EXTENSION = "tsvg.gz";
+
+  private static final Collection<String> CANDIDATE_EXTENSIONS = Arrays.asList(
+      EXTENSION,
+      LEGACY_EXTENSION,
+      MAC_OS_ALTERNATIVE_EXTENSION);
+
+  private GameDataFileUtils() {}
+
+  /**
+   * Appends the game data file extension to the specified file name.
+   *
+   * @param fileName The file name; must not be {@code null}.
+   *
+   * @return The file name with the game data file extension appended; never {@code null}.
+   */
+  public static String addExtension(final String fileName) {
+    checkNotNull(fileName);
+
+    return fileName + EXTENSION;
+  }
+
+  /**
+   * Appends the game data file extension to the specified file name if the file name does not end with the game data
+   * file extension.
+   *
+   * @param fileName The file name; must not be {@code null}.
+   *
+   * @return The file name ending with at most one occurrence of the game data file extension; never {@code null}.
+   */
+  public static String addExtensionIfAbsent(final String fileName) {
+    checkNotNull(fileName);
+
+    return addExtensionIfAbsent(fileName, IOCase.SYSTEM);
+  }
+
+  @VisibleForTesting
+  static String addExtensionIfAbsent(final String fileName, final IOCase ioCase) {
+    return ioCase.checkEndsWith(fileName, EXTENSION) ? fileName : addExtension(fileName);
+  }
+
+  /**
+   * Gets the game data file extension.
+   *
+   * @return The game data file extension including the leading period; never {@code null}.
+   */
+  public static String getExtension() {
+    return EXTENSION;
+  }
+
+  /**
+   * Indicates the specified file name is a game data file candidate.
+   *
+   * @param fileName The file name; must not be {@code null}.
+   *
+   * @return {@code true} if the specified file name is a game data file candidate; otherwise {@code false}.
+   */
+  public static boolean isCandidateFileName(final String fileName) {
+    checkNotNull(fileName);
+
+    return isCandidateFileName(fileName, IOCase.SYSTEM);
+  }
+
+  @VisibleForTesting
+  static boolean isCandidateFileName(final String fileName, final IOCase ioCase) {
+    return CANDIDATE_EXTENSIONS.stream().anyMatch(extension -> ioCase.checkEndsWith(fileName, extension));
+  }
+}

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -358,8 +358,12 @@ public class ServerGame extends AbstractGame {
   }
 
   private void autoSaveBefore(final IDelegate currentDelegate) {
-    final String stepName = currentDelegate.getName();
-    autoSave("autosaveBefore" + stepName.substring(0,1).toUpperCase() + stepName.substring(1) + ".tsvg");
+    autoSave(getAutoSaveBeforeFileName(currentDelegate.getName()));
+  }
+
+  private static String getAutoSaveBeforeFileName(final String stepName) {
+    final String baseFileName = "autosaveBefore" + stepName.substring(0, 1).toUpperCase() + stepName.substring(1);
+    return GameDataFileUtils.addExtension(baseFileName);
   }
 
   @Override
@@ -419,8 +423,7 @@ public class ServerGame extends AbstractGame {
     final boolean autoSaveThisDelegate = currentDelegate.getClass().isAnnotationPresent(AutoSave.class)
         && currentDelegate.getClass().getAnnotation(AutoSave.class).afterStepEnd();
     if (autoSaveThisDelegate && currentStep.getName().endsWith("Move")) {
-      autoSave("autosaveAfter" + currentStep.getName().substring(0,1).toUpperCase()
-          + currentStep.getName().substring(1) + ".tsvg");
+      autoSave(getAutoSaveAfterFileNameForGameStep(currentStep));
     }
     endStep();
     if (m_isGameOver) {
@@ -432,10 +435,23 @@ public class ServerGame extends AbstractGame {
           ? SaveGameFileChooser.getAutoSaveEvenFileName() : SaveGameFileChooser.getAutoSaveOddFileName());
     }
     if (autoSaveThisDelegate && !currentStep.getName().endsWith("Move")) {
-      final String typeName = currentDelegate.getClass().getTypeName();
-      final String phaseName = typeName.substring(typeName.lastIndexOf('.') + 1).replaceFirst("Delegate$", "");
-      autoSave("autosaveAfter" + phaseName.substring(0,1).toUpperCase() + phaseName.substring(1) + ".tsvg");
+      autoSave(getAutoSaveAfterFileNameForDelegate(currentDelegate));
     }
+  }
+
+  private static String getAutoSaveAfterFileNameForGameStep(final GameStep gameStep) {
+    return getAutoSaveAfterFileName(gameStep.getName());
+  }
+
+  private static String getAutoSaveAfterFileNameForDelegate(final IDelegate delegate) {
+    final String typeName = delegate.getClass().getTypeName();
+    final String stepName = typeName.substring(typeName.lastIndexOf('.') + 1).replaceFirst("Delegate$", "");
+    return getAutoSaveAfterFileName(stepName);
+  }
+
+  private static String getAutoSaveAfterFileName(final String stepName) {
+    final String baseFileName = "autosaveAfter" + stepName.substring(0, 1).toUpperCase() + stepName.substring(1);
+    return GameDataFileUtils.addExtension(baseFileName);
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/networkMaintenance/GetGameSaveClientAction.java
+++ b/src/main/java/games/strategy/engine/framework/networkMaintenance/GetGameSaveClientAction.java
@@ -27,7 +27,7 @@ public class GetGameSaveClientAction extends AbstractAction {
   @Override
   public void actionPerformed(final ActionEvent e) {
     final Frame frame = JOptionPane.getFrameForComponent(m_parent);
-    final File f = TripleAMenuBar.getSaveGameLocationDialog(frame);
+    final File f = TripleAMenuBar.getSaveGameLocation(frame);
     if (f != null) {
       final byte[] bytes = m_serverRemote.getSaveGame();
       try (FileOutputStream fout = new FileOutputStream(f)) {

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -23,6 +23,7 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ServerGame;
@@ -370,13 +371,11 @@ public class ServerLauncher extends AbstractLauncher {
   }
 
   private void saveAndEndGame(final INode node) {
-    final DateFormat format = new SimpleDateFormat("MMM_dd_'at'_HH_mm");
     SaveGameFileChooser.ensureMapsFolderExists();
     // a hack, if headless save to the autosave to avoid polluting our savegames folder with a million saves
     final File f = m_headless
         ? new File(ClientContext.folderSettings().getSaveGamePath(), SaveGameFileChooser.getAutoSaveFileName())
-        : new File(ClientContext.folderSettings().getSaveGamePath(),
-            "connection_lost_on_" + format.format(new Date()) + ".tsvg");
+        : new File(ClientContext.folderSettings().getSaveGamePath(), getConnectionLostFileName());
     try {
       m_serverGame.saveGame(f);
     } catch (final Exception e) {
@@ -398,6 +397,12 @@ public class ServerLauncher extends AbstractLauncher {
     } else {
       System.out.println("Connection lost to:" + node.getName() + " game is over.  Game saved to:" + f.getName());
     }
+  }
+
+  private static String getConnectionLostFileName() {
+    final DateFormat dateFormat = new SimpleDateFormat("MMM_dd_'at'_HH_mm");
+    final String baseFileName = "connection_lost_on_" + dateFormat.format(new Date());
+    return GameDataFileUtils.addExtension(baseFileName);
   }
 }
 

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -126,7 +126,6 @@ public class GameSelectorModel extends Observable {
           newData = (new GameParser(file.getAbsolutePath())).parse(fis, gameName, false);
         }
       } else {
-        // the extension should be tsvg, but
         // try to load it as a saved game whatever the extension
         newData = manager.loadGame(file);
       }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -31,6 +31,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUI;
+import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.GameSelectorModel;
@@ -352,11 +353,7 @@ public class GameSelectorPanel extends JPanel implements Observer {
       fileDialog.setMode(FileDialog.LOAD);
       SaveGameFileChooser.ensureMapsFolderExists();
       fileDialog.setDirectory(new File(ClientContext.folderSettings().getSaveGamePath()).getPath());
-      fileDialog.setFilenameFilter((dir, name) -> {
-        // the extension should be .tsvg, but find svg extensions as well
-        // also, macs download the file as tsvg.gz, so accept that as well
-        return name.endsWith(".tsvg") || name.endsWith(".svg") || name.endsWith("tsvg.gz");
-      });
+      fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
       fileDialog.setVisible(true);
       final String fileName = fileDialog.getFile();
       final String dirName = fileDialog.getDirectory();

--- a/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -6,14 +6,15 @@ import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 
 public class SaveGameFileChooser extends JFileChooser {
   private static final long serialVersionUID = 1548668790891292106L;
-  private static final String AUTOSAVE_FILE_NAME = "autosave.tsvg";
-  private static final String AUTOSAVE_ODD_ROUND_FILE_NAME = "autosave_round_odd.tsvg";
-  private static final String AUTOSAVE_EVEN_ROUND_FILE_NAME = "autosave_round_even.tsvg";
+  private static final String AUTOSAVE_FILE_NAME = GameDataFileUtils.addExtension("autosave");
+  private static final String AUTOSAVE_ODD_ROUND_FILE_NAME = GameDataFileUtils.addExtension("autosave_round_odd");
+  private static final String AUTOSAVE_EVEN_ROUND_FILE_NAME = GameDataFileUtils.addExtension("autosave_round_even");
   private static SaveGameFileChooser s_instance;
 
   public enum AUTOSAVE_TYPE {
@@ -62,7 +63,7 @@ public class SaveGameFileChooser extends JFileChooser {
 
   private SaveGameFileChooser() {
     super();
-    setFileFilter(m_gameDataFileFilter);
+    setFileFilter(createGameDataFileFilter());
     ensureMapsFolderExists();
     setCurrentDirectory(new File(ClientContext.folderSettings().getSaveGamePath()));
   }
@@ -80,20 +81,17 @@ public class SaveGameFileChooser extends JFileChooser {
     }
   }
 
-  FileFilter m_gameDataFileFilter = new FileFilter() {
-    @Override
-    public boolean accept(final File f) {
-      if (f.isDirectory()) {
-        return true;
+  private static FileFilter createGameDataFileFilter() {
+    return new FileFilter() {
+      @Override
+      public boolean accept(final File file) {
+        return file.isDirectory() || GameDataFileUtils.isCandidateFileName(file.getName());
       }
-      // the extension should be .tsvg, but find svg extensions as well
-      // also, macs download the file as tsvg.gz, so accept that as well
-      return f.getName().endsWith(".tsvg") || f.getName().endsWith(".svg") || f.getName().endsWith("tsvg.gz");
-    }
 
-    @Override
-    public String getDescription() {
-      return "Saved Games, *.tsvg";
-    }
-  };
+      @Override
+      public String getDescription() {
+        return "Saved Games, *" + GameDataFileUtils.getExtension();
+      }
+    };
+  }
 }

--- a/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
+++ b/src/main/java/games/strategy/engine/pbem/PBEMMessagePoster.java
@@ -11,6 +11,7 @@ import javax.swing.SwingUtilities;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.history.IDelegateHistoryWriter;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.triplea.ui.MainGameFrame;
@@ -109,8 +110,8 @@ public class PBEMMessagePoster implements Serializable {
       saveGameSb.append(m_forumPoster.getTopicId()).append("_");
     }
     saveGameSb.append(m_currentPlayer.getName().substring(0, Math.min(3, m_currentPlayer.getName().length() - 1)))
-        .append(m_roundNumber).append(".tsvg");
-    final String saveGameName = saveGameSb.toString();
+        .append(m_roundNumber);
+    final String saveGameName = GameDataFileUtils.addExtension(saveGameSb.toString());
     if (m_forumPoster != null) {
       if (includeSaveGame) {
         m_forumPoster.addSaveGame(m_saveGameFile, saveGameName);
@@ -257,7 +258,7 @@ public class PBEMMessagePoster implements Serializable {
           postingDelegate.setHasPostedTurnSummary(true);
         }
         try {
-          saveGameFile = File.createTempFile("triplea", ".tsvg");
+          saveGameFile = File.createTempFile("triplea", GameDataFileUtils.getExtension());
           if (saveGameFile != null) {
             mainGameFrame.getGame().saveGame(saveGameFile);
             posterPbem.setSaveGame(saveGameFile);

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1733,7 +1733,7 @@ public class TripleAFrame extends MainGameFrame {
         data.acquireReadLock();
         // m_data.acquireWriteLock();
         try {
-          final File f = TripleAMenuBar.getSaveGameLocationDialog(TripleAFrame.this);
+          final File f = TripleAMenuBar.getSaveGameLocation(TripleAFrame.this);
           if (f != null) {
             try (FileOutputStream fout = new FileOutputStream(f)) {
               final GameData datacopy = GameDataUtils.cloneGameData(data, true);

--- a/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -46,7 +46,7 @@ class FileMenu {
 
   private JMenuItem createSaveMenu() {
     final JMenuItem menuFileSave = new JMenuItem(SwingAction.of("Save", e -> {
-      final File f = TripleAMenuBar.getSaveGameLocationDialog(frame);
+      final File f = TripleAMenuBar.getSaveGameLocation(frame);
       if (f != null) {
         game.saveGame(f);
         JOptionPane.showMessageDialog(frame, "Game Saved", "Game Saved", JOptionPane.INFORMATION_MESSAGE);

--- a/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -53,6 +53,7 @@ import org.pushingpixels.substance.api.skin.SubstanceTwilightLookAndFeel;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
+import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
@@ -102,27 +103,18 @@ public class TripleAMenuBar extends JMenuBar {
     if (SystemProperties.isMac()) {
       final FileDialog fileDialog = new FileDialog(frame);
       fileDialog.setMode(FileDialog.SAVE);
-
-
       fileDialog.setDirectory(ClientContext.folderSettings().getSaveGamePath());
-      fileDialog.setFilenameFilter((dir, name) -> {
-        // the extension should be .tsvg, but find svg extensions as well
-        return name.endsWith(".tsvg") || name.endsWith(".svg");
-      });
+      fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
       fileDialog.setVisible(true);
-      String fileName = fileDialog.getFile();
-      final String dirName = fileDialog.getDirectory();
+
+      final String fileName = fileDialog.getFile();
       if (fileName == null) {
         return null;
-      } else {
-        if (!fileName.endsWith(".tsvg")) {
-          fileName += ".tsvg";
-        }
-        // If the user selects a filename that already exists,
-        // the AWT Dialog on Mac OS X will ask the user for confirmation
-        final File f = new File(dirName, fileName);
-        return f;
       }
+
+      // If the user selects a filename that already exists,
+      // the AWT Dialog on Mac OS X will ask the user for confirmation
+      return new File(fileDialog.getDirectory(), GameDataFileUtils.addExtensionIfAbsent(fileName));
     } else { // Non-Mac platforms should use the normal Swing JFileChooser
       final JFileChooser fileChooser = SaveGameFileChooser.getInstance();
       final int rVal = fileChooser.showSaveDialog(frame);
@@ -140,9 +132,7 @@ public class TripleAMenuBar extends JMenuBar {
           return null;
         }
       }
-      if (!f.getName().toLowerCase().endsWith(".tsvg")) {
-        f = new File(f.getParent(), f.getName() + ".tsvg");
-      }
+      f = new File(f.getParent(), GameDataFileUtils.addExtensionIfAbsent(f.getName()));
       // A small warning so users will not over-write a file
       if (f.exists()) {
         final int choice =

--- a/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -94,9 +94,14 @@ public class TripleAMenuBar extends JMenuBar {
     lobby.add(new RemoveGameFromLobbyAction(watcher));
   }
 
-
-  public static File getSaveGameLocationDialog(final Frame frame) {
-
+  /**
+   * Displays a file chooser dialog for the user to select the file to which the current game should be saved.
+   *
+   * @param frame The owner of the file chooser dialog; may be {@code null}.
+   *
+   * @return The file to which the current game should be saved or {@code null} if the user cancelled the operation.
+   */
+  public static File getSaveGameLocation(final Frame frame) {
     // For some strange reason,
     // the only way to get a Mac OS X native-style file dialog
     // is to use an AWT FileDialog instead of a Swing JDialog

--- a/src/test/java/games/strategy/engine/framework/GameDataFileUtilsTests.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataFileUtilsTests.java
@@ -1,0 +1,158 @@
+package games.strategy.engine.framework;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.io.IOCase;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+@RunWith(Enclosed.class)
+public final class GameDataFileUtilsTests {
+  public static final class AddExtensionTest {
+    private static String addExtension(final String fileName) {
+      return GameDataFileUtils.addExtension(fileName);
+    }
+
+    @Test
+    public void shouldAddExtensionWhenExtensionAbsent() {
+      assertThat(addExtension("file"), is("file.tsvg"));
+    }
+
+    @Test
+    public void shouldAddExtensionWhenExtensionPresent() {
+      assertThat(addExtension("file.tsvg"), is("file.tsvg.tsvg"));
+    }
+  }
+
+  @RunWith(Enclosed.class)
+  public static final class AddExtensionIfAbsentTests {
+    public static final class WhenFileSystemIsCaseSensitiveTest {
+      private static String addExtensionIfAbsent(final String fileName) {
+        return GameDataFileUtils.addExtensionIfAbsent(fileName, IOCase.SENSITIVE);
+      }
+
+      @Test
+      public void shouldAddExtensionWhenExtensionAbsent() {
+        assertThat(addExtensionIfAbsent("file"), is("file.tsvg"));
+      }
+
+      @Test
+      public void shouldNotAddExtensionWhenSameCasedExtensionPresent() {
+        assertThat(addExtensionIfAbsent("file.tsvg"), is("file.tsvg"));
+      }
+
+      @Test
+      public void shouldAddExtensionWhenDifferentCasedExtensionPresent() {
+        assertThat(addExtensionIfAbsent("file.TSVG"), is("file.TSVG.tsvg"));
+      }
+    }
+
+    public static final class WhenFileSystemIsCaseInsensitiveTest {
+      private static String addExtensionIfAbsent(final String fileName) {
+        return GameDataFileUtils.addExtensionIfAbsent(fileName, IOCase.INSENSITIVE);
+      }
+
+      @Test
+      public void shouldAddExtensionWhenExtensionAbsent() {
+        assertThat(addExtensionIfAbsent("file"), is("file.tsvg"));
+      }
+
+      @Test
+      public void shouldNotAddExtensionWhenSameCasedExtensionPresent() {
+        assertThat(addExtensionIfAbsent("file.tsvg"), is("file.tsvg"));
+      }
+
+      @Test
+      public void shouldNotAddExtensionWhenDifferentCasedExtensionPresent() {
+        assertThat(addExtensionIfAbsent("file.TSVG"), is("file.TSVG"));
+      }
+    }
+  }
+
+  @RunWith(Enclosed.class)
+  public static final class IsCandidateFileNameTests {
+    public static final class WhenFileSystemIsCaseSensitiveTest {
+      private static boolean isCandidateFileName(final String fileName) {
+        return GameDataFileUtils.isCandidateFileName(fileName, IOCase.SENSITIVE);
+      }
+
+      @Test
+      public void shouldReturnFalseWhenExtensionAbsent() {
+        assertThat(isCandidateFileName("file"), is(false));
+      }
+
+      @Test
+      public void shouldReturnTrueWhenSameCasedPrimaryExtensionPresent() {
+        assertThat(isCandidateFileName("file.tsvg"), is(true));
+      }
+
+      @Test
+      public void shouldReturnFalseWhenDifferentCasedPrimaryExtensionPresent() {
+        assertThat(isCandidateFileName("file.TSVG"), is(false));
+      }
+
+      @Test
+      public void shouldReturnTrueWhenSameCasedLegacyExtensionPresent() {
+        assertThat(isCandidateFileName("file.svg"), is(true));
+      }
+
+      @Test
+      public void shouldReturnFalseWhenDifferentCasedLegacyExtensionPresent() {
+        assertThat(isCandidateFileName("file.SVG"), is(false));
+      }
+
+      @Test
+      public void shouldReturnTrueWhenSameCasedMacOsAlternativeExtensionPresent() {
+        assertThat(isCandidateFileName("filetsvg.gz"), is(true));
+      }
+
+      @Test
+      public void shouldReturnFalseWhenDifferentCasedMacOsAlternativeExtensionPresent() {
+        assertThat(isCandidateFileName("fileTSVG.GZ"), is(false));
+      }
+    }
+
+    public static final class WhenFileSystemIsCaseInsensitiveTest {
+      private static boolean isCandidateFileName(final String fileName) {
+        return GameDataFileUtils.isCandidateFileName(fileName, IOCase.INSENSITIVE);
+      }
+
+      @Test
+      public void shouldReturnFalseWhenExtensionAbsent() {
+        assertThat(isCandidateFileName("file"), is(false));
+      }
+
+      @Test
+      public void shouldReturnTrueWhenSameCasedPrimaryExtensionPresent() {
+        assertThat(isCandidateFileName("file.tsvg"), is(true));
+      }
+
+      @Test
+      public void shouldReturnTrueWhenDifferentCasedPrimaryExtensionPresent() {
+        assertThat(isCandidateFileName("file.TSVG"), is(true));
+      }
+
+      @Test
+      public void shouldReturnTrueWhenSameCasedLegacyExtensionPresent() {
+        assertThat(isCandidateFileName("file.svg"), is(true));
+      }
+
+      @Test
+      public void shouldReturnTrueWhenDifferentCasedLegacyExtensionPresent() {
+        assertThat(isCandidateFileName("file.SVG"), is(true));
+      }
+
+      @Test
+      public void shouldReturnTrueWhenSameCasedMacOsAlternativeExtensionPresent() {
+        assertThat(isCandidateFileName("filetsvg.gz"), is(true));
+      }
+
+      @Test
+      public void shouldReturnTrueWhenDifferentCasedMacOsAlternativeExtensionPresent() {
+        assertThat(isCandidateFileName("fileTSVG.GZ"), is(true));
+      }
+    }
+  }
+}

--- a/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameSequence;
+import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.ui.NewGameChooserEntry;
 import games.strategy.util.Version;
 
@@ -134,7 +135,7 @@ public class GameSelectorModelTest {
     testObj.load((GameData) null, ".xml");
     assertThat(testObj.isSavedGame(), is(false));
 
-    testObj.load((GameData) null, "file.tsvg");
+    testObj.load((GameData) null, GameDataFileUtils.addExtension("file"));
     assertThat(testObj.isSavedGame(), is(true));
   }
 


### PR DESCRIPTION
This PR moves all logic related to game data file extensions to the new `GameDataFileUtils` class.

This PR is a prerequisite for forthcoming serialization proxy PRs.  It is part of a plan to introduce a feature toggle for saving and loading games using the new serialization format.  (TL;DR: skip ahead to "Functional changes".)

I plan on introducing serialization proxy save game support in parallel with the existing save game implementation.  This will allow users to beta test the new feature without any loss of functionality.  Users can opt-in to the new feature via a feature toggle while it's in development.

In order to ensure save games in the new format do not interfere with the current format  (e.g. by overwriting auto saves), I intend to use a different extension (e.g. `.tsvgx`) for the new format (at least while it's in development).  Currently, the logic for using the `.tsvg` extension (among some other uncommon extensions) is scattered throughout the code base.  Therefore, it was desirable to encapsulate it in one place to reduce the number of locations in the code where the feature toggle will need to be introduced to use the new file extension.

#### Functional changes
* Extracted the new class `GameDataFileUtils` which provides a few utilities for working with game data file name extensions:
    * constructing file names with the appropriate extension for a game data file
    * determining if a file name is a candidate game data file (used by file choosers)
* The new `GameDataFileUtils` methods operate in a case-insensitive manner if the underlying file system is case insensitive as reported by Apache Commons IO's `IOCase` class.  The existing code inconsistently checked for a case-insensitive file system.  We now apply that factor consistently.

#### Functional issues for review
* Please advise if `GameDataFileUtils` should be renamed or placed in a more appropriate package.
* `IOCase` is not a perfect solution for detecting a case-insensitive file system.  It uses the path separator character to make a decision.  This doesn't work on MacOS with the case-insensitive file system enabled.  I don't think this is that big of a deal since a lot of existing checks rely on simply looking at the platform (e.g. `SystemProperties#isWindows()`).
* There was existing code to display save game files that had the extensions `.svg` and `tsvg.gz` (note no leading period!).  The former was apparently the legacy save game file extension, while the latter is  an artifact of how save game files are downloaded on Macs (see e9f3c06).  I don't know how to reproduce the Mac case (e.g. is it due to a mail client saving a PBEM attachment?) nor if it is something we need to continue to support.

#### Refactoring changes
* In some places, I extracted new methods to encapsulate the creation of a file name that required a few lines of code (e.g. autosaves).
* I renamed `TripleAMenuBar#getSaveGameLocationDialog()` to `getSaveGameLocation()`.  The `Dialog` suffix doesn't make sense for the current implementation.

#### Refactoring issues for review
None.

#### Testing
I manually tested the following scenarios to ensure save game files are named appropriately:

* Save game during local game
    * With and without specifying `.tsvg` extension in file chooser
* Save game during PBEM game
* Autosave before/after steps
* Autosave after even/odd rounds
* Autosave on headed server after client disconnects during network game
* Autosave on headless server after client disconnects during network game

I also verified the file choosers displayed the expected files:

* Load game file chooser shows `.tsvg`, `.svg`, and `tsvg.gz` files
* Save game file chooser shows `.tsvg`, `.svg`, and `tsvg.gz` files

Note that I only ran these tests on Linux.  The unit tests should cover the Windows case-insensitive possibilities.  I am unable to test on Mac.