### PR TITLE
Enable assertions in Eclipse launch configurations

### DIFF
--- a/eclipse/launchers/GameRunner_run_game.launch
+++ b/eclipse/launchers/GameRunner_run_game.launch
@@ -10,5 +10,5 @@
 <booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.GameRunner"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="triplea"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dcom.sun.management.jmxremote=true &#13;&#10;-Dcom.sun.management.jmxremote.port=3614 &#13;&#10;-Dcom.sun.management.jmxremote.authenticate=false &#13;&#10;-Dcom.sun.management.jmxremote.ssl=false"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea&#10;-Dcom.sun.management.jmxremote=true &#13;&#10;-Dcom.sun.management.jmxremote.port=3614 &#13;&#10;-Dcom.sun.management.jmxremote.authenticate=false &#13;&#10;-Dcom.sun.management.jmxremote.ssl=false"/>
 </launchConfiguration>

--- a/eclipse/launchers/HeadlessGameServer_local_test.launch
+++ b/eclipse/launchers/HeadlessGameServer_local_test.launch
@@ -10,4 +10,5 @@
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.framework.headlessGameServer.HeadlessGameServer"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="triplea.game.host.console=true &#13;&#10;triplea.game= triplea.server=true &#13;&#10;triplea.port=3300&#13;&#10;triplea.lobby.host=127.0.0.1&#13;&#10;triplea.lobby.port=3300&#13;&#10;triplea.name=Bot1_TestServer &#13;&#10;triplea.lobby.game.hostedBy=Bot1_TestServer&#13;&#10;triplea.lobby.game.supportEmail=developer@gmail.com&#13;&#10;triplea.lobby.game.comments=automated_host"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="triplea"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
 </launchConfiguration>

--- a/eclipse/launchers/LobbyServer_no_ui.launch
+++ b/eclipse/launchers/LobbyServer_no_ui.launch
@@ -8,4 +8,5 @@
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.lobby.server.LobbyServer"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="triplea"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
 </launchConfiguration>

--- a/eclipse/launchers/LobbyServer_with_ui.launch
+++ b/eclipse/launchers/LobbyServer_with_ui.launch
@@ -9,4 +9,5 @@
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="games.strategy.engine.lobby.server.LobbyServer"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="triplea.lobby.ui=true&#13;&#10;triplea.lobby.console=true"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="triplea"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
 </launchConfiguration>


### PR DESCRIPTION
This PR enables assertions in the JVM when running any of the TripleA launch configurations from Eclipse.

Recently, I've been adding assertions for things like thread affinity and lock acquisition to fail fast during development.  It seemed useful to have the assertion facility enabled at all times when running from the IDE.  This change is non-functional and does not affect users.