### PR TITLE
Remove logic that destroys all defenders so that they can be captured

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -826,27 +826,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        final Match<Unit> unitList = Matches.unitCanBeInBattle(true, !m_battleSite.isWater(), 1, false, true, true);
-        final List<Unit> sortedAttackingUnits = new ArrayList<>(Match.getMatches(m_attackingUnits, unitList));
-        Collections.sort(sortedAttackingUnits, new UnitBattleComparator(false,
-            BattleCalculator.getCostsForTUV(bridge.getPlayerID(), m_data),
-            TerritoryEffectHelper.getEffects(m_battleSite), m_data, false, false));
-        Collections.reverse(sortedAttackingUnits);
-        if (DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedAttackingUnits, m_defendingUnits,
-            false, false, m_data, m_battleSite, TerritoryEffectHelper.getEffects(m_battleSite), false, null),
-            m_data) > 0) {
-          final Match<Unit> unitList2 = Matches.unitCanBeInBattle(false, !m_battleSite.isWater(), 1, false, true, true);
-          final List<Unit> sortedDefendingUnits = new ArrayList<>(Match.getMatches(m_defendingUnits, unitList2));
-          Collections.sort(sortedDefendingUnits, new UnitBattleComparator(false,
-              BattleCalculator.getCostsForTUV(bridge.getPlayerID(), m_data),
-              TerritoryEffectHelper.getEffects(m_battleSite), m_data, false, false));
-          Collections.reverse(sortedDefendingUnits);
-          if (DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(sortedDefendingUnits,
-              m_defendingUnits, true, false, m_data, m_battleSite, TerritoryEffectHelper.getEffects(m_battleSite),
-              false, null), m_data) == 0) {
-            remove(m_defendingUnits, bridge, m_battleSite, true);
-          }
-        }
         clearWaitingToDie(bridge);
       }
     });


### PR DESCRIPTION
Fixes #1952 by reverting part of #1646 