### PR TITLE
Replace CompositeMatchAnd subclass with Match#all() (part 1)

### DIFF
--- a/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -7,7 +7,7 @@ import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.util.CompositeMatchAnd;
+import games.strategy.util.Match;
 
 public class PlayerID extends NamedAttachable implements NamedUnitHolder {
   private static final long serialVersionUID = -2284878450555315947L;
@@ -154,14 +154,14 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
     boolean hasFactory = false;
     boolean ownsLand = false;
     for (final Territory t : data.getMap().getTerritories()) {
-      if (t.getUnits().someMatch(new CompositeMatchAnd<>(Matches.unitIsOwnedBy(this),
+      if (t.getUnits().someMatch(Match.all(Matches.unitIsOwnedBy(this),
           Matches.unitHasAttackValueOfAtLeast(1), Matches.UnitCanMove, Matches.UnitIsLand))) {
         return true;
       }
       if (t.getOwner().equals(this)) {
         ownsLand = true;
       }
-      if (t.getUnits().someMatch(new CompositeMatchAnd<>(Matches.unitIsOwnedBy(this), Matches.UnitCanProduceUnits))) {
+      if (t.getUnits().someMatch(Match.all(Matches.unitIsOwnedBy(this), Matches.UnitCanProduceUnits))) {
         hasFactory = true;
       }
       if (ownsLand && hasFactory) {

--- a/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.RelationshipType;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 /**
@@ -47,7 +46,7 @@ class RelationshipChange extends Change {
     // now redraw territories in case of new hostility
     if (Matches.RelationshipTypeIsAtWar.match(data.getRelationshipTypeList().getRelationshipType(m_NewRelation))) {
       for (final Territory t : Match.getMatches(data.getMap().getTerritories(),
-          new CompositeMatchAnd<>(
+          Match.all(
               Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerID(m_player1)),
               Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerID(m_player2))))) {
         t.notifyChanged();

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -55,7 +55,6 @@ import games.strategy.triplea.ui.BattleDisplay;
 import games.strategy.triplea.ui.PlaceData;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.ui.SwingAction;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.Tuple;
@@ -388,8 +387,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
         && !id.getRepairFrontier().getRules().isEmpty()) {
       final GameData data = getGameData();
       if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
-        final Match<Unit> myDamaged =
-            new CompositeMatchAnd<>(Matches.unitIsOwnedBy(id), Matches.UnitHasTakenSomeBombingUnitDamage);
+        final Match<Unit> myDamaged = Match.all(Matches.unitIsOwnedBy(id), Matches.UnitHasTakenSomeBombingUnitDamage);
         final Collection<Unit> damagedUnits = new ArrayList<>();
         for (final Territory t : data.getMap().getTerritories()) {
           damagedUnits.addAll(Match.getMatches(t.getUnits().getUnits(), myDamaged));

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -16,7 +16,6 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 /**
@@ -158,7 +157,7 @@ public class AIUtils {
         // If this is the first carrier seek
         if (seekedCarrier == null) {
           final int seekedCarrierIndex = getIndexOfLastUnitMatching(result,
-              new CompositeMatchAnd<>(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+              Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
           if (seekedCarrierIndex == -1) {
             // No carriers left
             break;
@@ -187,7 +186,7 @@ public class AIUtils {
             filledCarriers.add(seekedCarrier);
             // Find the next carrier
             seekedCarrier = getLastUnitMatching(result,
-                new CompositeMatchAnd<>(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               // No carriers left
               break;
@@ -225,7 +224,7 @@ public class AIUtils {
             }
             // Find the next carrier
             seekedCarrier = getLastUnitMatching(result,
-                new CompositeMatchAnd<>(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               // No carriers left
               break;

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -42,7 +42,6 @@ import games.strategy.triplea.delegate.remote.ITechDelegate;
 import games.strategy.triplea.player.AbstractBasePlayer;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.ui.AbstractUIContext;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.ThreadUtil;
@@ -320,8 +319,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
       if (notOwned.isEmpty()) {
         // only owned territories left
         final boolean nonFactoryUnitsLeft = Match.someMatch(unitChoices, Matches.UnitCanProduceUnits.invert());
-        final Match<Unit> ownedFactories =
-            new CompositeMatchAnd<>(Matches.UnitCanProduceUnits, Matches.unitIsOwnedBy(me));
+        final Match<Unit> ownedFactories = Match.all(Matches.UnitCanProduceUnits, Matches.unitIsOwnedBy(me));
         final List<Territory> capitals = TerritoryAttachment.getAllCapitals(me, data);
         final List<Territory> test = new ArrayList<>(capitals);
         test.retainAll(territoryChoices);
@@ -333,7 +331,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
             picked = test.get(0);
           } else {
             if (capitals.isEmpty()) {
-              capitals.addAll(Match.getMatches(data.getMap().getTerritories(), new CompositeMatchAnd<>(
+              capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.all(
                   Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.TerritoryIsLand)));
             }
             final List<Territory> doesNotHaveFactoryYet =
@@ -364,7 +362,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
             picked = test.get(0);
           } else {
             if (capitals.isEmpty()) {
-              capitals.addAll(Match.getMatches(data.getMap().getTerritories(), new CompositeMatchAnd<>(
+              capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.all(
                   Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.TerritoryIsLand)));
             }
             if (capitals.isEmpty()) {
@@ -395,7 +393,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
           picked = test.get(0);
         } else {
           if (capitals.isEmpty()) {
-            capitals.addAll(Match.getMatches(data.getMap().getTerritories(), new CompositeMatchAnd<>(
+            capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.all(
                 Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.TerritoryIsLand)));
           }
           if (capitals.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -46,7 +46,6 @@ import games.strategy.triplea.delegate.MoveValidator;
 import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.dataObjects.MoveValidationResult;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 /**
@@ -1218,7 +1217,7 @@ class ProNonCombatMoveAI {
           final Set<Territory> cantHoldTerritories = new HashSet<>();
           while (true) {
             final Match<Territory> match =
-                new CompositeMatchAnd<>(ProMatches.territoryCanMoveSeaUnitsThrough(player, data, false),
+                Match.all(ProMatches.territoryCanMoveSeaUnitsThrough(player, data, false),
                     Matches.territoryIsInList(cantHoldTerritories).invert());
             final Route route = data.getMap().getRoute_IgnoreEnd(currentTerritory, patd.getTerritory(), match);
             if (route == null

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
@@ -21,7 +21,6 @@ import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.delegate.DelegateFinder;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.PoliticsDelegate;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 /**
@@ -51,7 +50,7 @@ class ProPoliticsAI {
         AIPoliticalUtils.getPoliticalActionsTowardsWar(player, politicsDelegate.getTestedConditions(), data);
     ProLogger.trace("War options: " + actionChoicesTowardsWar);
     final List<PoliticalActionAttachment> validWarActions =
-        Match.getMatches(actionChoicesTowardsWar, new CompositeMatchAnd<>(
+        Match.getMatches(actionChoicesTowardsWar, Match.all(
             Matches.abstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())));
     ProLogger.trace("Valid War options: " + validWarActions);
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -45,8 +45,6 @@ import games.strategy.triplea.delegate.MoveValidator;
 import games.strategy.triplea.delegate.dataObjects.PlaceableUnits;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -75,7 +73,7 @@ class ProPurchaseAI {
     // Current data at the start of combat move
     this.data = data;
     this.player = player;
-    final CompositeMatch<Unit> ourFactories = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player),
+    final Match<Unit> ourFactories = Match.all(Matches.unitIsOwnedBy(player),
         Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
     final List<Territory> rfactories = Match.getMatches(data.getMap().getTerritories(),
         ProMatches.territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data));

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -108,16 +108,13 @@ final class ProTechAI {
       float strength = 0.0F;
       float airStrength = 0.0F;
       ePlayer = playerIter.next();
-      final CompositeMatch<Unit> enemyPlane =
-          new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.unitIsOwnedBy(ePlayer), Matches.UnitCanMove);
-      final CompositeMatch<Unit> enemyTransport = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(ePlayer),
+      final Match<Unit> enemyPlane = Match.all(Matches.UnitIsAir, Matches.unitIsOwnedBy(ePlayer), Matches.UnitCanMove);
+      final Match<Unit> enemyTransport = Match.all(Matches.unitIsOwnedBy(ePlayer),
           Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
-      final CompositeMatch<Unit> enemyShip =
-          new CompositeMatchAnd<>(Matches.unitIsOwnedBy(ePlayer), Matches.UnitIsSea, Matches.UnitCanMove);
-      final CompositeMatch<Unit> enemyTransportable = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(ePlayer),
+      final Match<Unit> enemyShip = Match.all(Matches.unitIsOwnedBy(ePlayer), Matches.UnitIsSea, Matches.UnitCanMove);
+      final Match<Unit> enemyTransportable = Match.all(Matches.unitIsOwnedBy(ePlayer),
           Matches.UnitCanBeTransported, Matches.UnitIsNotAA, Matches.UnitCanMove);
-      final CompositeMatch<Unit> aTransport =
-          new CompositeMatchAnd<>(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
+      final Match<Unit> aTransport = Match.all(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
       final List<Territory> eFTerrs = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0;
       int maxBomberDistance = 0;
@@ -370,9 +367,9 @@ final class ProTechAI {
       final List<Territory> blockTerr, final GameData data, final PlayerID ePlayer) {
     final HashSet<Integer> ignore = new HashSet<>();
     ignore.add(1);
-    final CompositeMatch<Unit> blitzUnit =
-        new CompositeMatchAnd<>(Matches.unitIsOwnedBy(ePlayer), Matches.UnitCanBlitz, Matches.UnitCanMove);
-    final CompositeMatch<Territory> validBlitzRoute = new CompositeMatchAnd<>(
+    final Match<Unit> blitzUnit =
+        Match.all(Matches.unitIsOwnedBy(ePlayer), Matches.UnitCanBlitz, Matches.UnitCanMove);
+    final Match<Territory> validBlitzRoute = Match.all(
         Matches.territoryHasNoEnemyUnits(ePlayer, data), Matches.territoryIsNotImpassableToLandUnits(ePlayer, data));
     final List<Route> routes = new ArrayList<>();
     final List<Unit> blitzUnits =
@@ -465,10 +462,9 @@ final class ProTechAI {
     final Queue<Territory> q = new LinkedList<>();
     Territory lz = null;
     Territory ac = null;
-    final CompositeMatch<Unit> enemyPlane =
-        new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.unitIsOwnedBy(player), Matches.UnitCanMove);
-    final CompositeMatch<Unit> enemyCarrier =
-        new CompositeMatchAnd<>(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player), Matches.UnitCanMove);
+    final Match<Unit> enemyPlane = Match.all(Matches.UnitIsAir, Matches.unitIsOwnedBy(player), Matches.UnitCanMove);
+    final Match<Unit> enemyCarrier =
+        Match.all(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player), Matches.UnitCanMove);
     q.add(start);
     Territory current = null;
     distance.put(start, 0);
@@ -541,9 +537,8 @@ final class ProTechAI {
     }
     final CompositeMatch<Unit> ignore =
         new CompositeMatchAnd<>(Matches.UnitIsInfrastructure.invert(), Matches.alliedUnit(player, data).invert());
-    final CompositeMatch<Unit> sub = new CompositeMatchAnd<>(Matches.UnitIsSub.invert());
-    final CompositeMatch<Unit> transport =
-        new CompositeMatchAnd<>(Matches.UnitIsTransport.invert(), Matches.UnitIsLand.invert());
+    final Match<Unit> sub = Match.all(Matches.UnitIsSub.invert());
+    final Match<Unit> transport = Match.all(Matches.UnitIsTransport.invert(), Matches.UnitIsLand.invert());
     final CompositeMatch<Unit> unitCond = ignore;
     if (Properties.getIgnoreTransportInMovement(data)) {
       unitCond.add(transport);
@@ -551,8 +546,8 @@ final class ProTechAI {
     if (Properties.getIgnoreSubInMovement(data)) {
       unitCond.add(sub);
     }
-    final CompositeMatch<Territory> routeCond =
-        new CompositeMatchAnd<>(Matches.territoryHasUnitsThatMatch(unitCond).invert(), Matches.TerritoryIsWater);
+    final Match<Territory> routeCond =
+        Match.all(Matches.territoryHasUnitsThatMatch(unitCond).invert(), Matches.TerritoryIsWater);
     final Match<Territory> routeCondition;
     if (attacking) {
       routeCondition = Match.any(Matches.territoryIs(destination), routeCond);
@@ -668,7 +663,7 @@ final class ProTechAI {
    */
   private static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units
-    final CompositeMatch<Unit> limitShips = new CompositeMatchAnd<>(unitCondition);
+    final Match<Unit> limitShips = Match.all(unitCondition);
     final List<Territory> shipTerr = new ArrayList<>();
     final Collection<Territory> tNeighbors = data.getMap().getTerritories();
     for (final Territory t2 : tNeighbors) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -186,11 +186,11 @@ public class ProTerritoryManager {
         maxScrambleDistance = ua.getMaxScrambleDistance();
       }
     }
-    final Match<Unit> airbasesCanScramble = new CompositeMatchAnd<>(Matches.unitIsEnemyOf(data, player),
+    final Match<Unit> airbasesCanScramble = Match.all(Matches.unitIsEnemyOf(data, player),
         Matches.UnitIsAirBase, Matches.UnitIsNotDisabled, Matches.unitIsBeingTransported().invert());
     final CompositeMatchAnd<Territory> canScramble = new CompositeMatchAnd<>(
         Match.any(Matches.TerritoryIsWater, Matches.isTerritoryEnemy(player, data)),
-        Matches.territoryHasUnitsThatMatch(new CompositeMatchAnd<>(Matches.UnitCanScramble,
+        Matches.territoryHasUnitsThatMatch(Match.all(Matches.UnitCanScramble,
             Matches.unitIsEnemyOf(data, player), Matches.UnitIsNotDisabled)),
         Matches.territoryHasUnitsThatMatch(airbasesCanScramble));
     if (fromIslandOnly) {
@@ -221,7 +221,7 @@ public class ProTerritoryManager {
         final int maxCanScramble = getMaxScrambleCount(airbases);
         final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.TerritoryIsNotImpassable);
         List<Unit> canScrambleAir = from.getUnits()
-            .getMatches(new CompositeMatchAnd<>(Matches.unitIsEnemyOf(data, player), Matches.UnitCanScramble,
+            .getMatches(Match.all(Matches.unitIsEnemyOf(data, player), Matches.UnitCanScramble,
                 Matches.UnitIsNotDisabled, Matches.UnitWasScrambled.invert(),
                 Matches.unitCanScrambleOnRouteDistance(toBattleRoute)));
 
@@ -244,7 +244,7 @@ public class ProTerritoryManager {
   }
 
   private static int getMaxScrambleCount(final Collection<Unit> airbases) {
-    if (!Match.allMatch(airbases, new CompositeMatchAnd<>(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
+    if (!Match.allMatch(airbases, Match.all(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
       throw new IllegalStateException("All units must be viable airbases");
     }
 
@@ -736,10 +736,10 @@ public class ProTerritoryManager {
       // Find my transports and amphibious units that have movement left
       final List<Unit> myTransportUnits =
           myUnitTerritory.getUnits().getMatches(ProMatches.unitCanBeMovedAndIsOwnedTransport(player, isCombatMove));
-      Match<Territory> unloadAmphibTerritoryMatch = new CompositeMatchAnd<>(
+      Match<Territory> unloadAmphibTerritoryMatch = Match.all(
           ProMatches.territoryCanMoveLandUnits(player, data, isCombatMove), moveAmphibToTerritoryMatch);
       if (isIgnoringRelationships) {
-        unloadAmphibTerritoryMatch = new CompositeMatchAnd<>(
+        unloadAmphibTerritoryMatch = Match.all(
             ProMatches.territoryCanPotentiallyMoveLandUnits(player, data), moveAmphibToTerritoryMatch);
       }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -13,7 +13,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 /**
@@ -27,7 +26,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> match = Match.any(Matches.territoryIsInList(alliedTerritories),
-            new CompositeMatchAnd<>(Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data),
+            Match.all(Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data),
                 Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false,
                     false, true, true),
                 Matches.territoryIsInList(enemyTerritories).invert()));
@@ -41,7 +40,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
+        final Match<Territory> match = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
             Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, false,
                 true, false));
         return match.match(t);
@@ -53,7 +52,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
+        final Match<Territory> match = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
             Matches.territoryIsPassableAndNotRestricted(player, data));
         return match.match(t);
       }
@@ -66,7 +65,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> match =
-            new CompositeMatchAnd<>(ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove),
+            Match.all(ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove),
                 Matches.territoryHasEnemyAaForAnything(player, data).invert());
         return match.match(t);
       }
@@ -78,7 +77,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> territoryMatch = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
+        final Match<Territory> territoryMatch = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
             Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
                 false, false));
         final Match<Unit> unitMatch =
@@ -93,7 +92,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> territoryMatch = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
+        final Match<Territory> territoryMatch = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
             Matches.territoryIsPassableAndNotRestricted(player, data));
         final Match<Unit> unitMatch =
             Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).invert();
@@ -107,7 +106,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
+        final Match<Territory> match = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
             Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
                 false, false));
         return match.match(t);
@@ -119,7 +118,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(Matches.TerritoryIsLand,
+        final Match<Territory> match = Match.all(Matches.TerritoryIsLand,
             Matches.territoryDoesNotCostMoneyToEnter(data), Matches.territoryIsPassableAndNotRestricted(player, data));
         return match.match(t);
       }
@@ -130,7 +129,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(Matches.isTerritoryAllied(player, data),
+        final Match<Territory> match = Match.all(Matches.isTerritoryAllied(player, data),
             territoryCanMoveLandUnits(player, data, false));
         return match.match(t);
       }
@@ -144,15 +143,15 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         Match<Territory> match =
-            new CompositeMatchAnd<>(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
+            Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
                 Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data),
                 Matches.territoryIsInList(enemyTerritories).invert());
         if (isCombatMove && Matches.UnitCanBlitz.match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
-          final Match<Territory> alliedWithNoEnemiesMatch = new CompositeMatchAnd<>(
+          final Match<Territory> alliedWithNoEnemiesMatch = Match.all(
               Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data));
           final Match<Territory> alliedOrBlitzableMatch =
               Match.any(alliedWithNoEnemiesMatch, territoryIsBlitzable(player, data, u));
-          match = new CompositeMatchAnd<>(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
+          match = Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
               alliedOrBlitzableMatch, Matches.territoryIsInList(enemyTerritories).invert());
         }
         return match.match(t);
@@ -173,7 +172,7 @@ public class ProMatches {
               Matches.territoryIsInList(clearedTerritories), territoryIsBlitzable(player, data, u));
         }
         final Match<Territory> match =
-            new CompositeMatchAnd<>(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
+            Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
                 alliedMatch, Matches.territoryIsInList(blockedTerritories).invert());
         return match.match(t);
       }
@@ -200,7 +199,7 @@ public class ProMatches {
             && Matches.isTerritoryEnemyAndNotUnownedWater(player, data).match(t)) {
           return false;
         }
-        final Match<Territory> match = new CompositeMatchAnd<>(Matches.territoryDoesNotCostMoneyToEnter(data),
+        final Match<Territory> match = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
             Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, true,
                 false, false));
         return match.match(t);
@@ -213,7 +212,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(territoryCanMoveSeaUnits(player, data, isCombatMove),
+        final Match<Territory> match = Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
             territoryHasOnlyIgnoredUnits(player, data));
         return match.match(t);
       }
@@ -225,7 +224,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(territoryCanMoveSeaUnits(player, data, isCombatMove),
+        final Match<Territory> match = Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
             Matches.territoryIsNotInList(notTerritories));
         return match.match(t);
       }
@@ -240,7 +239,7 @@ public class ProMatches {
       public boolean match(final Territory t) {
         final Match<Territory> onlyIgnoredOrClearedMatch = Match.any(
             territoryHasOnlyIgnoredUnits(player, data), Matches.territoryIsInList(clearedTerritories));
-        final Match<Territory> match = new CompositeMatchAnd<>(territoryCanMoveSeaUnits(player, data, isCombatMove),
+        final Match<Territory> match = Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
             onlyIgnoredOrClearedMatch, Matches.territoryIsNotInList(notTerritories));
         return match.match(t);
       }
@@ -311,10 +310,9 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Unit> infraFactoryMatch =
-            new CompositeMatchAnd<>(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+        final Match<Unit> infraFactoryMatch = Match.all(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
         final Match<Territory> match =
-            new CompositeMatchAnd<>(Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
+            Match.all(Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
         return match.match(t);
       }
     };
@@ -325,7 +323,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> match =
-            new CompositeMatchAnd<>(territoryHasInfraFactoryAndIsLand(), Matches.isTerritoryEnemy(player, data));
+            Match.all(territoryHasInfraFactoryAndIsLand(), Matches.isTerritoryEnemy(player, data));
         return match.match(t);
       }
     };
@@ -336,12 +334,11 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> ownedAndCantBeHeld = new CompositeMatchAnd<>(Matches.isTerritoryOwnedBy(player),
+        final Match<Territory> ownedAndCantBeHeld = Match.all(Matches.isTerritoryOwnedBy(player),
             Matches.territoryIsInList(territoriesThatCantBeHeld));
         final Match<Territory> enemyOrOwnedCantBeHeld =
             Match.any(Matches.isTerritoryOwnedBy(players), ownedAndCantBeHeld);
-        final Match<Territory> match =
-            new CompositeMatchAnd<>(territoryHasInfraFactoryAndIsLand(), enemyOrOwnedCantBeHeld);
+        final Match<Territory> match = Match.all(territoryHasInfraFactoryAndIsLand(), enemyOrOwnedCantBeHeld);
         return match.match(t);
       }
     };
@@ -352,7 +349,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(territoryIsNotConqueredOwnedLand(player, data),
+        final Match<Territory> match = Match.all(territoryIsNotConqueredOwnedLand(player, data),
             territoryHasInfraFactoryAndIsOwnedLand(player));
         return match.match(t);
       }
@@ -364,7 +361,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(territoryHasNonMobileInfraFactory(),
+        final Match<Territory> match = Match.all(territoryHasNonMobileInfraFactory(),
             territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data));
         return match.match(t);
       }
@@ -375,7 +372,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Unit> nonMobileInfraFactoryMatch = new CompositeMatchAnd<>(Matches.UnitCanProduceUnits,
+        final Match<Unit> nonMobileInfraFactoryMatch = Match.all(Matches.UnitCanProduceUnits,
             Matches.UnitIsInfrastructure, Matches.unitHasMovementLeft.invert());
         final Match<Territory> match = Matches.territoryHasUnitsThatMatch(nonMobileInfraFactoryMatch);
         return match.match(t);
@@ -387,9 +384,9 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Unit> infraFactoryMatch = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player),
+        final Match<Unit> infraFactoryMatch = Match.all(Matches.unitIsOwnedBy(player),
             Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
-        final Match<Territory> match = new CompositeMatchAnd<>(Matches.isTerritoryOwnedBy(player),
+        final Match<Territory> match = Match.all(Matches.isTerritoryOwnedBy(player),
             Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
         return match.match(t);
       }
@@ -400,9 +397,8 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Unit> infraFactoryMatch =
-            new CompositeMatchAnd<>(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
-        final Match<Territory> match = new CompositeMatchAnd<>(Matches.isTerritoryAllied(player, data),
+        final Match<Unit> infraFactoryMatch = Match.all(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+        final Match<Territory> match = Match.all(Matches.isTerritoryAllied(player, data),
             Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
         return match.match(t);
       }
@@ -414,7 +410,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(territoryHasInfraFactoryAndIsOwnedLand(player),
+        final Match<Territory> match = Match.all(territoryHasInfraFactoryAndIsOwnedLand(player),
             Matches.territoryHasNeighborMatching(data, Matches.TerritoryIsWater));
         return match.match(t);
       }
@@ -426,7 +422,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(territoryIsNotConqueredOwnedLand(player, data),
+        final Match<Territory> match = Match.all(territoryIsNotConqueredOwnedLand(player, data),
             territoryHasInfraFactoryAndIsOwnedLand(player).invert());
         return match.match(t);
       }
@@ -438,7 +434,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> territoryMatch = new CompositeMatchAnd<>(Matches.isTerritoryOwnedBy(players),
+        final Match<Territory> territoryMatch = Match.all(Matches.isTerritoryOwnedBy(players),
             Matches.territoryHasUnitsThatMatch(Matches.UnitIsLand));
         final Match<Territory> match = Matches.territoryHasNeighborMatching(data, territoryMatch);
         return match.match(t);
@@ -450,11 +446,11 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> alliedLand = new CompositeMatchAnd<>(territoryCanMoveLandUnits(player, data, false),
+        final Match<Territory> alliedLand = Match.all(territoryCanMoveLandUnits(player, data, false),
             Matches.isTerritoryAllied(player, data));
         final Match<Territory> hasNoEnemyNeighbors = Matches
             .territoryHasNeighborMatching(data, ProMatches.territoryIsEnemyNotNeutralLand(player, data)).invert();
-        final Match<Territory> match = new CompositeMatchAnd<>(alliedLand, hasNoEnemyNeighbors);
+        final Match<Territory> match = Match.all(alliedLand, hasNoEnemyNeighbors);
         return match.match(t);
       }
     };
@@ -464,7 +460,7 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Territory> match = new CompositeMatchAnd<>(territoryCanMoveLandUnits(player, data, false),
+        final Match<Territory> match = Match.all(territoryCanMoveLandUnits(player, data, false),
             Matches.isTerritoryEnemy(player, data));
         return match.match(t);
       }
@@ -476,7 +472,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> match =
-            new CompositeMatchAnd<>(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
+            Match.all(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
         return match.match(t);
       }
     };
@@ -488,8 +484,8 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> isMatch =
-            new CompositeMatchAnd<>(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
-        final Match<Territory> adjacentMatch = new CompositeMatchAnd<>(territoryCanMoveLandUnits(player, data, false),
+            Match.all(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
+        final Match<Territory> adjacentMatch = Match.all(territoryCanMoveLandUnits(player, data, false),
             Matches.territoryHasNeighborMatching(data, isMatch));
         final Match<Territory> match = Match.any(isMatch, adjacentMatch);
         return match.match(t);
@@ -502,7 +498,7 @@ public class ProMatches {
       @Override
       public boolean match(final Territory t) {
         final Match<Territory> alliedLand =
-            new CompositeMatchAnd<>(Matches.TerritoryIsLand, Matches.isTerritoryAllied(player, data));
+            Match.all(Matches.TerritoryIsLand, Matches.isTerritoryAllied(player, data));
         final Match<Territory> match = Match.any(territoryIsEnemyNotNeutralLand(player, data), alliedLand);
         return match.match(t);
       }
@@ -550,11 +546,11 @@ public class ProMatches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        final Match<Unit> myUnitIsLand = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitIsLand);
+        final Match<Unit> myUnitIsLand = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsLand);
         final Match<Territory> territoryIsLandAndAdjacentToMyLandUnits =
-            new CompositeMatchAnd<>(Matches.TerritoryIsLand,
+            Match.all(Matches.TerritoryIsLand,
                 Matches.territoryHasNeighborMatching(data, Matches.territoryHasUnitsThatMatch(myUnitIsLand)));
-        final Match<Territory> match = new CompositeMatchAnd<>(territoryIsLandAndAdjacentToMyLandUnits,
+        final Match<Territory> match = Match.all(territoryIsLandAndAdjacentToMyLandUnits,
             territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
         return match.match(t);
       }
@@ -568,8 +564,7 @@ public class ProMatches {
         if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
           return false;
         }
-        final Match<Territory> match =
-            new CompositeMatchAnd<>(Matches.isTerritoryAllied(player, data), Matches.TerritoryIsLand);
+        final Match<Territory> match = Match.all(Matches.isTerritoryAllied(player, data), Matches.TerritoryIsLand);
         return match.match(t);
       }
     };
@@ -582,8 +577,7 @@ public class ProMatches {
         if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
           return false;
         }
-        final Match<Territory> match =
-            new CompositeMatchAnd<>(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
+        final Match<Territory> match = Match.all(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
         return match.match(t);
       }
     };
@@ -596,7 +590,7 @@ public class ProMatches {
         final Match<Territory> hasOwnedFactoryNeighbor =
             Matches.territoryHasNeighborMatching(data, ProMatches.territoryHasInfraFactoryAndIsOwnedLand(player));
         final Match<Territory> match =
-            new CompositeMatchAnd<>(hasOwnedFactoryNeighbor, ProMatches.territoryCanMoveSeaUnits(player, data, true));
+            Match.all(hasOwnedFactoryNeighbor, ProMatches.territoryCanMoveSeaUnits(player, data, true));
         return match.match(t);
       }
     };
@@ -606,7 +600,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft);
+        final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft);
         return match.match(u);
       }
     };
@@ -619,7 +613,7 @@ public class ProMatches {
         if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
           return false;
         }
-        final Match<Unit> match = new CompositeMatchAnd<>(unitCanBeMovedAndIsOwned(player), Matches.UnitIsAir);
+        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsAir);
         return match.match(u);
       }
     };
@@ -632,7 +626,7 @@ public class ProMatches {
         if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
           return false;
         }
-        final Match<Unit> match = new CompositeMatchAnd<>(unitCanBeMovedAndIsOwned(player), Matches.UnitIsLand,
+        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsLand,
             Matches.unitIsBeingTransported().invert());
         return match.match(u);
       }
@@ -646,7 +640,7 @@ public class ProMatches {
         if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
           return false;
         }
-        final Match<Unit> match = new CompositeMatchAnd<>(unitCanBeMovedAndIsOwned(player), Matches.UnitIsSea);
+        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsSea);
         return match.match(u);
       }
     };
@@ -659,7 +653,7 @@ public class ProMatches {
         if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
           return false;
         }
-        final Match<Unit> match = new CompositeMatchAnd<>(unitCanBeMovedAndIsOwned(player), Matches.UnitIsTransport);
+        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsTransport);
         return match.match(u);
       }
     };
@@ -672,8 +666,7 @@ public class ProMatches {
         if (Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
           return false;
         }
-        final Match<Unit> match =
-            new CompositeMatchAnd<>(unitCanBeMovedAndIsOwned(player), Matches.unitCanBombard(player));
+        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.unitCanBombard(player));
         return match.match(u);
       }
     };
@@ -683,7 +676,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(unitCanBeMovedAndIsOwned(player),
+        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player),
             Matches.UnitCanNotMoveDuringCombatMove, Matches.UnitIsInfrastructure);
         return match.match(u);
       }
@@ -696,9 +689,9 @@ public class ProMatches {
       @Override
       public boolean match(final Unit u) {
         final Match<Unit> myUnitHasNoMovementMatch =
-            new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft.invert());
+            Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft.invert());
         final Match<Unit> alliedUnitMatch =
-            new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data),
+            Match.all(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data),
                 Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(t.getUnits().getUnits(), null, player,
                     data, false).invert());
         final Match<Unit> match = Match.any(myUnitHasNoMovementMatch, alliedUnitMatch);
@@ -712,7 +705,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(unitCantBeMovedAndIsAlliedDefender(player, data, t),
+        final Match<Unit> match = Match.all(unitCantBeMovedAndIsAlliedDefender(player, data, t),
             Matches.UnitIsNotInfrastructure);
         return match.match(u);
       }
@@ -723,7 +716,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.UnitIsLand, Matches.isUnitAllied(player, data),
+        final Match<Unit> match = Match.all(Matches.UnitIsLand, Matches.isUnitAllied(player, data),
             Matches.UnitIsNotInfrastructure);
         return match.match(u);
       }
@@ -735,7 +728,7 @@ public class ProMatches {
       @Override
       public boolean match(final Unit u) {
         final Match<Unit> match =
-            new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data));
+            Match.all(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data));
         return match.match(u);
       }
     };
@@ -745,7 +738,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(unitIsAlliedNotOwned(player, data), Matches.UnitIsAir);
+        final Match<Unit> match = Match.all(unitIsAlliedNotOwned(player, data), Matches.UnitIsAir);
         return match.match(u);
       }
     };
@@ -755,7 +748,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.isUnitAllied(player, data), Matches.UnitIsAir);
+        final Match<Unit> match = Match.all(Matches.isUnitAllied(player, data), Matches.UnitIsAir);
         return match.match(u);
       }
     };
@@ -765,7 +758,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.UnitIsAir);
+        final Match<Unit> match = Match.all(Matches.enemyUnit(player, data), Matches.UnitIsAir);
         return match.match(u);
       }
     };
@@ -775,8 +768,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match =
-            new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.UnitIsAAforAnything.invert());
+        final Match<Unit> match = Match.all(Matches.enemyUnit(player, data), Matches.UnitIsAAforAnything.invert());
         return match.match(u);
       }
     };
@@ -786,8 +778,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match =
-            new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.UnitIsNotInfrastructure);
+        final Match<Unit> match = Match.all(Matches.enemyUnit(player, data), Matches.UnitIsNotInfrastructure);
         return match.match(u);
       }
     };
@@ -797,7 +788,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.UnitIsNotLand);
+        final Match<Unit> match = Match.all(Matches.enemyUnit(player, data), Matches.UnitIsNotLand);
         return match.match(u);
       }
     };
@@ -807,7 +798,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.enemyUnit(player, data), unitIsNeutral().invert());
+        final Match<Unit> match = Match.all(Matches.enemyUnit(player, data), unitIsNeutral().invert());
         return match.match(u);
       }
     };
@@ -829,7 +820,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.unitOwnedBy(player), Matches.UnitIsAir);
+        final Match<Unit> match = Match.all(Matches.unitOwnedBy(player), Matches.UnitIsAir);
         return match.match(u);
       }
     };
@@ -839,7 +830,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
+        final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
             Matches.unitIsTransporting());
         return match.match(u);
       }
@@ -851,7 +842,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
+        final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
             Matches.unitIsTransporting().invert());
         return match.match(u);
       }
@@ -867,7 +858,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.UnitIsNotLand, Matches.unitIsOwnedBy(player));
+        final Match<Unit> match = Match.all(Matches.UnitIsNotLand, Matches.unitIsOwnedBy(player));
         return match.match(u);
       }
     };
@@ -877,7 +868,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitIsTransport);
+        final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsTransport);
         return match.match(u);
       }
     };
@@ -888,7 +879,7 @@ public class ProMatches {
       @Override
       public boolean match(final Unit u) {
         final Match<Unit> match =
-            new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported, Matches.UnitCanMove);
+            Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported, Matches.UnitCanMove);
         return match.match(u);
       }
     };
@@ -898,7 +889,7 @@ public class ProMatches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final Match<Unit> match = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported,
+        final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported,
             Matches.UnitCanNotMoveDuringCombatMove.invert(), Matches.UnitCanMove);
         return match.match(u);
       }
@@ -913,7 +904,7 @@ public class ProMatches {
         if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
           return false;
         }
-        final Match<Unit> match = new CompositeMatchAnd<>(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved,
+        final Match<Unit> match = Match.all(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved,
             Matches.unitHasMovementLeft, Matches.unitIsBeingTransported().invert());
         return match.match(u);
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -36,7 +36,6 @@ import games.strategy.triplea.delegate.AbstractPlaceDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.OriginalOwnerTracker;
 import games.strategy.triplea.delegate.TransportTracker;
-import games.strategy.util.CompositeMatch;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
@@ -102,8 +101,7 @@ public class ProPurchaseUtils {
 
         // Find number of unit type that are already built and about to be placed
         int currentlyBuilt = 0;
-        final CompositeMatch<Unit> unitTypeOwnedBy =
-            new CompositeMatchAnd<>(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(player));
+        final Match<Unit> unitTypeOwnedBy = Match.all(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(player));
         final List<Territory> allTerritories = data.getMap().getTerritories();
         for (final Territory t : allTerritories) {
           currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
@@ -20,7 +20,6 @@ import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.AirMovementValidator;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TransportTracker;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 /**
@@ -259,7 +258,7 @@ public class ProTransportUtils {
         // If this is the first carrier seek and not last unit
         if (seekedCarrier == null && i > 0) {
           final int seekedCarrierIndex = AIUtils.getIndexOfLastUnitMatching(result,
-              new CompositeMatchAnd<>(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+              Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
           if (seekedCarrierIndex == -1) {
             break; // No carriers left
           }
@@ -289,7 +288,7 @@ public class ProTransportUtils {
 
             // Find the next carrier
             seekedCarrier = AIUtils.getLastUnitMatching(result,
-                new CompositeMatchAnd<>(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               break; // No carriers left
             }
@@ -332,7 +331,7 @@ public class ProTransportUtils {
 
             // Find the next carrier
             seekedCarrier = AIUtils.getLastUnitMatching(result,
-                new CompositeMatchAnd<>(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               break; // No carriers left
             }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -13,8 +13,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.ai.AIUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 class Utils {
@@ -105,7 +103,7 @@ class Utils {
    */
   static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units
-    final CompositeMatch<Unit> limitShips = new CompositeMatchAnd<>(unitCondition);
+    final Match<Unit> limitShips = Match.all(unitCondition);
     final List<Territory> shipTerr = new ArrayList<>();
     final Collection<Territory> tNeighbors = data.getMap().getTerritories();
     for (final Territory t2 : tNeighbors) {

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -69,7 +69,7 @@ public class WeakAI extends AbstractAI {
       }
     };
     final Match<Territory> routeCond =
-        new CompositeMatchAnd<>(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
+        Match.all(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
     final Route withNoEnemy = Utils.findNearest(ourCapitol, endMatch, routeCond, data);
     if (withNoEnemy != null && withNoEnemy.numberOfSteps() > 0) {
       return withNoEnemy;
@@ -91,8 +91,7 @@ public class WeakAI extends AbstractAI {
     // find a land route to an enemy territory from our capitol
     final Route invasionRoute =
         Utils.findNearest(capitol, Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data),
-            new CompositeMatchAnd<>(Matches.TerritoryIsLand, Matches.TerritoryIsNeutralButNotWater.invert()),
-            data);
+            Match.all(Matches.TerritoryIsLand, Matches.TerritoryIsNeutralButNotWater.invert()), data);
     return invasionRoute == null;
   }
 
@@ -218,8 +217,7 @@ public class WeakAI extends AbstractAI {
     }
     final Territory lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     final Territory landOn = amphibRoute.getEnd();
-    final CompositeMatch<Unit> landAndOwned =
-        new CompositeMatchAnd<>(Matches.UnitIsLand, Matches.unitIsOwnedBy(player));
+    final Match<Unit> landAndOwned = Match.all(Matches.UnitIsLand, Matches.unitIsOwnedBy(player));
     final List<Unit> units = lastSeaZoneOnAmphib.getUnits().getMatches(landAndOwned);
     if (units.size() > 0) {
       // just try to make the move, the engine will stop us if it doesnt work
@@ -278,7 +276,7 @@ public class WeakAI extends AbstractAI {
     firstSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(0);
     lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     final Match<Unit> ownedAndNotMoved =
-        new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved, Transporting);
+        Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved, Transporting);
     final List<Unit> unitsToMove = new ArrayList<>();
     final List<Unit> transports = firstSeaZoneOnAmphib.getUnits().getMatches(ownedAndNotMoved);
     if (transports.size() <= maxTrans) {
@@ -309,8 +307,7 @@ public class WeakAI extends AbstractAI {
       firstSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(1);
       lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     }
-    final Match<Unit> ownedAndNotMoved =
-        new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved);
+    final Match<Unit> ownedAndNotMoved = Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved);
     for (final Territory t : data.getMap()) {
       // move sea units to the capitol, unless they are loaded transports
       if (t.isWater()) {
@@ -342,7 +339,7 @@ public class WeakAI extends AbstractAI {
   private static Route getMaxSeaRoute(final GameData data, final Territory start, final Territory destination,
       final PlayerID player) {
     final Match<Territory> routeCond =
-        new CompositeMatchAnd<>(Matches.TerritoryIsWater, Matches.territoryHasEnemyUnits(player, data).invert(),
+        Match.all(Matches.TerritoryIsWater, Matches.territoryHasEnemyUnits(player, data).invert(),
             Matches.territoryHasNonAllowedCanal(player, null, data).invert());
     Route r = data.getMap().getRoute(start, destination, routeCond);
     if (r == null) {
@@ -371,8 +368,8 @@ public class WeakAI extends AbstractAI {
       final Territory enemy = t;
       final float enemyStrength = AIUtils.strength(enemy.getUnits().getUnits(), false, true);
       if (enemyStrength > 0) {
-        final CompositeMatch<Unit> attackable =
-            new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), new Match<Unit>() {
+        final Match<Unit> attackable =
+            Match.all(Matches.unitIsOwnedBy(player), new Match<Unit>() {
               @Override
               public boolean match(final Unit o) {
                 return !unitsAlreadyMoved.contains(o);
@@ -412,20 +409,20 @@ public class WeakAI extends AbstractAI {
       return null;
     }
     final Match<Territory> routeCondition =
-        new CompositeMatchAnd<>(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
+        Match.all(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
     // should select all territories with loaded transports
     final Match<Territory> transportOnSea =
-        new CompositeMatchAnd<>(Matches.TerritoryIsWater, Matches.territoryHasLandUnitsOwnedBy(player));
+        Match.all(Matches.TerritoryIsWater, Matches.territoryHasLandUnitsOwnedBy(player));
     Route altRoute = null;
     final int length = Integer.MAX_VALUE;
     for (final Territory t : data.getMap()) {
       if (!transportOnSea.match(t)) {
         continue;
       }
-      final CompositeMatchAnd<Unit> ownedTransports =
-          new CompositeMatchAnd<>(Matches.UnitCanTransport, Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved);
-      final CompositeMatchAnd<Territory> enemyTerritory =
-          new CompositeMatchAnd<>(Matches.isTerritoryEnemy(player, data), Matches.TerritoryIsLand,
+      final Match<Unit> ownedTransports =
+          Match.all(Matches.UnitCanTransport, Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved);
+      final Match<Territory> enemyTerritory =
+          Match.all(Matches.isTerritoryEnemy(player, data), Matches.TerritoryIsLand,
               Matches.TerritoryIsNeutralButNotWater.invert(), Matches.TerritoryIsEmpty);
       final int trans = t.getUnits().countMatches(ownedTransports);
       if (trans > 0) {
@@ -464,8 +461,8 @@ public class WeakAI extends AbstractAI {
       moveOfType.add(Matches.UnitCanMove);
       moveOfType.add(Matches.UnitIsNotInfrastructure);
       moveOfType.add(Matches.UnitIsLand);
-      final CompositeMatchAnd<Territory> moveThrough =
-          new CompositeMatchAnd<>(Matches.TerritoryIsImpassable.invert(),
+      final Match<Territory> moveThrough =
+          Match.all(Matches.TerritoryIsImpassable.invert(),
               Matches.TerritoryIsNeutralButNotWater.invert(), Matches.TerritoryIsLand);
       final List<Unit> units = t.getUnits().getMatches(moveOfType);
       if (units.size() == 0) {
@@ -498,8 +495,8 @@ public class WeakAI extends AbstractAI {
           moveRoutes.add(route);
         }
       } else { // if we cant move to a capitol, move towards the enemy
-        final CompositeMatchAnd<Territory> routeCondition =
-            new CompositeMatchAnd<>(Matches.TerritoryIsLand, Matches.TerritoryIsImpassable.invert());
+        final Match<Territory> routeCondition =
+            Match.all(Matches.TerritoryIsLand, Matches.TerritoryIsImpassable.invert());
         Route newRoute = Utils.findNearest(t, Matches.territoryHasEnemyLandUnits(player, data), routeCondition, data);
         // move to any enemy territory
         if (newRoute == null) {
@@ -524,19 +521,19 @@ public class WeakAI extends AbstractAI {
     // this works because we are on the server
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
     final Match<Territory> canLand =
-        new CompositeMatchAnd<>(Matches.isTerritoryAllied(player, data), new Match<Territory>() {
+        Match.all(Matches.isTerritoryAllied(player, data), new Match<Territory>() {
           @Override
           public boolean match(final Territory o) {
             return !delegate.getBattleTracker().wasConquered(o);
           }
         });
-    final Match<Territory> routeCondition = new CompositeMatchAnd<>(
+    final Match<Territory> routeCondition = Match.all(
         Matches.territoryHasEnemyAaForCombatOnly(player, data).invert(), Matches.TerritoryIsImpassable.invert());
     for (final Territory t : delegateRemote.getTerritoriesWhereAirCantLand()) {
       final Route noAaRoute = Utils.findNearest(t, canLand, routeCondition, data);
       final Route aaRoute = Utils.findNearest(t, canLand, Matches.TerritoryIsImpassable.invert(), data);
       final Collection<Unit> airToLand =
-          t.getUnits().getMatches(new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.unitIsOwnedBy(player)));
+          t.getUnits().getMatches(Match.all(Matches.UnitIsAir, Matches.unitIsOwnedBy(player)));
       // dont bother to see if all the air units have enough movement points
       // to move without aa guns firing
       // simply move first over no aa, then with aa
@@ -627,7 +624,7 @@ public class WeakAI extends AbstractAI {
           final List<Unit> unitsSortedByCost = new ArrayList<>(attackFrom.getUnits().getUnits());
           Collections.sort(unitsSortedByCost, AIUtils.getCostComparator());
           for (final Unit unit : unitsSortedByCost) {
-            final Match<Unit> match = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitIsLand,
+            final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsLand,
                 Matches.UnitIsNotInfrastructure, Matches.UnitCanMove, Matches.UnitIsNotAA,
                 Matches.UnitCanNotMoveDuringCombatMove.invert());
             if (!unitsAlreadyMoved.contains(unit) && match.match(unit)) {
@@ -716,7 +713,7 @@ public class WeakAI extends AbstractAI {
       final List<Route> moveRoutes, final PlayerID player) {
     final Match<Territory> enemyFactory = Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player,
         Matches.UnitCanProduceUnitsAndCanBeDamaged);
-    final Match<Unit> ownBomber = new CompositeMatchAnd<>(Matches.UnitIsStrategicBomber, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownBomber = Match.all(Matches.UnitIsStrategicBomber, Matches.unitIsOwnedBy(player));
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> bombers = t.getUnits().getMatches(ownBomber);
       if (bombers.isEmpty()) {
@@ -730,8 +727,7 @@ public class WeakAI extends AbstractAI {
   }
 
   private static int countTransports(final GameData data, final PlayerID player) {
-    final CompositeMatchAnd<Unit> ownedTransport =
-        new CompositeMatchAnd<>(Matches.UnitIsTransport, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedTransport = Match.all(Matches.UnitIsTransport, Matches.unitIsOwnedBy(player));
     int sum = 0;
     for (final Territory t : data.getMap()) {
       sum += t.getUnits().countMatches(ownedTransport);
@@ -740,8 +736,7 @@ public class WeakAI extends AbstractAI {
   }
 
   private static int countLandUnits(final GameData data, final PlayerID player) {
-    final CompositeMatchAnd<Unit> ownedLandUnit =
-        new CompositeMatchAnd<>(Matches.UnitIsLand, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedLandUnit = Match.all(Matches.UnitIsLand, Matches.unitIsOwnedBy(player));
     int sum = 0;
     for (final Territory t : data.getMap()) {
       sum += t.getUnits().countMatches(ownedLandUnit);
@@ -813,8 +808,7 @@ public class WeakAI extends AbstractAI {
     final List<ProductionRule> rules = player.getProductionFrontier().getRules();
     final IntegerMap<ProductionRule> purchase = new IntegerMap<>();
     List<RepairRule> rrules = Collections.emptyList();
-    final CompositeMatch<Unit> ourFactories =
-        new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitCanProduceUnits);
+    final Match<Unit> ourFactories = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCanProduceUnits);
     final List<Territory> rfactories =
         Match.getMatches(Utils.findUnitTerr(data, ourFactories), Matches.isTerritoryOwnedBy(player));
     // figure out if anything needs to be repaired

--- a/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -17,7 +17,6 @@ import games.strategy.engine.data.annotations.GameProperty;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 /**
@@ -142,7 +141,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
       return new ArrayList<>();
     }
     return Match.getMatches(getPoliticalActionAttachments(player),
-        new CompositeMatchAnd<>(
+        Match.all(
             Matches.abstractUserActionAttachmentCanBeAttempted(testedConditions),
             Matches.politicalActionAffectsAtLeastOneAlivePlayer(player, data)));
   }

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -36,7 +36,6 @@ import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.ThreadUtil;
@@ -1009,7 +1008,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         allUnits.retainAll(Match.getMatches(allUnits, Matches.enemyUnitOfAnyOfThesePlayers(players, data)));
       } else if (exclType.equals("enemy_surface")) { // any enemy units (not trn/sub) in the territory
         allUnits.retainAll(
-            Match.getMatches(allUnits, new CompositeMatchAnd<>(Matches.enemyUnitOfAnyOfThesePlayers(players, data),
+            Match.getMatches(allUnits, Match.all(Matches.enemyUnitOfAnyOfThesePlayers(players, data),
                 Matches.UnitIsNotSub, Matches.UnitIsNotTransportButCouldBeCombatTransport)));
       } else {
         return false;

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -23,7 +23,6 @@ import games.strategy.triplea.delegate.GenericTechAdvance;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.TechTracker;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -1269,7 +1268,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allJets = Match.getMatches(data.getUnitTypeList().getAllUnitTypes(),
-              new CompositeMatchAnd<>(Matches.UnitTypeIsAir, Matches.UnitTypeIsStrategicBomber.invert()));
+              Match.all(Matches.UnitTypeIsAir, Matches.UnitTypeIsStrategicBomber.invert()));
           final boolean ww2v3TechModel = games.strategy.triplea.Properties.getWW2V3TechModel(data);
           for (final UnitType jet : allJets) {
             if (ww2v3TechModel) {

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -47,7 +47,6 @@ import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.ui.NotificationMessages;
 import games.strategy.triplea.ui.display.ITripleADisplay;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.Tuple;
@@ -1503,7 +1502,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     for (final UnitType ut : uMap.keySet()) {
       final int removeNum = uMap.getInt(ut);
       final Collection<Unit> toRemove = Match.getNMatches(terr.getUnits().getUnits(), removeNum,
-          new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(ut)));
+          Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(ut)));
       if (!toRemove.isEmpty()) {
         totalRemoved.addAll(toRemove);
         change.add(ChangeFactory.removeUnits(terr, toRemove));

--- a/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -19,7 +19,6 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 import games.strategy.util.Tuple;
 
@@ -174,7 +173,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
    */
   public static Collection<UserActionAttachment> getValidActions(final PlayerID player,
       final HashMap<ICondition, Boolean> testedConditions, final GameData data) {
-    return Match.getMatches(getUserActionAttachments(player), new CompositeMatchAnd<>(
+    return Match.getMatches(getUserActionAttachments(player), Match.all(
         Matches.abstractUserActionAttachmentCanBeAttempted(testedConditions)));
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -23,7 +23,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.dataObjects.CasualtyDetails;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 /**
@@ -185,7 +184,7 @@ class AAInMoveUtil implements Serializable {
       final Set<UnitType> airborneTypesTargettedToo = airborneTechTargetsAllowed.get(currentTypeAa);
       final Collection<Unit> validTargetedUnitsForThisRoll =
           Match.getMatches(units, Match.any(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
-              new CompositeMatchAnd<Unit>(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
+              Match.all(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
       // once we fire the AA guns, we can't undo
       // otherwise you could keep undoing and redoing
       // until you got the roll you wanted

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -34,7 +34,6 @@ import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.util.BonusIncomeUtils;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.ThreadUtil;
@@ -307,7 +306,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
           if (PossibleNewOwners.contains(terrNewOwner)) {
             // PlayerOwnerChange
             final Collection<Unit> units =
-                currTerritory.getUnits().getMatches(new CompositeMatchAnd<>(Matches.unitOwnedBy(Player),
+                currTerritory.getUnits().getMatches(Match.all(Matches.unitOwnedBy(Player),
                     Matches.unitCanBeGivenByTerritoryTo(terrNewOwner)));
             if (!units.isEmpty()) {
               change.add(ChangeFactory.changeOwner(units, terrNewOwner, currTerritory));
@@ -368,7 +367,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     if (blockable.isEmpty()) {
       return 0;
     }
-    final Match<Unit> enemyUnits = new CompositeMatchAnd<>(Matches.enemyUnit(player, data));
+    final Match<Unit> enemyUnits = Match.all(Matches.enemyUnit(player, data));
     int totalLoss = 0;
     final boolean rollDiceForBlockadeDamage = games.strategy.triplea.Properties.getConvoyBlockadesRollDiceForCost(data);
     final Collection<String> transcripts = new ArrayList<>();
@@ -378,7 +377,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     for (final Territory b : blockable) {
       // match will check for land, convoy zones, and also contested territories
       final List<Territory> viableNeighbors =
-          Match.getMatches(map.getNeighbors(b), new CompositeMatchAnd<>(Matches.isTerritoryOwnedBy(player),
+          Match.getMatches(map.getNeighbors(b), Match.all(Matches.isTerritoryOwnedBy(player),
               Matches.territoryCanCollectIncomeFrom(player, data)));
       final int maxLoss = getProduction(viableNeighbors);
       if (maxLoss <= 0) {

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -32,7 +32,6 @@ import games.strategy.triplea.delegate.dataObjects.PlaceableUnits;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.ui.SwingComponents;
-import games.strategy.util.CompositeMatch;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
@@ -516,8 +515,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!producer.getUnits().someMatch(Matches.UnitCanProduceUnits)) {
       return null;
     }
-    final CompositeMatch<Unit> ownedFighters =
-        new CompositeMatchAnd<>(Matches.UnitCanLandOnCarrier, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedFighters = Match.all(Matches.UnitCanLandOnCarrier, Matches.unitIsOwnedBy(player));
     if (!producer.getUnits().someMatch(ownedFighters)) {
       return null;
     }
@@ -643,7 +641,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!producer.getOwner().equals(player)) {
       // sea constructions require either owning the sea zone or owning a surrounding land territory
       if (producer.isWater()
-          && Match.someMatch(testUnits, new CompositeMatchAnd<>(Matches.UnitIsSea, Matches.UnitIsConstruction))) {
+          && Match.someMatch(testUnits, Match.all(Matches.UnitIsSea, Matches.UnitIsConstruction))) {
         boolean ownedNeighbor = false;
         for (final Territory current : getData().getMap().getNeighbors(to, Matches.TerritoryIsLand)) {
           if (current.getOwner().equals(player) && (canProduceInConquered || !wasConquered(current))) {
@@ -896,17 +894,14 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     // we add factories and constructions later
     if (water || wasFactoryThereAtStart || (!water && isPlayerAllowedToPlacementAnyTerritoryOwnedLand(player))) {
       final Match<Unit> seaOrLandMatch = water ? Matches.UnitIsSea : Matches.UnitIsLand;
-      placeableUnits
-          .addAll(Match.getMatches(units, new CompositeMatchAnd<>(seaOrLandMatch, Matches.UnitIsNotConstruction)));
+      placeableUnits.addAll(Match.getMatches(units, Match.all(seaOrLandMatch, Matches.UnitIsNotConstruction)));
       if (!water) {
-        placeableUnits.addAll(
-            Match.getMatches(units, new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.UnitIsNotConstruction)));
+        placeableUnits.addAll(Match.getMatches(units, Match.all(Matches.UnitIsAir, Matches.UnitIsNotConstruction)));
       } else if (((isBid || canProduceFightersOnCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
           && Match.someMatch(allProducedUnits, Matches.UnitIsCarrier))
           || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
               && Match.someMatch(to.getUnits().getUnits(), Matches.UnitIsCarrier))) {
-        placeableUnits.addAll(
-            Match.getMatches(units, new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
+        placeableUnits.addAll(Match.getMatches(units, Match.all(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
       }
     }
     if (Match.someMatch(units, Matches.UnitIsConstruction)) {
@@ -998,7 +993,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       final Collection<UnitType> requiredUnits = requiredUnitsMap.keySet();
       for (final UnitType ut : requiredUnits) {
         final int requiredNumber = requiredUnitsMap.getInt(ut);
-        final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = new CompositeMatchAnd<>(
+        final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.all(
             Matches.unitIsOwnedBy(unit.getOwner()), Matches.unitIsOfType(ut),
             Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.UnitHasNotTakenAnyDamage, Matches.UnitIsNotDisabled);
         final Collection<Unit> unitsBeingRemoved =

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -304,7 +304,7 @@ public class AirBattle extends AbstractBattle {
       if (!bombers.isEmpty()) {
         HashMap<Unit, HashSet<Unit>> targets = null;
         final Collection<Unit> enemyTargetsTotal = m_battleSite.getUnits()
-            .getMatches(new CompositeMatchAnd<>(Matches.enemyUnit(bridge.getPlayerID(), m_data),
+            .getMatches(Match.all(Matches.enemyUnit(bridge.getPlayerID(), m_data),
                 Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
                 Matches.unitIsBeingTransported().invert()));
         for (final Unit unit : bombers) {
@@ -651,7 +651,7 @@ public class AirBattle extends AbstractBattle {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
-        final CompositeMatch<Unit> canIntercept = new CompositeMatchAnd<>(Matches.unitCanAirBattle);
+        final Match<Unit> canIntercept = Match.all(Matches.unitCanAirBattle);
         return canIntercept.match(u);
       }
     };

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -23,7 +23,6 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.dataObjects.MoveValidationResult;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -60,7 +59,7 @@ public class AirMovementValidator {
     final Territory routeEnd = route.getEnd();
     final Territory routeStart = route.getStart();
     // we cannot forget to account for allied air at our location already
-    final Match<Unit> airAlliedNotOwned = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player).invert(),
+    final Match<Unit> airAlliedNotOwned = Match.all(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
     final HashSet<Unit> airThatMustLandOnCarriersHash = new HashSet<>();
     airThatMustLandOnCarriersHash.addAll(Match.getMatches(routeEnd.getUnits().getUnits(), airAlliedNotOwned));
@@ -159,7 +158,7 @@ public class AirMovementValidator {
       final List<Territory> landingSpots, final Map<Unit, Collection<Unit>> movedCarriersAndTheirFighters,
       final PlayerID player, final GameData data) {
     final IntegerMap<Territory> startingSpace = new IntegerMap<>();
-    final Match<Unit> carrierAlliedNotOwned = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player).invert(),
+    final Match<Unit> carrierAlliedNotOwned = Match.all(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsCarrier);
     // final Match<Unit> airAlliedNotOwned = new CompositeMatchAnd<Unit>(Matches.unitIsOwnedBy(player).invert(),
     // Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
@@ -197,13 +196,12 @@ public class AirMovementValidator {
       final List<Territory> landingSpots, final Collection<Territory> potentialCarrierOrigins,
       final Map<Unit, Collection<Unit>> movedCarriersAndTheirFighters, final Collection<Unit> airThatMustLandOnCarriers,
       final Collection<Unit> airNotToConsider, final PlayerID player, final Route route, final GameData data) {
-    final Match<Unit> ownedCarrierMatch =
-        new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier);
+    final Match<Unit> ownedCarrierMatch = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier);
     final Match<Unit> ownedAirMatch =
-        new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
-    final Match<Unit> alliedNotOwnedAirMatch = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player).invert(),
+        Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
+    final Match<Unit> alliedNotOwnedAirMatch = Match.all(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
-    final Match<Unit> alliedNotOwnedCarrierMatch = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player).invert(),
+    final Match<Unit> alliedNotOwnedCarrierMatch = Match.all(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsCarrier);
     final Territory routeEnd = route.getEnd();
     final boolean areNeutralsPassableByAir = areNeutralsPassableByAir(data);
@@ -464,7 +462,7 @@ public class AirMovementValidator {
 
   private static int maxMovementLeftForAllOwnedCarriers(final PlayerID player, final GameData data) {
     int max = 0;
-    final Match<Unit> ownedCarrier = new CompositeMatchAnd<>(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedCarrier = Match.all(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player));
     for (final Territory t : data.getMap().getTerritories()) {
       for (final Unit carrier : t.getUnits().getMatches(ownedCarrier)) {
         max = Math.max(max, ((TripleAUnit) carrier).getMovementLeft());
@@ -520,7 +518,7 @@ public class AirMovementValidator {
   private static List<Unit> getAirUnitsToValidate(final Collection<Unit> units, final Route route,
       final PlayerID player) {
     final Match<Unit> ownedAirMatch =
-        new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.unitOwnedBy(player), Matches.UnitIsKamikaze.invert());
+        Match.all(Matches.UnitIsAir, Matches.unitOwnedBy(player), Matches.UnitIsKamikaze.invert());
     final List<Unit> ownedAir = new ArrayList<>();
     ownedAir.addAll(Match.getMatches(route.getEnd().getUnits().getUnits(), ownedAirMatch));
     ownedAir.addAll(Match.getMatches(units, ownedAirMatch));
@@ -685,7 +683,7 @@ public class AirMovementValidator {
         if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER).match(unit)) {
           int cargo = 0;
           final Collection<Unit> airCargo = territoryUnitsAreCurrentlyIn.getUnits()
-              .getMatches(new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier));
+              .getMatches(Match.all(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier));
           for (final Unit airUnit : airCargo) {
             final TripleAUnit taUnit = (TripleAUnit) airUnit;
             if (taUnit.getTransportedBy() != null && taUnit.getTransportedBy().equals(unit)) {

--- a/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -11,7 +11,6 @@ import games.strategy.triplea.ai.weakAI.WeakAI;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.ui.display.ITripleADisplay;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 /**
@@ -89,7 +88,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
     if (games.strategy.triplea.Properties.getTriggers(data)) {
       final String stepName = data.getSequence().getStep().getName();
       // we use AND in order to make sure there are uses and when is set correctly.
-      final Match<TriggerAttachment> baseDelegateWhenTriggerMatch = new CompositeMatchAnd<>(
+      final Match<TriggerAttachment> baseDelegateWhenTriggerMatch = Match.all(
           TriggerAttachment.availableUses, TriggerAttachment.whenOrDefaultMatch(beforeOrAfter, stepName));
       TriggerAttachment.collectAndFireTriggers(new HashSet<>(data.getPlayerList().getPlayers()),
           baseDelegateWhenTriggerMatch, m_bridge, beforeOrAfter, stepName);

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -41,7 +41,6 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.LinkedIntegerMap;
 import games.strategy.util.Match;
@@ -594,7 +593,7 @@ public class BattleCalculator {
     final Collection<Unit> killedNonAmphibUnits = new ArrayList<>();
     final Collection<UnitType> amphibTypes = new ArrayList<>();
     // Get a list of all selected killed units that are NOT amphibious
-    final Match<Unit> aMatch = new CompositeMatchAnd<>(Matches.UnitIsLand, Matches.UnitWasNotAmphibious);
+    final Match<Unit> aMatch = Match.all(Matches.UnitIsLand, Matches.UnitWasNotAmphibious);
     killedNonAmphibUnits.addAll(Match.getMatches(killed, aMatch));
     // If all killed units are amphibious, just return them
     if (killedNonAmphibUnits.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -687,7 +687,7 @@ public class BattleTracker implements java.io.Serializable {
     // Remove any bombing raids against captured territory
     // TODO: see if necessary
     if (Match.someMatch(territory.getUnits().getUnits(),
-        new CompositeMatchAnd<>(Matches.unitIsEnemyOf(data, id), Matches.UnitCanBeDamaged))) {
+        Match.all(Matches.unitIsEnemyOf(data, id), Matches.UnitCanBeDamaged))) {
       final IBattle bombingBattle = getPendingBattle(territory, true, null);
       if (bombingBattle != null) {
         final BattleResults results = new BattleResults(bombingBattle, WhoWon.DRAW, data);
@@ -744,8 +744,8 @@ public class BattleTracker implements java.io.Serializable {
     final GameData data = bridge.getData();
     // destroy any units that should be destroyed on capture
     if (games.strategy.triplea.Properties.getUnitsCanBeDestroyedInsteadOfCaptured(data)) {
-      final CompositeMatch<Unit> enemyToBeDestroyed =
-          new CompositeMatchAnd<>(Matches.enemyUnit(id, data), Matches.unitDestroyedWhenCapturedByOrFrom(id));
+      final Match<Unit> enemyToBeDestroyed =
+          Match.all(Matches.enemyUnit(id, data), Matches.unitDestroyedWhenCapturedByOrFrom(id));
       final Collection<Unit> destroyed = territory.getUnits().getMatches(enemyToBeDestroyed);
       if (!destroyed.isEmpty()) {
         final Change destroyUnits = ChangeFactory.removeUnits(territory, destroyed);
@@ -771,7 +771,7 @@ public class BattleTracker implements java.io.Serializable {
       }
     }
     // destroy any disabled units owned by the enemy that are NOT infrastructure or factories
-    final CompositeMatch<Unit> enemyToBeDestroyed = new CompositeMatchAnd<>(Matches.enemyUnit(id, data),
+    final Match<Unit> enemyToBeDestroyed = Match.all(Matches.enemyUnit(id, data),
         Matches.UnitIsDisabled, Matches.UnitIsInfrastructure.invert());
     final Collection<Unit> destroyed = territory.getUnits().getMatches(enemyToBeDestroyed);
     if (!destroyed.isEmpty()) {
@@ -783,8 +783,7 @@ public class BattleTracker implements java.io.Serializable {
       }
     }
     // take over non combatants
-    final CompositeMatch<Unit> enemyNonCom =
-        new CompositeMatchAnd<>(Matches.enemyUnit(id, data), Matches.UnitIsInfrastructure);
+    final Match<Unit> enemyNonCom = Match.all(Matches.enemyUnit(id, data), Matches.UnitIsInfrastructure);
     final Match<Unit> willBeCaptured = Match.any(enemyNonCom,
         Matches.unitCanBeCapturedOnEnteringToInThisTerritory(id, territory, data));
     final Collection<Unit> nonCom = territory.getUnits().getMatches(willBeCaptured);

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -12,8 +12,6 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -115,10 +113,10 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       final PlayerID player) {
     final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
     final Collection<Unit> placeableUnits = new ArrayList<>();
-    final CompositeMatch<Unit> groundUnits =
+    final Match<Unit> groundUnits =
         // we add factories and constructions later
-        new CompositeMatchAnd<>(Matches.UnitIsLand, Matches.UnitIsNotConstruction);
-    final CompositeMatch<Unit> airUnits = new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.UnitIsNotConstruction);
+        Match.all(Matches.UnitIsLand, Matches.UnitIsNotConstruction);
+    final Match<Unit> airUnits = Match.all(Matches.UnitIsAir, Matches.UnitIsNotConstruction);
     placeableUnits.addAll(Match.getMatches(units, groundUnits));
     placeableUnits.addAll(Match.getMatches(units, airUnits));
     if (Match.someMatch(units, Matches.UnitIsConstruction)) {

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -30,7 +30,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Die.DieType;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.LinkedIntegerMap;
 import games.strategy.util.Match;
@@ -646,7 +645,7 @@ public class DiceRoll implements Externalizable {
       if (!((allies && rule.getAllied()) || (!allies && rule.getEnemy()))) {
         continue;
       }
-      final CompositeMatchAnd<Unit> canSupport = new CompositeMatchAnd<>(
+      final Match<Unit> canSupport = Match.all(
           Matches.unitIsOfType((UnitType) rule.getAttachedTo()), Matches.unitOwnedBy(rule.getPlayers()));
       final List<Unit> supporters = Match.getMatches(unitsGivingTheSupport, canSupport);
       int numSupport = supporters.size();

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -91,7 +91,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
-              new CompositeMatchAnd<>(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
+              Match.all(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
           if (!Match.allMatch(landUnitsToAdd, Matches.UnitCanBeTransported)) {

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -15,7 +15,6 @@ import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.util.TransportUtils;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.Triple;
@@ -75,7 +74,7 @@ class EditValidator {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
-              new CompositeMatchAnd<>(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
+              Match.all(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
           if (!Match.allMatch(landUnitsToAdd, Matches.UnitCanBeTransported)) {
@@ -91,15 +90,12 @@ class EditValidator {
           }
         }
         if (Match.someMatch(units, Matches.UnitIsAir)) {
-          if (Match.someMatch(units,
-              new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier.invert()))) {
+          if (Match.someMatch(units, Match.all(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier.invert()))) {
             return "Cannot add air to water unless it can land on carriers";
           }
           // Set up matches
-          final Match<Unit> friendlyCarriers =
-              new CompositeMatchAnd<>(Matches.UnitIsCarrier, Matches.alliedUnit(player, data));
-          final Match<Unit> friendlyAirUnits =
-              new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.alliedUnit(player, data));
+          final Match<Unit> friendlyCarriers = Match.all(Matches.UnitIsCarrier, Matches.alliedUnit(player, data));
+          final Match<Unit> friendlyAirUnits = Match.all(Matches.UnitIsAir, Matches.alliedUnit(player, data));
           // Determine transport capacity
           final int carrierCapacityTotal =
               AirMovementValidator.carrierCapacity(territory.getUnits().getMatches(friendlyCarriers), territory)

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -27,7 +27,6 @@ import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.LocalizeHTML;
@@ -107,7 +106,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
       final Match<TriggerAttachment> endRoundDelegateTriggerMatch =
-          new CompositeMatchAnd<>(AbstractTriggerAttachment.availableUses,
+          Match.all(AbstractTriggerAttachment.availableUses,
               AbstractTriggerAttachment.whenOrDefaultMatch(null, null), Match.any(
                   TriggerAttachment.activateTriggerMatch(), TriggerAttachment.victoryMatch()));
       // get all possible triggers based on this match.

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -33,7 +33,6 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.ThreadUtil;
@@ -75,8 +74,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final StringBuilder endTurnReport = new StringBuilder();
     final GameData data = getData();
     final PlayerID player = data.getSequence().getStep().getPlayerID();
-    final Match<Unit> myCreatorsMatch =
-        new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitCreatesUnits);
+    final Match<Unit> myCreatorsMatch = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCreatesUnits);
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> myCreators = Match.getMatches(t.getUnits().getUnits(), myCreatorsMatch);
@@ -108,7 +106,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           change.add(place);
         }
         if (!toAddSea.isEmpty()) {
-          final Match<Territory> myTerrs = new CompositeMatchAnd<>(Matches.TerritoryIsWater);
+          final Match<Territory> myTerrs = Match.all(Matches.TerritoryIsWater);
           final Collection<Territory> waterNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (waterNeighbors != null && !waterNeighbors.isEmpty()) {
             final Territory tw = getRandomTerritory(waterNeighbors, bridge);
@@ -121,8 +119,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           }
         }
         if (!toAddLand.isEmpty()) {
-          final Match<Territory> myTerrs =
-              new CompositeMatchAnd<>(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
+          final Match<Territory> myTerrs = Match.all(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
           final Collection<Territory> landNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (landNeighbors != null && !landNeighbors.isEmpty()) {
             final Territory tl = getRandomTerritory(landNeighbors, bridge);
@@ -167,7 +164,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final StringBuilder endTurnReport = new StringBuilder();
     final GameData data = getData();
     final PlayerID player = data.getSequence().getStep().getPlayerID();
-    final Match<Unit> myCreatorsMatch = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player),
+    final Match<Unit> myCreatorsMatch = Match.all(Matches.unitIsOwnedBy(player),
         negativeResources ? Matches.UnitCreatesResourcesNegative : Matches.UnitCreatesResourcesPositive);
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> myCreators = Match.getMatches(t.getUnits().getUnits(), myCreatorsMatch);
@@ -215,7 +212,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final boolean useTriggers = games.strategy.triplea.Properties.getTriggers(data);
     if (useTriggers) {
       // add conditions required for triggers
-      final Match<TriggerAttachment> endTurnDelegateTriggerMatch = new CompositeMatchAnd<>(
+      final Match<TriggerAttachment> endTurnDelegateTriggerMatch = Match.all(
           AbstractTriggerAttachment.availableUses, AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
           Match.any(TriggerAttachment.resourceMatch()));
       toFirePossible.addAll(TriggerAttachment.collectForAllTriggersMatching(

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -100,13 +100,13 @@ public class Fire implements IExecutable {
     final int hitCount = m_dice.getHits();
     AbstractBattle.getDisplay(bridge).notifyDice(m_dice, m_stepName);
     final int countTransports =
-        Match.countMatches(m_attackableUnits, new CompositeMatchAnd<>(Matches.UnitIsTransport, Matches.UnitIsSea));
+        Match.countMatches(m_attackableUnits, Match.all(Matches.UnitIsTransport, Matches.UnitIsSea));
     if (countTransports > 0 && isTransportCasualtiesRestricted(bridge.getData())) {
       final CasualtyDetails message;
       final Collection<Unit> nonTransports = Match.getMatches(m_attackableUnits,
           Match.any(Matches.UnitIsNotTransportButCouldBeCombatTransport, Matches.UnitIsNotSea));
       final Collection<Unit> transportsOnly = Match.getMatches(m_attackableUnits,
-          new CompositeMatchAnd<>(Matches.UnitIsTransportButNotCombatTransport, Matches.UnitIsSea));
+          Match.all(Matches.UnitIsTransportButNotCombatTransport, Matches.UnitIsSea));
       final int numPossibleHits = AbstractBattle.getMaxHits(nonTransports);
       // more hits than combat units
       if (hitCount > numPossibleHits) {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -667,8 +667,7 @@ public class Matches {
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {
-        return t.getUnits()
-            .someMatch(new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier));
+        return t.getUnits().someMatch(Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier));
       }
     };
   }
@@ -866,7 +865,7 @@ public class Matches {
             return true;
           }
         }
-        return Match.someMatch(targets, new CompositeMatchAnd<>(Matches.UnitIsAirborne,
+        return Match.someMatch(targets, Match.all(Matches.UnitIsAirborne,
             Matches.unitIsOfTypes(airborneTechTargetsAllowed.get(ua.getTypeAA()))));
       }
     };
@@ -925,7 +924,7 @@ public class Matches {
   static Match<Unit> unitIsAaThatCanFire(final Collection<Unit> unitsMovingOrAttacking,
       final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed, final PlayerID playerMovingOrAttacking,
       final Match<Unit> typeOfAa, final int battleRoundNumber, final boolean defending, final GameData data) {
-    return new CompositeMatchAnd<>(Matches.enemyUnit(playerMovingOrAttacking, data),
+    return Match.all(Matches.enemyUnit(playerMovingOrAttacking, data),
         Matches.unitIsBeingTransported().invert(),
         Matches.unitIsAaThatCanHitTheseUnits(unitsMovingOrAttacking, typeOfAa, airborneTechTargetsAllowed),
         Matches.unitIsAaThatWillNotFireIfPresentEnemyUnits(unitsMovingOrAttacking).invert(),
@@ -1200,7 +1199,7 @@ public class Matches {
         // CompositeMatchAnd<Territory>(Matches.TerritoryIsPassableAndNotRestricted(player),
         // Matches.territoryHasEnemyLandNeighbor(data,
         // player));
-        final CompositeMatch<Territory> condition = new CompositeMatchAnd<>(Matches.TerritoryIsLand,
+        final Match<Territory> condition = Match.all(Matches.TerritoryIsLand,
             Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data));
         return data.getMap().getNeighbors(t, condition).size() > 0;
       }
@@ -1311,7 +1310,7 @@ public class Matches {
         if (!data.getRelationshipTracker().isAllied(t.getOwner(), player)) {
           return false;
         }
-        return t.getUnits().someMatch(new CompositeMatchAnd<>(Matches.alliedUnit(player, data), unitMatch));
+        return t.getUnits().someMatch(Match.all(Matches.alliedUnit(player, data), unitMatch));
       }
     };
   }
@@ -1324,7 +1323,7 @@ public class Matches {
         if (!t.getOwner().equals(player)) {
           return false;
         }
-        return t.getUnits().someMatch(new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), unitMatch));
+        return t.getUnits().someMatch(Match.all(Matches.unitIsOwnedBy(player), unitMatch));
       }
     };
   }
@@ -1381,7 +1380,7 @@ public class Matches {
         if (t.getOwner().isNull()) {
           return false;
         }
-        return t.getUnits().someMatch(new CompositeMatchAnd<>(Matches.enemyUnit(player, data), unitMatch));
+        return t.getUnits().someMatch(Match.all(Matches.enemyUnit(player, data), unitMatch));
       }
     };
   }
@@ -1921,8 +1920,7 @@ public class Matches {
   }
 
   public static Match<Territory> territoryHasLandUnitsOwnedBy(final PlayerID player) {
-    final CompositeMatch<Unit> unitOwnedBy = new CompositeMatchAnd<>(unitIsOwnedBy(player), UnitIsLand);
-    return Match.of(t -> t.getUnits().someMatch(unitOwnedBy));
+    return Match.of(t -> t.getUnits().someMatch(Match.all(unitIsOwnedBy(player), UnitIsLand)));
   }
 
   public static Match<Territory> territoryHasUnitsOwnedBy(final PlayerID player) {
@@ -1963,11 +1961,11 @@ public class Matches {
   }
 
   public static Match<Territory> territoryHasEnemyLandUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().someMatch(new CompositeMatchAnd<>(enemyUnit(player, data), UnitIsLand)));
+    return Match.of(t -> t.getUnits().someMatch(Match.all(enemyUnit(player, data), UnitIsLand)));
   }
 
   public static Match<Territory> territoryHasEnemySeaUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().someMatch(new CompositeMatchAnd<>(enemyUnit(player, data), UnitIsSea)));
+    return Match.of(t -> t.getUnits().someMatch(Match.all(enemyUnit(player, data), UnitIsSea)));
   }
 
   public static Match<Territory> territoryHasEnemyUnits(final PlayerID player, final GameData data) {
@@ -1992,7 +1990,7 @@ public class Matches {
         }
         final Set<PlayerID> enemies = new HashSet<>();
         for (final Unit u : t.getUnits()
-            .getMatches(new CompositeMatchAnd<>(enemyUnit(player, data), UnitIsNotAir, UnitIsNotInfrastructure))) {
+            .getMatches(Match.all(enemyUnit(player, data), UnitIsNotAir, UnitIsNotInfrastructure))) {
           enemies.add(u.getOwner());
         }
         return (Matches.isAtWarWithAnyOfThesePlayers(enemies, data)).match(t.getOwner());
@@ -2095,9 +2093,9 @@ public class Matches {
     };
   }
 
-  public static final Match<Unit> UnitIsLand = new CompositeMatchAnd<>(UnitIsNotSea, UnitIsNotAir);
-  public static final Match<UnitType> UnitTypeIsLand =
-      new CompositeMatchAnd<>(UnitTypeIsNotSea, UnitTypeIsNotAir);
+  public static final Match<Unit> UnitIsLand = Match.all(UnitIsNotSea, UnitIsNotAir);
+
+  public static final Match<UnitType> UnitTypeIsLand = Match.all(UnitTypeIsNotSea, UnitTypeIsNotAir);
 
   public static final Match<Unit> UnitIsNotLand = UnitIsLand.invert();
 
@@ -2159,9 +2157,9 @@ public class Matches {
   public static Match<Territory> territoryIsBlockedSea(final PlayerID player, final GameData data) {
     final CompositeMatch<Unit> ignore =
         new CompositeMatchAnd<>(Matches.UnitIsInfrastructure.invert(), Matches.alliedUnit(player, data).invert());
-    final CompositeMatch<Unit> sub = new CompositeMatchAnd<>(Matches.UnitIsSub.invert());
-    final CompositeMatch<Unit> transport =
-        new CompositeMatchAnd<>(Matches.UnitIsTransportButNotCombatTransport.invert(), Matches.UnitIsLand.invert());
+    final Match<Unit> sub = Match.all(Matches.UnitIsSub.invert());
+    final Match<Unit> transport =
+        Match.all(Matches.UnitIsTransportButNotCombatTransport.invert(), Matches.UnitIsLand.invert());
     final CompositeMatch<Unit> unitCond = ignore;
     if (Properties.getIgnoreTransportInMovement(data)) {
       unitCond.add(transport);
@@ -2169,7 +2167,7 @@ public class Matches {
     if (Properties.getIgnoreSubInMovement(data)) {
       unitCond.add(sub);
     }
-    final CompositeMatch<Territory> routeCondition = new CompositeMatchAnd<>(
+    final Match<Territory> routeCondition = Match.all(
         Matches.territoryHasUnitsThatMatch(unitCond).invert(), Matches.TerritoryIsWater);
     return routeCondition;
   }
@@ -2222,18 +2220,17 @@ public class Matches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit damagedUnit) {
-        final Match<Unit> damaged =
-            new CompositeMatchAnd<>(Matches.UnitHasMoreThanOneHitPointTotal, Matches.UnitHasTakenSomeDamage);
+        final Match<Unit> damaged = Match.all(Matches.UnitHasMoreThanOneHitPointTotal, Matches.UnitHasTakenSomeDamage);
         if (!damaged.match(damagedUnit)) {
           return false;
         }
-        final Match<Unit> repairUnit = new CompositeMatchAnd<>(Matches.alliedUnit(player, data),
+        final Match<Unit> repairUnit = Match.all(Matches.alliedUnit(player, data),
             Matches.UnitCanRepairOthers, Matches.unitCanRepairThisUnit(damagedUnit));
         if (Match.someMatch(territory.getUnits().getUnits(), repairUnit)) {
           return true;
         }
         if (Matches.UnitIsSea.match(damagedUnit)) {
-          final Match<Unit> repairUnitLand = new CompositeMatchAnd<>(repairUnit, Matches.UnitIsLand);
+          final Match<Unit> repairUnitLand = Match.all(repairUnit, Matches.UnitIsLand);
           final List<Territory> neighbors =
               new ArrayList<>(data.getMap().getNeighbors(territory, Matches.TerritoryIsLand));
           for (final Territory current : neighbors) {
@@ -2242,7 +2239,7 @@ public class Matches {
             }
           }
         } else if (Matches.UnitIsLand.match(damagedUnit)) {
-          final Match<Unit> repairUnitSea = new CompositeMatchAnd<>(repairUnit, Matches.UnitIsSea);
+          final Match<Unit> repairUnitSea = Match.all(repairUnit, Matches.UnitIsSea);
           final List<Territory> neighbors =
               new ArrayList<>(data.getMap().getNeighbors(territory, Matches.TerritoryIsWater));
           for (final Territory current : neighbors) {
@@ -2300,13 +2297,13 @@ public class Matches {
     return new Match<Unit>() {
       @Override
       public boolean match(final Unit unitWhichWillGetBonus) {
-        final Match<Unit> givesBonusUnit = new CompositeMatchAnd<>(Matches.alliedUnit(player, data),
+        final Match<Unit> givesBonusUnit = Match.all(Matches.alliedUnit(player, data),
             unitCanGiveBonusMovementToThisUnit(unitWhichWillGetBonus));
         if (Match.someMatch(territory.getUnits().getUnits(), givesBonusUnit)) {
           return true;
         }
         if (Matches.UnitIsSea.match(unitWhichWillGetBonus)) {
-          final Match<Unit> givesBonusUnitLand = new CompositeMatchAnd<>(givesBonusUnit, Matches.UnitIsLand);
+          final Match<Unit> givesBonusUnitLand = Match.all(givesBonusUnit, Matches.UnitIsLand);
           final List<Territory> neighbors =
               new ArrayList<>(data.getMap().getNeighbors(territory, Matches.TerritoryIsLand));
           for (final Territory current : neighbors) {
@@ -2416,7 +2413,7 @@ public class Matches {
         final Collection<UnitType> requiredUnits = requiredUnitsMap.keySet();
         boolean canBuild = true;
         for (final UnitType ut : requiredUnits) {
-          final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = new CompositeMatchAnd<>(
+          final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.all(
               Matches.unitIsOwnedBy(unitWhichRequiresUnits.getOwner()), Matches.unitIsOfType(ut),
               Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.UnitHasNotTakenAnyDamage, Matches.UnitIsNotDisabled);
           final int requiredNumber = requiredUnitsMap.getInt(ut);
@@ -2454,7 +2451,7 @@ public class Matches {
         if (!Matches.UnitRequiresUnitsOnCreation.match(unitWhichRequiresUnits)) {
           return true;
         }
-        final Match<Unit> unitIsOwnedByAndNotDisabled = new CompositeMatchAnd<>(
+        final Match<Unit> unitIsOwnedByAndNotDisabled = Match.all(
             Matches.unitIsOwnedBy(unitWhichRequiresUnits.getOwner()), Matches.UnitIsNotDisabled);
         unitsInTerritoryAtStartOfTurn
             .retainAll(Match.getMatches(unitsInTerritoryAtStartOfTurn, unitIsOwnedByAndNotDisabled));
@@ -2516,13 +2513,13 @@ public class Matches {
   public static final Match<Unit> UnitIsNotConstruction = UnitIsConstruction.invert();
 
   public static final Match<Unit> UnitCanProduceUnitsAndIsConstruction =
-      new CompositeMatchAnd<>(UnitCanProduceUnits, UnitIsConstruction);
+      Match.all(UnitCanProduceUnits, UnitIsConstruction);
   public static final Match<UnitType> UnitTypeCanProduceUnitsAndIsConstruction =
-      new CompositeMatchAnd<>(UnitTypeCanProduceUnits, UnitTypeIsConstruction);
+      Match.all(UnitTypeCanProduceUnits, UnitTypeIsConstruction);
   public static final Match<Unit> UnitCanProduceUnitsAndIsInfrastructure =
-      new CompositeMatchAnd<>(UnitCanProduceUnits, UnitIsInfrastructure);
+      Match.all(UnitCanProduceUnits, UnitIsInfrastructure);
   public static final Match<Unit> UnitCanProduceUnitsAndCanBeDamaged =
-      new CompositeMatchAnd<>(UnitCanProduceUnits, UnitCanBeDamaged);
+      Match.all(UnitCanProduceUnits, UnitCanBeDamaged);
   /**
    * See if a unit can invade. Units with canInvadeFrom not set, or set to "all", can invade from any other unit.
    * Otherwise, units must have
@@ -2780,7 +2777,7 @@ public class Matches {
     };
   }
 
-  public static Match<AbstractUserActionAttachment> abstractUserActionAttachmentCanBeAttempted(
+  public static <T extends AbstractUserActionAttachment> Match<T> abstractUserActionAttachmentCanBeAttempted(
       final HashMap<ICondition, Boolean> testedConditions) {
     return Match.of(uaa -> uaa.hasAttemptsLeft() && uaa.canPerform(testedConditions));
   }
@@ -3054,7 +3051,7 @@ public class Matches {
             // ANY match
             final Match.CompositeBuilder<UnitType> defenseMatchAnyBuilder = Match.newCompositeBuilder();
             if (!doNotIncludeAa) {
-              defenseMatchAnyBuilder.add(new CompositeMatchAnd<>(Matches.UnitTypeIsAAforCombatOnly,
+              defenseMatchAnyBuilder.add(Match.all(Matches.UnitTypeIsAAforCombatOnly,
                   Matches.unitTypeIsAaThatCanFireOnRound(battleRound)));
             }
             defenseMatchAnyBuilder.add(supporterOrNotInfrastructure);

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -78,14 +78,14 @@ public class MoveDelegate extends AbstractMoveDelegate {
       // OR. use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
       HashMap<ICondition, Boolean> testedConditions = null;
       final Match<TriggerAttachment> moveCombatDelegateBeforeBonusTriggerMatch =
-          new CompositeMatchAnd<>(AbstractTriggerAttachment.availableUses,
+          Match.all(AbstractTriggerAttachment.availableUses,
               AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
               Match.any(AbstractTriggerAttachment.notificationMatch(),
                   TriggerAttachment.playerPropertyMatch(), TriggerAttachment.relationshipTypePropertyMatch(),
                   TriggerAttachment.territoryPropertyMatch(), TriggerAttachment.territoryEffectPropertyMatch(),
                   TriggerAttachment.removeUnitsMatch(), TriggerAttachment.changeOwnershipMatch()));
       final Match<TriggerAttachment> moveCombatDelegateAfterBonusTriggerMatch =
-          new CompositeMatchAnd<>(AbstractTriggerAttachment.availableUses,
+          Match.all(AbstractTriggerAttachment.availableUses,
               AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
               Match.any(TriggerAttachment.placeMatch()));
       final Match<TriggerAttachment> moveCombatDelegateAllTriggerMatch = Match.any(
@@ -239,7 +239,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
     // right now, land units on transports have movement taken away when they their transport moves
     moveableUnitOwnedByMe.add(Match.any(Matches.unitHasMovementLeft,
-        new CompositeMatchAnd<Unit>(Matches.UnitIsLand, Matches.unitIsBeingTransported())));
+        Match.all(Matches.UnitIsLand, Matches.unitIsBeingTransported())));
 
     // if not non combat, cannot move aa units
     if (GameStepPropertiesHelper.isCombatMove(getData())) {
@@ -318,11 +318,11 @@ public class MoveDelegate extends AbstractMoveDelegate {
   private static void removeMovementFromAirOnDamagedAlliedCarriers(final IDelegateBridge aBridge,
       final PlayerID player) {
     final GameData data = aBridge.getData();
-    final Match<Unit> crippledAlliedCarriersMatch = new CompositeMatchAnd<>(Matches.isUnitAllied(player, data),
+    final Match<Unit> crippledAlliedCarriersMatch = Match.all(Matches.isUnitAllied(player, data),
         Matches.unitIsOwnedBy(player).invert(), Matches.UnitIsCarrier,
         Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
     final Match<Unit> ownedFightersMatch =
-        new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitIsAir,
+        Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsAir,
             Matches.UnitCanLandOnCarrier, Matches.unitHasMovementLeft);
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
@@ -360,18 +360,18 @@ public class MoveDelegate extends AbstractMoveDelegate {
           }
           int bonusMovement = Integer.MIN_VALUE;
           final Collection<Unit> givesBonusUnits = new ArrayList<>();
-          final Match<Unit> givesBonusUnit = new CompositeMatchAnd<>(Matches.alliedUnit(player, data),
+          final Match<Unit> givesBonusUnit = Match.all(Matches.alliedUnit(player, data),
               Matches.unitCanGiveBonusMovementToThisUnit(u));
           givesBonusUnits.addAll(Match.getMatches(t.getUnits().getUnits(), givesBonusUnit));
           if (Matches.UnitIsSea.match(u)) {
-            final Match<Unit> givesBonusUnitLand = new CompositeMatchAnd<>(givesBonusUnit, Matches.UnitIsLand);
+            final Match<Unit> givesBonusUnitLand = Match.all(givesBonusUnit, Matches.UnitIsLand);
             final List<Territory> neighbors =
                 new ArrayList<>(data.getMap().getNeighbors(t, Matches.TerritoryIsLand));
             for (final Territory current : neighbors) {
               givesBonusUnits.addAll(Match.getMatches(current.getUnits().getUnits(), givesBonusUnitLand));
             }
           } else if (Matches.UnitIsLand.match(u)) {
-            final Match<Unit> givesBonusUnitSea = new CompositeMatchAnd<>(givesBonusUnit, Matches.UnitIsSea);
+            final Match<Unit> givesBonusUnitSea = Match.all(givesBonusUnit, Matches.UnitIsSea);
             final List<Territory> neighbors =
                 new ArrayList<>(data.getMap().getNeighbors(t, Matches.TerritoryIsWater));
             for (final Territory current : neighbors) {
@@ -399,8 +399,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final boolean repairOnlyOwn =
         games.strategy.triplea.Properties.getBattleshipsRepairAtBeginningOfRound(aBridge.getData());
     final Match<Unit> damagedUnits =
-        new CompositeMatchAnd<>(Matches.UnitHasMoreThanOneHitPointTotal, Matches.UnitHasTakenSomeDamage);
-    final Match<Unit> damagedUnitsOwned = new CompositeMatchAnd<>(damagedUnits, Matches.unitIsOwnedBy(player));
+        Match.all(Matches.UnitHasMoreThanOneHitPointTotal, Matches.UnitHasTakenSomeDamage);
+    final Match<Unit> damagedUnitsOwned = Match.all(damagedUnits, Matches.unitIsOwnedBy(player));
     final Map<Territory, Set<Unit>> damagedMap = new HashMap<>();
     final Iterator<Territory> iterTerritories = data.getMap().getTerritories().iterator();
     while (iterTerritories.hasNext()) {
@@ -415,7 +415,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
           damaged = new HashSet<>(current.getUnits().getMatches(damagedUnits));
         }
       } else {
-        damaged = new HashSet<>(current.getUnits().getMatches(new CompositeMatchAnd<>(damagedUnitsOwned,
+        damaged = new HashSet<>(current.getUnits().getMatches(Match.all(damagedUnitsOwned,
             Matches.unitCanBeRepairedByFacilitiesInItsTerritory(current, player, data))));
       }
       if (!damaged.isEmpty()) {
@@ -474,18 +474,18 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
     final Set<Unit> repairUnitsForThisUnit = new HashSet<>();
     final PlayerID owner = unitToBeRepaired.getOwner();
-    final Match<Unit> repairUnit = new CompositeMatchAnd<>(Matches.alliedUnit(owner, data),
+    final Match<Unit> repairUnit = Match.all(Matches.alliedUnit(owner, data),
         Matches.UnitCanRepairOthers, Matches.unitCanRepairThisUnit(unitToBeRepaired));
     repairUnitsForThisUnit.addAll(territoryUnitIsIn.getUnits().getMatches(repairUnit));
     if (Matches.UnitIsSea.match(unitToBeRepaired)) {
-      final Match<Unit> repairUnitLand = new CompositeMatchAnd<>(repairUnit, Matches.UnitIsLand);
+      final Match<Unit> repairUnitLand = Match.all(repairUnit, Matches.UnitIsLand);
       final List<Territory> neighbors =
           new ArrayList<>(data.getMap().getNeighbors(territoryUnitIsIn, Matches.TerritoryIsLand));
       for (final Territory current : neighbors) {
         repairUnitsForThisUnit.addAll(current.getUnits().getMatches(repairUnitLand));
       }
     } else if (Matches.UnitIsLand.match(unitToBeRepaired)) {
-      final Match<Unit> repairUnitSea = new CompositeMatchAnd<>(repairUnit, Matches.UnitIsSea);
+      final Match<Unit> repairUnitSea = Match.all(repairUnit, Matches.UnitIsSea);
       final List<Territory> neighbors =
           new ArrayList<>(data.getMap().getNeighbors(territoryUnitIsIn, Matches.TerritoryIsWater));
       for (final Territory current : neighbors) {
@@ -568,8 +568,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
   }
 
   static Collection<Territory> getEmptyNeutral(final Route route) {
-    final Match<Territory> emptyNeutral =
-        new CompositeMatchAnd<>(Matches.TerritoryIsEmpty, Matches.TerritoryIsNeutralButNotWater);
+    final Match<Territory> emptyNeutral = Match.all(Matches.TerritoryIsEmpty, Matches.TerritoryIsNeutralButNotWater);
     final Collection<Territory> neutral = route.getMatches(emptyNeutral);
     return neutral;
   }

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -29,7 +29,6 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.ui.MovePanel;
 import games.strategy.triplea.util.TransportUtils;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 import games.strategy.util.Util;
 
@@ -171,7 +170,7 @@ public class MovePerformer implements Serializable {
           // could it be a bombing raid
           final Collection<Unit> enemyUnits = route.getEnd().getUnits().getMatches(Matches.enemyUnit(id, data));
           final Collection<Unit> enemyTargetsTotal = Match.getMatches(enemyUnits,
-              new CompositeMatchAnd<>(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(route.getEnd()).invert(),
+              Match.all(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(route.getEnd()).invert(),
                   Matches.unitIsBeingTransported().invert()));
           final Match.CompositeBuilder<Unit> allBombingRaidBuilder = Match.newCompositeBuilder();
           allBombingRaidBuilder.add(Matches.UnitIsStrategicBomber);
@@ -247,7 +246,7 @@ public class MovePerformer implements Serializable {
             // could get really
             // difficult if we want these recorded in battle records).
             for (final Territory t : route
-                .getMatches(new CompositeMatchAnd<>(
+                .getMatches(Match.all(
                     Matches
                         .territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(
                             id),
@@ -339,12 +338,11 @@ public class MovePerformer implements Serializable {
     }
     if (routeEnd != null && games.strategy.triplea.Properties.getSubsCanEndNonCombatMoveWithEnemies(data)
         && GameStepPropertiesHelper.isNonCombatMove(data, false) && routeEnd.getUnits()
-            .someMatch(new CompositeMatchAnd<>(Matches.unitIsEnemyOf(data, id), Matches.UnitIsDestroyer))) {
+            .someMatch(Match.all(Matches.unitIsEnemyOf(data, id), Matches.UnitIsDestroyer))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we want to make sure we
       // can't keep moving them
       // if there is an enemy destroyer there
-      for (final Unit unit : Match.getMatches(units,
-          new CompositeMatchAnd<>(Matches.UnitIsSub, Matches.UnitIsAir.invert()))) {
+      for (final Unit unit : Match.getMatches(units, Match.all(Matches.UnitIsSub, Matches.UnitIsAir.invert()))) {
         change.add(ChangeFactory.markNoMovementChange(Collections.singleton(unit)));
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -239,8 +239,7 @@ public class MoveValidator {
           && !Match.allMatch(units, Matches.UnitIsAir)) {
         return result.setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
       }
-      for (final Unit u : Match.getMatches(units, new CompositeMatchAnd<>(Matches.UnitCanBlitz.invert(),
-          Matches.UnitIsNotAir))) {
+      for (final Unit u : Match.getMatches(units, Match.all(Matches.UnitCanBlitz.invert(), Matches.UnitIsNotAir))) {
         result.addDisallowedUnit("Not all units can blitz out of empty enemy territory", u);
       }
     }
@@ -296,10 +295,9 @@ public class MoveValidator {
         nonBlitzingUnits.removeAll(UnitAttachment.getUnitsWhichReceivesAbilityWhenWith(units, "canBlitz", data));
         final Match<Territory> territoryIsNotEnd = Matches.territoryIs(route.getEnd()).invert();
         final Match<Territory> nonFriendlyTerritories = Matches.isTerritoryFriendly(player, data).invert();
-        final Match<Territory> notEndOrFriendlyTerrs =
-            new CompositeMatchAnd<>(nonFriendlyTerritories, territoryIsNotEnd);
+        final Match<Territory> notEndOrFriendlyTerrs = Match.all(nonFriendlyTerritories, territoryIsNotEnd);
         final Match<Territory> foughtOver = Matches.territoryWasFoughOver(AbstractMoveDelegate.getBattleTracker(data));
-        final Match<Territory> notEndWasFought = new CompositeMatchAnd<>(territoryIsNotEnd, foughtOver);
+        final Match<Territory> notEndWasFought = Match.all(territoryIsNotEnd, foughtOver);
         final boolean wasStartFoughtOver =
             AbstractMoveDelegate.getBattleTracker(data).wasConquered(route.getStart())
                 || AbstractMoveDelegate.getBattleTracker(data).wasBlitzed(route.getStart());
@@ -410,8 +408,7 @@ public class MoveValidator {
       // if there are non-paratroopers present, then we cannot fly over stuff
       // if there are neutral territories in the middle, we cannot fly over (unless allowed to)
       // otherwise we can generally fly over anything in noncombat
-      if (route.someMatch(new CompositeMatchAnd<>(Matches.TerritoryIsNeutralButNotWater,
-          Matches.TerritoryIsWater.invert()))
+      if (route.someMatch(Match.all(Matches.TerritoryIsNeutralButNotWater, Matches.TerritoryIsWater.invert()))
           && (!games.strategy.triplea.Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
         return result.setErrorReturnResult("Air units cannot fly over neutral territories in non combat");
       }
@@ -685,8 +682,7 @@ public class MoveValidator {
   private static int getMechanizedSupportAvail(final Collection<Unit> units, final PlayerID player) {
     int mechanizedSupportAvailable = 0;
     if (TechAttachment.isMechanizedInfantry(player)) {
-      final CompositeMatch<Unit> transportLand =
-          new CompositeMatchAnd<>(Matches.UnitIsLandTransport, Matches.unitIsOwnedBy(player));
+      final Match<Unit> transportLand = Match.all(Matches.UnitIsLandTransport, Matches.unitIsOwnedBy(player));
       mechanizedSupportAvailable = Match.countMatches(units, transportLand);
     }
     return mechanizedSupportAvailable;
@@ -769,8 +765,7 @@ public class MoveValidator {
   }
 
   private static boolean enemyDestroyerOnPath(final Route route, final PlayerID player, final GameData data) {
-    final Match<Unit> enemyDestroyer =
-        new CompositeMatchAnd<>(Matches.UnitIsDestroyer, Matches.enemyUnit(player, data));
+    final Match<Unit> enemyDestroyer = Match.all(Matches.UnitIsDestroyer, Matches.enemyUnit(player, data));
     for (final Territory current : route.getMiddleSteps()) {
       if (current.getUnits().someMatch(enemyDestroyer)) {
         return true;
@@ -912,8 +907,7 @@ public class MoveValidator {
     // If there are non-sea transports return
     final boolean seaOrNoTransportsPresent =
         transportsToLoad.isEmpty()
-            || Match.someMatch(transportsToLoad, new CompositeMatchAnd<>(Matches.UnitIsSea,
-                Matches.UnitCanTransport));
+            || Match.someMatch(transportsToLoad, Match.all(Matches.UnitIsSea, Matches.UnitCanTransport));
     if (!seaOrNoTransportsPresent) {
       return result;
     }
@@ -937,10 +931,9 @@ public class MoveValidator {
               || games.strategy.triplea.Properties.getUseKamikazeSuicideAttacks(data);
       final boolean submarinesPreventUnescortedAmphibAssaults =
           games.strategy.triplea.Properties.getSubmarinesPreventUnescortedAmphibiousAssaults(data);
-      final Match<Unit> enemySubmarineMatch =
-          new CompositeMatchAnd<>(Matches.unitIsEnemyOf(data, player), Matches.UnitIsSub);
+      final Match<Unit> enemySubmarineMatch = Match.all(Matches.unitIsEnemyOf(data, player), Matches.UnitIsSub);
       final Match<Unit> ownedSeaNonTransportMatch =
-          new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.UnitIsSea,
+          Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsSea,
               Matches.UnitIsNotTransportButCouldBeCombatTransport);
       for (final Unit transport : transports) {
         if (!isNonCombat && route.numberOfStepsIncludingStart() == 2) {
@@ -1045,8 +1038,8 @@ public class MoveValidator {
       if (!isEditMode && !route.hasExactlyOneStep() && nonParatroopersPresent(player, landAndAir)) {
         return result.setErrorReturnResult("Units cannot move before loading onto transports");
       }
-      final CompositeMatch<Unit> enemyNonSubmerged =
-          new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.UnitIsSubmerged.invert());
+      final Match<Unit> enemyNonSubmerged =
+          Match.all(Matches.enemyUnit(player, data), Matches.UnitIsSubmerged.invert());
       if (route.getEnd().getUnits().someMatch(enemyNonSubmerged) && nonParatroopersPresent(player, landAndAir)) {
         if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
           if (!AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(player,
@@ -1160,7 +1153,7 @@ public class MoveValidator {
   }
 
   private static List<Unit> getParatroopsRequiringTransport(final Collection<Unit> units, final Route route) {
-    return Match.getMatches(units, new CompositeMatchAnd<>(Matches.UnitIsAirTransportable, new Match<Unit>() {
+    return Match.getMatches(units, Match.all(Matches.UnitIsAirTransportable, new Match<Unit>() {
       @Override
       public boolean match(final Unit u) {
         return TripleAUnit.get(u).getMovementLeft() < route.getMovementCost(u) || route.crossesWater()
@@ -1431,7 +1424,7 @@ public class MoveValidator {
     final Map<Unit, Collection<Unit>> mapping = new HashMap<>();
     // get air that must be carried by our carriers
     final Collection<Unit> ownedCarrier =
-        Match.getMatches(units, new CompositeMatchAnd<>(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player)));
+        Match.getMatches(units, Match.all(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player)));
     final Iterator<Unit> ownedCarrierIter = ownedCarrier.iterator();
     while (ownedCarrierIter.hasNext()) {
       final Unit carrier = ownedCarrierIter.next();
@@ -1503,8 +1496,7 @@ public class MoveValidator {
     // now find the default route
     Route defaultRoute;
     if (isNeutralsImpassable) {
-      defaultRoute =
-          data.getMap().getRoute_IgnoreEnd(start, end, new CompositeMatchAnd<>(noNeutral, noImpassable));
+      defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end, Match.all(noNeutral, noImpassable));
     } else {
       defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end, noImpassable);
     }
@@ -1514,7 +1506,7 @@ public class MoveValidator {
       // at least try for a route without impassable territories, but allowing restricted territories, since there is a
       // chance politics may change in the future.
       defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-          (isNeutralsImpassable ? new CompositeMatchAnd<>(noNeutral, Matches.TerritoryIsImpassable)
+          (isNeutralsImpassable ? Match.all(noNeutral, Matches.TerritoryIsImpassable)
               : Matches.TerritoryIsImpassable));
       // ok, so there really is nothing, so just return any route, without conditions
       if (defaultRoute == null) {
@@ -1535,10 +1527,10 @@ public class MoveValidator {
       Route landRoute;
       if (isNeutralsImpassable) {
         landRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-            new CompositeMatchAnd<>(Matches.TerritoryIsLand, noNeutral, noImpassable));
+            Match.all(Matches.TerritoryIsLand, noNeutral, noImpassable));
       } else {
         landRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-            new CompositeMatchAnd<>(Matches.TerritoryIsLand, noImpassable));
+            Match.all(Matches.TerritoryIsLand, noImpassable));
       }
       if (landRoute != null
           && ((landRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
@@ -1553,8 +1545,7 @@ public class MoveValidator {
     // dont force a water route, since planes may be moving
     if (start.isWater() && end.isWater()) {
       final Route waterRoute =
-          data.getMap().getRoute_IgnoreEnd(start, end,
-              new CompositeMatchAnd<>(Matches.TerritoryIsWater, noImpassable));
+          data.getMap().getRoute_IgnoreEnd(start, end, Match.all(Matches.TerritoryIsWater, noImpassable));
       if (waterRoute != null
           && ((waterRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
               .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) || (forceLandOrSeaRoute && Match
@@ -1569,26 +1560,26 @@ public class MoveValidator {
     if (isNeutralsImpassable) {
       tests = new ArrayList<>(Arrays.asList(
           // best if no enemy and no neutral
-          new CompositeMatchAnd<>(noEnemy, noNeutral),
+          Match.all(noEnemy, noNeutral),
           // we will be satisfied if no aa and no neutral
-          new CompositeMatchAnd<>(noAa, noNeutral)));
+          Match.all(noAa, noNeutral)));
     } else {
       tests = new ArrayList<>(Arrays.asList(
           // best if no enemy and no neutral
-          new CompositeMatchAnd<>(noEnemy, noNeutral),
+          Match.all(noEnemy, noNeutral),
           // we will be satisfied if no aa and no neutral
-          new CompositeMatchAnd<>(noAa, noNeutral),
+          Match.all(noAa, noNeutral),
           // single matches
           noEnemy, noAa, noNeutral));
     }
     for (final Match<Territory> t : tests) {
       Match<Territory> testMatch = null;
       if (mustGoLand) {
-        testMatch = new CompositeMatchAnd<>(t, Matches.TerritoryIsLand, noImpassable);
+        testMatch = Match.all(t, Matches.TerritoryIsLand, noImpassable);
       } else if (mustGoSea) {
-        testMatch = new CompositeMatchAnd<>(t, Matches.TerritoryIsWater, noImpassable);
+        testMatch = Match.all(t, Matches.TerritoryIsWater, noImpassable);
       } else {
-        testMatch = new CompositeMatchAnd<>(t, noImpassable);
+        testMatch = Match.all(t, noImpassable);
       }
       final Route testRoute = data.getMap().getRoute_IgnoreEnd(start, end, testMatch);
       if (testRoute != null

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1407,7 +1407,7 @@ public class MoveValidator {
     // but not us that can land on a carrier
     final CompositeMatch<Unit> friendlyNotOwnedAir = new CompositeMatchAnd<>();
     friendlyNotOwnedAir.add(Matches.alliedUnit(player, data));
-    friendlyNotOwnedAir.addInverse(Matches.unitIsOwnedBy(player));
+    friendlyNotOwnedAir.add(Matches.unitIsOwnedBy(player).invert());
     friendlyNotOwnedAir.add(Matches.UnitCanLandOnCarrier);
     final Collection<Unit> alliedAir = Match.getMatches(startUnits, friendlyNotOwnedAir);
     if (alliedAir.isEmpty()) {
@@ -1417,7 +1417,7 @@ public class MoveValidator {
     final CompositeMatch<Unit> friendlyNotOwnedCarrier = new CompositeMatchAnd<>();
     friendlyNotOwnedCarrier.add(Matches.UnitIsCarrier);
     friendlyNotOwnedCarrier.add(Matches.alliedUnit(player, data));
-    friendlyNotOwnedCarrier.addInverse(Matches.unitIsOwnedBy(player));
+    friendlyNotOwnedCarrier.add(Matches.unitIsOwnedBy(player).invert());
     final Collection<Unit> alliedCarrier = Match.getMatches(startUnits, friendlyNotOwnedCarrier);
     final Iterator<Unit> alliedCarrierIter = alliedCarrier.iterator();
     while (alliedCarrierIter.hasNext()) {

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -1263,7 +1263,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // the air unit may have come from a conquered or enemy territory, don't allow retreating
     final Match<Territory> conqueuredOrEnemy = Match.any(
         Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(m_attacker, m_data),
-        new CompositeMatchAnd<Territory>(
+        Match.all(
             // Matches.TerritoryIsLand,
             Matches.TerritoryIsWater, Matches.territoryWasFoughOver(m_battleTracker)));
     possible.removeAll(Match.getMatches(possible, conqueuredOrEnemy));
@@ -1816,24 +1816,24 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Collection<Unit> unitsToKill;
     final boolean hasUnitsThatCanRollLeft;
     if (attacker) {
-      hasUnitsThatCanRollLeft = Match.someMatch(m_attackingUnits, new CompositeMatchAnd<>(notSubmergedAndType,
+      hasUnitsThatCanRollLeft = Match.someMatch(m_attackingUnits, Match.all(notSubmergedAndType,
           Matches.unitIsSupporterOrHasCombatAbility(attacker)));
       unitsToKill = Match.getMatches(m_attackingUnits,
-          new CompositeMatchAnd<>(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
+          Match.all(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
     } else {
-      hasUnitsThatCanRollLeft = Match.someMatch(m_defendingUnits, new CompositeMatchAnd<>(notSubmergedAndType,
+      hasUnitsThatCanRollLeft = Match.someMatch(m_defendingUnits, Match.all(notSubmergedAndType,
           Matches.unitIsSupporterOrHasCombatAbility(attacker)));
       unitsToKill = Match.getMatches(m_defendingUnits,
-          new CompositeMatchAnd<>(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
+          Match.all(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
     }
     final boolean enemy = !attacker;
     final boolean enemyHasUnitsThatCanRollLeft;
     if (enemy) {
       enemyHasUnitsThatCanRollLeft = Match.someMatch(m_attackingUnits,
-          new CompositeMatchAnd<>(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
+          Match.all(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
     } else {
       enemyHasUnitsThatCanRollLeft = Match.someMatch(m_defendingUnits,
-          new CompositeMatchAnd<>(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
+          Match.all(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
     }
     if (!hasUnitsThatCanRollLeft && enemyHasUnitsThatCanRollLeft) {
       remove(unitsToKill, bridge, m_battleSite, !attacker);
@@ -2056,7 +2056,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   private void fireSuicideUnitsAttack() {
     // TODO: add a global toggle for returning fire (Veqryn)
-    final CompositeMatch<Unit> attackableUnits = new CompositeMatchAnd<>(
+    final Match<Unit> attackableUnits = Match.all(
         Matches.unitIsNotInfrastructureAndNotCapturedOnEntering(m_attacker, m_battleSite, m_data),
         Matches.UnitIsSuicide.invert(), Matches.unitIsBeingTransported().invert());
     final Collection<Unit> suicideAttackers = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);
@@ -2088,7 +2088,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return;
     }
     // TODO: add a global toggle for returning fire (Veqryn)
-    final CompositeMatch<Unit> attackableUnits = new CompositeMatchAnd<>(Matches.UnitIsNotInfrastructure,
+    final Match<Unit> attackableUnits = Match.all(Matches.UnitIsNotInfrastructure,
         Matches.UnitIsSuicide.invert(), Matches.unitIsBeingTransported().invert());
     final Collection<Unit> suicideDefenders = Match.getMatches(m_defendingUnits, Matches.UnitIsSuicide);
     final Collection<Unit> attackedAttackers = Match.getMatches(m_attackingUnits, attackableUnits);
@@ -2197,8 +2197,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         final Collection<Unit> validAttackingUnitsForThisRoll =
             Match.getMatches((m_defending ? m_attackingUnits : m_defendingUnits),
                 Match.any(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
-                    new CompositeMatchAnd<Unit>(Matches.UnitIsAirborne,
-                        Matches.unitIsOfTypes(airborneTypesTargettedToo))));
+                    Match.all(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         final IExecutable rollDice = new IExecutable() {
           private static final long serialVersionUID = 6435935558879109347L;
 
@@ -2349,7 +2348,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     unitList.removeAll(Match.getMatches(unitList,
         Matches.unitCanBeCapturedOnEnteringToInThisTerritory(m_attacker, m_battleSite, m_data)));
     // remove any allied air units that are stuck on damaged carriers (veqryn)
-    unitList.removeAll(Match.getMatches(unitList, new CompositeMatchAnd<>(Matches.unitIsBeingTransported(),
+    unitList.removeAll(Match.getMatches(unitList, Match.all(Matches.unitIsBeingTransported(),
         Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
     // remove any units that were in air combat (veqryn)
     unitList.removeAll(Match.getMatches(unitList, Matches.UnitWasInAirBattle));
@@ -2613,8 +2612,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // TODO: why do we keep checking throughout this entire class if the units in m_defendingUnits are allied with
     // defender, and if the
     // units in m_attackingUnits are allied with the attacker? Does it really matter?
-    final CompositeMatch<Unit> alliedDefendingAir =
-        new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.UnitWasScrambled.invert());
+    final Match<Unit> alliedDefendingAir = Match.all(Matches.UnitIsAir, Matches.UnitWasScrambled.invert());
     final Collection<Unit> m_defendingAir = Match.getMatches(m_defendingUnits, alliedDefendingAir);
     // no planes, exit
     if (m_defendingAir.isEmpty()) {
@@ -2656,7 +2654,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // carrier unit
     final Collection<Unit> carriers = Match.getMatches(attackingUnits, Matches.UnitIsCarrier);
     if (!carriers.isEmpty() && !games.strategy.triplea.Properties.getAlliedAirIndependent(data)) {
-      final Match<Unit> alliedFighters = new CompositeMatchAnd<>(Matches.isUnitAllied(attacker, data),
+      final Match<Unit> alliedFighters = Match.all(Matches.isUnitAllied(attacker, data),
           Matches.unitIsOwnedBy(attacker).invert(), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
       final Collection<Unit> alliedAirInTerr = Match.getMatches(attackingUnits, alliedFighters);
       for (final Unit fighter : alliedAirInTerr) {

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -29,7 +29,6 @@ import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.delegate.remote.IPoliticsDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.ui.PoliticsText;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 /**
@@ -58,7 +57,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-      final Match<TriggerAttachment> politicsDelegateTriggerMatch = new CompositeMatchAnd<>(
+      final Match<TriggerAttachment> politicsDelegateTriggerMatch = Match.all(
           TriggerAttachment.availableUses, TriggerAttachment.whenOrDefaultMatch(null, null),
           Match.any(TriggerAttachment.relationshipChangeMatch()));
       // get all possible triggers based on this match.

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -37,8 +37,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitTypeComparator;
 import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -65,7 +63,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
         // First set up a match for what we want to have fire as a default in this delegate. List out as a composite
         // match OR.
         // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-        final Match<TriggerAttachment> purchaseDelegateTriggerMatch = new CompositeMatchAnd<>(
+        final Match<TriggerAttachment> purchaseDelegateTriggerMatch = Match.all(
             AbstractTriggerAttachment.availableUses, AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
             Match.any(TriggerAttachment.prodMatch(),
                 TriggerAttachment.prodFrontierEditMatch(), TriggerAttachment.purchaseMatch()));
@@ -175,8 +173,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
           // count how many units are yet to be placed or are in the field
           int currentlyBuilt = m_player.getUnits().countMatches(Matches.unitIsOfType(type));
 
-          final CompositeMatch<Unit> unitTypeOwnedBy =
-              new CompositeMatchAnd<>(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(m_player));
+          final Match<Unit> unitTypeOwnedBy = Match.all(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(m_player));
           final Collection<Territory> allTerrs = getData().getMap().getTerritories();
           for (final Territory t : allTerrs) {
             currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -20,7 +20,6 @@ import games.strategy.engine.message.IRemote;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.ThreadUtil;
@@ -221,7 +220,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
   }
 
   public Match<Territory> getTerritoryPickableMatch() {
-    return new CompositeMatchAnd<>(Matches.TerritoryIsLand, Matches.TerritoryIsNotImpassable,
+    return Match.all(Matches.TerritoryIsLand, Matches.TerritoryIsNotImpassable,
         Matches.isTerritoryOwnedBy(PlayerID.NULL_PLAYERID), Matches.TerritoryIsEmpty);
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -29,7 +29,6 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.util.CompositeMatch;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
@@ -132,7 +131,7 @@ public class RocketsFireHelper {
 
   Set<Territory> getTerritoriesWithRockets(final GameData data, final PlayerID player) {
     final Set<Territory> territories = new HashSet<>();
-    final CompositeMatch<Unit> ownedRockets = rocketMatch(player, data);
+    final Match<Unit> ownedRockets = rocketMatch(player, data);
     final BattleTracker tracker = AbstractMoveDelegate.getBattleTracker(data);
     for (final Territory current : data.getMap()) {
       if (tracker.wasConquered(current)) {
@@ -145,8 +144,8 @@ public class RocketsFireHelper {
     return territories;
   }
 
-  CompositeMatch<Unit> rocketMatch(final PlayerID player, final GameData data) {
-    return new CompositeMatchAnd<>(Matches.UnitIsRocket, Matches.unitIsOwnedBy(player), Matches.UnitIsNotDisabled,
+  Match<Unit> rocketMatch(final PlayerID player, final GameData data) {
+    return Match.all(Matches.UnitIsRocket, Matches.unitIsOwnedBy(player), Matches.UnitIsNotDisabled,
         Matches.unitIsBeingTransported().invert(), Matches.UnitIsSubmerged.invert(), Matches.unitHasNotMoved);
   }
 
@@ -160,12 +159,12 @@ public class RocketsFireHelper {
     if (!isRocketsCanFlyOverImpassables(data)) {
       allowed.add(Matches.TerritoryIsNotImpassable);
     }
-    final CompositeMatchAnd<Unit> attackableUnits =
-        new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert());
+    final Match<Unit> attackableUnits =
+        Match.all(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert());
     for (final Territory current : possible) {
       final Route route = data.getMap().getRoute(territory, current, allowed);
       if (route != null && route.numberOfSteps() <= maxDistance) {
-        if (current.getUnits().someMatch(new CompositeMatchAnd<>(attackableUnits,
+        if (current.getUnits().someMatch(Match.all(attackableUnits,
             Matches.unitIsAtMaxDamageOrNotCanBeDamaged(current).invert()))) {
           hasFactory.add(current);
         }
@@ -188,7 +187,7 @@ public class RocketsFireHelper {
     final boolean DamageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
     // unit damage vs territory damage
     final Collection<Unit> enemyUnits = attackedTerritory.getUnits().getMatches(
-        new CompositeMatchAnd<>(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
+        Match.all(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
     final Collection<Unit> enemyTargetsTotal =
         Match.getMatches(enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).invert());
     final Collection<Unit> targets = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -24,7 +24,6 @@ import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.delegate.IBattle.BattleType;
 import games.strategy.triplea.delegate.dataObjects.MoveValidationResult;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -292,7 +291,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   }
 
   private static Match<Unit> getAirborneMatch(final Set<UnitType> types, final Collection<PlayerID> unitOwners) {
-    return new CompositeMatchAnd<>(Matches.unitIsOwnedByOfAnyOfThesePlayers(unitOwners),
+    return Match.all(Matches.unitIsOwnedByOfAnyOfThesePlayers(unitOwners),
         Matches.unitIsOfTypes(types), Matches.UnitIsNotDisabled, Matches.unitHasNotMoved,
         Matches.UnitIsAirborne.invert());
   }

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -35,7 +35,6 @@ import games.strategy.triplea.delegate.dataObjects.CasualtyDetails;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.oddsCalculator.ta.BattleResults;
 import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -92,7 +91,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     // fill in defenders
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
-    final Match<Unit> defenders = new CompositeMatchAnd<>(Matches.enemyUnit(m_attacker, m_data),
+    final Match<Unit> defenders = Match.all(Matches.enemyUnit(m_attacker, m_data),
         Match.any(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
             Matches.unitIsAaThatCanFire(m_attackingUnits, airborneTechTargetsAllowed, m_attacker,
                 Matches.UnitIsAAforBombingThisUnitOnly, m_round, true, m_data)));
@@ -358,7 +357,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         if (determineAttackers) {
           validAttackingUnitsForThisRoll = Match.getMatches(m_attackingUnits, Match.any(
               Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
-              new CompositeMatchAnd<Unit>(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
+              Match.all(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         }
 
         final IExecutable roll = new IExecutable() {

--- a/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -16,7 +16,6 @@ import games.strategy.triplea.MapSupport;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TriggerAttachment;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 import games.strategy.util.Util;
 
@@ -58,7 +57,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-      final Match<TriggerAttachment> techActivationDelegateTriggerMatch = new CompositeMatchAnd<>(
+      final Match<TriggerAttachment> techActivationDelegateTriggerMatch = Match.all(
           TriggerAttachment.availableUses, TriggerAttachment.whenOrDefaultMatch(null, null),
           Match.any(TriggerAttachment.unitPropertyMatch(), TriggerAttachment.techMatch(),
               TriggerAttachment.supportMatch()));

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -31,7 +31,6 @@ import games.strategy.triplea.delegate.dataObjects.TechResults;
 import games.strategy.triplea.delegate.remote.ITechDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.Util;
@@ -78,7 +77,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-      final Match<TriggerAttachment> technologyDelegateTriggerMatch = new CompositeMatchAnd<>(
+      final Match<TriggerAttachment> technologyDelegateTriggerMatch = Match.all(
           AbstractTriggerAttachment.availableUses, AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
           Match.any(TriggerAttachment.techAvailableMatch()));
       // get all possible triggers based on this match.

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -19,7 +19,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.dataObjects.MoveDescription;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.ui.MovePanel;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 import games.strategy.util.Util;
 
@@ -127,7 +126,7 @@ public class UndoableMove extends AbstractUndoableMove {
           if (routeUnitUsedToMove != null && routeUnitUsedToMove.getEnd() != null) {
             final Territory end = routeUnitUsedToMove.getEnd();
             final Collection<Unit> enemyTargetsTotal = end.getUnits()
-                .getMatches(new CompositeMatchAnd<>(Matches.enemyUnit(bridge.getPlayerID(), data),
+                .getMatches(Match.all(Matches.enemyUnit(bridge.getPlayerID(), data),
                     Matches.unitIsAtMaxDamageOrNotCanBeDamaged(end).invert(),
                     Matches.unitIsBeingTransported().invert()));
             final Collection<Unit> enemyTargets = Match.getMatches(enemyTargetsTotal,

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -48,8 +48,6 @@ import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
 import games.strategy.triplea.delegate.remote.ITechDelegate;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
 import games.strategy.triplea.ui.display.ITripleADisplay;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 import games.strategy.util.Tuple;
 
@@ -598,9 +596,8 @@ class DummyPlayer extends AbstractAI {
     }
     if (submerge) {
       // submerge if all air vs subs
-      final CompositeMatch<Unit> seaSub = new CompositeMatchAnd<>(Matches.UnitIsSea, Matches.UnitIsSub);
-      final CompositeMatch<Unit> planeNotDestroyer =
-          new CompositeMatchAnd<>(Matches.UnitIsAir, Matches.UnitIsDestroyer.invert());
+      final Match<Unit> seaSub = Match.all(Matches.UnitIsSea, Matches.UnitIsSub);
+      final Match<Unit> planeNotDestroyer = Match.all(Matches.UnitIsAir, Matches.UnitIsDestroyer.invert());
       final List<Unit> ourUnits = getOurUnits();
       final List<Unit> enemyUnits = getEnemyUnits();
       if (ourUnits == null || enemyUnits == null) {

--- a/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -17,7 +17,6 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechAdvance;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 public class ExtendedStats extends StatPanel {
@@ -208,8 +207,7 @@ public class ExtendedStats extends StatPanel {
     @Override
     public double getValue(final PlayerID player, final GameData data) {
       int rVal = 0;
-      final Match<Unit> ownedBy =
-          new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(m_ut));
+      final Match<Unit> ownedBy = Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(m_ut));
       for (final Territory place : data.getMap().getTerritories()) {
         rVal += place.getUnits().countMatches(ownedBy);
       }

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -463,7 +463,7 @@ public class MovePanel extends AbstractMovePanel {
     Collection<Unit> transportsToLoad = Collections.emptyList();
     if (MoveValidator.isLoad(units, s_dependentUnits, route, getData(), getCurrentPlayer())) {
       transportsToLoad = route.getEnd().getUnits().getMatches(
-          new CompositeMatchAnd<>(Matches.UnitIsTransport, Matches.alliedUnit(getCurrentPlayer(), getData())));
+          Match.all(Matches.UnitIsTransport, Matches.alliedUnit(getCurrentPlayer(), getData())));
     }
     List<Unit> best = new ArrayList<>(units);
     // if the player selects a land unit and other units
@@ -864,8 +864,7 @@ public class MovePanel extends AbstractMovePanel {
         // Load Bombers with paratroops
         if ((!nonCombat || IsParatroopersCanMoveDuringNonCombat(getData()))
             && TechAttachment.isAirTransportable(getCurrentPlayer())
-            && Match.someMatch(selectedUnits,
-                new CompositeMatchAnd<>(Matches.UnitIsAirTransport, Matches.unitHasNotMoved))) {
+            && Match.someMatch(selectedUnits, Match.all(Matches.UnitIsAirTransport, Matches.unitHasNotMoved))) {
           final PlayerID player = getCurrentPlayer();
           // TODO Transporting allied units
           // Get the potential units to load

--- a/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+
 import javax.swing.Action;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -37,7 +38,6 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.ui.ScrollableTextField;
 import games.strategy.ui.ScrollableTextFieldListener;
 import games.strategy.ui.SwingAction;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -123,8 +123,8 @@ public class ProductionRepairPanel extends JPanel {
     try {
       this.m_id = player;
       this.m_allowedPlayersToRepair = allowedPlayersToRepair;
-      final CompositeMatchAnd<Unit> myDamagedUnits =
-          new CompositeMatchAnd<>(Matches.unitIsOwnedByOfAnyOfThesePlayers(m_allowedPlayersToRepair),
+      final Match<Unit> myDamagedUnits =
+          Match.all(Matches.unitIsOwnedByOfAnyOfThesePlayers(m_allowedPlayersToRepair),
               Matches.UnitHasTakenSomeBombingUnitDamage);
       final Collection<Territory> terrsWithPotentiallyDamagedUnits =
           Match.getMatches(data.getMap().getTerritories(), Matches.territoryHasUnitsThatMatch(myDamagedUnits));

--- a/src/main/java/games/strategy/util/CompositeMatch.java
+++ b/src/main/java/games/strategy/util/CompositeMatch.java
@@ -23,13 +23,6 @@ public abstract class CompositeMatch<T> extends Match<T> {
   }
 
   /**
-   * Add the inverse of a match. Equivalent to add(match.invert()).
-   */
-  public void addInverse(final Match<T> match) {
-    add(match.invert());
-  }
-
-  /**
    * Returns the matches, does not return a copy
    * so be careful about modifying. Also note this could
    * be regenerated when new matches are added.

--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -187,6 +187,33 @@ public abstract class Match<T> {
   }
 
   /**
+   * Creates a new match whose condition is satisfied if the test object matches all of the specified conditions.
+   *
+   * @param matches An array of matches; must not be {@code null}.
+   *
+   * @return A new match; never {@code null}.
+   */
+  @SafeVarargs
+  public static <T> Match<T> all(final Match<T>... matches) {
+    checkNotNull(matches);
+
+    return all(Arrays.asList(matches));
+  }
+
+  /**
+   * Creates a new match whose condition is satisfied if the test object matches all of the specified conditions.
+   *
+   * @param matches A collection of matches; must not be {@code null}.
+   *
+   * @return A new match; never {@code null}.
+   */
+  public static <T> Match<T> all(final Collection<Match<T>> matches) {
+    checkNotNull(matches);
+
+    return Match.of(value -> matches.stream().allMatch(match -> match.match(value)));
+  }
+
+  /**
    * Creates a new match whose condition is satisfied if the test object matches any of the specified conditions.
    *
    * @param matches An array of matches; must not be {@code null}.

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -24,7 +24,6 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.random.ScriptedRandomSource;
 import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
@@ -565,7 +564,7 @@ public class MoveDelegateTest extends DelegateTest {
     route3.setStart(japanSeaZone);
     route3.add(sfeSeaZone);
     final Collection<Unit> remainingTrns = Match.getMatches(japanSeaZone.getUnits().getUnits(),
-        new CompositeMatchAnd<>(Matches.unitHasNotMoved, Matches.UnitWasNotLoadedThisTurn));
+        Match.all(Matches.unitHasNotMoved, Matches.UnitWasNotLoadedThisTurn));
     results = delegate.move(remainingTrns, route3);
     assertNull(results);
   }

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -81,7 +81,6 @@ import games.strategy.triplea.delegate.dataObjects.PlaceableUnits;
 import games.strategy.triplea.delegate.dataObjects.TechResults;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.xml.TestMapGameData;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 public class RevisedTest {
@@ -540,7 +539,7 @@ public class RevisedTest {
     eeToSz5.add(sz5);
     // load the transport in the baltic
     final List<Unit> infantry = eastEurope.getUnits()
-        .getMatches(new CompositeMatchAnd<>(Matches.unitIsOfType(infantryType), Matches.unitIsOwnedBy(japanese)));
+        .getMatches(Match.all(Matches.unitIsOfType(infantryType), Matches.unitIsOwnedBy(japanese)));
     assertEquals(1, infantry.size());
     final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.UnitIsTransport).get(0);
     String error = moveDelegate.move(infantry, eeToSz5, Collections.<Unit>singletonList(transport));
@@ -726,7 +725,7 @@ public class RevisedTest {
     sz45To50.setStart(sz45);
     sz45To50.add(sz50);
     final List<Unit> japSub =
-        sz45.getUnits().getMatches(new CompositeMatchAnd<>(Matches.UnitIsSub, Matches.unitIsOwnedBy(japanese)));
+        sz45.getUnits().getMatches(Match.all(Matches.UnitIsSub, Matches.unitIsOwnedBy(japanese)));
     error = moveDelegate.move(japSub, sz45To50);
     // make sure no error
     assertNull(error);

--- a/src/test/java/games/strategy/util/MatchTest.java
+++ b/src/test/java/games/strategy/util/MatchTest.java
@@ -88,13 +88,6 @@ public class MatchTest {
   }
 
   @Test
-  public void testAddInverse() {
-    final CompositeMatch<Object> and = new CompositeMatchAnd<>();
-    and.addInverse(Match.always());
-    assertFalse(and.match(new Object()));
-  }
-
-  @Test
   public void testMap() {
     final HashMap<String, String> map = new HashMap<>();
     map.put("a", "b");

--- a/src/test/java/games/strategy/util/MatchTest.java
+++ b/src/test/java/games/strategy/util/MatchTest.java
@@ -47,20 +47,35 @@ public class MatchTest {
   }
 
   @Test
+  public void testAll() {
+    assertTrue(Match.all().match(VALUE));
+
+    assertTrue(Match.all(Match.always()).match(VALUE));
+    assertFalse(Match.all(Match.never()).match(VALUE));
+
+    assertTrue(Match.all(Match.always(), Match.always()).match(VALUE));
+    assertFalse(Match.all(Match.always(), Match.never()).match(VALUE));
+    assertFalse(Match.all(Match.never(), Match.always()).match(VALUE));
+    assertFalse(Match.all(Match.never(), Match.never()).match(VALUE));
+  }
+
+  @Test
   public void testAnd() {
+    assertTrue(new CompositeMatchAnd<>().match(0));
+
     CompositeMatch<Integer> and = new CompositeMatchAnd<>(pos, neg);
-    assertTrue(!and.match(1));
-    assertTrue(!Match.someMatch(ints, and));
-    assertTrue(!Match.someMatch(ints, and));
+    assertFalse(and.match(1));
+    assertFalse(Match.someMatch(ints, and));
+    assertFalse(Match.someMatch(ints, and));
     assertEquals(0, Match.getMatches(ints, and).size());
     and.add(zero);
-    assertTrue(!Match.someMatch(ints, and));
-    assertTrue(!Match.allMatch(ints, and));
+    assertFalse(Match.someMatch(ints, and));
+    assertFalse(Match.allMatch(ints, and));
     assertEquals(0, Match.getMatches(ints, and).size());
     and = new CompositeMatchAnd<>(pos, pos);
     assertTrue(and.match(1));
     assertTrue(Match.someMatch(ints, and));
-    assertTrue(!Match.allMatch(ints, and));
+    assertFalse(Match.allMatch(ints, and));
     assertEquals(3, Match.getMatches(ints, and).size());
   }
 


### PR DESCRIPTION
This is one part of multiple PRs whose goal is to remove the `CompositeMatchAnd` subclass and replace its instances with calls to the new `Match#all()` factory method or use of the `Match$CompositeBuilder` class.

There were three types of `CompositeMatchAnd` usage throughout the codebase:

* single-step initialization
* multi-step initialization without branching
* multi-step initialization with branching

This PR addresses single-step initialization, which is described below along with an example of how it was replaced.

#### Single-step initialization

This is the case where all component matches are passed directly to the `CompositeMatchAnd` constructor and no calls are made to `CompositeMatch#add()`.  For example, the following code:

```java
new CompositeMatchAnd<>(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure)
```

would be replaced with:

```java
Match.all(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure)
```