### PR TITLE
Remove finalize() overrides

### DIFF
--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
@@ -203,12 +203,6 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
     }
   }
 
-  @Override
-  protected void finalize() throws Throwable {
-    shutdown();
-    super.finalize();
-  }
-
   private void awaitLatch() {
     try {
       // there is a small chance calculate or setCalculateData or something could be called in between calls to

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -198,12 +198,6 @@ class OddsCalculatorPanel extends JPanel {
     }
   }
 
-  @Override
-  protected void finalize() throws Throwable {
-    shutdown();
-    super.finalize();
-  }
-
   private static double percentageOfFreeMemoryAvailable() {
     final Runtime runtime = Runtime.getRuntime();
     final long maxMemory = runtime.maxMemory();


### PR DESCRIPTION
- It is buggy to use 'finalize()', there is no guarantee it will be called at all and can cause GC issues
- Checking the methods removed, we call 'shutdown', looks like we call them in other appropriate places and do not really rely on 'finalize' to be called anyways (code reviewers, please double check this if you would).