### PR TITLE
Move JTextAreaOptionPane to tools.image

### DIFF
--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -29,7 +29,6 @@ import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.util.PointFileReaderWriter;
-import tools.map.making.JTextAreaOptionPane;
 
 public class AutoPlacementFinder {
   private static int PLACEWIDTH = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;

--- a/src/main/java/tools/image/JTextAreaOptionPane.java
+++ b/src/main/java/tools/image/JTextAreaOptionPane.java
@@ -1,4 +1,4 @@
-package tools.map.making;
+package tools.image;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -16,7 +16,7 @@ import javax.swing.WindowConstants;
 /**
  * A text area that can show updates scrolling by.
  */
-public class JTextAreaOptionPane {
+class JTextAreaOptionPane {
   private final JTextArea editor = new JTextArea();
   private final JFrame windowFrame = new JFrame();
   private final JButton okButton = new JButton();
@@ -24,7 +24,7 @@ public class JTextAreaOptionPane {
   private final Window parentComponent;
   private int counter;
 
-  public JTextAreaOptionPane(final JFrame parentComponent, final String initialEditorText, final String labelText,
+  JTextAreaOptionPane(final JFrame parentComponent, final String initialEditorText, final String labelText,
       final String title, final Image icon, final int editorSizeX, final int editorSizeY, final boolean logToSystemOut,
       final int latchCount, final CountDownLatch countDownLatch) {
     this.logToSystemOut = logToSystemOut;
@@ -70,18 +70,18 @@ public class JTextAreaOptionPane {
     }
   }
 
-  public void show() {
+  void show() {
     windowFrame.pack();
     windowFrame.setLocationRelativeTo(parentComponent);
     windowFrame.setVisible(true);
   }
 
-  public void dispose() {
+  void dispose() {
     windowFrame.setVisible(false);
     windowFrame.dispose();
   }
 
-  public void countDown() {
+  void countDown() {
     counter--;
     setWidgetActivation();
   }
@@ -94,7 +94,7 @@ public class JTextAreaOptionPane {
     editor.setCaretPosition(editor.getText().length());
   }
 
-  public void appendNewLine(final String text) {
+  void appendNewLine(final String text) {
     append(text + "\r\n");
   }
 }

--- a/src/main/java/tools/image/TileImageBreaker.java
+++ b/src/main/java/tools/image/TileImageBreaker.java
@@ -19,7 +19,6 @@ import javax.swing.JOptionPane;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.ui.screen.TileManager;
-import tools.map.making.JTextAreaOptionPane;
 
 /**
  * Utility for breaking an image into seperate smaller images.

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -27,7 +27,6 @@ import games.strategy.debug.ClientLogger;
 import games.strategy.triplea.ui.screen.TileManager;
 import games.strategy.ui.Util;
 import games.strategy.util.PointFileReaderWriter;
-import tools.map.making.JTextAreaOptionPane;
 
 /**
  * For taking a folder of basetiles and putting them back together into an image.


### PR DESCRIPTION
This PR moves the `JTextAreaOptionPane` class to the `tools.image` package because this is the only package that uses `JTextAreaOptionPane`.  The visibility of all `JTextAreaOptionPane` members was subsequently reduced to package-private.