### PR TITLE
Enable codecov, add coverage report and travis build upload step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ addons:
 install: true
 services:
 - postgresql
-after_success: ./.travis/update_checkstyle_thresholds
+after_success: 
+- ./.travis/update_checkstyle_thresholds
+- bash <(curl -s https://codecov.io/bash)  # upload_coverage_report_to_codecov
 before_deploy:
 - ./.travis/install_install4j
 - ENGINE_VERSION=$(grep "engine_version" game_engine.properties | sed 's/.*= *//g')

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 - postgresql
 after_success: 
 - ./.travis/update_checkstyle_thresholds
-- bash <(curl -s https://codecov.io/bash)  # upload_coverage_report_to_codecov
+- bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
 before_deploy:
 - ./.travis/install_install4j
 - ENGINE_VERSION=$(grep "engine_version" game_engine.properties | sed 's/.*= *//g')

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![Travis](https://img.shields.io/travis/triplea-game/triplea.svg?style=flat-square)](https://travis-ci.org/triplea-game/triplea)[![TripleA license](https://img.shields.io/github/license/triplea-game/triplea.svg?style=flat-square)](https://github.com/triplea-game/triplea/blob/master/LICENSE)<br>
 TripleA is a free game engine that runs on open source and is community supported. 
 
+[![Code Coverage](https://img.shields.io/codecov/c/github/pvorb/property-providers/develop.svg)](https://codecov.io/github/pvorb/property-providers?branch=develop)
+
 Installing TripleA and Playing
 ==============================
 - Download and install TripleA: http://triplea-game.github.io/download/

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'application'
     id 'checkstyle'
+    id 'jacoco'
     id 'com.github.ben-manes.versions' version '0.12.0'
     id 'com.github.johnrengelman.shadow' version '1.2.3'
     id 'com.install4j.gradle' version '6.1.2'
@@ -102,6 +103,13 @@ task integTest(type: Test) {
     }
 
     mustRunAfter tasks.test
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+    }
 }
 
 def assetsDirectory = file("${buildDir}/assets")
@@ -211,7 +219,7 @@ gradle.taskGraph.whenReady { graph ->
 }
 
 check {
-    dependsOn 'integTest', 'validateYamls'
+    dependsOn 'integTest', 'validateYamls', 'jacocoTestReport'
 }
 
 checkstyle {


### PR DESCRIPTION
Codecov - https://codecov.io
Build tool that will let us see test coverage from PRs. Does not fail builds, adds reporting only.

To add, first we add jacoco test coverage reporting. To get coverage output, run: `./gradlew clean test jacocoTestReport`. Then reports will be in 'build/reports/jacoco/'

The integration with codecov is pretty straight forward. Our travis build script downloads their shell script and runs it to do the upload. There is a `CODECOV_TOKEN` env variable that needs to be set. I've obtained that from the codecov website and added it to the travis build here: https://travis-ci.org/triplea-game/triplea/settings

After this is merged, wth small luck we should start seeing test coverage reports being uploaded to codecov.