### PR TITLE
Replace CompositeMatchAnd subclass with Match#all() (part 2)

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -563,7 +563,7 @@ final class ProTechAI {
     // if we fail due to canal, then don't go near any enemy canals
     if (MoveValidator.validateCanal(r, null, player, data) != null) {
       r = data.getMap().getRoute(start, destination,
-          new CompositeMatchAnd<>(routeCondition, Matches.territoryHasNonAllowedCanal(player, null, data).invert()));
+          Match.all(routeCondition, Matches.territoryHasNonAllowedCanal(player, null, data).invert()));
     }
     if (r == null || r.getEnd() == null) {
       return null;

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -36,8 +36,6 @@ import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
 import games.strategy.triplea.delegate.remote.ITechDelegate;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.Util;
@@ -451,13 +449,13 @@ public class WeakAI extends AbstractAI {
         }
       }
       // these are the units we can move
-      final CompositeMatch<Unit> moveOfType = new CompositeMatchAnd<>();
-      moveOfType.add(Matches.unitIsOwnedBy(player));
-      moveOfType.add(Matches.UnitIsNotAA);
-      // we can never move factories
-      moveOfType.add(Matches.UnitCanMove);
-      moveOfType.add(Matches.UnitIsNotInfrastructure);
-      moveOfType.add(Matches.UnitIsLand);
+      final Match<Unit> moveOfType = Match.all(
+          Matches.unitIsOwnedBy(player),
+          Matches.UnitIsNotAA,
+          // we can never move factories
+          Matches.UnitCanMove,
+          Matches.UnitIsNotInfrastructure,
+          Matches.UnitIsLand);
       final Match<Territory> moveThrough =
           Match.all(Matches.TerritoryIsImpassable.invert(),
               Matches.TerritoryIsNeutralButNotWater.invert(), Matches.TerritoryIsLand);
@@ -649,18 +647,20 @@ public class WeakAI extends AbstractAI {
     for (final Territory enemy : enemyOwned) {
       final float enemyStrength = AIUtils.strength(enemy.getUnits().getUnits(), false, false);
       if (enemyStrength > 0) {
-        final CompositeMatch<Unit> attackable = new CompositeMatchAnd<>(Matches.unitIsOwnedBy(player),
-            Matches.UnitIsStrategicBomber.invert(), new Match<Unit>() {
+        final Match<Unit> attackable = Match.all(
+            Matches.unitIsOwnedBy(player),
+            Matches.UnitIsStrategicBomber.invert(),
+            new Match<Unit>() {
               @Override
               public boolean match(final Unit o) {
                 return !unitsAlreadyMoved.contains(o);
               }
-            });
-        attackable.add(Matches.UnitIsNotAA);
-        attackable.add(Matches.UnitCanMove);
-        attackable.add(Matches.UnitIsNotInfrastructure);
-        attackable.add(Matches.UnitCanNotMoveDuringCombatMove.invert());
-        attackable.add(Matches.UnitIsNotSea);
+            },
+            Matches.UnitIsNotAA,
+            Matches.UnitCanMove,
+            Matches.UnitIsNotInfrastructure,
+            Matches.UnitCanNotMoveDuringCombatMove.invert(),
+            Matches.UnitIsNotSea);
         final Set<Territory> dontMoveFrom = new HashSet<>();
         // find our strength that we can attack with
         int ourStrength = 0;

--- a/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -14,8 +14,7 @@ import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
+import games.strategy.util.Match;
 
 /**
  * Utility for detecting and removing units that can't land at the end of a phase.
@@ -41,9 +40,7 @@ public class AirThatCantLandUtil {
     final Iterator<Territory> territories = data.getMap().getTerritories().iterator();
     while (territories.hasNext()) {
       final Territory current = territories.next();
-      final CompositeMatch<Unit> ownedAir = new CompositeMatchAnd<>();
-      ownedAir.add(Matches.UnitIsAir);
-      ownedAir.add(Matches.unitIsOwnedBy(player));
+      final Match<Unit> ownedAir = Match.all(Matches.UnitIsAir, Matches.unitIsOwnedBy(player));
       final Collection<Unit> air = current.getUnits().getMatches(ownedAir);
       if (air.size() != 0 && !AirMovementValidator.canLand(air, current, player, data)) {
         cantLand.add(current);
@@ -58,9 +55,7 @@ public class AirThatCantLandUtil {
     final Iterator<Territory> territories = getTerritoriesWhereAirCantLand(player).iterator();
     while (territories.hasNext()) {
       final Territory current = territories.next();
-      final CompositeMatch<Unit> ownedAir = new CompositeMatchAnd<>();
-      ownedAir.add(Matches.UnitIsAir);
-      ownedAir.add(Matches.alliedUnit(player, data));
+      final Match<Unit> ownedAir = Match.all(Matches.UnitIsAir, Matches.alliedUnit(player, data));
       final Collection<Unit> air = current.getUnits().getMatches(ownedAir);
       final boolean hasNeighboringFriendlyFactory =
           map.getNeighbors(current, Matches.territoryHasAlliedIsFactoryOrCanProduceUnits(data, player)).size() > 0;

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -40,7 +40,6 @@ import games.strategy.triplea.delegate.remote.IBattleDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.oddsCalculator.ta.BattleResults;
 import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.util.CompositeMatch;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
@@ -1076,13 +1075,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // Get those that are neighbors
       final Collection<Territory> areSeaNeighbors = Match.getMatches(neighbors, neighboringSeaZonesWithAlliedUnits);
       // Set up match criteria for allied carriers
-      final CompositeMatch<Unit> alliedCarrier = new CompositeMatchAnd<>();
-      alliedCarrier.add(Matches.UnitIsCarrier);
-      alliedCarrier.add(Matches.alliedUnit(defender, data));
+      final Match<Unit> alliedCarrier = Match.all(Matches.UnitIsCarrier, Matches.alliedUnit(defender, data));
       // Set up match criteria for allied planes
-      final CompositeMatch<Unit> alliedPlane = new CompositeMatchAnd<>();
-      alliedPlane.add(Matches.UnitIsAir);
-      alliedPlane.add(Matches.alliedUnit(defender, data));
+      final Match<Unit> alliedPlane = Match.all(Matches.UnitIsAir, Matches.alliedUnit(defender, data));
       // See if neighboring carriers have any capacity available
       for (final Territory currentTerritory : areSeaNeighbors) {
         // get the capacity of the carriers and cost of fighters
@@ -1148,8 +1143,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   }
 
   private static void landPlanesOnCarriers(final IDelegateBridge bridge, final Match<Unit> alliedDefendingAir,
-      final Collection<Unit> defendingAir, final CompositeMatch<Unit> alliedCarrier,
-      final CompositeMatch<Unit> alliedPlane, final Territory newTerritory, final Territory battleSite) {
+      final Collection<Unit> defendingAir, final Match<Unit> alliedCarrier,
+      final Match<Unit> alliedPlane, final Territory newTerritory, final Territory battleSite) {
     // Get the capacity of the carriers in the selected zone
     final Collection<Unit> alliedCarriersSelected = newTerritory.getUnits().getMatches(alliedCarrier);
     final Collection<Unit> alliedPlanesSelected = newTerritory.getUnits().getMatches(alliedPlane);

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -42,8 +42,6 @@ import games.strategy.triplea.delegate.dataObjects.BattleRecord;
 import games.strategy.triplea.delegate.dataObjects.BattleRecords;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.oddsCalculator.ta.BattleResults;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.Tuple;
@@ -394,11 +392,11 @@ public class BattleTracker implements java.io.Serializable {
     }
     final boolean canConquerMiddleSteps = Match.someMatch(presentFromStartTilEnd, Matches.UnitIsNotAir);
     final boolean scramblingEnabled = games.strategy.triplea.Properties.getScramble_Rules_In_Effect(data);
-    final CompositeMatch<Territory> conquerable = new CompositeMatchAnd<>();
-    conquerable.add(Matches.territoryIsEmptyOfCombatUnits(data, id));
-    conquerable.add(Match.any(
-        Matches.territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(id),
-        Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(id, data)));
+    final Match<Territory> conquerable = Match.all(
+        Matches.territoryIsEmptyOfCombatUnits(data, id),
+        Match.any(
+            Matches.territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(id),
+            Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(id, data)));
     final Collection<Territory> conquered = new ArrayList<>();
     if (canConquerMiddleSteps) {
       conquered.addAll(route.getMatches(conquerable));
@@ -500,9 +498,9 @@ public class BattleTracker implements java.io.Serializable {
           - Match.countMatches(arrivedUnits, Matches.UnitIsAir)
           - Match.countMatches(arrivedUnits, Matches.UnitIsSubmerged);
       // If transports are restricted from controlling sea zones, subtract them
-      final CompositeMatch<Unit> transportsCanNotControl = new CompositeMatchAnd<>();
-      transportsCanNotControl.add(Matches.UnitIsTransportAndNotDestroyer);
-      transportsCanNotControl.add(Matches.UnitIsTransportButNotCombatTransport);
+      final Match<Unit> transportsCanNotControl = Match.all(
+          Matches.UnitIsTransportAndNotDestroyer,
+          Matches.UnitIsTransportButNotCombatTransport);
       if (!games.strategy.triplea.Properties.getTransportControlSeaZone(data)) {
         totalMatches -= Match.countMatches(arrivedUnits, transportsCanNotControl);
       }

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -21,8 +21,6 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.remote.IEditDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TransportUtils;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 import games.strategy.util.Triple;
@@ -151,9 +149,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
         m_bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
       }
     } else {
-      final CompositeMatch<Unit> enemyNonCom = new CompositeMatchAnd<>();
-      enemyNonCom.add(Matches.UnitIsInfrastructure);
-      enemyNonCom.add(Matches.enemyUnit(player, data));
+      final Match<Unit> enemyNonCom = Match.all(Matches.UnitIsInfrastructure, Matches.enemyUnit(player, data));
       final Collection<Unit> units = territory.getUnits().getMatches(enemyNonCom);
       // mark no movement for enemy units
       m_bridge.addChange(ChangeFactory.markNoMovementChange(units));

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -15,8 +15,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.net.GUID;
 import games.strategy.triplea.delegate.dataObjects.CasualtyDetails;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
 public class Fire implements IExecutable {
@@ -122,9 +120,9 @@ public class Fire implements IExecutable {
         // Leave enough transports for each defender for overlfows so they can select who loses them.
         while (playerIter.hasNext()) {
           final PlayerID player = playerIter.next();
-          final CompositeMatch<Unit> match = new CompositeMatchAnd<>();
-          match.add(Matches.UnitIsTransportButNotCombatTransport);
-          match.add(Matches.unitIsOwnedBy(player));
+          final Match<Unit> match = Match.all(
+              Matches.UnitIsTransportButNotCombatTransport,
+              Matches.unitIsOwnedBy(player));
           final Collection<Unit> playerTransports = Match.getMatches(transportsOnly, match);
           final int transportsToRemove = Math.max(0, playerTransports.size() - extraHits);
           transportsOnly.removeAll(

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1698,17 +1698,11 @@ public class Matches {
   }
 
   private static Match<Unit> unitIsEnemyAaForAnything(final PlayerID player, final GameData data) {
-    final CompositeMatch<Unit> comp = new CompositeMatchAnd<>();
-    comp.add(UnitIsAAforAnything);
-    comp.add(enemyUnit(player, data));
-    return comp;
+    return Match.all(UnitIsAAforAnything, enemyUnit(player, data));
   }
 
   private static Match<Unit> unitIsEnemyAaForCombat(final PlayerID player, final GameData data) {
-    final CompositeMatch<Unit> comp = new CompositeMatchAnd<>();
-    comp.add(UnitIsAAforCombatOnly);
-    comp.add(enemyUnit(player, data));
-    return comp;
+    return Match.all(UnitIsAAforCombatOnly, enemyUnit(player, data));
   }
 
   static Match<Unit> unitIsInTerritory(final Territory territory) {
@@ -1901,9 +1895,7 @@ public class Matches {
   }
 
   static Match<Territory> territoryHasNonSubmergedEnemyUnits(final PlayerID player, final GameData data) {
-    final CompositeMatch<Unit> match = new CompositeMatchAnd<>();
-    match.add(enemyUnit(player, data));
-    match.add(UnitIsSubmerged.invert());
+    final Match<Unit> match = Match.all(enemyUnit(player, data), UnitIsSubmerged.invert());
     return new Match<Territory>() {
       @Override
       public boolean match(final Territory t) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -33,7 +33,6 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
-import games.strategy.util.CompositeMatch;
 import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 
@@ -1398,19 +1397,19 @@ public class MoveValidator {
       final Collection<Unit> startUnits, final GameData data, final PlayerID player) {
     // we want to get all air units that are owned by our allies
     // but not us that can land on a carrier
-    final CompositeMatch<Unit> friendlyNotOwnedAir = new CompositeMatchAnd<>();
-    friendlyNotOwnedAir.add(Matches.alliedUnit(player, data));
-    friendlyNotOwnedAir.add(Matches.unitIsOwnedBy(player).invert());
-    friendlyNotOwnedAir.add(Matches.UnitCanLandOnCarrier);
+    final Match<Unit> friendlyNotOwnedAir = Match.all(
+        Matches.alliedUnit(player, data),
+        Matches.unitIsOwnedBy(player).invert(),
+        Matches.UnitCanLandOnCarrier);
     final Collection<Unit> alliedAir = Match.getMatches(startUnits, friendlyNotOwnedAir);
     if (alliedAir.isEmpty()) {
       return Collections.emptyMap();
     }
     // remove air that can be carried by allied
-    final CompositeMatch<Unit> friendlyNotOwnedCarrier = new CompositeMatchAnd<>();
-    friendlyNotOwnedCarrier.add(Matches.UnitIsCarrier);
-    friendlyNotOwnedCarrier.add(Matches.alliedUnit(player, data));
-    friendlyNotOwnedCarrier.add(Matches.unitIsOwnedBy(player).invert());
+    final Match<Unit> friendlyNotOwnedCarrier = Match.all(
+        Matches.UnitIsCarrier,
+        Matches.alliedUnit(player, data),
+        Matches.unitIsOwnedBy(player).invert());
     final Collection<Unit> alliedCarrier = Match.getMatches(startUnits, friendlyNotOwnedCarrier);
     final Iterator<Unit> alliedCarrierIter = alliedCarrier.iterator();
     while (alliedCarrierIter.hasNext()) {

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -20,8 +20,6 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.dataObjects.BattleRecord;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.oddsCalculator.ta.BattleResults;
-import games.strategy.util.CompositeMatch;
-import games.strategy.util.CompositeMatchAnd;
 import games.strategy.util.Match;
 import games.strategy.util.Util;
 
@@ -104,11 +102,8 @@ public class NonFightingBattle extends DependentBattle {
   }
 
   boolean hasAttackingUnits() {
-    final CompositeMatch<Unit> attackingLand = new CompositeMatchAnd<>();
-    attackingLand.add(Matches.alliedUnit(m_attacker, m_data));
-    attackingLand.add(Matches.UnitIsLand);
-    final boolean someAttacking = m_battleSite.getUnits().someMatch(attackingLand);
-    return someAttacking;
+    final Match<Unit> attackingLand = Match.all(Matches.alliedUnit(m_attacker, m_data), Matches.UnitIsLand);
+    return m_battleSite.getUnits().someMatch(attackingLand);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.util.CompositeMatch;
 import games.strategy.util.CompositeMatchAnd;
+import games.strategy.util.Match;
 
 /**
  * Utility for detecting and removing units that can't land at the end of a phase.
@@ -22,9 +23,7 @@ public class UnitsThatCantFightUtil {
 
   // TODO Used to notify of kamikazi attacks
   Collection<Territory> getTerritoriesWhereUnitsCantFight(final PlayerID player) {
-    final CompositeMatch<Unit> enemyAttackUnits = new CompositeMatchAnd<>();
-    enemyAttackUnits.add(Matches.enemyUnit(player, m_data));
-    enemyAttackUnits.add(Matches.unitCanAttack(player));
+    final Match<Unit> enemyAttackUnits = Match.all(Matches.enemyUnit(player, m_data), Matches.unitCanAttack(player));
     final Collection<Territory> cantFight = new ArrayList<>();
     for (final Territory current : m_data.getMap()) {
       // get all owned non-combat units

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -326,11 +326,8 @@ public class MovePanel extends AbstractMovePanel {
     return rVal;
   }
 
-  private CompositeMatch<Unit> getUnloadableMatch(final Route route, final Collection<Unit> units) {
-    final CompositeMatch<Unit> unloadable = new CompositeMatchAnd<>();
-    unloadable.add(getMovableMatch(route, units));
-    unloadable.add(Matches.UnitIsLand);
-    return unloadable;
+  private Match<Unit> getUnloadableMatch(final Route route, final Collection<Unit> units) {
+    return Match.all(getMovableMatch(route, units), Matches.UnitIsLand);
   }
 
   private CompositeMatch<Unit> getMovableMatch(final Route route, final Collection<Unit> units) {
@@ -356,9 +353,7 @@ public class MovePanel extends AbstractMovePanel {
         return TripleAUnit.get(u).getMovementLeft() >= route.getMovementCost(u);
       });
       if (route.isUnload()) {
-        final CompositeMatch<Unit> notLandAndCanMove = new CompositeMatchAnd<>();
-        notLandAndCanMove.add(enoughMovement);
-        notLandAndCanMove.add(Matches.UnitIsNotLand);
+        final Match<Unit> notLandAndCanMove = Match.all(enoughMovement, Matches.UnitIsNotLand);
         final Match<Unit> landOrCanMove = Match.any(Matches.UnitIsLand, notLandAndCanMove);
         movable.add(landOrCanMove);
       } else {
@@ -579,9 +574,9 @@ public class MovePanel extends AbstractMovePanel {
     for (final Unit unit : unitsToLoad) {
       minTransportCost = Math.min(minTransportCost, UnitAttachment.get(unit.getType()).getTransportCost());
     }
-    final CompositeMatch<Unit> candidateTransportsMatch = new CompositeMatchAnd<>();
-    candidateTransportsMatch.add(Matches.UnitIsTransport);
-    candidateTransportsMatch.add(Matches.alliedUnit(unitOwner, getGameData()));
+    final Match<Unit> candidateTransportsMatch = Match.all(
+        Matches.UnitIsTransport,
+        Matches.alliedUnit(unitOwner, getGameData()));
     final List<Unit> candidateTransports = Match.getMatches(endOwnedUnits, candidateTransportsMatch);
 
     // remove transports that don't have enough capacity
@@ -1253,9 +1248,7 @@ public class MovePanel extends AbstractMovePanel {
         return;
       }
       final PlayerID owner = getUnitOwner(selectedUnits);
-      final CompositeMatchAnd<Unit> match =
-          new CompositeMatchAnd<>(Matches.unitIsOwnedBy(owner)/* , Matches.UnitIsNotFactory */);
-      match.add(Matches.UnitCanMove);
+      final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(owner), Matches.UnitCanMove);
       final boolean someOwned = Match.someMatch(units, match);
       final boolean isCorrectTerritory = firstSelectedTerritory == null || firstSelectedTerritory == territory;
       if (someOwned && isCorrectTerritory) {

--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -278,6 +278,16 @@ public abstract class Match<T> {
     }
 
     /**
+     * Creates a new match whose condition is satisfied if the test object matches all of the conditions added to this
+     * builder.
+     *
+     * @return A new match; never {@code null}.
+     */
+    public Match<T> all() {
+      return Match.all(matches);
+    }
+
+    /**
      * Creates a new match whose condition is satisfied if the test object matches any of the conditions added to this
      * builder.
      *

--- a/src/test/java/games/strategy/util/MatchTest.java
+++ b/src/test/java/games/strategy/util/MatchTest.java
@@ -113,6 +113,19 @@ public class MatchTest {
   }
 
   @Test
+  public void testBuildAll() {
+    assertTrue(Match.newCompositeBuilder().all().match(VALUE));
+
+    assertTrue(Match.newCompositeBuilder().add(Match.always()).all().match(VALUE));
+    assertFalse(Match.newCompositeBuilder().add(Match.never()).all().match(VALUE));
+
+    assertTrue(Match.newCompositeBuilder().add(Match.always()).add(Match.always()).all().match(VALUE));
+    assertFalse(Match.newCompositeBuilder().add(Match.always()).add(Match.never()).all().match(VALUE));
+    assertFalse(Match.newCompositeBuilder().add(Match.never()).add(Match.always()).all().match(VALUE));
+    assertFalse(Match.newCompositeBuilder().add(Match.never()).add(Match.never()).all().match(VALUE));
+  }
+
+  @Test
   public void testBuildAny() {
     assertFalse(Match.newCompositeBuilder().any().match(VALUE));
 


### PR DESCRIPTION
This is one part of multiple PRs whose goal is to remove the `CompositeMatchAnd` subclass and replace its instances with calls to the new `Match#all()` factory method or use of the `Match$CompositeBuilder` class.

There were three types of `CompositeMatchAnd` usage throughout the codebase:

* single-step initialization
* multi-step initialization without branching
* multi-step initialization with branching

This PR addresses multi-step initialization without branching, which is described below along with an example of how it was replaced.

#### Multi-step initialization without branching

This is the case where the `CompositeMatchAnd` constructor is typically called with no arguments and subsequent calls are made to `CompositeMatch#add()`.  However, the code path through the `add()` calls does not branch, and the collection of component matches is known at compile time.  Thus, the code can be replaced by passing all component matches directly to the constructor.  For example, the following code:

```java
final CompositeMatch<Unit> alliedCarrier = new CompositeMatchAnd<>();
alliedCarrier.add(Matches.UnitIsCarrier);
alliedCarrier.add(Matches.alliedUnit(defender, data));
```

would be replaced with:

```java
final Match<Unit> alliedCarrier = Match.all(Matches.UnitIsCarrier, Matches.alliedUnit(defender, data));
```