### PR TITLE
split arg parsing code between gui client and headless (bot) client

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -1,0 +1,58 @@
+package games.strategy.engine.framework;
+
+import java.util.Arrays;
+
+import games.strategy.triplea.settings.SystemPreferenceKey;
+import games.strategy.triplea.settings.SystemPreferences;
+
+public class ArgParser {
+  /**
+   * Move command line arguments to System.properties
+   * @return Return true if all args were valid and accepted, false otherwise.
+   */
+  public static boolean handleCommandLineArgs(
+      final String[] args, final String[] availableProperties, GameRunner.GameMode gameMode) {
+    if (args.length == 1 && !args[0].contains("=")) {
+      // assume a default single arg, convert the format so we can process as normally.
+      args[0] = GameRunner.TRIPLEA_GAME_PROPERTY + "=" + args[0];
+    }
+
+    for (final String arg : args) {
+      String key;
+      final int indexOf = arg.indexOf('=');
+      if (indexOf > 0) {
+        key = arg.substring(0, indexOf);
+      } else {
+        throw new IllegalArgumentException("Argument " + arg + " doesn't match pattern 'key=value'");
+      }
+      if (!setSystemProperty(key, getValue(arg), availableProperties)) {
+        System.out.println("Unrecognized: " + arg + ", available: " + Arrays.asList(availableProperties));
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean setSystemProperty(String key, String value, String[] availableProperties) {
+    for (final String property : availableProperties) {
+      if (key.equals(property)) {
+        if (property.equals(GameRunner.MAP_FOLDER)) {
+          SystemPreferences.put(SystemPreferenceKey.MAP_FOLDER_OVERRIDE, value);
+        } else {
+          System.getProperties().setProperty(property, value);
+        }
+        System.out.println(property + ":" + value);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String getValue(final String arg) {
+    final int index = arg.indexOf('=');
+    if (index == -1) {
+      return "";
+    }
+    return arg.substring(index + 1);
+  }
+}

--- a/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -11,7 +11,7 @@ public class ArgParser {
    * @return Return true if all args were valid and accepted, false otherwise.
    */
   public static boolean handleCommandLineArgs(
-      final String[] args, final String[] availableProperties, GameRunner.GameMode gameMode) {
+      final String[] args, final String[] availableProperties) {
     if (args.length == 1 && !args[0].contains("=")) {
       // assume a default single arg, convert the format so we can process as normally.
       args[0] = GameRunner.TRIPLEA_GAME_PROPERTY + "=" + args[0];

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -110,6 +110,11 @@ public class GameRunner {
 
 
 
+  /**
+   * Launches the "main" TripleA gui enabled game client.
+   * No args will launch a client, additional args can be supplied to specify additional behavior.
+   * Warning: game engine code invokes this method to spawn new game clients.
+   */
   public static void main(final String[] args) {
     ErrorConsole.getConsole();
     // do after we handle command line args
@@ -214,6 +219,9 @@ public class GameRunner {
   }
 
 
+  /**
+   * Returns the property set parsed from a 'system.ini' file (as found at the project root).
+   */
   public static Properties getSystemIni() {
     final Properties rVal = new Properties();
     final File systemIni = new File(ClientFileSystemHelper.getRootFolder(), SYSTEM_INI);
@@ -227,6 +235,9 @@ public class GameRunner {
     return rVal;
   }
 
+  /**
+   * Writes a set of properties to the system.ini file.
+   */
   public static void writeSystemIni(final Properties properties) {
     final Properties toWrite;
 

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -117,6 +117,10 @@ public class GameRunner {
    */
   public static void main(final String[] args) {
     ErrorConsole.getConsole();
+    if (!ArgParser.handleCommandLineArgs(args, COMMAND_LINE_ARGS)) {
+      usage();
+      return;
+    }
     // do after we handle command line args
     Memory.checkForMemoryXMX();
 
@@ -126,10 +130,6 @@ public class GameRunner {
     HttpProxy.setupProxies();
     new Thread(GameRunner::checkLocalSystem).start();
     new Thread(GameRunner::checkForUpdates).start();
-    if (!ArgParser.handleCommandLineArgs(args, COMMAND_LINE_ARGS)) {
-      usage();
-      return;
-    }
 
     final String version = System.getProperty(TRIPLEA_ENGINE_VERSION_BIN);
     if (version != null && version.length() > 0) {

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -51,10 +51,6 @@ import games.strategy.util.Version;
  */
 public class GameRunner {
 
-  public enum GameMode {
-    SWING_CLIENT, HEADLESS_BOT
-  }
-
   public static final String TRIPLEA_HEADLESS = "triplea.headless";
   public static final String TRIPLEA_GAME_HOST_CONSOLE_PROPERTY = "triplea.game.host.console";
   public static final int LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM = 21600;
@@ -119,13 +115,13 @@ public class GameRunner {
     // do after we handle command line args
     Memory.checkForMemoryXMX();
 
-    SwingUtilities.invokeLater(() -> LookAndFeel.setupLookAndFeel());
+    SwingUtilities.invokeLater(LookAndFeel::setupLookAndFeel);
     showMainFrame();
-    new Thread(() -> setupLogging(GameMode.SWING_CLIENT)).start();
+    new Thread(GameRunner::setupLogging).start();
     HttpProxy.setupProxies();
     new Thread(GameRunner::checkLocalSystem).start();
-    new Thread(() -> checkForUpdates()).start();
-    if(!ArgParser.handleCommandLineArgs(args, COMMAND_LINE_ARGS, GameMode.SWING_CLIENT)) {
+    new Thread(GameRunner::checkForUpdates).start();
+    if (!ArgParser.handleCommandLineArgs(args, COMMAND_LINE_ARGS)) {
       usage();
       return;
     }
@@ -202,21 +198,19 @@ public class GameRunner {
 
 
 
-  private static void setupLogging(GameMode gameMode) {
-    if (gameMode == GameMode.SWING_CLIENT) {
-      Toolkit.getDefaultToolkit().getSystemEventQueue().push(new EventQueue() {
-        @Override
-        protected void dispatchEvent(AWTEvent newEvent) {
-          try {
-            super.dispatchEvent(newEvent);
-            // This ensures, that all exceptions/errors inside any swing framework (like substance) are logged correctly
-          } catch (Throwable t) {
-            ClientLogger.logError(t);
-            throw t;
-          }
+  private static void setupLogging() {
+    Toolkit.getDefaultToolkit().getSystemEventQueue().push(new EventQueue() {
+      @Override
+      protected void dispatchEvent(AWTEvent newEvent) {
+        try {
+          super.dispatchEvent(newEvent);
+          // This ensures, that all exceptions/errors inside any swing framework (like substance) are logged correctly
+        } catch (Throwable t) {
+          ClientLogger.logError(t);
+          throw t;
         }
-      });
-    }
+      }
+    });
   }
 
 

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -435,22 +435,23 @@ public class HeadlessGameServer {
     s_logger.info("Game Server initialized");
   }
 
-  private static synchronized void restartLobbyWatcher(final SetupPanelModel setupPanelModel, final ServerGame iGame) {
+  private static synchronized void restartLobbyWatcher(
+      final SetupPanelModel setupPanelModel, final ServerGame serverGame) {
     try {
       final ISetupPanel setup = setupPanelModel.getPanel();
       if (setup == null) {
         return;
       }
-      if (iGame != null) {
+      if (serverGame != null) {
         return;
       }
       if (setup.canGameStart()) {
         return;
       }
       if (setup instanceof ServerSetupPanel) {
-        ((ServerSetupPanel) setup).repostLobbyWatcher(iGame);
+        ((ServerSetupPanel) setup).repostLobbyWatcher(serverGame);
       } else if (setup instanceof HeadlessServerSetup) {
-        ((HeadlessServerSetup) setup).repostLobbyWatcher(iGame);
+        ((HeadlessServerSetup) setup).repostLobbyWatcher(serverGame);
       }
     } catch (final Exception e) {
       ClientLogger.logQuietly(e);
@@ -680,8 +681,10 @@ public class HeadlessGameServer {
         + "   " + GameRunner.LOBBY_GAME_SUPPORT_PASSWORD + "=<password for remote actions, such as remote stop game>\n"
         + "   " + GameRunner.LOBBY_GAME_RECONNECTION + "=<seconds between refreshing lobby connection [min "
         + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM + "]>\n"
-        + "   " + GameRunner.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME + "=<seconds to wait for all clients to start the game>\n"
-        + "   " + GameRunner.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME + "=<seconds to wait for an observer joining the game>\n"
+        + "   " + GameRunner.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME
+        + "=<seconds to wait for all clients to start the game>\n"
+        + "   " + GameRunner.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME
+        + "=<seconds to wait for an observer joining the game>\n"
         + "   " + GameRunner.MAP_FOLDER + "=mapFolder"
         + "\n"
         + "   You must start the Name and HostedBy with \"Bot\".\n"
@@ -721,15 +724,15 @@ public class HeadlessGameServer {
       printUsage = true;
     }
 
-    final String reconnection =
-        System.getProperty(GameRunner.LOBBY_GAME_RECONNECTION, "" + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT);
+    final String reconnection = System.getProperty(GameRunner.LOBBY_GAME_RECONNECTION,
+        "" + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT);
     try {
       final int reconnect = Integer.parseInt(reconnection);
       if (reconnect < GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM) {
         System.out.println("Invalid argument: " + GameRunner.LOBBY_GAME_RECONNECTION
             + " must be an integer equal to or greater than " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM
-            + " seconds, and should normally be either " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT + " or "
-            + (2 * GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT) + " seconds.");
+            + " seconds, and should normally be either " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT
+            + " or " + (2 * GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT) + " seconds.");
         printUsage = true;
       }
     } catch (final NumberFormatException e) {

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -17,6 +17,7 @@ import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.IChatPanel;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.properties.GameProperties;
+import games.strategy.engine.framework.ArgParser;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
@@ -35,6 +36,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.util.MD5Crypt;
 import games.strategy.util.ThreadUtil;
 import games.strategy.util.TimeManager;
+import games.strategy.util.Util;
 
 /**
  * A way of hosting a game, but headless.
@@ -648,12 +650,125 @@ public class HeadlessGameServer {
   }
 
   public static void main(final String[] args) {
-    GameRunner.handleCommandLineArgs(args, getProperties(), GameRunner.GameMode.HEADLESS_BOT);
+    System.getProperties().setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
+    if(!ArgParser.handleCommandLineArgs(args, getProperties(), GameRunner.GameMode.HEADLESS_BOT)) {
+      usage();
+      return;
+    }
+
+    handleHeadlessGameServerArgs();
     ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
     try {
       new HeadlessGameServer();
     } catch (final Exception e) {
       ClientLogger.logError("Failed to start game server: " + e);
     }
+  }
+
+  private static void usage() {
+    System.out.println("\nUsage and Valid Arguments:\n"
+        + "   " + GameRunner.TRIPLEA_GAME_PROPERTY + "=<FILE_NAME>\n"
+        + "   " + GameRunner.TRIPLEA_GAME_HOST_CONSOLE_PROPERTY + "=<true/false>\n"
+        + "   " + GameRunner.TRIPLEA_SERVER_PROPERTY + "=true\n"
+        + "   " + GameRunner.TRIPLEA_PORT_PROPERTY + "=<PORT>\n"
+        + "   " + GameRunner.TRIPLEA_NAME_PROPERTY + "=<PLAYER_NAME>\n"
+        + "   " + GameRunner.LOBBY_HOST + "=<LOBBY_HOST>\n"
+        + "   " + LobbyServer.TRIPLEA_LOBBY_PORT_PROPERTY + "=<LOBBY_PORT>\n"
+        + "   " + GameRunner.LOBBY_GAME_COMMENTS + "=<LOBBY_GAME_COMMENTS>\n"
+        + "   " + GameRunner.LOBBY_GAME_HOSTED_BY + "=<LOBBY_GAME_HOSTED_BY>\n"
+        + "   " + GameRunner.LOBBY_GAME_SUPPORT_EMAIL + "=<youremail@emailprovider.com>\n"
+        + "   " + GameRunner.LOBBY_GAME_SUPPORT_PASSWORD + "=<password for remote actions, such as remote stop game>\n"
+        + "   " + GameRunner.LOBBY_GAME_RECONNECTION + "=<seconds between refreshing lobby connection [min "
+        + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM + "]>\n"
+        + "   " + GameRunner.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME + "=<seconds to wait for all clients to start the game>\n"
+        + "   " + GameRunner.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME + "=<seconds to wait for an observer joining the game>\n"
+        + "   " + GameRunner.MAP_FOLDER + "=mapFolder"
+        + "\n"
+        + "   You must start the Name and HostedBy with \"Bot\".\n"
+        + "   Game Comments must have this string in it: \"automated_host\".\n"
+        + "   You must include a support email for your host, so that you can be alerted by lobby admins when your "
+        + "host has an error."
+        + " (For example they may email you when your host is down and needs to be restarted.)\n"
+        + "   Support password is a remote access password that will allow lobby admins to remotely take the "
+        + "following actions: ban player, stop game, shutdown server."
+        + " (Please email this password to one of the lobby moderators, or private message an admin on the "
+        + "TripleaWarClub.org website forum.)\n");
+  }
+
+  private static void handleHeadlessGameServerArgs() {
+    boolean printUsage = false;
+    final String playerName = System.getProperty(GameRunner.TRIPLEA_NAME_PROPERTY, "");
+    final String hostName = System.getProperty(GameRunner.LOBBY_GAME_HOSTED_BY, "");
+    if (playerName.length() < 7 || hostName.length() < 7 || !hostName.equals(playerName)
+        || !playerName.startsWith("Bot") || !hostName.startsWith("Bot")) {
+      System.out.println(
+          "Invalid argument: " + GameRunner.TRIPLEA_NAME_PROPERTY + " and " + GameRunner.LOBBY_GAME_HOSTED_BY
+              + " must start with \"Bot\" and be at least 7 characters long and be the same.");
+      printUsage = true;
+    }
+
+    final String comments = System.getProperty(GameRunner.LOBBY_GAME_COMMENTS, "");
+    if (!comments.contains("automated_host")) {
+      System.out.println(
+          "Invalid argument: " + GameRunner.LOBBY_GAME_COMMENTS + " must contain the string \"automated_host\".");
+      printUsage = true;
+    }
+
+    final String email = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_EMAIL, "");
+    if (email.length() < 3 || !Util.isMailValid(email)) {
+      System.out.println(
+          "Invalid argument: " + GameRunner.LOBBY_GAME_SUPPORT_EMAIL + " must contain a valid email address.");
+      printUsage = true;
+    }
+
+    final String reconnection =
+        System.getProperty(GameRunner.LOBBY_GAME_RECONNECTION, "" + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT);
+    try {
+      final int reconnect = Integer.parseInt(reconnection);
+      if (reconnect < GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM) {
+        System.out.println("Invalid argument: " + GameRunner.LOBBY_GAME_RECONNECTION
+            + " must be an integer equal to or greater than " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM
+            + " seconds, and should normally be either " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT + " or "
+            + (2 * GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT) + " seconds.");
+        printUsage = true;
+      }
+    } catch (final NumberFormatException e) {
+      System.out.println("Invalid argument: " + GameRunner.LOBBY_GAME_RECONNECTION
+          + " must be an integer equal to or greater than " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM
+          + " seconds, and should normally be either " + GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT + " or "
+          + (2 * GameRunner.LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT) + " seconds.");
+      printUsage = true;
+    }
+    // no passwords allowed for bots
+    // take any actions or commit to preferences
+    final String clientWait = System.getProperty(GameRunner.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME, "");
+    final String observerWait = System.getProperty(GameRunner.TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME, "");
+    if (clientWait.length() > 0) {
+      try {
+        final int wait = Integer.parseInt(clientWait);
+        GameRunner.setServerStartGameSyncWaitTime(wait);
+      } catch (final NumberFormatException e) {
+        System.out.println(
+            "Invalid argument: " + GameRunner.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME + " must be an integer.");
+        printUsage = true;
+      }
+    }
+    if (observerWait.length() > 0) {
+      try {
+        final int wait = Integer.parseInt(observerWait);
+        GameRunner.setServerObserverJoinWaitTime(wait);
+      } catch (final NumberFormatException e) {
+        System.out.println(
+            "Invalid argument: " + GameRunner.TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME + " must be an integer.");
+        printUsage = true;
+      }
+    }
+
+    if (printUsage) {
+      usage();
+      System.exit(-1);
+    }
+
+
   }
 }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -651,7 +651,7 @@ public class HeadlessGameServer {
 
   public static void main(final String[] args) {
     System.getProperties().setProperty(GameRunner.TRIPLEA_HEADLESS, "true");
-    if(!ArgParser.handleCommandLineArgs(args, getProperties(), GameRunner.GameMode.HEADLESS_BOT)) {
+    if (!ArgParser.handleCommandLineArgs(args, getProperties())) {
       usage();
       return;
     }

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -1,0 +1,85 @@
+package games.strategy.engine.framework;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class ArgParserTest {
+
+
+  @Test
+  public void argsTurnIntoSystemProps() {
+    assertThat("check precondition, system property for our test key should not be set yet.",
+        System.getProperty(TestData.propKey), nullValue());
+
+    boolean result = ArgParser.handleCommandLineArgs(
+        TestData.sampleArgInput, TestData.samplePropertyNameSet);
+
+    assertThat("prop key was supplied as an available value, "
+            + " which was passed as a test value - everything should "
+            + "have parsed well, expect true result",
+        result, is(true));
+    assertThat("system property should now be set to our test value",
+        System.getProperty(TestData.propKey), is(TestData.propValue));
+  }
+
+  @Test
+  public void emptySystemPropertiesCanBeSet() {
+    ArgParser.handleCommandLineArgs(new String[] {"a="}, new String[] {"a"});
+    assertThat("expecting the system property to be empty string instead of null",
+        System.getProperty("a"), is(""));
+  }
+
+  @Test
+  public void malformedInputThrowsException() {
+    Arrays.asList(
+        new String[] {"=a"}, // no key
+        new String[] {"="},
+        new String[] {"a=b", "a"},
+        new String[] {"a=b", " "})
+        .forEach(invalidInput -> {
+          try {
+            ArgParser.handleCommandLineArgs(invalidInput, new String[] {"a"});
+            fail("Did not throw an exception as expected on input: " + Arrays.asList(invalidInput));
+          } catch (IllegalArgumentException expected) {
+            // expected
+          }
+        });
+  }
+
+  @Test
+  public void singleArgIsAssumedToBeGameProperty() {
+    ArgParser.handleCommandLineArgs(new String[] {TestData.propValue}, new String[] {GameRunner.TRIPLEA_GAME_PROPERTY});
+    assertThat("if we pass only one arg, it is assumed to mean we are specifying the 'game property'",
+        System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY), is(TestData.propValue));
+  }
+
+  @Test
+  public void returnFalseIfWeCannotMapKeysToAvailableSet() {
+    final String[] validKeys = {"a", "b"};
+    Arrays.asList(
+        new String[] {"notMapped="},
+        new String[] {"notMapped=test"},
+        new String[] {"notMapped=test", "a=valid"},
+        new String[] {"a=valid", "notMapped=test"},
+        new String[] {"a=valid", "notMapped=test", "b=valid"},
+        new String[] {"a=valid", "b=valid", "notMapped=test"})
+        .forEach(invalidInput ->
+            assertThat("A key in the input is not in the valid key set, expecting this to be seen"
+                    + "as invalid: " + Arrays.asList(invalidInput),
+                ArgParser.handleCommandLineArgs(invalidInput, validKeys), is(false)));
+  }
+
+
+  private interface TestData {
+    String propKey = "key";
+    String propValue = "value";
+    String[] sampleArgInput = new String[] {propKey + "=" + propValue};
+    String[] samplePropertyNameSet = new String[] {propKey};
+  }
+}

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -7,10 +7,16 @@ import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 
+import org.junit.After;
 import org.junit.Test;
 
 public class ArgParserTest {
 
+
+  @After
+  public void teardown() {
+    System.clearProperty(GameRunner.TRIPLEA_GAME_PROPERTY);
+  }
 
   @Test
   public void argsTurnIntoSystemProps() {


### PR DESCRIPTION
Goal here is to remove some of the conditional logic in shared code between the headless and gui enabled clients. This is pretty much a straight refactoring update. There are 2-3 iterations worth of changes and stopped there to keep the diff smaller and more reviewable. 

To do this client specific code was moved out of conditional branches and moved to locations that are specific to GUI client or headless client setup (basically move the caller specific code wrapped in conditionals to the respective caller instead).

A good chunk of common code is in the  'argParsing' logic, which was extracted to a new class
 and a test case was written for it.  One semantic difference, Arg parsing now returns a boolean if param matching fails. This is not the best per-say, but in the interest of scope - that is not being refactored further on this branch for the moment. 

The usage method of GameRunner was shared with a pretty clean if/else block - this was simply broken up. 

One call out - the location of where we set the `headless = true` property was moved up in the call stack, we now set it earlier than when we used to before. The new location in the HeadlessGameServer main method is simply to make that step more explicit. (should be safe - I believe any code that depended on this property is after arg parsing, so moving it to a location that is earlier in the call flow should be okay.) 