### PR TITLE
Fix deprecations in java 9

### DIFF
--- a/src/main/java/games/strategy/engine/config/GameEnginePropertyReader.java
+++ b/src/main/java/games/strategy/engine/config/GameEnginePropertyReader.java
@@ -41,6 +41,8 @@ public class GameEnginePropertyReader extends PropertyFileReader {
   }
 
   private static class NetworkFetchException extends RuntimeException {
+    private static final long serialVersionUID = -8963534515318619962L;
+
     NetworkFetchException(final String url, final Exception exception) {
       super("Failed to get download file url: " + url, exception);
     }

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -453,7 +453,7 @@ public class GameParser {
           "Class <" + className + "> could not be instantiated. ->" + e.getMessage());
     } catch (final IllegalAccessException e) {
       throw new GameParseException(mapName, "Constructor could not be accessed ->" + e.getMessage());
-    } catch (NoSuchMethodException | SecurityException | IllegalArgumentException | InvocationTargetException e) {
+    } catch (ReflectiveOperationException e) {
       throw new GameParseException(mapName, "Exception while constructing object ->" + e.getMessage());
     }
     return instance;

--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -15,6 +15,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicReference;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -443,15 +444,17 @@ public class GameParser {
     Object instance = null;
     try {
       final Class<?> instanceClass = Class.forName(className);
-      instance = instanceClass.newInstance();
+      instance = instanceClass.getDeclaredConstructor().newInstance();
       // a lot can go wrong, the following list is just a subset of potential pitfalls
-    } catch (final ClassNotFoundException cnfe) {
+    } catch (final ClassNotFoundException e) {
       throw new GameParseException(mapName, "Class <" + className + "> could not be found.");
-    } catch (final InstantiationException ie) {
+    } catch (final InstantiationException e) {
       throw new GameParseException(mapName,
-          "Class <" + className + "> could not be instantiated. ->" + ie.getMessage());
-    } catch (final IllegalAccessException iae) {
-      throw new GameParseException(mapName, "Constructor could not be accessed ->" + iae.getMessage());
+          "Class <" + className + "> could not be instantiated. ->" + e.getMessage());
+    } catch (final IllegalAccessException e) {
+      throw new GameParseException(mapName, "Constructor could not be accessed ->" + e.getMessage());
+    } catch (NoSuchMethodException | SecurityException | IllegalArgumentException | InvocationTargetException e) {
+      throw new GameParseException(mapName, "Exception while constructing object ->" + e.getMessage());
     }
     return instance;
   }

--- a/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
@@ -2,6 +2,7 @@ package games.strategy.engine.data.properties;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import javax.swing.JComponent;
 
@@ -27,12 +28,12 @@ public class DoubleProperty extends AEditableProperty {
     m_max = max;
     m_min = min;
     m_places = numberOfPlaces;
-    m_value = roundToPlace(def, numberOfPlaces, BigDecimal.ROUND_FLOOR);
+    m_value = roundToPlace(def, numberOfPlaces, RoundingMode.FLOOR);
   }
 
-  private static double roundToPlace(final double number, final int places, final int BigDecimalRoundingMode) {
+  private static double roundToPlace(final double number, final int places, final RoundingMode roundingMode) {
     BigDecimal bd = new BigDecimal(number);
-    bd = bd.setScale(places, BigDecimalRoundingMode);
+    bd = bd.setScale(places, roundingMode);
     return bd.doubleValue();
   }
 
@@ -50,7 +51,7 @@ public class DoubleProperty extends AEditableProperty {
           + "You should delete your option cache, located at "
           + new File(ClientFileSystemHelper.getUserRootFolder(), "optionCache").toString());
     } else {
-      m_value = roundToPlace((Double) value, m_places, BigDecimal.ROUND_FLOOR);
+      m_value = roundToPlace((Double) value, m_places, RoundingMode.FLOOR);
     }
   }
 
@@ -67,7 +68,7 @@ public class DoubleProperty extends AEditableProperty {
     if (value instanceof Double) {
       double d;
       try {
-        d = roundToPlace((Double) value, m_places, BigDecimal.ROUND_FLOOR);
+        d = roundToPlace((Double) value, m_places, RoundingMode.FLOOR);
       } catch (final Exception e) {
         return false;
       }

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -200,7 +200,7 @@ public class GameDataManager {
       final String className = (String) input.readObject();
       IDelegate instance;
       try {
-        instance = (IDelegate) Class.forName(className).newInstance();
+        instance = (IDelegate) Class.forName(className).getDeclaredConstructor().newInstance();
         instance.initialize(name, displayName);
         data.getDelegateList().addDelegate(instance);
       } catch (final Exception e) {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/EnginePreferences.java
@@ -15,7 +15,6 @@ import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
-import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JLabel;

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PBEMSetupPanel.java
@@ -268,7 +268,7 @@ public class PBEMSetupPanel extends SetupPanel implements Observer {
     IBean cached = LocalBeanCache.INSTANCE.getSerializable(theClassType.getCanonicalName());
     if (cached == null) {
       try {
-        cached = theClassType.newInstance();
+        cached = theClassType.getDeclaredConstructor().newInstance();
       } catch (final Exception e) {
         throw new RuntimeException(
             "Bean of type " + theClassType + " doesn't have public default constructor, error: " + e.getMessage());

--- a/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/userDB/Database.java
@@ -210,18 +210,6 @@ public class Database {
     backupThread.start();
   }
 
-  /**
-   * This must be the first db call made.
-   * Run Database as a main method to run the backup.
-   */
-  private static void restoreFromBackup(final File backupDir) throws SQLException {
-    // http://www-128.ibm.com/developerworks/db2/library/techarticle/dm-0502thalamati/
-    final String url = "jdbc:derby:ta_users;restoreFrom=" + backupDir.getAbsolutePath();
-    final Properties props = getDbProps();
-    final Connection con = DriverManager.getConnection(url, props);
-    con.close();
-  }
-
   private static Properties getDbProps() {
     final Properties props = new Properties();
     props.put("user", "user1");

--- a/src/main/java/games/strategy/triplea/ui/MouseDetails.java
+++ b/src/main/java/games/strategy/triplea/ui/MouseDetails.java
@@ -33,7 +33,7 @@ public class MouseDetails {
   }
 
   public boolean isRightButton() {
-    return (m_mouseEvent.getModifiers() & InputEvent.BUTTON3_MASK) != 0;
+    return (m_mouseEvent.getModifiersEx() & InputEvent.BUTTON3_DOWN_MASK) != 0;
   }
 
   public boolean isControlDown() {

--- a/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -5,6 +5,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -78,18 +79,18 @@ public class TabbedProductionPanel extends ProductionPanel {
       int m_maxColumns;
       if (largestList <= 36) {
         m_maxColumns = Math.max(8,
-            Math.min(12, new BigDecimal(largestList).divide(new BigDecimal(3), BigDecimal.ROUND_UP).intValue()));
+            Math.min(12, new BigDecimal(largestList).divide(new BigDecimal(3), RoundingMode.UP).intValue()));
       } else if (largestList <= 64) {
         m_maxColumns = Math.max(8,
-            Math.min(16, new BigDecimal(largestList).divide(new BigDecimal(4), BigDecimal.ROUND_UP).intValue()));
+            Math.min(16, new BigDecimal(largestList).divide(new BigDecimal(4), RoundingMode.UP).intValue()));
       } else {
         m_maxColumns = Math.max(8,
-            Math.min(16, new BigDecimal(largestList).divide(new BigDecimal(5), BigDecimal.ROUND_UP).intValue()));
+            Math.min(16, new BigDecimal(largestList).divide(new BigDecimal(5), RoundingMode.UP).intValue()));
       }
       m_rows =
-          Math.max(2, new BigDecimal(largestList).divide(new BigDecimal(m_maxColumns), BigDecimal.ROUND_UP).intValue());
+          Math.max(2, new BigDecimal(largestList).divide(new BigDecimal(m_maxColumns), RoundingMode.UP).intValue());
       m_columns =
-          Math.max(3, new BigDecimal(largestList).divide(new BigDecimal(m_rows), BigDecimal.ROUND_UP).intValue());
+          Math.max(3, new BigDecimal(largestList).divide(new BigDecimal(m_rows), RoundingMode.UP).intValue());
     } else {
       m_rows = Math.max(2, properties.getRows());
       // There are small display problems if the size is less than 2x3 cells.

--- a/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.ui;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
@@ -73,9 +74,9 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     m_showOdds.addActionListener(e -> showBattleCalc.actionPerformed(e));
     final JComponent contentPane = (JComponent) m_frame.getContentPane();
     contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke('B', java.awt.event.InputEvent.META_MASK), show_battle_calc);
+        .put(KeyStroke.getKeyStroke('B', InputEvent.META_DOWN_MASK), show_battle_calc);
     contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke('B', java.awt.event.InputEvent.CTRL_MASK), show_battle_calc);
+        .put(KeyStroke.getKeyStroke('B', InputEvent.CTRL_DOWN_MASK), show_battle_calc);
     contentPane.getActionMap().put(show_battle_calc, showBattleCalc);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -17,6 +17,7 @@ import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.WindowAdapter;
@@ -508,13 +509,13 @@ public class TripleAFrame extends MainGameFrame {
     final String zoom_map_in = "zoom_map_in";
     // do both = and + (since = is what you get when you hit ctrl+ )
     ((JComponent) getContentPane()).getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke('+', java.awt.event.InputEvent.META_MASK), zoom_map_in);
+        .put(KeyStroke.getKeyStroke('+', InputEvent.META_DOWN_MASK), zoom_map_in);
     ((JComponent) getContentPane()).getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke('+', java.awt.event.InputEvent.CTRL_MASK), zoom_map_in);
+        .put(KeyStroke.getKeyStroke('+', InputEvent.CTRL_DOWN_MASK), zoom_map_in);
     ((JComponent) getContentPane()).getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke('=', java.awt.event.InputEvent.META_MASK), zoom_map_in);
+        .put(KeyStroke.getKeyStroke('=', InputEvent.META_DOWN_MASK), zoom_map_in);
     ((JComponent) getContentPane()).getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke('=', java.awt.event.InputEvent.CTRL_MASK), zoom_map_in);
+        .put(KeyStroke.getKeyStroke('=', InputEvent.CTRL_DOWN_MASK), zoom_map_in);
     ((JComponent) getContentPane()).getActionMap().put(zoom_map_in, new AbstractAction(zoom_map_in) {
       private static final long serialVersionUID = -7565304172320049817L;
 
@@ -527,9 +528,9 @@ public class TripleAFrame extends MainGameFrame {
     });
     final String zoom_map_out = "zoom_map_out";
     ((JComponent) getContentPane()).getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke('-', java.awt.event.InputEvent.META_MASK), zoom_map_out);
+        .put(KeyStroke.getKeyStroke('-', InputEvent.META_DOWN_MASK), zoom_map_out);
     ((JComponent) getContentPane()).getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke('-', java.awt.event.InputEvent.CTRL_MASK), zoom_map_out);
+        .put(KeyStroke.getKeyStroke('-', InputEvent.CTRL_DOWN_MASK), zoom_map_out);
     ((JComponent) getContentPane()).getActionMap().put(zoom_map_out, new AbstractAction(zoom_map_out) {
       private static final long serialVersionUID = 7677111833274819304L;
 

--- a/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -183,7 +183,7 @@ public class TripleAMenuBar extends JMenuBar {
       final List<String> substanceLooks = getLookAndFeelAvailableList();
       for (final String s : substanceLooks) {
         final Class<?> c = Class.forName(s);
-        final LookAndFeel lf = (LookAndFeel) c.newInstance();
+        final LookAndFeel lf = (LookAndFeel) c.getDeclaredConstructor().newInstance();
         lookAndFeels.put(lf.getName(), s);
       }
     } catch (final Exception e) {

--- a/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -204,7 +204,7 @@ public class ImageScrollerLargeView extends JComponent {
       public void mouseDragged(final MouseEvent e) {
         requestFocusInWindow();
         // the right button must be the one down
-        if ((e.getModifiers() & InputEvent.BUTTON3_MASK) != 0 || (e.getModifiers() & InputEvent.BUTTON2_MASK) != 0) {
+        if ((e.getModifiersEx() & InputEvent.BUTTON3_DOWN_MASK) != 0 || (e.getModifiersEx() & InputEvent.BUTTON2_DOWN_MASK) != 0) {
           wasLastActionDragging = true;
           m_inside = false;
           // read in location

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -171,9 +171,9 @@ public class CenterPicker extends JFrame {
     exitAction.putValue(Action.SHORT_DESCRIPTION, "Exit The Program");
     // set up the menu items
     final JMenuItem openItem = new JMenuItem(openAction);
-    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_MASK));
+    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem saveItem = new JMenuItem(saveAction);
-    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_MASK));
+    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem exitItem = new JMenuItem(exitAction);
     // set up the menu bar
     final JMenuBar menuBar = new JMenuBar();

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -310,9 +310,9 @@ public class DecorationPlacer extends JFrame {
     exitAction.putValue(Action.SHORT_DESCRIPTION, "Exit The Program");
     // set up the menu items
     final JMenuItem openItem = new JMenuItem(openAction);
-    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_MASK));
+    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem saveItem = new JMenuItem(saveAction);
-    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_MASK));
+    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem exitItem = new JMenuItem(exitAction);
     // set up the menu bar
     final JMenuBar menuBar = new JMenuBar();

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -265,9 +265,9 @@ public class PolygonGrabber extends JFrame {
     autoAction.putValue(Action.SHORT_DESCRIPTION, "Autodetect Polygons around Centers");
     // set up the menu items
     final JMenuItem openItem = new JMenuItem(openAction);
-    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_MASK));
+    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem saveItem = new JMenuItem(saveAction);
-    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_MASK));
+    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem exitItem = new JMenuItem(exitAction);
     s_islandMode = false;
     modeItem = new JCheckBoxMenuItem("Island Mode", false);

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -116,9 +116,9 @@ public class MapPropertiesMaker extends JFrame {
     exitAction.putValue(Action.SHORT_DESCRIPTION, "Exit The Program");
     // set up the menu items
     final JMenuItem openItem = new JMenuItem(openAction);
-    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_MASK));
+    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem saveItem = new JMenuItem(saveAction);
-    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_MASK));
+    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem exitItem = new JMenuItem(exitAction);
     // set up the menu bar
     final JMenuBar menuBar = new JMenuBar();

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -329,9 +329,9 @@ public class PlacementPicker extends JFrame {
     exitAction.putValue(Action.SHORT_DESCRIPTION, "Exit The Program");
     // set up the menu items
     final JMenuItem openItem = new JMenuItem(openAction);
-    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_MASK));
+    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem saveItem = new JMenuItem(saveAction);
-    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_MASK));
+    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem exitItem = new JMenuItem(exitAction);
     // set up the menu bar
     final JMenuBar menuBar = new JMenuBar();

--- a/src/main/java/tools/map/xml/creator/MapXmlCreator.java
+++ b/src/main/java/tools/map/xml/creator/MapXmlCreator.java
@@ -409,9 +409,9 @@ public class MapXmlCreator extends JFrame {
     exitAction.putValue(Action.SHORT_DESCRIPTION, "Exit The Program");
     // set up the menu items
     final JMenuItem openItem = new JMenuItem(openAction);
-    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_MASK));
+    openItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem saveItem = new JMenuItem(saveAction);
-    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_MASK));
+    saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem exitItem = new JMenuItem(exitAction);
     // set up the menu bar
     final JMenuBar menuBar = new JMenuBar();

--- a/src/main/java/tools/map/xml/creator/UnitPlacementsPanel.java
+++ b/src/main/java/tools/map/xml/creator/UnitPlacementsPanel.java
@@ -179,7 +179,7 @@ public class UnitPlacementsPanel extends ImageScrollPanePanel {
       final JTextField[] countFields = new JTextField[playerUnitTypes.size()];
       // copy playPlacements map
       this.playerPlacements = playerPlacements.entrySet().stream()
-      .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), new Integer(e.getValue())))
+      .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), e.getValue()))
       .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
       this.setLayout(new GridBagLayout());
       final JTextArea title = new JTextArea("Choose units");


### PR DESCRIPTION
Follow-up of #1882 
This PR removes deprecations which are introduced with java 9.

The compilation log basically contains 2 types of warnings/errors:
1. Observer and Observable have benn deprecated in java 9, we should probably remove the usage of those classes ([more information](http://download.java.net/java/jdk9/docs/api/java/util/Observable.html))
2. `Enumeration<TreeNode> cannot be converted to Enumeration<HistoryNode>` I have no idea why this is happening! I tried changing the cast, but nothing seems to work \:c

[Java 9 Countdown](http://www.java9countdown.xyz/)

Current gradle output when compiling against java 9:
[Gist](https://gist.github.com/RoiEXLab/bcc46a53c62958a4bb472a0c4b3f5e8f#file-java9)
Output when compiling with the latest java 9 jdk with java 8 source setting:
[Gist](https://gist.github.com/RoiEXLab/bcc46a53c62958a4bb472a0c4b3f5e8f#file-java9-8)