### PR TITLE
Add task to create aggregate coverage report for all test tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
 install: true
 services:
 - postgresql
+script: ./gradlew check jacocoRootReport
 after_success: 
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle

--- a/build.gradle
+++ b/build.gradle
@@ -105,10 +105,22 @@ task integTest(type: Test) {
     mustRunAfter tasks.test
 }
 
-jacocoTestReport {
+task jacocoRootReport(type: JacocoReport) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    description = 'Generates code coverage report for all Test tasks.'
+
+    sourceSets sourceSets.main
+    executionData fileTree(buildDir).include('**/jacoco/*.exec')
+
     reports {
-        xml.enabled true
-        html.enabled true
+        html {
+            destination = file("${project.jacoco.reportsDir}/root/html")
+            enabled = true
+        }
+        xml {
+            destination = file("${project.jacoco.reportsDir}/root/jacocoRootReport.xml")
+            enabled = true
+        }
     }
 }
 
@@ -219,7 +231,7 @@ gradle.taskGraph.whenReady { graph ->
 }
 
 check {
-    dependsOn 'integTest', 'validateYamls', 'jacocoTestReport'
+    dependsOn 'integTest', 'validateYamls'
 }
 
 checkstyle {


### PR DESCRIPTION
This PR adds a new Gradle task which generates a code coverage report based on execution data from both unit and integration tests.  We currently only generate a report based on the unit tests.

#### Functional changes
None.

#### Refactoring changes
None.

#### Other changes
* The `jacocoRootReport` Gradle task was added to collect execution data from all Test tasks (`test` and `integTest` in our case).  It simply aggregates all JaCoCo `*.exec` files in the project build directory.
* After a day of running Gradle builds since code coverage was introduced, I don't see a need to generate the code coverage **reports** every time the `check` task is run.  It's an extra 10 seconds and 9 MiB file that is only really needed by a dev on demand.  (Note that code coverage **metrics** are still collected with the `test` task [part of `check`], which means you can run `jacocoRootReport` at any time without a rebuild.)  I removed the dependency of `check` on any code coverage reporting task and modified the Travis build to explicitly run the `jacocoRootReport` task.

#### Other changes for review
* There may be disagreement over my decision to pull the code coverage report task out of the `check` task.  Please advise if that's the case, and I'll add it back in.

#### Testing

I ran this branch on Travis to verify it is picking up the execution data from the `integTest` task.  Below are the Codecov metrics for `master` showing the `g.s.data.engine.lobby.server.userDB` package (the only package containing code directly exercised by the integration tests):

![coverage-master](https://user-images.githubusercontent.com/4826349/27007671-fe7771f4-4e28-11e7-9162-73060b142f1a.png)

And next are the Codecov metrics for this branch showing the same information:

![coverage-branch](https://user-images.githubusercontent.com/4826349/27007673-0cfa68b2-4e29-11e7-98bb-2e9b0a4797f2.png)

You can see that the coverage has increased for the `userDB` package due to the inclusion of the integration tests.