### PR TITLE
Remove online only memory property

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -262,14 +262,6 @@ class EnginePreferences extends JDialog {
       final ButtonGroup bgroup = new ButtonGroup();
       bgroup.add(noneButton);
       bgroup.add(userButton);
-      final boolean onlineOnlyOriginalSetting = Memory.getUseMaxMemorySettingOnlyForOnlineJoinOrHost(systemIni);
-      final JCheckBox onlyOnlineCheckBox =
-          new JCheckBox("Only use these user memory settings for online games (join/host). [Default = On]");
-      onlyOnlineCheckBox.setSelected(onlineOnlyOriginalSetting);
-      onlyOnlineCheckBox.setToolTipText(
-          "<html>If checked, only joining and hosting from online lobby will be affected by these settings."
-              + "<br />If unchecked, TripleA will automatically restart itself with the new memory setting every time "
-              + "you start TripleA.</html>");
       final JButton test = new JButton("Test User Settings");
       test.addActionListener(SwingAction.of("Test User Settings", event -> {
         tested.set(true);
@@ -299,8 +291,6 @@ class EnginePreferences extends JDialog {
           + "<br />a new TripleA process is able to run with your new max memory setting. "
           + "<br />If one does not run, you had better lower the setting or just use the default. </p></em></html>"));
       radioPanel.add(new JLabel(" "));
-      radioPanel.add(onlyOnlineCheckBox);
-      radioPanel.add(new JLabel(" "));
       radioPanel.add(noneButton);
       radioPanel.add(userButton);
       radioPanel.add(new JLabel("Maximum Memory (in MB): "));
@@ -322,16 +312,9 @@ class EnginePreferences extends JDialog {
       if (noneButton.isSelected()) {
         Memory.clearMaxMemory();
       } else if (userButton.isSelected()) {
-        final boolean setOnlineOnly = onlineOnlyOriginalSetting != onlyOnlineCheckBox.isSelected();
         final boolean setMaxMemory = newMaxMemory.getValue() > 64 && tested.get();
-        if (setOnlineOnly || setMaxMemory) {
-          Properties prop;
-          if (setMaxMemory) {
-            prop = Memory.setMaxMemoryInMB(newMaxMemory.getValue());
-          } else {
-            prop = new Properties();
-          }
-          Memory.setUseMaxMemorySettingOnlyForOnlineJoinOrHost(onlyOnlineCheckBox.isSelected(), prop);
+        if (setMaxMemory) {
+          Properties prop = Memory.setMaxMemoryInMB(newMaxMemory.getValue());
           GameRunner.writeSystemIni(prop);
         }
       }

--- a/src/main/java/games/strategy/engine/framework/system/Memory.java
+++ b/src/main/java/games/strategy/engine/framework/system/Memory.java
@@ -7,9 +7,6 @@ import games.strategy.engine.framework.GameRunner;
 
 public class Memory {
   public static final String TRIPLEA_MEMORY_SET = "triplea.memory.set";
-
-  private static final String TRIPLEA_MEMORY_ONLINE_ONLY = "triplea.memory.onlineOnly";
-  // what should our xmx be approximately?
   private static final String TRIPLEA_MEMORY_XMX = "triplea.memory.Xmx";
   private static final String TRIPLEA_MEMORY_USE_DEFAULT = "triplea.memory.useDefault";
 
@@ -25,9 +22,6 @@ public class Memory {
     }
     final Properties systemIni = GameRunner.getSystemIni();
     if (useDefaultMaxMemory(systemIni)) {
-      return;
-    }
-    if (getUseMaxMemorySettingOnlyForOnlineJoinOrHost(systemIni)) {
       return;
     }
     long xmx = getMaxMemoryFromSystemIniFileInMB(systemIni);
@@ -79,7 +73,7 @@ public class Memory {
   public static int getMaxMemoryFromSystemIniFileInMB(final Properties systemIni) {
     final String maxMemoryString = systemIni.getProperty(TRIPLEA_MEMORY_XMX, "").trim();
     int maxMemorySet = -1;
-    if (maxMemoryString.length() > 0) {
+    if (!maxMemoryString.isEmpty()) {
       try {
         maxMemorySet = Integer.parseInt(maxMemoryString);
       } catch (final NumberFormatException e) {
@@ -90,7 +84,7 @@ public class Memory {
   }
 
   public static Properties setMaxMemoryInMB(final int maxMemoryInMb) {
-    System.out.println("Setting max memory for TripleA to: " + maxMemoryInMb + "m");
+    ClientLogger.logQuietly("Setting max memory for TripleA to: " + maxMemoryInMb + "m");
     final Properties prop = new Properties();
     prop.put(TRIPLEA_MEMORY_USE_DEFAULT, "false");
     prop.put(TRIPLEA_MEMORY_XMX, "" + maxMemoryInMb);
@@ -100,19 +94,8 @@ public class Memory {
   public static void clearMaxMemory() {
     final Properties prop = new Properties();
     prop.put(TRIPLEA_MEMORY_USE_DEFAULT, "true");
-    prop.put(TRIPLEA_MEMORY_ONLINE_ONLY, "true");
     prop.put(TRIPLEA_MEMORY_XMX, "");
     GameRunner.writeSystemIni(prop);
-  }
-
-  public static void setUseMaxMemorySettingOnlyForOnlineJoinOrHost(final boolean useForOnlineOnly,
-      final Properties prop) {
-    prop.put(TRIPLEA_MEMORY_ONLINE_ONLY, "" + useForOnlineOnly);
-  }
-
-  public static boolean getUseMaxMemorySettingOnlyForOnlineJoinOrHost(final Properties systemIni) {
-    final String forOnlineOnlyString = systemIni.getProperty(TRIPLEA_MEMORY_ONLINE_ONLY, "true");
-    return Boolean.parseBoolean(forOnlineOnlyString);
   }
 
 }

--- a/system.ini
+++ b/system.ini
@@ -2,4 +2,3 @@
 #Sat May 18 03:25:51 CST 2013
 triplea.memory.useDefault=true
 triplea.memory.Xmx=
-triplea.memory.onlineOnly=true


### PR DESCRIPTION
Screenshot of the checkbox being removed is below:
![memory_settings](https://user-images.githubusercontent.com/12397753/26954222-acc6ec16-4c63-11e7-82e5-8137d9cb55e5.png)


Reason to remove:
- the option is not straight forward, unclear exactly why it should be used. May as well let a custom memory override update all game instances, odd for it to be online only
- rarely used if at all