### PR TITLE
Validate map thumbnail image URLs (#1818)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,8 +116,12 @@ git {
 
 task validateYamls(group: 'verification', description: 'Validates YAML files.') {
     doLast {
-        validateYaml(file('lobby_server.yaml'), file("$schemasDir/lobby_server.json"))
-        validateYaml(file('triplea_maps.yaml'), file("$schemasDir/triplea_maps.json"))
+        def lobbyServerYamlFile = file('lobby_server.yaml')
+        validateYaml(lobbyServerYamlFile, file("$schemasDir/lobby_server.json"))
+
+        def mapsYamlFile = file('triplea_maps.yaml')
+        validateYaml(mapsYamlFile, file("$schemasDir/triplea_maps.json"))
+        validateMapsYamlLinks(mapsYamlFile)
     }
 }
 

--- a/gradle/scripts/yaml.gradle
+++ b/gradle/scripts/yaml.gradle
@@ -2,8 +2,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.github.fge.jsonschema.main.JsonSchemaFactory
 import org.apache.http.HttpStatus
-import org.apache.http.client.methods.HttpHead
-import org.apache.http.impl.client.HttpClients
+import org.asynchttpclient.DefaultAsyncHttpClient
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 
@@ -16,9 +15,24 @@ buildscript {
         classpath group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.8.1'
         classpath group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.8.8'
         classpath group: 'com.github.fge', name: 'json-schema-validator', version: '2.2.6'
-        classpath group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
+        classpath group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.6'
+        classpath group: 'org.asynchttpclient', name: 'async-http-client', version: '2.0.32'
         classpath group: 'org.yaml', name: 'snakeyaml', version: '1.18'
     }
+}
+
+def poll(Collection collection, Closure closure) {
+    if (collection.empty) {
+        return null
+    }
+
+    def value = null
+    while ((value = collection.find(closure)) == null) {
+        Thread.yield()
+    }
+
+    collection.remove(value)
+    return value
 }
 
 // Temporary until SnakeYAML defaults to no duplicate keys per YAML 1.2 spec
@@ -53,17 +67,19 @@ ext.validateMapsYamlLinks = { yamlFile ->
     def maps = yaml.load(yamlFile.text)
     def imageUrls = maps . collect { it['img'] } . findAll { it != null }
 
-    def client = HttpClients.createDefault()
-    imageUrls.each {
-        try {
-            def request = new HttpHead(it)
-            def response  = client.execute(request)
-            if (response.statusLine.statusCode != HttpStatus.SC_OK) {
-                throw new GradleException("$it: map thumbnail image not available")
+    def client = new DefaultAsyncHttpClient()
+    try {
+        def tasks = imageUrls.collect { client.prepareHead(it).execute() }
+
+        def task = null
+        while ((task = poll(tasks, { it.done })) != null) {
+            def response = task.get()
+            if (response.statusCode != HttpStatus.SC_OK) {
+                throw new GradleException("$response.uri: map thumbnail image not available ($response.statusCode)")
             }
-        } catch (Exception e) {
-            throw new GradleException("$it: failure during map thumbnail image request", e)
         }
+    } finally {
+        client.close()
     }
 }
 

--- a/gradle/scripts/yaml.gradle
+++ b/gradle/scripts/yaml.gradle
@@ -1,6 +1,9 @@
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.github.fge.jsonschema.main.JsonSchemaFactory
+import org.apache.http.HttpStatus
+import org.apache.http.client.methods.HttpHead
+import org.apache.http.impl.client.HttpClients
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 
@@ -13,6 +16,7 @@ buildscript {
         classpath group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.8.1'
         classpath group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.8.8'
         classpath group: 'com.github.fge', name: 'json-schema-validator', version: '2.2.6'
+        classpath group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
         classpath group: 'org.yaml', name: 'snakeyaml', version: '1.18'
     }
 }
@@ -41,6 +45,25 @@ def validateSchema(yamlFile, jsonSchemaFile) {
     def report = schema.validate(yaml, true)
     if (!report.success) {
         throw new GradleException("$yamlFile: $report")
+    }
+}
+
+ext.validateMapsYamlLinks = { yamlFile ->
+    def yaml = new Yaml()
+    def maps = yaml.load(yamlFile.text)
+    def imageUrls = maps . collect { it['img'] } . findAll { it != null }
+
+    def client = HttpClients.createDefault()
+    imageUrls.each {
+        try {
+            def request = new HttpHead(it)
+            def response  = client.execute(request)
+            if (response.statusLine.statusCode != HttpStatus.SC_OK) {
+                throw new GradleException("$it: map thumbnail image not available")
+            }
+        } catch (Exception e) {
+            throw new GradleException("$it: failure during map thumbnail image request", e)
+        }
     }
 }
 

--- a/gradle/scripts/yaml.gradle
+++ b/gradle/scripts/yaml.gradle
@@ -78,6 +78,7 @@ ext.validateMapsYamlLinks = { yamlFile ->
         def task = null
         while ((task = poll(tasks, { it.done })) != null) {
             def response = task.get()
+            logger.info("Map thumbnail image status ($response.uri): $response.statusCode")
             if (response.statusCode != HttpStatus.SC_OK) {
                 throw new GradleException("$response.uri: map thumbnail image not available ($response.statusCode)")
             }

--- a/gradle/scripts/yaml.gradle
+++ b/gradle/scripts/yaml.gradle
@@ -3,6 +3,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.github.fge.jsonschema.main.JsonSchemaFactory
 import org.apache.http.HttpStatus
 import org.asynchttpclient.DefaultAsyncHttpClient
+import org.asynchttpclient.DefaultAsyncHttpClientConfig
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 
@@ -67,7 +68,10 @@ ext.validateMapsYamlLinks = { yamlFile ->
     def maps = yaml.load(yamlFile.text)
     def imageUrls = maps . collect { it['img'] } . findAll { it != null }
 
-    def client = new DefaultAsyncHttpClient()
+    def clientConfig = new DefaultAsyncHttpClientConfig.Builder()
+            .setFollowRedirect(true)
+            .build()
+    def client = new DefaultAsyncHttpClient(clientConfig)
     try {
         def tasks = imageUrls.collect { client.prepareHead(it).execute() }
 


### PR DESCRIPTION
This PR partially addresses #1818 by validating map thumbnail image URLs in `triplea_maps.yaml`.

#### Functional changes
None.

#### Refactoring changes
None.

#### Other changes
* The `validateYamls` Gradle task was augmented to make a HEAD request for each map thumbnail image and ensure the response has a status code of 200.  The build will fail if any response returns a status code other than 200.

#### Other issues for review
* I chose to fail fast if any map thumbnail image is not available.  That is, if multiple images are not available, the build will only report the first failure.  The user will have to re-run the build after fixing the first failure to discover subsequent failures.
* Currently, it takes less than five seconds on my machine to check the thumbnails in the current `triplea_maps.yaml`.  Although it's probably not necessary at this point, we should consider running checks like this one outside of the `check` task.  Potentially making tens or hundreds of requests could slow down the build enough to make it painful for local development.  We might want to consider something like an `extendedCheck` task that is used to run these potentially long-running checks independently of the quick local checks performed in `check`.

#### Testing
I verified the map thumbnail images in the current `triplea_maps.yaml` are all available and the build succeeds.

I changed one map thumbnail image URL to point to an unknown resource (i.e. server will return 404) and verified that the build fails.

I verified redirects are followed.