### PR TITLE
Fix installer build break [High Priority]

### DIFF
--- a/.travis/build_installers
+++ b/.travis/build_installers
@@ -7,7 +7,7 @@
 # and packaging and runs install4j to generate the final installer files.
 #
 
-TAGGED_VERSION=$1
+export TAGGED_VERSION=$1
 
 ## update engine version number to have the build number
 sed -i "s/engine_version.*/engine_version = $TAGGED_VERSION/" game_engine.properties


### PR DESCRIPTION
This PR fixes the `build_installers` script, which is currently failing on `master`.

The Gradle `release` task requires the `TAGGED_VERSION` environment variable to be defined.  This PR exports `TAGGED_VERSION` into the environment of the `build_installers` script so it is available to all child processes.  (`TAGGED_VERSION` is **not** exported into the environment of the calling script so there's no chance of polluting the caller's context.)

An alternative solution would have been to pass `TAGGED_VERSION` into the environment of the Gradle process directly on line 16:

```shell
TAGGED_VERSION=$TAGGED_VERSION ./gradlew release
```

Please advise if that solution is preferable.