### PR TITLE
Replace AlwaysMatch and NeverMatch subclasses with factory method

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -342,7 +342,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
               picked = territoryChoices.get(0);
             } else {
               final IntegerMap<Territory> distanceMap =
-                  data.getMap().getDistance(capitals.get(0), doesNotHaveFactoryYet, Match.getAlwaysMatch());
+                  data.getMap().getDistance(capitals.get(0), doesNotHaveFactoryYet, Match.always());
               picked = distanceMap.lowestKey();
             }
           }
@@ -353,7 +353,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
           if (!test.isEmpty()) {
             if (test.size() < maxTerritoriesToPopulate) {
               final IntegerMap<Territory> distanceMap =
-                  data.getMap().getDistance(test.get(0), territoryChoices, Match.getAlwaysMatch());
+                  data.getMap().getDistance(test.get(0), territoryChoices, Match.always());
               for (int i = 0; i < maxTerritoriesToPopulate; i++) {
                 final Territory choice = distanceMap.lowestKey();
                 distanceMap.removeKey(choice);
@@ -371,7 +371,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
               picked = territoryChoices.get(0);
             } else {
               final IntegerMap<Territory> distanceMap =
-                  data.getMap().getDistance(capitals.get(0), territoryChoices, Match.getAlwaysMatch());
+                  data.getMap().getDistance(capitals.get(0), territoryChoices, Match.always());
               if (territoryChoices.contains(capitals.get(0))) {
                 distanceMap.put(capitals.get(0), 0);
               }
@@ -402,7 +402,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
             picked = territoryChoices.get(0);
           } else {
             final IntegerMap<Territory> distanceMap =
-                data.getMap().getDistance(capitals.get(0), notOwned, Match.getAlwaysMatch());
+                data.getMap().getDistance(capitals.get(0), notOwned, Match.always());
             picked = distanceMap.lowestKey();
           }
         }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -618,7 +618,7 @@ final class ProTechAI {
     if (!neutral || Properties.getNeutralsImpassable(data)) {
       endCond.add(Matches.TerritoryIsNeutralButNotWater.invert());
     }
-    return findFontier(territory, endCond, Match.getAlwaysMatch(), distance, data);
+    return findFontier(territory, endCond, Match.always(), distance, data);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -278,7 +278,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         }
       }
       final Collection<Unit> placedUnits =
-          Match.getNMatches(unitsCanBePlacedByThisProducer, maxPlaceable, Match.getAlwaysMatch());
+          Match.getNMatches(unitsCanBePlacedByThisProducer, maxPlaceable, Match.always());
       performPlaceFrom(producer, placedUnits, at, m_player);
       unitsLeftToPlace.removeAll(placedUnits);
     }
@@ -1437,7 +1437,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         continue;
       }
       Collections.sort(canBePlacedHere, getHardestToPlaceWithRequiresUnitsRestrictions(true));
-      final Collection<Unit> placedHere = Match.getNMatches(canBePlacedHere, productionHere, Match.getAlwaysMatch());
+      final Collection<Unit> placedHere = Match.getNMatches(canBePlacedHere, productionHere, Match.always());
       unitsLeftToPlace.removeAll(placedHere);
     }
     return unitsLeftToPlace.isEmpty();

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -216,7 +216,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
       return result.setErrorReturnResult("Airborne Bases Must Have Launch Capacity");
     } else if (airborneCapacity < units.size()) {
       final Collection<Unit> overMax = new ArrayList<>(units);
-      overMax.removeAll(Match.getNMatches(units, airborneCapacity, Match.getAlwaysMatch()));
+      overMax.removeAll(Match.getNMatches(units, airborneCapacity, Match.always()));
       for (final Unit u : overMax) {
         result.addDisallowedUnit("Airborne Base Capacity Has Been Reached", u);
       }

--- a/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -155,7 +155,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
         } else if (Match.allMatch(m_unitChoices, Matches.unitIsOfType(m_unitChoices.get(0).getType()))) {
           // if we have only 1 unit type, set it to that
           m_pickedUnits.clear();
-          m_pickedUnits.addAll(Match.getNMatches(m_unitChoices, m_unitsPerPick, Match.getAlwaysMatch()));
+          m_pickedUnits.addAll(Match.getNMatches(m_unitChoices, m_unitsPerPick, Match.always()));
         } else {
           EventThreadJOptionPane.showMessageDialog(m_parent, "Must Choose Units For This Territory",
               "Must Choose Units For This Territory", JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler(true));

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1004,7 +1004,7 @@ public class TripleAFrame extends MainGameFrame {
       final List<Territory> territoryChoices, final List<Unit> unitChoices, final int unitsPerPick) {
     if (messageAndDialogThreadPool == null) {
       return Tuple.of(territoryChoices.iterator().next(),
-          new HashSet<>(Match.getNMatches(unitChoices, unitsPerPick, Match.getAlwaysMatch())));
+          new HashSet<>(Match.getNMatches(unitChoices, unitsPerPick, Match.always())));
     }
     // total hacks
     messageAndDialogThreadPool.waitForAll();

--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -25,13 +25,20 @@ import java.util.function.Predicate;
  * </p>
  */
 public abstract class Match<T> {
+  @SuppressWarnings("rawtypes")
+  private static final Match ALWAYS = Match.of(it -> true);
 
-  public static <T> Match<T> getAlwaysMatch() {
-    return new AlwaysMatch<>();
+  @SuppressWarnings("rawtypes")
+  private static final Match NEVER = Match.of(it -> false);
+
+  @SuppressWarnings("unchecked")
+  public static <T> Match<T> always() {
+    return ALWAYS;
   }
 
-  public static <T> Match<T> getNeverMatch() {
-    return new NeverMatch<>();
+  @SuppressWarnings("unchecked")
+  public static <T> Match<T> never() {
+    return NEVER;
   }
 
   /**
@@ -163,21 +170,5 @@ public abstract class Match<T> {
         return condition.test(value);
       }
     };
-  }
-}
-
-
-class NeverMatch<T> extends Match<T> {
-  @Override
-  public boolean match(final T o) {
-    return false;
-  }
-}
-
-
-class AlwaysMatch<T> extends Match<T> {
-  @Override
-  public boolean match(final T o) {
-    return true;
   }
 }

--- a/src/test/java/games/strategy/util/MatchTest.java
+++ b/src/test/java/games/strategy/util/MatchTest.java
@@ -1,6 +1,7 @@
 package games.strategy.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -44,9 +45,9 @@ public class MatchTest {
 
   @Test
   public void testNever() {
-    assertTrue(!Match.someMatch(ints, Match.getNeverMatch()));
-    assertTrue(!Match.allMatch(ints, Match.getNeverMatch()));
-    assertEquals(0, Match.getMatches(ints, Match.getNeverMatch()).size());
+    assertFalse(Match.someMatch(ints, Match.never()));
+    assertFalse(Match.allMatch(ints, Match.never()));
+    assertEquals(0, Match.getMatches(ints, Match.never()).size());
   }
 
   @Test
@@ -61,9 +62,9 @@ public class MatchTest {
 
   @Test
   public void testAlways() {
-    assertTrue(Match.someMatch(ints, Match.getAlwaysMatch()));
-    assertTrue(Match.allMatch(ints, Match.getAlwaysMatch()));
-    assertEquals(7, Match.getMatches(ints, Match.getAlwaysMatch()).size());
+    assertTrue(Match.someMatch(ints, Match.always()));
+    assertTrue(Match.allMatch(ints, Match.always()));
+    assertEquals(7, Match.getMatches(ints, Match.always()).size());
   }
 
   @Test
@@ -103,7 +104,7 @@ public class MatchTest {
     map.put("a", "b");
     map.put("b", "c");
     map.put("c", "d");
-    assertEquals(Match.getKeysWhereValueMatch(map, Match.getAlwaysMatch()).size(), 3);
-    assertEquals(Match.getKeysWhereValueMatch(map, Match.getNeverMatch()).size(), 0);
+    assertEquals(3, Match.getKeysWhereValueMatch(map, Match.always()).size());
+    assertEquals(0, Match.getKeysWhereValueMatch(map, Match.never()).size());
   }
 }


### PR DESCRIPTION
This PR replaces the package-private `AlwaysMatch` and `NeverMatch` subclasses with the general `Match#of()` factory method.  I also renamed the `Match#getAlwaysMatch()` and `Match#getNeverMatch()` methods to `always()` and `never()`, respectively.