### PR TITLE
Report code coverage metrics to Codecov for unit tests only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 install: true
 services:
 - postgresql
-script: ./gradlew check jacocoRootReport
+script: ./gradlew check jacocoTestReport
 after_success: 
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle

--- a/build.gradle
+++ b/build.gradle
@@ -250,3 +250,10 @@ checkstyleTest {
     maxWarnings = checkstyleTestMaxWarnings.toInteger()
     source sourceSets.test.output.resourcesDir
 }
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+    }
+}


### PR DESCRIPTION
This PR modifies the Travis build to only report code coverage metrics from unit tests to Codecov.  Code coverage metrics from integration tests will be ignored.

Per @DanVanAtta's recommendation [here](https://github.com/triplea-game/triplea/pull/1869#issuecomment-308269716).