### PR TITLE
Add Issue/PR template Files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+## General
+We are all just humans and we all make mistakes, but please be polite in conversations, and follow the golden rule.
+
+## Pull Requests
+We appreciate every new developer who wants to contribute to the TripleA project.
+If you want to create a Pull Request, please make sure your PR matches our requirements:
+1. Make sure your PR follows our [code guidelines](http://www.triplea-game.org/dev_docs/dev/code_standards/)
+2. Make sure your PR follows our [code formatting guidelines](http://www.triplea-game.org/dev_docs/dev/code_format/)
+3. Make sure you understand our [process of reviewing](http://www.triplea-game.org/dev_docs/dev/code_reviews/)
+
+Every PR is validated with travis, an automated build service.
+If this build fails (and it's not because of some occasional server outages),  you are required to change something so the build passes.
+
+## Issues
+Open an issue if you want to report a bug or request a feature.
+If it's a severe bug we are probably going to fix it pretty fast but feature requests have a pretty low priority in comparison.
+Nobody is getting paid for this, so please be aware that we are not always able to respond on the same day as we are all doing this in our free time.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+## Bugs
+### Reporting
+Please check if this bug has already been reported FIRST, if it hasn't, feel free to proceed.
+Make sure to provide all the necessary information we could need when reporting a bug.
+This includes:
+ - Tell us which version of TripleA you are using. Maybe the bug is already fixed in the latest pre-release.
+ - ALWAYS provide steps on how to reproduce. If we don't know what exactly occurred we can't fix it.
+
+### Formatting
+In case TripleA opens the console and an error (a so called 'stacktrace') shows up, please post this exact error here, but please keep 2 things in mind:
+1. Always put your stacktrace in a code segment, you can do this by simply selecting the whole stacktrace and clicking on the 'Insert Code' button (&lt;&gt;)
+2. If your stacktrace is too long, please consider creating a gist on gist.github.com and pasting the code there. This keeps the issue clean and readable. Don't forget linking to your gist.
+-->
+TripleA version I'm using:
+
+What I expected to happen was:
+
+What actually happened was:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,8 +12,10 @@ In case TripleA opens the console and an error (a so called 'stacktrace') shows 
 1. Always put your stacktrace in a code segment, you can do this by simply selecting the whole stacktrace and clicking on the 'Insert Code' button (&lt;&gt;)
 2. If your stacktrace is too long, please consider creating a gist on gist.github.com and pasting the code there. This keeps the issue clean and readable. Don't forget linking to your gist.
 -->
-TripleA version I'm using:
+### TripleA version I'm using:
 
-What I expected to happen was:
+### What I did:
 
-What actually happened was:
+### What I expected to happen was:
+
+### What actually happened was:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!--
+So you want to create a PR? That's great!
+Just check a couple of things before creating it:
+Make sure this PR follows our code standards.
+Those standards include formatting and some general code guidelines.
+Read more about those standards here:
+http://www.triplea-game.org/dev_docs/dev/code_format/
+http://www.triplea-game.org/dev_docs/dev/code_standards/
+
+If you want to learn more about the process of reviewing PRs you can read more about it here:
+http://www.triplea-game.org/dev_docs/dev/code_reviews/
+-->


### PR DESCRIPTION
Goal is to remind people of some things when or before creating an issue/PR.
A thing that is bugging me for a while, is that a lot of people simply don't format their StackTraces as code, which makes them hard to read.
I need some suggestions though:
 - Is my Issue template ok?
 - What should I add to the CONTRIBUTING template?
 - What should WE remind PR-creators of?