### PR TITLE
Rename 'Map Options' button to 'Game Options'.

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -146,8 +146,8 @@ public class GameSelectorPanel extends JPanel implements Observer {
         + "you have downloaded.</html>");
     m_loadSavedGame = new JButton("Open Saved Game");
     m_loadSavedGame.setToolTipText("Open a previously saved game, or an autosave.");
-    m_gameOptions = new JButton("Map Options");
-    m_gameOptions.setToolTipText("<html>Set options for the currently selected game, <br>such as enabling/disabling "
+    m_gameOptions = new JButton("Game Options");
+    m_gameOptions.setToolTipText("<html>Set options for the current game, <br>such as enabling/disabling "
         + "Low Luck, or Technology, etc.</html>");
   }
 


### PR DESCRIPTION
 Sticking with pervasive TripleA terminology, game is a map plus game rules, a map is just tiles and no game rules or units. The options refer then to the 'game'. The help text still uses the 'game' terminology even. I think this rename helps clear up quite a bit that these options can update save games as well. For example, players often ask how to switch from LL to dice or vice versa, and it's not clear that updating options on a load would update the current game. Part of that is that we put very close the 'map select' option, which is clearly for new games. Associating then 'map select' and 'map options' would seem pretty natural, but is misleading.

Before:
![before](https://user-images.githubusercontent.com/12397753/26916801-89f2eea2-4be0-11e7-9395-00dc4421969d.png)

After:
![post_rename](https://user-images.githubusercontent.com/12397753/26916779-7ae16894-4be0-11e7-8f78-0694b9d0c64f.png)

