### PR TITLE
Lobby start update, init DB first

### DIFF
--- a/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java
@@ -58,13 +58,13 @@ public class LobbyServer {
     try {
       // send args to system properties
       handleCommandLineArgs(args);
+      logger.info("Starting database");
+      // initialize the database
+      Database.getDerbyConnection().close();
       ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
       final int port = Integer.parseInt(System.getProperty(TRIPLEA_LOBBY_PORT_PROPERTY, "3303"));
       logger.info("Trying to listen on port:" + port);
       new LobbyServer(port);
-      logger.info("Starting database");
-      // initialize the database
-      Database.getDerbyConnection().close();
       logger.info("Lobby started");
     } catch (final Exception ex) {
       logger.log(Level.SEVERE, ex.toString(), ex);


### PR DESCRIPTION
Currently the lobby start up sequencing is lobby service first, then init and start database. A problem here is that if there is an issue starting or connecting to database, the lobby service is left in a running but non-functional state. Launching the app again then fails due to a port collision. In production contexts this can be problematic if we fail to notice database issues. In this case we could launch the service, see it is running, and potentially walk away.

The update here simply changes the start up order, so we init DB first and then lobby. In this case if there are problems with database we will have a failure to start, and the lobby service will never launch. Not only is it easier to notice and monitor for this problem, and cleanup/recovery is simpler (pertinent in dev context).