### PR TITLE
Checkstyle: Fix abbreviation violations in local variables (part 4)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 checkstyleIntegTestMaxWarnings=1
-checkstyleMainMaxWarnings=4250
+checkstyleMainMaxWarnings=4194
 checkstyleTestMaxWarnings=54

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -248,15 +248,15 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   }
 
   private static int getVCAmount(final GameData data, final String alliance, final String type) {
-    int defaultVC = 20;
+    int defaultVc = 20;
     if (type.equals(" Total Victory VCs")) {
-      defaultVC = 18;
+      defaultVc = 18;
     } else if (type.equals(" Honorable Victory VCs")) {
-      defaultVC = 15;
+      defaultVc = 15;
     } else if (type.equals(" Projection of Power VCs")) {
-      defaultVC = 13;
+      defaultVc = 13;
     }
-    return data.getProperties().get((alliance + type), defaultVC);
+    return data.getProperties().get((alliance + type), defaultVc);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -269,11 +269,11 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
         final Change use = ChangeFactory.attachmentPropertyChange(rule, Integer.toString(uses), "uses");
         bridge.addChange(use);
       }
-      final String PUMessage = MyFormatter.attachmentNameToText(rule.getName()) + ": " + player.getName()
+      final String puMessage = MyFormatter.attachmentNameToText(rule.getName()) + ": " + player.getName()
           + " met a national objective for an additional " + toAdd + MyFormatter.pluralize(" PU", toAdd) + "; end with "
           + total + MyFormatter.pluralize(" PU", total);
-      bridge.getHistoryWriter().startEvent(PUMessage);
-      endTurnReport.append(PUMessage).append("<br />");
+      bridge.getHistoryWriter().startEvent(puMessage);
+      endTurnReport.append(puMessage).append("<br />");
     }
     return endTurnReport.toString();
   }

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -251,17 +251,19 @@ public class InitializationDelegate extends BaseTripleADelegate {
       if (destroyer != null && !frontier.getRules().contains(destroyer)) {
         change.add(ChangeFactory.addProductionRule(destroyer, frontier));
       }
-      final ProductionRule artilleryIT =
+      final ProductionRule artilleryIndustrialTechnology =
           data.getProductionRuleList().getProductionRule("buyArtilleryIndustrialTechnology");
-      final ProductionRule destroyerIT =
+      final ProductionRule destroyerIndustrialTechnology =
           data.getProductionRuleList().getProductionRule("buyDestroyerIndustrialTechnology");
-      final ProductionFrontier frontierIT =
+      final ProductionFrontier frontierIndustrialTechnology =
           data.getProductionFrontierList().getProductionFrontier("productionIndustrialTechnology");
-      if (artilleryIT != null && !frontierIT.getRules().contains(artilleryIT)) {
-        change.add(ChangeFactory.addProductionRule(artilleryIT, frontierIT));
+      if (artilleryIndustrialTechnology != null
+          && !frontierIndustrialTechnology.getRules().contains(artilleryIndustrialTechnology)) {
+        change.add(ChangeFactory.addProductionRule(artilleryIndustrialTechnology, frontierIndustrialTechnology));
       }
-      if (destroyerIT != null && !frontierIT.getRules().contains(destroyerIT)) {
-        change.add(ChangeFactory.addProductionRule(destroyerIT, frontierIT));
+      if (destroyerIndustrialTechnology != null
+          && !frontierIndustrialTechnology.getRules().contains(destroyerIndustrialTechnology)) {
+        change.add(ChangeFactory.addProductionRule(destroyerIndustrialTechnology, frontierIndustrialTechnology));
       }
       if (!change.isEmpty()) {
         aBridge.getHistoryWriter().startEvent("Adding destroyers and artillery production rules");
@@ -280,9 +282,9 @@ public class InitializationDelegate extends BaseTripleADelegate {
       /*
        * Find the productionRules, if the unit is NOT a sea unit, add it to the ShipYards prod rule.
        */
-      final ProductionFrontier frontierNONShipyards =
+      final ProductionFrontier frontierNonShipyards =
           data.getProductionFrontierList().getProductionFrontier("production");
-      final Collection<ProductionRule> rules = frontierNONShipyards.getRules();
+      final Collection<ProductionRule> rules = frontierNonShipyards.getRules();
       for (final ProductionRule rule : rules) {
         final String ruleName = rule.getName();
         final IntegerMap<NamedAttachable> ruleResults = rule.getResults();

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -869,17 +869,17 @@ public class Matches {
   };
 
   public static Match<Unit> UnitIsAAthatCanHitTheseUnits(final Collection<Unit> targets,
-      final Match<Unit> typeOfAntiAir, final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed) {
+      final Match<Unit> typeOfAa, final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit obj) {
-        if (!typeOfAntiAir.match(obj)) {
+        if (!typeOfAa.match(obj)) {
           return false;
         }
         final UnitAttachment ua = UnitAttachment.get(obj.getType());
-        final Set<UnitType> targetsAntiAir = ua.getTargetsAA(obj.getData());
+        final Set<UnitType> targetsAa = ua.getTargetsAA(obj.getData());
         for (final Unit u : targets) {
-          if (targetsAntiAir.contains(u.getType())) {
+          if (targetsAa.contains(u.getType())) {
             return true;
           }
         }
@@ -889,11 +889,11 @@ public class Matches {
     };
   }
 
-  static Match<Unit> UnitIsAAofTypeAA(final String typeAntiAir) {
+  static Match<Unit> UnitIsAAofTypeAA(final String typeAa) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit obj) {
-        return UnitAttachment.get(obj.getType()).getTypeAA().matches(typeAntiAir);
+        return UnitAttachment.get(obj.getType()).getTypeAA().matches(typeAa);
       }
     };
   }
@@ -924,8 +924,8 @@ public class Matches {
     return new Match<UnitType>() {
       @Override
       public boolean match(final UnitType obj) {
-        final int maxRoundsAntiAir = UnitAttachment.get(obj).getMaxRoundsAA();
-        return maxRoundsAntiAir < 0 || maxRoundsAntiAir >= battleRoundNumber;
+        final int maxRoundsAa = UnitAttachment.get(obj).getMaxRoundsAA();
+        return maxRoundsAa < 0 || maxRoundsAa >= battleRoundNumber;
       }
     };
   }
@@ -941,10 +941,10 @@ public class Matches {
 
   static Match<Unit> UnitIsAAthatCanFire(final Collection<Unit> unitsMovingOrAttacking,
       final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed, final PlayerID playerMovingOrAttacking,
-      final Match<Unit> typeOfAntiAir, final int battleRoundNumber, final boolean defending, final GameData data) {
+      final Match<Unit> typeOfAa, final int battleRoundNumber, final boolean defending, final GameData data) {
     return new CompositeMatchAnd<>(Matches.enemyUnit(playerMovingOrAttacking, data),
         Matches.unitIsBeingTransported().invert(),
-        Matches.UnitIsAAthatCanHitTheseUnits(unitsMovingOrAttacking, typeOfAntiAir, airborneTechTargetsAllowed),
+        Matches.UnitIsAAthatCanHitTheseUnits(unitsMovingOrAttacking, typeOfAa, airborneTechTargetsAllowed),
         Matches.UnitIsAAthatWillNotFireIfPresentEnemyUnits(unitsMovingOrAttacking).invert(),
         Matches.UnitIsAAthatCanFireOnRound(battleRoundNumber),
         (defending ? UnitAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero
@@ -3234,19 +3234,19 @@ public class Matches {
 
   public static Match<Unit> UnitCanBeInBattle(final boolean attack, final boolean isLandBattle,
       final int battleRound, final boolean includeAttackersThatCanNotMove,
-      final boolean doNotIncludeAntiAir, final boolean doNotIncludeBombardingSeaUnits) {
+      final boolean doNotIncludeAa, final boolean doNotIncludeBombardingSeaUnits) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
         return Matches.UnitTypeCanBeInBattle(attack, isLandBattle, u.getOwner(), battleRound,
-            includeAttackersThatCanNotMove, doNotIncludeAntiAir, doNotIncludeBombardingSeaUnits).match(u.getType());
+            includeAttackersThatCanNotMove, doNotIncludeAa, doNotIncludeBombardingSeaUnits).match(u.getType());
       }
     };
   }
 
   public static Match<UnitType> UnitTypeCanBeInBattle(final boolean attack, final boolean isLandBattle,
       final PlayerID player, final int battleRound, final boolean includeAttackersThatCanNotMove,
-      final boolean doNotIncludeAntiAir, final boolean doNotIncludeBombardingSeaUnits) {
+      final boolean doNotIncludeAa, final boolean doNotIncludeBombardingSeaUnits) {
     return new Match<UnitType>() {
       @Override
       public boolean match(final UnitType ut) {
@@ -3282,7 +3282,7 @@ public class Matches {
           {
             // OR match
             final CompositeMatch<UnitType> defenseMatchOr = new CompositeMatchOr<>();
-            if (!doNotIncludeAntiAir) {
+            if (!doNotIncludeAa) {
               defenseMatchOr.add(new CompositeMatchAnd<>(Matches.UnitTypeIsAAforCombatOnly,
                   Matches.UnitTypeIsAAthatCanFireOnRound(battleRound)));
             }

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -366,18 +366,18 @@ public class Matches {
     };
   }
 
-  static Match<Unit> UnitDestroyedWhenCapturedByOrFrom(final PlayerID playerBY) {
+  static Match<Unit> UnitDestroyedWhenCapturedByOrFrom(final PlayerID playerBy) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit o) {
         final Match<Unit> byOrFrom =
-            new CompositeMatchOr<>(UnitDestroyedWhenCapturedBy(playerBY), UnitDestroyedWhenCapturedFrom());
+            new CompositeMatchOr<>(UnitDestroyedWhenCapturedBy(playerBy), UnitDestroyedWhenCapturedFrom());
         return byOrFrom.match(o);
       }
     };
   }
 
-  private static Match<Unit> UnitDestroyedWhenCapturedBy(final PlayerID playerBY) {
+  private static Match<Unit> UnitDestroyedWhenCapturedBy(final PlayerID playerBy) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -386,7 +386,7 @@ public class Matches {
           return false;
         }
         for (final Tuple<String, PlayerID> tuple : ua.getDestroyedWhenCapturedBy()) {
-          if (tuple.getFirst().equals("BY") && tuple.getSecond().equals(playerBY)) {
+          if (tuple.getFirst().equals("BY") && tuple.getSecond().equals(playerBy)) {
             return true;
           }
         }
@@ -869,17 +869,17 @@ public class Matches {
   };
 
   public static Match<Unit> UnitIsAAthatCanHitTheseUnits(final Collection<Unit> targets,
-      final Match<Unit> typeOfAA, final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed) {
+      final Match<Unit> typeOfAntiAir, final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit obj) {
-        if (!typeOfAA.match(obj)) {
+        if (!typeOfAntiAir.match(obj)) {
           return false;
         }
         final UnitAttachment ua = UnitAttachment.get(obj.getType());
-        final Set<UnitType> targetsAA = ua.getTargetsAA(obj.getData());
+        final Set<UnitType> targetsAntiAir = ua.getTargetsAA(obj.getData());
         for (final Unit u : targets) {
-          if (targetsAA.contains(u.getType())) {
+          if (targetsAntiAir.contains(u.getType())) {
             return true;
           }
         }
@@ -889,11 +889,11 @@ public class Matches {
     };
   }
 
-  static Match<Unit> UnitIsAAofTypeAA(final String typeAA) {
+  static Match<Unit> UnitIsAAofTypeAA(final String typeAntiAir) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit obj) {
-        return UnitAttachment.get(obj.getType()).getTypeAA().matches(typeAA);
+        return UnitAttachment.get(obj.getType()).getTypeAA().matches(typeAntiAir);
       }
     };
   }
@@ -924,8 +924,8 @@ public class Matches {
     return new Match<UnitType>() {
       @Override
       public boolean match(final UnitType obj) {
-        final int maxRoundsAA = UnitAttachment.get(obj).getMaxRoundsAA();
-        return maxRoundsAA < 0 || maxRoundsAA >= battleRoundNumber;
+        final int maxRoundsAntiAir = UnitAttachment.get(obj).getMaxRoundsAA();
+        return maxRoundsAntiAir < 0 || maxRoundsAntiAir >= battleRoundNumber;
       }
     };
   }
@@ -941,10 +941,10 @@ public class Matches {
 
   static Match<Unit> UnitIsAAthatCanFire(final Collection<Unit> unitsMovingOrAttacking,
       final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed, final PlayerID playerMovingOrAttacking,
-      final Match<Unit> typeOfAA, final int battleRoundNumber, final boolean defending, final GameData data) {
+      final Match<Unit> typeOfAntiAir, final int battleRoundNumber, final boolean defending, final GameData data) {
     return new CompositeMatchAnd<>(Matches.enemyUnit(playerMovingOrAttacking, data),
         Matches.unitIsBeingTransported().invert(),
-        Matches.UnitIsAAthatCanHitTheseUnits(unitsMovingOrAttacking, typeOfAA, airborneTechTargetsAllowed),
+        Matches.UnitIsAAthatCanHitTheseUnits(unitsMovingOrAttacking, typeOfAntiAir, airborneTechTargetsAllowed),
         Matches.UnitIsAAthatWillNotFireIfPresentEnemyUnits(unitsMovingOrAttacking).invert(),
         Matches.UnitIsAAthatCanFireOnRound(battleRoundNumber),
         (defending ? UnitAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero
@@ -3234,19 +3234,19 @@ public class Matches {
 
   public static Match<Unit> UnitCanBeInBattle(final boolean attack, final boolean isLandBattle,
       final int battleRound, final boolean includeAttackersThatCanNotMove,
-      final boolean doNotIncludeAA, final boolean doNotIncludeBombardingSeaUnits) {
+      final boolean doNotIncludeAntiAir, final boolean doNotIncludeBombardingSeaUnits) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
         return Matches.UnitTypeCanBeInBattle(attack, isLandBattle, u.getOwner(), battleRound,
-            includeAttackersThatCanNotMove, doNotIncludeAA, doNotIncludeBombardingSeaUnits).match(u.getType());
+            includeAttackersThatCanNotMove, doNotIncludeAntiAir, doNotIncludeBombardingSeaUnits).match(u.getType());
       }
     };
   }
 
   public static Match<UnitType> UnitTypeCanBeInBattle(final boolean attack, final boolean isLandBattle,
       final PlayerID player, final int battleRound, final boolean includeAttackersThatCanNotMove,
-      final boolean doNotIncludeAA, final boolean doNotIncludeBombardingSeaUnits) {
+      final boolean doNotIncludeAntiAir, final boolean doNotIncludeBombardingSeaUnits) {
     return new Match<UnitType>() {
       @Override
       public boolean match(final UnitType ut) {
@@ -3261,41 +3261,41 @@ public class Matches {
         final Match<UnitType> combat;
         if (attack) {
           // AND match
-          final CompositeMatch<UnitType> attackMatchAND = new CompositeMatchAnd<>();
-          attackMatchAND.add(supporterOrNotInfrastructure);
+          final CompositeMatch<UnitType> attackMatchAnd = new CompositeMatchAnd<>();
+          attackMatchAnd.add(supporterOrNotInfrastructure);
           if (!includeAttackersThatCanNotMove) {
-            attackMatchAND.add(Matches.UnitTypeCanNotMoveDuringCombatMove.invert());
-            attackMatchAND.add(Matches.UnitTypeCanMove(player));
+            attackMatchAnd.add(Matches.UnitTypeCanNotMoveDuringCombatMove.invert());
+            attackMatchAnd.add(Matches.UnitTypeCanMove(player));
           }
           if (isLandBattle) {
             if (doNotIncludeBombardingSeaUnits) {
-              attackMatchAND.add(Matches.UnitTypeIsSea.invert());
+              attackMatchAnd.add(Matches.UnitTypeIsSea.invert());
             }
           } else { // is sea battle
-            attackMatchAND.add(Matches.UnitTypeIsLand.invert());
+            attackMatchAnd.add(Matches.UnitTypeIsLand.invert());
           }
           // assign it
-          combat = attackMatchAND;
+          combat = attackMatchAnd;
         } else { // defense
           // AND match
-          final CompositeMatch<UnitType> defenseMatchAND = new CompositeMatchAnd<>();
+          final CompositeMatch<UnitType> defenseMatchAnd = new CompositeMatchAnd<>();
           {
             // OR match
-            final CompositeMatch<UnitType> defenseMatchOR = new CompositeMatchOr<>();
-            if (!doNotIncludeAA) {
-              defenseMatchOR.add(new CompositeMatchAnd<>(Matches.UnitTypeIsAAforCombatOnly,
+            final CompositeMatch<UnitType> defenseMatchOr = new CompositeMatchOr<>();
+            if (!doNotIncludeAntiAir) {
+              defenseMatchOr.add(new CompositeMatchAnd<>(Matches.UnitTypeIsAAforCombatOnly,
                   Matches.UnitTypeIsAAthatCanFireOnRound(battleRound)));
             }
-            defenseMatchOR.add(supporterOrNotInfrastructure);
-            defenseMatchAND.add(defenseMatchOR);
+            defenseMatchOr.add(supporterOrNotInfrastructure);
+            defenseMatchAnd.add(defenseMatchOr);
           }
           if (isLandBattle) {
-            defenseMatchAND.add(Matches.UnitTypeIsSea.invert());
+            defenseMatchAnd.add(Matches.UnitTypeIsSea.invert());
           } else { // is sea battle
-            defenseMatchAND.add(Matches.UnitTypeIsLand.invert());
+            defenseMatchAnd.add(Matches.UnitTypeIsLand.invert());
           }
           // assign it
-          combat = defenseMatchAND;
+          combat = defenseMatchAnd;
         }
         return combat.match(ut);
       }

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -87,7 +87,7 @@ public class MovePerformer implements Serializable {
    */
   private void populateStack(final Collection<Unit> units, final Route route, final PlayerID id,
       final Collection<Unit> transportsToLoad) {
-    final IExecutable preAAFire = new IExecutable() {
+    final IExecutable preAntiAirFire = new IExecutable() {
       private static final long serialVersionUID = -7945930782650355037L;
 
       @Override
@@ -105,7 +105,7 @@ public class MovePerformer implements Serializable {
       }
     };
     // hack to allow the executables to share state
-    final IExecutable fireAA = new IExecutable() {
+    final IExecutable fireAntiAir = new IExecutable() {
       private static final long serialVersionUID = -3780228078499895244L;
 
       @Override
@@ -131,7 +131,7 @@ public class MovePerformer implements Serializable {
         arrivingUnits = Util.difference(units, aaCasualtiesWithDependents);
       }
     };
-    final IExecutable postAAFire = new IExecutable() {
+    final IExecutable postAntiAirFire = new IExecutable() {
       private static final long serialVersionUID = 670783657414493643L;
 
       @Override
@@ -282,9 +282,9 @@ public class MovePerformer implements Serializable {
         m_moveDelegate.updateUndoableMoves(m_currentMove);
       }
     };
-    m_executionStack.push(postAAFire);
-    m_executionStack.push(fireAA);
-    m_executionStack.push(preAAFire);
+    m_executionStack.push(postAntiAirFire);
+    m_executionStack.push(fireAntiAir);
+    m_executionStack.push(preAntiAirFire);
     m_executionStack.execute(m_bridge);
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -87,7 +87,7 @@ public class MovePerformer implements Serializable {
    */
   private void populateStack(final Collection<Unit> units, final Route route, final PlayerID id,
       final Collection<Unit> transportsToLoad) {
-    final IExecutable preAntiAirFire = new IExecutable() {
+    final IExecutable preAaFire = new IExecutable() {
       private static final long serialVersionUID = -7945930782650355037L;
 
       @Override
@@ -105,7 +105,7 @@ public class MovePerformer implements Serializable {
       }
     };
     // hack to allow the executables to share state
-    final IExecutable fireAntiAir = new IExecutable() {
+    final IExecutable fireAa = new IExecutable() {
       private static final long serialVersionUID = -3780228078499895244L;
 
       @Override
@@ -131,7 +131,7 @@ public class MovePerformer implements Serializable {
         arrivingUnits = Util.difference(units, aaCasualtiesWithDependents);
       }
     };
-    final IExecutable postAntiAirFire = new IExecutable() {
+    final IExecutable postAaFire = new IExecutable() {
       private static final long serialVersionUID = 670783657414493643L;
 
       @Override
@@ -282,9 +282,9 @@ public class MovePerformer implements Serializable {
         m_moveDelegate.updateUndoableMoves(m_currentMove);
       }
     };
-    m_executionStack.push(postAntiAirFire);
-    m_executionStack.push(fireAntiAir);
-    m_executionStack.push(preAntiAirFire);
+    m_executionStack.push(postAaFire);
+    m_executionStack.push(fireAa);
+    m_executionStack.push(preAaFire);
     m_executionStack.execute(m_bridge);
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -557,7 +557,7 @@ public class MoveValidator {
       }
       for (final Unit unit : moveTest) {
         if (!hasEnoughMovementForRoute.match(unit)) {
-          boolean unitOK = false;
+          boolean unitOk = false;
           if ((Matches.UnitIsAirTransportable.match(unit) && Matches.unitHasNotMoved.match(unit))
               && (mechanizedSupportAvailable > 0 && Matches.unitHasNotMoved.match(unit) && Matches.UnitIsInfantry
                   .match(unit))) {
@@ -568,11 +568,11 @@ public class MoveValidator {
             if (Match.someMatch(units, Matches.UnitIsAirTransport)) {
               for (final Unit airTransport : dependencies.keySet()) {
                 if (dependencies.get(airTransport) == null || dependencies.get(airTransport).contains(unit)) {
-                  unitOK = true;
+                  unitOk = true;
                   break;
                 }
               }
-              if (!unitOK) {
+              if (!unitOk) {
                 result.addDisallowedUnit("Not all units have enough movement", unit);
               }
             } else {
@@ -581,11 +581,11 @@ public class MoveValidator {
           } else if (Matches.UnitIsAirTransportable.match(unit) && Matches.unitHasNotMoved.match(unit)) {
             for (final Unit airTransport : dependencies.keySet()) {
               if (dependencies.get(airTransport) == null || dependencies.get(airTransport).contains(unit)) {
-                unitOK = true;
+                unitOk = true;
                 break;
               }
             }
-            if (!unitOK) {
+            if (!unitOk) {
               result.addDisallowedUnit("Not all units have enough movement", unit);
             }
           } else if (mechanizedSupportAvailable > 0 && Matches.unitHasNotMoved.match(unit)
@@ -1497,7 +1497,7 @@ public class MoveValidator {
     // No neutral countries on route predicate
     final Match<Territory> noNeutral = Matches.TerritoryIsNeutralButNotWater.invert();
     // No aa guns on route predicate
-    final Match<Territory> noAA = Matches.territoryHasEnemyAAforAnything(player, data).invert();
+    final Match<Territory> noAntiAir = Matches.territoryHasEnemyAAforAnything(player, data).invert();
     // no enemy units on the route predicate
     final Match<Territory> noEnemy = Matches.territoryHasEnemyUnits(player, data).invert();
     // no impassable or restricted territories
@@ -1582,15 +1582,15 @@ public class MoveValidator {
           // best if no enemy and no neutral
           new CompositeMatchAnd<>(noEnemy, noNeutral),
           // we will be satisfied if no aa and no neutral
-          new CompositeMatchAnd<>(noAA, noNeutral)));
+          new CompositeMatchAnd<>(noAntiAir, noNeutral)));
     } else {
       tests = new ArrayList<>(Arrays.asList(
           // best if no enemy and no neutral
           new CompositeMatchAnd<>(noEnemy, noNeutral),
           // we will be satisfied if no aa and no neutral
-          new CompositeMatchAnd<>(noAA, noNeutral),
+          new CompositeMatchAnd<>(noAntiAir, noNeutral),
           // single matches
-          noEnemy, noAA, noNeutral));
+          noEnemy, noAntiAir, noNeutral));
     }
     for (final Match<Territory> t : tests) {
       Match<Territory> testMatch = null;

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1497,7 +1497,7 @@ public class MoveValidator {
     // No neutral countries on route predicate
     final Match<Territory> noNeutral = Matches.TerritoryIsNeutralButNotWater.invert();
     // No aa guns on route predicate
-    final Match<Territory> noAntiAir = Matches.territoryHasEnemyAAforAnything(player, data).invert();
+    final Match<Territory> noAa = Matches.territoryHasEnemyAAforAnything(player, data).invert();
     // no enemy units on the route predicate
     final Match<Territory> noEnemy = Matches.territoryHasEnemyUnits(player, data).invert();
     // no impassable or restricted territories
@@ -1582,15 +1582,15 @@ public class MoveValidator {
           // best if no enemy and no neutral
           new CompositeMatchAnd<>(noEnemy, noNeutral),
           // we will be satisfied if no aa and no neutral
-          new CompositeMatchAnd<>(noAntiAir, noNeutral)));
+          new CompositeMatchAnd<>(noAa, noNeutral)));
     } else {
       tests = new ArrayList<>(Arrays.asList(
           // best if no enemy and no neutral
           new CompositeMatchAnd<>(noEnemy, noNeutral),
           // we will be satisfied if no aa and no neutral
-          new CompositeMatchAnd<>(noAntiAir, noNeutral),
+          new CompositeMatchAnd<>(noAa, noNeutral),
           // single matches
-          noEnemy, noAntiAir, noNeutral));
+          noEnemy, noAa, noNeutral));
     }
     for (final Match<Territory> t : tests) {
       Match<Territory> testMatch = null;

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -490,17 +490,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   List<String> determineStepStrings(final boolean showFirstRun, final IDelegateBridge bridge) {
     final List<String> steps = new ArrayList<>();
     if (canFireOffensiveAA()) {
-      for (final String typeAA : UnitAttachment.getAllOfTypeAAs(m_offensiveAA)) {
-        steps.add(m_attacker.getName() + " " + typeAA + AA_GUNS_FIRE_SUFFIX);
-        steps.add(m_defender.getName() + SELECT_PREFIX + typeAA + CASUALTIES_SUFFIX);
-        steps.add(m_defender.getName() + REMOVE_PREFIX + typeAA + CASUALTIES_SUFFIX);
+      for (final String typeAntiAir : UnitAttachment.getAllOfTypeAAs(m_offensiveAA)) {
+        steps.add(m_attacker.getName() + " " + typeAntiAir + AA_GUNS_FIRE_SUFFIX);
+        steps.add(m_defender.getName() + SELECT_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
+        steps.add(m_defender.getName() + REMOVE_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
       }
     }
     if (canFireDefendingAA()) {
-      for (final String typeAA : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
-        steps.add(m_defender.getName() + " " + typeAA + AA_GUNS_FIRE_SUFFIX);
-        steps.add(m_attacker.getName() + SELECT_PREFIX + typeAA + CASUALTIES_SUFFIX);
-        steps.add(m_attacker.getName() + REMOVE_PREFIX + typeAA + CASUALTIES_SUFFIX);
+      for (final String typeAntiAir : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
+        steps.add(m_defender.getName() + " " + typeAntiAir + AA_GUNS_FIRE_SUFFIX);
+        steps.add(m_attacker.getName() + SELECT_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
+        steps.add(m_attacker.getName() + REMOVE_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
       }
     }
     if (showFirstRun) {
@@ -685,9 +685,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private void addFightStartToStack(final boolean firstRun, final List<IExecutable> steps) {
-    final boolean offensiveAA = canFireOffensiveAA();
-    final boolean defendingAA = canFireDefendingAA();
-    if (offensiveAA) {
+    final boolean offensiveAntiAir = canFireOffensiveAA();
+    final boolean defendingAntiAir = canFireDefendingAA();
+    if (offensiveAntiAir) {
       steps.add(new IExecutable() {
         private static final long serialVersionUID = 3802352588499530533L;
 
@@ -697,7 +697,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         }
       });
     }
-    if (defendingAA) {
+    if (defendingAntiAir) {
       steps.add(new IExecutable() {
         private static final long serialVersionUID = -1370090785540214199L;
 
@@ -707,7 +707,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         }
       });
     }
-    if (offensiveAA || defendingAA) {
+    if (offensiveAntiAir || defendingAntiAir) {
       steps.add(new IExecutable() {
         private static final long serialVersionUID = 8762796262264296436L;
 
@@ -1999,7 +1999,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   void removeCasualties(final Collection<Unit> killed, final ReturnFire returnFire, final boolean defender,
-      final IDelegateBridge bridge, final boolean isAA) {
+      final IDelegateBridge bridge, final boolean isAntiAir) {
     if (killed.isEmpty()) {
       return;
     }
@@ -2190,18 +2190,18 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       if ((m_defending && !canFireDefendingAA()) || (!m_defending && !canFireOffensiveAA())) {
         return;
       }
-      for (final String currentTypeAA : (m_defending ? m_defendingAAtypes : m_offensiveAAtypes)) {
-        final Collection<Unit> currentPossibleAA =
-            Match.getMatches((m_defending ? m_defendingAA : m_offensiveAA), Matches.UnitIsAAofTypeAA(currentTypeAA));
-        final Set<UnitType> targetUnitTypesForThisTypeAA =
-            UnitAttachment.get(currentPossibleAA.iterator().next().getType()).getTargetsAA(m_data);
+      for (final String currentTypeAntiAir : (m_defending ? m_defendingAAtypes : m_offensiveAAtypes)) {
+        final Collection<Unit> currentPossibleAntiAir = Match.getMatches((m_defending ? m_defendingAA : m_offensiveAA),
+            Matches.UnitIsAAofTypeAA(currentTypeAntiAir));
+        final Set<UnitType> targetUnitTypesForThisTypeAntiAir =
+            UnitAttachment.get(currentPossibleAntiAir.iterator().next().getType()).getTargetsAA(m_data);
         final Set<UnitType> airborneTypesTargettedToo =
-            m_defending ? TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAA)
+            m_defending ? TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAntiAir)
                 : new HashSet<>();
         final Collection<Unit> validAttackingUnitsForThisRoll =
             Match.getMatches((m_defending ? m_attackingUnits : m_defendingUnits),
                 new CompositeMatchOr<>(Matches
-                    .unitIsOfTypes(targetUnitTypesForThisTypeAA),
+                    .unitIsOfTypes(targetUnitTypesForThisTypeAntiAir),
                     new CompositeMatchAnd<Unit>(Matches.UnitIsAirborne,
                         Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         final IExecutable rollDice = new IExecutable() {
@@ -2211,10 +2211,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             validAttackingUnitsForThisRoll.removeAll(m_casualtiesSoFar);
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              m_dice =
-                  DiceRoll.rollAA(validAttackingUnitsForThisRoll, currentPossibleAA, bridge, m_battleSite, m_defending);
+              m_dice = DiceRoll.rollAA(validAttackingUnitsForThisRoll, currentPossibleAntiAir, bridge, m_battleSite,
+                  m_defending);
               if (!m_headless) {
-                if (currentTypeAA.equals("AA")) {
+                if (currentTypeAntiAir.equals("AA")) {
                   if (m_dice.getHits() > 0) {
                     bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT,
                         (m_defending ? m_defender : m_attacker));
@@ -2225,11 +2225,12 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
                 } else {
                   if (m_dice.getHits() > 0) {
                     bridge.getSoundChannelBroadcaster().playSoundForAll(
-                        SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAA.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
+                        SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAntiAir.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
                         (m_defending ? m_defender : m_attacker));
                   } else {
                     bridge.getSoundChannelBroadcaster().playSoundForAll(
-                        SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAA.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
+                        SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAntiAir.toLowerCase()
+                            + SoundPath.CLIP_BATTLE_X_MISS,
                         (m_defending ? m_defender : m_attacker));
                   }
                 }
@@ -2244,7 +2245,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
               final CasualtyDetails details =
-                  selectCasualties(validAttackingUnitsForThisRoll, currentPossibleAA, bridge, currentTypeAA);
+                  selectCasualties(validAttackingUnitsForThisRoll, currentPossibleAntiAir, bridge, currentTypeAntiAir);
               markDamaged(details.getDamaged(), bridge);
               m_casualties = details;
               m_casualtiesSoFar.addAll(details.getKilled());
@@ -2257,7 +2258,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              notifyCasualtiesAA(bridge, currentTypeAA);
+              notifyCasualtiesAA(bridge, currentTypeAntiAir);
               removeCasualties(m_casualties.getKilled(), ReturnFire.ALL, !m_defending, bridge, m_defending);
             }
           }
@@ -2270,23 +2271,23 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
 
     private CasualtyDetails selectCasualties(final Collection<Unit> validAttackingUnitsForThisRoll,
-        final Collection<Unit> defendingAA, final IDelegateBridge bridge, final String currentTypeAA) {
+        final Collection<Unit> defendingAntiAir, final IDelegateBridge bridge, final String currentTypeAntiAir) {
       // send defender the dice roll so he can see what the dice are while he waits for attacker to select casualties
       getDisplay(bridge).notifyDice(m_dice, (m_defending ? m_attacker.getName() : m_defender.getName())
-          + SELECT_PREFIX + currentTypeAA + CASUALTIES_SUFFIX);
+          + SELECT_PREFIX + currentTypeAntiAir + CASUALTIES_SUFFIX);
       return BattleCalculator.getAACasualties(!m_defending, validAttackingUnitsForThisRoll,
-          (m_defending ? m_attackingUnits : m_defendingUnits), defendingAA,
+          (m_defending ? m_attackingUnits : m_defendingUnits), defendingAntiAir,
           (m_defending ? m_defendingUnits : m_attackingUnits), m_dice, bridge, (m_defending ? m_defender : m_attacker),
           (m_defending ? m_attacker : m_defender), m_battleID, m_battleSite, m_territoryEffects, m_isAmphibious,
           m_amphibiousLandAttackers);
     }
 
-    private void notifyCasualtiesAA(final IDelegateBridge bridge, final String currentTypeAA) {
+    private void notifyCasualtiesAA(final IDelegateBridge bridge, final String currentTypeAntiAir) {
       if (m_headless) {
         return;
       }
       getDisplay(bridge).casualtyNotification(m_battleID,
-          (m_defending ? m_attacker.getName() : m_defender.getName()) + REMOVE_PREFIX + currentTypeAA
+          (m_defending ? m_attacker.getName() : m_defender.getName()) + REMOVE_PREFIX + currentTypeAntiAir
               + CASUALTIES_SUFFIX,
           m_dice, (m_defending ? m_attacker : m_defender), new ArrayList<>(m_casualties.getKilled()),
           new ArrayList<>(m_casualties.getDamaged()), m_dependentUnits);
@@ -2337,7 +2338,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    *         in a water battle.
    */
   private List<Unit> removeNonCombatants(final Collection<Unit> units, final boolean attacking,
-      final boolean doNotIncludeAA, final boolean doNotIncludeSeaBombardmentUnits, final boolean removeForNextRound) {
+      final boolean doNotIncludeAntiAir, final boolean doNotIncludeSeaBombardmentUnits,
+      final boolean removeForNextRound) {
     final List<Unit> unitList = new ArrayList<>(units);
     if (m_battleSite.isWater()) {
       unitList.removeAll(Match.getMatches(unitList, Matches.UnitIsLand));
@@ -2346,7 +2348,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // remove infrastructure units that can't take part in combat (air/naval bases, etc...)
     unitList.removeAll(Match.getMatches(unitList,
         Matches.UnitCanBeInBattle(attacking, !m_battleSite.isWater(),
-            (removeForNextRound ? m_round + 1 : m_round), true, doNotIncludeAA, doNotIncludeSeaBombardmentUnits)
+            (removeForNextRound ? m_round + 1 : m_round), true, doNotIncludeAntiAir, doNotIncludeSeaBombardmentUnits)
             .invert()));
     // remove any disabled units from combat
     unitList.removeAll(Match.getMatches(unitList, Matches.UnitIsDisabled));
@@ -2361,11 +2363,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return unitList;
   }
 
-  private void removeNonCombatants(final IDelegateBridge bridge, final boolean doNotIncludeAA,
+  private void removeNonCombatants(final IDelegateBridge bridge, final boolean doNotIncludeAntiAir,
       final boolean doNotIncludeSeaBombardmentUnits, final boolean removeForNextRound) {
-    final List<Unit> notRemovedDefending = removeNonCombatants(m_defendingUnits, false, doNotIncludeAA,
+    final List<Unit> notRemovedDefending = removeNonCombatants(m_defendingUnits, false, doNotIncludeAntiAir,
         doNotIncludeSeaBombardmentUnits, removeForNextRound);
-    final List<Unit> notRemovedAttacking = removeNonCombatants(m_attackingUnits, true, doNotIncludeAA,
+    final List<Unit> notRemovedAttacking = removeNonCombatants(m_attackingUnits, true, doNotIncludeAntiAir,
         doNotIncludeSeaBombardmentUnits, removeForNextRound);
     final Collection<Unit> toRemoveDefending = Util.difference(m_defendingUnits, notRemovedDefending);
     final Collection<Unit> toRemoveAttacking = Util.difference(m_attackingUnits, notRemovedAttacking);

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -490,17 +490,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   List<String> determineStepStrings(final boolean showFirstRun, final IDelegateBridge bridge) {
     final List<String> steps = new ArrayList<>();
     if (canFireOffensiveAA()) {
-      for (final String typeAntiAir : UnitAttachment.getAllOfTypeAAs(m_offensiveAA)) {
-        steps.add(m_attacker.getName() + " " + typeAntiAir + AA_GUNS_FIRE_SUFFIX);
-        steps.add(m_defender.getName() + SELECT_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
-        steps.add(m_defender.getName() + REMOVE_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
+      for (final String typeAa : UnitAttachment.getAllOfTypeAAs(m_offensiveAA)) {
+        steps.add(m_attacker.getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
+        steps.add(m_defender.getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
+        steps.add(m_defender.getName() + REMOVE_PREFIX + typeAa + CASUALTIES_SUFFIX);
       }
     }
     if (canFireDefendingAA()) {
-      for (final String typeAntiAir : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
-        steps.add(m_defender.getName() + " " + typeAntiAir + AA_GUNS_FIRE_SUFFIX);
-        steps.add(m_attacker.getName() + SELECT_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
-        steps.add(m_attacker.getName() + REMOVE_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
+      for (final String typeAa : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
+        steps.add(m_defender.getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
+        steps.add(m_attacker.getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
+        steps.add(m_attacker.getName() + REMOVE_PREFIX + typeAa + CASUALTIES_SUFFIX);
       }
     }
     if (showFirstRun) {
@@ -685,9 +685,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private void addFightStartToStack(final boolean firstRun, final List<IExecutable> steps) {
-    final boolean offensiveAntiAir = canFireOffensiveAA();
-    final boolean defendingAntiAir = canFireDefendingAA();
-    if (offensiveAntiAir) {
+    final boolean offensiveAa = canFireOffensiveAA();
+    final boolean defendingAa = canFireDefendingAA();
+    if (offensiveAa) {
       steps.add(new IExecutable() {
         private static final long serialVersionUID = 3802352588499530533L;
 
@@ -697,7 +697,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         }
       });
     }
-    if (defendingAntiAir) {
+    if (defendingAa) {
       steps.add(new IExecutable() {
         private static final long serialVersionUID = -1370090785540214199L;
 
@@ -707,7 +707,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         }
       });
     }
-    if (offensiveAntiAir || defendingAntiAir) {
+    if (offensiveAa || defendingAa) {
       steps.add(new IExecutable() {
         private static final long serialVersionUID = 8762796262264296436L;
 
@@ -1999,7 +1999,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   void removeCasualties(final Collection<Unit> killed, final ReturnFire returnFire, final boolean defender,
-      final IDelegateBridge bridge, final boolean isAntiAir) {
+      final IDelegateBridge bridge, final boolean isAa) {
     if (killed.isEmpty()) {
       return;
     }
@@ -2190,18 +2190,18 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       if ((m_defending && !canFireDefendingAA()) || (!m_defending && !canFireOffensiveAA())) {
         return;
       }
-      for (final String currentTypeAntiAir : (m_defending ? m_defendingAAtypes : m_offensiveAAtypes)) {
-        final Collection<Unit> currentPossibleAntiAir = Match.getMatches((m_defending ? m_defendingAA : m_offensiveAA),
-            Matches.UnitIsAAofTypeAA(currentTypeAntiAir));
-        final Set<UnitType> targetUnitTypesForThisTypeAntiAir =
-            UnitAttachment.get(currentPossibleAntiAir.iterator().next().getType()).getTargetsAA(m_data);
+      for (final String currentTypeAa : (m_defending ? m_defendingAAtypes : m_offensiveAAtypes)) {
+        final Collection<Unit> currentPossibleAa =
+            Match.getMatches((m_defending ? m_defendingAA : m_offensiveAA), Matches.UnitIsAAofTypeAA(currentTypeAa));
+        final Set<UnitType> targetUnitTypesForThisTypeAa =
+            UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAA(m_data);
         final Set<UnitType> airborneTypesTargettedToo =
-            m_defending ? TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAntiAir)
+            m_defending ? TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAa)
                 : new HashSet<>();
         final Collection<Unit> validAttackingUnitsForThisRoll =
             Match.getMatches((m_defending ? m_attackingUnits : m_defendingUnits),
                 new CompositeMatchOr<>(Matches
-                    .unitIsOfTypes(targetUnitTypesForThisTypeAntiAir),
+                    .unitIsOfTypes(targetUnitTypesForThisTypeAa),
                     new CompositeMatchAnd<Unit>(Matches.UnitIsAirborne,
                         Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         final IExecutable rollDice = new IExecutable() {
@@ -2211,10 +2211,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             validAttackingUnitsForThisRoll.removeAll(m_casualtiesSoFar);
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              m_dice = DiceRoll.rollAA(validAttackingUnitsForThisRoll, currentPossibleAntiAir, bridge, m_battleSite,
-                  m_defending);
+              m_dice =
+                  DiceRoll.rollAA(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, m_battleSite, m_defending);
               if (!m_headless) {
-                if (currentTypeAntiAir.equals("AA")) {
+                if (currentTypeAa.equals("AA")) {
                   if (m_dice.getHits() > 0) {
                     bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT,
                         (m_defending ? m_defender : m_attacker));
@@ -2225,12 +2225,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
                 } else {
                   if (m_dice.getHits() > 0) {
                     bridge.getSoundChannelBroadcaster().playSoundForAll(
-                        SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAntiAir.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
+                        SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAa.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
                         (m_defending ? m_defender : m_attacker));
                   } else {
                     bridge.getSoundChannelBroadcaster().playSoundForAll(
-                        SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAntiAir.toLowerCase()
-                            + SoundPath.CLIP_BATTLE_X_MISS,
+                        SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAa.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
                         (m_defending ? m_defender : m_attacker));
                   }
                 }
@@ -2245,7 +2244,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
               final CasualtyDetails details =
-                  selectCasualties(validAttackingUnitsForThisRoll, currentPossibleAntiAir, bridge, currentTypeAntiAir);
+                  selectCasualties(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, currentTypeAa);
               markDamaged(details.getDamaged(), bridge);
               m_casualties = details;
               m_casualtiesSoFar.addAll(details.getKilled());
@@ -2258,7 +2257,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              notifyCasualtiesAA(bridge, currentTypeAntiAir);
+              notifyCasualtiesAA(bridge, currentTypeAa);
               removeCasualties(m_casualties.getKilled(), ReturnFire.ALL, !m_defending, bridge, m_defending);
             }
           }
@@ -2271,23 +2270,23 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
 
     private CasualtyDetails selectCasualties(final Collection<Unit> validAttackingUnitsForThisRoll,
-        final Collection<Unit> defendingAntiAir, final IDelegateBridge bridge, final String currentTypeAntiAir) {
+        final Collection<Unit> defendingAa, final IDelegateBridge bridge, final String currentTypeAa) {
       // send defender the dice roll so he can see what the dice are while he waits for attacker to select casualties
       getDisplay(bridge).notifyDice(m_dice, (m_defending ? m_attacker.getName() : m_defender.getName())
-          + SELECT_PREFIX + currentTypeAntiAir + CASUALTIES_SUFFIX);
+          + SELECT_PREFIX + currentTypeAa + CASUALTIES_SUFFIX);
       return BattleCalculator.getAACasualties(!m_defending, validAttackingUnitsForThisRoll,
-          (m_defending ? m_attackingUnits : m_defendingUnits), defendingAntiAir,
+          (m_defending ? m_attackingUnits : m_defendingUnits), defendingAa,
           (m_defending ? m_defendingUnits : m_attackingUnits), m_dice, bridge, (m_defending ? m_defender : m_attacker),
           (m_defending ? m_attacker : m_defender), m_battleID, m_battleSite, m_territoryEffects, m_isAmphibious,
           m_amphibiousLandAttackers);
     }
 
-    private void notifyCasualtiesAA(final IDelegateBridge bridge, final String currentTypeAntiAir) {
+    private void notifyCasualtiesAA(final IDelegateBridge bridge, final String currentTypeAa) {
       if (m_headless) {
         return;
       }
       getDisplay(bridge).casualtyNotification(m_battleID,
-          (m_defending ? m_attacker.getName() : m_defender.getName()) + REMOVE_PREFIX + currentTypeAntiAir
+          (m_defending ? m_attacker.getName() : m_defender.getName()) + REMOVE_PREFIX + currentTypeAa
               + CASUALTIES_SUFFIX,
           m_dice, (m_defending ? m_attacker : m_defender), new ArrayList<>(m_casualties.getKilled()),
           new ArrayList<>(m_casualties.getDamaged()), m_dependentUnits);
@@ -2338,8 +2337,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    *         in a water battle.
    */
   private List<Unit> removeNonCombatants(final Collection<Unit> units, final boolean attacking,
-      final boolean doNotIncludeAntiAir, final boolean doNotIncludeSeaBombardmentUnits,
-      final boolean removeForNextRound) {
+      final boolean doNotIncludeAa, final boolean doNotIncludeSeaBombardmentUnits, final boolean removeForNextRound) {
     final List<Unit> unitList = new ArrayList<>(units);
     if (m_battleSite.isWater()) {
       unitList.removeAll(Match.getMatches(unitList, Matches.UnitIsLand));
@@ -2348,7 +2346,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // remove infrastructure units that can't take part in combat (air/naval bases, etc...)
     unitList.removeAll(Match.getMatches(unitList,
         Matches.UnitCanBeInBattle(attacking, !m_battleSite.isWater(),
-            (removeForNextRound ? m_round + 1 : m_round), true, doNotIncludeAntiAir, doNotIncludeSeaBombardmentUnits)
+            (removeForNextRound ? m_round + 1 : m_round), true, doNotIncludeAa, doNotIncludeSeaBombardmentUnits)
             .invert()));
     // remove any disabled units from combat
     unitList.removeAll(Match.getMatches(unitList, Matches.UnitIsDisabled));
@@ -2363,11 +2361,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return unitList;
   }
 
-  private void removeNonCombatants(final IDelegateBridge bridge, final boolean doNotIncludeAntiAir,
+  private void removeNonCombatants(final IDelegateBridge bridge, final boolean doNotIncludeAa,
       final boolean doNotIncludeSeaBombardmentUnits, final boolean removeForNextRound) {
-    final List<Unit> notRemovedDefending = removeNonCombatants(m_defendingUnits, false, doNotIncludeAntiAir,
+    final List<Unit> notRemovedDefending = removeNonCombatants(m_defendingUnits, false, doNotIncludeAa,
         doNotIncludeSeaBombardmentUnits, removeForNextRound);
-    final List<Unit> notRemovedAttacking = removeNonCombatants(m_attackingUnits, true, doNotIncludeAntiAir,
+    final List<Unit> notRemovedAttacking = removeNonCombatants(m_attackingUnits, true, doNotIncludeAa,
         doNotIncludeSeaBombardmentUnits, removeForNextRound);
     final Collection<Unit> toRemoveDefending = Util.difference(m_defendingUnits, notRemovedDefending);
     final Collection<Unit> toRemoveAttacking = Util.difference(m_attackingUnits, notRemovedAttacking);

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -188,19 +188,19 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     m_AAtypes = UnitAttachment.getAllOfTypeAAs(m_defendingAA);
     // reverse since stacks are in reverse order
     Collections.reverse(m_AAtypes);
-    final boolean hasAA = m_defendingAA.size() > 0;
+    final boolean hasAntiAir = m_defendingAA.size() > 0;
     m_steps = new ArrayList<>();
-    if (hasAA) {
-      for (final String typeAA : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
-        m_steps.add(typeAA + AA_GUNS_FIRE_SUFFIX);
-        m_steps.add(SELECT_PREFIX + typeAA + CASUALTIES_SUFFIX);
-        m_steps.add(REMOVE_PREFIX + typeAA + CASUALTIES_SUFFIX);
+    if (hasAntiAir) {
+      for (final String typeAntiAir : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
+        m_steps.add(typeAntiAir + AA_GUNS_FIRE_SUFFIX);
+        m_steps.add(SELECT_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
+        m_steps.add(REMOVE_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
       }
     }
     m_steps.add(RAID);
     showBattle(bridge);
     final List<IExecutable> steps = new ArrayList<>();
-    if (hasAA) {
+    if (hasAntiAir) {
       // global1940 rules - each target type fires an AA shot against the planes bombing it
       m_targets.entrySet().stream()
           .filter(entry -> entry.getKey().getUnitAttachment().getIsAAforBombingThisUnitOnly())
@@ -230,12 +230,12 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         // TODO remove the reference to the constant.japanese- replace with a rule
         if (isPacificTheater() || isSBRVictoryPoints()) {
           if (m_defender.getName().equals(Constants.PLAYER_NAME_JAPANESE)) {
-            Change changeVP;
+            Change changeVp;
             final PlayerAttachment pa = PlayerAttachment.get(m_defender);
             if (pa != null) {
-              changeVP =
+              changeVp =
                   ChangeFactory.attachmentPropertyChange(pa, ((-(m_bombingRaidTotal / 10)) + pa.getVps()), "vps");
-              bridge.addChange(changeVP);
+              bridge.addChange(changeVp);
               bridge.getHistoryWriter().addChildToEvent("Bombing raid costs " + (m_bombingRaidTotal / 10) + " "
                   + MyFormatter.pluralize("vp", (m_bombingRaidTotal / 10)));
             }
@@ -349,16 +349,16 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     @Override
     public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
       final boolean isEditMode = BaseEditDelegate.getEditMode(bridge.getData());
-      for (final String currentTypeAA : m_AAtypes) {
-        final Collection<Unit> currentPossibleAA =
-            Match.getMatches(m_defendingAA, Matches.UnitIsAAofTypeAA(currentTypeAA));
-        final Set<UnitType> targetUnitTypesForThisTypeAA =
-            UnitAttachment.get(currentPossibleAA.iterator().next().getType()).getTargetsAA(m_data);
+      for (final String currentTypeAntiAir : m_AAtypes) {
+        final Collection<Unit> currentPossibleAntiAir =
+            Match.getMatches(m_defendingAA, Matches.UnitIsAAofTypeAA(currentTypeAntiAir));
+        final Set<UnitType> targetUnitTypesForThisTypeAntiAir =
+            UnitAttachment.get(currentPossibleAntiAir.iterator().next().getType()).getTargetsAA(m_data);
         final Set<UnitType> airborneTypesTargettedToo =
-            TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAA);
+            TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAntiAir);
         if (determineAttackers) {
           validAttackingUnitsForThisRoll = Match.getMatches(m_attackingUnits, new CompositeMatchOr<>(
-              Matches.unitIsOfTypes(targetUnitTypesForThisTypeAA),
+              Matches.unitIsOfTypes(targetUnitTypesForThisTypeAntiAir),
               new CompositeMatchAnd<Unit>(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         }
 
@@ -369,8 +369,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             validAttackingUnitsForThisRoll.removeAll(m_casualtiesSoFar);
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              m_dice = DiceRoll.rollAA(validAttackingUnitsForThisRoll, currentPossibleAA, bridge, m_battleSite, true);
-              if (currentTypeAA.equals("AA")) {
+              m_dice =
+                  DiceRoll.rollAA(validAttackingUnitsForThisRoll, currentPossibleAntiAir, bridge, m_battleSite, true);
+              if (currentTypeAntiAir.equals("AA")) {
                 if (m_dice.getHits() > 0) {
                   bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT, m_defender);
                 } else {
@@ -379,11 +380,11 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
               } else {
                 if (m_dice.getHits() > 0) {
                   bridge.getSoundChannelBroadcaster().playSoundForAll(
-                      SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAA.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
+                      SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAntiAir.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
                       m_defender);
                 } else {
                   bridge.getSoundChannelBroadcaster().playSoundForAll(
-                      SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAA.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
+                      SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAntiAir.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
                       m_defender);
                 }
               }
@@ -396,8 +397,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              final CasualtyDetails details =
-                  calculateCasualties(validAttackingUnitsForThisRoll, currentPossibleAA, bridge, m_dice, currentTypeAA);
+              final CasualtyDetails details = calculateCasualties(validAttackingUnitsForThisRoll,
+                  currentPossibleAntiAir, bridge, m_dice, currentTypeAntiAir);
               markDamaged(details.getDamaged(), bridge);
               m_casualties = details;
               m_casualtiesSoFar.addAll(details.getKilled());
@@ -410,7 +411,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              notifyAAHits(bridge, m_dice, m_casualties, currentTypeAA);
+              notifyAAHits(bridge, m_dice, m_casualties, currentTypeAntiAir);
             }
           }
         };
@@ -420,7 +421,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              removeAAHits(bridge, m_casualties, currentTypeAA);
+              removeAAHits(bridge, m_casualties, currentTypeAntiAir);
             }
           }
         };
@@ -464,14 +465,14 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   }
 
   private CasualtyDetails calculateCasualties(final Collection<Unit> validAttackingUnitsForThisRoll,
-      final Collection<Unit> defendingAA, final IDelegateBridge bridge, final DiceRoll dice,
-      final String currentTypeAA) {
-    getDisplay(bridge).notifyDice(dice, SELECT_PREFIX + currentTypeAA + CASUALTIES_SUFFIX);
+      final Collection<Unit> defendingAntiAir, final IDelegateBridge bridge, final DiceRoll dice,
+      final String currentTypeAntiAir) {
+    getDisplay(bridge).notifyDice(dice, SELECT_PREFIX + currentTypeAntiAir + CASUALTIES_SUFFIX);
     final boolean isEditMode = BaseEditDelegate.getEditMode(m_data);
     final boolean allowMultipleHitsPerUnit =
-        Match.allMatch(defendingAA, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
+        Match.allMatch(defendingAntiAir, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
     if (isEditMode) {
-      final String text = currentTypeAA + AA_GUNS_FIRE_SUFFIX;
+      final String text = currentTypeAntiAir + AA_GUNS_FIRE_SUFFIX;
       final CasualtyDetails casualtySelection = BattleCalculator.selectCasualties(RAID, m_attacker,
           validAttackingUnitsForThisRoll, m_attackingUnits, m_defender, m_defendingUnits, m_isAmphibious,
           m_amphibiousLandAttackers, m_battleSite, m_territoryEffects, bridge, text, /* dice */null,
@@ -479,8 +480,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       return casualtySelection;
     }
     final CasualtyDetails casualties = BattleCalculator.getAACasualties(false, validAttackingUnitsForThisRoll,
-        m_attackingUnits, defendingAA, m_defendingUnits, dice, bridge, m_defender, m_attacker, m_battleID, m_battleSite,
-        m_territoryEffects, m_isAmphibious, m_amphibiousLandAttackers);
+        m_attackingUnits, defendingAntiAir, m_defendingUnits, dice, bridge, m_defender, m_attacker, m_battleID,
+        m_battleSite, m_territoryEffects, m_isAmphibious, m_amphibiousLandAttackers);
     final int totalExpectingHits =
         dice.getHits() > validAttackingUnitsForThisRoll.size() ? validAttackingUnitsForThisRoll.size() : dice.getHits();
     if (casualties.size() != totalExpectingHits) {
@@ -491,8 +492,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   }
 
   private void notifyAAHits(final IDelegateBridge bridge, final DiceRoll dice, final CasualtyDetails casualties,
-      final String currentTypeAA) {
-    getDisplay(bridge).casualtyNotification(m_battleID, REMOVE_PREFIX + currentTypeAA + CASUALTIES_SUFFIX, dice,
+      final String currentTypeAntiAir) {
+    getDisplay(bridge).casualtyNotification(m_battleID, REMOVE_PREFIX + currentTypeAntiAir + CASUALTIES_SUFFIX, dice,
         m_attacker, new ArrayList<>(casualties.getKilled()), new ArrayList<>(casualties.getDamaged()),
         Collections.emptyMap());
     final Runnable r = () -> {
@@ -522,11 +523,11 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   }
 
   private void removeAAHits(final IDelegateBridge bridge, final CasualtyDetails casualties,
-      final String currentTypeAA) {
+      final String currentTypeAntiAir) {
     final List<Unit> killed = casualties.getKilled();
     if (!killed.isEmpty()) {
-      bridge.getHistoryWriter().addChildToEvent(MyFormatter.unitsToTextNoOwner(killed) + " killed by " + currentTypeAA,
-          new ArrayList<>(killed));
+      bridge.getHistoryWriter().addChildToEvent(
+          MyFormatter.unitsToTextNoOwner(killed) + " killed by " + currentTypeAntiAir, new ArrayList<>(killed));
       final IntegerMap<UnitType> costs = BattleCalculator.getCostsForTUV(m_attacker, m_data);
       final int tuvLostAttacker = BattleCalculator.getTUV(killed, m_attacker, costs, m_data);
       m_attackerLostTUV += tuvLostAttacker;

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -188,19 +188,19 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     m_AAtypes = UnitAttachment.getAllOfTypeAAs(m_defendingAA);
     // reverse since stacks are in reverse order
     Collections.reverse(m_AAtypes);
-    final boolean hasAntiAir = m_defendingAA.size() > 0;
+    final boolean hasAa = m_defendingAA.size() > 0;
     m_steps = new ArrayList<>();
-    if (hasAntiAir) {
-      for (final String typeAntiAir : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
-        m_steps.add(typeAntiAir + AA_GUNS_FIRE_SUFFIX);
-        m_steps.add(SELECT_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
-        m_steps.add(REMOVE_PREFIX + typeAntiAir + CASUALTIES_SUFFIX);
+    if (hasAa) {
+      for (final String typeAa : UnitAttachment.getAllOfTypeAAs(m_defendingAA)) {
+        m_steps.add(typeAa + AA_GUNS_FIRE_SUFFIX);
+        m_steps.add(SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
+        m_steps.add(REMOVE_PREFIX + typeAa + CASUALTIES_SUFFIX);
       }
     }
     m_steps.add(RAID);
     showBattle(bridge);
     final List<IExecutable> steps = new ArrayList<>();
-    if (hasAntiAir) {
+    if (hasAa) {
       // global1940 rules - each target type fires an AA shot against the planes bombing it
       m_targets.entrySet().stream()
           .filter(entry -> entry.getKey().getUnitAttachment().getIsAAforBombingThisUnitOnly())
@@ -349,16 +349,16 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     @Override
     public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
       final boolean isEditMode = BaseEditDelegate.getEditMode(bridge.getData());
-      for (final String currentTypeAntiAir : m_AAtypes) {
-        final Collection<Unit> currentPossibleAntiAir =
-            Match.getMatches(m_defendingAA, Matches.UnitIsAAofTypeAA(currentTypeAntiAir));
-        final Set<UnitType> targetUnitTypesForThisTypeAntiAir =
-            UnitAttachment.get(currentPossibleAntiAir.iterator().next().getType()).getTargetsAA(m_data);
+      for (final String currentTypeAa : m_AAtypes) {
+        final Collection<Unit> currentPossibleAa =
+            Match.getMatches(m_defendingAA, Matches.UnitIsAAofTypeAA(currentTypeAa));
+        final Set<UnitType> targetUnitTypesForThisTypeAa =
+            UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAA(m_data);
         final Set<UnitType> airborneTypesTargettedToo =
-            TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAntiAir);
+            TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAa);
         if (determineAttackers) {
           validAttackingUnitsForThisRoll = Match.getMatches(m_attackingUnits, new CompositeMatchOr<>(
-              Matches.unitIsOfTypes(targetUnitTypesForThisTypeAntiAir),
+              Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
               new CompositeMatchAnd<Unit>(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         }
 
@@ -369,9 +369,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             validAttackingUnitsForThisRoll.removeAll(m_casualtiesSoFar);
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              m_dice =
-                  DiceRoll.rollAA(validAttackingUnitsForThisRoll, currentPossibleAntiAir, bridge, m_battleSite, true);
-              if (currentTypeAntiAir.equals("AA")) {
+              m_dice = DiceRoll.rollAA(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, m_battleSite, true);
+              if (currentTypeAa.equals("AA")) {
                 if (m_dice.getHits() > 0) {
                   bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AA_HIT, m_defender);
                 } else {
@@ -380,11 +379,11 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
               } else {
                 if (m_dice.getHits() > 0) {
                   bridge.getSoundChannelBroadcaster().playSoundForAll(
-                      SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAntiAir.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
+                      SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAa.toLowerCase() + SoundPath.CLIP_BATTLE_X_HIT,
                       m_defender);
                 } else {
                   bridge.getSoundChannelBroadcaster().playSoundForAll(
-                      SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAntiAir.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
+                      SoundPath.CLIP_BATTLE_X_PREFIX + currentTypeAa.toLowerCase() + SoundPath.CLIP_BATTLE_X_MISS,
                       m_defender);
                 }
               }
@@ -397,8 +396,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              final CasualtyDetails details = calculateCasualties(validAttackingUnitsForThisRoll,
-                  currentPossibleAntiAir, bridge, m_dice, currentTypeAntiAir);
+              final CasualtyDetails details =
+                  calculateCasualties(validAttackingUnitsForThisRoll, currentPossibleAa, bridge, m_dice, currentTypeAa);
               markDamaged(details.getDamaged(), bridge);
               m_casualties = details;
               m_casualtiesSoFar.addAll(details.getKilled());
@@ -411,7 +410,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              notifyAAHits(bridge, m_dice, m_casualties, currentTypeAntiAir);
+              notifyAAHits(bridge, m_dice, m_casualties, currentTypeAa);
             }
           }
         };
@@ -421,7 +420,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!validAttackingUnitsForThisRoll.isEmpty()) {
-              removeAAHits(bridge, m_casualties, currentTypeAntiAir);
+              removeAAHits(bridge, m_casualties, currentTypeAa);
             }
           }
         };
@@ -465,14 +464,14 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   }
 
   private CasualtyDetails calculateCasualties(final Collection<Unit> validAttackingUnitsForThisRoll,
-      final Collection<Unit> defendingAntiAir, final IDelegateBridge bridge, final DiceRoll dice,
-      final String currentTypeAntiAir) {
-    getDisplay(bridge).notifyDice(dice, SELECT_PREFIX + currentTypeAntiAir + CASUALTIES_SUFFIX);
+      final Collection<Unit> defendingAa, final IDelegateBridge bridge, final DiceRoll dice,
+      final String currentTypeAa) {
+    getDisplay(bridge).notifyDice(dice, SELECT_PREFIX + currentTypeAa + CASUALTIES_SUFFIX);
     final boolean isEditMode = BaseEditDelegate.getEditMode(m_data);
     final boolean allowMultipleHitsPerUnit =
-        Match.allMatch(defendingAntiAir, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
+        Match.allMatch(defendingAa, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
     if (isEditMode) {
-      final String text = currentTypeAntiAir + AA_GUNS_FIRE_SUFFIX;
+      final String text = currentTypeAa + AA_GUNS_FIRE_SUFFIX;
       final CasualtyDetails casualtySelection = BattleCalculator.selectCasualties(RAID, m_attacker,
           validAttackingUnitsForThisRoll, m_attackingUnits, m_defender, m_defendingUnits, m_isAmphibious,
           m_amphibiousLandAttackers, m_battleSite, m_territoryEffects, bridge, text, /* dice */null,
@@ -480,8 +479,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       return casualtySelection;
     }
     final CasualtyDetails casualties = BattleCalculator.getAACasualties(false, validAttackingUnitsForThisRoll,
-        m_attackingUnits, defendingAntiAir, m_defendingUnits, dice, bridge, m_defender, m_attacker, m_battleID,
-        m_battleSite, m_territoryEffects, m_isAmphibious, m_amphibiousLandAttackers);
+        m_attackingUnits, defendingAa, m_defendingUnits, dice, bridge, m_defender, m_attacker, m_battleID, m_battleSite,
+        m_territoryEffects, m_isAmphibious, m_amphibiousLandAttackers);
     final int totalExpectingHits =
         dice.getHits() > validAttackingUnitsForThisRoll.size() ? validAttackingUnitsForThisRoll.size() : dice.getHits();
     if (casualties.size() != totalExpectingHits) {
@@ -492,8 +491,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   }
 
   private void notifyAAHits(final IDelegateBridge bridge, final DiceRoll dice, final CasualtyDetails casualties,
-      final String currentTypeAntiAir) {
-    getDisplay(bridge).casualtyNotification(m_battleID, REMOVE_PREFIX + currentTypeAntiAir + CASUALTIES_SUFFIX, dice,
+      final String currentTypeAa) {
+    getDisplay(bridge).casualtyNotification(m_battleID, REMOVE_PREFIX + currentTypeAa + CASUALTIES_SUFFIX, dice,
         m_attacker, new ArrayList<>(casualties.getKilled()), new ArrayList<>(casualties.getDamaged()),
         Collections.emptyMap());
     final Runnable r = () -> {
@@ -523,11 +522,11 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   }
 
   private void removeAAHits(final IDelegateBridge bridge, final CasualtyDetails casualties,
-      final String currentTypeAntiAir) {
+      final String currentTypeAa) {
     final List<Unit> killed = casualties.getKilled();
     if (!killed.isEmpty()) {
-      bridge.getHistoryWriter().addChildToEvent(
-          MyFormatter.unitsToTextNoOwner(killed) + " killed by " + currentTypeAntiAir, new ArrayList<>(killed));
+      bridge.getHistoryWriter().addChildToEvent(MyFormatter.unitsToTextNoOwner(killed) + " killed by " + currentTypeAa,
+          new ArrayList<>(killed));
       final IntegerMap<UnitType> costs = BattleCalculator.getCostsForTUV(m_attacker, m_data);
       final int tuvLostAttacker = BattleCalculator.getTUV(killed, m_attacker, costs, m_data);
       m_attackerLostTUV += tuvLostAttacker;


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in local variables.

For the most part, I did **not** expand abbreviations where they caused a violation; I simply converted them using the abbreviation naming convention established in #1659.  Please advise if any should be expanded.

The abbreviations that were expanded included:

* `AA` --> `AntiAir`
* `IT` --> `IndustrialTechnology`

Due to the large number of violations that fall under this category, the fixes are being split over multiple PRs to keep the review size reasonable.