### PR TITLE
Remove unnecessary semicolons

### DIFF
--- a/gradle/scripts/yaml.gradle
+++ b/gradle/scripts/yaml.gradle
@@ -11,10 +11,10 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.github.fge.jsonschema.main.JsonSchemaFactory
 
 import org.apache.http.HttpStatus
-import org.apache.http.client.config.CookieSpecs;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.client.config.CookieSpecs
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.client.methods.HttpHead
+import org.apache.http.impl.client.HttpClients
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 

--- a/src/main/java/tools/map/xml/creator/MapXmlUiHelper.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlUiHelper.java
@@ -191,7 +191,7 @@ public class MapXmlUiHelper {
     final GridBagConstraints gbcTemplateNew = new GridBagConstraints();
     gbcTemplateNew.insets = new Insets(0, 0, 5, 5);
     gbcTemplateNew.anchor = GridBagConstraints.WEST;
-    ;
+
     return gbcTemplateNew;
   }
 

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -1412,7 +1412,7 @@ public class WW2V3_41_Test {
     final Territory sz13 = territory("13 Sea Zone", gameData);
     final Territory sz14 = territory("14 Sea Zone", gameData);
     final Territory sz15 = territory("15 Sea Zone", gameData);
-    ;
+
     when(dummyPlayer.retreatQuery(any(), anyBoolean(), any(),
         any(), contains(BattleStepStrings.RETREAT_PLANES))).thenThrow(
             new AssertionError("The Message is not allowed to contain the BattleStepStrings.RETREAT_PLANES constant"));


### PR DESCRIPTION
This PR removes some unnecessary semicolons that I accidentally introduced into Groovy code during #1856.  I also removed a couple of instances that were present in Java code.