### PR TITLE
Remove max memory as a user setting available in GUI, move to game_engine.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ task allPlatform(type: Zip, group: 'release', dependsOn: [renameShadowJar, updat
         into('icons')
         exclude("icon.icns")
     }
-    ['readme.html', 'changelog.txt', 'system.ini', 'game_engine.properties', 'lobby_server.yaml',
+    ['readme.html', 'changelog.txt', 'game_engine.properties', 'lobby_server.yaml',
      'run-headless-game-host-mac-os.sh', 'run-headless-game-host.sh', 'run-headless-game-host-windows.bat',
      'triplea_unix.sh', 'triplea_windows.bat', 'triplea_mac_os_x.sh'].each { fileName ->
         from(fileName)

--- a/game_engine.properties
+++ b/game_engine.properties
@@ -12,4 +12,4 @@ lobby_properties_file_backup = lobby_server.yaml
 
 # Override setting for max memory in MB, leave blank to use default.
 # It is recommended to use the default, setting a value too high or too low can cause TripleA to be unstable.
-max_memory=1024
+max_memory=

--- a/game_engine.properties
+++ b/game_engine.properties
@@ -10,3 +10,6 @@ Map_List_File = http://raw.githubusercontent.com/triplea-game/triplea/master/tri
 lobby_properties_file_url = http://raw.githubusercontent.com/triplea-game/triplea/master/lobby_server.yaml?raw=true
 lobby_properties_file_backup = lobby_server.yaml
 
+# Override setting for max memory in MB, leave blank to use default.
+# It is recommended to use the default, setting a value too high or too low can cause TripleA to be unstable.
+max_memory=1024

--- a/src/main/java/games/strategy/debug/DebugUtils.java
+++ b/src/main/java/games/strategy/debug/DebugUtils.java
@@ -10,8 +10,6 @@ import java.util.List;
 import java.util.Properties;
 
 import games.strategy.engine.ClientContext;
-import games.strategy.engine.framework.GameRunner;
-import games.strategy.engine.framework.system.Memory;
 
 /**
  * Moved out of Console class, so that we don't need swing.
@@ -42,7 +40,7 @@ public class DebugUtils {
         result.append("\n");
       }
     }
-    long[] deadlocks = threadMxBean.findDeadlockedThreads();
+    final long[] deadlocks = threadMxBean.findDeadlockedThreads();
 
     if (deadlocks != null) {
       result.append("DEADLOCKS!!");
@@ -64,10 +62,6 @@ public class DebugUtils {
     buf.append("Free memory: ").append(runtime.freeMemory() / mb).append("\r\n");
     buf.append("Total memory: ").append(runtime.totalMemory() / mb).append("\r\n");
     buf.append("Max memory: ").append(runtime.maxMemory() / mb).append("\r\n");
-    final int currentMaxSetting = Memory.getMaxMemoryFromSystemIniFileInMB(GameRunner.getSystemIni());
-    if (currentMaxSetting > 0) {
-      buf.append("Max Memory user setting within 22% of: ").append(currentMaxSetting).append("\r\n");
-    }
     return buf.toString();
   }
 

--- a/src/main/java/games/strategy/engine/ClientContext.java
+++ b/src/main/java/games/strategy/engine/ClientContext.java
@@ -38,7 +38,7 @@ import games.strategy.triplea.settings.scrolling.ScrollSettings;
  * </code></pre>
  */
 public final class ClientContext {
-  private static ClientContext instance = new ClientContext();
+  private static final ClientContext instance = new ClientContext();
 
   private final MapDownloadController mapDownloadController;
   private final EngineVersion engineVersion;

--- a/src/main/java/games/strategy/engine/config/GameEnginePropertyReader.java
+++ b/src/main/java/games/strategy/engine/config/GameEnginePropertyReader.java
@@ -5,6 +5,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 
 import games.strategy.util.Version;
 
@@ -69,6 +70,18 @@ public class GameEnginePropertyReader extends PropertyFileReader {
     return super.readProperty(GameEngineProperty.LOBBY_PROPS_BACKUP_FILE);
   }
 
+
+  public MaxMemorySetting readMaxMemory() {
+    final String value = super.readProperty(GameEngineProperty.MAX_MEMORY);
+
+    if(Strings.nullToEmpty(value).isEmpty()) {
+      return MaxMemorySetting.NOT_SET;
+    }
+
+    return MaxMemorySetting.of(value);
+  }
+
+
   @VisibleForTesting
   interface GameEngineProperty {
     String MAP_LISTING_FILE = "Map_List_File";
@@ -76,5 +89,6 @@ public class GameEnginePropertyReader extends PropertyFileReader {
     String ENGINE_VERSION = "engine_version";
     String LOBBY_PROPS_URL = "lobby_properties_file_url";
     String LOBBY_PROPS_BACKUP_FILE = "lobby_properties_file_backup";
+    String MAX_MEMORY = "max_memory";
   }
 }

--- a/src/main/java/games/strategy/engine/config/MaxMemorySetting.java
+++ b/src/main/java/games/strategy/engine/config/MaxMemorySetting.java
@@ -1,0 +1,42 @@
+package games.strategy.engine.config;
+
+import com.google.common.base.Preconditions;
+
+public class MaxMemorySetting {
+
+  static final MaxMemorySetting NOT_SET = new MaxMemorySetting();
+
+  public final boolean isSet;
+  public final long value;
+
+  private MaxMemorySetting() {
+    isSet = false;
+    value = -1L;
+  }
+
+  private MaxMemorySetting(final long value) {
+    isSet = true;
+    this.value = value;
+
+    if (value < 1L) {
+      throw new IllegalArgumentException("Invalid value for max memory, must be positive, but found: " + value);
+    }
+  }
+
+  static MaxMemorySetting of(final String value) {
+    Preconditions.checkNotNull(value,
+        "Value should not be null, if null, we consider the memory setting to not be "
+            + "set and should not be not be executing this code path..");
+    try {
+      // truncate any decimal values here - keep it simple.
+      // Accept the user supplied value, but drop the decimal values (extra bytes).
+      final long longValue = (long) Double.parseDouble(value);
+
+      return new MaxMemorySetting(longValue);
+    } catch (final NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Invalid number for max memory, must be a positive number, but found: " + value, e);
+    }
+  }
+
+}

--- a/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -7,10 +7,7 @@ import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.prefs.Preferences;
-
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
@@ -33,11 +30,9 @@ import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ProcessRunnerUtil;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.engine.framework.system.HttpProxy;
-import games.strategy.engine.framework.system.Memory;
 import games.strategy.sound.SoundOptions;
 import games.strategy.triplea.settings.SettingsWindow;
 import games.strategy.triplea.ui.menubar.TripleAMenuBar;
-import games.strategy.ui.IntTextField;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
 import games.strategy.util.CountDownLatchHandler;
@@ -247,78 +242,6 @@ class EnginePreferences extends JDialog {
         GameRunner.resetServerObserverJoinWaitTime();
       }
     }));
-    m_setMaxMemory.addActionListener(SwingAction.of("Set Max Memory Usage", e -> {
-      // TODO: this action should all be coming from Memory.java
-      final AtomicBoolean tested = new AtomicBoolean();
-      tested.set(false);
-      final Properties systemIni = GameRunner.getSystemIni();
-      final int currentSetting = Memory.getMaxMemoryFromSystemIniFileInMB(systemIni);
-      final boolean useDefault = Memory.useDefaultMaxMemory(systemIni) || currentSetting <= 0;
-      final int currentMaxMemoryInMb = (int) (Memory.getMaxMemoryInBytes() / (1024 * 1024));
-      final IntTextField newMaxMemory = new IntTextField(0, (1024 * 3), currentMaxMemoryInMb, 5);
-      final JRadioButton noneButton = new JRadioButton("Use Default", useDefault);
-      final JRadioButton userButton = new JRadioButton("Use These User Settings:", !useDefault);
-      final ButtonGroup bgroup = new ButtonGroup();
-      bgroup.add(noneButton);
-      bgroup.add(userButton);
-      final JButton test = new JButton("Test User Settings");
-      test.addActionListener(SwingAction.of("Test User Settings", event -> {
-        tested.set(true);
-        System.out.println("Testing TripleA launch with max memory of: " + newMaxMemory.getValue() + "m");
-        // it is in MB
-        GameRunner.startNewTripleA((((long) newMaxMemory.getValue()) * 1024 * 1024) + 67108864);
-      }));
-      final JPanel radioPanel = new JPanel();
-      radioPanel.setLayout(new BoxLayout(radioPanel, BoxLayout.Y_AXIS));
-      radioPanel.add(new JLabel("<html>Configure TripleA's Maxmimum Memory Usage Settings: "
-          + "<br />(TripleA will only use 80-90% of this, the rest is used by Java VM)</html>"));
-      radioPanel.add(new JLabel(" "));
-      radioPanel.add(new JLabel(
-          "<html><b>WARNING: You could permanently stop TripleA from working if you mess with this! </b></html>"));
-      radioPanel.add(new JLabel("<html><em><p>By default TripleA uses a bit less than 1gb of RAM memory, "
-          + "<br />and this is because on some computers Java can fail when greater than 1gb (1024mb). "
-          + "<br />The symptoms of this failing are: TripleA not starting, not being able to 'Join' or 'Host' "
-          + "<br />in the online lobby, and not being able to start the map creator. "
-          + "<br />For whatever max you set, Java requires you to have approximately double that much "
-          + "<br />free memory available, not being used by your operating system or other programs you are running. "
-          + "<br />Otherwise, TripleA will fail to start, and/or fail to join/host games online. "
-          + "<br />If you do mess this up, you can always run TripleA by command line with a different setting: "
-          + "<br />java -Xmx512m -classpath triplea.jar games.strategy.engine.framework.GameRunner "
-          + "triplea.memory.set=true"
-          + "<br />Or you can delete or change the 'system.ini' file located where TripleA was installed. </p>"
-          + "<br /><p>In order to make sure you do not mess this up, click the 'Test' button and make sure that "
-          + "<br />a new TripleA process is able to run with your new max memory setting. "
-          + "<br />If one does not run, you had better lower the setting or just use the default. </p></em></html>"));
-      radioPanel.add(new JLabel(" "));
-      radioPanel.add(noneButton);
-      radioPanel.add(userButton);
-      radioPanel.add(new JLabel("Maximum Memory (in MB): "));
-      radioPanel.add(newMaxMemory);
-      radioPanel.add(new JLabel(" "));
-      radioPanel.add(new JLabel("<html>After clicking the 'Test' button, a new TripleA should launch. "
-          + "<br />If nothing launches, there is something wrong and you probably set the maximum too high. "
-          + "<br />You MUST test user settings before you use them! Otherwise the engine will discard changes. "
-          + "<br />TripleA has no way of knowing if this fails or succeeds, and there will not be an error message of "
-          + "any kind. </html>"));
-      radioPanel.add(test);
-      radioPanel.add(new JLabel(" "));
-      final Object[] options = {"Accept", "Cancel"};
-      final int answer = JOptionPane.showOptionDialog(m_parentFrame, radioPanel, "Max Memory Settings",
-          JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, options[1]);
-      if (answer != JOptionPane.YES_OPTION) {
-        return;
-      }
-      if (noneButton.isSelected()) {
-        Memory.clearMaxMemory();
-      } else if (userButton.isSelected()) {
-        final boolean setMaxMemory = newMaxMemory.getValue() > 64 && tested.get();
-        if (setMaxMemory) {
-          Properties prop = Memory.setMaxMemoryInMB(newMaxMemory.getValue());
-          GameRunner.writeSystemIni(prop);
-        }
-      }
-
-    }));
     m_mapCreator
         .addActionListener(SwingAction.of("Run the Map Creator", e -> ProcessRunnerUtil.runClass(MapCreator.class)));
     m_mapXmlCreator.addActionListener(
@@ -331,21 +254,12 @@ class EnginePreferences extends JDialog {
 
   private static void reportMemoryUsageToConsole() {
     final int mb = 1024 * 1024;
-    // Getting the runtime reference from system
     final Runtime runtime = Runtime.getRuntime();
     System.out.println("Heap utilization statistics [MB]");
-    // Print used memory
     System.out.println("Used Memory: " + (runtime.totalMemory() - runtime.freeMemory()) / mb);
-    // Print free memory
     System.out.println("Free Memory: " + runtime.freeMemory() / mb);
-    // Print total available memory
     System.out.println("Total Memory: " + runtime.totalMemory() / mb);
-    // Print Maximum available memory
     System.out.println("Max Memory: " + runtime.maxMemory() / mb);
-    final int currentMaxSetting = Memory.getMaxMemoryFromSystemIniFileInMB(GameRunner.getSystemIni());
-    if (currentMaxSetting > 0) {
-      System.out.println("Max Memory user setting within 20% of: " + currentMaxSetting);
-    }
   }
 
   private void setWidgetActivation() {}

--- a/src/main/java/games/strategy/engine/framework/system/Memory.java
+++ b/src/main/java/games/strategy/engine/framework/system/Memory.java
@@ -1,50 +1,36 @@
 package games.strategy.engine.framework.system;
 
-import com.google.common.base.Strings;
-
-import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
-import games.strategy.engine.config.GameEngineProperty;
 
 public class Memory {
   public static final String TRIPLEA_MEMORY_SET = "triplea.memory.set";
 
-
   public static boolean isMemoryXmxSet() {
-    final String memSetString = System.getProperty(TRIPLEA_MEMORY_SET, "false");
-    final boolean memSet = Boolean.parseBoolean(memSetString);
-    // if we have already set the memory, then return.
-    // (example: we used process runner to create a new triplea with a specific memory)
+    // The presence of the system prop means we received this value from command line args
+    // (our command line arg parsing puts each value into a system prop..)
+    // If we see this as set, it means we have set teh memory and everything is fine.
+
+    final boolean memSet = Boolean.parseBoolean(System.getProperty(TRIPLEA_MEMORY_SET, "false"));
+
     if (memSet) {
+      // system prop is set, memory has been set..
       return true;
     }
 
-    final String maxMemorySetting = ClientContext.propertyReader().readProperty(GameEngineProperty.MAX_MEMORY);
-    if (Strings.nullToEmpty(maxMemorySetting).isEmpty() || Long.parseLong(maxMemorySetting) < 32L) {
-      return true;
-    }
-
-    return false;
+    // case: no memory setting, next we check the user setting. If no user setting present, then we return
+    // true since we are at a default memory config with a default user value (blank/not set)
+    return !ClientContext.gameEnginePropertyReader().readMaxMemory().isSet;
   }
 
   public static long getMaxMemoryInBytes() {
-    final long userSetValue = readMaxMemory();
-
-    if (userSetValue < 0) {
-      return Runtime.getRuntime().maxMemory();
-    } else {
+    if (ClientContext.gameEnginePropertyReader().readMaxMemory().isSet) {
+      final long userSetValue = readMaxMemory();
       return userSetValue * 1024 * 1024;
     }
+    return Runtime.getRuntime().maxMemory();
   }
 
   private static long readMaxMemory() {
-    final String value = ClientContext.propertyReader().readProperty(GameEngineProperty.MAX_MEMORY);
-    try {
-      return Long.parseLong(value);
-    } catch (final NumberFormatException e) {
-      ClientLogger.logError(
-          "Ignoring invalid number: " + value + ", for property: " + GameEngineProperty.MAX_MEMORY);
-      return -1;
-    }
+    return ClientContext.gameEnginePropertyReader().readMaxMemory().value;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/system/Memory.java
+++ b/src/main/java/games/strategy/engine/framework/system/Memory.java
@@ -1,101 +1,50 @@
 package games.strategy.engine.framework.system;
 
-import java.util.Properties;
+import com.google.common.base.Strings;
 
 import games.strategy.debug.ClientLogger;
-import games.strategy.engine.framework.GameRunner;
+import games.strategy.engine.ClientContext;
+import games.strategy.engine.config.GameEngineProperty;
 
 public class Memory {
   public static final String TRIPLEA_MEMORY_SET = "triplea.memory.set";
-  private static final String TRIPLEA_MEMORY_XMX = "triplea.memory.Xmx";
-  private static final String TRIPLEA_MEMORY_USE_DEFAULT = "triplea.memory.useDefault";
 
 
-
-  public static void checkForMemoryXMX() {
+  public static boolean isMemoryXmxSet() {
     final String memSetString = System.getProperty(TRIPLEA_MEMORY_SET, "false");
     final boolean memSet = Boolean.parseBoolean(memSetString);
     // if we have already set the memory, then return.
     // (example: we used process runner to create a new triplea with a specific memory)
     if (memSet) {
-      return;
+      return true;
     }
-    final Properties systemIni = GameRunner.getSystemIni();
-    if (useDefaultMaxMemory(systemIni)) {
-      return;
-    }
-    long xmx = getMaxMemoryFromSystemIniFileInMB(systemIni);
-    // if xmx less than zero, return (because it means we do not want to change it)
-    if (xmx <= 0) {
-      return;
-    }
-    final int mb = 1024 * 1024;
-    xmx = xmx * mb;
-    final long currentMaxMemory = Runtime.getRuntime().maxMemory();
-    System.out.println("Current max memory: " + currentMaxMemory + ";  and new xmx should be: " + xmx);
-    final long diff = Math.abs(currentMaxMemory - xmx);
-    // Runtime.maxMemory is never accurate, and is usually off by 5% to 15%,
-    // so if our difference is less than 22% we should just ignore the difference
-    if (diff <= xmx * 0.22) {
-      return;
-    }
-    // the difference is significant enough that we should re-run triplea with a larger number
-    GameRunner.startNewTripleA(xmx);
-    // must exit now
-    System.exit(0);
-  }
 
-  public static boolean useDefaultMaxMemory(final Properties systemIni) {
-    final String useDefaultMaxMemoryString = systemIni.getProperty(TRIPLEA_MEMORY_USE_DEFAULT, "true");
-    return Boolean.parseBoolean(useDefaultMaxMemoryString);
+    final String maxMemorySetting = ClientContext.propertyReader().readProperty(GameEngineProperty.MAX_MEMORY);
+    if (Strings.nullToEmpty(maxMemorySetting).isEmpty() || Long.parseLong(maxMemorySetting) < 32L) {
+      return true;
+    }
+
+    return false;
   }
 
   public static long getMaxMemoryInBytes() {
-    final Properties systemIni = GameRunner.getSystemIni();
-    final String useDefaultMaxMemoryString = systemIni.getProperty(TRIPLEA_MEMORY_USE_DEFAULT, "true");
-    final boolean useDefaultMaxMemory = Boolean.parseBoolean(useDefaultMaxMemoryString);
-    final String maxMemoryString = systemIni.getProperty(TRIPLEA_MEMORY_XMX, "").trim();
-    // for whatever reason, .maxMemory() returns a value about 12% smaller than the real Xmx value.
-    // Just something to be aware of.
-    long max = Runtime.getRuntime().maxMemory();
-    if (!useDefaultMaxMemory && maxMemoryString.length() > 0) {
-      try {
-        final int maxMemorySet = Integer.parseInt(maxMemoryString);
-        // it is in MB
-        max = 1024 * 1024 * ((long) maxMemorySet);
-      } catch (final NumberFormatException e) {
-        ClientLogger.logQuietly(e);
-      }
+    final long userSetValue = readMaxMemory();
+
+    if (userSetValue < 0) {
+      return Runtime.getRuntime().maxMemory();
+    } else {
+      return userSetValue * 1024 * 1024;
     }
-    return max;
   }
 
-  public static int getMaxMemoryFromSystemIniFileInMB(final Properties systemIni) {
-    final String maxMemoryString = systemIni.getProperty(TRIPLEA_MEMORY_XMX, "").trim();
-    int maxMemorySet = -1;
-    if (!maxMemoryString.isEmpty()) {
-      try {
-        maxMemorySet = Integer.parseInt(maxMemoryString);
-      } catch (final NumberFormatException e) {
-        ClientLogger.logQuietly(e);
-      }
+  private static long readMaxMemory() {
+    final String value = ClientContext.propertyReader().readProperty(GameEngineProperty.MAX_MEMORY);
+    try {
+      return Long.parseLong(value);
+    } catch (final NumberFormatException e) {
+      ClientLogger.logError(
+          "Ignoring invalid number: " + value + ", for property: " + GameEngineProperty.MAX_MEMORY);
+      return -1;
     }
-    return maxMemorySet;
   }
-
-  public static Properties setMaxMemoryInMB(final int maxMemoryInMb) {
-    ClientLogger.logQuietly("Setting max memory for TripleA to: " + maxMemoryInMb + "m");
-    final Properties prop = new Properties();
-    prop.put(TRIPLEA_MEMORY_USE_DEFAULT, "false");
-    prop.put(TRIPLEA_MEMORY_XMX, "" + maxMemoryInMb);
-    return prop;
-  }
-
-  public static void clearMaxMemory() {
-    final Properties prop = new Properties();
-    prop.put(TRIPLEA_MEMORY_USE_DEFAULT, "true");
-    prop.put(TRIPLEA_MEMORY_XMX, "");
-    GameRunner.writeSystemIni(prop);
-  }
-
 }

--- a/src/test/java/games/strategy/engine/config/MaxMemorySettingTest.java
+++ b/src/test/java/games/strategy/engine/config/MaxMemorySettingTest.java
@@ -1,0 +1,41 @@
+package games.strategy.engine.config;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class MaxMemorySettingTest {
+  @Test
+  public void contractTests() {
+    assertThat(MaxMemorySetting.of("1").isSet, is(true));
+    assertThat(MaxMemorySetting.NOT_SET.isSet, is(false));
+  }
+
+  @Test
+  public void decimalValuesTruncatedToIntegerValues() {
+    assertThat(MaxMemorySetting.of("123.3").value, is(123L));
+  }
+
+  @Test
+  public void verifyInputParsing() {
+    Arrays.asList(
+        "",
+        "NaN",
+        "-",
+        "-0.1",
+        "-1"
+    ).forEach(invalidValue -> {
+      try {
+        MaxMemorySetting.of(invalidValue);
+        fail(invalidValue + ", was expected to trigger an illegal arg exception");
+      } catch (final IllegalArgumentException expected) {
+        // expected
+      }
+    });
+  }
+}

--- a/system.ini
+++ b/system.ini
@@ -1,4 +1,0 @@
-#system.ini
-#Sat May 18 03:25:51 CST 2013
-triplea.memory.useDefault=true
-triplea.memory.Xmx=


### PR DESCRIPTION
Notable updates:
- remove GUI support for updating java xmx (max memory)
- remove the 'xmx' property in `system.ini` and add an equivalent `max_memory` property to `game_engine.properties`
- simplify the check for if memory is set and move the responsibility for relaunching the game to apply custom memory settings. Have GameRunner do the launch of a new game and simply return from main(), avoiding a call to System.exit. Second, avoid the 'within 20% of current memory', if there is an override set, then use it.
- remove the 'xmx use default' property in system.ini, instead we'll rely on `max_memory` being set in properties or not set. This removes the last property in `system.ini`, the file was removed along with the related build config.