### PR TITLE
Remove the option for delayed parsing.

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -19,9 +19,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
-
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 
@@ -57,15 +55,14 @@ public class GameRunner {
     SWING_CLIENT, HEADLESS_BOT
   }
 
+
   public static final String TRIPLEA_HEADLESS = "triplea.headless";
   public static final String TRIPLEA_GAME_HOST_CONSOLE_PROPERTY = "triplea.game.host.console";
   public static final int LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM = 21600;
   public static final int LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT = 2 * LOBBY_RECONNECTION_REFRESH_SECONDS_MINIMUM;
   public static final String NO_REMOTE_REQUESTS_ALLOWED = "noRemoteRequestsAllowed";
 
-  // not arguments:
   public static final int PORT = 3300;
-  private static final String DELAYED_PARSING = "DelayedParsing";
   // do not include this in the getProperties list. they are only for loading an old savegame.
   public static final String OLD_EXTENSION = ".old";
   // argument options below:
@@ -89,7 +86,6 @@ public class GameRunner {
   public static final String TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME = "triplea.server.startGameSyncWaitTime";
   public static final String TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME = "triplea.server.observerJoinWaitTime";
   // non-commandline-argument-properties (for preferences)
-  // first time we've run this version of triplea?
   private static final String SYSTEM_INI = "system.ini";
   public static final int MINIMUM_CLIENT_GAMEDATA_LOAD_GRACE_TIME = 20;
   private static final int DEFAULT_CLIENT_GAMEDATA_LOAD_GRACE_TIME =
@@ -107,7 +103,7 @@ public class GameRunner {
 
   public static final String MAP_FOLDER = "mapFolder";
 
-  private static String[] COMMAND_LINE_ARGS =
+  private static final String[] COMMAND_LINE_ARGS =
       {TRIPLEA_GAME_PROPERTY, TRIPLEA_SERVER_PROPERTY, TRIPLEA_CLIENT_PROPERTY, TRIPLEA_HOST_PROPERTY,
           TRIPLEA_PORT_PROPERTY, TRIPLEA_NAME_PROPERTY, TRIPLEA_SERVER_PASSWORD_PROPERTY, TRIPLEA_STARTED,
           LobbyServer.TRIPLEA_LOBBY_PORT_PROPERTY,
@@ -115,7 +111,7 @@ public class GameRunner {
           HttpProxy.PROXY_PORT, TRIPLEA_DO_NOT_CHECK_FOR_UPDATES, Memory.TRIPLEA_MEMORY_SET, MAP_FOLDER};
 
 
-  private static void usage(GameMode gameMode) {
+  private static void usage(final GameMode gameMode) {
     if (gameMode == GameMode.HEADLESS_BOT) {
       System.out.println("\nUsage and Valid Arguments:\n"
           + "   " + TRIPLEA_GAME_PROPERTY + "=<FILE_NAME>\n"
@@ -211,7 +207,8 @@ public class GameRunner {
   /**
    * Move command line arguments to System.properties
    */
-  public static void handleCommandLineArgs(final String[] args, final String[] availableProperties, GameMode gameMode) {
+  public static void handleCommandLineArgs(final String[] args, final String[] availableProperties,
+      final GameMode gameMode) {
     if (args.length == 1 && !args[0].contains("=")) {
       // assume a default single arg, convert the format so we can process as normally.
       args[0] = GameRunner.TRIPLEA_GAME_PROPERTY + "=" + args[0];
@@ -219,7 +216,7 @@ public class GameRunner {
 
     boolean usagePrinted = false;
     for (final String arg : args) {
-      String key;
+      final String key;
       final int indexOf = arg.indexOf('=');
       if (indexOf > 0) {
         key = arg.substring(0, indexOf);
@@ -335,7 +332,7 @@ public class GameRunner {
     }
   }
 
-  private static boolean setSystemProperty(String key, String value, String[] availableProperties) {
+  private static boolean setSystemProperty(final String key, final String value, final String[] availableProperties) {
     for (final String property : availableProperties) {
       if (key.equals(property)) {
         if (property.equals(MAP_FOLDER)) {
@@ -358,15 +355,15 @@ public class GameRunner {
     return arg.substring(index + 1);
   }
 
-  private static void setupLogging(GameMode gameMode) {
+  private static void setupLogging(final GameMode gameMode) {
     if (gameMode == GameMode.SWING_CLIENT) {
       Toolkit.getDefaultToolkit().getSystemEventQueue().push(new EventQueue() {
         @Override
-        protected void dispatchEvent(AWTEvent newEvent) {
+        protected void dispatchEvent(final AWTEvent newEvent) {
           try {
             super.dispatchEvent(newEvent);
             // This ensures, that all exceptions/errors inside any swing framework (like substance) are logged correctly
-          } catch (Throwable t) {
+          } catch (final Throwable t) {
             ClientLogger.logError(t);
             throw t;
           }
@@ -402,22 +399,6 @@ public class GameRunner {
     try (FileOutputStream fos = new FileOutputStream(systemIni)) {
       toWrite.store(fos, SYSTEM_INI);
     } catch (final IOException e) {
-      ClientLogger.logQuietly(e);
-    }
-  }
-
-
-  public static boolean getDelayedParsing() {
-    final Preferences pref = Preferences.userNodeForPackage(GameRunner.class);
-    return pref.getBoolean(DELAYED_PARSING, true);
-  }
-
-  public static void setDelayedParsing(final boolean delayedParsing) {
-    final Preferences pref = Preferences.userNodeForPackage(GameRunner.class);
-    pref.putBoolean(DELAYED_PARSING, delayedParsing);
-    try {
-      pref.sync();
-    } catch (final BackingStoreException e) {
       ClientLogger.logQuietly(e);
     }
   }
@@ -552,7 +533,7 @@ public class GameRunner {
    * @return true if we have any out of date maps.
    */
   private static boolean checkForUpdatedMaps() {
-    MapDownloadController downloadController = ClientContext.mapDownloadController();
+    final MapDownloadController downloadController = ClientContext.mapDownloadController();
     return downloadController.checkDownloadedMapsAreLatest();
   }
 
@@ -795,7 +776,7 @@ public class GameRunner {
   public static void exitGameIfFinished() {
     SwingUtilities.invokeLater(() -> {
       boolean allFramesClosed = true;
-      for (Frame f : Frame.getFrames()) {
+      for (final Frame f : Frame.getFrames()) {
         if (f.isVisible()) {
           allFramesClosed = false;
           break;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -55,7 +55,6 @@ class EnginePreferences extends JDialog {
   private final Frame m_parentFrame;
   private JButton m_okButton;
   private JButton m_lookAndFeel;
-  private JButton m_gameParser;
   private JButton m_setupProxies;
   private JButton m_hostWaitTime;
   private JButton m_setMaxMemory;
@@ -83,7 +82,6 @@ class EnginePreferences extends JDialog {
   private void createComponents() {
     m_okButton = new JButton("OK");
     m_lookAndFeel = new JButton("Set Look And Feel");
-    m_gameParser = new JButton("Enable/Disable Delayed Parsing of Game XML's");
     m_setupProxies = new JButton("Setup Network and Proxy Settings");
     m_hostWaitTime = new JButton("Set Max Host Wait Time for Clients and Observers");
     m_setMaxMemory = new JButton("Set Max Memory Usage");
@@ -107,8 +105,6 @@ class EnginePreferences extends JDialog {
     SoundOptions.addToPanel(buttonsPanel);
     buttonsPanel.add(new JLabel(" "));
     buttonsPanel.add(m_lookAndFeel);
-    buttonsPanel.add(new JLabel(" "));
-    buttonsPanel.add(m_gameParser);
     buttonsPanel.add(new JLabel(" "));
     buttonsPanel.add(m_setupProxies);
     buttonsPanel.add(new JLabel(" "));
@@ -154,30 +150,6 @@ class EnginePreferences extends JDialog {
             "The look and feel has been applied. Please restart TripleA for it to take full effect",
             new CountDownLatchHandler(true));
       }
-    }));
-    m_gameParser.addActionListener(SwingAction.of("Enable/Disable Delayed Parsing of Game XML's", e -> {
-      // TODO: replace with 2 radio buttons
-      final boolean current = GameRunner.getDelayedParsing();
-      final Object[] options = {"Parse Selected", "Parse All", "Cancel"};
-      final int answer = JOptionPane.showOptionDialog(m_parentFrame,
-          new JLabel("<html>Delay Parsing of Game Data from XML until game is selected?" + "<br><br>'" + options[1]
-              + "' means each map is fully parsed as TripleA starts (useful for testing to make sure all your maps are "
-              + "valid, but can slow down the game significantly)."
-              + "<br><br>Your current setting is: '" + (current ? options[0].toString() : options[1].toString())
-              + "'</html>"),
-          "Select Parsing Method", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options,
-          options[2]);
-      if (answer == JOptionPane.CANCEL_OPTION) {
-        return;
-      }
-      final boolean delay = (answer == JOptionPane.YES_OPTION);
-      if (delay == current) {
-        return;
-      }
-      GameRunner.setDelayedParsing(delay);
-      EventThreadJOptionPane.showMessageDialog(m_parentFrame, "Please restart TripleA to avoid any potential errors",
-          new CountDownLatchHandler(true));
-
     }));
     m_setupProxies.addActionListener(SwingAction.of("Setup Network and Proxy Settings", e -> {
       // TODO: this action listener should probably come from the HttpProxy class

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooserEntry.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooserEntry.java
@@ -52,9 +52,9 @@ public class NewGameChooserEntry {
     }
 
     try (InputStream input = inputStream.get()) {
-      final boolean delayParsing = GameRunner.getDelayedParsing();
+      boolean delayParsing = true;
       gameData = new GameParser(uri.toString()).parse(input, gameName, delayParsing);
-      gameDataFullyLoaded = !delayParsing;
+      gameDataFullyLoaded = false;
       gameNameAndMapNameProperty = getGameName() + ":" + getMapNameProperty();
     }
   }
@@ -72,7 +72,8 @@ public class NewGameChooserEntry {
     }
 
     try (InputStream input = inputStream.get()) {
-      gameData = new GameParser(url.toString()).parse(input, gameName, false);
+      boolean delayParsing = false;
+      gameData = new GameParser(url.toString()).parse(input, gameName, delayParsing);
       gameDataFullyLoaded = true;
 
     } catch (final EngineVersionException e) {


### PR DESCRIPTION
This removes the 'delayed parsing' option and uses a 'true' value for that option always. As such the UI control is also remove:

![disable_game_parsing](https://user-images.githubusercontent.com/12397753/26917804-7f5fbf8e-4be4-11e7-96ca-d90aa4b506bf.png)


What the option does:
-  This option would take effect when loading the list of maps available for selection. When delayed parsing is on, we do a 'shallow' parse of the XML files which is faster than a 'deep' or 'full' parse. When delayed parsing is off, we do a 'full' parsing of every game on the list.

Full parsing can be problematic when maps that parse slowly are on the list (EG: 'War of the Relics').  In previous conversations about that map, this feature did not have much value even to map makers. Hence, the removal, this is something that should not be changed from the default.