### PR TITLE
Checkstyle: Fix abbreviation violations in local variables (part 5)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 checkstyleIntegTestMaxWarnings=1
-checkstyleMainMaxWarnings=4194
+checkstyleMainMaxWarnings=4116
 checkstyleTestMaxWarnings=54

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecord.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecord.java
@@ -70,14 +70,14 @@ public class BattleRecord implements Serializable {
 
   @SerializationProxySupport
   private BattleRecord(final Territory battleSite, final PlayerID attacker, final PlayerID defender,
-      final int attackerLostTUV,
-      final int defenderLostTUV, final BattleResultDescription battleResultDescription, final BattleType battleType,
+      final int attackerLostTuv,
+      final int defenderLostTuv, final BattleResultDescription battleResultDescription, final BattleType battleType,
       final BattleResults battleResults) {
     this.battleSite = battleSite;
     this.attacker = attacker;
     this.defender = defender;
-    this.attackerLostTUV = attackerLostTUV;
-    this.defenderLostTUV = defenderLostTUV;
+    this.attackerLostTUV = attackerLostTuv;
+    this.defenderLostTUV = defenderLostTuv;
     this.battleResultDescription = battleResultDescription;
     this.battleType = battleType;
     this.battleResults = battleResults;
@@ -136,11 +136,11 @@ public class BattleRecord implements Serializable {
     this.battleType = battleType;
   }
 
-  protected void setResult(final PlayerID defender, final int attackerLostTUV, final int defenderLostTUV,
+  protected void setResult(final PlayerID defender, final int attackerLostTuv, final int defenderLostTuv,
       final BattleResultDescription battleResultDescription, final BattleResults battleResults) {
     this.defender = defender;
-    this.attackerLostTUV = attackerLostTUV;
-    this.defenderLostTUV = defenderLostTUV;
+    this.attackerLostTUV = attackerLostTuv;
+    this.defenderLostTUV = defenderLostTuv;
     this.battleResultDescription = battleResultDescription;
     this.battleResults = battleResults;
   }

--- a/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
+++ b/src/main/java/games/strategy/triplea/delegate/dataObjects/BattleRecords.java
@@ -87,21 +87,21 @@ public class BattleRecords implements Serializable {
     return playerRecords;
   }
 
-  public static int getLostTUVforBattleRecords(final Collection<BattleRecord> brs, final boolean attackerLostTUV,
+  public static int getLostTUVforBattleRecords(final Collection<BattleRecord> brs, final boolean attackerLostTuv,
       final boolean includeNullPlayer) {
-    int totalLostTUV = 0;
+    int lostTuv = 0;
     for (final BattleRecord br : brs) {
       if (!includeNullPlayer && (br.getDefender() == null || br.getAttacker() == null || br.getDefender().isNull()
           || br.getAttacker().isNull())) {
         continue;
       }
-      if (attackerLostTUV) {
-        totalLostTUV += br.getAttackerLostTUV();
+      if (attackerLostTuv) {
+        lostTuv += br.getAttackerLostTUV();
       } else {
-        totalLostTUV += br.getDefenderLostTUV();
+        lostTuv += br.getDefenderLostTUV();
       }
     }
-    return totalLostTUV;
+    return lostTuv;
   }
 
   public static boolean getWereThereBattlesInTerritoriesMatching(final Collection<BattleRecord> brs,
@@ -128,21 +128,21 @@ public class BattleRecords implements Serializable {
     return false;
   }
 
-  public void removeBattle(final PlayerID currentPlayer, final GUID battleID) {
+  public void removeBattle(final PlayerID currentPlayer, final GUID battleId) {
     final HashMap<GUID, BattleRecord> current = m_records.get(currentPlayer);
     // we can't count on this being the current player. If we created a battle using edit mode, then the battle might be
     // under a different
     // player.
-    if (current == null || !current.containsKey(battleID)) {
+    if (current == null || !current.containsKey(battleId)) {
       for (final Entry<PlayerID, HashMap<GUID, BattleRecord>> entry : m_records.entrySet()) {
-        if (entry.getValue() != null && entry.getValue().containsKey(battleID)) {
-          entry.getValue().remove(battleID);
+        if (entry.getValue() != null && entry.getValue().containsKey(battleId)) {
+          entry.getValue().remove(battleId);
           return;
         }
       }
       throw new IllegalStateException("Trying to remove info from battle records that do not exist");
     }
-    current.remove(battleID);
+    current.remove(battleId);
   }
 
   public void addRecord(final BattleRecords other) {
@@ -188,29 +188,29 @@ public class BattleRecords implements Serializable {
     }
   }
 
-  public void addBattle(final PlayerID currentPlayerAndAttacker, final GUID battleID, final Territory battleSite,
+  public void addBattle(final PlayerID currentPlayerAndAttacker, final GUID battleId, final Territory battleSite,
       final BattleType battleType) {
     HashMap<GUID, BattleRecord> current = m_records.get(currentPlayerAndAttacker);
     if (current == null) {
       current = new HashMap<>();
     }
     final BattleRecord initial = new BattleRecord(battleSite, currentPlayerAndAttacker, battleType);
-    current.put(battleID, initial);
+    current.put(battleId, initial);
     m_records.put(currentPlayerAndAttacker, current);
   }
 
-  public void addResultToBattle(final PlayerID currentPlayer, final GUID battleID, final PlayerID defender,
-      final int attackerLostTUV, final int defenderLostTUV, final BattleResultDescription battleResultDescription,
+  public void addResultToBattle(final PlayerID currentPlayer, final GUID battleId, final PlayerID defender,
+      final int attackerLostTuv, final int defenderLostTuv, final BattleResultDescription battleResultDescription,
       final BattleResults battleResults) {
     final HashMap<GUID, BattleRecord> current = m_records.get(currentPlayer);
     if (current == null) {
       throw new IllegalStateException("Trying to add info to battle records that do not exist");
     }
-    if (!current.containsKey(battleID)) {
+    if (!current.containsKey(battleId)) {
       throw new IllegalStateException("Trying to add info to a battle that does not exist");
     }
-    final BattleRecord record = current.get(battleID);
-    record.setResult(defender, attackerLostTUV, defenderLostTUV, battleResultDescription, battleResults);
+    final BattleRecord record = current.get(battleId);
+    record.setResult(defender, attackerLostTuv, defenderLostTuv, battleResultDescription, battleResults);
   }
 
   public void clear() {

--- a/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -31,15 +31,15 @@ public class DiceImageFactory {
   private final Map<Integer, Image> m_imagesIgnored = new HashMap<>();
 
   public DiceImageFactory(final ResourceLoader loader, final int diceSides) {
-    final int PIP_SIZE = 6;
+    final int pipSize = 6;
     m_diceSides = Math.max(6, diceSides);
     m_resourceLoader = loader;
-    generateDice(PIP_SIZE, Color.black, m_images);
-    generateDice(PIP_SIZE, Color.red, m_imagesHit);
-    generateDice(PIP_SIZE, s_ignored, m_imagesIgnored);
+    generateDice(pipSize, Color.black, m_images);
+    generateDice(pipSize, Color.red, m_imagesHit);
+    generateDice(pipSize, s_ignored, m_imagesIgnored);
   }
 
-  private void generateDice(final int PIP_SIZE, final Color color, final Map<Integer, Image> images) {
+  private void generateDice(final int pipSize, final Color color, final Map<Integer, Image> images) {
     final ImageFactory iFactory = new ImageFactory();
     iFactory.setResourceLoader(m_resourceLoader);
     for (int i = 1; i <= m_diceSides; i++) {
@@ -63,30 +63,30 @@ public class DiceImageFactory {
         ((Graphics2D) graphics).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
         // center dot
         if (i == 1 || i == 3 || i == 5) {
-          graphics.fillOval(DIE_WIDTH / 2 - (PIP_SIZE / 2), DIE_HEIGHT / 2 - (PIP_SIZE / 2), PIP_SIZE, PIP_SIZE);
+          graphics.fillOval(DIE_WIDTH / 2 - (pipSize / 2), DIE_HEIGHT / 2 - (pipSize / 2), pipSize, pipSize);
         }
         // dots in top left and bottom right
         if (i == 3 || i == 5 || i == 4) {
-          graphics.fillOval(DIE_WIDTH / 4 - (PIP_SIZE / 2), DIE_HEIGHT / 4 - (PIP_SIZE / 2), PIP_SIZE, PIP_SIZE);
-          graphics.fillOval(3 * DIE_WIDTH / 4 - (PIP_SIZE / 2), 3 * DIE_HEIGHT / 4 - (PIP_SIZE / 2), PIP_SIZE,
-              PIP_SIZE);
+          graphics.fillOval(DIE_WIDTH / 4 - (pipSize / 2), DIE_HEIGHT / 4 - (pipSize / 2), pipSize, pipSize);
+          graphics.fillOval(3 * DIE_WIDTH / 4 - (pipSize / 2), 3 * DIE_HEIGHT / 4 - (pipSize / 2), pipSize,
+              pipSize);
         }
         // dots in bottom left and top right
         if (i == 5 || i == 4) {
-          graphics.fillOval(3 * DIE_WIDTH / 4 - (PIP_SIZE / 2), DIE_HEIGHT / 4 - (PIP_SIZE / 2), PIP_SIZE, PIP_SIZE);
-          graphics.fillOval(DIE_WIDTH / 4 - (PIP_SIZE / 2), 3 * DIE_HEIGHT / 4 - (PIP_SIZE / 2), PIP_SIZE, PIP_SIZE);
+          graphics.fillOval(3 * DIE_WIDTH / 4 - (pipSize / 2), DIE_HEIGHT / 4 - (pipSize / 2), pipSize, pipSize);
+          graphics.fillOval(DIE_WIDTH / 4 - (pipSize / 2), 3 * DIE_HEIGHT / 4 - (pipSize / 2), pipSize, pipSize);
         }
         // center two for 2
         if (i == 2 || i == 6) {
-          graphics.fillOval(DIE_WIDTH / 3 - (PIP_SIZE / 2), DIE_HEIGHT / 2 - (PIP_SIZE / 2), PIP_SIZE, PIP_SIZE);
-          graphics.fillOval(2 * DIE_WIDTH / 3 - (PIP_SIZE / 2), DIE_HEIGHT / 2 - (PIP_SIZE / 2), PIP_SIZE, PIP_SIZE);
+          graphics.fillOval(DIE_WIDTH / 3 - (pipSize / 2), DIE_HEIGHT / 2 - (pipSize / 2), pipSize, pipSize);
+          graphics.fillOval(2 * DIE_WIDTH / 3 - (pipSize / 2), DIE_HEIGHT / 2 - (pipSize / 2), pipSize, pipSize);
         }
         if (i == 6) {
-          graphics.fillOval(DIE_WIDTH / 3 - (PIP_SIZE / 2), DIE_HEIGHT / 4 - (PIP_SIZE / 2), PIP_SIZE, PIP_SIZE);
-          graphics.fillOval(2 * DIE_WIDTH / 3 - (PIP_SIZE / 2), DIE_HEIGHT / 4 - (PIP_SIZE / 2), PIP_SIZE, PIP_SIZE);
-          graphics.fillOval(DIE_WIDTH / 3 - (PIP_SIZE / 2), 3 * DIE_HEIGHT / 4 - (PIP_SIZE / 2), PIP_SIZE, PIP_SIZE);
-          graphics.fillOval(2 * DIE_WIDTH / 3 - (PIP_SIZE / 2), 3 * DIE_HEIGHT / 4 - (PIP_SIZE / 2), PIP_SIZE,
-              PIP_SIZE);
+          graphics.fillOval(DIE_WIDTH / 3 - (pipSize / 2), DIE_HEIGHT / 4 - (pipSize / 2), pipSize, pipSize);
+          graphics.fillOval(2 * DIE_WIDTH / 3 - (pipSize / 2), DIE_HEIGHT / 4 - (pipSize / 2), pipSize, pipSize);
+          graphics.fillOval(DIE_WIDTH / 3 - (pipSize / 2), 3 * DIE_HEIGHT / 4 - (pipSize / 2), pipSize, pipSize);
+          graphics.fillOval(2 * DIE_WIDTH / 3 - (pipSize / 2), 3 * DIE_HEIGHT / 4 - (pipSize / 2), pipSize,
+              pipSize);
         }
         if (i > 6) {
           graphics.setFont(new Font("Arial", Font.BOLD, 16));

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/AggregateResults.java
@@ -79,18 +79,18 @@ public class AggregateResults implements Serializable {
   /**
    * First is Attacker, Second is Defender.
    */
-  public Tuple<Double, Double> getAverageTUVofUnitsLeftOver(final IntegerMap<UnitType> attackerCostsForTUV,
-      final IntegerMap<UnitType> defenderCostsForTUV) {
+  public Tuple<Double, Double> getAverageTUVofUnitsLeftOver(final IntegerMap<UnitType> attackerCostsForTuv,
+      final IntegerMap<UnitType> defenderCostsForTuv) {
     if (m_results.isEmpty()) { // can be empty!
       return Tuple.of(0.0, 0.0);
     }
-    double attackerTUV = 0;
-    double defenderTUV = 0;
+    double attackerTuv = 0;
+    double defenderTuv = 0;
     for (final BattleResults result : m_results) {
-      attackerTUV += BattleCalculator.getTUV(result.getRemainingAttackingUnits(), attackerCostsForTUV);
-      defenderTUV += BattleCalculator.getTUV(result.getRemainingDefendingUnits(), defenderCostsForTUV);
+      attackerTuv += BattleCalculator.getTUV(result.getRemainingAttackingUnits(), attackerCostsForTuv);
+      defenderTuv += BattleCalculator.getTUV(result.getRemainingDefendingUnits(), defenderCostsForTuv);
     }
-    return Tuple.of(attackerTUV / m_results.size(), defenderTUV / m_results.size());
+    return Tuple.of(attackerTuv / m_results.size(), defenderTuv / m_results.size());
   }
 
   public double getAverageTUVswing(final PlayerID attacker, final Collection<Unit> attackers, final PlayerID defender,
@@ -98,14 +98,14 @@ public class AggregateResults implements Serializable {
     if (m_results.isEmpty()) { // can be empty!
       return 0.0;
     }
-    final IntegerMap<UnitType> attackerCostsForTUV = BattleCalculator.getCostsForTUV(attacker, data);
-    final IntegerMap<UnitType> defenderCostsForTUV = BattleCalculator.getCostsForTUV(defender, data);
-    final int attackerTotalTUV = BattleCalculator.getTUV(attackers, attackerCostsForTUV);
-    final int defenderTotalTUV = BattleCalculator.getTUV(defenders, defenderCostsForTUV);
+    final IntegerMap<UnitType> attackerCostsForTuv = BattleCalculator.getCostsForTUV(attacker, data);
+    final IntegerMap<UnitType> defenderCostsForTuv = BattleCalculator.getCostsForTUV(defender, data);
+    final int attackerTuv = BattleCalculator.getTUV(attackers, attackerCostsForTuv);
+    final int defenderTuv = BattleCalculator.getTUV(defenders, defenderCostsForTuv);
     // could we possibly cause a bug by comparing UnitType's from one game data, to a different game data's UnitTypes?
-    final Tuple<Double, Double> average = getAverageTUVofUnitsLeftOver(attackerCostsForTUV, defenderCostsForTUV);
-    final double attackerLost = attackerTotalTUV - average.getFirst();
-    final double defenderLost = defenderTotalTUV - average.getSecond();
+    final Tuple<Double, Double> average = getAverageTUVofUnitsLeftOver(attackerCostsForTuv, defenderCostsForTuv);
+    final double attackerLost = attackerTuv - average.getFirst();
+    final double defenderLost = defenderTuv - average.getSecond();
     return defenderLost - attackerLost;
   }
 

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -590,7 +590,7 @@ class DummyPlayer extends AbstractAI {
    * This is because the battle calc does not know where the attackers are actually coming from.
    */
   @Override
-  public Territory retreatQuery(final GUID battleID, final boolean submerge, final Territory battleSite,
+  public Territory retreatQuery(final GUID battleId, final boolean submerge, final Territory battleSite,
       final Collection<Territory> possibleTerritories, final String message) {
     // null = do not retreat
     if (possibleTerritories.isEmpty()) {
@@ -649,7 +649,7 @@ class DummyPlayer extends AbstractAI {
       final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
       final PlayerID hit, final Collection<Unit> friendlyUnits, final PlayerID enemyPlayer,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
-      final CasualtyList defaultCasualties, final GUID battleID, final Territory battlesite,
+      final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
       final boolean allowMultipleHitsPerUnit) {
     final List<Unit> rDamaged = new ArrayList<>(defaultCasualties.getDamaged());
     final List<Unit> rKilled = new ArrayList<>(defaultCasualties.getKilled());

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -775,10 +775,10 @@ class OddsCalculatorPanel extends JPanel {
           BattleCalculator.getCostsForTUV(getAttacker(), m_data), m_data));
       m_defenderUnitsTotalTUV.setText("TUV: " + BattleCalculator.getTUV(defenders, getDefender(),
           BattleCalculator.getCostsForTUV(getDefender(), m_data), m_data));
-      final int attackHP = BattleCalculator.getTotalHitpointsLeft(attackers);
-      final int defenseHP = BattleCalculator.getTotalHitpointsLeft(defenders);
-      m_attackerUnitsTotalHitpoints.setText("HP: " + attackHP);
-      m_defenderUnitsTotalHitpoints.setText("HP: " + defenseHP);
+      final int attackHitPoints = BattleCalculator.getTotalHitpointsLeft(attackers);
+      final int defenseHitPoints = BattleCalculator.getTotalHitpointsLeft(defenders);
+      m_attackerUnitsTotalHitpoints.setText("HP: " + attackHitPoints);
+      m_defenderUnitsTotalHitpoints.setText("HP: " + defenseHitPoints);
       final boolean isAmphibiousBattle = isAmphibiousBattle();
       final Collection<TerritoryEffect> territoryEffects = getTerritoryEffects();
       final IntegerMap<UnitType> costs = BattleCalculator.getCostsForTUV(getAttacker(), m_data);

--- a/src/main/java/games/strategy/triplea/player/AbstractBasePlayer.java
+++ b/src/main/java/games/strategy/triplea/player/AbstractBasePlayer.java
@@ -31,9 +31,9 @@ public abstract class AbstractBasePlayer implements IGamePlayer {
    * Anything that overrides this MUST call super.initialize(iPlayerBridge, playerID);
    */
   @Override
-  public void initialize(final IPlayerBridge iPlayerBridge, final PlayerID playerID) {
+  public void initialize(final IPlayerBridge iPlayerBridge, final PlayerID playerId) {
     playerBridge = iPlayerBridge;
-    this.playerID = playerID;
+    this.playerID = playerId;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
@@ -50,7 +50,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
    *        - can be null
    * @param defaultCasualties
    *        - default casualties as selected by the game
-   * @param battleID
+   * @param battleId
    *        - the battle we are fighting in, may be null if this is an aa casualty selection during a move
    * @param battlesite
    *        - the territory where this happened
@@ -61,7 +61,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
   CasualtyDetails selectCasualties(Collection<Unit> selectFrom, Map<Unit, Collection<Unit>> dependents, int count,
       String message, DiceRoll dice, PlayerID hit, Collection<Unit> friendlyUnits, PlayerID enemyPlayer,
       Collection<Unit> enemyUnits, boolean amphibious, Collection<Unit> amphibiousLandAttackers,
-      CasualtyList defaultCasualties, GUID battleID, Territory battlesite, boolean allowMultipleHitsPerUnit);
+      CasualtyList defaultCasualties, GUID battleId, Territory battlesite, boolean allowMultipleHitsPerUnit);
 
   /**
    * Select a fixed dice roll
@@ -218,7 +218,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
   /**
    * Ask the player if he wishes to retreat.
    *
-   * @param battleID
+   * @param battleId
    *        - the battle
    * @param submerge
    *        - is submerging possible (means the retreat territory CAN be the current battle territory)
@@ -228,7 +228,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
    *        - user displayable message
    * @return the territory to retreat to, or null if the player doesnt wish to retreat
    */
-  Territory retreatQuery(GUID battleID, boolean submerge, Territory battleTerritory,
+  Territory retreatQuery(GUID battleId, boolean submerge, Territory battleTerritory,
       Collection<Territory> possibleTerritories, String message);
 
   /**

--- a/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
@@ -43,9 +43,9 @@ public class PlayerOrder {
           && (currentStep.getName().endsWith("Bid") || currentStep.getName().endsWith("BidPlace"))) {
         continue;
       }
-      final PlayerID currentPlayerID = currentStep.getPlayerID();
-      if (currentPlayerID != null && !currentPlayerID.isNull()) {
-        m_playerSet.add(currentPlayerID);
+      final PlayerID currentPlayerId = currentStep.getPlayerID();
+      if (currentPlayerId != null && !currentPlayerId.isNull()) {
+        m_playerSet.add(currentPlayerId);
       }
     }
     FileWriter turnWriter = null;
@@ -57,8 +57,8 @@ public class PlayerOrder {
     final Iterator<PlayerID> playerIterator = noDuplicates.iterator();
     int count = 1;
     while (playerIterator.hasNext()) {
-      final PlayerID currentPlayerID = playerIterator.next();
-      turnWriter.write(count + ". " + currentPlayerID.getName() + "\r\n");
+      final PlayerID currentPlayerId = playerIterator.next();
+      turnWriter.write(count + ". " + currentPlayerId.getName() + "\r\n");
       count++;
     }
     turnWriter.close();

--- a/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
@@ -38,11 +38,11 @@ public class PrintGenerationData {
   }
 
   /**
-   * @param samePUMap
+   * @param samePuMap
    *        the samePUMap to set.
    */
-  protected void setSamePUMap(final Map<Integer, Integer> samePUMap) {
-    m_SamePUMap = samePUMap;
+  protected void setSamePUMap(final Map<Integer, Integer> samePuMap) {
+    m_SamePUMap = samePuMap;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -117,10 +117,10 @@ public class BattleDisplay extends JPanel {
 
   BattleDisplay(final GameData data, final Territory territory, final PlayerID attacker, final PlayerID defender,
       final Collection<Unit> attackingUnits, final Collection<Unit> defendingUnits, final Collection<Unit> killedUnits,
-      final Collection<Unit> attackingWaitingToDie, final Collection<Unit> defendingWaitingToDie, final GUID battleID,
+      final Collection<Unit> attackingWaitingToDie, final Collection<Unit> defendingWaitingToDie, final GUID battleId,
       final MapPanel mapPanel, final boolean isAmphibious, final BattleType battleType,
       final Collection<Unit> amphibiousLandAttackers) {
-    m_battleID = battleID;
+    m_battleID = battleId;
     m_defender = defender;
     m_attacker = attacker;
     m_location = territory;
@@ -215,12 +215,12 @@ public class BattleDisplay extends JPanel {
    *
    * @param aKilledUnits
    *        list of units killed
-   * @param aPlayerID
+   * @param playerId
    *        player kills belongs to
    */
-  private Collection<Unit> updateKilledUnits(final Collection<Unit> aKilledUnits, final PlayerID aPlayerID) {
+  private Collection<Unit> updateKilledUnits(final Collection<Unit> aKilledUnits, final PlayerID playerId) {
     final JPanel lCausalityPanel;
-    if (aPlayerID.equals(m_defender)) {
+    if (playerId.equals(m_defender)) {
       lCausalityPanel = m_casualtiesInstantPanelDefender;
     } else {
       lCausalityPanel = m_casualtiesInstantPanelAttacker;

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -181,20 +181,20 @@ public class BattlePanel extends ActionPanel {
     }
   }
 
-  private boolean ensureBattleIsDisplayed(final GUID battleID) {
+  private boolean ensureBattleIsDisplayed(final GUID battleId) {
     if (SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("Wrong threads");
     }
     GUID displayed = m_currentBattleDisplayed;
     int count = 0;
-    while (displayed == null || !battleID.equals(displayed)) {
+    while (displayed == null || !battleId.equals(displayed)) {
       count++;
       ThreadUtil.sleep(count);
       // something is wrong, we shouldnt have to wait this long
       if (count > 200) {
         ErrorConsole.getConsole().dumpStacks();
         new IllegalStateException(
-            "battle not displayed, looking for:" + battleID + " showing:" + m_currentBattleDisplayed).printStackTrace();
+            "battle not displayed, looking for:" + battleId + " showing:" + m_currentBattleDisplayed).printStackTrace();
         return false;
       }
       displayed = m_currentBattleDisplayed;
@@ -206,11 +206,11 @@ public class BattlePanel extends ActionPanel {
     return m_battleFrame;
   }
 
-  public void listBattle(final GUID battleID, final List<String> steps) {
+  public void listBattle(final GUID battleId, final List<String> steps) {
     if (!SwingUtilities.isEventDispatchThread()) {
       final Runnable r = () -> {
         // recursive call
-        listBattle(battleID, steps);
+        listBattle(battleId, steps);
       };
       try {
         SwingUtilities.invokeLater(r);
@@ -226,7 +226,7 @@ public class BattlePanel extends ActionPanel {
     }
   }
 
-  public void showBattle(final GUID battleID, final Territory location,
+  public void showBattle(final GUID battleId, final Territory location,
       final Collection<Unit> attackingUnits, final Collection<Unit> defendingUnits, final Collection<Unit> killedUnits,
       final Collection<Unit> attackingWaitingToDie, final Collection<Unit> defendingWaitingToDie,
       final PlayerID attacker, final PlayerID defender,
@@ -238,7 +238,7 @@ public class BattlePanel extends ActionPanel {
       }
       if (!getMap().getUIContext().getShowMapOnly()) {
         m_battleDisplay = new BattleDisplay(getData(), location, attacker, defender, attackingUnits, defendingUnits,
-            killedUnits, attackingWaitingToDie, defendingWaitingToDie, battleID, BattlePanel.this.getMap(),
+            killedUnits, attackingWaitingToDie, defendingWaitingToDie, battleId, BattlePanel.this.getMap(),
             isAmphibious, battleType, amphibiousLandAttackers);
         m_battleFrame.setTitle(attacker.getName() + " attacks " + defender.getName() + " in " + location.getName());
         m_battleFrame.getContentPane().removeAll();
@@ -263,7 +263,7 @@ public class BattlePanel extends ActionPanel {
           m_battleFrame.setVisible(false);
         }
         m_battleFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-        m_currentBattleDisplayed = battleID;
+        m_currentBattleDisplayed = battleId;
         SwingUtilities.invokeLater(() -> m_battleFrame.toFront());
       }
     });
@@ -353,14 +353,14 @@ public class BattlePanel extends ActionPanel {
 
   public CasualtyDetails getCasualties(final Collection<Unit> selectFrom, final Map<Unit, Collection<Unit>> dependents,
       final int count, final String message, final DiceRoll dice, final PlayerID hit,
-      final CasualtyList defaultCasualties, final GUID battleID, final boolean allowMultipleHitsPerUnit) {
+      final CasualtyList defaultCasualties, final GUID battleId, final boolean allowMultipleHitsPerUnit) {
     // if the battle display is null, then this is an aa fire during move
-    if (battleID == null) {
+    if (battleId == null) {
       return getCasualtiesAA(selectFrom, dependents, count, message, dice, hit, defaultCasualties,
           allowMultipleHitsPerUnit);
     } else {
       // something is wong
-      if (!ensureBattleIsDisplayed(battleID)) {
+      if (!ensureBattleIsDisplayed(battleId)) {
         System.out.println("Battle Not Displayed?? " + message);
         return new CasualtyDetails(defaultCasualties.getKilled(), defaultCasualties.getDamaged(), true);
       }
@@ -404,16 +404,16 @@ public class BattlePanel extends ActionPanel {
     return Util.runInSwingEventThread(task);
   }
 
-  public Territory getRetreat(final GUID battleID, final String message, final Collection<Territory> possible,
+  public Territory getRetreat(final GUID battleId, final String message, final Collection<Territory> possible,
       final boolean submerge) {
     // something is really wrong
-    if (!ensureBattleIsDisplayed(battleID)) {
+    if (!ensureBattleIsDisplayed(battleId)) {
       return null;
     }
     return m_battleDisplay.getRetreat(message, possible, submerge);
   }
 
-  public void gotoStep(final GUID battleID, final String step) {
+  public void gotoStep(final GUID battleId, final String step) {
     SwingUtilities.invokeLater(() -> {
       if (m_battleDisplay != null) {
         m_battleDisplay.setStep(step);
@@ -429,7 +429,7 @@ public class BattlePanel extends ActionPanel {
     });
   }
 
-  public void bombingResults(final GUID battleID, final List<Die> dice, final int cost) {
+  public void bombingResults(final GUID battleId, final List<Die> dice, final int cost) {
     SwingUtilities.invokeLater(() -> {
       if (m_battleDisplay != null) {
         m_battleDisplay.bombingResults(dice, cost);

--- a/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -634,7 +634,7 @@ class ObjectivePanelDummyPlayer extends AbstractAI {
   }
 
   @Override
-  public Territory retreatQuery(final GUID battleID, final boolean submerge, final Territory battleSite,
+  public Territory retreatQuery(final GUID battleId, final boolean submerge, final Territory battleSite,
       final Collection<Territory> possibleTerritories, final String message) {
     throw new UnsupportedOperationException();
   }
@@ -656,7 +656,7 @@ class ObjectivePanelDummyPlayer extends AbstractAI {
       final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
       final PlayerID hit, final Collection<Unit> friendlyUnits, final PlayerID enemyPlayer,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
-      final CasualtyList defaultCasualties, final GUID battleID, final Territory battlesite,
+      final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
       final boolean allowMultipleHitsPerUnit) {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
@@ -18,12 +18,12 @@ public class PlayersPanel {
   public static void showPlayers(final IGame game, final Component parent) {
     JPanel panel = SwingComponents.newJPanelWithVerticalBoxLayout();
     for (final String player : game.getPlayerManager().getPlayers()) {
-      final PlayerID playerID = game.getData().getPlayerList().getPlayerID(player);
-      if (playerID.isAI()) {
-        panel.add(new JLabel(playerID.getWhoAmI().split(":")[1] + " is " + playerID.getName(), JLabel.RIGHT));
+      final PlayerID playerId = game.getData().getPlayerList().getPlayerID(player);
+      if (playerId.isAI()) {
+        panel.add(new JLabel(playerId.getWhoAmI().split(":")[1] + " is " + playerId.getName(), JLabel.RIGHT));
       } else {
         panel.add(
-            new JLabel(game.getPlayerManager().getNode(player).getName() + " is " + playerID.getName(), JLabel.RIGHT));
+            new JLabel(game.getPlayerManager().getNode(player).getName() + " is " + playerId.getName(), JLabel.RIGHT));
       }
     }
 

--- a/src/main/java/games/strategy/triplea/ui/UIContext.java
+++ b/src/main/java/games/strategy/triplea/ui/UIContext.java
@@ -106,10 +106,10 @@ public class UIContext extends AbstractUIContext {
     m_cursor = Cursor.getDefaultCursor();
     final Toolkit toolkit = Toolkit.getDefaultToolkit();
     // URL's use "/" not "\"
-    final URL cursorURL = m_resourceLoader.getResource("misc" + "/" + "cursor.gif");
-    if (cursorURL != null) {
+    final URL cursorUrl = m_resourceLoader.getResource("misc" + "/" + "cursor.gif");
+    if (cursorUrl != null) {
       try {
-        final Image image = ImageIO.read(cursorURL);
+        final Image image = ImageIO.read(cursorUrl);
         if (image != null) {
           final Point hotSpot = new Point(m_mapData.getMapCursorHotspotX(), m_mapData.getMapCursorHotspotY());
           m_cursor = toolkit.createCustomCursor(image, hotSpot, data.getGameName() + " Cursor");

--- a/src/main/java/games/strategy/triplea/ui/display/HeadlessDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/HeadlessDisplay.java
@@ -34,7 +34,7 @@ public class HeadlessDisplay implements ITripleADisplay {
       final String message, final String title) {}
 
   @Override
-  public void showBattle(final GUID battleID, final Territory location, final String battleTitle,
+  public void showBattle(final GUID battleId, final Territory location, final String battleTitle,
       final Collection<Unit> attackingUnits,
       final Collection<Unit> defendingUnits, final Collection<Unit> killedUnits,
       final Collection<Unit> attackingWaitingToDie,
@@ -44,26 +44,26 @@ public class HeadlessDisplay implements ITripleADisplay {
       final Collection<Unit> amphibiousLandAttackers) {}
 
   @Override
-  public void listBattleSteps(final GUID battleID, final List<String> steps) {}
+  public void listBattleSteps(final GUID battleId, final List<String> steps) {}
 
   @Override
-  public void battleEnd(final GUID battleID, final String message) {}
+  public void battleEnd(final GUID battleId, final String message) {}
 
   @Override
-  public void casualtyNotification(final GUID battleID, final String step, final DiceRoll dice, final PlayerID player,
+  public void casualtyNotification(final GUID battleId, final String step, final DiceRoll dice, final PlayerID player,
       final Collection<Unit> killed,
       final Collection<Unit> damaged, final Map<Unit, Collection<Unit>> dependents) {}
 
   @Override
-  public void deadUnitNotification(final GUID battleID, final PlayerID player, final Collection<Unit> dead,
+  public void deadUnitNotification(final GUID battleId, final PlayerID player, final Collection<Unit> dead,
       final Map<Unit, Collection<Unit>> dependents) {}
 
   @Override
-  public void changedUnitsNotification(final GUID battleID, final PlayerID player, final Collection<Unit> removedUnits,
+  public void changedUnitsNotification(final GUID battleId, final PlayerID player, final Collection<Unit> removedUnits,
       final Collection<Unit> addedUnits, final Map<Unit, Collection<Unit>> dependents) {}
 
   @Override
-  public void bombingResults(final GUID battleID, final List<Die> dice, final int cost) {}
+  public void bombingResults(final GUID battleId, final List<Die> dice, final int cost) {}
 
   @Override
   public void notifyRetreat(final String shortMessage, final String message, final String step,

--- a/src/main/java/games/strategy/triplea/ui/display/ITripleADisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/ITripleADisplay.java
@@ -33,7 +33,7 @@ public interface ITripleADisplay extends IDisplay {
    * Display info about the battle.
    * This is the first message to be displayed in a battle
    *
-   * @param battleID
+   * @param battleId
    *        - a unique id for the battle
    * @param location
    *        - where the battle occurs
@@ -52,44 +52,44 @@ public interface ITripleADisplay extends IDisplay {
    * @param defender
    *        - PlayerID of defender
    */
-  void showBattle(GUID battleID, Territory location, String battleTitle, Collection<Unit> attackingUnits,
+  void showBattle(GUID battleId, Territory location, String battleTitle, Collection<Unit> attackingUnits,
       Collection<Unit> defendingUnits, Collection<Unit> killedUnits, Collection<Unit> attackingWaitingToDie,
       Collection<Unit> defendingWaitingToDie, Map<Unit, Collection<Unit>> dependentUnits, final PlayerID attacker,
       final PlayerID defender, final boolean isAmphibious, final BattleType battleType,
       final Collection<Unit> amphibiousLandAttackers);
 
   /**
-   * @param battleID
+   * @param battleId
    *        - the battle we are listing steps for.
    * @param steps
    *        - a collection of strings denoting all steps in the battle
    */
-  void listBattleSteps(GUID battleID, List<String> steps);
+  void listBattleSteps(GUID battleId, List<String> steps);
 
   /**
    * The given battle has ended.
    */
-  void battleEnd(GUID battleID, String message);
+  void battleEnd(GUID battleId, String message);
 
   /**
    * Notify that the casualties occurred.
    */
-  void casualtyNotification(GUID battleID, String step, DiceRoll dice, PlayerID player, Collection<Unit> killed,
+  void casualtyNotification(GUID battleId, String step, DiceRoll dice, PlayerID player, Collection<Unit> killed,
       Collection<Unit> damaged, Map<Unit, Collection<Unit>> dependents);
 
   /**
    * Notify that the casualties occurred, and only the casualty.
    */
-  void deadUnitNotification(GUID battleID, PlayerID player, Collection<Unit> dead,
+  void deadUnitNotification(GUID battleId, PlayerID player, Collection<Unit> dead,
       Map<Unit, Collection<Unit>> dependents);
 
-  void changedUnitsNotification(GUID battleID, PlayerID player, Collection<Unit> removedUnits,
+  void changedUnitsNotification(GUID battleId, PlayerID player, Collection<Unit> removedUnits,
       Collection<Unit> addedUnits, Map<Unit, Collection<Unit>> dependents);
 
   /**
    * Notification of the results of a bombing raid.
    */
-  void bombingResults(GUID battleID, List<Die> dice, int cost);
+  void bombingResults(GUID battleId, List<Die> dice, int cost);
 
   /**
    * Notify that the given player has retreated some or all of his units.

--- a/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
@@ -33,47 +33,47 @@ public class TripleADisplay implements ITripleADisplay {
   // TODO: unit_dependents and battleTitle are both likely not used, they have been removed
   // from BattlePane().showBattle( .. ) already
   @Override
-  public void showBattle(final GUID battleID, final Territory location, final String battleTitle,
+  public void showBattle(final GUID battleId, final Territory location, final String battleTitle,
       final Collection<Unit> attackingUnits, final Collection<Unit> defendingUnits, final Collection<Unit> killedUnits,
       final Collection<Unit> attackingWaitingToDie, final Collection<Unit> defendingWaitingToDie,
       final Map<Unit, Collection<Unit>> unit_dependents, final PlayerID attacker, final PlayerID defender,
       final boolean isAmphibious, final BattleType battleType, final Collection<Unit> amphibiousLandAttackers) {
-    m_ui.getBattlePanel().showBattle(battleID, location, attackingUnits, defendingUnits, killedUnits,
+    m_ui.getBattlePanel().showBattle(battleId, location, attackingUnits, defendingUnits, killedUnits,
         attackingWaitingToDie, defendingWaitingToDie, attacker, defender, isAmphibious, battleType,
         amphibiousLandAttackers);
   }
 
   @Override
-  public void listBattleSteps(final GUID battleID, final List<String> steps) {
-    m_ui.getBattlePanel().listBattle(battleID, steps);
+  public void listBattleSteps(final GUID battleId, final List<String> steps) {
+    m_ui.getBattlePanel().listBattle(battleId, steps);
   }
 
   @Override
-  public void casualtyNotification(final GUID battleID, final String step, final DiceRoll dice, final PlayerID player,
+  public void casualtyNotification(final GUID battleId, final String step, final DiceRoll dice, final PlayerID player,
       final Collection<Unit> killed, final Collection<Unit> damaged, final Map<Unit, Collection<Unit>> dependents) {
     m_ui.getBattlePanel().casualtyNotification(step, dice, player, killed, damaged, dependents);
   }
 
   @Override
-  public void deadUnitNotification(final GUID battleID, final PlayerID player, final Collection<Unit> killed,
+  public void deadUnitNotification(final GUID battleId, final PlayerID player, final Collection<Unit> killed,
       final Map<Unit, Collection<Unit>> dependents) {
     m_ui.getBattlePanel().deadUnitNotification(player, killed, dependents);
   }
 
   @Override
-  public void changedUnitsNotification(final GUID battleID, final PlayerID player, final Collection<Unit> removedUnits,
+  public void changedUnitsNotification(final GUID battleId, final PlayerID player, final Collection<Unit> removedUnits,
       final Collection<Unit> addedUnits, final Map<Unit, Collection<Unit>> dependents) {
     m_ui.getBattlePanel().changedUnitsNotification(player, removedUnits, addedUnits, dependents);
   }
 
   @Override
-  public void battleEnd(final GUID battleID, final String message) {
+  public void battleEnd(final GUID battleId, final String message) {
     m_ui.getBattlePanel().battleEndMessage(message);
   }
 
   @Override
-  public void bombingResults(final GUID battleID, final List<Die> dice, final int cost) {
-    m_ui.getBattlePanel().bombingResults(battleID, dice, cost);
+  public void bombingResults(final GUID battleId, final List<Die> dice, final int cost) {
+    m_ui.getBattlePanel().bombingResults(battleId, dice, cost);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -75,8 +75,8 @@ class ExportMenu {
 
   // TODO: create a second menu option for parsing current attachments
   private void addExportXML(final JMenu parentMenu) {
-    final Action exportXML = SwingAction.of("Export game.xml File (Beta)", e -> exportXMLFile());
-    parentMenu.add(exportXML).setMnemonic(KeyEvent.VK_X);
+    final Action exportXml = SwingAction.of("Export game.xml File (Beta)", e -> exportXMLFile());
+    parentMenu.add(exportXml).setMnemonic(KeyEvent.VK_X);
   }
 
   private void exportXMLFile() {
@@ -209,10 +209,10 @@ class ExportMenu {
       final Set<PlayerID> playerOrderSetNoDuplicates = new LinkedHashSet<>(playerOrderList);
       final Iterator<PlayerID> playerOrderIterator = playerOrderSetNoDuplicates.iterator();
       while (playerOrderIterator.hasNext()) {
-        final PlayerID currentPlayerID = playerOrderIterator.next();
-        text.append(currentPlayerID.getName()).append(",");
+        final PlayerID currentPlayerId = playerOrderIterator.next();
+        text.append(currentPlayerId.getName()).append(",");
         final Iterator<String> allianceName =
-            gameData.getAllianceTracker().getAlliancesPlayerIsIn(currentPlayerID).iterator();
+            gameData.getAllianceTracker().getAlliancesPlayerIsIn(currentPlayerId).iterator();
         while (allianceName.hasNext()) {
           text.append(allianceName.next()).append(",");
         }

--- a/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -59,7 +59,7 @@ class FileMenu {
   }
 
   JMenuItem addPostPBEM() {
-    final JMenuItem menuPBEM = new JMenuItem(SwingAction.of("Post PBEM/PBF Gamesave", e -> {
+    final JMenuItem menuPbem = new JMenuItem(SwingAction.of("Post PBEM/PBF Gamesave", e -> {
       if (gameData == null || !PBEMMessagePoster.GameDataHasPlayByEmailOrForumMessengers(gameData)) {
         return;
       }
@@ -78,10 +78,10 @@ class FileMenu {
         gameData.releaseReadLock();
       }
     }));
-    menuPBEM.setMnemonic(KeyEvent.VK_P);
-    menuPBEM.setAccelerator(
+    menuPbem.setMnemonic(KeyEvent.VK_P);
+    menuPbem.setAccelerator(
         KeyStroke.getKeyStroke(KeyEvent.VK_P, java.awt.Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-    return menuPBEM;
+    return menuPbem;
   }
 
   void addExitMenu(final JMenu parentMenu) {

--- a/src/main/java/games/strategy/util/LocalizeHTML.java
+++ b/src/main/java/games/strategy/util/LocalizeHTML.java
@@ -92,18 +92,18 @@ public class LocalizeHTML {
           // remove full parent path
           final String imageFileName = link.substring(Math.max((link.lastIndexOf("/") + 1), 0));
           // replace when testing with: "REPLACEMENTPATH/" + imageFileName;
-          URL replacementURL = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + imageFileName);
+          URL replacementUrl = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + imageFileName);
 
-          if (replacementURL == null || replacementURL.toString().length() == 0) {
+          if (replacementUrl == null || replacementUrl.toString().length() == 0) {
             System.out.println("Could not find: " + mapNameDir + "/" + ASSET_IMAGE_FOLDER + imageFileName);
-            replacementURL = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + ASSET_IMAGE_NOT_FOUND);
+            replacementUrl = ourResourceLoader.getResource(ASSET_IMAGE_FOLDER + ASSET_IMAGE_NOT_FOUND);
           }
-          if (replacementURL == null || replacementURL.toString().length() == 0) {
+          if (replacementUrl == null || replacementUrl.toString().length() == 0) {
             System.err.println("Could not find: " + ASSET_IMAGE_FOLDER + ASSET_IMAGE_NOT_FOUND);
             continue;
           }
 
-          rVal = rVal.replaceAll(link, replacementURL.toString());
+          rVal = rVal.replaceAll(link, replacementUrl.toString());
         }
       }
     }

--- a/src/main/java/games/strategy/util/Util.java
+++ b/src/main/java/games/strategy/util/Util.java
@@ -119,15 +119,15 @@ public class Util {
    * allow multiple fully qualified email addresses separated by spaces, or a blank string.
    */
   public static boolean isMailValid(final String emailAddress) {
-    final String QUOTEDSTRING = "\"(?:[^\"\\\\]|\\\\\\p{ASCII})*\"";
-    final String ATOM = "[^()<>@,;:\\\\\".\\[\\] \\x28\\p{Cntrl}]+";
-    final String WORD = "(?:" + ATOM + "|" + QUOTEDSTRING + ")";
-    final String SUBDOMAIN = "(?:" + ATOM + "|\\[(?:[^\\[\\]\\\\]|\\\\\\p{ASCII})*\\])";
-    final String DOMAIN = SUBDOMAIN + "(?:\\." + SUBDOMAIN + ")*";
-    final String LOCALPART = WORD + "(?:\\." + WORD + ")*";
-    final String EMAIL = LOCALPART + "@" + DOMAIN;
+    final String quotedString = "\"(?:[^\"\\\\]|\\\\\\p{ASCII})*\"";
+    final String atom = "[^()<>@,;:\\\\\".\\[\\] \\x28\\p{Cntrl}]+";
+    final String word = "(?:" + atom + "|" + quotedString + ")";
+    final String subdomain = "(?:" + atom + "|\\[(?:[^\\[\\]\\\\]|\\\\\\p{ASCII})*\\])";
+    final String domain = subdomain + "(?:\\." + subdomain + ")*";
+    final String localPart = word + "(?:\\." + word + ")*";
+    final String email = localPart + "@" + domain;
     // String regex = "(\\s*[\\w\\.-]+@\\w+\\.[\\w\\.]+\\s*)*";
-    final String regex = "(\\s*" + EMAIL + "\\s*)*";
+    final String regex = "(\\s*" + email + "\\s*)*";
     return emailAddress.matches(regex);
   }
 


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in local variables.

For the most part, I did **not** expand abbreviations where they caused a violation; I simply converted them using the abbreviation naming convention established in #1659.  Please advise if any should be expanded.

The abbreviations that were expanded included:

* `HP` --> `HitPoints`

There were a couple of occurrences of variables that contained both `total` and `tuv` in the name.  In those cases, I removed `total` as [previously discussed](https://github.com/triplea-game/triplea/pull/1814#discussion_r120042996).

Due to the large number of violations that fall under this category, the fixes are being split over multiple PRs to keep the review size reasonable.  **This is the last part of this series of changes.**