### PR TITLE
Replace anonymous Match subclasses with factory method (part 2)

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -737,15 +737,6 @@ final class ProTechAI {
    * Assumes that water is passable to air units always.
    */
   private static Match<Territory> TerritoryIsImpassableToAirUnits() {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        if (Matches.TerritoryIsLand.match(t) && Matches.TerritoryIsImpassable.match(t)) {
-          return true;
-        }
-        return false;
-      }
-    };
+    return Match.all(Matches.TerritoryIsLand, Matches.TerritoryIsImpassable);
   }
-
 }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -22,161 +22,102 @@ public class ProMatches {
 
   public static Match<Territory> territoryCanLandAirUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove, final List<Territory> enemyTerritories, final List<Territory> alliedTerritories) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.any(Matches.territoryIsInList(alliedTerritories),
-            Match.all(Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data),
-                Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false,
-                    false, true, true),
-                Matches.territoryIsInList(enemyTerritories).invert()));
-        return match.match(t);
-      }
-    };
+    return Match.any(Matches.territoryIsInList(alliedTerritories),
+        Match.all(Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data),
+            Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false,
+                false, true, true),
+            Matches.territoryIsInList(enemyTerritories).invert()));
   }
 
   public static Match<Territory> territoryCanMoveAirUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, false,
-                true, false));
-        return match.match(t);
-      }
-    };
+    return Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+        Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, false,
+            true, false));
   }
 
   public static Match<Territory> territoryCanPotentiallyMoveAirUnits(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.territoryIsPassableAndNotRestricted(player, data));
-        return match.match(t);
-      }
-    };
+    return Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+        Matches.territoryIsPassableAndNotRestricted(player, data));
   }
 
   public static Match<Territory> territoryCanMoveAirUnitsAndNoAA(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match =
-            Match.all(ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove),
-                Matches.territoryHasEnemyAaForAnything(player, data).invert());
-        return match.match(t);
-      }
-    };
+    return Match.all(ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove),
+        Matches.territoryHasEnemyAaForAnything(player, data).invert());
   }
 
   public static Match<Territory> territoryCanMoveSpecificLandUnit(final PlayerID player, final GameData data,
       final boolean isCombatMove, final Unit u) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> territoryMatch = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
-                false, false));
-        final Match<Unit> unitMatch =
-            Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).invert();
-        return territoryMatch.match(t) && unitMatch.match(u);
-      }
-    };
+    return Match.of(t -> {
+      final Match<Territory> territoryMatch = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+          Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
+              false, false));
+      final Match<Unit> unitMatch =
+          Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).invert();
+      return territoryMatch.match(t) && unitMatch.match(u);
+    });
   }
 
   public static Match<Territory> territoryCanPotentiallyMoveSpecificLandUnit(final PlayerID player, final GameData data,
       final Unit u) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> territoryMatch = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.territoryIsPassableAndNotRestricted(player, data));
-        final Match<Unit> unitMatch =
-            Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).invert();
-        return territoryMatch.match(t) && unitMatch.match(u);
-      }
-    };
+    return Match.of(t -> {
+      final Match<Territory> territoryMatch = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+          Matches.territoryIsPassableAndNotRestricted(player, data));
+      final Match<Unit> unitMatch =
+          Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).invert();
+      return territoryMatch.match(t) && unitMatch.match(u);
+    });
   }
 
   public static Match<Territory> territoryCanMoveLandUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
-                false, false));
-        return match.match(t);
-      }
-    };
+    return Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+        Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
+            false, false));
   }
 
   public static Match<Territory> territoryCanPotentiallyMoveLandUnits(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(Matches.TerritoryIsLand,
-            Matches.territoryDoesNotCostMoneyToEnter(data), Matches.territoryIsPassableAndNotRestricted(player, data));
-        return match.match(t);
-      }
-    };
+    return Match.all(Matches.TerritoryIsLand,
+        Matches.territoryDoesNotCostMoneyToEnter(data), Matches.territoryIsPassableAndNotRestricted(player, data));
   }
 
   public static Match<Territory> territoryCanMoveLandUnitsAndIsAllied(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(Matches.isTerritoryAllied(player, data),
-            territoryCanMoveLandUnits(player, data, false));
-        return match.match(t);
-      }
-    };
+    return Match.all(Matches.isTerritoryAllied(player, data),
+        territoryCanMoveLandUnits(player, data, false));
   }
 
   public static Match<Territory> territoryCanMoveLandUnitsThrough(final PlayerID player, final GameData data,
       final Unit u, final Territory startTerritory, final boolean isCombatMove,
       final List<Territory> enemyTerritories) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        Match<Territory> match =
-            Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
-                Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data),
-                Matches.territoryIsInList(enemyTerritories).invert());
-        if (isCombatMove && Matches.UnitCanBlitz.match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
-          final Match<Territory> alliedWithNoEnemiesMatch = Match.all(
-              Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data));
-          final Match<Territory> alliedOrBlitzableMatch =
-              Match.any(alliedWithNoEnemiesMatch, territoryIsBlitzable(player, data, u));
-          match = Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
-              alliedOrBlitzableMatch, Matches.territoryIsInList(enemyTerritories).invert());
-        }
-        return match.match(t);
+    return Match.of(t -> {
+      Match<Territory> match =
+          Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
+              Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data),
+              Matches.territoryIsInList(enemyTerritories).invert());
+      if (isCombatMove && Matches.UnitCanBlitz.match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
+        final Match<Territory> alliedWithNoEnemiesMatch = Match.all(
+            Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data));
+        final Match<Territory> alliedOrBlitzableMatch =
+            Match.any(alliedWithNoEnemiesMatch, territoryIsBlitzable(player, data, u));
+        match = Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
+            alliedOrBlitzableMatch, Matches.territoryIsInList(enemyTerritories).invert());
       }
-    };
+      return match.match(t);
+    });
   }
 
   public static Match<Territory> territoryCanMoveLandUnitsThroughIgnoreEnemyUnits(final PlayerID player,
       final GameData data, final Unit u, final Territory startTerritory, final boolean isCombatMove,
       final List<Territory> blockedTerritories, final List<Territory> clearedTerritories) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        Match<Territory> alliedMatch = Match.any(Matches.isTerritoryAllied(player, data),
-            Matches.territoryIsInList(clearedTerritories));
-        if (isCombatMove && Matches.UnitCanBlitz.match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
-          alliedMatch = Match.any(Matches.isTerritoryAllied(player, data),
-              Matches.territoryIsInList(clearedTerritories), territoryIsBlitzable(player, data, u));
-        }
-        final Match<Territory> match =
-            Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
-                alliedMatch, Matches.territoryIsInList(blockedTerritories).invert());
-        return match.match(t);
-      }
-    };
+    Match<Territory> alliedMatch = Match.any(Matches.isTerritoryAllied(player, data),
+        Matches.territoryIsInList(clearedTerritories));
+    if (isCombatMove && Matches.UnitCanBlitz.match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
+      alliedMatch = Match.any(Matches.isTerritoryAllied(player, data),
+          Matches.territoryIsInList(clearedTerritories), territoryIsBlitzable(player, data, u));
+    }
+    return Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
+        alliedMatch, Matches.territoryIsInList(blockedTerritories).invert());
   }
 
   private static Match<Territory> territoryIsBlitzable(final PlayerID player, final GameData data, final Unit u) {
@@ -186,60 +127,39 @@ public class ProMatches {
 
   public static Match<Territory> territoryCanMoveSeaUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final boolean navalMayNotNonComIntoControlled =
-            Properties.getWW2V2(data) || Properties.getNavalUnitsMayNotNonCombatMoveIntoControlledSeaZones(data);
-        if (!isCombatMove && navalMayNotNonComIntoControlled
-            && Matches.isTerritoryEnemyAndNotUnownedWater(player, data).match(t)) {
-          return false;
-        }
-        final Match<Territory> match = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
-            Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, true,
-                false, false));
-        return match.match(t);
+    return Match.of(t -> {
+      final boolean navalMayNotNonComIntoControlled =
+          Properties.getWW2V2(data) || Properties.getNavalUnitsMayNotNonCombatMoveIntoControlledSeaZones(data);
+      if (!isCombatMove && navalMayNotNonComIntoControlled
+          && Matches.isTerritoryEnemyAndNotUnownedWater(player, data).match(t)) {
+        return false;
       }
-    };
+      final Match<Territory> match = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+          Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, true,
+              false, false));
+      return match.match(t);
+    });
   }
 
   public static Match<Territory> territoryCanMoveSeaUnitsThrough(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
-            territoryHasOnlyIgnoredUnits(player, data));
-        return match.match(t);
-      }
-    };
+    return Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
+        territoryHasOnlyIgnoredUnits(player, data));
   }
 
   public static Match<Territory> territoryCanMoveSeaUnitsAndNotInList(final PlayerID player, final GameData data,
       final boolean isCombatMove, final List<Territory> notTerritories) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
-            Matches.territoryIsNotInList(notTerritories));
-        return match.match(t);
-      }
-    };
+    return Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
+        Matches.territoryIsNotInList(notTerritories));
   }
 
   public static Match<Territory> territoryCanMoveSeaUnitsThroughOrClearedAndNotInList(final PlayerID player,
       final GameData data, final boolean isCombatMove, final List<Territory> clearedTerritories,
       final List<Territory> notTerritories) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> onlyIgnoredOrClearedMatch = Match.any(
-            territoryHasOnlyIgnoredUnits(player, data), Matches.territoryIsInList(clearedTerritories));
-        final Match<Territory> match = Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
-            onlyIgnoredOrClearedMatch, Matches.territoryIsNotInList(notTerritories));
-        return match.match(t);
-      }
-    };
+    final Match<Territory> onlyIgnoredOrClearedMatch = Match.any(
+        territoryHasOnlyIgnoredUnits(player, data), Matches.territoryIsInList(clearedTerritories));
+    return Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
+        onlyIgnoredOrClearedMatch, Matches.territoryIsNotInList(notTerritories));
   }
 
   private static Match<Territory> territoryHasOnlyIgnoredUnits(final PlayerID player, final GameData data) {
@@ -275,202 +195,102 @@ public class ProMatches {
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsLand() {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Unit> infraFactoryMatch = Match.all(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
-        final Match<Territory> match =
-            Match.all(Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
-        return match.match(t);
-      }
-    };
+    final Match<Unit> infraFactoryMatch = Match.all(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+    return Match.all(Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsEnemyLand(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match =
-            Match.all(territoryHasInfraFactoryAndIsLand(), Matches.isTerritoryEnemy(player, data));
-        return match.match(t);
-      }
-    };
+    return Match.all(territoryHasInfraFactoryAndIsLand(), Matches.isTerritoryEnemy(player, data));
   }
 
   static Match<Territory> territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(final PlayerID player,
       final List<PlayerID> players, final List<Territory> territoriesThatCantBeHeld) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> ownedAndCantBeHeld = Match.all(Matches.isTerritoryOwnedBy(player),
-            Matches.territoryIsInList(territoriesThatCantBeHeld));
-        final Match<Territory> enemyOrOwnedCantBeHeld =
-            Match.any(Matches.isTerritoryOwnedBy(players), ownedAndCantBeHeld);
-        final Match<Territory> match = Match.all(territoryHasInfraFactoryAndIsLand(), enemyOrOwnedCantBeHeld);
-        return match.match(t);
-      }
-    };
+    final Match<Territory> ownedAndCantBeHeld = Match.all(Matches.isTerritoryOwnedBy(player),
+        Matches.territoryIsInList(territoriesThatCantBeHeld));
+    final Match<Territory> enemyOrOwnedCantBeHeld =
+        Match.any(Matches.isTerritoryOwnedBy(players), ownedAndCantBeHeld);
+    return Match.all(territoryHasInfraFactoryAndIsLand(), enemyOrOwnedCantBeHeld);
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
       final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(territoryIsNotConqueredOwnedLand(player, data),
-            territoryHasInfraFactoryAndIsOwnedLand(player));
-        return match.match(t);
-      }
-    };
+    return Match.all(territoryIsNotConqueredOwnedLand(player, data),
+        territoryHasInfraFactoryAndIsOwnedLand(player));
   }
 
   public static Match<Territory> territoryHasNonMobileInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
       final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(territoryHasNonMobileInfraFactory(),
-            territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data));
-        return match.match(t);
-      }
-    };
+    return Match.all(territoryHasNonMobileInfraFactory(),
+        territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data));
   }
 
   private static Match<Territory> territoryHasNonMobileInfraFactory() {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Unit> nonMobileInfraFactoryMatch = Match.all(Matches.UnitCanProduceUnits,
-            Matches.UnitIsInfrastructure, Matches.unitHasMovementLeft.invert());
-        final Match<Territory> match = Matches.territoryHasUnitsThatMatch(nonMobileInfraFactoryMatch);
-        return match.match(t);
-      }
-    };
+    final Match<Unit> nonMobileInfraFactoryMatch = Match.all(Matches.UnitCanProduceUnits,
+        Matches.UnitIsInfrastructure, Matches.unitHasMovementLeft.invert());
+    return Matches.territoryHasUnitsThatMatch(nonMobileInfraFactoryMatch);
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsOwnedLand(final PlayerID player) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Unit> infraFactoryMatch = Match.all(Matches.unitIsOwnedBy(player),
-            Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
-        final Match<Territory> match = Match.all(Matches.isTerritoryOwnedBy(player),
-            Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
-        return match.match(t);
-      }
-    };
+    final Match<Unit> infraFactoryMatch = Match.all(Matches.unitIsOwnedBy(player),
+        Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+    return Match.all(Matches.isTerritoryOwnedBy(player),
+        Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsAlliedLand(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Unit> infraFactoryMatch = Match.all(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
-        final Match<Territory> match = Match.all(Matches.isTerritoryAllied(player, data),
-            Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
-        return match.match(t);
-      }
-    };
+    final Match<Unit> infraFactoryMatch = Match.all(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+    return Match.all(Matches.isTerritoryAllied(player, data),
+        Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsOwnedLandAdjacentToSea(final PlayerID player,
       final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(territoryHasInfraFactoryAndIsOwnedLand(player),
-            Matches.territoryHasNeighborMatching(data, Matches.TerritoryIsWater));
-        return match.match(t);
-      }
-    };
+    return Match.all(territoryHasInfraFactoryAndIsOwnedLand(player),
+        Matches.territoryHasNeighborMatching(data, Matches.TerritoryIsWater));
   }
 
   public static Match<Territory> territoryHasNoInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
       final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(territoryIsNotConqueredOwnedLand(player, data),
-            territoryHasInfraFactoryAndIsOwnedLand(player).invert());
-        return match.match(t);
-      }
-    };
+    return Match.all(territoryIsNotConqueredOwnedLand(player, data),
+        territoryHasInfraFactoryAndIsOwnedLand(player).invert());
   }
 
   public static Match<Territory> territoryHasNeighborOwnedByAndHasLandUnit(final GameData data,
       final List<PlayerID> players) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> territoryMatch = Match.all(Matches.isTerritoryOwnedBy(players),
-            Matches.territoryHasUnitsThatMatch(Matches.UnitIsLand));
-        final Match<Territory> match = Matches.territoryHasNeighborMatching(data, territoryMatch);
-        return match.match(t);
-      }
-    };
+    final Match<Territory> territoryMatch = Match.all(Matches.isTerritoryOwnedBy(players),
+        Matches.territoryHasUnitsThatMatch(Matches.UnitIsLand));
+    return Matches.territoryHasNeighborMatching(data, territoryMatch);
   }
 
   static Match<Territory> territoryIsAlliedLandAndHasNoEnemyNeighbors(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> alliedLand = Match.all(territoryCanMoveLandUnits(player, data, false),
-            Matches.isTerritoryAllied(player, data));
-        final Match<Territory> hasNoEnemyNeighbors = Matches
-            .territoryHasNeighborMatching(data, ProMatches.territoryIsEnemyNotNeutralLand(player, data)).invert();
-        final Match<Territory> match = Match.all(alliedLand, hasNoEnemyNeighbors);
-        return match.match(t);
-      }
-    };
+    final Match<Territory> alliedLand = Match.all(territoryCanMoveLandUnits(player, data, false),
+        Matches.isTerritoryAllied(player, data));
+    final Match<Territory> hasNoEnemyNeighbors = Matches
+        .territoryHasNeighborMatching(data, ProMatches.territoryIsEnemyNotNeutralLand(player, data)).invert();
+    return Match.all(alliedLand, hasNoEnemyNeighbors);
   }
 
   public static Match<Territory> territoryIsEnemyLand(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match = Match.all(territoryCanMoveLandUnits(player, data, false),
-            Matches.isTerritoryEnemy(player, data));
-        return match.match(t);
-      }
-    };
+    return Match.all(territoryCanMoveLandUnits(player, data, false),
+        Matches.isTerritoryEnemy(player, data));
   }
 
   public static Match<Territory> territoryIsEnemyNotNeutralLand(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> match =
-            Match.all(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
-        return match.match(t);
-      }
-    };
+    return Match.all(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
   }
 
   public static Match<Territory> territoryIsOrAdjacentToEnemyNotNeutralLand(final PlayerID player,
       final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> isMatch =
-            Match.all(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
-        final Match<Territory> adjacentMatch = Match.all(territoryCanMoveLandUnits(player, data, false),
-            Matches.territoryHasNeighborMatching(data, isMatch));
-        final Match<Territory> match = Match.any(isMatch, adjacentMatch);
-        return match.match(t);
-      }
-    };
+    final Match<Territory> isMatch =
+        Match.all(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
+    final Match<Territory> adjacentMatch = Match.all(territoryCanMoveLandUnits(player, data, false),
+        Matches.territoryHasNeighborMatching(data, isMatch));
+    return Match.any(isMatch, adjacentMatch);
   }
 
   public static Match<Territory> territoryIsEnemyNotNeutralOrAllied(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> alliedLand =
-            Match.all(Matches.TerritoryIsLand, Matches.isTerritoryAllied(player, data));
-        final Match<Territory> match = Match.any(territoryIsEnemyNotNeutralLand(player, data), alliedLand);
-        return match.match(t);
-      }
-    };
+    final Match<Territory> alliedLand = Match.all(Matches.TerritoryIsLand, Matches.isTerritoryAllied(player, data));
+    return Match.any(territoryIsEnemyNotNeutralLand(player, data), alliedLand);
   }
 
   public static Match<Territory> territoryIsEnemyOrCantBeHeld(final PlayerID player, final GameData data,
@@ -492,265 +312,152 @@ public class ProMatches {
 
   public static Match<Territory> territoryIsEnemyOrCantBeHeldAndIsAdjacentToMyLandUnits(final PlayerID player,
       final GameData data, final List<Territory> territoriesThatCantBeHeld) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Unit> myUnitIsLand = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsLand);
-        final Match<Territory> territoryIsLandAndAdjacentToMyLandUnits =
-            Match.all(Matches.TerritoryIsLand,
-                Matches.territoryHasNeighborMatching(data, Matches.territoryHasUnitsThatMatch(myUnitIsLand)));
-        final Match<Territory> match = Match.all(territoryIsLandAndAdjacentToMyLandUnits,
-            territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
-        return match.match(t);
-      }
-    };
+    final Match<Unit> myUnitIsLand = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsLand);
+    final Match<Territory> territoryIsLandAndAdjacentToMyLandUnits =
+        Match.all(Matches.TerritoryIsLand,
+            Matches.territoryHasNeighborMatching(data, Matches.territoryHasUnitsThatMatch(myUnitIsLand)));
+    return Match.all(territoryIsLandAndAdjacentToMyLandUnits,
+        territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
   }
 
   public static Match<Territory> territoryIsNotConqueredAlliedLand(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
-          return false;
-        }
-        final Match<Territory> match = Match.all(Matches.isTerritoryAllied(player, data), Matches.TerritoryIsLand);
-        return match.match(t);
+    return Match.of(t -> {
+      if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
+        return false;
       }
-    };
+      final Match<Territory> match = Match.all(Matches.isTerritoryAllied(player, data), Matches.TerritoryIsLand);
+      return match.match(t);
+    });
   }
 
   public static Match<Territory> territoryIsNotConqueredOwnedLand(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
-          return false;
-        }
-        final Match<Territory> match = Match.all(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
-        return match.match(t);
+    return Match.of(t -> {
+      if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
+        return false;
       }
-    };
+      final Match<Territory> match = Match.all(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
+      return match.match(t);
+    });
   }
 
   public static Match<Territory> territoryIsWaterAndAdjacentToOwnedFactory(final PlayerID player, final GameData data) {
-    return new Match<Territory>() {
-      @Override
-      public boolean match(final Territory t) {
-        final Match<Territory> hasOwnedFactoryNeighbor =
-            Matches.territoryHasNeighborMatching(data, ProMatches.territoryHasInfraFactoryAndIsOwnedLand(player));
-        final Match<Territory> match =
-            Match.all(hasOwnedFactoryNeighbor, ProMatches.territoryCanMoveSeaUnits(player, data, true));
-        return match.match(t);
-      }
-    };
+    final Match<Territory> hasOwnedFactoryNeighbor =
+        Matches.territoryHasNeighborMatching(data, ProMatches.territoryHasInfraFactoryAndIsOwnedLand(player));
+    return Match.all(hasOwnedFactoryNeighbor, ProMatches.territoryCanMoveSeaUnits(player, data, true));
   }
 
   private static Match<Unit> unitCanBeMovedAndIsOwned(final PlayerID player) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft);
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft);
   }
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedAir(final PlayerID player, final boolean isCombatMove) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
-          return false;
-        }
-        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsAir);
-        return match.match(u);
+    return Match.of(u -> {
+      if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+        return false;
       }
-    };
+      final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsAir);
+      return match.match(u);
+    });
   }
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedLand(final PlayerID player, final boolean isCombatMove) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
-          return false;
-        }
-        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsLand,
-            Matches.unitIsBeingTransported().invert());
-        return match.match(u);
+    return Match.of(u -> {
+      if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+        return false;
       }
-    };
+      final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsLand,
+          Matches.unitIsBeingTransported().invert());
+      return match.match(u);
+    });
   }
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedSea(final PlayerID player, final boolean isCombatMove) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
-          return false;
-        }
-        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsSea);
-        return match.match(u);
+    return Match.of(u -> {
+      if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+        return false;
       }
-    };
+      final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsSea);
+      return match.match(u);
+    });
   }
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedTransport(final PlayerID player, final boolean isCombatMove) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
-          return false;
-        }
-        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsTransport);
-        return match.match(u);
+    return Match.of(u -> {
+      if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+        return false;
       }
-    };
+      final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsTransport);
+      return match.match(u);
+    });
   }
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedBombard(final PlayerID player) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        if (Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
-          return false;
-        }
-        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.unitCanBombard(player));
-        return match.match(u);
+    return Match.of(u -> {
+      if (Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+        return false;
       }
-    };
+      final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.unitCanBombard(player));
+      return match.match(u);
+    });
   }
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedNonCombatInfra(final PlayerID player) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player),
-            Matches.UnitCanNotMoveDuringCombatMove, Matches.UnitIsInfrastructure);
-        return match.match(u);
-      }
-    };
+    return Match.all(unitCanBeMovedAndIsOwned(player),
+        Matches.UnitCanNotMoveDuringCombatMove, Matches.UnitIsInfrastructure);
   }
 
   public static Match<Unit> unitCantBeMovedAndIsAlliedDefender(final PlayerID player, final GameData data,
       final Territory t) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> myUnitHasNoMovementMatch =
-            Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft.invert());
-        final Match<Unit> alliedUnitMatch =
-            Match.all(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data),
-                Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(t.getUnits().getUnits(), null, player,
-                    data, false).invert());
-        final Match<Unit> match = Match.any(myUnitHasNoMovementMatch, alliedUnitMatch);
-        return match.match(u);
-      }
-    };
+    final Match<Unit> myUnitHasNoMovementMatch =
+        Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft.invert());
+    final Match<Unit> alliedUnitMatch =
+        Match.all(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data),
+            Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(t.getUnits().getUnits(), null, player,
+                data, false).invert());
+    return Match.any(myUnitHasNoMovementMatch, alliedUnitMatch);
   }
 
   public static Match<Unit> unitCantBeMovedAndIsAlliedDefenderAndNotInfra(final PlayerID player, final GameData data,
       final Territory t) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(unitCantBeMovedAndIsAlliedDefender(player, data, t),
-            Matches.UnitIsNotInfrastructure);
-        return match.match(u);
-      }
-    };
+    return Match.all(unitCantBeMovedAndIsAlliedDefender(player, data, t),
+        Matches.UnitIsNotInfrastructure);
   }
 
   public static Match<Unit> unitIsAlliedLandAndNotInfra(final PlayerID player, final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.UnitIsLand, Matches.isUnitAllied(player, data),
-            Matches.UnitIsNotInfrastructure);
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.UnitIsLand, Matches.isUnitAllied(player, data),
+        Matches.UnitIsNotInfrastructure);
   }
 
   public static Match<Unit> unitIsAlliedNotOwned(final PlayerID player, final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match =
-            Match.all(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data));
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data));
   }
 
   public static Match<Unit> unitIsAlliedNotOwnedAir(final PlayerID player, final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(unitIsAlliedNotOwned(player, data), Matches.UnitIsAir);
-        return match.match(u);
-      }
-    };
+    return Match.all(unitIsAlliedNotOwned(player, data), Matches.UnitIsAir);
   }
 
   static Match<Unit> unitIsAlliedAir(final PlayerID player, final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.isUnitAllied(player, data), Matches.UnitIsAir);
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.isUnitAllied(player, data), Matches.UnitIsAir);
   }
 
   public static Match<Unit> unitIsEnemyAir(final PlayerID player, final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.enemyUnit(player, data), Matches.UnitIsAir);
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.enemyUnit(player, data), Matches.UnitIsAir);
   }
 
   public static Match<Unit> unitIsEnemyAndNotAA(final PlayerID player, final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.enemyUnit(player, data), Matches.UnitIsAAforAnything.invert());
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.enemyUnit(player, data), Matches.UnitIsAAforAnything.invert());
   }
 
   public static Match<Unit> unitIsEnemyAndNotInfa(final PlayerID player, final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.enemyUnit(player, data), Matches.UnitIsNotInfrastructure);
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.enemyUnit(player, data), Matches.UnitIsNotInfrastructure);
   }
 
   public static Match<Unit> unitIsEnemyNotLand(final PlayerID player, final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.enemyUnit(player, data), Matches.UnitIsNotLand);
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.enemyUnit(player, data), Matches.UnitIsNotLand);
   }
 
   static Match<Unit> unitIsEnemyNotNeutral(final PlayerID player, final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.enemyUnit(player, data), unitIsNeutral().invert());
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.enemyUnit(player, data), unitIsNeutral().invert());
   }
 
   private static Match<Unit> unitIsNeutral() {
@@ -758,36 +465,18 @@ public class ProMatches {
   }
 
   static Match<Unit> unitIsOwnedAir(final PlayerID player) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.unitOwnedBy(player), Matches.UnitIsAir);
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.unitOwnedBy(player), Matches.UnitIsAir);
   }
 
   public static Match<Unit> unitIsOwnedAndMatchesTypeAndIsTransporting(final PlayerID player, final UnitType unitType) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
-            Matches.unitIsTransporting());
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
+        Matches.unitIsTransporting());
   }
 
   public static Match<Unit> unitIsOwnedAndMatchesTypeAndNotTransporting(final PlayerID player,
       final UnitType unitType) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
-            Matches.unitIsTransporting().invert());
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
+        Matches.unitIsTransporting().invert());
   }
 
   public static Match<Unit> UnitIsOwnedCarrier(final PlayerID player) {
@@ -796,60 +485,32 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsOwnedNotLand(final PlayerID player) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.UnitIsNotLand, Matches.unitIsOwnedBy(player));
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.UnitIsNotLand, Matches.unitIsOwnedBy(player));
   }
 
   public static Match<Unit> unitIsOwnedTransport(final PlayerID player) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsTransport);
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsTransport);
   }
 
   public static Match<Unit> unitIsOwnedTransportableUnit(final PlayerID player) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match =
-            Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported, Matches.UnitCanMove);
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported, Matches.UnitCanMove);
   }
 
   public static Match<Unit> unitIsOwnedCombatTransportableUnit(final PlayerID player) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported,
-            Matches.UnitCanNotMoveDuringCombatMove.invert(), Matches.UnitCanMove);
-        return match.match(u);
-      }
-    };
+    return Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported,
+        Matches.UnitCanNotMoveDuringCombatMove.invert(), Matches.UnitCanMove);
   }
 
   public static Match<Unit> unitIsOwnedTransportableUnitAndCanBeLoaded(final PlayerID player,
       final boolean isCombatMove) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
-          return false;
-        }
-        final Match<Unit> match = Match.all(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved,
-            Matches.unitHasMovementLeft, Matches.unitIsBeingTransported().invert());
-        return match.match(u);
+    return Match.of(u -> {
+      if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+        return false;
       }
-    };
+      final Match<Unit> match = Match.all(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved,
+          Matches.unitHasMovementLeft, Matches.unitIsBeingTransported().invert());
+      return match.match(u);
+    });
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -366,12 +366,7 @@ public class WeakAI extends AbstractAI {
       final float enemyStrength = AIUtils.strength(enemy.getUnits().getUnits(), false, true);
       if (enemyStrength > 0) {
         final Match<Unit> attackable =
-            Match.all(Matches.unitIsOwnedBy(player), new Match<Unit>() {
-              @Override
-              public boolean match(final Unit o) {
-                return !unitsAlreadyMoved.contains(o);
-              }
-            });
+            Match.all(Matches.unitIsOwnedBy(player), Match.of(o -> !unitsAlreadyMoved.contains(o)));
         final Set<Territory> dontMoveFrom = new HashSet<>();
         // find our strength that we can attack with
         int ourStrength = 0;
@@ -518,12 +513,7 @@ public class WeakAI extends AbstractAI {
     // this works because we are on the server
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
     final Match<Territory> canLand =
-        Match.all(Matches.isTerritoryAllied(player, data), new Match<Territory>() {
-          @Override
-          public boolean match(final Territory o) {
-            return !delegate.getBattleTracker().wasConquered(o);
-          }
-        });
+        Match.all(Matches.isTerritoryAllied(player, data), Match.of(o -> !delegate.getBattleTracker().wasConquered(o)));
     final Match<Territory> routeCondition = Match.all(
         Matches.territoryHasEnemyAaForCombatOnly(player, data).invert(), Matches.TerritoryIsImpassable.invert());
     for (final Territory t : delegateRemote.getTerritoriesWhereAirCantLand()) {

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -638,13 +638,8 @@ public class AirBattle extends AbstractBattle {
   }
 
   static Match<Unit> attackingGroundSeaBattleEscorts(final PlayerID attacker, final GameData data) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        final Match<Unit> canIntercept = Match.all(Matches.unitCanAirBattle);
-        return canIntercept.match(u);
-      }
-    };
+    final Match<Unit> canIntercept = Matches.unitCanAirBattle;
+    return canIntercept;
   }
 
   private static Match<Unit> defendingGroundSeaBattleInterceptors(final PlayerID attacker, final GameData data) {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -114,17 +114,14 @@ public class Matches {
     return (ua.getTransportCapacity() != -1 && ua.getIsSea() && !ua.getIsCombatTransport());
   });
 
-  public static final Match<Unit> UnitIsNotTransportButCouldBeCombatTransport = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      if (ua.getTransportCapacity() == -1) {
-        return true;
-      } else {
-        return ua.getIsCombatTransport() && ua.getIsSea();
-      }
+  public static final Match<Unit> UnitIsNotTransportButCouldBeCombatTransport = Match.of(unit -> {
+    final UnitAttachment ua = UnitAttachment.get(unit.getType());
+    if (ua.getTransportCapacity() == -1) {
+      return true;
+    } else {
+      return ua.getIsCombatTransport() && ua.getIsSea();
     }
-  };
+  });
 
   public static final Match<Unit> UnitIsDestroyer =
       Match.of(unit -> UnitAttachment.get(unit.getType()).getIsDestroyer());
@@ -151,12 +148,8 @@ public class Matches {
     return ua.getIsStrategicBomber();
   });
 
-  public static final Match<Unit> UnitIsStrategicBomber = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit obj) {
-      return UnitTypeIsStrategicBomber.match(obj.getType());
-    }
-  };
+  public static final Match<Unit> UnitIsStrategicBomber =
+      Match.of(obj -> UnitTypeIsStrategicBomber.match(obj.getType()));
 
   public static final Match<Unit> UnitIsNotStrategicBomber = UnitIsStrategicBomber.invert();
 
@@ -170,27 +163,18 @@ public class Matches {
 
   public static final Match<UnitType> UnitTypeCannotLandOnCarrier = UnitTypeCanLandOnCarrier.invert();
 
-  public static final Match<Unit> unitHasMoved = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit obj) {
-      final Unit unit = obj;
-      return TripleAUnit.get(unit).getAlreadyMoved() > 0;
-    }
-  };
+  public static final Match<Unit> unitHasMoved = Match.of(unit -> TripleAUnit.get(unit).getAlreadyMoved() > 0);
 
   public static final Match<Unit> unitHasNotMoved = unitHasMoved.invert();
 
   static Match<Unit> unitCanAttack(final PlayerID id) {
-    return new Match<Unit>() {
-      @Override
-      public boolean match(final Unit unit) {
-        final UnitAttachment ua = UnitAttachment.get(unit.getType());
-        if (ua.getMovement(id) <= 0) {
-          return false;
-        }
-        return ua.getAttack(id) > 0;
+    return Match.of(unit -> {
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      if (ua.getMovement(id) <= 0) {
+        return false;
       }
-    };
+      return ua.getAttack(id) > 0;
+    });
   }
 
   public static Match<Unit> unitHasAttackValueOfAtLeast(final int attackValue) {
@@ -205,56 +189,23 @@ public class Matches {
     return Match.of(unit -> data.getRelationshipTracker().isAtWar(unit.getOwner(), player));
   }
 
-  public static final Match<Unit> UnitIsNotSea = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit obj) {
-      final Unit unit = obj;
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return !ua.getIsSea();
-    }
-  };
-  public static final Match<UnitType> UnitTypeIsSea = new Match<UnitType>() {
-    @Override
-    public boolean match(final UnitType obj) {
-      final UnitAttachment ua = UnitAttachment.get(obj);
-      return ua.getIsSea();
-    }
-  };
-  public static final Match<UnitType> UnitTypeIsNotSea = new Match<UnitType>() {
-    @Override
-    public boolean match(final UnitType type) {
-      final UnitAttachment ua = UnitAttachment.get(type);
-      return !ua.getIsSea();
-    }
-  };
-  public static final Match<UnitType> UnitTypeIsSeaOrAir = new Match<UnitType>() {
-    @Override
-    public boolean match(final UnitType type) {
-      final UnitAttachment ua = UnitAttachment.get(type);
-      return ua.getIsSea() || ua.getIsAir();
-    }
-  };
-  public static final Match<UnitType> UnitTypeIsCarrier = new Match<UnitType>() {
-    @Override
-    public boolean match(final UnitType type) {
-      final UnitAttachment ua = UnitAttachment.get(type);
-      return (ua.getCarrierCapacity() != -1);
-    }
-  };
-  public static final Match<Unit> UnitIsAir = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua.getIsAir();
-    }
-  };
-  public static final Match<Unit> UnitIsNotAir = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return !ua.getIsAir();
-    }
-  };
+  public static final Match<Unit> UnitIsNotSea = Match.of(unit -> !UnitAttachment.get(unit.getType()).getIsSea());
+
+  public static final Match<UnitType> UnitTypeIsSea = Match.of(type -> UnitAttachment.get(type).getIsSea());
+
+  public static final Match<UnitType> UnitTypeIsNotSea = Match.of(type -> !UnitAttachment.get(type).getIsSea());
+
+  public static final Match<UnitType> UnitTypeIsSeaOrAir = Match.of(type -> {
+    final UnitAttachment ua = UnitAttachment.get(type);
+    return ua.getIsSea() || ua.getIsAir();
+  });
+
+  public static final Match<UnitType> UnitTypeIsCarrier =
+      Match.of(type -> UnitAttachment.get(type).getCarrierCapacity() != -1);
+
+  public static final Match<Unit> UnitIsAir = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsAir());
+
+  public static final Match<Unit> UnitIsNotAir = Match.of(unit -> !UnitAttachment.get(unit.getType()).getIsAir());
 
   public static Match<UnitType> unitTypeCanBombard(final PlayerID id) {
     return Match.of(type -> UnitAttachment.get(type).getCanBombard(id));

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1153,13 +1153,10 @@ public class MoveValidator {
   }
 
   private static List<Unit> getParatroopsRequiringTransport(final Collection<Unit> units, final Route route) {
-    return Match.getMatches(units, Match.all(Matches.UnitIsAirTransportable, new Match<Unit>() {
-      @Override
-      public boolean match(final Unit u) {
-        return TripleAUnit.get(u).getMovementLeft() < route.getMovementCost(u) || route.crossesWater()
-            || route.getEnd().isWater();
-      }
-    }));
+    return Match.getMatches(units, Match.all(Matches.UnitIsAirTransportable, Match.of(u -> {
+      return TripleAUnit.get(u).getMovementLeft() < route.getMovementCost(u) || route.crossesWater()
+          || route.getEnd().isWater();
+    })));
   }
 
   private static MoveValidationResult validateParatroops(final boolean nonCombat, final GameData data,

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -204,62 +204,59 @@ public class MovePanel extends AbstractMovePanel {
     final Set<Unit> defaultSelections = TransportUtils.findMinTransportsToUnload(unitsToUnload, candidateTransports);
 
     // Match criteria to ensure that chosen transports will match selected units
-    final Match<Collection<Unit>> transportsToUnloadMatch = new Match<Collection<Unit>>() {
-      @Override
-      public boolean match(final Collection<Unit> units) {
-        final List<Unit> sortedTransports = Match.getMatches(units, Matches.UnitIsTransport);
-        final Collection<Unit> availableUnits = new ArrayList<>(unitsToUnload);
+    final Match<Collection<Unit>> transportsToUnloadMatch = Match.of(units -> {
+      final List<Unit> sortedTransports = Match.getMatches(units, Matches.UnitIsTransport);
+      final Collection<Unit> availableUnits = new ArrayList<>(unitsToUnload);
 
-        // track the changing capacities of the transports as we assign units
-        final IntegerMap<Unit> capacityMap = new IntegerMap<>();
-        for (final Unit transport : sortedTransports) {
+      // track the changing capacities of the transports as we assign units
+      final IntegerMap<Unit> capacityMap = new IntegerMap<>();
+      for (final Unit transport : sortedTransports) {
+        final Collection<Unit> transporting = TripleAUnit.get(transport).getTransporting();
+        capacityMap.add(transport, TransportUtils.getTransportCost(transporting));
+      }
+      boolean hasChanged = false;
+      final Comparator<Unit> increasingCapacityComparator =
+          UnitComparator.getIncreasingCapacityComparator(sortedTransports);
+
+      // This algorithm will ensure that it is actually possible to distribute
+      // the selected units amongst the current selection of chosen transports.
+      do {
+        hasChanged = false;
+
+        // Sort transports by increasing capacity
+        Collections.sort(sortedTransports, increasingCapacityComparator);
+
+        // Try to remove one unit from each transport, in succession
+        final Iterator<Unit> transportIter = sortedTransports.iterator();
+        while (transportIter.hasNext()) {
+          final Unit transport = transportIter.next();
           final Collection<Unit> transporting = TripleAUnit.get(transport).getTransporting();
-          capacityMap.add(transport, TransportUtils.getTransportCost(transporting));
-        }
-        boolean hasChanged = false;
-        final Comparator<Unit> increasingCapacityComparator =
-            UnitComparator.getIncreasingCapacityComparator(sortedTransports);
+          if (transporting == null) {
+            continue;
+          }
+          final Collection<UnitCategory> transCategories = UnitSeperator.categorize(transporting);
+          final Iterator<Unit> unitIter = availableUnits.iterator();
+          while (unitIter.hasNext()) {
+            final Unit unit = unitIter.next();
+            final Collection<UnitCategory> unitCategory = UnitSeperator.categorize(Collections.singleton(unit));
 
-        // This algorithm will ensure that it is actually possible to distribute
-        // the selected units amongst the current selection of chosen transports.
-        do {
-          hasChanged = false;
+            // Is one of the transported units of the same type we want to unload?
+            if (Util.someIntersect(transCategories, unitCategory)) {
 
-          // Sort transports by increasing capacity
-          Collections.sort(sortedTransports, increasingCapacityComparator);
-
-          // Try to remove one unit from each transport, in succession
-          final Iterator<Unit> transportIter = sortedTransports.iterator();
-          while (transportIter.hasNext()) {
-            final Unit transport = transportIter.next();
-            final Collection<Unit> transporting = TripleAUnit.get(transport).getTransporting();
-            if (transporting == null) {
-              continue;
-            }
-            final Collection<UnitCategory> transCategories = UnitSeperator.categorize(transporting);
-            final Iterator<Unit> unitIter = availableUnits.iterator();
-            while (unitIter.hasNext()) {
-              final Unit unit = unitIter.next();
-              final Collection<UnitCategory> unitCategory = UnitSeperator.categorize(Collections.singleton(unit));
-
-              // Is one of the transported units of the same type we want to unload?
-              if (Util.someIntersect(transCategories, unitCategory)) {
-
-                // Unload the unit, remove the transport from our list, and continue
-                hasChanged = true;
-                unitIter.remove();
-                transportIter.remove();
-                break;
-              }
+              // Unload the unit, remove the transport from our list, and continue
+              hasChanged = true;
+              unitIter.remove();
+              transportIter.remove();
+              break;
             }
           }
-          // Repeat until there are no units left or no changes occur
-        } while (availableUnits.size() > 0 && hasChanged);
+        }
+        // Repeat until there are no units left or no changes occur
+      } while (availableUnits.size() > 0 && hasChanged);
 
-        // If we haven't seen all of the transports (and removed them) then there are extra transports that don't fit
-        return (sortedTransports.size() == 0);
-      }
-    };
+      // If we haven't seen all of the transports (and removed them) then there are extra transports that don't fit
+      return (sortedTransports.size() == 0);
+    });
 
     // Choosing what transports to unload
     final UnitChooser chooser = new UnitChooser(candidateTransports, defaultSelections,
@@ -695,14 +692,11 @@ public class MovePanel extends AbstractMovePanel {
     }
 
     // the match criteria to ensure that chosen transports will match selected units
-    final Match<Collection<Unit>> transportsToLoadMatch = new Match<Collection<Unit>>() {
-      @Override
-      public boolean match(final Collection<Unit> units) {
-        final Collection<Unit> transports = Match.getMatches(units, Matches.UnitIsTransport);
-        // prevent too many transports from being selected
-        return (transports.size() <= Math.min(unitsToLoad.size(), candidateTransports.size()));
-      }
-    };
+    final Match<Collection<Unit>> transportsToLoadMatch = Match.of(units -> {
+      final Collection<Unit> transports = Match.getMatches(units, Matches.UnitIsTransport);
+      // prevent too many transports from being selected
+      return (transports.size() <= Math.min(unitsToLoad.size(), candidateTransports.size()));
+    });
     final UnitChooser chooser = new UnitChooser(candidateTransports, defaultSelections,
         endMustMoveWith.getMustMoveWith(), /* categorizeMovement */true, /* categorizeTransportCost */false,
         getGameData(), /* allowTwoHit */false, getMap().getUIContext(), transportsToLoadMatch);
@@ -764,18 +758,15 @@ public class MovePanel extends AbstractMovePanel {
       }
       // basic match criteria only
       final CompositeMatch<Unit> unitsToMoveMatch = getMovableMatch(null, null);
-      final Match<Collection<Unit>> ownerMatch = new Match<Collection<Unit>>() {
-        @Override
-        public boolean match(final Collection<Unit> unitsToCheck) {
-          final PlayerID owner = unitsToCheck.iterator().next().getOwner();
-          for (final Unit unit : unitsToCheck) {
-            if (!owner.equals(unit.getOwner())) {
-              return false;
-            }
+      final Match<Collection<Unit>> ownerMatch = Match.of(unitsToCheck -> {
+        final PlayerID owner = unitsToCheck.iterator().next().getOwner();
+        for (final Unit unit : unitsToCheck) {
+          if (!owner.equals(unit.getOwner())) {
+            return false;
           }
-          return true;
         }
-      };
+        return true;
+      });
       if (units.isEmpty() && selectedUnits.isEmpty()) {
         if (!me.isShiftDown()) {
           final List<Unit> unitsToMove = t.getUnits().getMatches(unitsToMoveMatch);
@@ -903,13 +894,10 @@ public class MovePanel extends AbstractMovePanel {
     public Collection<Unit> getAirTransportsToLoad(final Collection<Unit> candidateAirTransports) {
       final Set<Unit> defaultSelections = new HashSet<>();
       // prevent too many bombers from being selected
-      final Match<Collection<Unit>> transportsToLoadMatch = new Match<Collection<Unit>>() {
-        @Override
-        public boolean match(final Collection<Unit> units) {
-          final Collection<Unit> airTransports = Match.getMatches(units, Matches.UnitIsAirTransport);
-          return (airTransports.size() <= candidateAirTransports.size());
-        }
-      };
+      final Match<Collection<Unit>> transportsToLoadMatch = Match.of(units -> {
+        final Collection<Unit> airTransports = Match.getMatches(units, Matches.UnitIsAirTransport);
+        return (airTransports.size() <= candidateAirTransports.size());
+      });
       // Allow player to select which to load.
       final UnitChooser chooser = new UnitChooser(candidateAirTransports, defaultSelections, s_dependentUnits,
           /* categorizeMovement */true, /* categorizeTransportCost */false, getGameData(), /* allowTwoHit */false,
@@ -948,20 +936,17 @@ public class MovePanel extends AbstractMovePanel {
       }
       final Set<Unit> defaultSelections = new HashSet<>();
       // Check to see if there's room for the selected units
-      final Match<Collection<Unit>> unitsToLoadMatch = new Match<Collection<Unit>>() {
-        @Override
-        public boolean match(final Collection<Unit> units) {
-          final Collection<Unit> unitsToLoad = Match.getMatches(units, Matches.UnitIsAirTransportable);
-          final Map<Unit, Unit> unitMap = TransportUtils.mapTransportsToLoad(unitsToLoad, airTransportsToLoad);
-          boolean ableToLoad = true;
-          for (final Unit unit : unitsToLoad) {
-            if (!unitMap.keySet().contains(unit)) {
-              ableToLoad = false;
-            }
+      final Match<Collection<Unit>> unitsToLoadMatch = Match.of(units -> {
+        final Collection<Unit> unitsToLoad = Match.getMatches(units, Matches.UnitIsAirTransportable);
+        final Map<Unit, Unit> unitMap = TransportUtils.mapTransportsToLoad(unitsToLoad, airTransportsToLoad);
+        boolean ableToLoad = true;
+        for (final Unit unit : unitsToLoad) {
+          if (!unitMap.keySet().contains(unit)) {
+            ableToLoad = false;
           }
-          return ableToLoad;
         }
-      };
+        return ableToLoad;
+      });
       List<Unit> loadedUnits = new ArrayList<>(capableUnitsToLoad);
       if (!airTransportsToLoad.isEmpty()) {
         // Get a list of the units that could be loaded on the transport (based upon transport capacity)
@@ -1142,16 +1127,13 @@ public class MovePanel extends AbstractMovePanel {
         }
         // this match will make sure we can't select more units
         // of a specific type then we had originally selected
-        final Match<Collection<Unit>> unitTypeCountMatch = new Match<Collection<Unit>>() {
-          @Override
-          public boolean match(final Collection<Unit> units) {
-            final IntegerMap<UnitType> currentMap = new IntegerMap<>();
-            for (final Unit unit : units) {
-              currentMap.add(unit.getType(), 1);
-            }
-            return maxMap.greaterThanOrEqualTo(currentMap);
+        final Match<Collection<Unit>> unitTypeCountMatch = Match.of(unitsToCheck -> {
+          final IntegerMap<UnitType> currentMap = new IntegerMap<>();
+          for (final Unit unit : unitsToCheck) {
+            currentMap.add(unit.getType(), 1);
           }
-        };
+          return maxMap.greaterThanOrEqualTo(currentMap);
+        });
         allowSpecificUnitSelection(units, route, false, unitTypeCountMatch);
         if (units.isEmpty()) {
           cancelMove();


### PR DESCRIPTION
This is one part of multiple PRs whose goal is to replace anonymous `Match` subclasses with the `Match#of()` factory method to avoid the unnecessary boilerplate of the anonymous class syntax.

This PR is more easily reviewed with whitespace changes ignored (`?w=1`).