### PR TITLE
Replace anonymous Match subclasses with factory method (part 1)

### DIFF
--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -116,12 +116,7 @@ public class TripleAUnit extends Unit {
     for (final Territory t : getData().getMap()) {
       // find the territory this transport is in
       if (t.getUnits().getUnits().contains(this)) {
-        return t.getUnits().getMatches(new Match<Unit>() {
-          @Override
-          public boolean match(final Unit o) {
-            return TripleAUnit.get(o).getTransportedBy() == TripleAUnit.this;
-          }
-        });
+        return t.getUnits().getMatches(Match.of(o -> TripleAUnit.get(o).getTransportedBy() == TripleAUnit.this));
       }
     }
     return Collections.emptyList();
@@ -130,12 +125,8 @@ public class TripleAUnit extends Unit {
   public List<Unit> getTransporting(final Collection<Unit> transportedUnitsPossible) {
     // we don't store the units we are transporting
     // rather we look at the transported by property of units
-    return Match.getMatches(transportedUnitsPossible, new Match<Unit>() {
-      @Override
-      public boolean match(final Unit o) {
-        return TripleAUnit.get(o).getTransportedBy() == TripleAUnit.this;
-      }
-    });
+    return Match.getMatches(transportedUnitsPossible,
+        Match.of(o -> TripleAUnit.get(o).getTransportedBy() == TripleAUnit.this));
   }
 
   public List<Unit> getUnloaded() {

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -180,12 +180,8 @@ public class ProMatches {
   }
 
   private static Match<Territory> territoryIsBlitzable(final PlayerID player, final GameData data, final Unit u) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        return Matches.territoryIsBlitzable(player, data).match(t) && TerritoryEffectHelper.unitKeepsBlitz(u, t);
-      }
-    };
+    return Match.of(t -> Matches.territoryIsBlitzable(player, data).match(t)
+        && TerritoryEffectHelper.unitKeepsBlitz(u, t));
   }
 
   public static Match<Territory> territoryCanMoveSeaUnits(final PlayerID player, final GameData data,
@@ -247,63 +243,35 @@ public class ProMatches {
   }
 
   private static Match<Territory> territoryHasOnlyIgnoredUnits(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Unit> subOnly = Match.any(Matches.UnitIsInfrastructure, Matches.UnitIsSub,
-            Matches.enemyUnit(player, data).invert());
-        return (Properties.getIgnoreSubInMovement(data) && t.getUnits().allMatch(subOnly))
-            || Matches.territoryHasNoEnemyUnits(player, data).match(t);
-      }
-    };
+    return Match.of(t -> {
+      final Match<Unit> subOnly = Match.any(Matches.UnitIsInfrastructure, Matches.UnitIsSub,
+          Matches.enemyUnit(player, data).invert());
+      return (Properties.getIgnoreSubInMovement(data) && t.getUnits().allMatch(subOnly))
+          || Matches.territoryHasNoEnemyUnits(player, data).match(t);
+    });
   }
 
   public static Match<Territory> territoryHasEnemyUnitsOrCantBeHeld(final PlayerID player, final GameData data,
       final List<Territory> territoriesThatCantBeHeld) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.any(Matches.territoryHasEnemyUnits(player, data),
-            Matches.territoryIsInList(territoriesThatCantBeHeld));
-        return match.match(t);
-      }
-    };
+    return Match.any(Matches.territoryHasEnemyUnits(player, data),
+        Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
   public static Match<Territory> territoryHasPotentialEnemyUnits(final PlayerID player, final GameData data,
       final List<PlayerID> players) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.any(Matches.territoryHasEnemyUnits(player, data),
-            Matches.territoryHasUnitsThatMatch(Matches.unitOwnedBy(players)));
-        return match.match(t);
-      }
-    };
+    return Match.any(Matches.territoryHasEnemyUnits(player, data),
+        Matches.territoryHasUnitsThatMatch(Matches.unitOwnedBy(players)));
   }
 
   public static Match<Territory> territoryHasNoEnemyUnitsOrCleared(final PlayerID player, final GameData data,
       final List<Territory> clearedTerritories) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.any(Matches.territoryHasNoEnemyUnits(player, data),
-            Matches.territoryIsInList(clearedTerritories));
-        return match.match(t);
-      }
-    };
+    return Match.any(Matches.territoryHasNoEnemyUnits(player, data), Matches.territoryIsInList(clearedTerritories));
   }
 
   public static Match<Territory> territoryIsEnemyOrHasEnemyUnitsOrCantBeHeld(final PlayerID player, final GameData data,
       final List<Territory> territoriesThatCantBeHeld) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.any(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
-            Matches.territoryHasEnemyUnits(player, data), Matches.territoryIsInList(territoriesThatCantBeHeld));
-        return match.match(t);
-      }
-    };
+    return Match.any(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
+        Matches.territoryHasEnemyUnits(player, data), Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsLand() {
@@ -507,38 +475,19 @@ public class ProMatches {
 
   public static Match<Territory> territoryIsEnemyOrCantBeHeld(final PlayerID player, final GameData data,
       final List<Territory> territoriesThatCantBeHeld) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.any(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
-            Matches.territoryIsInList(territoriesThatCantBeHeld));
-        return match.match(t);
-      }
-    };
+    return Match.any(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
+        Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
   public static Match<Territory> territoryIsPotentialEnemy(final PlayerID player, final GameData data,
       final List<PlayerID> players) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.any(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
-            Matches.isTerritoryOwnedBy(players));
-        return match.match(t);
-      }
-    };
+    return Match.any(Matches.isTerritoryEnemyAndNotUnownedWater(player, data), Matches.isTerritoryOwnedBy(players));
   }
 
   public static Match<Territory> territoryIsPotentialEnemyOrHasPotentialEnemyUnits(final PlayerID player,
       final GameData data, final List<PlayerID> players) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.any(territoryIsPotentialEnemy(player, data, players),
-            territoryHasPotentialEnemyUnits(player, data, players));
-        return match.match(t);
-      }
-    };
+    return Match.any(territoryIsPotentialEnemy(player, data, players),
+        territoryHasPotentialEnemyUnits(player, data, players));
   }
 
   public static Match<Territory> territoryIsEnemyOrCantBeHeldAndIsAdjacentToMyLandUnits(final PlayerID player,
@@ -805,15 +754,7 @@ public class ProMatches {
   }
 
   private static Match<Unit> unitIsNeutral() {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        if (u.getOwner().isNull()) {
-          return true;
-        }
-        return false;
-      }
-    };
+    return Match.of(u -> u.getOwner().isNull());
   }
 
   static Match<Unit> unitIsOwnedAir(final PlayerID player) {
@@ -919,28 +860,25 @@ public class ProMatches {
    * @return whether the territory contains one of the required combos of units
    */
   public static Match<Unit> unitWhichRequiresUnitsHasRequiredUnits(final Territory t) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit unitWhichRequiresUnits) {
-        if (!Matches.UnitRequiresUnitsOnCreation.match(unitWhichRequiresUnits)) {
-          return true;
-        }
-        final Collection<Unit> unitsAtStartOfTurnInProducer = t.getUnits().getUnits();
-        if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInProducer)
-            .match(unitWhichRequiresUnits)) {
-          return true;
-        }
-        if (t.isWater() && Matches.UnitIsSea.match(unitWhichRequiresUnits)) {
-          for (final Territory neighbor : t.getData().getMap().getNeighbors(t, Matches.TerritoryIsLand)) {
-            final Collection<Unit> unitsAtStartOfTurnInCurrent = neighbor.getUnits().getUnits();
-            if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
-                .match(unitWhichRequiresUnits)) {
-              return true;
-            }
+    return Match.of(unitWhichRequiresUnits -> {
+      if (!Matches.UnitRequiresUnitsOnCreation.match(unitWhichRequiresUnits)) {
+        return true;
+      }
+      final Collection<Unit> unitsAtStartOfTurnInProducer = t.getUnits().getUnits();
+      if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInProducer)
+          .match(unitWhichRequiresUnits)) {
+        return true;
+      }
+      if (t.isWater() && Matches.UnitIsSea.match(unitWhichRequiresUnits)) {
+        for (final Territory neighbor : t.getData().getMap().getNeighbors(t, Matches.TerritoryIsLand)) {
+          final Collection<Unit> unitsAtStartOfTurnInCurrent = neighbor.getUnits().getUnits();
+          if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
+              .match(unitWhichRequiresUnits)) {
+            return true;
           }
         }
-        return false;
       }
-    };
+      return false;
+    });
   }
 }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -61,13 +61,10 @@ public class WeakAI extends AbstractAI {
       return null;
     }
     final Territory ourCapitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
-    final Match<Territory> endMatch = new Match<Territory>() {
-      @Override
-      public boolean match(final Territory o) {
-        final boolean impassable = TerritoryAttachment.get(o) != null && TerritoryAttachment.get(o).getIsImpassable();
-        return !impassable && !o.isWater() && Utils.hasLandRouteToEnemyOwnedCapitol(o, player, data);
-      }
-    };
+    final Match<Territory> endMatch = Match.of(o -> {
+      final boolean impassable = TerritoryAttachment.get(o) != null && TerritoryAttachment.get(o).getIsImpassable();
+      return !impassable && !o.isWater() && Utils.hasLandRouteToEnemyOwnedCapitol(o, player, data);
+    });
     final Match<Territory> routeCond =
         Match.all(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
     final Route withNoEnemy = Utils.findNearest(ourCapitol, endMatch, routeCond, data);
@@ -1082,10 +1079,5 @@ public class WeakAI extends AbstractAI {
     return true;
   }
 
-  public static final Match<Unit> Transporting = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit o) {
-      return (TripleAUnit.get(o).getTransporting().size() > 0);
-    }
-  };
+  public static final Match<Unit> Transporting = Match.of(o -> TripleAUnit.get(o).getTransporting().size() > 0);
 }

--- a/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -240,29 +240,21 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
    *         false
    */
   public static Match<TriggerAttachment> whenOrDefaultMatch(final String beforeOrAfter, final String stepName) {
-    return new Match<TriggerAttachment>() {
-      @Override
-      public boolean match(final TriggerAttachment t) {
-        if (beforeOrAfter == null && stepName == null && t.getWhen().isEmpty()) {
-          return true;
-        } else if (beforeOrAfter != null && stepName != null && !t.getWhen().isEmpty()) {
-          for (final Tuple<String, String> w : t.getWhen()) {
-            if (beforeOrAfter.equals(w.getFirst()) && stepName.equals(w.getSecond())) {
-              return true;
-            }
+    return Match.of(t -> {
+      if (beforeOrAfter == null && stepName == null && t.getWhen().isEmpty()) {
+        return true;
+      } else if (beforeOrAfter != null && stepName != null && !t.getWhen().isEmpty()) {
+        for (final Tuple<String, String> w : t.getWhen()) {
+          if (beforeOrAfter.equals(w.getFirst()) && stepName.equals(w.getSecond())) {
+            return true;
           }
         }
-        return false;
       }
-    };
+      return false;
+    });
   }
 
-  public static Match<TriggerAttachment> availableUses = new Match<TriggerAttachment>() {
-    @Override
-    public boolean match(final TriggerAttachment t) {
-      return t.getUses() != 0;
-    }
-  };
+  public static final Match<TriggerAttachment> availableUses = Match.of(t -> t.getUses() != 0);
 
   public static Match<TriggerAttachment> notificationMatch() {
     return Match.of(t -> t.getNotification() != null);

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1380,33 +1380,30 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
    *         required combos as well).
    */
   public Match<Unit> unitWhichRequiresUnitsHasRequiredUnits(final Territory to, final boolean doNotCountNeighbors) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit unitWhichRequiresUnits) {
-        if (!Matches.UnitRequiresUnitsOnCreation.match(unitWhichRequiresUnits)) {
-          return true;
-        }
-        final Collection<Unit> unitsAtStartOfTurnInProducer = unitsAtStartOfStepInTerritory(to);
-        // do not need to remove unowned here, as this match will remove unowned units from consideration.
-        if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInProducer)
-            .match(unitWhichRequiresUnits)) {
-          return true;
-        }
-        if (!doNotCountNeighbors) {
-          if (Matches.UnitIsSea.match(unitWhichRequiresUnits)) {
-            for (final Territory current : getAllProducers(to, m_player,
-                Collections.singletonList(unitWhichRequiresUnits), true)) {
-              final Collection<Unit> unitsAtStartOfTurnInCurrent = unitsAtStartOfStepInTerritory(current);
-              if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
-                  .match(unitWhichRequiresUnits)) {
-                return true;
-              }
+    return Match.of(unitWhichRequiresUnits -> {
+      if (!Matches.UnitRequiresUnitsOnCreation.match(unitWhichRequiresUnits)) {
+        return true;
+      }
+      final Collection<Unit> unitsAtStartOfTurnInProducer = unitsAtStartOfStepInTerritory(to);
+      // do not need to remove unowned here, as this match will remove unowned units from consideration.
+      if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInProducer)
+          .match(unitWhichRequiresUnits)) {
+        return true;
+      }
+      if (!doNotCountNeighbors) {
+        if (Matches.UnitIsSea.match(unitWhichRequiresUnits)) {
+          for (final Territory current : getAllProducers(to, m_player,
+              Collections.singletonList(unitWhichRequiresUnits), true)) {
+            final Collection<Unit> unitsAtStartOfTurnInCurrent = unitsAtStartOfStepInTerritory(current);
+            if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)
+                .match(unitWhichRequiresUnits)) {
+              return true;
             }
           }
         }
-        return false;
       }
-    };
+      return false;
+    });
   }
 
   private boolean getCanAllUnitsWithRequiresUnitsBePlacedCorrectly(final Collection<Unit> units, final Territory to) {

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -630,21 +630,11 @@ public class AirBattle extends AbstractBattle {
   }
 
   private static Match<Unit> unitHasAirDefenseGreaterThanZero() {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        return UnitAttachment.get(u.getType()).getAirDefense(u.getOwner()) > 0;
-      }
-    };
+    return Match.of(u -> UnitAttachment.get(u.getType()).getAirDefense(u.getOwner()) > 0);
   }
 
   private static Match<Unit> unitHasAirAttackGreaterThanZero() {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        return UnitAttachment.get(u.getType()).getAirAttack(u.getOwner()) > 0;
-      }
-    };
+    return Match.of(u -> UnitAttachment.get(u.getType()).getAirAttack(u.getOwner()) > 0);
   }
 
   static Match<Unit> attackingGroundSeaBattleEscorts(final PlayerID attacker, final GameData data) {

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -598,12 +598,7 @@ public class AirMovementValidator {
   }
 
   private static Match<Unit> UnitCanFindLand(final GameData data, final Territory current) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        return canFindLand(data, u, current);
-      }
-    };
+    return Match.of(u -> canFindLand(data, u, current));
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -278,12 +278,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     return games.strategy.triplea.Properties.getNationalObjectives(getData());
   }
 
-  private static Match<RulesAttachment> availableUses = new Match<RulesAttachment>() {
-    @Override
-    public boolean match(final RulesAttachment ra) {
-      return ra.getUses() != 0;
-    }
-  };
+  private static final Match<RulesAttachment> availableUses = Match.of(ra -> ra.getUses() != 0);
 
   @Override
   protected String addOtherResources(final IDelegateBridge aBridge) {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -77,75 +77,43 @@ import games.strategy.util.Util;
  * </p>
  */
 public class Matches {
-  public static final Match<Object> IsTerritory = new Match<Object>() {
-    @Override
-    public boolean match(final Object o) {
-      return o != null && o instanceof Territory;
-    }
-  };
+  public static final Match<Object> IsTerritory = Match.of(o -> o != null && o instanceof Territory);
+
   public static final Match<Unit> UnitHasMoreThanOneHitPointTotal = new Match<Unit>() {
     @Override
     public boolean match(final Unit unit) {
       return UnitTypeHasMoreThanOneHitPointTotal.match(unit.getType());
     }
   };
-  public static final Match<UnitType> UnitTypeHasMoreThanOneHitPointTotal = new Match<UnitType>() {
-    @Override
-    public boolean match(final UnitType ut) {
-      final UnitAttachment ua = UnitAttachment.get(ut);
-      return ua.getHitPoints() > 1;
-    }
-  };
-  public static final Match<Unit> UnitHasTakenSomeDamage = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      return unit.getHits() > 0;
-    }
-  };
+
+  public static final Match<UnitType> UnitTypeHasMoreThanOneHitPointTotal =
+      Match.of(ut -> UnitAttachment.get(ut).getHitPoints() > 1);
+
+  public static final Match<Unit> UnitHasTakenSomeDamage = Match.of(unit -> unit.getHits() > 0);
 
   public static final Match<Unit> UnitHasNotTakenAnyDamage = UnitHasTakenSomeDamage.invert();
 
-  public static final Match<Unit> UnitHasOnlyOneHitPointLeft = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua.getHitPoints() - unit.getHits() <= 1;
-    }
-  };
-  public static final Match<Unit> UnitIsSea = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua.getIsSea();
-    }
-  };
-  public static final Match<Unit> UnitIsSub = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua.getIsSub();
-    }
-  };
+  public static final Match<Unit> UnitHasOnlyOneHitPointLeft =
+      Match.of(unit -> UnitAttachment.get(unit.getType()).getHitPoints() - unit.getHits() <= 1);
+
+  public static final Match<Unit> UnitIsSea = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSea());
+
+  public static final Match<Unit> UnitIsSub = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSub());
 
   public static final Match<Unit> UnitIsNotSub = UnitIsSub.invert();
 
-  public static final Match<Unit> UnitIsCombatTransport = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return (ua.getIsCombatTransport() && ua.getIsSea());
-    }
-  };
+  public static final Match<Unit> UnitIsCombatTransport = Match.of(unit -> {
+    final UnitAttachment ua = UnitAttachment.get(unit.getType());
+    return (ua.getIsCombatTransport() && ua.getIsSea());
+  });
 
   public static final Match<Unit> UnitIsNotCombatTransport = UnitIsCombatTransport.invert();
 
-  public static final Match<Unit> UnitIsTransportButNotCombatTransport = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return (ua.getTransportCapacity() != -1 && ua.getIsSea() && !ua.getIsCombatTransport());
-    }
-  };
+  public static final Match<Unit> UnitIsTransportButNotCombatTransport = Match.of(unit -> {
+    final UnitAttachment ua = UnitAttachment.get(unit.getType());
+    return (ua.getTransportCapacity() != -1 && ua.getIsSea() && !ua.getIsCombatTransport());
+  });
+
   public static final Match<Unit> UnitIsNotTransportButCouldBeCombatTransport = new Match<Unit>() {
     @Override
     public boolean match(final Unit unit) {
@@ -157,45 +125,32 @@ public class Matches {
       }
     }
   };
-  public static final Match<Unit> UnitIsDestroyer = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua.getIsDestroyer();
-    }
-  };
-  public static final Match<UnitType> UnitTypeIsDestroyer = new Match<UnitType>() {
-    @Override
-    public boolean match(final UnitType type) {
-      final UnitAttachment ua = UnitAttachment.get(type);
-      return ua.getIsDestroyer();
-    }
-  };
-  public static final Match<Unit> UnitIsTransport = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return (ua.getTransportCapacity() != -1 && ua.getIsSea());
-    }
-  };
+
+  public static final Match<Unit> UnitIsDestroyer =
+      Match.of(unit -> UnitAttachment.get(unit.getType()).getIsDestroyer());
+
+  public static final Match<UnitType> UnitTypeIsDestroyer = Match.of(type -> UnitAttachment.get(type).getIsDestroyer());
+
+  public static final Match<Unit> UnitIsTransport = Match.of(unit -> {
+    final UnitAttachment ua = UnitAttachment.get(unit.getType());
+    return (ua.getTransportCapacity() != -1 && ua.getIsSea());
+  });
+
   public static final Match<Unit> UnitIsNotTransport = UnitIsTransport.invert();
-  public static final Match<Unit> UnitIsTransportAndNotDestroyer = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return (!Matches.UnitIsDestroyer.match(unit) && ua.getTransportCapacity() != -1 && ua.getIsSea());
+
+  public static final Match<Unit> UnitIsTransportAndNotDestroyer = Match.of(unit -> {
+    final UnitAttachment ua = UnitAttachment.get(unit.getType());
+    return (!Matches.UnitIsDestroyer.match(unit) && ua.getTransportCapacity() != -1 && ua.getIsSea());
+  });
+
+  public static final Match<UnitType> UnitTypeIsStrategicBomber = Match.of(obj -> {
+    final UnitAttachment ua = UnitAttachment.get(obj);
+    if (ua == null) {
+      return false;
     }
-  };
-  public static final Match<UnitType> UnitTypeIsStrategicBomber = new Match<UnitType>() {
-    @Override
-    public boolean match(final UnitType obj) {
-      final UnitAttachment ua = UnitAttachment.get(obj);
-      if (ua == null) {
-        return false;
-      }
-      return ua.getIsStrategicBomber();
-    }
-  };
+    return ua.getIsStrategicBomber();
+  });
+
   public static final Match<Unit> UnitIsStrategicBomber = new Match<Unit>() {
     @Override
     public boolean match(final Unit obj) {
@@ -205,16 +160,13 @@ public class Matches {
 
   public static final Match<Unit> UnitIsNotStrategicBomber = UnitIsStrategicBomber.invert();
 
-  public static final Match<UnitType> UnitTypeCanLandOnCarrier = new Match<UnitType>() {
-    @Override
-    public boolean match(final UnitType obj) {
-      final UnitAttachment ua = UnitAttachment.get(obj);
-      if (ua == null) {
-        return false;
-      }
-      return ua.getCarrierCost() != -1;
+  public static final Match<UnitType> UnitTypeCanLandOnCarrier = Match.of(obj -> {
+    final UnitAttachment ua = UnitAttachment.get(obj);
+    if (ua == null) {
+      return false;
     }
-  };
+    return ua.getCarrierCost() != -1;
+  });
 
   public static final Match<UnitType> UnitTypeCannotLandOnCarrier = UnitTypeCanLandOnCarrier.invert();
 

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -1230,13 +1230,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // In WW2V2 and WW2V3 we need to filter out territories where only planes
     // came from since planes cannot define retreat paths
     if (isWW2V2() || isWW2V3()) {
-      possible = Match.getMatches(possible, new Match<Territory>() {
-        @Override
-        public boolean match(final Territory t) {
-          final Collection<Unit> units = m_attackingFromMap.get(t);
-          return !Match.allMatch(units, Matches.UnitIsAir);
-        }
-      });
+      possible = Match.getMatches(possible, Match.of(t -> {
+        final Collection<Unit> units = m_attackingFromMap.get(t);
+        return !Match.allMatch(units, Matches.UnitIsAir);
+      }));
     }
 
     // the air unit may have come from a conquered or enemy territory, don't allow retreating
@@ -1364,15 +1361,12 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final CompositeMatch<Territory> match =
         new CompositeMatchAnd<>(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, m_data));
     // make sure we can move through the any canals
-    final Match<Territory> canalMatch = new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Route r = new Route();
-        r.setStart(m_battleSite);
-        r.add(t);
-        return MoveValidator.validateCanal(r, unitsToRetreat, m_defender, m_data) == null;
-      }
-    };
+    final Match<Territory> canalMatch = Match.of(t -> {
+      final Route r = new Route();
+      r.setStart(m_battleSite);
+      r.add(t);
+      return MoveValidator.validateCanal(r, unitsToRetreat, m_defender, m_data) == null;
+    });
     match.add(canalMatch);
     possible = Match.getMatches(possible, match);
     return possible;

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -225,18 +225,15 @@ public class RandomStartDelegate extends BaseTripleADelegate {
   }
 
   private Match<PlayerID> getPlayerCanPickMatch() {
-    return new Match<PlayerID>() {
-      @Override
-      public boolean match(final PlayerID player) {
-        if (player == null || player.equals(PlayerID.NULL_PLAYERID)) {
-          return false;
-        }
-        if (player.getUnits().isEmpty()) {
-          return false;
-        }
-        return !player.getIsDisabled();
+    return Match.of(player -> {
+      if (player == null || player.equals(PlayerID.NULL_PLAYERID)) {
+        return false;
       }
-    };
+      if (player.getUnits().isEmpty()) {
+        return false;
+      }
+      return !player.getIsDisabled();
+    });
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -141,12 +141,8 @@ class EditPanel extends ActionPanel {
           for (final Unit u : m_selectedUnits) {
             selectedUnitTypes.add(u.getType());
           }
-          final List<Unit> allOfCorrectType = Match.getMatches(allUnits, new Match<Unit>() {
-            @Override
-            public boolean match(final Unit o) {
-              return selectedUnitTypes.contains(o.getType());
-            }
-          });
+          final List<Unit> allOfCorrectType = Match.getMatches(allUnits,
+              Match.of(o -> selectedUnitTypes.contains(o.getType())));
           final int allCategories =
               UnitSeperator.categorize(allOfCorrectType, mustMoveWithDetails.getMustMoveWith(), true, true).size();
           final int selectedCategories =

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -349,15 +349,12 @@ public class MovePanel extends AbstractMovePanel {
       movable.add(Matches.UnitCanNotMoveDuringCombatMove.invert());
     }
     if (route != null) {
-      final Match<Unit> enoughMovement = new Match<Unit>() {
-        @Override
-        public boolean match(final Unit u) {
-          if (BaseEditDelegate.getEditMode(getData())) {
-            return true;
-          }
-          return TripleAUnit.get(u).getMovementLeft() >= route.getMovementCost(u);
+      final Match<Unit> enoughMovement = Match.of(u -> {
+        if (BaseEditDelegate.getEditMode(getData())) {
+          return true;
         }
-      };
+        return TripleAUnit.get(u).getMovementLeft() >= route.getMovementCost(u);
+      });
       if (route.isUnload()) {
         final CompositeMatch<Unit> notLandAndCanMove = new CompositeMatchAnd<>();
         notLandAndCanMove.add(enoughMovement);
@@ -629,12 +626,7 @@ public class MovePanel extends AbstractMovePanel {
     final Collection<Unit> incapableTransports =
         Match.getMatches(capableTransports, Matches.transportCannotUnload(route.getEnd()));
     capableTransports.removeAll(incapableTransports);
-    final Match<Unit> alliedMatch = new Match<Unit>() {
-      @Override
-      public boolean match(final Unit transport) {
-        return (!transport.getOwner().equals(unitOwner));
-      }
-    };
+    final Match<Unit> alliedMatch = Match.of(transport -> !transport.getOwner().equals(unitOwner));
     final Collection<Unit> alliedTransports = Match.getMatches(capableTransports, alliedMatch);
     capableTransports.removeAll(alliedTransports);
 

--- a/src/test/java/games/strategy/engine/data/MapTest.java
+++ b/src/test/java/games/strategy/engine/data/MapTest.java
@@ -123,13 +123,7 @@ public class MapTest {
 
   @Test
   public void testImpossibleConditionRoute() {
-    final Match<Territory> test = new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        return false;
-      }
-    };
-    assertNull(map.getRoute(aa, ba, test));
+    assertNull(map.getRoute(aa, ba, Match.never()));
   }
 
   @Test


### PR DESCRIPTION
This is one part of multiple PRs whose goal is to replace anonymous `Match` subclasses with the `Match#of()` factory method to avoid the unnecessary boilerplate of the anonymous class syntax.

This PR is more easily reviewed with whitespace changes ignored (`?w=1`).