### PR TITLE
Variable rename, drop 'm_' prefix on mostly swing classes

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/ui/ClientOptions.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ClientOptions.java
@@ -6,7 +6,6 @@ import java.awt.Container;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-
 import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -23,10 +22,10 @@ import games.strategy.ui.SwingAction;
  */
 public class ClientOptions extends JDialog {
   private static final long serialVersionUID = 8036055679545539809L;
-  private JTextField m_nameField;
-  private JTextField m_addressField;
-  private IntTextField m_portField;
-  private boolean m_okPressed;
+  private JTextField nameField;
+  private JTextField addressField;
+  private IntTextField portField;
+  private boolean okPressed;
 
   /**
    * Creates a new instance of ClientOptions.
@@ -36,16 +35,16 @@ public class ClientOptions extends JDialog {
     super(JOptionPane.getFrameForComponent(parent), "Client options", true);
     initComponents();
     layoutComponents();
-    m_nameField.setText(defaultName);
-    m_portField.setValue(defaultPort);
-    m_addressField.setText(defaultAddress);
+    nameField.setText(defaultName);
+    portField.setValue(defaultPort);
+    addressField.setText(defaultAddress);
     pack();
   }
 
   @Override
   public String getName() {
     // fixes crash by truncating names to 20 characters
-    final String s = m_nameField.getText().trim();
+    final String s = nameField.getText().trim();
     if (s.length() > 20) {
       return s.substring(0, 20);
     }
@@ -53,18 +52,18 @@ public class ClientOptions extends JDialog {
   }
 
   public String getAddress() {
-    return m_addressField.getText().trim();
+    return addressField.getText().trim();
   }
 
   public int getPort() {
-    return m_portField.getValue();
+    return portField.getValue();
   }
 
   private void initComponents() {
-    m_nameField = new JTextField(10);
-    m_addressField = new JTextField(10);
-    m_portField = new IntTextField(0, Integer.MAX_VALUE);
-    m_portField.setColumns(7);
+    nameField = new JTextField(10);
+    addressField = new JTextField(10);
+    portField = new IntTextField(0, Integer.MAX_VALUE);
+    portField.setColumns(7);
   }
 
   private void layoutComponents() {
@@ -92,15 +91,15 @@ public class ClientOptions extends JDialog {
     layout.setConstraints(portLabel, labelConstraints);
     layout.setConstraints(nameLabel, labelConstraints);
     layout.setConstraints(addressLabel, labelConstraints);
-    layout.setConstraints(m_portField, fieldConstraints);
-    layout.setConstraints(m_nameField, fieldConstraints);
-    layout.setConstraints(m_addressField, fieldConstraints);
+    layout.setConstraints(portField, fieldConstraints);
+    layout.setConstraints(nameField, fieldConstraints);
+    layout.setConstraints(addressField, fieldConstraints);
     fields.add(nameLabel);
-    fields.add(m_nameField);
+    fields.add(nameField);
     fields.add(portLabel);
-    fields.add(m_portField);
+    fields.add(portField);
     fields.add(addressLabel);
-    fields.add(m_addressField);
+    fields.add(addressField);
     content.add(fields, BorderLayout.CENTER);
     final JPanel buttons = new JPanel();
     buttons.add(new JButton(m_okAction));
@@ -109,12 +108,12 @@ public class ClientOptions extends JDialog {
   }
 
   public boolean getOKPressed() {
-    return m_okPressed;
+    return okPressed;
   }
 
   private final Action m_okAction = SwingAction.of("Connect", e -> {
     setVisible(false);
-    m_okPressed = true;
+    okPressed = true;
   });
   private final Action m_cancelAction = SwingAction.of("Cancel", e -> setVisible(false));
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -21,8 +21,9 @@ import games.strategy.engine.data.properties.IEditableProperty;
  */
 public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
   // chars illegal on windows (on linux/mac anything that is allowed on windows works fine)
-  static final char[] s_illegalChars = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-      22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 34, 42, 58, 60, 62, 63, 92, 124};
+  private static final char[] ILLEGAL_CHARS =
+      {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+          22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 34, 42, 58, 60, 62, 63, 92, 124};
 
   /**
    * Caches the gameOptions stored in the game data, and associates with this game. only values that are serializable
@@ -104,7 +105,7 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
     final StringBuilder sb = new StringBuilder();
     for (int i = 0, charArrayLength = gameName.length(); i < charArrayLength; i++) {
       final char c = gameName.charAt(i);
-      if (Arrays.binarySearch(s_illegalChars, c) < 0) {
+      if (Arrays.binarySearch(ILLEGAL_CHARS, c) < 0) {
         sb.append(c);
       }
     }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/GameSelectorPanel.java
@@ -44,30 +44,30 @@ import games.strategy.ui.SwingComponents;
 public class GameSelectorPanel extends JPanel implements Observer {
   private static final long serialVersionUID = -4598107601238030020L;
 
-  private JLabel m_engineVersionLabel;
-  private JLabel m_engineVersionText;
-  private JLabel m_nameText;
-  private JLabel m_versionText;
-  private JLabel m_fileNameLabel;
-  private JLabel m_fileNameText;
-  private JLabel m_nameLabel;
-  private JLabel m_versionLabel;
-  private JLabel m_roundLabel;
-  private JLabel m_roundText;
-  private JButton m_loadSavedGame;
-  private JButton m_loadNewGame;
-  private JButton m_gameOptions;
-  private final GameSelectorModel m_model;
-  private final IGamePropertiesCache m_gamePropertiesCache = new FileBackedGamePropertiesCache();
-  private final Map<String, Object> m_originalPropertiesMap = new HashMap<>();
+  private JLabel engineVersionLabel;
+  private JLabel engineVersionText;
+  private JLabel nameText;
+  private JLabel versionText;
+  private JLabel fileNameLabel;
+  private JLabel fileNameText;
+  private JLabel nameLabel;
+  private JLabel versionLabel;
+  private JLabel roundLabel;
+  private JLabel roundText;
+  private JButton loadSavedGame;
+  private JButton loadNewGame;
+  private JButton gameOptions;
+  private final GameSelectorModel model;
+  private final IGamePropertiesCache gamePropertiesCache = new FileBackedGamePropertiesCache();
+  private final Map<String, Object> originalPropertiesMap = new HashMap<>();
 
   GameSelectorPanel(final GameSelectorModel model) {
-    m_model = model;
-    m_model.addObserver(this);
+    this.model = model;
+    this.model.addObserver(this);
     final GameData data = model.getGameData();
     if (data != null) {
       setOriginalPropertiesMap(data);
-      m_gamePropertiesCache.loadCachedGamePropertiesInto(data);
+      gamePropertiesCache.loadCachedGamePropertiesInto(data);
     }
     createComponents();
     layoutComponents();
@@ -78,22 +78,22 @@ public class GameSelectorPanel extends JPanel implements Observer {
 
   private void updateGameData() {
     if (!SwingUtilities.isEventDispatchThread()) {
-      SwingUtilities.invokeLater(() -> updateGameData());
+      SwingUtilities.invokeLater(this::updateGameData);
       return;
     }
-    m_nameText.setText(m_model.getGameName());
-    m_versionText.setText(m_model.getGameVersion());
-    m_roundText.setText(m_model.getGameRound());
-    String fileName = m_model.getFileName();
+    nameText.setText(model.getGameName());
+    versionText.setText(model.getGameVersion());
+    roundText.setText(model.getGameRound());
+    String fileName = model.getFileName();
     if (fileName != null && fileName.length() > 1) {
       try {
         fileName = URLDecoder.decode(fileName, "UTF-8");
       } catch (final IllegalArgumentException | UnsupportedEncodingException e) { // ignore
       }
     }
-    m_fileNameText.setText(getFormattedFileNameText(fileName,
-        Math.max(22, 3 + m_nameText.getText().length() + m_nameLabel.getText().length())));
-    m_fileNameText.setToolTipText(fileName);
+    fileNameText.setText(getFormattedFileNameText(fileName,
+        Math.max(22, 3 + nameText.getText().length() + nameLabel.getText().length())));
+    fileNameText.setToolTipText(fileName);
   }
 
   /**
@@ -131,24 +131,24 @@ public class GameSelectorPanel extends JPanel implements Observer {
   }
 
   private void createComponents() {
-    m_engineVersionLabel = new JLabel("Engine Version:");
+    engineVersionLabel = new JLabel("Engine Version:");
     String version = ClientContext.engineVersion().getFullVersion();
-    m_engineVersionText = new JLabel(version);
-    m_nameLabel = new JLabel("Map Name:");
-    m_versionLabel = new JLabel("Map Version:");
-    m_roundLabel = new JLabel("Game Round:");
-    m_fileNameLabel = new JLabel("File Name:");
-    m_nameText = new JLabel();
-    m_versionText = new JLabel();
-    m_roundText = new JLabel();
-    m_fileNameText = new JLabel();
-    m_loadNewGame = new JButton("Select Map");
-    m_loadNewGame.setToolTipText("<html>Select a game from all the maps/games that come with TripleA, <br>and the ones "
+    engineVersionText = new JLabel(version);
+    nameLabel = new JLabel("Map Name:");
+    versionLabel = new JLabel("Map Version:");
+    roundLabel = new JLabel("Game Round:");
+    fileNameLabel = new JLabel("File Name:");
+    nameText = new JLabel();
+    versionText = new JLabel();
+    roundText = new JLabel();
+    fileNameText = new JLabel();
+    loadNewGame = new JButton("Select Map");
+    loadNewGame.setToolTipText("<html>Select a game from all the maps/games that come with TripleA, <br>and the ones "
         + "you have downloaded.</html>");
-    m_loadSavedGame = new JButton("Open Saved Game");
-    m_loadSavedGame.setToolTipText("Open a previously saved game, or an autosave.");
-    m_gameOptions = new JButton("Map Options");
-    m_gameOptions.setToolTipText("<html>Set options for the currently selected game, <br>such as enabling/disabling "
+    loadSavedGame = new JButton("Open Saved Game");
+    loadSavedGame.setToolTipText("Open a previously saved game, or an autosave.");
+    gameOptions = new JButton("Map Options");
+    gameOptions.setToolTipText("<html>Set options for the currently selected game, <br>such as enabling/disabling "
         + "Low Luck, or Technology, etc.</html>");
   }
 
@@ -156,32 +156,32 @@ public class GameSelectorPanel extends JPanel implements Observer {
 
   private void layoutComponents() {
     setLayout(new GridBagLayout());
-    add(m_engineVersionLabel, buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
-    add(m_engineVersionText, buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
+    add(engineVersionLabel, buildGridCell(0, 0, new Insets(10, 10, 3, 5)));
+    add(engineVersionText, buildGridCell(1, 0, new Insets(10, 0, 3, 0)));
 
-    add(m_nameLabel, buildGridCell(0, 1, new Insets(0, 10, 3, 5)));
-    add(m_nameText, buildGridCell(1, 1, new Insets(0, 0, 3, 0)));
+    add(nameLabel, buildGridCell(0, 1, new Insets(0, 10, 3, 5)));
+    add(nameText, buildGridCell(1, 1, new Insets(0, 0, 3, 0)));
 
-    add(m_versionLabel, buildGridCell(0, 2, new Insets(0, 10, 3, 5)));
-    add(m_versionText, buildGridCell(1, 2, new Insets(0, 0, 3, 0)));
+    add(versionLabel, buildGridCell(0, 2, new Insets(0, 10, 3, 5)));
+    add(versionText, buildGridCell(1, 2, new Insets(0, 0, 3, 0)));
 
-    add(m_roundLabel, buildGridCell(0, 3, new Insets(0, 10, 3, 5)));
-    add(m_roundText, buildGridCell(1, 3, new Insets(0, 0, 3, 0)));
+    add(roundLabel, buildGridCell(0, 3, new Insets(0, 10, 3, 5)));
+    add(roundText, buildGridCell(1, 3, new Insets(0, 0, 3, 0)));
 
-    add(m_fileNameLabel, buildGridCell(0, 4, new Insets(20, 10, 3, 5)));
+    add(fileNameLabel, buildGridCell(0, 4, new Insets(20, 10, 3, 5)));
 
-    add(m_fileNameText, buildGridRow(0, 5, new Insets(0, 10, 3, 5)));
+    add(fileNameText, buildGridRow(0, 5, new Insets(0, 10, 3, 5)));
 
-    add(m_loadNewGame, buildGridRow(0, 6, new Insets(25, 10, 10, 10)));
+    add(loadNewGame, buildGridRow(0, 6, new Insets(25, 10, 10, 10)));
 
-    add(m_loadSavedGame, buildGridRow(0, 7, new Insets(0, 10, 10, 10)));
+    add(loadSavedGame, buildGridRow(0, 7, new Insets(0, 10, 10, 10)));
 
     JButton downloadMapButton =
         SwingComponents.newJButton("Download Maps", "Click this button to install additional maps",
-            () -> DownloadMapsWindow.showDownloadMapsWindow());
+            DownloadMapsWindow::showDownloadMapsWindow);
     add(downloadMapButton, buildGridRow(0, 8, new Insets(0, 10, 10, 10)));
 
-    add(m_gameOptions, buildGridRow(0, 9, new Insets(25, 10, 10, 10)));
+    add(gameOptions, buildGridRow(0, 9, new Insets(25, 10, 10, 10)));
 
     // spacer
     add(new JPanel(), new GridBagConstraints(0, 10, 2, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH,
@@ -212,21 +212,21 @@ public class GameSelectorPanel extends JPanel implements Observer {
 
 
   private void setupListeners() {
-    m_loadNewGame.addActionListener(e -> {
+    loadNewGame.addActionListener(e -> {
       if (canSelectLocalGameData()) {
         selectGameFile(false);
       } else if (canChangeHostBotGameData()) {
-        final ClientModel clientModelForHostBots = m_model.getClientModelForHostBots();
+        final ClientModel clientModelForHostBots = model.getClientModelForHostBots();
         if (clientModelForHostBots != null) {
           clientModelForHostBots.getHostBotSetMapClientAction(GameSelectorPanel.this).actionPerformed(e);
         }
       }
     });
-    m_loadSavedGame.addActionListener(e -> {
+    loadSavedGame.addActionListener(e -> {
       if (canSelectLocalGameData()) {
         selectGameFile(true);
       } else if (canChangeHostBotGameData()) {
-        final ClientModel clientModelForHostBots = m_model.getClientModelForHostBots();
+        final ClientModel clientModelForHostBots = model.getClientModelForHostBots();
         if (clientModelForHostBots != null) {
           final JPopupMenu menu = new JPopupMenu();
           menu.add(clientModelForHostBots.getHostBotChangeGameToSaveGameClientAction(GameSelectorPanel.this));
@@ -239,16 +239,16 @@ public class GameSelectorPanel extends JPanel implements Observer {
           menu.add(clientModelForHostBots.getHostBotChangeToAutosaveClientAction(GameSelectorPanel.this,
               SaveGameFileChooser.AUTOSAVE_TYPE.AUTOSAVE_EVEN));
           menu.add(clientModelForHostBots.getHostBotGetGameSaveClientAction(GameSelectorPanel.this));
-          final Point point = m_loadSavedGame.getLocation();
-          menu.show(GameSelectorPanel.this, point.x + m_loadSavedGame.getWidth(), point.y);
+          final Point point = loadSavedGame.getLocation();
+          menu.show(GameSelectorPanel.this, point.x + loadSavedGame.getWidth(), point.y);
         }
       }
     });
-    m_gameOptions.addActionListener(e -> {
+    gameOptions.addActionListener(e -> {
       if (canSelectLocalGameData()) {
         selectGameOptions();
       } else if (canChangeHostBotGameData()) {
-        final ClientModel clientModelForHostBots = m_model.getClientModelForHostBots();
+        final ClientModel clientModelForHostBots = model.getClientModelForHostBots();
         if (clientModelForHostBots != null) {
           clientModelForHostBots.getHostBotChangeGameOptionsClientAction(GameSelectorPanel.this).actionPerformed(e);
         }
@@ -257,10 +257,10 @@ public class GameSelectorPanel extends JPanel implements Observer {
   }
 
   private void setOriginalPropertiesMap(final GameData data) {
-    m_originalPropertiesMap.clear();
+    originalPropertiesMap.clear();
     if (data != null) {
       for (final IEditableProperty property : data.getProperties().getEditableProperties()) {
-        m_originalPropertiesMap.put(property.getName(), property.getValue());
+        originalPropertiesMap.put(property.getName(), property.getValue());
       }
     }
   }
@@ -268,10 +268,10 @@ public class GameSelectorPanel extends JPanel implements Observer {
   private void selectGameOptions() {
     // backup current game properties before showing dialog
     final Map<String, Object> currentPropertiesMap = new HashMap<>();
-    for (final IEditableProperty property : m_model.getGameData().getProperties().getEditableProperties()) {
+    for (final IEditableProperty property : model.getGameData().getProperties().getEditableProperties()) {
       currentPropertiesMap.put(property.getName(), property.getValue());
     }
-    final PropertiesUI panel = new PropertiesUI(m_model.getGameData().getProperties(), true);
+    final PropertiesUI panel = new PropertiesUI(model.getGameData().getProperties(), true);
     final JScrollPane scroll = new JScrollPane(panel);
     scroll.setBorder(null);
     scroll.getViewport().setBorder(null);
@@ -286,24 +286,24 @@ public class GameSelectorPanel extends JPanel implements Observer {
     final Object buttonPressed = pane.getValue();
     if (buttonPressed == null || buttonPressed.equals(cancel)) {
       // restore properties, if cancel was pressed, or window was closed
-      final Iterator<IEditableProperty> itr = m_model.getGameData().getProperties().getEditableProperties().iterator();
+      final Iterator<IEditableProperty> itr = model.getGameData().getProperties().getEditableProperties().iterator();
       while (itr.hasNext()) {
         final IEditableProperty property = itr.next();
         property.setValue(currentPropertiesMap.get(property.getName()));
       }
     } else if (buttonPressed.equals(reset)) {
-      if (!m_originalPropertiesMap.isEmpty()) {
+      if (!originalPropertiesMap.isEmpty()) {
         // restore properties, if cancel was pressed, or window was closed
         final Iterator<IEditableProperty> itr =
-            m_model.getGameData().getProperties().getEditableProperties().iterator();
+            model.getGameData().getProperties().getEditableProperties().iterator();
         while (itr.hasNext()) {
           final IEditableProperty property = itr.next();
-          property.setValue(m_originalPropertiesMap.get(property.getName()));
+          property.setValue(originalPropertiesMap.get(property.getName()));
         }
         selectGameOptions();
       }
     } else if (buttonPressed.equals(makeDefault)) {
-      m_gamePropertiesCache.cacheGameProperties(m_model.getGameData());
+      gamePropertiesCache.cacheGameProperties(model.getGameData());
     } else {
       // ok was clicked, and we have modified the properties already
     }
@@ -316,29 +316,29 @@ public class GameSelectorPanel extends JPanel implements Observer {
     }
     final boolean canSelectGameData = canSelectLocalGameData();
     final boolean canChangeHostBotGameData = canChangeHostBotGameData();
-    m_loadSavedGame.setEnabled(canSelectGameData || canChangeHostBotGameData);
-    m_loadNewGame.setEnabled(canSelectGameData || canChangeHostBotGameData);
+    loadSavedGame.setEnabled(canSelectGameData || canChangeHostBotGameData);
+    loadNewGame.setEnabled(canSelectGameData || canChangeHostBotGameData);
     // Disable game options if there are none.
-    if (canChangeHostBotGameData || (canSelectGameData && m_model.getGameData() != null
-        && m_model.getGameData().getProperties().getEditableProperties().size() > 0)) {
-      m_gameOptions.setEnabled(true);
+    if (canChangeHostBotGameData || (canSelectGameData && model.getGameData() != null
+        && model.getGameData().getProperties().getEditableProperties().size() > 0)) {
+      gameOptions.setEnabled(true);
     } else {
-      m_gameOptions.setEnabled(false);
+      gameOptions.setEnabled(false);
     }
     // we don't want them starting new games if we are an old jar
     if (ClientFileSystemHelper.areWeOldExtraJar()) {
-      m_loadNewGame.setEnabled(false);
-      m_loadNewGame.setToolTipText(
+      loadNewGame.setEnabled(false);
+      loadNewGame.setToolTipText(
           "This is disabled on older engine jars, please start new games with the latest version of TripleA.");
     }
   }
 
   private boolean canSelectLocalGameData() {
-    return m_model != null && m_model.canSelect();
+    return model != null && model.canSelect();
   }
 
   private boolean canChangeHostBotGameData() {
-    return m_model != null && m_model.isHostHeadlessBot();
+    return model != null && model.isHostHeadlessBot();
   }
 
   @Override
@@ -384,11 +384,11 @@ public class GameSelectorPanel extends JPanel implements Observer {
       if (file == null || !file.exists()) {
         return;
       }
-      m_model.load(file, this);
-      setOriginalPropertiesMap(m_model.getGameData());
+      model.load(file, this);
+      setOriginalPropertiesMap(model.getGameData());
     } else {
       final NewGameChooserEntry entry =
-          NewGameChooser.chooseGame(JOptionPane.getFrameForComponent(this), m_model.getGameName());
+          NewGameChooser.chooseGame(JOptionPane.getFrameForComponent(this), model.getGameName());
       if (entry != null) {
         if (!entry.isGameDataLoaded()) {
           try {
@@ -399,11 +399,11 @@ public class GameSelectorPanel extends JPanel implements Observer {
             return;
           }
         }
-        m_model.load(entry);
-        setOriginalPropertiesMap(m_model.getGameData());
+        model.load(entry);
+        setOriginalPropertiesMap(model.getGameData());
         // only for new games, not saved games, we set the default options, and set them only once (the first time it is
         // loaded)
-        m_gamePropertiesCache.loadCachedGamePropertiesInto(m_model.getGameData());
+        gamePropertiesCache.loadCachedGamePropertiesInto(model.getGameData());
       }
     }
   }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -37,19 +37,19 @@ import games.strategy.util.Version;
 public class MetaSetupPanel extends SetupPanel {
 
   private static final long serialVersionUID = 3926503672972937677L;
-  private JButton m_startLocal;
-  private JButton m_startPBEM;
-  private JButton m_hostGame;
-  private JButton m_connectToHostedGame;
-  private JButton m_connectToLobby;
-  private JButton m_enginePreferences;
-  private JButton m_ruleBook;
-  private JButton m_helpButton;
+  private JButton startLocal;
+  private JButton startPbem;
+  private JButton hostGame;
+  private JButton connectToHostedGame;
+  private JButton connectToLobby;
+  private JButton enginePreferences;
+  private JButton ruleBook;
+  private JButton helpButton;
 
-  private final SetupPanelModel m_model;
+  private final SetupPanelModel model;
 
   public MetaSetupPanel(final SetupPanelModel model) {
-    this.m_model = model;
+    this.model = model;
 
     createComponents();
     layoutComponents();
@@ -58,33 +58,33 @@ public class MetaSetupPanel extends SetupPanel {
   }
 
   private void createComponents() {
-    m_connectToLobby = new JButton("Play Online");
-    final Font bigButtonFont = new Font(m_connectToLobby.getFont().getName(), m_connectToLobby.getFont().getStyle(),
-        m_connectToLobby.getFont().getSize() + 3);
-    m_connectToLobby.setFont(bigButtonFont);
-    m_connectToLobby.setToolTipText("<html>Find Games Online on the Lobby Server. <br>"
+    connectToLobby = new JButton("Play Online");
+    final Font bigButtonFont = new Font(connectToLobby.getFont().getName(), connectToLobby.getFont().getStyle(),
+        connectToLobby.getFont().getSize() + 3);
+    connectToLobby.setFont(bigButtonFont);
+    connectToLobby.setToolTipText("<html>Find Games Online on the Lobby Server. <br>"
         + "TripleA is MEANT to be played Online against other humans. <br>"
         + "Any other way is not as fun!</html>");
-    m_startLocal = new JButton("Start Local Game");
-    m_startLocal.setToolTipText("<html>Start a game on this computer. <br>"
+    startLocal = new JButton("Start Local Game");
+    startLocal.setToolTipText("<html>Start a game on this computer. <br>"
         + "You can play against a friend sitting besides you (hotseat mode), <br>"
         + "or against one of the AIs.</html>");
-    m_startPBEM = new JButton("Start PBEM (Play-By-Email/Forum) Game");
-    m_startPBEM.setToolTipText("<html>Starts a game which will be emailed back and forth between all players, <br>"
+    startPbem = new JButton("Start PBEM (Play-By-Email/Forum) Game");
+    startPbem.setToolTipText("<html>Starts a game which will be emailed back and forth between all players, <br>"
         + "or be posted to an online forum or message board.</html>");
-    m_hostGame = new JButton("Host Networked Game");
-    m_hostGame.setToolTipText("<html>Hosts a network game, which people can connect to. <br>"
+    hostGame = new JButton("Host Networked Game");
+    hostGame.setToolTipText("<html>Hosts a network game, which people can connect to. <br>"
         + "Anyone on a LAN will be able to connect. <br>"
         + "Anyone from the internet can connect as well, but only if the host has configured port forwarding "
         + "correctly.</html>");
-    m_connectToHostedGame = new JButton("Connect to Networked Game");
-    m_connectToHostedGame
+    connectToHostedGame = new JButton("Connect to Networked Game");
+    connectToHostedGame
         .setToolTipText("<html>Connects to someone's hosted game, <br>so long as you know their IP address.</html>");
-    m_enginePreferences = new JButton("Engine Preferences");
-    m_enginePreferences.setToolTipText("<html>Configure certain options related to the engine.");
-    m_ruleBook = new JButton("Rule Book");
-    m_helpButton = new JButton("Help");
-    m_ruleBook.setToolTipText("<html>Download a manual of how to play <br>"
+    enginePreferences = new JButton("Engine Preferences");
+    enginePreferences.setToolTipText("<html>Configure certain options related to the engine.");
+    ruleBook = new JButton("Rule Book");
+    helpButton = new JButton("Help");
+    ruleBook.setToolTipText("<html>Download a manual of how to play <br>"
         + "(it is also included in the directory TripleA was installed to).</html>");
   }
 
@@ -93,21 +93,21 @@ public class MetaSetupPanel extends SetupPanel {
     // top space
     add(new JPanel(), new GridBagConstraints(0, 0, 1, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH,
         new Insets(00, 0, 0, 0), 0, 0));
-    add(m_connectToLobby, new GridBagConstraints(0, 1, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
+    add(connectToLobby, new GridBagConstraints(0, 1, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(10, 0, 0, 0), 0, 0));
-    add(m_startLocal, new GridBagConstraints(0, 2, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
+    add(startLocal, new GridBagConstraints(0, 2, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(10, 0, 0, 0), 0, 0));
-    add(m_startPBEM, new GridBagConstraints(0, 3, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
+    add(startPbem, new GridBagConstraints(0, 3, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(10, 0, 0, 0), 0, 0));
-    add(m_hostGame, new GridBagConstraints(0, 4, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
+    add(hostGame, new GridBagConstraints(0, 4, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(10, 0, 0, 0), 0, 0));
-    add(m_connectToHostedGame, new GridBagConstraints(0, 5, 1, 1, 0, 0, GridBagConstraints.CENTER,
+    add(connectToHostedGame, new GridBagConstraints(0, 5, 1, 1, 0, 0, GridBagConstraints.CENTER,
         GridBagConstraints.NONE, new Insets(10, 0, 0, 0), 0, 0));
-    add(m_enginePreferences, new GridBagConstraints(0, 6, 1, 1, 0, 0, GridBagConstraints.CENTER,
+    add(enginePreferences, new GridBagConstraints(0, 6, 1, 1, 0, 0, GridBagConstraints.CENTER,
         GridBagConstraints.NONE, new Insets(10, 0, 0, 0), 0, 0));
-    add(m_ruleBook, new GridBagConstraints(0, 8, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
+    add(ruleBook, new GridBagConstraints(0, 8, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(10, 0, 0, 0), 0, 0));
-    add(m_helpButton, new GridBagConstraints(0, 9, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
+    add(helpButton, new GridBagConstraints(0, 9, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(10, 0, 0, 0), 0, 0));
     // top space
     add(new JPanel(), new GridBagConstraints(0, 100, 1, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH,
@@ -115,14 +115,14 @@ public class MetaSetupPanel extends SetupPanel {
   }
 
   private void setupListeners() {
-    m_startLocal.addActionListener(e -> m_model.showLocal());
-    m_startPBEM.addActionListener(e -> m_model.showPBEM());
-    m_hostGame.addActionListener(e -> m_model.showServer(MetaSetupPanel.this));
-    m_connectToHostedGame.addActionListener(e -> m_model.showClient(MetaSetupPanel.this));
-    m_connectToLobby.addActionListener(e -> connectToLobby());
-    m_enginePreferences.addActionListener(e -> enginePreferences());
-    m_ruleBook.addActionListener(e -> ruleBook());
-    m_helpButton.addActionListener(e -> helpPage());
+    startLocal.addActionListener(e -> model.showLocal());
+    startPbem.addActionListener(e -> model.showPBEM());
+    hostGame.addActionListener(e -> model.showServer(MetaSetupPanel.this));
+    connectToHostedGame.addActionListener(e -> model.showClient(MetaSetupPanel.this));
+    connectToLobby.addActionListener(e -> connectToLobby());
+    enginePreferences.addActionListener(e -> enginePreferences());
+    ruleBook.addActionListener(e -> ruleBook());
+    helpButton.addActionListener(e -> helpPage());
   }
 
   private static void ruleBook() {
@@ -225,15 +225,15 @@ public class MetaSetupPanel extends SetupPanel {
 
   @Override
   public void setWidgetActivation() {
-    if (m_model == null || m_model.getGameSelectorModel() == null
-        || m_model.getGameSelectorModel().getGameData() == null) {
-      m_startLocal.setEnabled(false);
-      m_startPBEM.setEnabled(false);
-      m_hostGame.setEnabled(false);
+    if (model == null || model.getGameSelectorModel() == null
+        || model.getGameSelectorModel().getGameData() == null) {
+      startLocal.setEnabled(false);
+      startPbem.setEnabled(false);
+      hostGame.setEnabled(false);
     } else {
-      m_startLocal.setEnabled(true);
-      m_startPBEM.setEnabled(true);
-      m_hostGame.setEnabled(true);
+      startLocal.setEnabled(true);
+      startPbem.setEnabled(true);
+      hostGame.setEnabled(true);
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
@@ -7,7 +7,6 @@ import java.awt.Container;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-
 import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -28,13 +27,13 @@ import games.strategy.ui.SwingAction;
  */
 public class ServerOptions extends JDialog {
   private static final long serialVersionUID = -9074816386666798281L;
-  private JTextField m_nameField;
-  private IntTextField m_portField;
-  private JPasswordField m_passwordField;
-  private boolean m_okPressed;
-  private JCheckBox m_requirePasswordCheckBox;
-  private JTextField m_comment;
-  private boolean m_showComment = false;
+  private JTextField nameField;
+  private IntTextField portField;
+  private JPasswordField passwordField;
+  private boolean okPressed;
+  private JCheckBox requirePasswordCheckBox;
+  private JTextField comment;
+  private boolean showComment = false;
 
   /**
    * Creates a new instance of ServerOptions.
@@ -42,28 +41,28 @@ public class ServerOptions extends JDialog {
   public ServerOptions(final Component owner, final String defaultName, final int defaultPort,
       final boolean showComment) {
     super(owner == null ? null : JOptionPane.getFrameForComponent(owner), "Server options", true);
-    m_showComment = showComment;
+    this.showComment = showComment;
     initComponents();
     layoutComponents();
     setupActions();
-    m_nameField.setText(defaultName);
-    m_portField.setValue(defaultPort);
+    nameField.setText(defaultName);
+    portField.setValue(defaultPort);
     setWidgetActivation();
     pack();
   }
 
   public void setNameEditable(final boolean editable) {
-    m_nameField.setEditable(editable);
+    nameField.setEditable(editable);
   }
 
   private void setupActions() {
-    m_requirePasswordCheckBox.addActionListener(e -> setWidgetActivation());
+    requirePasswordCheckBox.addActionListener(e -> setWidgetActivation());
   }
 
   @Override
   public String getName() {
     // fixes crash by truncating names to 20 characters
-    final String s = m_nameField.getText().trim();
+    final String s = nameField.getText().trim();
     if (s.length() > 20) {
       return s.substring(0, 20);
     }
@@ -71,10 +70,10 @@ public class ServerOptions extends JDialog {
   }
 
   public String getPassword() {
-    if (!m_requirePasswordCheckBox.isSelected()) {
+    if (!requirePasswordCheckBox.isSelected()) {
       return null;
     }
-    final String password = new String(m_passwordField.getPassword());
+    final String password = new String(passwordField.getPassword());
     if (password.trim().length() == 0) {
       return null;
     }
@@ -82,17 +81,17 @@ public class ServerOptions extends JDialog {
   }
 
   public int getPort() {
-    return m_portField.getValue();
+    return portField.getValue();
   }
 
   private void initComponents() {
-    m_nameField = new JTextField(10);
-    m_portField = new IntTextField(0, Integer.MAX_VALUE);
-    m_portField.setColumns(7);
-    m_passwordField = new JPasswordField();
-    m_passwordField.setColumns(10);
-    m_comment = new JTextField();
-    m_comment.setColumns(20);
+    nameField = new JTextField(10);
+    portField = new IntTextField(0, Integer.MAX_VALUE);
+    portField.setColumns(7);
+    passwordField = new JPasswordField();
+    passwordField.setColumns(10);
+    comment = new JTextField();
+    comment.setColumns(20);
   }
 
   private void layoutComponents() {
@@ -111,7 +110,7 @@ public class ServerOptions extends JDialog {
     fieldConstraints.anchor = GridBagConstraints.WEST;
     fieldConstraints.gridx = 1;
     fieldConstraints.insets = fieldSpacing;
-    m_requirePasswordCheckBox = new JCheckBox("");
+    requirePasswordCheckBox = new JCheckBox("");
     final JLabel passwordRequiredLabel = new JLabel("Require Password:");
     final JPanel fields = new JPanel();
     final GridBagLayout layout = new GridBagLayout();
@@ -123,24 +122,24 @@ public class ServerOptions extends JDialog {
     layout.setConstraints(portLabel, labelConstraints);
     layout.setConstraints(nameLabel, labelConstraints);
     layout.setConstraints(passwordLabel, labelConstraints);
-    layout.setConstraints(m_portField, fieldConstraints);
-    layout.setConstraints(m_nameField, fieldConstraints);
-    layout.setConstraints(m_passwordField, fieldConstraints);
-    layout.setConstraints(m_requirePasswordCheckBox, fieldConstraints);
+    layout.setConstraints(portField, fieldConstraints);
+    layout.setConstraints(nameField, fieldConstraints);
+    layout.setConstraints(passwordField, fieldConstraints);
+    layout.setConstraints(requirePasswordCheckBox, fieldConstraints);
     layout.setConstraints(passwordRequiredLabel, labelConstraints);
     fields.add(nameLabel);
-    fields.add(m_nameField);
+    fields.add(nameField);
     fields.add(portLabel);
-    fields.add(m_portField);
+    fields.add(portField);
     fields.add(passwordRequiredLabel);
-    fields.add(m_requirePasswordCheckBox);
+    fields.add(requirePasswordCheckBox);
     fields.add(passwordLabel);
-    fields.add(m_passwordField);
-    if (m_showComment) {
+    fields.add(passwordField);
+    if (showComment) {
       layout.setConstraints(commentLabel, labelConstraints);
-      layout.setConstraints(m_comment, fieldConstraints);
+      layout.setConstraints(comment, fieldConstraints);
       fields.add(commentLabel);
-      fields.add(m_comment);
+      fields.add(comment);
     }
     content.add(fields, BorderLayout.CENTER);
     final JPanel buttons = new JPanel();
@@ -150,13 +149,13 @@ public class ServerOptions extends JDialog {
   }
 
   public boolean getOKPressed() {
-    return m_okPressed;
+    return okPressed;
   }
 
   private void setWidgetActivation() {
-    m_passwordField.setEnabled(m_requirePasswordCheckBox.isSelected());
-    final Color backGround = m_passwordField.isEnabled() ? m_portField.getBackground() : getBackground();
-    m_passwordField.setBackground(backGround);
+    passwordField.setEnabled(requirePasswordCheckBox.isSelected());
+    final Color backGround = passwordField.isEnabled() ? portField.getBackground() : getBackground();
+    passwordField.setBackground(backGround);
     if (ClientFileSystemHelper.areWeOldExtraJar()
         && System.getProperty(GameRunner.TRIPLEA_SERVER_PROPERTY, "false").equalsIgnoreCase("true")) {
       setNameEditable(false);
@@ -165,12 +164,12 @@ public class ServerOptions extends JDialog {
 
   private final Action m_okAction = SwingAction.of("OK", e -> {
     setVisible(false);
-    m_okPressed = true;
+    okPressed = true;
   });
 
   private final Action m_cancelAction = SwingAction.of("Cancel", e -> setVisible(false));
 
   public String getComments() {
-    return m_comment.getText();
+    return comment.getText();
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -49,20 +49,20 @@ import games.strategy.util.ThreadUtil;
 /** Setup panel displayed for hosting a non-lobby network game (using host option from main panel). */
 public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener {
   private static final long serialVersionUID = -2849872641665561807L;
-  private final ServerModel m_model;
-  private JTextField m_portField;
-  private JTextField m_addressField;
-  private JTextField m_nameField;
-  private List<PlayerRow> m_playerRows = new ArrayList<>();
-  private final GameSelectorModel m_gameSelectorModel;
-  private JPanel m_info;
-  private JPanel m_networkPanel;
-  private final InGameLobbyWatcherWrapper m_lobbyWatcher = new InGameLobbyWatcherWrapper();
+  private final ServerModel model;
+  private JTextField portField;
+  private JTextField addressField;
+  private JTextField nameField;
+  private List<PlayerRow> playerRows = new ArrayList<>();
+  private final GameSelectorModel gameSelectorModel;
+  private JPanel info;
+  private JPanel networkPanel;
+  private final InGameLobbyWatcherWrapper lobbyWatcher = new InGameLobbyWatcherWrapper();
 
   public ServerSetupPanel(final ServerModel model, final GameSelectorModel gameSelectorModel) {
-    m_model = model;
-    m_gameSelectorModel = gameSelectorModel;
-    m_model.setRemoteModelListener(this);
+    this.model = model;
+    this.gameSelectorModel = gameSelectorModel;
+    this.model.setRemoteModelListener(this);
     createLobbyWatcher();
     createComponents();
     layoutComponents();
@@ -72,10 +72,10 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
   }
 
   void createLobbyWatcher() {
-    if (m_lobbyWatcher != null) {
-      m_lobbyWatcher.setInGameLobbyWatcher(InGameLobbyWatcher.newInGameLobbyWatcher(m_model.getMessenger(), this,
-          m_lobbyWatcher.getInGameLobbyWatcher()));
-      m_lobbyWatcher.setGameSelectorModel(m_gameSelectorModel);
+    if (lobbyWatcher != null) {
+      lobbyWatcher.setInGameLobbyWatcher(InGameLobbyWatcher.newInGameLobbyWatcher(model.getMessenger(), this,
+          lobbyWatcher.getInGameLobbyWatcher()));
+      lobbyWatcher.setGameSelectorModel(gameSelectorModel);
     }
   }
 
@@ -94,49 +94,49 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
   }
 
   void shutDownLobbyWatcher() {
-    if (m_lobbyWatcher != null) {
-      m_lobbyWatcher.shutDown();
+    if (lobbyWatcher != null) {
+      lobbyWatcher.shutDown();
     }
   }
 
   private void createComponents() {
-    final IServerMessenger messenger = m_model.getMessenger();
+    final IServerMessenger messenger = model.getMessenger();
     final Color backGround = new JTextField().getBackground();
-    m_portField = new JTextField("" + messenger.getLocalNode().getPort());
-    m_portField.setEnabled(true);
-    m_portField.setEditable(false);
-    m_portField.setBackground(backGround);
-    m_portField.setColumns(6);
-    m_addressField = new JTextField(messenger.getLocalNode().getAddress().getHostAddress());
-    m_addressField.setEnabled(true);
-    m_addressField.setEditable(false);
-    m_addressField.setBackground(backGround);
-    m_addressField.setColumns(20);
-    m_nameField = new JTextField(messenger.getLocalNode().getName());
-    m_nameField.setEnabled(true);
-    m_nameField.setEditable(false);
-    m_nameField.setBackground(backGround);
-    m_nameField.setColumns(20);
-    m_info = new JPanel();
-    m_networkPanel = new JPanel();
+    portField = new JTextField("" + messenger.getLocalNode().getPort());
+    portField.setEnabled(true);
+    portField.setEditable(false);
+    portField.setBackground(backGround);
+    portField.setColumns(6);
+    addressField = new JTextField(messenger.getLocalNode().getAddress().getHostAddress());
+    addressField.setEnabled(true);
+    addressField.setEditable(false);
+    addressField.setBackground(backGround);
+    addressField.setColumns(20);
+    nameField = new JTextField(messenger.getLocalNode().getName());
+    nameField.setEnabled(true);
+    nameField.setEditable(false);
+    nameField.setBackground(backGround);
+    nameField.setColumns(20);
+    info = new JPanel();
+    networkPanel = new JPanel();
   }
 
   private void layoutComponents() {
     setLayout(new BorderLayout());
-    m_info.setLayout(new GridBagLayout());
-    m_info.add(new JLabel("Name:"), new GridBagConstraints(0, 0, 1, 1, 0, 0.0, GridBagConstraints.EAST,
+    info.setLayout(new GridBagLayout());
+    info.add(new JLabel("Name:"), new GridBagConstraints(0, 0, 1, 1, 0, 0.0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(5, 10, 0, 5), 0, 0));
-    m_info.add(new JLabel("Address:"), new GridBagConstraints(0, 1, 1, 1, 0, 0.0, GridBagConstraints.EAST,
+    info.add(new JLabel("Address:"), new GridBagConstraints(0, 1, 1, 1, 0, 0.0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(5, 10, 0, 5), 0, 0));
-    m_info.add(new JLabel("Port:"), new GridBagConstraints(0, 2, 1, 1, 0, 0.0, GridBagConstraints.EAST,
+    info.add(new JLabel("Port:"), new GridBagConstraints(0, 2, 1, 1, 0, 0.0, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(5, 10, 0, 5), 0, 0));
-    m_info.add(m_nameField, new GridBagConstraints(1, 0, 1, 1, 0.5, 1.0, GridBagConstraints.WEST,
+    info.add(nameField, new GridBagConstraints(1, 0, 1, 1, 0.5, 1.0, GridBagConstraints.WEST,
         GridBagConstraints.BOTH, new Insets(5, 0, 0, 5), 0, 0));
-    m_info.add(m_addressField, new GridBagConstraints(1, 1, 1, 1, 0.5, 1.0, GridBagConstraints.WEST,
+    info.add(addressField, new GridBagConstraints(1, 1, 1, 1, 0.5, 1.0, GridBagConstraints.WEST,
         GridBagConstraints.BOTH, new Insets(5, 0, 0, 5), 0, 0));
-    m_info.add(m_portField, new GridBagConstraints(1, 2, 1, 1, 0.5, 1.0, GridBagConstraints.WEST,
+    info.add(portField, new GridBagConstraints(1, 2, 1, 1, 0.5, 1.0, GridBagConstraints.WEST,
         GridBagConstraints.BOTH, new Insets(5, 0, 0, 5), 0, 0));
-    add(m_info, BorderLayout.NORTH);
+    add(info, BorderLayout.NORTH);
   }
 
   private void layoutPlayers() {
@@ -146,8 +146,8 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     final Insets spacing = new Insets(3, 16, 0, 0);
     final Insets lastSpacing = new Insets(3, 16, 0, 16);
     int gridx = 0;
-    final boolean disableable = !m_model.getPlayersAllowedToBeDisabled().isEmpty()
-        || m_model.getPlayersEnabledListing().containsValue(Boolean.FALSE);
+    final boolean disableable = !model.getPlayersAllowedToBeDisabled().isEmpty()
+        || model.getPlayersEnabledListing().containsValue(Boolean.FALSE);
     final GridBagConstraints enabledPlayerConstraints = new GridBagConstraints();
     if (disableable) {
       enabledPlayerConstraints.anchor = GridBagConstraints.WEST;
@@ -200,7 +200,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     allianceLabel.setForeground(Color.black);
     layout.setConstraints(allianceLabel, allianceConstraints);
     players.add(allianceLabel);
-    final Iterator<PlayerRow> iter = m_playerRows.iterator();
+    final Iterator<PlayerRow> iter = playerRows.iterator();
     if (!iter.hasNext()) {
       final JLabel noPlayers = new JLabel("Load a game file first");
       layout.setConstraints(noPlayers, nameConstraints);
@@ -224,13 +224,13 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
       players.add(row.getAlliance());
     }
     removeAll();
-    add(m_info, BorderLayout.NORTH);
+    add(info, BorderLayout.NORTH);
     final JScrollPane scroll = new JScrollPane(players, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
         ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
     scroll.setBorder(null);
     scroll.setViewportBorder(null);
     add(scroll, BorderLayout.CENTER);
-    add(m_networkPanel, BorderLayout.SOUTH);
+    add(networkPanel, BorderLayout.SOUTH);
     invalidate();
     validate();
   }
@@ -242,34 +242,34 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
 
   @Override
   public void shutDown() {
-    m_model.setRemoteModelListener(IRemoteModelListener.NULL_LISTENER);
-    m_model.shutDown();
-    if (m_lobbyWatcher != null) {
-      m_lobbyWatcher.shutDown();
+    model.setRemoteModelListener(IRemoteModelListener.NULL_LISTENER);
+    model.shutDown();
+    if (lobbyWatcher != null) {
+      lobbyWatcher.shutDown();
     }
   }
 
   @Override
   public void cancel() {
-    m_model.setRemoteModelListener(IRemoteModelListener.NULL_LISTENER);
-    m_model.cancel();
-    if (m_lobbyWatcher != null) {
-      m_lobbyWatcher.shutDown();
+    model.setRemoteModelListener(IRemoteModelListener.NULL_LISTENER);
+    model.cancel();
+    if (lobbyWatcher != null) {
+      lobbyWatcher.shutDown();
     }
   }
 
   @Override
   public void postStartGame() {
-    final GameData data = m_gameSelectorModel.getGameData();
+    final GameData data = gameSelectorModel.getGameData();
     data.getProperties().set(PBEMMessagePoster.PBEM_GAME_PROP_NAME, false);
   }
 
   @Override
   public boolean canGameStart() {
-    if (m_gameSelectorModel.getGameData() == null || m_model == null) {
+    if (gameSelectorModel.getGameData() == null || model == null) {
       return false;
     }
-    final Map<String, String> players = m_model.getPlayersToNodeListing();
+    final Map<String, String> players = model.getPlayersToNodeListing();
     if (players == null || players.isEmpty()) {
       return false;
     }
@@ -279,7 +279,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
       }
     }
     // make sure at least 1 player is enabled
-    final Map<String, Boolean> someoneEnabled = m_model.getPlayersEnabledListing();
+    final Map<String, Boolean> someoneEnabled = model.getPlayersEnabledListing();
     for (final boolean bool : someoneEnabled.values()) {
       if (bool) {
         return true;
@@ -302,9 +302,9 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     if (!SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("Wrong thread");
     }
-    final Map<String, String> playersToNode = m_model.getPlayersToNodeListing();
-    final Map<String, Boolean> playersEnabled = m_model.getPlayersEnabledListing();
-    for (final PlayerRow row : m_playerRows) {
+    final Map<String, String> playersToNode = model.getPlayersToNodeListing();
+    final Map<String, Boolean> playersEnabled = model.getPlayersEnabledListing();
+    for (final PlayerRow row : playerRows) {
       row.update(playersToNode, playersEnabled);
     }
     super.notifyObservers();
@@ -314,18 +314,18 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     if (!SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("Wrong thread");
     }
-    m_playerRows = new ArrayList<>();
-    final Map<String, String> players = m_model.getPlayersToNodeListing();
-    final Map<String, Boolean> playersEnabled = m_model.getPlayersEnabledListing();
+    playerRows = new ArrayList<>();
+    final Map<String, String> players = model.getPlayersToNodeListing();
+    final Map<String, Boolean> playersEnabled = model.getPlayersEnabledListing();
     final Map<String, Collection<String>> m_playerNamesAndAlliancesInTurnOrder =
-        m_model.getPlayerNamesAndAlliancesInTurnOrderLinkedHashMap();
-    final Map<String, String> reloadSelections = PlayerID.currentPlayers(m_gameSelectorModel.getGameData());
+        model.getPlayerNamesAndAlliancesInTurnOrderLinkedHashMap();
+    final Map<String, String> reloadSelections = PlayerID.currentPlayers(gameSelectorModel.getGameData());
     final Set<String> playerNames = m_playerNamesAndAlliancesInTurnOrder.keySet();
     for (final String name : playerNames) {
       final PlayerRow newPlayerRow =
           new PlayerRow(name, reloadSelections, m_playerNamesAndAlliancesInTurnOrder.get(name),
-              m_gameSelectorModel.getGameData().getGameLoader().getServerPlayerTypes());
-      m_playerRows.add(newPlayerRow);
+              gameSelectorModel.getGameData().getGameLoader().getServerPlayerTypes());
+      playerRows.add(newPlayerRow);
       newPlayerRow.update(players, playersEnabled);
     }
     layoutPlayers();
@@ -344,7 +344,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     PlayerRow(final String playerName, final Map<String, String> reloadSelections,
         final Collection<String> playerAlliances, final String[] types) {
       m_nameLabel = new JLabel(playerName);
-      m_playerLabel = new JLabel(m_model.getMessenger().getLocalNode().getName());
+      m_playerLabel = new JLabel(model.getMessenger().getLocalNode().getName());
       m_localCheckBox = new JCheckBox();
       m_localCheckBox.addActionListener(m_localPlayerActionListener);
       m_localCheckBox.setSelected(true);
@@ -360,11 +360,11 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
       }
       if (!(previousSelection.equals("no_one")) && Arrays.asList(types).contains(previousSelection)) {
         m_type.setSelectedItem(previousSelection);
-        m_model.setLocalPlayerType(m_nameLabel.getText(), (String) m_type.getSelectedItem());
+        model.setLocalPlayerType(m_nameLabel.getText(), (String) m_type.getSelectedItem());
       } else if (playerName.startsWith("Neutral") || playerName.startsWith("AI")) {
         // the 4th in the list should be Pro AI (Hard AI)
         m_type.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 3))]);
-        m_model.setLocalPlayerType(m_nameLabel.getText(), (String) m_type.getSelectedItem());
+        model.setLocalPlayerType(m_nameLabel.getText(), (String) m_type.getSelectedItem());
       }
       if (playerAlliances.contains(playerName)) {
         m_alliance = new JLabel();
@@ -372,7 +372,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
         m_alliance = new JLabel(playerAlliances.toString());
       }
       m_type.addActionListener(
-          e -> m_model.setLocalPlayerType(m_nameLabel.getText(), (String) m_type.getSelectedItem()));
+          e -> model.setLocalPlayerType(m_nameLabel.getText(), (String) m_type.getSelectedItem()));
     }
 
     public JComboBox<String> getType() {
@@ -405,7 +405,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
         text = "-";
       }
       m_playerLabel.setText(text);
-      m_localCheckBox.setSelected(text.equals(m_model.getMessenger().getLocalNode().getName()));
+      m_localCheckBox.setSelected(text.equals(model.getMessenger().getLocalNode().getName()));
       m_enabledCheckBox.setSelected(playersEnabled.get(m_nameLabel.getText()));
       setWidgetActivation();
     }
@@ -416,16 +416,16 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
       m_playerLabel.setEnabled(m_enabledCheckBox.isSelected());
       m_localCheckBox.setEnabled(m_enabledCheckBox.isSelected());
       m_alliance.setEnabled(m_enabledCheckBox.isSelected());
-      m_enabledCheckBox.setEnabled(m_model.getPlayersAllowedToBeDisabled().contains(m_nameLabel.getText()));
+      m_enabledCheckBox.setEnabled(model.getPlayersAllowedToBeDisabled().contains(m_nameLabel.getText()));
     }
 
     private final ActionListener m_localPlayerActionListener = new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent e) {
         if (m_localCheckBox.isSelected()) {
-          m_model.takePlayer(m_nameLabel.getText());
+          model.takePlayer(m_nameLabel.getText());
         } else {
-          m_model.releasePlayer(m_nameLabel.getText());
+          model.releasePlayer(m_nameLabel.getText());
         }
         setWidgetActivation();
       }
@@ -434,11 +434,11 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
       @Override
       public void actionPerformed(final ActionEvent e) {
         if (m_enabledCheckBox.isSelected()) {
-          m_model.enablePlayer(m_nameLabel.getText());
+          model.enablePlayer(m_nameLabel.getText());
           // the 1st in the list should be human
           m_type.setSelectedItem(m_types[0]);
         } else {
-          m_model.disablePlayer(m_nameLabel.getText());
+          model.disablePlayer(m_nameLabel.getText());
           // the 2nd in the list should be Weak AI
           m_type.setSelectedItem(m_types[Math.max(0, Math.min(m_types.length - 1, 1))]);
         }
@@ -449,34 +449,34 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
 
   @Override
   public IChatPanel getChatPanel() {
-    return m_model.getChatPanel();
+    return model.getChatPanel();
   }
 
   public ServerModel getModel() {
-    return m_model;
+    return model;
   }
 
   @Override
   public synchronized ILauncher getLauncher() {
-    final ServerLauncher launcher = (ServerLauncher) m_model.getLauncher();
+    final ServerLauncher launcher = (ServerLauncher) model.getLauncher();
     if (launcher == null) {
       return null;
     }
-    launcher.setInGameLobbyWatcher(m_lobbyWatcher);
+    launcher.setInGameLobbyWatcher(lobbyWatcher);
     return launcher;
   }
 
   @Override
   public List<Action> getUserActions() {
     final List<Action> rVal = new ArrayList<>();
-    rVal.add(new BootPlayerAction(this, m_model.getMessenger()));
-    rVal.add(new BanPlayerAction(this, m_model.getMessenger()));
-    rVal.add(new MutePlayerAction(this, m_model.getMessenger()));
+    rVal.add(new BootPlayerAction(this, model.getMessenger()));
+    rVal.add(new BanPlayerAction(this, model.getMessenger()));
+    rVal.add(new MutePlayerAction(this, model.getMessenger()));
     rVal.add(
-        new SetPasswordAction(this, m_lobbyWatcher, (ClientLoginValidator) m_model.getMessenger().getLoginValidator()));
-    if (m_lobbyWatcher != null && m_lobbyWatcher.isActive()) {
-      rVal.add(new EditGameCommentAction(m_lobbyWatcher, ServerSetupPanel.this));
-      rVal.add(new RemoveGameFromLobbyAction(m_lobbyWatcher));
+        new SetPasswordAction(this, lobbyWatcher, (ClientLoginValidator) model.getMessenger().getLoginValidator()));
+    if (lobbyWatcher != null && lobbyWatcher.isActive()) {
+      rVal.add(new EditGameCommentAction(lobbyWatcher, ServerSetupPanel.this));
+      rVal.add(new RemoveGameFromLobbyAction(lobbyWatcher));
     }
     return rVal;
   }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Observer;
 import java.util.concurrent.CopyOnWriteArrayList;
-
 import javax.swing.Action;
 import javax.swing.JPanel;
 
@@ -13,21 +12,21 @@ import games.strategy.engine.framework.startup.launcher.ILauncher;
 
 public abstract class SetupPanel extends JPanel implements ISetupPanel {
   private static final long serialVersionUID = 4001323470187210773L;
-  private final List<Observer> m_listeners = new CopyOnWriteArrayList<>();
+  private final List<Observer> listeners = new CopyOnWriteArrayList<>();
 
   @Override
   public void addObserver(final Observer observer) {
-    m_listeners.add(observer);
+    listeners.add(observer);
   }
 
   @Override
   public void removeObserver(final Observer observer) {
-    m_listeners.add(observer);
+    listeners.add(observer);
   }
 
   @Override
   public void notifyObservers() {
-    for (final Observer observer : m_listeners) {
+    for (final Observer observer : listeners) {
       observer.update(null, null);
     }
   }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
@@ -17,13 +17,13 @@ import games.strategy.engine.random.PBEMDiceRoller;
  */
 public class DiceServerEditor extends EditorPanel {
   private static final long serialVersionUID = -451810815037661114L;
-  private final JButton m_testDiceyButton = new JButton("Test Server");
-  private final JTextField m_toAddress = new JTextField();
-  private final JTextField m_ccAddress = new JTextField();
-  private final JTextField m_gameId = new JTextField();
-  private final JLabel m_toLabel = new JLabel("To:");
-  private final JLabel m_ccLabel = new JLabel("Cc:");
-  private final IRemoteDiceServer m_bean;
+  private final JButton testDiceyButton = new JButton("Test Server");
+  private final JTextField toAddress = new JTextField();
+  private final JTextField ccAddress = new JTextField();
+  private final JTextField gameId = new JTextField();
+  private final JLabel toLabel = new JLabel("To:");
+  private final JLabel ccLabel = new JLabel("Cc:");
+  private final IRemoteDiceServer remoteDiceServer;
 
   /**
    * Creating a new instance.
@@ -32,34 +32,34 @@ public class DiceServerEditor extends EditorPanel {
    *        the DiceServer bean to edit
    */
   public DiceServerEditor(final IRemoteDiceServer diceServer) {
-    m_bean = diceServer;
+    remoteDiceServer = diceServer;
     final int bottomSpace = 1;
     final int labelSpace = 2;
     int row = 0;
-    if (m_bean.sendsEmail()) {
-      add(m_toLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
+    if (remoteDiceServer.sendsEmail()) {
+      add(toLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
           new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-      add(m_toAddress, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST,
+      add(toAddress, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST,
           GridBagConstraints.HORIZONTAL, new Insets(0, 0, bottomSpace, 0), 0, 0));
-      m_toAddress.setText(m_bean.getToAddress());
+      toAddress.setText(remoteDiceServer.getToAddress());
       row++;
-      add(m_ccLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
+      add(ccLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
           new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-      add(m_ccAddress, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST,
+      add(ccAddress, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST,
           GridBagConstraints.HORIZONTAL, new Insets(0, 0, bottomSpace, 0), 0, 0));
-      m_ccAddress.setText(m_bean.getCcAddress());
+      ccAddress.setText(remoteDiceServer.getCcAddress());
       row++;
     }
-    if (m_bean.supportsGameId()) {
+    if (remoteDiceServer.supportsGameId()) {
       final JLabel m_gameIdLabel = new JLabel("Game ID:");
       add(m_gameIdLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
           new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-      add(m_gameId, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
+      add(gameId, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
           new Insets(0, 0, bottomSpace, 0), 0, 0));
-      m_gameId.setText(m_bean.getGameId());
+      gameId.setText(remoteDiceServer.getGameId());
       row++;
     }
-    add(m_testDiceyButton, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
+    add(testDiceyButton, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
         new Insets(0, 0, bottomSpace, 0), 0, 0));
     setupListeners();
   }
@@ -68,13 +68,13 @@ public class DiceServerEditor extends EditorPanel {
    * Configures the listeners for the gui components.
    */
   private void setupListeners() {
-    m_testDiceyButton.addActionListener(e -> {
+    testDiceyButton.addActionListener(e -> {
       final PBEMDiceRoller random = new PBEMDiceRoller(getDiceServer(), null);
       random.test();
     });
     final DocumentListener docListener = new EditorChangedFiringDocumentListener();
-    m_toAddress.getDocument().addDocumentListener(docListener);
-    m_ccAddress.getDocument().addDocumentListener(docListener);
+    toAddress.getDocument().addDocumentListener(docListener);
+    ccAddress.getDocument().addDocumentListener(docListener);
   }
 
   @Override
@@ -82,11 +82,11 @@ public class DiceServerEditor extends EditorPanel {
     boolean toValid = true;
     boolean ccValid = true;
     if (getDiceServer().sendsEmail()) {
-      toValid = validateTextField(m_toAddress, m_toLabel, new EmailValidator(false));
-      ccValid = validateTextField(m_ccAddress, m_ccLabel, new EmailValidator(true));
+      toValid = validateTextField(toAddress, toLabel, new EmailValidator(false));
+      ccValid = validateTextField(ccAddress, ccLabel, new EmailValidator(true));
     }
     final boolean allValid = toValid && ccValid;
-    m_testDiceyButton.setEnabled(allValid);
+    testDiceyButton.setEnabled(allValid);
     return allValid;
   }
 
@@ -101,13 +101,13 @@ public class DiceServerEditor extends EditorPanel {
    * @return the dice server
    */
   private IRemoteDiceServer getDiceServer() {
-    if (m_bean.sendsEmail()) {
-      m_bean.setCcAddress(m_ccAddress.getText());
-      m_bean.setToAddress(m_toAddress.getText());
+    if (remoteDiceServer.sendsEmail()) {
+      remoteDiceServer.setCcAddress(ccAddress.getText());
+      remoteDiceServer.setToAddress(toAddress.getText());
     }
-    if (m_bean.supportsGameId()) {
-      m_bean.setGameId(m_gameId.getText());
+    if (remoteDiceServer.supportsGameId()) {
+      remoteDiceServer.setGameId(gameId.getText());
     }
-    return m_bean;
+    return remoteDiceServer;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/EditorPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/EditorPanel.java
@@ -22,11 +22,11 @@ import games.strategy.engine.framework.startup.ui.editors.validators.NonEmptyVal
 public abstract class EditorPanel extends JPanel {
   private static final long serialVersionUID = 8156959717037201321L;
   public static final String EDITOR_CHANGE = "EditorChange";
-  protected final Color m_labelColor;
+  protected final Color labelColor;
 
   public EditorPanel() {
     super(new GridBagLayout());
-    m_labelColor = new JLabel().getForeground();
+    labelColor = new JLabel().getForeground();
   }
 
   /**
@@ -84,7 +84,7 @@ public abstract class EditorPanel extends JPanel {
    */
   protected boolean validateText(final String text, final JLabel label, final IValidator IValidator) {
     boolean valid = true;
-    Color color = m_labelColor;
+    Color color = labelColor;
     if (!IValidator.isValid(text)) {
       valid = false;
       color = Color.RED;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -6,7 +6,6 @@ import java.awt.Insets;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
@@ -28,19 +27,19 @@ import games.strategy.ui.ProgressWindow;
  */
 public class EmailSenderEditor extends EditorPanel {
   private static final long serialVersionUID = -4647781117491269926L;
-  private final GenericEmailSender m_bean;
-  private final JTextField m_subject = new JTextField();
-  private final JTextField m_toAddress = new JTextField();
-  private final JTextField m_host = new JTextField();
-  private final JTextField m_port = new JTextField();
-  private final JTextField m_login = new JTextField();
-  private final JCheckBox m_useTLS = new JCheckBox("Use TLS encryption");
-  private final JTextField m_password = new JPasswordField();
-  private final JLabel m_toLabel = new JLabel("To:");
-  private final JLabel m_hostLabel = new JLabel("Host:");
-  private final JLabel m_portLabel = new JLabel("Port:");
-  private final JButton m_testEmail = new JButton("Test Email");
-  private final JCheckBox m_alsoPostAfterCombatMove = new JCheckBox("Also Post After Combat Move");
+  private final GenericEmailSender genericEmailSender;
+  private final JTextField subject = new JTextField();
+  private final JTextField toAddress = new JTextField();
+  private final JTextField host = new JTextField();
+  private final JTextField port = new JTextField();
+  private final JTextField login = new JTextField();
+  private final JCheckBox useTls = new JCheckBox("Use TLS encryption");
+  private final JTextField password = new JPasswordField();
+  private final JLabel toLabel = new JLabel("To:");
+  private final JLabel hostLabel = new JLabel("Host:");
+  private final JLabel portLabel = new JLabel("Port:");
+  private final JButton testEmail = new JButton("Test Email");
+  private final JCheckBox alsoPostAfterCombatMove = new JCheckBox("Also Post After Combat Move");
 
   /**
    * creates a new instance.
@@ -52,70 +51,70 @@ public class EmailSenderEditor extends EditorPanel {
    */
   public EmailSenderEditor(final GenericEmailSender bean, final EditorConfiguration editorConfiguration) {
     super();
-    m_bean = bean;
-    m_subject.setText(m_bean.getSubjectPrefix());
-    m_host.setText(m_bean.getHost());
-    m_port.setText(String.valueOf(m_bean.getPort()));
-    m_toAddress.setText(m_bean.getToAddress());
-    m_login.setText(m_bean.getUserName());
-    m_password.setText(m_bean.getPassword());
-    m_useTLS.setSelected(m_bean.getEncryption() == GenericEmailSender.Encryption.TLS);
+    genericEmailSender = bean;
+    subject.setText(genericEmailSender.getSubjectPrefix());
+    host.setText(genericEmailSender.getHost());
+    port.setText(String.valueOf(genericEmailSender.getPort()));
+    toAddress.setText(genericEmailSender.getToAddress());
+    login.setText(genericEmailSender.getUserName());
+    password.setText(genericEmailSender.getPassword());
+    useTls.setSelected(genericEmailSender.getEncryption() == GenericEmailSender.Encryption.TLS);
     final int bottomSpace = 1;
     final int labelSpace = 2;
     int row = 0;
     add(new JLabel("Subject:"), new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST,
         GridBagConstraints.NONE, new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-    add(m_subject, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
+    add(subject, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
         new Insets(0, 0, bottomSpace, 0), 0, 0));
     row++;
-    add(m_toLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+    add(toLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
         new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-    add(m_toAddress, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST,
+    add(toAddress, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST,
         GridBagConstraints.HORIZONTAL, new Insets(0, 0, bottomSpace, 0), 0, 0));
     row++;
-    final JLabel m_loginLabel = new JLabel("Login:");
-    add(m_loginLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+    final JLabel loginLabel = new JLabel("Login:");
+    add(loginLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
         new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-    add(m_login, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
+    add(login, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
         new Insets(0, 0, bottomSpace, 0), 0, 0));
     row++;
-    final JLabel m_passwordLabel = new JLabel("Password:");
-    add(m_passwordLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST,
+    final JLabel passwordLabel = new JLabel("Password:");
+    add(passwordLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST,
         GridBagConstraints.NONE, new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-    add(m_password, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
+    add(password, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
         new Insets(0, 0, bottomSpace, 0), 0, 0));
     if (editorConfiguration.showHost) {
       row++;
-      add(m_hostLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+      add(hostLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
           new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-      add(m_host, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
+      add(host, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
           new Insets(0, 0, bottomSpace, 0), 0, 0));
     }
     if (editorConfiguration.showPort) {
       row++;
-      add(m_portLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+      add(portLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
           new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-      add(m_port, new GridBagConstraints(1, row, 2, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
+      add(port, new GridBagConstraints(1, row, 2, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
           new Insets(0, 0, bottomSpace, 0), 0, 0));
     }
     if (editorConfiguration.showEncryption) {
       row++;
-      add(m_useTLS, new GridBagConstraints(0, row, 2, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+      add(useTls, new GridBagConstraints(0, row, 2, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
           new Insets(0, 0, bottomSpace, 0), 0, 0));
       // add Test button on the same line as encryption
-      add(m_testEmail, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
+      add(testEmail, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
           new Insets(0, 0, bottomSpace, 0), 0, 0));
       row++;
-      add(m_alsoPostAfterCombatMove, new GridBagConstraints(0, row, 2, 1, 0, 0, GridBagConstraints.NORTHWEST,
+      add(alsoPostAfterCombatMove, new GridBagConstraints(0, row, 2, 1, 0, 0, GridBagConstraints.NORTHWEST,
           GridBagConstraints.NONE, new Insets(0, 0, bottomSpace, 0), 0, 0));
     } else {
       row++;
-      add(m_alsoPostAfterCombatMove, new GridBagConstraints(0, row, 2, 1, 0, 0, GridBagConstraints.NORTHWEST,
+      add(alsoPostAfterCombatMove, new GridBagConstraints(0, row, 2, 1, 0, 0, GridBagConstraints.NORTHWEST,
           GridBagConstraints.NONE, new Insets(0, 0, bottomSpace, 0), 0, 0));
-      add(m_testEmail, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
+      add(testEmail, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
           new Insets(0, 0, bottomSpace, 0), 0, 0));
       // or on a separate line if no encryption
-      // add(m_testEmail, new GridBagConstraints(1, row, 3, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
+      // add(testEmail, new GridBagConstraints(1, row, 3, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
       // new Insets(0, 0,
       // bottomSpace, 0), 0, 0));
     }
@@ -124,13 +123,13 @@ public class EmailSenderEditor extends EditorPanel {
 
   private void setupListeners() {
     final EditorChangedFiringDocumentListener listener = new EditorChangedFiringDocumentListener();
-    m_host.getDocument().addDocumentListener(listener);
-    m_login.getDocument().addDocumentListener(listener);
-    m_port.getDocument().addDocumentListener(listener);
-    m_password.getDocument().addDocumentListener(listener);
-    m_toAddress.getDocument().addDocumentListener(listener);
-    m_useTLS.addActionListener(e -> fireEditorChanged());
-    m_testEmail.addActionListener(e -> testEmail());
+    host.getDocument().addDocumentListener(listener);
+    login.getDocument().addDocumentListener(listener);
+    port.getDocument().addDocumentListener(listener);
+    password.getDocument().addDocumentListener(listener);
+    toAddress.getDocument().addDocumentListener(listener);
+    useTls.addActionListener(e -> fireEditorChanged());
+    testEmail.addActionListener(e -> testEmail());
   }
 
   /**
@@ -177,34 +176,34 @@ public class EmailSenderEditor extends EditorPanel {
 
   @Override
   public boolean isBeanValid() {
-    final boolean hostValid = validateTextFieldNotEmpty(m_host, m_hostLabel);
-    final boolean portValid = validateTextField(m_port, m_portLabel, new IntegerRangeValidator(0, 65635));
-    // boolean loginValid = validateTextFieldNotEmpty(m_login, m_loginLabel);
-    // boolean passwordValid = validateTextFieldNotEmpty(m_password, m_passwordLabel);
-    final boolean addressValid = validateTextField(m_toAddress, m_toLabel, new EmailValidator(false));
+    final boolean hostValid = validateTextFieldNotEmpty(host, hostLabel);
+    final boolean portValid = validateTextField(port, portLabel, new IntegerRangeValidator(0, 65635));
+    // boolean loginValid = validateTextFieldNotEmpty(login, loginLabel);
+    // boolean passwordValid = validateTextFieldNotEmpty(password, passwordLabel);
+    final boolean addressValid = validateTextField(toAddress, toLabel, new EmailValidator(false));
     final boolean allValid = hostValid && portValid && /* loginValid && passwordValid && */addressValid;
-    m_testEmail.setEnabled(allValid);
+    testEmail.setEnabled(allValid);
     return allValid;
   }
 
   @Override
   public IBean getBean() {
-    m_bean
-        .setEncryption(m_useTLS.isSelected() ? GenericEmailSender.Encryption.TLS : GenericEmailSender.Encryption.NONE);
-    m_bean.setSubjectPrefix(m_subject.getText());
-    m_bean.setHost(m_host.getText());
-    m_bean.setUserName(m_login.getText());
-    m_bean.setPassword(m_password.getText());
+    genericEmailSender
+        .setEncryption(useTls.isSelected() ? GenericEmailSender.Encryption.TLS : GenericEmailSender.Encryption.NONE);
+    genericEmailSender.setSubjectPrefix(subject.getText());
+    genericEmailSender.setHost(host.getText());
+    genericEmailSender.setUserName(login.getText());
+    genericEmailSender.setPassword(password.getText());
     int port = 0;
     try {
-      port = Integer.parseInt(m_port.getText());
+      port = Integer.parseInt(this.port.getText());
     } catch (final NumberFormatException e) {
       // ignore
     }
-    m_bean.setPort(port);
-    m_bean.setToAddress(m_toAddress.getText());
-    m_bean.setAlsoPostAfterCombatMove(m_alsoPostAfterCombatMove.isSelected());
-    return m_bean;
+    genericEmailSender.setPort(port);
+    genericEmailSender.setToAddress(toAddress.getText());
+    genericEmailSender.setAlsoPostAfterCombatMove(alsoPostAfterCombatMove.isSelected());
+    return genericEmailSender;
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/ForumPosterEditor.java
@@ -165,7 +165,7 @@ public class ForumPosterEditor extends EditorPanel {
       idValid = validateTextFieldNotEmpty(m_topicIdField, m_topicIdLabel);
       m_viewPosts.setEnabled(idValid);
     } else {
-      m_topicIdLabel.setForeground(m_labelColor);
+      m_topicIdLabel.setForeground(labelColor);
       m_viewPosts.setEnabled(false);
     }
     final boolean allValid = loginValid && passwordValid && idValid;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/MicroWebPosterEditor.java
@@ -41,59 +41,50 @@ import games.strategy.util.UrlStreams;
 public class MicroWebPosterEditor extends EditorPanel {
   private static final long serialVersionUID = -6069315084412575053L;
   public static final String HTTP_BLANK = "http://";
-  private final JButton m_viewSite = new JButton("View Web Site");
-  private final JButton m_testSite = new JButton("Test Web Site");
-  private final JButton m_initGame = new JButton("Initialize Game");
-  // private final JLabel m_idLabel = new JLabel("Site ID:");
-  private final JTextField m_id = new JTextField();
-  private final JLabel m_hostLabel = new JLabel("Host:");
-  private final JComboBox<String> m_hosts;
-  private final JCheckBox m_includeSaveGame = new JCheckBox("Send emails");
-  private final IWebPoster m_bean;
-  private final String[] m_parties;
-  private final JLabel m_gameNameLabel = new JLabel("Game Name:");
-  private final JTextField m_gameName = new JTextField();
+  private final JButton viewSite = new JButton("View Web Site");
+  private final JButton testSite = new JButton("Test Web Site");
+  private final JButton initGame = new JButton("Initialize Game");
+  private final JTextField id = new JTextField();
+  private final JLabel hostLabel = new JLabel("Host:");
+  private final JComboBox<String> hosts;
+  private final JCheckBox includeSaveGame = new JCheckBox("Send emails");
+  private final IWebPoster webPoster;
+  private final String[] parties;
+  private final JLabel gameNameLabel = new JLabel("Game Name:");
+  private final JTextField gameName = new JTextField();
 
   public MicroWebPosterEditor(final IWebPoster bean, final String[] parties) {
-    m_bean = bean;
-    m_parties = parties;
+    webPoster = bean;
+    this.parties = parties;
     final int bottomSpace = 1;
     final int labelSpace = 2;
     int row = 0;
-    add(m_hostLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
+    add(hostLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
         new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-    m_bean.addToAllHosts(m_bean.getHost());
-    m_hosts = new JComboBox<>(m_bean.getAllHosts());
-    m_hosts.setEditable(true);
-    m_hosts.setMaximumRowCount(6);
-    add(m_hosts, new GridBagConstraints(1, row, 1, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
+    webPoster.addToAllHosts(webPoster.getHost());
+    hosts = new JComboBox<>(webPoster.getAllHosts());
+    hosts.setEditable(true);
+    hosts.setMaximumRowCount(6);
+    add(hosts, new GridBagConstraints(1, row, 1, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
         new Insets(0, 0, bottomSpace, 0), 0, 0));
-    add(m_viewSite, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
+    add(viewSite, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
         new Insets(0, 2, bottomSpace, 0), 0, 0));
     row++;
-    add(m_gameNameLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
+    add(gameNameLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
         new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
-    add(m_gameName, new GridBagConstraints(1, row, 1, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
+    add(gameName, new GridBagConstraints(1, row, 1, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
         new Insets(0, 0, bottomSpace, 0), 0, 0));
-    m_gameName.setText(m_bean.getGameName());
-    add(m_initGame, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
+    gameName.setText(webPoster.getGameName());
+    add(initGame, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
         new Insets(0, 2, bottomSpace, 0), 0, 0));
-    if ((m_parties == null) || (m_parties.length == 0)) {
-      m_initGame.setEnabled(false);
+    if ((this.parties == null) || (this.parties.length == 0)) {
+      initGame.setEnabled(false);
     }
     row++;
-    // add(m_idLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, new
-    // Insets(0, 0,
-    // bottomSpace, labelSpace), 0, 0));
-    // add(m_id, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
-    // new Insets(0, 0,
-    // bottomSpace, 0), 0, 0));
-    // m_id.setText(m_bean.getSiteId());
-    // row++;
-    add(m_includeSaveGame, new GridBagConstraints(0, row, 2, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
+    add(includeSaveGame, new GridBagConstraints(0, row, 2, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
         new Insets(0, 0, 0, 0), 0, 0));
-    m_includeSaveGame.setSelected(m_bean.getMailSaveGame());
-    add(m_testSite, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
+    includeSaveGame.setSelected(webPoster.getMailSaveGame());
+    add(testSite, new GridBagConstraints(2, row, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
         new Insets(0, 2, bottomSpace, 0), 0, 0));
     setupListeners();
   }
@@ -102,26 +93,26 @@ public class MicroWebPosterEditor extends EditorPanel {
    * Configures the listeners for the gui components.
    */
   private void setupListeners() {
-    m_viewSite.addActionListener(e -> ((IWebPoster) getBean()).viewSite());
-    m_testSite.addActionListener(e -> testSite());
-    m_initGame.addActionListener(e -> initGame());
-    m_hosts.addActionListener(e -> fireEditorChanged());
+    viewSite.addActionListener(e -> ((IWebPoster) getBean()).viewSite());
+    testSite.addActionListener(e -> testSite());
+    initGame.addActionListener(e -> initGame());
+    hosts.addActionListener(e -> fireEditorChanged());
     // add a document listener which will validate input when the content of any input field is changed
     final DocumentListener docListener = new EditorChangedFiringDocumentListener();
-    // m_hosts.getDocument().addDocumentListener(docListener);
-    m_id.getDocument().addDocumentListener(docListener);
-    m_gameName.getDocument().addDocumentListener(docListener);
+    // hosts.getDocument().addDocumentListener(docListener);
+    id.getDocument().addDocumentListener(docListener);
+    gameName.getDocument().addDocumentListener(docListener);
   }
 
   private void initGame() {
-    if (m_parties == null) {
+    if (parties == null) {
       return;
     }
     final String hostUrl;
-    if (!((String) m_hosts.getSelectedItem()).endsWith("/")) {
-      hostUrl = (String) m_hosts.getSelectedItem();
+    if (!((String) hosts.getSelectedItem()).endsWith("/")) {
+      hostUrl = (String) hosts.getSelectedItem();
     } else {
-      hostUrl = m_hosts.getSelectedItem() + "/";
+      hostUrl = hosts.getSelectedItem() + "/";
     }
     final ArrayList<String> players = new ArrayList<>();
     try {
@@ -154,9 +145,9 @@ public class MicroWebPosterEditor extends EditorPanel {
     window.setLayout(new GridBagLayout());
     window.getContentPane().add(new JLabel("Select Players For Each Nation:"), new GridBagConstraints(0, 0, 2, 1, 0, 0,
         GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(20, 20, 20, 20), 0, 0));
-    final List<JComboBox<String>> comboBoxes = new ArrayList<>(m_parties.length);
-    for (int i = 0; i < m_parties.length; i++) {
-      final JLabel label = new JLabel(m_parties[i] + ": ");
+    final List<JComboBox<String>> comboBoxes = new ArrayList<>(parties.length);
+    for (int i = 0; i < parties.length; i++) {
+      final JLabel label = new JLabel(parties[i] + ": ");
       comboBoxes.add(i, new JComboBox<>());
       for (int p = 0; p < players.size(); p++) {
         comboBoxes.get(i).addItem(players.get((p)));
@@ -179,15 +170,15 @@ public class MicroWebPosterEditor extends EditorPanel {
       window.dispose();
       final StringBuilder sb = new StringBuilder();
       for (int i = 0; i < comboBoxes.size(); i++) {
-        sb.append(m_parties[i]);
+        sb.append(parties[i]);
         sb.append(": ");
         sb.append(comboBoxes.get(i).getSelectedItem());
         sb.append("\n");
       }
       HttpEntity entity = MultipartEntityBuilder.create()
-          .addTextBody("siteid", m_id.getText())
+          .addTextBody("siteid", id.getText())
           .addTextBody("players", sb.toString())
-          .addTextBody("gamename", m_gameName.getText())
+          .addTextBody("gamename", gameName.getText())
           .build();
       try {
         final String response = TripleAWebPoster.executePost(hostUrl, "create.php", entity);
@@ -203,9 +194,9 @@ public class MicroWebPosterEditor extends EditorPanel {
             "Error", JOptionPane.INFORMATION_MESSAGE);
       }
     });
-    window.getContentPane().add(btnOk, new GridBagConstraints(0, m_parties.length + 1, 1, 1, 0, 0,
+    window.getContentPane().add(btnOk, new GridBagConstraints(0, parties.length + 1, 1, 1, 0, 0,
         GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(30, 20, 20, 10), 0, 0));
-    window.getContentPane().add(btnClose, new GridBagConstraints(1, m_parties.length + 1, 1, 1, 0, 0,
+    window.getContentPane().add(btnClose, new GridBagConstraints(1, parties.length + 1, 1, 1, 0, 0,
         GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(30, 10, 20, 20), 0, 0));
     window.pack();
     window.setLocationRelativeTo(null);
@@ -240,7 +231,7 @@ public class MicroWebPosterEditor extends EditorPanel {
       // now that we have a result, marshall it back unto the swing thread
       SwingUtilities.invokeLater(() -> {
         try {
-          final String message = (exception != null) ? exception.toString() : m_bean.getServerMessage();
+          final String message = (exception != null) ? exception.toString() : webPoster.getServerMessage();
           JOptionPane.showMessageDialog(MainFrame.getInstance(), message, "Test Turn Summary Post",
               JOptionPane.INFORMATION_MESSAGE);
         } catch (final HeadlessException e) {
@@ -255,24 +246,24 @@ public class MicroWebPosterEditor extends EditorPanel {
 
   @Override
   public boolean isBeanValid() {
-    final boolean hostValid = validateText((String) m_hosts.getSelectedItem(), m_hostLabel,
+    final boolean hostValid = validateText((String) hosts.getSelectedItem(), hostLabel,
         text -> text != null && text.length() > 0 && !text.equalsIgnoreCase(HTTP_BLANK));
-    final boolean idValid = validateTextFieldNotEmpty(m_gameName, m_gameNameLabel);
+    final boolean idValid = validateTextFieldNotEmpty(gameName, gameNameLabel);
     final boolean allValid = hostValid && idValid;
-    m_testSite.setEnabled(allValid);
-    m_initGame.setEnabled(allValid);
-    m_viewSite.setEnabled(hostValid);
+    testSite.setEnabled(allValid);
+    initGame.setEnabled(allValid);
+    viewSite.setEnabled(hostValid);
     return allValid;
   }
 
   @Override
   public IBean getBean() {
-    m_bean.setHost((String) m_hosts.getSelectedItem());
-    m_bean.addToAllHosts((String) m_hosts.getSelectedItem());
-    m_bean.getAllHosts().remove(HTTP_BLANK);
-    m_bean.setSiteId(m_id.getText());
-    m_bean.setMailSaveGame(m_includeSaveGame.isSelected());
-    m_bean.setGameName(m_gameName.getText());
-    return m_bean;
+    webPoster.setHost((String) hosts.getSelectedItem());
+    webPoster.addToAllHosts((String) hosts.getSelectedItem());
+    webPoster.getAllHosts().remove(HTTP_BLANK);
+    webPoster.setSiteId(id.getText());
+    webPoster.setMailSaveGame(includeSaveGame.isSelected());
+    webPoster.setGameName(gameName.getText());
+    return webPoster;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/SelectAndViewEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/SelectAndViewEditor.java
@@ -8,7 +8,6 @@ import java.awt.Insets;
 import java.awt.event.ItemEvent;
 import java.beans.PropertyChangeListener;
 import java.util.List;
-
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -29,14 +28,13 @@ import games.strategy.triplea.ui.JButtonDialog;
  */
 public class SelectAndViewEditor extends EditorPanel {
   private static final long serialVersionUID = 1580648148539524876L;
-  JComboBox<IBean> m_selector = new JComboBox<>();
-  JPanel m_view = new JPanel();
-  JButton m_helpButton = new JButton("Help?");
-  private final PropertyChangeListener m_properChangeListener;
-  private EditorPanel m_editor;
-  private final JLabel m_selectorLabel;
-  private final JEditorPane m_helpPanel;
-  private final String m_defaultHelp;
+  private final JComboBox<IBean> selector = new JComboBox<>();
+  private final JPanel view = new JPanel();
+  private final PropertyChangeListener propertyChangeListener;
+  private EditorPanel editor;
+  private final JLabel selectorLabel;
+  private final JEditorPane helpPanel;
+  private final String defaultHelp;
 
   /**
    * creates a new editor.
@@ -48,48 +46,49 @@ public class SelectAndViewEditor extends EditorPanel {
    */
   public SelectAndViewEditor(final String labelTitle, final String defaultHelp) {
     super();
-    m_defaultHelp = defaultHelp;
-    final Font oldFont = m_helpButton.getFont();
-    m_helpButton.setFont(new Font(oldFont.getName(), Font.BOLD, oldFont.getSize()));
-    m_view.setLayout(new GridBagLayout());
-    m_selectorLabel = new JLabel(labelTitle + ":");
-    add(m_selectorLabel, new GridBagConstraints(0, 0, 1, 1, 0d, 0, GridBagConstraints.NORTHWEST,
+    this.defaultHelp = defaultHelp;
+    final JButton helpButton = new JButton("Help?");
+    final Font oldFont = helpButton.getFont();
+    helpButton.setFont(new Font(oldFont.getName(), Font.BOLD, oldFont.getSize()));
+    view.setLayout(new GridBagLayout());
+    selectorLabel = new JLabel(labelTitle + ":");
+    add(selectorLabel, new GridBagConstraints(0, 0, 1, 1, 0d, 0, GridBagConstraints.NORTHWEST,
         GridBagConstraints.NONE, new Insets(0, 0, 1, 2), 0, 0));
-    add(m_selector, new GridBagConstraints(1, 0, 1, 1, 1.0, 0, GridBagConstraints.NORTHWEST,
+    add(selector, new GridBagConstraints(1, 0, 1, 1, 1.0, 0, GridBagConstraints.NORTHWEST,
         GridBagConstraints.HORIZONTAL, new Insets(0, 0, 1, 0), 0, 0));
-    add(m_helpButton, new GridBagConstraints(2, 0, 1, 1, 0d, 0, GridBagConstraints.NORTHEAST, GridBagConstraints.NONE,
+    add(helpButton, new GridBagConstraints(2, 0, 1, 1, 0d, 0, GridBagConstraints.NORTHEAST, GridBagConstraints.NONE,
         new Insets(0, 0, 1, 0), 0, 0));
-    add(m_view, new GridBagConstraints(0, 1, 3, 1, 1.0, 1.0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+    add(view, new GridBagConstraints(0, 1, 3, 1, 1.0, 1.0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
         new Insets(0, 0, 0, 0), 0, 0));
-    m_selector.setRenderer(new DisplayNameComboBoxRender());
-    m_selector.addItemListener(e -> {
+    selector.setRenderer(new DisplayNameComboBoxRender());
+    selector.addItemListener(e -> {
       if (e.getStateChange() == ItemEvent.SELECTED) {
         updateView();
         fireEditorChanged();
       }
     });
-    m_properChangeListener = evt -> fireEditorChanged();
-    m_helpPanel = new JEditorPane();
-    m_helpPanel.setEditable(false);
-    m_helpPanel.setContentType("text/html");
-    m_helpPanel.setAutoscrolls(true);
-    m_helpPanel.setBackground(m_selectorLabel.getBackground());
+    propertyChangeListener = evt -> fireEditorChanged();
+    helpPanel = new JEditorPane();
+    helpPanel.setEditable(false);
+    helpPanel.setContentType("text/html");
+    helpPanel.setAutoscrolls(true);
+    helpPanel.setBackground(selectorLabel.getBackground());
     final Dimension preferredSize = new Dimension(500, 500);
-    m_helpPanel.setPreferredSize(preferredSize);
-    m_helpPanel.setSize(preferredSize);
+    helpPanel.setPreferredSize(preferredSize);
+    helpPanel.setSize(preferredSize);
     final JScrollPane notesScroll = new JScrollPane();
-    notesScroll.setViewportView(m_helpPanel);
+    notesScroll.setViewportView(helpPanel);
     notesScroll.setBorder(null);
     notesScroll.getViewport().setBorder(null);
-    m_helpButton.addActionListener(e -> {
-      String helpText;
+    helpButton.addActionListener(e -> {
+      final String helpText;
       if (getBean() == null) {
-        helpText = HelpSupport.loadHelp(m_defaultHelp);
+        helpText = HelpSupport.loadHelp(this.defaultHelp);
       } else {
         helpText = getBean().getHelpText();
       }
-      m_helpPanel.setText(helpText);
-      m_helpPanel.setCaretPosition(0);
+      helpPanel.setText(helpText);
+      helpPanel.setCaretPosition(0);
       JButtonDialog.showDialog(SelectAndViewEditor.this, "Help", notesScroll, "Close");
     });
   }
@@ -100,18 +99,18 @@ public class SelectAndViewEditor extends EditorPanel {
   private void updateView() {
     // todo(kg) Have the View use a card layout instead of removing all content
     // remove listeners from old editor, to avoid memory leak
-    if (m_editor != null) {
-      m_editor.removePropertyChangeListener(m_properChangeListener);
+    if (editor != null) {
+      editor.removePropertyChangeListener(propertyChangeListener);
     }
-    m_view.removeAll();
-    final IBean item = (IBean) m_selector.getSelectedItem();
-    m_editor = item.getEditor();
-    if (m_editor != null) {
+    view.removeAll();
+    final IBean item = (IBean) selector.getSelectedItem();
+    editor = item.getEditor();
+    if (editor != null) {
       // register a property change listener so we can re-notify our listeners
-      m_editor.addPropertyChangeListener(m_properChangeListener);
-      m_view.add(m_editor, new GridBagConstraints(0, 0, 1, 1, 1.0, 0, GridBagConstraints.NORTHWEST,
+      editor.addPropertyChangeListener(propertyChangeListener);
+      view.add(editor, new GridBagConstraints(0, 0, 1, 1, 1.0, 0, GridBagConstraints.NORTHWEST,
           GridBagConstraints.HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
-      m_editor.isBeanValid();
+      editor.isBeanValid();
     }
     revalidate();
     alignLabels();
@@ -123,21 +122,21 @@ public class SelectAndViewEditor extends EditorPanel {
    */
   private void alignLabels() {
     // resize the label to align with the nested editors labels
-    final int height = m_selectorLabel.getPreferredSize().height;
-    int width = m_selectorLabel.getPreferredSize().width;
-    if (m_editor != null) {
-      final int labelWidth = m_editor.getLabelWidth();
+    final int height = selectorLabel.getPreferredSize().height;
+    int width = selectorLabel.getPreferredSize().width;
+    if (editor != null) {
+      final int labelWidth = editor.getLabelWidth();
       if (width < labelWidth) {
         // resize this editors label
         width = labelWidth;
       } else {
         // resize nested editors labels
-        m_editor.setLabelWidth(width);
+        editor.setLabelWidth(width);
       }
     }
     final Dimension dimension = new Dimension(width, height);
-    m_selectorLabel.setPreferredSize(dimension);
-    m_selectorLabel.setSize(dimension);
+    selectorLabel.setPreferredSize(dimension);
+    selectorLabel.setSize(dimension);
   }
 
   /**
@@ -147,13 +146,13 @@ public class SelectAndViewEditor extends EditorPanel {
    *        the list of beans
    */
   public void setBeans(final List<? extends IBean> beans) {
-    m_selector.setModel(new DefaultComboBoxModel<>(beans.toArray(new IBean[beans.size()])));
+    selector.setModel(new DefaultComboBoxModel<>(beans.toArray(new IBean[beans.size()])));
     updateView();
   }
 
   @Override
   public boolean isBeanValid() {
-    return m_editor == null || m_editor.isBeanValid();
+    return editor == null || editor.isBeanValid();
   }
 
   /**
@@ -163,10 +162,10 @@ public class SelectAndViewEditor extends EditorPanel {
    */
   @Override
   public IBean getBean() {
-    if (m_editor == null) {
+    if (editor == null) {
       return null;
     }
-    return m_editor.getBean();
+    return editor.getBean();
   }
 
   /**
@@ -178,7 +177,7 @@ public class SelectAndViewEditor extends EditorPanel {
    *        the bean
    */
   public void setSelectedBean(final IBean bean) {
-    final DefaultComboBoxModel<IBean> model = (DefaultComboBoxModel<IBean>) m_selector.getModel();
+    final DefaultComboBoxModel<IBean> model = (DefaultComboBoxModel<IBean>) selector.getModel();
     final DefaultComboBoxModel<IBean> newModel = new DefaultComboBoxModel<>();
     boolean found = false;
     int i;
@@ -192,11 +191,11 @@ public class SelectAndViewEditor extends EditorPanel {
       }
     }
     if (found) {
-      m_selector.setModel(newModel);
+      selector.setModel(newModel);
     } else {
       model.addElement(bean);
     }
-    m_selector.setSelectedItem(bean);
+    selector.setSelectedItem(bean);
     updateView();
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/EmailValidator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/EmailValidator.java
@@ -6,7 +6,7 @@ import games.strategy.util.Util;
  * A validator which validates that a text string is an email.
  */
 public class EmailValidator implements IValidator {
-  private final boolean m_validIfEmpty;
+  private final boolean validIfEmpty;
 
   /**
    * create a new instance.
@@ -15,13 +15,13 @@ public class EmailValidator implements IValidator {
    *        is the text valid if empty
    */
   public EmailValidator(final boolean validIfEmpty) {
-    m_validIfEmpty = validIfEmpty;
+    this.validIfEmpty = validIfEmpty;
   }
 
   @Override
   public boolean isValid(final String text) {
     if (text.length() == 0) {
-      return m_validIfEmpty;
+      return validIfEmpty;
     }
     return Util.isMailValid(text);
   }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/IntegerRangeValidator.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/validators/IntegerRangeValidator.java
@@ -4,8 +4,8 @@ package games.strategy.engine.framework.startup.ui.editors.validators;
  * A validator that validates that a string is a integer, and within a given min/max range.
  */
 public class IntegerRangeValidator implements IValidator {
-  private final int m_min;
-  private final int m_max;
+  private final int min;
+  private final int max;
 
   /**
    * create a new instance.
@@ -16,15 +16,15 @@ public class IntegerRangeValidator implements IValidator {
    *        the maximal value
    */
   public IntegerRangeValidator(final int min, final int max) {
-    m_min = min;
-    m_max = max;
+    this.min = min;
+    this.max = max;
   }
 
   @Override
   public boolean isValid(final String text) {
     try {
       final int i = Integer.parseInt(text);
-      return m_min <= i && m_max >= i;
+      return min <= i && max >= i;
     } catch (final NumberFormatException e) {
       return false;
     }


### PR DESCRIPTION
Since we do not serialize UI classes to disk or across network, it is safe to update variable names. On this branch a number were updated to have internal variables not have a 'm_' prefix (and there are one or two other quick small updates)