### PR TITLE
Checkstyle: Fix naming violations in Matches

### DIFF
--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -411,7 +411,7 @@ public class TripleAUnit extends Unit {
   public static Unit getBiggestProducer(final Collection<Unit> units, final Territory producer, final PlayerID player,
       final GameData data, final boolean accountForDamage) {
     final CompositeMatchAnd<Unit> factoryMatch = new CompositeMatchAnd<>(
-        Matches.UnitIsOwnedAndIsFactoryOrCanProduceUnits(player), Matches.unitIsBeingTransported().invert());
+        Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player), Matches.unitIsBeingTransported().invert());
     if (producer.isWater()) {
       factoryMatch.add(Matches.UnitIsLand.invert());
     } else {

--- a/src/main/java/games/strategy/triplea/ai/AIPoliticalUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIPoliticalUtils.java
@@ -52,7 +52,7 @@ public class AIPoliticalUtils {
       }
       if (isFree(nextAction)) {
         acceptableActions.add(nextAction);
-      } else if (Match.countMatches(validActions, Matches.PoliticalActionHasCostBetween(0, 0)) > 1) {
+      } else if (Match.countMatches(validActions, Matches.politicalActionHasCostBetween(0, 0)) > 1) {
         if (Math.random() < .9 && isAcceptableCost(nextAction, id, data)) {
           acceptableActions.add(nextAction);
         }

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -622,7 +622,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
         final Iterator<PoliticalActionAttachment> actionWarIter = actionChoicesTowardsWar.iterator();
         while (actionWarIter.hasNext() && maxWarActionsPerTurn > 0) {
           final PoliticalActionAttachment action = actionWarIter.next();
-          if (!Matches.AbstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())
+          if (!Matches.abstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())
               .match(action)) {
             continue;
           }
@@ -646,7 +646,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
         final Iterator<PoliticalActionAttachment> actionOtherIter = actionChoicesOther.iterator();
         while (actionOtherIter.hasNext() && maxOtherActionsPerTurn > 0) {
           final PoliticalActionAttachment action = actionOtherIter.next();
-          if (!Matches.AbstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())
+          if (!Matches.abstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())
               .match(action)) {
             continue;
           }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
@@ -52,7 +52,7 @@ class ProPoliticsAI {
     ProLogger.trace("War options: " + actionChoicesTowardsWar);
     final List<PoliticalActionAttachment> validWarActions =
         Match.getMatches(actionChoicesTowardsWar, new CompositeMatchAnd<>(
-            Matches.AbstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())));
+            Matches.abstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())));
     ProLogger.trace("Valid War options: " + validWarActions);
 
     // Divide war actions into enemy and neutral
@@ -149,7 +149,7 @@ class ProPoliticsAI {
         final Iterator<PoliticalActionAttachment> actionOtherIter = actionChoicesOther.iterator();
         while (actionOtherIter.hasNext() && maxOtherActionsPerTurn > 0) {
           final PoliticalActionAttachment action = actionOtherIter.next();
-          if (!Matches.AbstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())
+          if (!Matches.abstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())
               .match(action)) {
             continue;
           }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -375,7 +375,7 @@ final class ProTechAI {
     final CompositeMatch<Unit> blitzUnit =
         new CompositeMatchAnd<>(Matches.unitIsOwnedBy(ePlayer), Matches.UnitCanBlitz, Matches.UnitCanMove);
     final CompositeMatch<Territory> validBlitzRoute = new CompositeMatchAnd<>(
-        Matches.territoryHasNoEnemyUnits(ePlayer, data), Matches.TerritoryIsNotImpassableToLandUnits(ePlayer, data));
+        Matches.territoryHasNoEnemyUnits(ePlayer, data), Matches.territoryIsNotImpassableToLandUnits(ePlayer, data));
     final List<Route> routes = new ArrayList<>();
     final List<Unit> blitzUnits =
         findAttackers(blitzHere, 2, ignore, ePlayer, data, blitzUnit, validBlitzRoute, blockTerr, routes, false);
@@ -430,7 +430,7 @@ final class ProTechAI {
             continue;
           }
           for (final Unit u : neighbor.getUnits()) {
-            if (unitCondition.match(u) && Matches.UnitHasEnoughMovementForRoutes(routes).match(u)) {
+            if (unitCondition.match(u) && Matches.unitHasEnoughMovementForRoutes(routes).match(u)) {
               units.add(u);
             }
           }
@@ -506,10 +506,10 @@ final class ProTechAI {
       }
     }
     for (final Unit u : unitDistance.keySet()) {
-      if (lz != null && Matches.UnitHasEnoughMovementForRoute(checked).match(u)) {
+      if (lz != null && Matches.unitHasEnoughMovementForRoute(checked).match(u)) {
         units.add(u);
       } else if (ac != null && Matches.UnitCanLandOnCarrier.match(u)
-          && Matches.UnitHasEnoughMovementForRoute(checked).match(u)) {
+          && Matches.unitHasEnoughMovementForRoute(checked).match(u)) {
         units.add(u);
       }
     }
@@ -598,7 +598,7 @@ final class ProTechAI {
     final List<Territory> checkList = getExactNeighbors(check, 1, data, false);
     for (final Territory t : checkList) {
       if (Matches.isTerritoryAllied(player, data).match(t)
-          && Matches.TerritoryIsNotImpassableToLandUnits(player, data).match(t)) {
+          && Matches.territoryIsNotImpassableToLandUnits(player, data).match(t)) {
         rVal.add(t);
       }
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -443,7 +443,7 @@ public class ProTerritoryManager {
         int range = TripleAUnit.get(mySeaUnit).getMovementLeft();
         if (isCheckingEnemyAttacks) {
           range = UnitAttachment.get(mySeaUnit.getType()).getMovement(player);
-          if (Matches.UnitCanBeGivenBonusMovementByFacilitiesInItsTerritory(myUnitTerritory, player, data)
+          if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(myUnitTerritory, player, data)
               .match(mySeaUnit)) {
             range++; // assumes bonus of +1 for now
           }
@@ -630,7 +630,7 @@ public class ProTerritoryManager {
         }
       }
       for (final Territory t : data.getMap().getTerritories()) {
-        if (t.getUnits().someMatch(Matches.UnitIsAlliedCarrier(player, data))) {
+        if (t.getUnits().someMatch(Matches.unitIsAlliedCarrier(player, data))) {
           possibleCarrierTerritories.add(t);
         }
       }
@@ -649,7 +649,7 @@ public class ProTerritoryManager {
         int range = TripleAUnit.get(myAirUnit).getMovementLeft();
         if (isCheckingEnemyAttacks) {
           range = UnitAttachment.get(myAirUnit.getType()).getMovement(player);
-          if (Matches.UnitCanBeGivenBonusMovementByFacilitiesInItsTerritory(myUnitTerritory, player, data)
+          if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(myUnitTerritory, player, data)
               .match(myAirUnit)) {
             range++; // assumes bonus of +1 for now
           }
@@ -751,7 +751,7 @@ public class ProTerritoryManager {
         int movesLeft = TripleAUnit.get(myTransportUnit).getMovementLeft();
         if (isCheckingEnemyAttacks) {
           movesLeft = UnitAttachment.get(myTransportUnit.getType()).getMovement(player);
-          if (Matches.UnitCanBeGivenBonusMovementByFacilitiesInItsTerritory(myUnitTerritory, player, data)
+          if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(myUnitTerritory, player, data)
               .match(myTransportUnit)) {
             movesLeft++; // assumes bonus of +1 for now
           }
@@ -922,7 +922,7 @@ public class ProTerritoryManager {
         int range = TripleAUnit.get(mySeaUnit).getMovementLeft();
         if (isCheckingEnemyAttacks) {
           range = UnitAttachment.get(mySeaUnit.getType()).getMovement(player);
-          if (Matches.UnitCanBeGivenBonusMovementByFacilitiesInItsTerritory(myUnitTerritory, player, data)
+          if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(myUnitTerritory, player, data)
               .match(mySeaUnit)) {
             range++; // assumes bonus of +1 for now
           }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -80,7 +80,7 @@ public class ProBattleUtils {
     final GameData data = ProData.getData();
 
     List<Unit> unitsThatCanFight =
-        Match.getMatches(myUnits, Matches.UnitCanBeInBattle(attacking, !t.isWater(), 1, false, true, true));
+        Match.getMatches(myUnits, Matches.unitCanBeInBattle(attacking, !t.isWater(), 1, false, true, true));
     if (Properties.getTransportCasualtiesRestricted(data)) {
       unitsThatCanFight = Match.getMatches(unitsThatCanFight, Matches.UnitIsTransportButNotCombatTransport.invert());
     }
@@ -94,7 +94,7 @@ public class ProBattleUtils {
     final GameData data = ProData.getData();
 
     final List<Unit> unitsThatCanFight =
-        Match.getMatches(myUnits, Matches.UnitCanBeInBattle(attacking, !t.isWater(), 1, false, true, true));
+        Match.getMatches(myUnits, Matches.unitCanBeInBattle(attacking, !t.isWater(), 1, false, true, true));
     final List<Unit> sortedUnitsList = new ArrayList<>(unitsThatCanFight);
     Collections.sort(sortedUnitsList, new UnitBattleComparator(!attacking, ProData.unitValueMap,
         TerritoryEffectHelper.getEffects(t), data, false, false));

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -30,7 +30,7 @@ public class ProMatches {
       public boolean match(final Territory t) {
         final Match<Territory> match = new CompositeMatchOr<>(Matches.territoryIsInList(alliedTerritories),
             new CompositeMatchAnd<>(Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data),
-                Matches.TerritoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false,
+                Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false,
                     false, true, true),
                 Matches.territoryIsInList(enemyTerritories).invert()));
         return match.match(t);
@@ -44,7 +44,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> match = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.TerritoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, false,
+            Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, false,
                 true, false));
         return match.match(t);
       }
@@ -56,7 +56,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> match = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.TerritoryIsPassableAndNotRestricted(player, data));
+            Matches.territoryIsPassableAndNotRestricted(player, data));
         return match.match(t);
       }
     };
@@ -69,7 +69,7 @@ public class ProMatches {
       public boolean match(final Territory t) {
         final Match<Territory> match =
             new CompositeMatchAnd<>(ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove),
-                Matches.territoryHasEnemyAAforAnything(player, data).invert());
+                Matches.territoryHasEnemyAaForAnything(player, data).invert());
         return match.match(t);
       }
     };
@@ -81,7 +81,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> territoryMatch = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.TerritoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
+            Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
                 false, false));
         final Match<Unit> unitMatch =
             Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).invert();
@@ -96,7 +96,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> territoryMatch = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.TerritoryIsPassableAndNotRestricted(player, data));
+            Matches.territoryIsPassableAndNotRestricted(player, data));
         final Match<Unit> unitMatch =
             Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).invert();
         return territoryMatch.match(t) && unitMatch.match(u);
@@ -110,7 +110,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> match = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.TerritoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
+            Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
                 false, false));
         return match.match(t);
       }
@@ -122,7 +122,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> match = new CompositeMatchAnd<>(Matches.TerritoryIsLand,
-            Matches.territoryDoesNotCostMoneyToEnter(data), Matches.TerritoryIsPassableAndNotRestricted(player, data));
+            Matches.territoryDoesNotCostMoneyToEnter(data), Matches.territoryIsPassableAndNotRestricted(player, data));
         return match.match(t);
       }
     };
@@ -186,7 +186,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        return Matches.TerritoryIsBlitzable(player, data).match(t) && TerritoryEffectHelper.unitKeepsBlitz(u, t);
+        return Matches.territoryIsBlitzable(player, data).match(t) && TerritoryEffectHelper.unitKeepsBlitz(u, t);
       }
     };
   }
@@ -203,7 +203,7 @@ public class ProMatches {
           return false;
         }
         final Match<Territory> match = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.TerritoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, true,
+            Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, true,
                 false, false));
         return match.match(t);
       }
@@ -942,14 +942,14 @@ public class ProMatches {
           return true;
         }
         final Collection<Unit> unitsAtStartOfTurnInProducer = t.getUnits().getUnits();
-        if (Matches.UnitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInProducer)
+        if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInProducer)
             .match(unitWhichRequiresUnits)) {
           return true;
         }
         if (t.isWater() && Matches.UnitIsSea.match(unitWhichRequiresUnits)) {
           for (final Territory neighbor : t.getData().getMap().getNeighbors(t, Matches.TerritoryIsLand)) {
             final Collection<Unit> unitsAtStartOfTurnInCurrent = neighbor.getUnits().getUnits();
-            if (Matches.UnitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
+            if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
                 .match(unitWhichRequiresUnits)) {
               return true;
             }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -136,9 +136,9 @@ public class ProOddsCalculator {
     final List<Unit> averageAttackersRemaining = results.getAverageAttackingUnitsRemaining();
     final List<Unit> averageDefendersRemaining = results.getAverageDefendingUnitsRemaining();
     final List<Unit> mainCombatAttackers =
-        Match.getMatches(attackingUnits, Matches.UnitCanBeInBattle(true, !t.isWater(), 1, false, true, true));
+        Match.getMatches(attackingUnits, Matches.unitCanBeInBattle(true, !t.isWater(), 1, false, true, true));
     final List<Unit> mainCombatDefenders =
-        Match.getMatches(defendingUnits, Matches.UnitCanBeInBattle(false, !t.isWater(), 1, false, true, true));
+        Match.getMatches(defendingUnits, Matches.unitCanBeInBattle(false, !t.isWater(), 1, false, true, true));
     double tuvSwing = results.getAverageTUVswing(attacker, mainCombatAttackers, defender, mainCombatDefenders, data);
     if (Matches.TerritoryIsNeutralButNotWater.match(t)) { // Set TUV swing for neutrals
       final double attackingUnitValue = BattleCalculator.getTUV(mainCombatAttackers, ProData.unitValueMap);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -212,7 +212,7 @@ public class ProPurchaseUtils {
         new HashSet<>(data.getMap().getTerritoriesOwnedBy(player));
     ownedOrHasUnitTerritories.addAll(ProData.myUnitTerritories);
     final List<Territory> potentialTerritories = Match.getMatches(ownedOrHasUnitTerritories,
-        Matches.TerritoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, false, false, false, false,
+        Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, false, false, false, false,
             false));
 
     // Create purchase territory holder for each factory territory
@@ -261,7 +261,7 @@ public class ProPurchaseUtils {
   private static int getUnitProduction(final Territory territory, final GameData data, final PlayerID player) {
 
     final CompositeMatchAnd<Unit> factoryMatch = new CompositeMatchAnd<>(
-        Matches.UnitIsOwnedAndIsFactoryOrCanProduceUnits(player), Matches.unitIsBeingTransported().invert());
+        Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player), Matches.unitIsBeingTransported().invert());
     if (territory.isWater()) {
       factoryMatch.add(Matches.UnitIsLand.invert());
     } else {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -148,7 +148,7 @@ public class ProUtils {
     for (final PlayerID otherPlayer : ePlayers) {
       enemyCapitals.addAll(TerritoryAttachment.getAllCurrentlyOwnedCapitals(otherPlayer, data));
     }
-    enemyCapitals.retainAll(Match.getMatches(enemyCapitals, Matches.TerritoryIsNotImpassableToLandUnits(player, data)));
+    enemyCapitals.retainAll(Match.getMatches(enemyCapitals, Matches.territoryIsNotImpassableToLandUnits(player, data)));
     enemyCapitals
         .retainAll(Match.getMatches(enemyCapitals, Matches.isTerritoryOwnedBy(getPotentialEnemyPlayers(player))));
     return enemyCapitals;
@@ -160,7 +160,7 @@ public class ProUtils {
     for (final PlayerID alliedPlayer : players) {
       capitals.addAll(TerritoryAttachment.getAllCurrentlyOwnedCapitals(alliedPlayer, data));
     }
-    capitals.retainAll(Match.getMatches(capitals, Matches.TerritoryIsNotImpassableToLandUnits(player, data)));
+    capitals.retainAll(Match.getMatches(capitals, Matches.territoryIsNotImpassableToLandUnits(player, data)));
     capitals.retainAll(Match.getMatches(capitals, Matches.isTerritoryAllied(player, data)));
     return capitals;
   }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -533,7 +533,7 @@ public class WeakAI extends AbstractAI {
           }
         });
     final Match<Territory> routeCondition = new CompositeMatchAnd<>(
-        Matches.territoryHasEnemyAAforCombatOnly(player, data).invert(), Matches.TerritoryIsImpassable.invert());
+        Matches.territoryHasEnemyAaForCombatOnly(player, data).invert(), Matches.TerritoryIsImpassable.invert());
     for (final Territory t : delegateRemote.getTerritoriesWhereAirCantLand()) {
       final Route noAaRoute = Utils.findNearest(t, canLand, routeCondition, data);
       final Route aaRoute = Utils.findNearest(t, canLand, Matches.TerritoryIsImpassable.invert(), data);
@@ -724,7 +724,7 @@ public class WeakAI extends AbstractAI {
       if (bombers.isEmpty()) {
         continue;
       }
-      final Match<Territory> routeCond = new InverseMatch<>(Matches.territoryHasEnemyAAforCombatOnly(player, data));
+      final Match<Territory> routeCond = new InverseMatch<>(Matches.territoryHasEnemyAaForCombatOnly(player, data));
       final Route bombRoute = Utils.findNearest(t, enemyFactory, routeCond, data);
       moveUnits.add(bombers);
       moveRoutes.add(bombRoute);
@@ -774,7 +774,7 @@ public class WeakAI extends AbstractAI {
               || Matches.UnitTypeIsInfrastructure.match(results) || Matches.UnitTypeIsAAforAnything.match(results)
               || Matches.UnitTypeHasMaxBuildRestrictions.match(results)
               || Matches.UnitTypeConsumesUnitsOnCreation.match(results)
-              || Matches.UnitTypeIsStatic(player).match(results)) {
+              || Matches.unitTypeIsStatic(player).match(results)) {
             continue;
           }
           final int cost = rule.getCosts().getInt(PUs);
@@ -968,7 +968,7 @@ public class WeakAI extends AbstractAI {
         if (Matches.UnitTypeIsAir.match(results) || Matches.UnitTypeIsInfrastructure.match(results)
             || Matches.UnitTypeIsAAforAnything.match(results) || Matches.UnitTypeHasMaxBuildRestrictions.match(results)
             || Matches.UnitTypeConsumesUnitsOnCreation.match(results)
-            || Matches.UnitTypeIsStatic(player).match(results)) {
+            || Matches.unitTypeIsStatic(player).match(results)) {
           continue;
         }
         final int transportCapacity = UnitAttachment.get(results).getTransportCapacity();

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -293,7 +293,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
       for (final PlayerID player : players) {
         originalTerrs.addAll(Match.getMatches(OriginalOwnerTracker.getOriginallyOwned(data, player),
             // TODO: does this account for occupiedTerrOf???
-            Matches.TerritoryIsNotImpassableToLandUnits(player, data)));
+            Matches.territoryIsNotImpassableToLandUnits(player, data)));
       }
       setTerritoryCount(String.valueOf(originalTerrs.size()));
       return originalTerrs;
@@ -308,7 +308,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
       final Set<Territory> ownedTerrsNoWater = new HashSet<>();
       for (final PlayerID player : players) {
         ownedTerrsNoWater.addAll(Match.getMatches(gameMap.getTerritoriesOwnedBy(player),
-            Matches.TerritoryIsNotImpassableToLandUnits(player, data)));
+            Matches.territoryIsNotImpassableToLandUnits(player, data)));
       }
       setTerritoryCount(String.valueOf(ownedTerrsNoWater.size()));
       return ownedTerrsNoWater;

--- a/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -143,7 +143,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
     }
     return Match.getMatches(getPoliticalActionAttachments(player),
         new CompositeMatchAnd<>(
-            Matches.AbstractUserActionAttachmentCanBeAttempted(testedConditions),
+            Matches.abstractUserActionAttachmentCanBeAttempted(testedConditions),
             Matches.politicalActionAffectsAtLeastOneAlivePlayer(player, data)));
   }
 

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1006,7 +1006,7 @@ public class UnitAttachment extends DefaultAttachment {
       final String filterForAbility, final GameData data) {
     final IntegerMap<Tuple<String, String>> map = new IntegerMap<>();
     final Collection<UnitType> canReceive =
-        getUnitTypesFromUnitList(Match.getMatches(units, Matches.UnitCanReceivesAbilityWhenWith()));
+        getUnitTypesFromUnitList(Match.getMatches(units, Matches.unitCanReceiveAbilityWhenWith()));
     for (final UnitType ut : canReceive) {
       final Collection<String> receives = UnitAttachment.get(ut).getReceivesAbilityWhenWith();
       for (final String receive : receives) {
@@ -1023,7 +1023,7 @@ public class UnitAttachment extends DefaultAttachment {
 
   public static Collection<Unit> getUnitsWhichReceivesAbilityWhenWith(final Collection<Unit> units,
       final String filterForAbility, final GameData data) {
-    if (Match.noneMatch(units, Matches.UnitCanReceivesAbilityWhenWith())) {
+    if (Match.noneMatch(units, Matches.unitCanReceiveAbilityWhenWith())) {
       return new ArrayList<>();
     }
     final Collection<Unit> unitsCopy = new ArrayList<>(units);
@@ -1032,7 +1032,7 @@ public class UnitAttachment extends DefaultAttachment {
         getReceivesAbilityWhenWithMap(unitsCopy, filterForAbility, data);
     for (final Tuple<String, String> abilityUnitType : whichGive.keySet()) {
       final Collection<Unit> receives = Match.getNMatches(unitsCopy, whichGive.getInt(abilityUnitType),
-          Matches.UnitCanReceivesAbilityWhenWith(filterForAbility, abilityUnitType.getSecond()));
+          Matches.unitCanReceiveAbilityWhenWith(filterForAbility, abilityUnitType.getSecond()));
       whichReceiveNoDuplicates.addAll(receives);
       unitsCopy.removeAll(receives);
     }
@@ -2980,7 +2980,7 @@ public class UnitAttachment extends DefaultAttachment {
       stats.append("can Give Attack Bonus To Other Units, ");
     } else {
       final List<UnitSupportAttachment> supports =
-          Match.getMatches(UnitSupportAttachment.get(unitType), Matches.UnitSupportAttachmentCanBeUsedByPlayer(player));
+          Match.getMatches(UnitSupportAttachment.get(unitType), Matches.unitSupportAttachmentCanBeUsedByPlayer(player));
       if (supports.size() > 0) {
         if (supports.size() > 2) {
           stats.append("can Modify Power Of Other Units, ");

--- a/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -175,7 +175,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
   public static Collection<UserActionAttachment> getValidActions(final PlayerID player,
       final HashMap<ICondition, Boolean> testedConditions, final GameData data) {
     return Match.getMatches(getUserActionAttachments(player), new CompositeMatchAnd<>(
-        Matches.AbstractUserActionAttachmentCanBeAttempted(testedConditions)));
+        Matches.abstractUserActionAttachmentCanBeAttempted(testedConditions)));
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -116,7 +116,7 @@ class AAInMoveUtil implements Serializable {
     // don't iterate over the end
     // that will be a battle
     // and handled else where in this tangled mess
-    final Match<Unit> hasAa = Matches.UnitIsAAthatCanFire(units, airborneTechTargetsAllowed, movingPlayer,
+    final Match<Unit> hasAa = Matches.unitIsAaThatCanFire(units, airborneTechTargetsAllowed, movingPlayer,
         Matches.UnitIsAAforFlyOverOnly, 1, true, data);
     // AA guns in transports shouldn't be able to fire
     final List<Territory> territoriesWhereAaWillFire = new ArrayList<>();
@@ -173,14 +173,14 @@ class AAInMoveUtil implements Serializable {
     final PlayerID movingPlayer = movingPlayer(units);
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(movingPlayer, getData());
-    final List<Unit> defendingAa = territory.getUnits().getMatches(Matches.UnitIsAAthatCanFire(units,
+    final List<Unit> defendingAa = territory.getUnits().getMatches(Matches.unitIsAaThatCanFire(units,
         airborneTechTargetsAllowed, movingPlayer, Matches.UnitIsAAforFlyOverOnly, 1, true, getData()));
     // comes ordered alphabetically already
     final List<String> AAtypes = UnitAttachment.getAllOfTypeAAs(defendingAa);
     // stacks are backwards
     Collections.reverse(AAtypes);
     for (final String currentTypeAa : AAtypes) {
-      final Collection<Unit> currentPossibleAa = Match.getMatches(defendingAa, Matches.UnitIsAAofTypeAA(currentTypeAa));
+      final Collection<Unit> currentPossibleAa = Match.getMatches(defendingAa, Matches.unitIsAaOfTypeAa(currentTypeAa));
       final Set<UnitType> targetUnitTypesForThisTypeAa =
           UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAA(getData());
       final Set<UnitType> airborneTypesTargettedToo = airborneTechTargetsAllowed.get(currentTypeAa);

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -308,7 +308,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
             // PlayerOwnerChange
             final Collection<Unit> units =
                 currTerritory.getUnits().getMatches(new CompositeMatchAnd<>(Matches.unitOwnedBy(Player),
-                    Matches.UnitCanBeGivenByTerritoryTo(terrNewOwner)));
+                    Matches.unitCanBeGivenByTerritoryTo(terrNewOwner)));
             if (!units.isEmpty()) {
               change.add(ChangeFactory.changeOwner(units, terrNewOwner, currTerritory));
               changeList.add(Tuple.of(currTerritory, units));

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -849,7 +849,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         return "Cannot place these units in " + to.getName() + " due to Unit Placement Restrictions";
       }
       if (Matches.UnitCanOnlyPlaceInOriginalTerritories.match(currentUnit)
-          && !Matches.TerritoryIsOriginallyOwnedBy(player).match(to)) {
+          && !Matches.territoryIsOriginallyOwnedBy(player).match(to)) {
         return "Cannot place these units in " + to.getName() + " as territory is not originally owned";
       }
     }
@@ -930,7 +930,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (Match.someMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
       final Collection<Unit> unitsWhichConsume = Match.getMatches(placeableUnits, Matches.UnitConsumesUnitsOnCreation);
       for (final Unit unit : unitsWhichConsume) {
-        if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
+        if (Matches.unitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
           placeableUnits.remove(unit);
         }
       }
@@ -964,7 +964,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         continue;
       }
       if (Matches.UnitCanOnlyPlaceInOriginalTerritories.match(currentUnit)
-          && !Matches.TerritoryIsOriginallyOwnedBy(player).match(to)) {
+          && !Matches.territoryIsOriginallyOwnedBy(player).match(to)) {
         continue;
       }
       // account for any unit placement restrictions by territory
@@ -984,7 +984,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final Collection<Unit> removedUnits = new ArrayList<>();
     final Collection<Unit> unitsWhichConsume = Match.getMatches(units, Matches.UnitConsumesUnitsOnCreation);
     for (final Unit unit : unitsWhichConsume) {
-      if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
+      if (Matches.unitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
         weCanConsume = false;
       }
       if (!weCanConsume) {
@@ -1087,7 +1087,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     // Can be null!
     final TerritoryAttachment ta = TerritoryAttachment.get(producer);
     final CompositeMatchAnd<Unit> factoryMatch = new CompositeMatchAnd<>(
-        Matches.UnitIsOwnedAndIsFactoryOrCanProduceUnits(player), Matches.unitIsBeingTransported().invert());
+        Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player), Matches.unitIsBeingTransported().invert());
     if (producer.isWater()) {
       factoryMatch.add(Matches.UnitIsLand.invert());
     } else {
@@ -1294,7 +1294,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       }
       // remove any units that require other units to be consumed on creation (veqryn)
       if (Matches.UnitConsumesUnitsOnCreation.match(currentUnit)
-          && Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(currentUnit)) {
+          && Matches.unitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(currentUnit)) {
         continue;
       }
       unitMapHeld.add(ua.getConstructionType(), 1);
@@ -1393,7 +1393,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         }
         final Collection<Unit> unitsAtStartOfTurnInProducer = unitsAtStartOfStepInTerritory(to);
         // do not need to remove unowned here, as this match will remove unowned units from consideration.
-        if (Matches.UnitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInProducer)
+        if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInProducer)
             .match(unitWhichRequiresUnits)) {
           return true;
         }
@@ -1402,7 +1402,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
             for (final Territory current : getAllProducers(to, m_player,
                 Collections.singletonList(unitWhichRequiresUnits), true)) {
               final Collection<Unit> unitsAtStartOfTurnInCurrent = unitsAtStartOfStepInTerritory(current);
-              if (Matches.UnitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
+              if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
                   .match(unitWhichRequiresUnits)) {
                 return true;
               }
@@ -1568,7 +1568,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       final PlayerID player) {
     final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
     final CompositeMatchAnd<Unit> factoryMatch = new CompositeMatchAnd<>(
-        Matches.UnitIsOwnedAndIsFactoryOrCanProduceUnits(player), Matches.unitIsBeingTransported().invert());
+        Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player), Matches.unitIsBeingTransported().invert());
     // land factories in water can't produce, and sea factories in land can't produce. air can produce like land if in
     // land, and like sea if
     // in water.

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -307,11 +307,11 @@ public class AirBattle extends AbstractBattle {
         HashMap<Unit, HashSet<Unit>> targets = null;
         final Collection<Unit> enemyTargetsTotal = m_battleSite.getUnits()
             .getMatches(new CompositeMatchAnd<>(Matches.enemyUnit(bridge.getPlayerID(), m_data),
-                Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
+                Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
                 Matches.unitIsBeingTransported().invert()));
         for (final Unit unit : bombers) {
           final Collection<Unit> enemyTargets =
-              Match.getMatches(enemyTargetsTotal, Matches.UnitIsLegalBombingTargetBy(unit));
+              Match.getMatches(enemyTargetsTotal, Matches.unitIsLegalBombingTargetBy(unit));
           if (!enemyTargets.isEmpty()) {
             Unit target = null;
             if (enemyTargets.size() > 1

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -121,7 +121,7 @@ public class AirMovementValidator {
         maxMovementLeftForAllOwnedCarriers, Matches.seaCanMoveOver(player, data)));
     potentialCarrierOrigins.remove(routeEnd);
     potentialCarrierOrigins
-        .removeAll(Match.getMatches(potentialCarrierOrigins, Matches.TerritoryHasOwnedCarrier(player).invert()));
+        .removeAll(Match.getMatches(potentialCarrierOrigins, Matches.territoryHasOwnedCarrier(player).invert()));
     // now see if we can move carriers there to pick up
     validateAirCaughtByMovingCarriersAndOwnedAndAlliedAir(result, landingSpots, potentialCarrierOrigins,
         movedCarriersAndTheirFighters, airThatMustLandOnCarriers, airNotToConsiderBecauseWeAreValidatingThem, player,
@@ -358,7 +358,7 @@ public class AirMovementValidator {
           continue;
         }
         final List<Unit> carrierCanReach =
-            Match.getMatches(ownedCarriersInCarrierSpot, Matches.UnitHasEnoughMovementForRoute(toLandingSpot));
+            Match.getMatches(ownedCarriersInCarrierSpot, Matches.unitHasEnoughMovementForRoute(toLandingSpot));
         if (carrierCanReach.isEmpty()) {
           // none can reach
           continue;
@@ -680,9 +680,9 @@ public class AirMovementValidator {
   public static int carrierCapacity(final Unit unit, final Territory territoryUnitsAreCurrentlyIn) {
     if (Matches.UnitIsCarrier.match(unit)) {
       // here we check to see if the unit can no longer carry units
-      if (Matches.UnitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLANDONCARRIER).match(unit)) {
+      if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLANDONCARRIER).match(unit)) {
         // and we must check to make sure we let any allied air that are cargo stay here
-        if (Matches.UnitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER).match(unit)) {
+        if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER).match(unit)) {
           int cargo = 0;
           final Collection<Unit> airCargo = territoryUnitsAreCurrentlyIn.getUnits()
               .getMatches(new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier));

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -1513,7 +1513,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final HashSet<Territory> availableWater = new HashSet<>();
       availableWater.addAll(Match.getMatches(possibleTerrs,
           new CompositeMatchAnd<>(
-              Matches.territoryHasUnitsThatMatch(Matches.UnitIsAlliedCarrier(alliedPlayer, data)),
+              Matches.territoryHasUnitsThatMatch(Matches.unitIsAlliedCarrier(alliedPlayer, data)),
               Matches.TerritoryIsWater)));
       availableWater.removeAll(battleTracker.getPendingBattleSites(false));
       // a rather simple calculation, either we can take all the air, or we can't, nothing in the middle
@@ -1522,7 +1522,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       while (waterIter.hasNext()) {
         final Territory t = waterIter.next();
         int carrierCapacity = AirMovementValidator
-            .carrierCapacity(t.getUnits().getMatches(Matches.UnitIsAlliedCarrier(alliedPlayer, data)), t);
+            .carrierCapacity(t.getUnits().getMatches(Matches.unitIsAlliedCarrier(alliedPlayer, data)), t);
         if (!t.equals(currentTerr)) {
           carrierCapacity -= AirMovementValidator.carrierCost(t.getUnits().getMatches(
               new CompositeMatchAnd<>(Matches.UnitCanLandOnCarrier, Matches.alliedUnit(alliedPlayer, data))));

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -411,7 +411,7 @@ public class BattleTracker implements java.io.Serializable {
     }
     // we handle the end of the route later
     conquered.remove(route.getEnd());
-    final Collection<Territory> blitzed = Match.getMatches(conquered, Matches.TerritoryIsBlitzable(id, data));
+    final Collection<Territory> blitzed = Match.getMatches(conquered, Matches.territoryIsBlitzable(id, data));
     m_blitzed.addAll(Match.getMatches(blitzed, Matches.isTerritoryEnemy(id, data)));
     m_conquered.addAll(Match.getMatches(conquered, Matches.isTerritoryEnemy(id, data)));
     for (final Territory current : conquered) {
@@ -457,7 +457,7 @@ public class BattleTracker implements java.io.Serializable {
         }
       } else {
         if (Matches.isTerritoryEnemy(id, data).match(route.getEnd())) {
-          if (Matches.TerritoryIsBlitzable(id, data).match(route.getEnd())) {
+          if (Matches.territoryIsBlitzable(id, data).match(route.getEnd())) {
             m_blitzed.add(route.getEnd());
           }
           m_conquered.add(route.getEnd());
@@ -652,7 +652,7 @@ public class BattleTracker implements java.io.Serializable {
     // if we have specially set this territory to have whenCapturedByGoesTo,
     // then we set that here (except we don't set it if we are liberating allied owned territory)
     if (ta != null && isTerritoryOwnerAnEnemy && newOwner.equals(id)
-        && Matches.TerritoryHasWhenCapturedByGoesTo().match(territory)) {
+        && Matches.territoryHasWhenCapturedByGoesTo().match(territory)) {
       for (final String value : ta.getWhenCapturedByGoesTo()) {
         final String[] s = value.split(":");
         final PlayerID capturingPlayer = data.getPlayerList().getPlayerID(s[0]);
@@ -747,7 +747,7 @@ public class BattleTracker implements java.io.Serializable {
     // destroy any units that should be destroyed on capture
     if (games.strategy.triplea.Properties.getUnitsCanBeDestroyedInsteadOfCaptured(data)) {
       final CompositeMatch<Unit> enemyToBeDestroyed =
-          new CompositeMatchAnd<>(Matches.enemyUnit(id, data), Matches.UnitDestroyedWhenCapturedByOrFrom(id));
+          new CompositeMatchAnd<>(Matches.enemyUnit(id, data), Matches.unitDestroyedWhenCapturedByOrFrom(id));
       final Collection<Unit> destroyed = territory.getUnits().getMatches(enemyToBeDestroyed);
       if (!destroyed.isEmpty()) {
         final Change destroyUnits = ChangeFactory.removeUnits(territory, destroyed);
@@ -761,7 +761,7 @@ public class BattleTracker implements java.io.Serializable {
     // destroy any capture on entering units, IF the property to destroy them instead of capture is turned on
     if (games.strategy.triplea.Properties.getOnEnteringUnitsDestroyedInsteadOfCaptured(data)) {
       final Collection<Unit> destroyed =
-          territory.getUnits().getMatches(Matches.UnitCanBeCapturedOnEnteringToInThisTerritory(id, territory, data));
+          territory.getUnits().getMatches(Matches.unitCanBeCapturedOnEnteringToInThisTerritory(id, territory, data));
       if (!destroyed.isEmpty()) {
         final Change destroyUnits = ChangeFactory.removeUnits(territory, destroyed);
         bridge.getHistoryWriter().addChildToEvent(id.getName() + " destroys some units instead of capturing them",
@@ -788,12 +788,12 @@ public class BattleTracker implements java.io.Serializable {
     final CompositeMatch<Unit> enemyNonCom =
         new CompositeMatchAnd<>(Matches.enemyUnit(id, data), Matches.UnitIsInfrastructure);
     final CompositeMatch<Unit> willBeCaptured = new CompositeMatchOr<>(enemyNonCom,
-        Matches.UnitCanBeCapturedOnEnteringToInThisTerritory(id, territory, data));
+        Matches.unitCanBeCapturedOnEnteringToInThisTerritory(id, territory, data));
     final Collection<Unit> nonCom = territory.getUnits().getMatches(willBeCaptured);
     // change any units that change unit types on capture
     if (games.strategy.triplea.Properties.getUnitsCanBeChangedOnCapture(data)) {
       final Collection<Unit> toReplace =
-          Match.getMatches(nonCom, Matches.UnitWhenCapturedChangesIntoDifferentUnitType());
+          Match.getMatches(nonCom, Matches.unitWhenCapturedChangesIntoDifferentUnitType());
       for (final Unit u : toReplace) {
         final LinkedHashMap<String, Tuple<String, IntegerMap<UnitType>>> map =
             UnitAttachment.get(u.getType()).getWhenCapturedChangesInto();
@@ -1162,7 +1162,7 @@ public class BattleTracker implements java.io.Serializable {
   private static List<Unit> getSortedDefendingUnits(final IDelegateBridge bridge, final GameData gameData,
       final Territory territory, final List<Unit> defenders) {
     final List<Unit> sortedUnitsList = new ArrayList<>(Match.getMatches(defenders,
-        Matches.UnitCanBeInBattle(true, !territory.isWater(), 1, false, true, true)));
+        Matches.unitCanBeInBattle(true, !territory.isWater(), 1, false, true, true)));
     Collections.sort(sortedUnitsList,
         new UnitBattleComparator(false, BattleCalculator.getCostsForTUV(bridge.getPlayerID(), gameData),
         TerritoryEffectHelper.getEffects(territory), gameData, false, false));

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -142,7 +142,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     if (Match.someMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
       final Collection<Unit> unitsWhichConsume = Match.getMatches(placeableUnits, Matches.UnitConsumesUnitsOnCreation);
       for (final Unit unit : unitsWhichConsume) {
-        if (Matches.UnitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
+        if (Matches.unitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
           placeableUnits.remove(unit);
         }
       }

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -321,7 +321,7 @@ public class Matches {
     };
   }
 
-  static Match<Unit> UnitCanBeGivenByTerritoryTo(final PlayerID player) {
+  static Match<Unit> unitCanBeGivenByTerritoryTo(final PlayerID player) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit o) {
@@ -332,7 +332,7 @@ public class Matches {
     };
   }
 
-  static Match<Unit> UnitCanBeCapturedOnEnteringToInThisTerritory(final PlayerID player, final Territory terr,
+  static Match<Unit> unitCanBeCapturedOnEnteringToInThisTerritory(final PlayerID player, final Territory terr,
       final GameData data) {
     return new Match<Unit>() {
       @Override
@@ -366,18 +366,18 @@ public class Matches {
     };
   }
 
-  static Match<Unit> UnitDestroyedWhenCapturedByOrFrom(final PlayerID playerBy) {
+  static Match<Unit> unitDestroyedWhenCapturedByOrFrom(final PlayerID playerBy) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit o) {
         final Match<Unit> byOrFrom =
-            new CompositeMatchOr<>(UnitDestroyedWhenCapturedBy(playerBy), UnitDestroyedWhenCapturedFrom());
+            new CompositeMatchOr<>(unitDestroyedWhenCapturedBy(playerBy), unitDestroyedWhenCapturedFrom());
         return byOrFrom.match(o);
       }
     };
   }
 
-  private static Match<Unit> UnitDestroyedWhenCapturedBy(final PlayerID playerBy) {
+  private static Match<Unit> unitDestroyedWhenCapturedBy(final PlayerID playerBy) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -395,7 +395,7 @@ public class Matches {
     };
   }
 
-  private static Match<Unit> UnitDestroyedWhenCapturedFrom() {
+  private static Match<Unit> unitDestroyedWhenCapturedFrom() {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -434,7 +434,7 @@ public class Matches {
     }
   };
 
-  static Match<Unit> UnitIsAtMaxDamageOrNotCanBeDamaged(final Territory t) {
+  static Match<Unit> unitIsAtMaxDamageOrNotCanBeDamaged(final Territory t) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unit) {
@@ -452,7 +452,7 @@ public class Matches {
     };
   }
 
-  static Match<Unit> UnitIsLegalBombingTargetBy(final Unit bomberOrRocket) {
+  static Match<Unit> unitIsLegalBombingTargetBy(final Unit bomberOrRocket) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unit) {
@@ -525,11 +525,11 @@ public class Matches {
   /**
    * Checks for having attack/defense and for providing support. Does not check for having AA ability.
    */
-  public static Match<Unit> UnitIsSupporterOrHasCombatAbility(final boolean attack) {
+  public static Match<Unit> unitIsSupporterOrHasCombatAbility(final boolean attack) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unit) {
-        return Matches.UnitTypeIsSupporterOrHasCombatAbility(attack, unit.getOwner()).match(unit.getType());
+        return Matches.unitTypeIsSupporterOrHasCombatAbility(attack, unit.getOwner()).match(unit.getType());
       }
     };
   }
@@ -537,7 +537,7 @@ public class Matches {
   /**
    * Checks for having attack/defense and for providing support. Does not check for having AA ability.
    */
-  private static Match<UnitType> UnitTypeIsSupporterOrHasCombatAbility(final boolean attack, final PlayerID player) {
+  private static Match<UnitType> unitTypeIsSupporterOrHasCombatAbility(final boolean attack, final PlayerID player) {
     return new Match<UnitType>() {
       @Override
       public boolean match(final UnitType ut) {
@@ -555,7 +555,7 @@ public class Matches {
     };
   }
 
-  public static Match<UnitSupportAttachment> UnitSupportAttachmentCanBeUsedByPlayer(final PlayerID player) {
+  public static Match<UnitSupportAttachment> unitSupportAttachmentCanBeUsedByPlayer(final PlayerID player) {
     return new Match<UnitSupportAttachment>() {
       @Override
       public boolean match(final UnitSupportAttachment usa) {
@@ -620,7 +620,7 @@ public class Matches {
     }
   };
 
-  static Match<Unit> UnitIsNotInfrastructureAndNotCapturedOnEntering(final PlayerID player,
+  static Match<Unit> unitIsNotInfrastructureAndNotCapturedOnEntering(final PlayerID player,
       final Territory terr, final GameData data) {
     return new Match<Unit>() {
       @Override
@@ -628,7 +628,7 @@ public class Matches {
         final Unit unit = obj;
         final UnitAttachment ua = UnitAttachment.get(unit.getType());
         return !ua.getIsInfrastructure()
-            && !UnitCanBeCapturedOnEnteringToInThisTerritory(player, terr, data).match(unit);
+            && !unitCanBeCapturedOnEnteringToInThisTerritory(player, terr, data).match(unit);
       }
     };
   }
@@ -682,7 +682,7 @@ public class Matches {
     }
   };
 
-  static Match<Territory> TerritoryHasOwnedCarrier(final PlayerID player) {
+  static Match<Territory> territoryHasOwnedCarrier(final PlayerID player) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -692,7 +692,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitIsAlliedCarrier(final PlayerID player, final GameData data) {
+  public static Match<Unit> unitIsAlliedCarrier(final PlayerID player, final GameData data) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit obj) {
@@ -868,7 +868,7 @@ public class Matches {
     }
   };
 
-  public static Match<Unit> UnitIsAAthatCanHitTheseUnits(final Collection<Unit> targets,
+  public static Match<Unit> unitIsAaThatCanHitTheseUnits(final Collection<Unit> targets,
       final Match<Unit> typeOfAa, final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed) {
     return new Match<Unit>() {
       @Override
@@ -889,7 +889,7 @@ public class Matches {
     };
   }
 
-  static Match<Unit> UnitIsAAofTypeAA(final String typeAa) {
+  static Match<Unit> unitIsAaOfTypeAa(final String typeAa) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit obj) {
@@ -905,7 +905,7 @@ public class Matches {
     }
   };
 
-  private static Match<Unit> UnitIsAAthatWillNotFireIfPresentEnemyUnits(final Collection<Unit> enemyUnitsPresent) {
+  private static Match<Unit> unitIsAaThatWillNotFireIfPresentEnemyUnits(final Collection<Unit> enemyUnitsPresent) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit obj) {
@@ -920,7 +920,7 @@ public class Matches {
     };
   }
 
-  private static Match<UnitType> UnitTypeIsAAthatCanFireOnRound(final int battleRoundNumber) {
+  private static Match<UnitType> unitTypeIsAaThatCanFireOnRound(final int battleRoundNumber) {
     return new Match<UnitType>() {
       @Override
       public boolean match(final UnitType obj) {
@@ -930,23 +930,23 @@ public class Matches {
     };
   }
 
-  private static Match<Unit> UnitIsAAthatCanFireOnRound(final int battleRoundNumber) {
+  private static Match<Unit> unitIsAaThatCanFireOnRound(final int battleRoundNumber) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit obj) {
-        return UnitTypeIsAAthatCanFireOnRound(battleRoundNumber).match(obj.getType());
+        return unitTypeIsAaThatCanFireOnRound(battleRoundNumber).match(obj.getType());
       }
     };
   }
 
-  static Match<Unit> UnitIsAAthatCanFire(final Collection<Unit> unitsMovingOrAttacking,
+  static Match<Unit> unitIsAaThatCanFire(final Collection<Unit> unitsMovingOrAttacking,
       final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed, final PlayerID playerMovingOrAttacking,
       final Match<Unit> typeOfAa, final int battleRoundNumber, final boolean defending, final GameData data) {
     return new CompositeMatchAnd<>(Matches.enemyUnit(playerMovingOrAttacking, data),
         Matches.unitIsBeingTransported().invert(),
-        Matches.UnitIsAAthatCanHitTheseUnits(unitsMovingOrAttacking, typeOfAa, airborneTechTargetsAllowed),
-        Matches.UnitIsAAthatWillNotFireIfPresentEnemyUnits(unitsMovingOrAttacking).invert(),
-        Matches.UnitIsAAthatCanFireOnRound(battleRoundNumber),
+        Matches.unitIsAaThatCanHitTheseUnits(unitsMovingOrAttacking, typeOfAa, airborneTechTargetsAllowed),
+        Matches.unitIsAaThatWillNotFireIfPresentEnemyUnits(unitsMovingOrAttacking).invert(),
+        Matches.unitIsAaThatCanFireOnRound(battleRoundNumber),
         (defending ? UnitAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero
             : UnitOffensiveAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero));
   }
@@ -1265,7 +1265,7 @@ public class Matches {
               continue;
             }
             if (data.getMap().getDistance(t, current,
-                Matches.TerritoryIsPassableAndNotRestricted(player, data)) != -1) {
+                Matches.territoryIsPassableAndNotRestricted(player, data)) != -1) {
               return true;
             }
           }
@@ -1292,7 +1292,7 @@ public class Matches {
               continue;
             }
             if (data.getMap().getDistance(t, current,
-                Matches.TerritoryIsNotImpassableToLandUnits(player, data)) != -1) {
+                Matches.territoryIsNotImpassableToLandUnits(player, data)) != -1) {
               return true;
             }
           }
@@ -1474,7 +1474,7 @@ public class Matches {
         if (!TerritoryIsWater.match(t)) {
           return false;
         }
-        return TerritoryIsPassableAndNotRestricted(player, data).match(t);
+        return territoryIsPassableAndNotRestricted(player, data).match(t);
       }
     };
   }
@@ -1487,7 +1487,7 @@ public class Matches {
         if (!areNeutralsPassableByAir && TerritoryIsNeutralButNotWater.match(t)) {
           return false;
         }
-        if (!TerritoryIsPassableAndNotRestricted(player, data).match(t)) {
+        if (!territoryIsPassableAndNotRestricted(player, data).match(t)) {
           return false;
         }
         return !(TerritoryIsLand.match(t)
@@ -1496,7 +1496,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> TerritoryIsPassableAndNotRestricted(final PlayerID player, final GameData data) {
+  public static Match<Territory> territoryIsPassableAndNotRestricted(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -1518,13 +1518,13 @@ public class Matches {
     };
   }
 
-  private static Match<Territory> TerritoryIsImpassableToLandUnits(final PlayerID player, final GameData data) {
+  private static Match<Territory> territoryIsImpassableToLandUnits(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
         if (t.isWater()) {
           return true;
-        } else if (Matches.TerritoryIsPassableAndNotRestricted(player, data).invert().match(t)) {
+        } else if (Matches.territoryIsPassableAndNotRestricted(player, data).invert().match(t)) {
           return true;
         }
         return false;
@@ -1532,11 +1532,11 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> TerritoryIsNotImpassableToLandUnits(final PlayerID player, final GameData data) {
+  public static Match<Territory> territoryIsNotImpassableToLandUnits(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        return TerritoryIsImpassableToLandUnits(player, data).invert().match(t);
+        return territoryIsImpassableToLandUnits(player, data).invert().match(t);
       }
     };
   }
@@ -1553,7 +1553,7 @@ public class Matches {
    * canMoveAirUnitsOverOwnedLand,
    * canLandAirUnitsOnOwnedLand, canMoveIntoDuringCombatMove, etc).
    */
-  public static Match<Territory> TerritoryIsPassableAndNotRestrictedAndOkByRelationships(
+  public static Match<Territory> territoryIsPassableAndNotRestrictedAndOkByRelationships(
       final PlayerID playerWhoOwnsAllTheUnitsMoving, final GameData data, final boolean isCombatMovePhase,
       final boolean hasLandUnitsNotBeingTransportedOrBeingLoaded, final boolean hasSeaUnitsNotBeingTransported,
       final boolean hasAirUnitsNotBeingTransported, final boolean isLandingZoneOnLandForAirUnits) {
@@ -1623,15 +1623,15 @@ public class Matches {
     }
   };
 
-  public static Match<Unit> UnitHasEnoughMovementForRoutes(final List<Route> route) {
-    return UnitHasEnoughMovementForRoute(Route.create(route));
+  public static Match<Unit> unitHasEnoughMovementForRoutes(final List<Route> route) {
+    return unitHasEnoughMovementForRoute(Route.create(route));
   }
 
-  public static Match<Unit> UnitHasEnoughMovementForRoute(final List<Territory> territories) {
-    return UnitHasEnoughMovementForRoute(new Route(territories));
+  public static Match<Unit> unitHasEnoughMovementForRoute(final List<Territory> territories) {
+    return unitHasEnoughMovementForRoute(new Route(territories));
   }
 
-  public static Match<Unit> UnitHasEnoughMovementForRoute(final Route route) {
+  public static Match<Unit> unitHasEnoughMovementForRoute(final Route route) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unit) {
@@ -1695,11 +1695,11 @@ public class Matches {
   public static final Match<Unit> UnitCanMove = new Match<Unit>() {
     @Override
     public boolean match(final Unit u) {
-      return UnitTypeCanMove(u.getOwner()).match(u.getType());
+      return unitTypeCanMove(u.getOwner()).match(u.getType());
     }
   };
 
-  private static Match<UnitType> UnitTypeCanMove(final PlayerID player) {
+  private static Match<UnitType> unitTypeCanMove(final PlayerID player) {
     return new Match<UnitType>() {
       @Override
       public boolean match(final UnitType obj) {
@@ -1710,11 +1710,11 @@ public class Matches {
 
   public static final Match<Unit> UnitIsStatic = new InverseMatch<>(UnitCanMove);
 
-  public static Match<UnitType> UnitTypeIsStatic(final PlayerID id) {
+  public static Match<UnitType> unitTypeIsStatic(final PlayerID id) {
     return new Match<UnitType>() {
       @Override
-      public boolean match(final UnitType uT) {
-        return !UnitTypeCanMove(id).match(uT);
+      public boolean match(final UnitType unitType) {
+        return !unitTypeCanMove(id).match(unitType);
       }
     };
   }
@@ -1827,14 +1827,14 @@ public class Matches {
     };
   }
 
-  private static Match<Unit> unitIsEnemyAAforAnything(final PlayerID player, final GameData data) {
+  private static Match<Unit> unitIsEnemyAaForAnything(final PlayerID player, final GameData data) {
     final CompositeMatch<Unit> comp = new CompositeMatchAnd<>();
     comp.add(UnitIsAAforAnything);
     comp.add(enemyUnit(player, data));
     return comp;
   }
 
-  private static Match<Unit> unitIsEnemyAAforCombat(final PlayerID player, final GameData data) {
+  private static Match<Unit> unitIsEnemyAaForCombat(final PlayerID player, final GameData data) {
     final CompositeMatch<Unit> comp = new CompositeMatchAnd<>();
     comp.add(UnitIsAAforCombatOnly);
     comp.add(enemyUnit(player, data));
@@ -1898,7 +1898,7 @@ public class Matches {
         if (t.getOwner().equals(PlayerID.NULL_PLAYERID) && t.isWater()) {
           return false;
         }
-        if (!Matches.TerritoryIsPassableAndNotRestricted(player, data).match(t)) {
+        if (!Matches.territoryIsPassableAndNotRestricted(player, data).match(t)) {
           return false;
         }
         return data.getRelationshipTracker().isAtWar(player, t.getOwner());
@@ -1906,7 +1906,7 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> TerritoryIsBlitzable(final PlayerID player, final GameData data) {
+  public static Match<Territory> territoryIsBlitzable(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -2061,20 +2061,20 @@ public class Matches {
     };
   }
 
-  public static Match<Territory> territoryHasEnemyAAforAnything(final PlayerID player, final GameData data) {
+  public static Match<Territory> territoryHasEnemyAaForAnything(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        return t.getUnits().someMatch(unitIsEnemyAAforAnything(player, data));
+        return t.getUnits().someMatch(unitIsEnemyAaForAnything(player, data));
       }
     };
   }
 
-  public static Match<Territory> territoryHasEnemyAAforCombatOnly(final PlayerID player, final GameData data) {
+  public static Match<Territory> territoryHasEnemyAaForCombatOnly(final PlayerID player, final GameData data) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        return t.getUnits().someMatch(Matches.unitIsEnemyAAforCombat(player, data));
+        return t.getUnits().someMatch(Matches.unitIsEnemyAaForCombat(player, data));
       }
     };
   }
@@ -2367,7 +2367,7 @@ public class Matches {
     }
   };
 
-  static Match<Unit> UnitCanRepairThisUnit(final Unit damagedUnit) {
+  static Match<Unit> unitCanRepairThisUnit(final Unit damagedUnit) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unitCanRepair) {
@@ -2393,7 +2393,7 @@ public class Matches {
    *         (It will also return true if this unit is Sea and an adjacent land territory has a land unit that can
    *         repair this unit.)
    */
-  public static Match<Unit> UnitCanBeRepairedByFacilitiesInItsTerritory(final Territory territory,
+  public static Match<Unit> unitCanBeRepairedByFacilitiesInItsTerritory(final Territory territory,
       final PlayerID player, final GameData data) {
     return new Match<Unit>() {
       @Override
@@ -2404,7 +2404,7 @@ public class Matches {
           return false;
         }
         final Match<Unit> repairUnit = new CompositeMatchAnd<>(Matches.alliedUnit(player, data),
-            Matches.UnitCanRepairOthers, Matches.UnitCanRepairThisUnit(damagedUnit));
+            Matches.UnitCanRepairOthers, Matches.unitCanRepairThisUnit(damagedUnit));
         if (Match.someMatch(territory.getUnits().getUnits(), repairUnit)) {
           return true;
         }
@@ -2443,7 +2443,7 @@ public class Matches {
     }
   };
 
-  static Match<Unit> UnitCanGiveBonusMovementToThisUnit(final Unit unitWhichWillGetBonus) {
+  static Match<Unit> unitCanGiveBonusMovementToThisUnit(final Unit unitWhichWillGetBonus) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unitCanGiveBonusMovement) {
@@ -2471,13 +2471,13 @@ public class Matches {
    *         bonus movement to
    *         this unit.)
    */
-  public static Match<Unit> UnitCanBeGivenBonusMovementByFacilitiesInItsTerritory(final Territory territory,
+  public static Match<Unit> unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(final Territory territory,
       final PlayerID player, final GameData data) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unitWhichWillGetBonus) {
         final Match<Unit> givesBonusUnit = new CompositeMatchAnd<>(Matches.alliedUnit(player, data),
-            UnitCanGiveBonusMovementToThisUnit(unitWhichWillGetBonus));
+            unitCanGiveBonusMovementToThisUnit(unitWhichWillGetBonus));
         if (Match.someMatch(territory.getUnits().getUnits(), givesBonusUnit)) {
           return true;
         }
@@ -2580,7 +2580,7 @@ public class Matches {
     }
   };
 
-  static Match<Unit> UnitWhichConsumesUnitsHasRequiredUnits(final Collection<Unit> unitsInTerritoryAtStartOfTurn) {
+  static Match<Unit> unitWhichConsumesUnitsHasRequiredUnits(final Collection<Unit> unitsInTerritoryAtStartOfTurn) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unitWhichRequiresUnits) {
@@ -2622,7 +2622,7 @@ public class Matches {
     }
   };
 
-  public static Match<Unit> UnitWhichRequiresUnitsHasRequiredUnitsInList(
+  public static Match<Unit> unitWhichRequiresUnitsHasRequiredUnitsInList(
       final Collection<Unit> unitsInTerritoryAtStartOfTurn) {
     return new Match<Unit>() {
       @Override
@@ -2762,7 +2762,7 @@ public class Matches {
   /**
    * If the territory is not land, returns true. Else, tests relationship of the owners.
    */
-  public static Match<Territory> TerritoryAllowsCanMoveLandUnitsOverOwnedLand(final PlayerID ownerOfUnitsMoving,
+  public static Match<Territory> territoryAllowsCanMoveLandUnitsOverOwnedLand(final PlayerID ownerOfUnitsMoving,
       final GameData data) {
     return new Match<Territory>() {
       @Override
@@ -2790,7 +2790,7 @@ public class Matches {
   /**
    * If the territory is not land, returns true. Else, tests relationship of the owners.
    */
-  public static Match<Territory> TerritoryAllowsCanMoveAirUnitsOverOwnedLand(final PlayerID ownerOfUnitsMoving,
+  public static Match<Territory> territoryAllowsCanMoveAirUnitsOverOwnedLand(final PlayerID ownerOfUnitsMoving,
       final GameData data) {
     return new Match<Territory>() {
       @Override
@@ -2897,7 +2897,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitIsOwnedAndIsFactoryOrCanProduceUnits(final PlayerID player) {
+  public static Match<Unit> unitIsOwnedAndIsFactoryOrCanProduceUnits(final PlayerID player) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -2906,7 +2906,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitCanReceivesAbilityWhenWith() {
+  public static Match<Unit> unitCanReceiveAbilityWhenWith() {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -2915,7 +2915,7 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitCanReceivesAbilityWhenWith(final String filterForAbility,
+  public static Match<Unit> unitCanReceiveAbilityWhenWith(final String filterForAbility,
       final String filterForUnitType) {
     return new Match<Unit>() {
       @Override
@@ -2931,7 +2931,7 @@ public class Matches {
     };
   }
 
-  private static Match<Unit> UnitHasWhenCombatDamagedEffect() {
+  private static Match<Unit> unitHasWhenCombatDamagedEffect() {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -2940,11 +2940,11 @@ public class Matches {
     };
   }
 
-  static Match<Unit> UnitHasWhenCombatDamagedEffect(final String filterForEffect) {
+  static Match<Unit> unitHasWhenCombatDamagedEffect(final String filterForEffect) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        if (!UnitHasWhenCombatDamagedEffect().match(u)) {
+        if (!unitHasWhenCombatDamagedEffect().match(u)) {
           return false;
         }
         final TripleAUnit taUnit = (TripleAUnit) u;
@@ -2967,7 +2967,7 @@ public class Matches {
     };
   }
 
-  static Match<Territory> TerritoryHasWhenCapturedByGoesTo() {
+  static Match<Territory> territoryHasWhenCapturedByGoesTo() {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -2980,7 +2980,7 @@ public class Matches {
     };
   }
 
-  static Match<Unit> UnitWhenCapturedChangesIntoDifferentUnitType() {
+  static Match<Unit> unitWhenCapturedChangesIntoDifferentUnitType() {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
@@ -2989,7 +2989,7 @@ public class Matches {
     };
   }
 
-  public static Match<AbstractUserActionAttachment> AbstractUserActionAttachmentCanBeAttempted(
+  public static Match<AbstractUserActionAttachment> abstractUserActionAttachmentCanBeAttempted(
       final HashMap<ICondition, Boolean> testedConditions) {
     return new Match<AbstractUserActionAttachment>() {
       @Override
@@ -2999,7 +2999,7 @@ public class Matches {
     };
   }
 
-  public static Match<PoliticalActionAttachment> PoliticalActionHasCostBetween(final int greaterThanEqualTo,
+  public static Match<PoliticalActionAttachment> politicalActionHasCostBetween(final int greaterThanEqualTo,
       final int lessThanEqualTo) {
     return new Match<PoliticalActionAttachment>() {
       @Override
@@ -3026,7 +3026,7 @@ public class Matches {
   /**
    * Accounts for OccupiedTerrOf. Returns false if there is no territory attachment (like if it is water).
    */
-  public static Match<Territory> TerritoryIsOriginallyOwnedBy(final PlayerID player) {
+  public static Match<Territory> territoryIsOriginallyOwnedBy(final PlayerID player) {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
@@ -3208,7 +3208,7 @@ public class Matches {
         if (t.getOwner().equals(PlayerID.NULL_PLAYERID) && t.isWater()) {
           return false;
         }
-        if (!Matches.TerritoryIsPassableAndNotRestricted(attacker, t.getData()).match(t)) {
+        if (!Matches.territoryIsPassableAndNotRestricted(attacker, t.getData()).match(t)) {
           return false;
         }
         return RelationshipTypeCanTakeOverOwnedTerritory
@@ -3232,19 +3232,19 @@ public class Matches {
     };
   }
 
-  public static Match<Unit> UnitCanBeInBattle(final boolean attack, final boolean isLandBattle,
+  public static Match<Unit> unitCanBeInBattle(final boolean attack, final boolean isLandBattle,
       final int battleRound, final boolean includeAttackersThatCanNotMove,
       final boolean doNotIncludeAa, final boolean doNotIncludeBombardingSeaUnits) {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        return Matches.UnitTypeCanBeInBattle(attack, isLandBattle, u.getOwner(), battleRound,
+        return Matches.unitTypeCanBeInBattle(attack, isLandBattle, u.getOwner(), battleRound,
             includeAttackersThatCanNotMove, doNotIncludeAa, doNotIncludeBombardingSeaUnits).match(u.getType());
       }
     };
   }
 
-  public static Match<UnitType> UnitTypeCanBeInBattle(final boolean attack, final boolean isLandBattle,
+  public static Match<UnitType> unitTypeCanBeInBattle(final boolean attack, final boolean isLandBattle,
       final PlayerID player, final int battleRound, final boolean includeAttackersThatCanNotMove,
       final boolean doNotIncludeAa, final boolean doNotIncludeBombardingSeaUnits) {
     return new Match<UnitType>() {
@@ -3257,7 +3257,7 @@ public class Matches {
         // combat abilities.
         final Match<UnitType> supporterOrNotInfrastructure =
             new CompositeMatchOr<>(Matches.UnitTypeIsInfrastructure.invert(),
-                Matches.UnitTypeIsSupporterOrHasCombatAbility(attack, player));
+                Matches.unitTypeIsSupporterOrHasCombatAbility(attack, player));
         final Match<UnitType> combat;
         if (attack) {
           // AND match
@@ -3265,7 +3265,7 @@ public class Matches {
           attackMatchAnd.add(supporterOrNotInfrastructure);
           if (!includeAttackersThatCanNotMove) {
             attackMatchAnd.add(Matches.UnitTypeCanNotMoveDuringCombatMove.invert());
-            attackMatchAnd.add(Matches.UnitTypeCanMove(player));
+            attackMatchAnd.add(Matches.unitTypeCanMove(player));
           }
           if (isLandBattle) {
             if (doNotIncludeBombardingSeaUnits) {
@@ -3284,7 +3284,7 @@ public class Matches {
             final CompositeMatch<UnitType> defenseMatchOr = new CompositeMatchOr<>();
             if (!doNotIncludeAa) {
               defenseMatchOr.add(new CompositeMatchAnd<>(Matches.UnitTypeIsAAforCombatOnly,
-                  Matches.UnitTypeIsAAthatCanFireOnRound(battleRound)));
+                  Matches.unitTypeIsAaThatCanFireOnRound(battleRound)));
             }
             defenseMatchOr.add(supporterOrNotInfrastructure);
             defenseMatchAnd.add(defenseMatchOr);

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -321,7 +321,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final GameData data = aBridge.getData();
     final Match<Unit> crippledAlliedCarriersMatch = new CompositeMatchAnd<>(Matches.isUnitAllied(player, data),
         Matches.unitIsOwnedBy(player).invert(), Matches.UnitIsCarrier,
-        Matches.UnitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
+        Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
     final Match<Unit> ownedFightersMatch =
         new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitIsAir,
             Matches.UnitCanLandOnCarrier, Matches.unitHasMovementLeft);
@@ -355,14 +355,14 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
       for (final Unit u : t.getUnits().getUnits()) {
-        if (Matches.UnitCanBeGivenBonusMovementByFacilitiesInItsTerritory(t, player, data).match(u)) {
+        if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(t, player, data).match(u)) {
           if (!Matches.isUnitAllied(player, data).match(u)) {
             continue;
           }
           int bonusMovement = Integer.MIN_VALUE;
           final Collection<Unit> givesBonusUnits = new ArrayList<>();
           final Match<Unit> givesBonusUnit = new CompositeMatchAnd<>(Matches.alliedUnit(player, data),
-              Matches.UnitCanGiveBonusMovementToThisUnit(u));
+              Matches.unitCanGiveBonusMovementToThisUnit(u));
           givesBonusUnits.addAll(Match.getMatches(t.getUnits().getUnits(), givesBonusUnit));
           if (Matches.UnitIsSea.match(u)) {
             final Match<Unit> givesBonusUnitLand = new CompositeMatchAnd<>(givesBonusUnit, Matches.UnitIsLand);
@@ -417,7 +417,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
         }
       } else {
         damaged = new HashSet<>(current.getUnits().getMatches(new CompositeMatchAnd<>(damagedUnitsOwned,
-            Matches.UnitCanBeRepairedByFacilitiesInItsTerritory(current, player, data))));
+            Matches.unitCanBeRepairedByFacilitiesInItsTerritory(current, player, data))));
       }
       if (!damaged.isEmpty()) {
         damagedMap.put(current, damaged);
@@ -449,7 +449,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     // now if damaged includes any carriers that are repairing, and have damaged abilities set for not allowing air
     // units to leave while damaged, we need to remove those air units now
     final Collection<Unit> damagedCarriers = Match.getMatches(fullyRepaired.keySet(),
-        Matches.UnitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
+        Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
 
     // now cycle through those now-repaired carriers, and remove allied air from being dependent
     final CompositeChange clearAlliedAir = new CompositeChange();
@@ -476,7 +476,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final Set<Unit> repairUnitsForThisUnit = new HashSet<>();
     final PlayerID owner = unitToBeRepaired.getOwner();
     final Match<Unit> repairUnit = new CompositeMatchAnd<>(Matches.alliedUnit(owner, data),
-        Matches.UnitCanRepairOthers, Matches.UnitCanRepairThisUnit(unitToBeRepaired));
+        Matches.UnitCanRepairOthers, Matches.unitCanRepairThisUnit(unitToBeRepaired));
     repairUnitsForThisUnit.addAll(territoryUnitIsIn.getUnits().getMatches(repairUnit));
     if (Matches.UnitIsSea.match(unitToBeRepaired)) {
       final Match<Unit> repairUnitLand = new CompositeMatchAnd<>(repairUnit, Matches.UnitIsLand);

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -173,7 +173,7 @@ public class MovePerformer implements Serializable {
           // could it be a bombing raid
           final Collection<Unit> enemyUnits = route.getEnd().getUnits().getMatches(Matches.enemyUnit(id, data));
           final Collection<Unit> enemyTargetsTotal = Match.getMatches(enemyUnits,
-              new CompositeMatchAnd<>(Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(route.getEnd()).invert(),
+              new CompositeMatchAnd<>(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(route.getEnd()).invert(),
                   Matches.unitIsBeingTransported().invert()));
           final CompositeMatchOr<Unit> allBombingRaid = new CompositeMatchOr<>(Matches.UnitIsStrategicBomber);
           final boolean canCreateAirBattle =
@@ -252,7 +252,7 @@ public class MovePerformer implements Serializable {
                     Matches
                         .territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(
                             id),
-                    Matches.TerritoryIsBlitzable(id, data)))) {
+                    Matches.territoryIsBlitzable(id, data)))) {
               if (Matches.isTerritoryEnemy(id, data).match(t) || Matches.territoryHasEnemyUnits(id, data).match(t)) {
                 continue;
               }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -237,7 +237,7 @@ public class MoveValidator {
         && Matches.isAtWar(route.getStart().getOwner(), data).match(player)
         && (route.someMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
             .isTerritoryEnemy(player, data).invert(), false))) {
-      if (!Matches.TerritoryIsBlitzable(player, data).match(route.getStart())
+      if (!Matches.territoryIsBlitzable(player, data).match(route.getStart())
           && !Match.allMatch(units, Matches.UnitIsAir)) {
         return result.setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
       }
@@ -253,7 +253,7 @@ public class MoveValidator {
         && !Matches.isAtWar(route.getStart().getOwner(), data).match(player)
         && (route.someMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
             .isTerritoryEnemy(player, data).invert(), false))) {
-      if (!Matches.TerritoryIsBlitzable(player, data).match(route.getStart())
+      if (!Matches.territoryIsBlitzable(player, data).match(route.getStart())
           && !Match.allMatch(units, Matches.UnitIsAir)) {
         return result.setErrorReturnResult("Cannot blitz out of a battle into enemy territory");
       }
@@ -283,7 +283,7 @@ public class MoveValidator {
         if (data.getRelationshipTracker().isAtWar(current.getOwner(), player)
             || AbstractMoveDelegate.getBattleTracker(data).wasConquered(current)) {
           enemyCount++;
-          allEnemyBlitzable &= Matches.TerritoryIsBlitzable(player, data).match(current);
+          allEnemyBlitzable &= Matches.territoryIsBlitzable(player, data).match(current);
         }
       }
       if (enemyCount > 0 && !allEnemyBlitzable) {
@@ -366,7 +366,7 @@ public class MoveValidator {
     if (route.someMatch(Matches.TerritoryIsImpassable)) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_IMPASSABLE);
     }
-    if (!route.someMatch(Matches.TerritoryIsPassableAndNotRestricted(player, data))) {
+    if (!route.someMatch(Matches.territoryIsPassableAndNotRestricted(player, data))) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_RESTRICTED);
     }
     final CompositeMatch<Territory> neutralOrEnemy =
@@ -551,7 +551,7 @@ public class MoveValidator {
       final Match<Unit> hasEnoughMovementForRoute;
       try {
         data.acquireReadLock();
-        hasEnoughMovementForRoute = Matches.UnitHasEnoughMovementForRoute(route);
+        hasEnoughMovementForRoute = Matches.unitHasEnoughMovementForRoute(route);
       } finally {
         data.releaseReadLock();
       }
@@ -593,7 +593,7 @@ public class MoveValidator {
             mechanizedSupportAvailable--;
           } else if (Matches.unitIsOwnedBy(player).invert().match(unit) && Matches.alliedUnit(player, data).match(unit)
               && Matches.UnitTypeCanLandOnCarrier.match(unit.getType())
-              && Match.someMatch(moveTest, Matches.UnitIsAlliedCarrier(unit.getOwner(), data))) {
+              && Match.someMatch(moveTest, Matches.unitIsAlliedCarrier(unit.getOwner(), data))) {
             // this is so that if the unit is owned by any ally and it is cargo, then it will not count.
             // (shouldn't it be a dependant in this case??)
           } else {
@@ -1497,19 +1497,19 @@ public class MoveValidator {
     // No neutral countries on route predicate
     final Match<Territory> noNeutral = Matches.TerritoryIsNeutralButNotWater.invert();
     // No aa guns on route predicate
-    final Match<Territory> noAa = Matches.territoryHasEnemyAAforAnything(player, data).invert();
+    final Match<Territory> noAa = Matches.territoryHasEnemyAaForAnything(player, data).invert();
     // no enemy units on the route predicate
     final Match<Territory> noEnemy = Matches.territoryHasEnemyUnits(player, data).invert();
     // no impassable or restricted territories
     final CompositeMatchAnd<Territory> noImpassable =
-        new CompositeMatchAnd<>(Matches.TerritoryIsPassableAndNotRestricted(player, data));
+        new CompositeMatchAnd<>(Matches.territoryIsPassableAndNotRestricted(player, data));
     // if we have air or land, we don't want to move over territories owned by players who's relationships will not let
     // us move into them
     if (hasAir) {
-      noImpassable.add(Matches.TerritoryAllowsCanMoveAirUnitsOverOwnedLand(player, data));
+      noImpassable.add(Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data));
     }
     if (hasLand) {
-      noImpassable.add(Matches.TerritoryAllowsCanMoveLandUnitsOverOwnedLand(player, data));
+      noImpassable.add(Matches.territoryAllowsCanMoveLandUnitsOverOwnedLand(player, data));
     }
     // now find the default route
     Route defaultRoute;

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -301,7 +301,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     canFire.addAll(m_defendingWaitingToDie);
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
-    m_defendingAA = Match.getMatches(canFire, Matches.UnitIsAAthatCanFire(m_attackingUnits, airborneTechTargetsAllowed,
+    m_defendingAA = Match.getMatches(canFire, Matches.unitIsAaThatCanFire(m_attackingUnits, airborneTechTargetsAllowed,
         m_attacker, Matches.UnitIsAAforCombatOnly, m_round, true, m_data));
     // comes ordered alphabetically
     m_defendingAAtypes = UnitAttachment.getAllOfTypeAAs(m_defendingAA);
@@ -314,7 +314,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     canFire.addAll(m_attackingUnits);
     canFire.addAll(m_attackingWaitingToDie);
     // no airborne targets for offensive aa
-    m_offensiveAA = Match.getMatches(canFire, Matches.UnitIsAAthatCanFire(m_defendingUnits,
+    m_offensiveAA = Match.getMatches(canFire, Matches.unitIsAaThatCanFire(m_defendingUnits,
         new HashMap<>(), m_defender, Matches.UnitIsAAforCombatOnly, m_round, false, m_data));
     // comes ordered alphabetically
     m_offensiveAAtypes = UnitAttachment.getAllOfTypeAAs(m_offensiveAA);
@@ -828,7 +828,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        final Match<Unit> unitList = Matches.UnitCanBeInBattle(true, !m_battleSite.isWater(), 1, false, true, true);
+        final Match<Unit> unitList = Matches.unitCanBeInBattle(true, !m_battleSite.isWater(), 1, false, true, true);
         final List<Unit> sortedAttackingUnits = new ArrayList<>(Match.getMatches(m_attackingUnits, unitList));
         Collections.sort(sortedAttackingUnits, new UnitBattleComparator(false,
             BattleCalculator.getCostsForTUV(bridge.getPlayerID(), m_data),
@@ -837,7 +837,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         if (DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedAttackingUnits, m_defendingUnits,
             false, false, m_data, m_battleSite, TerritoryEffectHelper.getEffects(m_battleSite), false, null),
             m_data) > 0) {
-          final Match<Unit> unitList2 = Matches.UnitCanBeInBattle(false, !m_battleSite.isWater(), 1, false, true, true);
+          final Match<Unit> unitList2 = Matches.unitCanBeInBattle(false, !m_battleSite.isWater(), 1, false, true, true);
           final List<Unit> sortedDefendingUnits = new ArrayList<>(Match.getMatches(m_defendingUnits, unitList2));
           Collections.sort(sortedDefendingUnits, new UnitBattleComparator(false,
               BattleCalculator.getCostsForTUV(bridge.getPlayerID(), m_data),
@@ -1821,12 +1821,12 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final boolean hasUnitsThatCanRollLeft;
     if (attacker) {
       hasUnitsThatCanRollLeft = Match.someMatch(m_attackingUnits, new CompositeMatchAnd<>(notSubmergedAndType,
-          Matches.UnitIsSupporterOrHasCombatAbility(attacker)));
+          Matches.unitIsSupporterOrHasCombatAbility(attacker)));
       unitsToKill = Match.getMatches(m_attackingUnits,
           new CompositeMatchAnd<>(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
     } else {
       hasUnitsThatCanRollLeft = Match.someMatch(m_defendingUnits, new CompositeMatchAnd<>(notSubmergedAndType,
-          Matches.UnitIsSupporterOrHasCombatAbility(attacker)));
+          Matches.unitIsSupporterOrHasCombatAbility(attacker)));
       unitsToKill = Match.getMatches(m_defendingUnits,
           new CompositeMatchAnd<>(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
     }
@@ -1834,10 +1834,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final boolean enemyHasUnitsThatCanRollLeft;
     if (enemy) {
       enemyHasUnitsThatCanRollLeft = Match.someMatch(m_attackingUnits,
-          new CompositeMatchAnd<>(notSubmergedAndType, Matches.UnitIsSupporterOrHasCombatAbility(enemy)));
+          new CompositeMatchAnd<>(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
     } else {
       enemyHasUnitsThatCanRollLeft = Match.someMatch(m_defendingUnits,
-          new CompositeMatchAnd<>(notSubmergedAndType, Matches.UnitIsSupporterOrHasCombatAbility(enemy)));
+          new CompositeMatchAnd<>(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
     }
     if (!hasUnitsThatCanRollLeft && enemyHasUnitsThatCanRollLeft) {
       remove(unitsToKill, bridge, m_battleSite, !attacker);
@@ -2033,7 +2033,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // TODO - check within the method for the bombarding limitations
     final Collection<Unit> bombard = getBombardingUnits();
     final Collection<Unit> attacked = Match.getMatches(m_defendingUnits,
-        Matches.UnitIsNotInfrastructureAndNotCapturedOnEntering(m_attacker, m_battleSite, m_data));
+        Matches.unitIsNotInfrastructureAndNotCapturedOnEntering(m_attacker, m_battleSite, m_data));
     // bombarding units cant move after bombarding
     if (!m_headless) {
       final Change change = ChangeFactory.markNoMovementChange(bombard);
@@ -2061,7 +2061,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void fireSuicideUnitsAttack() {
     // TODO: add a global toggle for returning fire (Veqryn)
     final CompositeMatch<Unit> attackableUnits = new CompositeMatchAnd<>(
-        Matches.UnitIsNotInfrastructureAndNotCapturedOnEntering(m_attacker, m_battleSite, m_data),
+        Matches.unitIsNotInfrastructureAndNotCapturedOnEntering(m_attacker, m_battleSite, m_data),
         Matches.UnitIsSuicide.invert(), Matches.unitIsBeingTransported().invert());
     final Collection<Unit> suicideAttackers = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);
     final Collection<Unit> attackedDefenders = Match.getMatches(m_defendingUnits, attackableUnits);
@@ -2192,7 +2192,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       }
       for (final String currentTypeAa : (m_defending ? m_defendingAAtypes : m_offensiveAAtypes)) {
         final Collection<Unit> currentPossibleAa =
-            Match.getMatches((m_defending ? m_defendingAA : m_offensiveAA), Matches.UnitIsAAofTypeAA(currentTypeAa));
+            Match.getMatches((m_defending ? m_defendingAA : m_offensiveAA), Matches.unitIsAaOfTypeAa(currentTypeAa));
         final Set<UnitType> targetUnitTypesForThisTypeAa =
             UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAA(m_data);
         final Set<UnitType> airborneTypesTargettedToo =
@@ -2345,14 +2345,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // still allow infrastructure type units that can provide support have combat abilities
     // remove infrastructure units that can't take part in combat (air/naval bases, etc...)
     unitList.removeAll(Match.getMatches(unitList,
-        Matches.UnitCanBeInBattle(attacking, !m_battleSite.isWater(),
+        Matches.unitCanBeInBattle(attacking, !m_battleSite.isWater(),
             (removeForNextRound ? m_round + 1 : m_round), true, doNotIncludeAa, doNotIncludeSeaBombardmentUnits)
             .invert()));
     // remove any disabled units from combat
     unitList.removeAll(Match.getMatches(unitList, Matches.UnitIsDisabled));
     // remove capturableOnEntering units (veqryn)
     unitList.removeAll(Match.getMatches(unitList,
-        Matches.UnitCanBeCapturedOnEnteringToInThisTerritory(m_attacker, m_battleSite, m_data)));
+        Matches.unitCanBeCapturedOnEnteringToInThisTerritory(m_attacker, m_battleSite, m_data)));
     // remove any allied air units that are stuck on damaged carriers (veqryn)
     unitList.removeAll(Match.getMatches(unitList, new CompositeMatchAnd<>(Matches.unitIsBeingTransported(),
         Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
@@ -2668,7 +2668,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         final TripleAUnit taUnit = (TripleAUnit) fighter;
         if (taUnit.getTransportedBy() != null) {
           final Unit carrierTransportingThisUnit = taUnit.getTransportedBy();
-          if (!Matches.UnitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER)
+          if (!Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER)
               .match(carrierTransportingThisUnit)) {
             change.add(ChangeFactory.unitPropertyChange(fighter, null, TripleAUnit.TRANSPORTED_BY));
           }

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -167,7 +167,7 @@ public class RocketsFireHelper {
       final Route route = data.getMap().getRoute(territory, current, allowed);
       if (route != null && route.numberOfSteps() <= maxDistance) {
         if (current.getUnits().someMatch(new CompositeMatchAnd<>(attackableUnits,
-            Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(current).invert()))) {
+            Matches.unitIsAtMaxDamageOrNotCanBeDamaged(current).invert()))) {
           hasFactory.add(current);
         }
       }
@@ -191,7 +191,7 @@ public class RocketsFireHelper {
     final Collection<Unit> enemyUnits = attackedTerritory.getUnits().getMatches(
         new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
     final Collection<Unit> enemyTargetsTotal =
-        Match.getMatches(enemyUnits, Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).invert());
+        Match.getMatches(enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).invert());
     final Collection<Unit> targets = new ArrayList<>();
     final Collection<Unit> rockets;
     // attackFrom could be null if WW2V1
@@ -427,7 +427,7 @@ public class RocketsFireHelper {
     if (Match.someMatch(targets, Matches.UnitCanDieFromReachingMaxDamage)) {
       final List<Unit> unitsCanDie = Match.getMatches(targets, Matches.UnitCanDieFromReachingMaxDamage);
       unitsCanDie
-          .retainAll(Match.getMatches(unitsCanDie, Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory)));
+          .retainAll(Match.getMatches(unitsCanDie, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory)));
       if (!unitsCanDie.isEmpty()) {
         // targets.removeAll(unitsCanDie);
         final Change removeDead = ChangeFactory.removeUnits(attackedTerritory, unitsCanDie);

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -245,10 +245,10 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
         games.strategy.triplea.Properties.getAirborneAttacksOnlyInExistingBattles(data);
     final boolean onlyEnemyTerritories =
         games.strategy.triplea.Properties.getAirborneAttacksOnlyInEnemyTerritories(data);
-    if (!Match.allMatch(route.getSteps(), Matches.TerritoryIsPassableAndNotRestricted(player, data))) {
+    if (!Match.allMatch(route.getSteps(), Matches.territoryIsPassableAndNotRestricted(player, data))) {
       return result.setErrorReturnResult("May Not Fly Over Impassable or Restricted Territories");
     }
-    if (!Match.allMatch(route.getSteps(), Matches.TerritoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))) {
+    if (!Match.allMatch(route.getSteps(), Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))) {
       return result.setErrorReturnResult("May Only Fly Over Territories Where Air May Move");
     }
     final boolean someLand = Match.someMatch(airborne, Matches.UnitIsLand);

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -94,14 +94,14 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
     final Match<Unit> defenders = new CompositeMatchAnd<>(Matches.enemyUnit(m_attacker, m_data),
-        new CompositeMatchOr<Unit>(Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
-            Matches.UnitIsAAthatCanFire(m_attackingUnits, airborneTechTargetsAllowed, m_attacker,
+        new CompositeMatchOr<Unit>(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
+            Matches.unitIsAaThatCanFire(m_attackingUnits, airborneTechTargetsAllowed, m_attacker,
                 Matches.UnitIsAAforBombingThisUnitOnly, m_round, true, m_data)));
     if (m_targets.isEmpty()) {
       m_defendingUnits = Match.getMatches(m_battleSite.getUnits().getUnits(), defenders);
     } else {
       final List<Unit> targets =
-          Match.getMatches(m_battleSite.getUnits().getUnits(), Matches.UnitIsAAthatCanFire(m_attackingUnits,
+          Match.getMatches(m_battleSite.getUnits().getUnits(), Matches.unitIsAaThatCanFire(m_attackingUnits,
               airborneTechTargetsAllowed, m_attacker, Matches.UnitIsAAforBombingThisUnitOnly, m_round, true, m_data));
       targets.addAll(m_targets.keySet());
       m_defendingUnits = targets;
@@ -175,7 +175,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     updateDefendingUnits();
     bridge.getHistoryWriter().startEvent("Strategic bombing raid in " + m_battleSite, m_battleSite);
     if (m_attackingUnits.isEmpty() || (m_defendingUnits.isEmpty()
-        || Match.noneMatch(m_defendingUnits, Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert()))) {
+        || Match.noneMatch(m_defendingUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert()))) {
       endBeforeRolling(bridge);
       return;
     }
@@ -183,7 +183,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     // TODO: determine if the target has the property, not just any unit with the property isAAforBombingThisUnitOnly
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
-    m_defendingAA = m_battleSite.getUnits().getMatches(Matches.UnitIsAAthatCanFire(m_attackingUnits,
+    m_defendingAA = m_battleSite.getUnits().getMatches(Matches.unitIsAaThatCanFire(m_attackingUnits,
         airborneTechTargetsAllowed, m_attacker, Matches.UnitIsAAforBombingThisUnitOnly, m_round, true, m_data));
     m_AAtypes = UnitAttachment.getAllOfTypeAAs(m_defendingAA);
     // reverse since stacks are in reverse order
@@ -257,7 +257,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         if (Match.someMatch(m_targets.keySet(), Matches.UnitCanDieFromReachingMaxDamage)) {
           final List<Unit> unitsCanDie = Match.getMatches(m_targets.keySet(), Matches.UnitCanDieFromReachingMaxDamage);
           unitsCanDie
-              .retainAll(Match.getMatches(unitsCanDie, Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite)));
+              .retainAll(Match.getMatches(unitsCanDie, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite)));
           if (!unitsCanDie.isEmpty()) {
             // m_targets.removeAll(unitsCanDie);
             final Change removeDead = ChangeFactory.removeUnits(m_battleSite, unitsCanDie);
@@ -351,7 +351,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       final boolean isEditMode = BaseEditDelegate.getEditMode(bridge.getData());
       for (final String currentTypeAa : m_AAtypes) {
         final Collection<Unit> currentPossibleAa =
-            Match.getMatches(m_defendingAA, Matches.UnitIsAAofTypeAA(currentTypeAa));
+            Match.getMatches(m_defendingAA, Matches.unitIsAaOfTypeAa(currentTypeAa));
         final Set<UnitType> targetUnitTypesForThisTypeAa =
             UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAA(m_data);
         final Set<UnitType> airborneTypesTargettedToo =

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -128,7 +128,7 @@ public class UndoableMove extends AbstractUndoableMove {
             final Territory end = routeUnitUsedToMove.getEnd();
             final Collection<Unit> enemyTargetsTotal = end.getUnits()
                 .getMatches(new CompositeMatchAnd<>(Matches.enemyUnit(bridge.getPlayerID(), data),
-                    Matches.UnitIsAtMaxDamageOrNotCanBeDamaged(end).invert(),
+                    Matches.unitIsAtMaxDamageOrNotCanBeDamaged(end).invert(),
                     Matches.unitIsBeingTransported().invert()));
             final Collection<Unit> enemyTargets = Match.getMatches(enemyTargetsTotal,
                 Matches.unitIsOfTypes(UnitAttachment.getAllowedBombingTargetsIntersection(

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -435,9 +435,9 @@ class OddsCalculatorPanel extends JPanel {
       m_draw.setText(formatPercentage(results.get().getDrawPercent()));
       final boolean isLand = isLand();
       final List<Unit> mainCombatAttackers =
-          Match.getMatches(attackers.get(), Matches.UnitCanBeInBattle(true, isLand, 1, false, true, true));
+          Match.getMatches(attackers.get(), Matches.unitCanBeInBattle(true, isLand, 1, false, true, true));
       final List<Unit> mainCombatDefenders =
-          Match.getMatches(defenders.get(), Matches.UnitCanBeInBattle(false, isLand, 1, false, true, true));
+          Match.getMatches(defenders.get(), Matches.unitCanBeInBattle(false, isLand, 1, false, true, true));
       final int attackersTotal = mainCombatAttackers.size();
       final int defendersTotal = mainCombatDefenders.size();
       m_defenderLeft.setText(formatValue(results.get().getAverageDefendingUnitsLeft()) + " /" + defendersTotal);
@@ -474,7 +474,7 @@ class OddsCalculatorPanel extends JPanel {
       units = Collections.emptyList();
     }
     final boolean isLand = isLand();
-    units = Match.getMatches(units, Matches.UnitCanBeInBattle(false, isLand, 1, false, false, false));
+    units = Match.getMatches(units, Matches.unitCanBeInBattle(false, isLand, 1, false, false, false));
     m_defendingUnitsPanel.init(getDefender(), units, isLand);
   }
 
@@ -483,7 +483,7 @@ class OddsCalculatorPanel extends JPanel {
       units = Collections.emptyList();
     }
     final boolean isLand = isLand();
-    units = Match.getMatches(units, Matches.UnitCanBeInBattle(true, isLand, 1, false, false, false));
+    units = Match.getMatches(units, Matches.unitCanBeInBattle(true, isLand, 1, false, false, false));
     m_attackingUnitsPanel.init(getAttacker(), units, isLand);
   }
 
@@ -760,9 +760,9 @@ class OddsCalculatorPanel extends JPanel {
       m_data.acquireReadLock();
       // do not include bombardment and aa guns in our "total" labels
       final List<Unit> attackers = Match.getMatches(m_attackingUnitsPanel.getUnits(),
-          Matches.UnitCanBeInBattle(true, isLand, 1, false, true, true));
+          Matches.unitCanBeInBattle(true, isLand, 1, false, true, true));
       final List<Unit> defenders = Match.getMatches(m_defendingUnitsPanel.getUnits(),
-          Matches.UnitCanBeInBattle(false, isLand, 1, false, true, true));
+          Matches.unitCanBeInBattle(false, isLand, 1, false, true, true));
       m_attackerUnitsTotalNumber.setText("Units: " + attackers.size());
       m_defenderUnitsTotalNumber.setText("Units: " + defenders.size());
       m_attackerUnitsTotalTUV.setText("TUV: " + BattleCalculator.getTUV(attackers, getAttacker(),
@@ -960,7 +960,7 @@ class PlayerUnitsPanel extends JPanel {
     // they have other
     // combat abilities.
     rVal = Match.getMatches(rVal,
-        Matches.UnitTypeCanBeInBattle(!m_defender, m_isLand, player, 1, false, false, false));
+        Matches.unitTypeCanBeInBattle(!m_defender, m_isLand, player, 1, false, false, false));
     return rVal;
   }
 


### PR DESCRIPTION
This PR fixes violations of the following Checkstyle rules in the `Matches` class:

* AbbreviationAsWordInName
* MethodName
* ParameterName

The vast majority of fixes changed method names that started with an upper-case letter to start with a lower-case letter.  There were also a few methods with `AA` in their name that were changed to `Aa`.