### PR TITLE
Add Button to Show/Hide Resource Modifers and Add PU Income Bonus Field

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -913,6 +913,8 @@ public class GameParser {
     }
     data.getPlayerList().forEach(playerId -> data.getProperties().addPlayerProperty(
         new NumberProperty(Constants.getIncomePercentageFor(playerId), null, 999, 0, 100)));
+    data.getPlayerList().forEach(playerId -> data.getProperties().addPlayerProperty(
+        new NumberProperty(Constants.getPuIncomeBonus(playerId), null, 999, 0, 0)));
   }
 
   private void parseEditableProperty(final Element property, final String name, final String defaultValue)

--- a/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 
+import javax.swing.Action;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
@@ -23,6 +25,7 @@ import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.pbem.PBEMMessagePoster;
 import games.strategy.engine.random.IRandomSource;
 import games.strategy.engine.random.PlainRandomSource;
+import games.strategy.ui.SwingAction;
 
 /** Setup panel when hosting a local game. */
 public class LocalSetupPanel extends SetupPanel implements Observer {
@@ -56,7 +59,7 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     final List<PlayerID> players = data.getPlayerList().getPlayers();
     // if the xml was created correctly, this list will be in turn order. we want to keep it that way.
     int gridx = 0;
-    int gridy = 0;
+    int gridy = 0;       
     if (!disableable.isEmpty() || playersEnablementListing.containsValue(Boolean.FALSE)) {
       final JLabel enableLabel = new JLabel("Use");
       this.add(enableLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
@@ -74,6 +77,10 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     final JLabel bonusLabel = new JLabel("Income");
     this.add(bonusLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 20, 5, 0), 0, 0));
+    bonusLabel.setVisible(false);
+    JButton resourceModifiers = new JButton();   
+    this.add(resourceModifiers, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.EAST,
+            GridBagConstraints.NONE, new Insets(5, 5, 5, 0), 0, 0));
     for (final PlayerID player : players) {
       final PlayerSelectorRow selector =
           new PlayerSelectorRow(player, reloadSelections, disableable, playersEnablementListing,
@@ -81,8 +88,17 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
       m_playerTypes.add(selector);
       if (!player.isHidden()) {
         selector.layout(++gridy, this);
-      }
+        selector.setResourceModifiersVisble(false);
+      }      
     }
+    
+    Action resourceModifiersAction = SwingAction.of("Resource Modifiers", e -> {
+    	boolean isVisible = bonusLabel.isVisible();
+    	bonusLabel.setVisible(!isVisible);
+        m_playerTypes.forEach(row -> row.setResourceModifiersVisble(!isVisible));
+    });
+    resourceModifiers.setAction(resourceModifiersAction);
+    
     validate();
     invalidate();
     setWidgetActivation();

--- a/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -1,23 +1,15 @@
 package games.strategy.engine.framework.startup.ui;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 
-import javax.swing.Action;
-import javax.swing.JButton;
-import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.message.PlayerListing;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.framework.startup.launcher.LocalLauncher;
@@ -25,7 +17,6 @@ import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.pbem.PBEMMessagePoster;
 import games.strategy.engine.random.IRandomSource;
 import games.strategy.engine.random.PlainRandomSource;
-import games.strategy.ui.SwingAction;
 
 /** Setup panel when hosting a local game. */
 public class LocalSetupPanel extends SetupPanel implements Observer {
@@ -36,85 +27,24 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
   public LocalSetupPanel(final GameSelectorModel model) {
     m_gameSelectorModel = model;
     createComponents();
-    layoutComponents();
+    layoutPlayerComponents(this, m_playerTypes, m_gameSelectorModel.getGameData());
     setupListeners();
     setWidgetActivation();
   }
 
   private void createComponents() {}
 
-  private void layoutComponents() {
-    final GameData data = m_gameSelectorModel.getGameData();
-    removeAll();
-    m_playerTypes.clear();
-    setLayout(new GridBagLayout());
-    if (data == null) {
-      add(new JLabel("No game selected!"));
-      return;
-    }
-    final Collection<String> disableable = data.getPlayerList().getPlayersThatMayBeDisabled();
-    final HashMap<String, Boolean> playersEnablementListing = data.getPlayerList().getPlayersEnabledListing();
-    final Map<String, String> reloadSelections = PlayerID.currentPlayers(data);
-    final String[] playerTypes = data.getGameLoader().getServerPlayerTypes();
-    final List<PlayerID> players = data.getPlayerList().getPlayers();
-    // if the xml was created correctly, this list will be in turn order. we want to keep it that way.
-    int gridx = 0;
-    int gridy = 0;       
-    if (!disableable.isEmpty() || playersEnablementListing.containsValue(Boolean.FALSE)) {
-      final JLabel enableLabel = new JLabel("Use");
-      this.add(enableLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
-          GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    }
-    final JLabel nameLabel = new JLabel("Name");
-    this.add(nameLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    final JLabel typeLabel = new JLabel("Type");
-    this.add(typeLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    final JLabel allianceLabel = new JLabel("Alliance");
-    this.add(allianceLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
-    final JLabel bonusLabel = new JLabel("Income");
-    this.add(bonusLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 20, 5, 0), 0, 0));
-    bonusLabel.setVisible(false);
-    JButton resourceModifiers = new JButton();   
-    this.add(resourceModifiers, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.EAST,
-            GridBagConstraints.NONE, new Insets(5, 5, 5, 0), 0, 0));
-    for (final PlayerID player : players) {
-      final PlayerSelectorRow selector =
-          new PlayerSelectorRow(player, reloadSelections, disableable, playersEnablementListing,
-              data.getAllianceTracker().getAlliancesPlayerIsIn(player), playerTypes, this, data.getProperties());
-      m_playerTypes.add(selector);
-      if (!player.isHidden()) {
-        selector.layout(++gridy, this);
-        selector.setResourceModifiersVisble(false);
-      }      
-    }
-    
-    Action resourceModifiersAction = SwingAction.of("Resource Modifiers", e -> {
-    	boolean isVisible = bonusLabel.isVisible();
-    	bonusLabel.setVisible(!isVisible);
-        m_playerTypes.forEach(row -> row.setResourceModifiersVisble(!isVisible));
-    });
-    resourceModifiers.setAction(resourceModifiersAction);
-    
-    validate();
-    invalidate();
-    setWidgetActivation();
-  }
-
   private void setupListeners() {
     m_gameSelectorModel.addObserver(this);
   }
 
   @Override
+  public void setWidgetActivation() {}
+
+  @Override
   public boolean isMetaSetupPanelInstance() {
     return false;
   }
-
-  @Override
-  public void setWidgetActivation() {}
 
   @Override
   public boolean canGameStart() {
@@ -149,10 +79,10 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
   @Override
   public void update(final Observable o, final Object arg) {
     if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater(() -> layoutComponents());
+      SwingUtilities.invokeLater(() -> layoutPlayerComponents(this, m_playerTypes, m_gameSelectorModel.getGameData()));
       return;
     }
-    layoutComponents();
+    layoutPlayerComponents(this, m_playerTypes, m_gameSelectorModel.getGameData());
   }
 
   @Override
@@ -172,4 +102,5 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
     final LocalLauncher launcher = new LocalLauncher(m_gameSelectorModel, randomSource, pl);
     return launcher;
   }
+
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -26,13 +26,10 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
 
   public LocalSetupPanel(final GameSelectorModel model) {
     m_gameSelectorModel = model;
-    createComponents();
     layoutPlayerComponents(this, m_playerTypes, m_gameSelectorModel.getGameData());
     setupListeners();
     setWidgetActivation();
   }
-
-  private void createComponents() {}
 
   private void setupListeners() {
     m_gameSelectorModel.addObserver(this);

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -26,6 +26,8 @@ class PlayerSelectorRow {
   private final JComboBox<String> playerTypes;
   private JComponent incomePercentage;
   private final JLabel incomePercentageLabel;
+  private JComponent puIncomeBonus;
+  private final JLabel puIncomeBonusLabel;
   private boolean enabled = true;
   private final JLabel name;
   private final JLabel alliances;
@@ -90,6 +92,14 @@ class PlayerSelectorRow {
     }
     incomePercentageLabel = new JLabel("%");
 
+    // TODO: remove null check for next incompatible release
+    puIncomeBonus = null;
+    if (gameProperties.getPlayerProperty(Constants.getPuIncomeBonus(player)) != null) {
+      puIncomeBonus =
+          gameProperties.getPlayerProperty(Constants.getPuIncomeBonus(player)).getEditorComponent();
+    }
+    puIncomeBonusLabel = new JLabel("PUs");
+
     setWidgetActivation();
   }
 
@@ -108,16 +118,26 @@ class PlayerSelectorRow {
     // TODO: remove null check for next incompatible release
     if (incomePercentage != null) {
       container.add(incomePercentage, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-          GridBagConstraints.NONE, new Insets(0, 20, 5, 0), 0, 0));
+          GridBagConstraints.NONE, new Insets(0, 20, 2, 0), 0, 0));
       container.add(incomePercentageLabel,
           new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
               GridBagConstraints.NONE, new Insets(0, 5, 5, 5), 0, 0));
     }
+    // TODO: remove null check for next incompatible release
+    if (puIncomeBonus != null) {
+      container.add(puIncomeBonus, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+          GridBagConstraints.NONE, new Insets(0, 20, 2, 0), 0, 0));
+      container.add(puIncomeBonusLabel,
+          new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+              GridBagConstraints.NONE, new Insets(0, 5, 5, 5), 0, 0));
+    }
   }
-  
+
   void setResourceModifiersVisble(boolean isVisible) {
-	  incomePercentage.setVisible(isVisible);
-	  incomePercentageLabel.setVisible(isVisible);
+    incomePercentage.setVisible(isVisible);
+    incomePercentageLabel.setVisible(isVisible);
+    puIncomeBonus.setVisible(isVisible);
+    puIncomeBonusLabel.setVisible(isVisible);
   }
 
   String getPlayerName() {
@@ -136,6 +156,8 @@ class PlayerSelectorRow {
     name.setEnabled(enabled);
     alliances.setEnabled(enabled);
     enabledCheckBox.setEnabled(disableable.contains(playerName));
+    incomePercentage.setEnabled(enabled);
+    puIncomeBonus.setEnabled(enabled);
     parent.notifyObservers();
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -114,6 +114,11 @@ class PlayerSelectorRow {
               GridBagConstraints.NONE, new Insets(0, 5, 5, 5), 0, 0));
     }
   }
+  
+  void setResourceModifiersVisble(boolean isVisible) {
+	  incomePercentage.setVisible(isVisible);
+	  incomePercentageLabel.setVisible(isVisible);
+  }
 
   String getPlayerName() {
     return playerName;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -1,15 +1,26 @@
 package games.strategy.engine.framework.startup.ui;
 
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Observer;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import games.strategy.engine.chat.IChatPanel;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
+import games.strategy.ui.SwingAction;
 
 public abstract class SetupPanel extends JPanel implements ISetupPanel {
   private static final long serialVersionUID = 4001323470187210773L;
@@ -70,4 +81,71 @@ public abstract class SetupPanel extends JPanel implements ISetupPanel {
   public List<Action> getUserActions() {
     return new ArrayList<>();
   }
+
+  void layoutPlayerComponents(JPanel panel, List<PlayerSelectorRow> playerRows, GameData data) {
+    panel.removeAll();
+    playerRows.clear();
+    panel.setLayout(new GridBagLayout());
+    if (data == null) {
+      panel.add(new JLabel("No game selected!"));
+      return;
+    }
+    final Collection<String> disableable = data.getPlayerList().getPlayersThatMayBeDisabled();
+    final HashMap<String, Boolean> playersEnablementListing = data.getPlayerList().getPlayersEnabledListing();
+    final Map<String, String> reloadSelections = PlayerID.currentPlayers(data);
+    final String[] playerTypes = data.getGameLoader().getServerPlayerTypes();
+    final List<PlayerID> players = data.getPlayerList().getPlayers();
+    // if the xml was created correctly, this list will be in turn order. we want to keep it that way.
+    int gridx = 0;
+    int gridy = 1;
+    if (!disableable.isEmpty() || playersEnablementListing.containsValue(Boolean.FALSE)) {
+      final JLabel enableLabel = new JLabel("Use");
+      panel.add(enableLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
+          GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
+    }
+    final JLabel nameLabel = new JLabel("Name");
+    panel.add(nameLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
+    final JLabel typeLabel = new JLabel("Type");
+    panel.add(typeLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
+    final JLabel allianceLabel = new JLabel("Alliance");
+    panel.add(allianceLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
+    JButton resourceModifiers = new JButton();
+    panel.add(resourceModifiers, new GridBagConstraints(gridx, gridy - 1, 3, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(5, 5, 5, 0), 0, 0));
+    final JLabel incomeLabel = new JLabel("Income");
+    panel.add(incomeLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 20, 5, 0), 0, 0));
+    incomeLabel.setVisible(false);
+    gridx++;
+    final JLabel puIncomeBonusLabel = new JLabel("Flat Income");
+    panel.add(puIncomeBonusLabel, new GridBagConstraints(gridx++, gridy, 2, 1, 0, 0, GridBagConstraints.WEST,
+        GridBagConstraints.NONE, new Insets(0, 20, 5, 0), 0, 0));
+    puIncomeBonusLabel.setVisible(false);
+    gridx++;
+    for (final PlayerID player : players) {
+      final PlayerSelectorRow selector =
+          new PlayerSelectorRow(player, reloadSelections, disableable, playersEnablementListing,
+              data.getAllianceTracker().getAlliancesPlayerIsIn(player), playerTypes, this, data.getProperties());
+      playerRows.add(selector);
+      if (!player.isHidden()) {
+        selector.layout(++gridy, panel);
+        selector.setResourceModifiersVisble(false);
+      }
+    }
+
+    Action resourceModifiersAction = SwingAction.of("Resource Modifiers", e -> {
+      boolean isVisible = incomeLabel.isVisible();
+      incomeLabel.setVisible(!isVisible);
+      puIncomeBonusLabel.setVisible(!isVisible);
+      playerRows.forEach(row -> row.setResourceModifiersVisble(!isVisible));
+    });
+    resourceModifiers.setAction(resourceModifiersAction);
+
+    panel.validate();
+    panel.invalidate();
+  }
+
 }

--- a/src/main/java/games/strategy/triplea/Constants.java
+++ b/src/main/java/games/strategy/triplea/Constants.java
@@ -260,4 +260,8 @@ public interface Constants {
     return playerId.getName() + " Income Percentage";
   }
 
+  public static String getPuIncomeBonus(final PlayerID playerId) {
+    return playerId.getName() + "PU Income Bonus";
+  }
+
 }

--- a/src/main/java/games/strategy/triplea/Properties.java
+++ b/src/main/java/games/strategy/triplea/Properties.java
@@ -538,6 +538,10 @@ public class Properties implements Constants {
     return data.getProperties().get(Constants.getIncomePercentageFor(playerId), 100);
   }
 
+  public static int getPuIncomeBonus(final PlayerID playerId, final GameData data) {
+    return data.getProperties().get(Constants.getPuIncomeBonus(playerId), 0);
+  }
+
   public static int getRelationshipsLastExtraRounds(final GameData data) {
     return data.getProperties().get(RELATIONSHIPS_LAST_EXTRA_ROUNDS, 0);
   }

--- a/src/main/java/games/strategy/triplea/util/BonusIncomeUtils.java
+++ b/src/main/java/games/strategy/triplea/util/BonusIncomeUtils.java
@@ -4,6 +4,7 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.util.IntegerMap;
 
@@ -12,7 +13,7 @@ public class BonusIncomeUtils {
 
   /**
    * Add bonus income based on the player's set percentage for all resources.
-   * 
+   *
    * @return string that summarizes all the changes
    */
   public static String addBonusIncome(final IntegerMap<Resource> income, final IDelegateBridge bridge,
@@ -21,13 +22,25 @@ public class BonusIncomeUtils {
     for (final Resource resource : income.keySet()) {
       final int amount = income.getInt(resource);
       final int incomePercent = Properties.getIncomePercentage(player, bridge.getData());
-      final int bonusIncome = (int) Math.round(((double) amount * (double) (incomePercent - 100) / 100));
+      int puIncomeBonus = 0;
+      if (resource.getName().equals(Constants.PUS)) {
+        puIncomeBonus = Properties.getPuIncomeBonus(player, bridge.getData());
+      }
+      int bonusIncome = (int) Math.round(((double) amount * (double) (incomePercent - 100) / 100)) + puIncomeBonus;
       if (bonusIncome == 0) {
         continue;
       }
       final int total = player.getResources().getQuantity(resource) + bonusIncome;
-      final String message = "Giving " + player.getName() + " " + (incomePercent - 100) + "% bonus income of "
-          + bonusIncome + " " + resource.getName() + "; end with " + total + " " + resource.getName();
+      String message = "Giving " + player.getName();
+      if (puIncomeBonus > 0) {
+        message += " " + puIncomeBonus + " &";
+      }
+      if (incomePercent != 100) {
+        message += " " + incomePercent + "% income for " + bonusIncome + " ";
+      } else {
+        message = message.replace("&", "");
+      }
+      message += resource.getName() + "; end with " + total + " " + resource.getName();
       bridge.getHistoryWriter().startEvent(message);
       bridge.addChange(ChangeFactory.changeResourcesChange(player, resource, bonusIncome));
       sb.append(message).append("<br />");

--- a/src/main/java/games/strategy/triplea/util/BonusIncomeUtils.java
+++ b/src/main/java/games/strategy/triplea/util/BonusIncomeUtils.java
@@ -33,7 +33,7 @@ public class BonusIncomeUtils {
       final int total = player.getResources().getQuantity(resource) + bonusIncome;
       String message = "Giving " + player.getName();
       if (puIncomeBonus > 0) {
-        message += " " + puIncomeBonus + " &";
+        message += " " + puIncomeBonus + " PUs &";
       }
       if (incomePercent != 100) {
         message += " " + incomePercent + "% income for " + bonusIncome + " ";


### PR DESCRIPTION
**Functional Changes**
1. Button added on 'player selection' UI to show/hide resource modifier fields to avoid overwhelming users with too much info. It defaults to hidden.
2. Added new PU income bonus to go along with the existing income percentage field to provide instead a flat PU bonus income.

**Non-Functional Changes**
1. Did a significant refactoring consolidation between LocalSetupPanel and PBEMSetupPanel to extract the player list parameters into a single shared method in SetupPanel. Still plenty more clean up that can be done but this at least avoids major duplication of code and having to update multiple places.

**Initial Player Screen**
![image](https://user-images.githubusercontent.com/1427689/26996363-691dd112-4d37-11e7-93d5-deffe9bdce8a.png)

**After Clicking 'Resource Modifiers' Button**
![image](https://user-images.githubusercontent.com/1427689/26996380-7ed76e1e-4d37-11e7-9ec7-ad1594dc3a13.png)
