### PR TITLE
Center ProgressWindow relative to owner

### DIFF
--- a/src/main/java/games/strategy/ui/ProgressWindow.java
+++ b/src/main/java/games/strategy/ui/ProgressWindow.java
@@ -14,6 +14,13 @@ import javax.swing.border.LineBorder;
 public class ProgressWindow extends JWindow {
   private static final long serialVersionUID = 4102671321734509406L;
 
+  /**
+   * Initializes a new instance of the {@code ProgressWindow} class.
+   *
+   * @param owner The frame from which the window is displayed; if {@code null} the shared owner will be used and this
+   *        window will not be focusable.
+   * @param title The progress message; may be {@code null}.
+   */
   public ProgressWindow(final Frame owner, final String title) {
     super(owner);
     final JLabel label = new JLabel(title);
@@ -30,5 +37,6 @@ public class ProgressWindow extends JWindow {
     setSize(200, 80);
     add(panel, BorderLayout.CENTER);
     pack();
+    setLocationRelativeTo(owner);
   }
 }


### PR DESCRIPTION
Prior to [a1687a7](https://github.com/triplea-game/triplea/commit/a1687a75d1d3aeedd64b481c59772674a7741204#diff-daf9fbfd6ffe4aae572b7d99e2c6a941), `ProgressWindow` was centered relative to the screen.  After [a1687a7](https://github.com/triplea-game/triplea/commit/a1687a75d1d3aeedd64b481c59772674a7741204#diff-daf9fbfd6ffe4aae572b7d99e2c6a941), it was not centered at all:

![progress-window-old](https://user-images.githubusercontent.com/4826349/27254662-f02fb110-535a-11e7-8484-b477a67f49fa.png)

This PR centers it relative to its owner:

![progress-window-new](https://user-images.githubusercontent.com/4826349/27254664-fb425882-535a-11e7-87e9-df28e0bbaca6.png)

I also fixed a Checkstyle JavadocMethod warning while I was here.