### PR TITLE
Standardize README badge styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/13dd86379fff49d3b96fd3f3d954d4e8)](https://www.codacy.com/app/dhvatta/triplea?utm_source=github.com&utm_medium=referral&utm_content=triplea-game/triplea&utm_campaign=badger)
-[![Travis](https://img.shields.io/travis/triplea-game/triplea.svg?style=flat-square)](https://travis-ci.org/triplea-game/triplea)[![TripleA license](https://img.shields.io/github/license/triplea-game/triplea.svg?style=flat-square)](https://github.com/triplea-game/triplea/blob/master/LICENSE)
-[![codecov](https://codecov.io/gh/triplea-game/triplea/branch/master/graph/badge.svg)](https://codecov.io/gh/triplea-game/triplea)<br>
+[![Codacy Badge](https://img.shields.io/codacy/grade/13dd86379fff49d3b96fd3f3d954d4e8/master.svg?style=flat-square)](https://www.codacy.com/app/dhvatta/triplea?utm_source=github.com&utm_medium=referral&utm_content=triplea-game/triplea&utm_campaign=badger)
+[![Travis](https://img.shields.io/travis/triplea-game/triplea.svg?style=flat-square)](https://travis-ci.org/triplea-game/triplea)
+[![TripleA license](https://img.shields.io/github/license/triplea-game/triplea.svg?style=flat-square)](https://github.com/triplea-game/triplea/blob/master/LICENSE)
+[![codecov](https://img.shields.io/codecov/c/github/triplea-game/triplea/master.svg?style=flat-square)](https://codecov.io/gh/triplea-game/triplea)
 
-TripleA is a free game engine that runs on open source and is community supported. 
+TripleA is a free game engine that runs on open source and is community supported.
 
 Installing TripleA and Playing
 ==============================


### PR DESCRIPTION
This PR standardizes the README badge styles in light of the recently-added Codacy and Codecov badges.

Current badge style:

![badges-old](https://user-images.githubusercontent.com/4826349/27007792-93611c9e-4e2d-11e7-9e71-c10f8f11dd11.png)

Proposed badge style:

![badges-new](https://user-images.githubusercontent.com/4826349/27007794-a3822cb2-4e2d-11e7-8a42-209e12743e5d.png)

In order to get a consistent look, I'm using Shields.io for all badges.  As you can see, this slightly changes the Codacy and Codecov badges:

* the left-hand-side text is different
* the right-hand-side color is different

The left-hand-side text is the default that Shields.io provides, which is provider agnostic.  It's straightforward to change this text if necessary.

The right-hand-side color is a bit different.  While Shields.io gives you the ability to change the color, I believe it's only for badges that have a constant color.  Both Codacy and Codecov badges change color based on the health of the project.  I think if we attempt to override the color, it will remove the dynamic color feature.  Not 100% on this, though.

I also ensured there was some whitespace between all badges.  Not sure if having no whitespace between the original two badges was intentional.

All suggestions welcome.