### PR TITLE
Fix Could Not Find Step Name In Battle Window Bug

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/BattleStepStrings.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleStepStrings.java
@@ -23,9 +23,6 @@ public interface BattleStepStrings {
   String SELECT_CASUALTIES = " select casualties";
   String REMOVE_CASUALTIES = "Remove casualties";
   String SUBS_WITHDRAW = " withdraw subs?";
-  String PLANES_WITHDRAW = " withdraw planes?";
-  String RETREAT_PLANES = " retreat planes?";
-  String NONAMPHIB_WITHDRAW = " withdraw non-amphibious units?";
   String SUBS_SUBMERGE = " submerge subs?";
   String ATTACKER_WITHDRAW = " withdraw?";
   String SUICIDE_ATTACK = "Suicide and Munition units Attack";

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -667,12 +667,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // option shown
     // later, if our sea units die, we may ask the user to retreat
     final boolean someAirAtSea = m_battleSite.isWater() && Match.someMatch(m_attackingUnits, Matches.UnitIsAir);
-    if (canAttackerRetreat() || someAirAtSea) {
+    if (canAttackerRetreat() || someAirAtSea || canAttackerRetreatPartialAmphib() || canAttackerRetreatPlanes()) {
       steps.add(m_attacker.getName() + ATTACKER_WITHDRAW);
-    } else if (canAttackerRetreatPartialAmphib()) {
-      steps.add(m_attacker.getName() + NONAMPHIB_WITHDRAW);
-    } else if (canAttackerRetreatPlanes()) {
-      steps.add(m_attacker.getName() + PLANES_WITHDRAW);
     }
     return steps;
   }
@@ -1422,7 +1418,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (subs) {
       text = retreatingPlayer.getName() + " retreat subs?";
     } else if (planes) {
-      text = retreatingPlayer.getName() + RETREAT_PLANES;
+      text = retreatingPlayer.getName() + " retreat planes?";
     } else if (partialAmphib) {
       text = retreatingPlayer.getName() + " retreat non-amphibious units?";
     } else {
@@ -1434,10 +1430,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     } else {
       if (subs) {
         step = m_attacker.getName() + (canSubsSubmerge ? SUBS_SUBMERGE : SUBS_WITHDRAW);
-      } else if (planes) {
-        step = m_attacker.getName() + PLANES_WITHDRAW;
-      } else if (partialAmphib) {
-        step = m_attacker.getName() + NONAMPHIB_WITHDRAW;
       } else {
         step = m_attacker.getName() + ATTACKER_WITHDRAW;
       }

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3_41_Test.java
@@ -46,9 +46,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -94,7 +91,6 @@ import games.strategy.triplea.delegate.dataObjects.PlaceableUnits;
 import games.strategy.triplea.delegate.dataObjects.TechResults;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.player.ITripleAPlayer;
-import games.strategy.triplea.ui.display.ITripleADisplay;
 import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
@@ -1395,54 +1391,6 @@ public class WW2V3_41_Test {
     final String error =
         moveDelegate(gameData).move(bomberAndParatroop, new Route(germany, poland, eastPoland, beloRussia));
     assertValid(error);
-  }
-
-  @Test
-  public void testAmphibAttackWithPlanesOnlyAskRetreatOnce() {
-    final PlayerID germans = germans(gameData);
-    final ITestDelegateBridge bridge = getDelegateBridge(germans);
-    bridge.setStepName("CombatMove");
-    moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
-    moveDelegate(gameData).start();
-    final Territory france = territory("France", gameData);
-    final Territory egypt = territory("Egypt", gameData);
-    final Territory balkans = territory("Balkans", gameData);
-    final Territory libya = territory("Libya", gameData);
-    final Territory germany = territory("Germany", gameData);
-    final Territory sz13 = territory("13 Sea Zone", gameData);
-    final Territory sz14 = territory("14 Sea Zone", gameData);
-    final Territory sz15 = territory("15 Sea Zone", gameData);
-
-    when(dummyPlayer.retreatQuery(any(), anyBoolean(), any(),
-        any(), contains(BattleStepStrings.RETREAT_PLANES))).thenThrow(
-            new AssertionError("The Message is not allowed to contain the BattleStepStrings.RETREAT_PLANES constant"));
-    bridge.setRemote(dummyPlayer);
-    final ITripleADisplay dummyDisplay = mock(ITripleADisplay.class);
-    doThrow(new AssertionError(
-        "None of the Battle steps is allow to contain the BattleStepStrings.PLANES_WITHDRAW constant"))
-            .when(dummyDisplay).listBattleSteps(any(), argThat(list -> {
-              for (final String string : list) {
-                if (string.contains(BattleStepStrings.PLANES_WITHDRAW)) {
-                  return true;
-                }
-              }
-              return false;
-            }));
-    bridge.setDisplay(dummyDisplay);
-    // move units for amphib assault
-    load(france.getUnits().getMatches(Matches.UnitIsInfantry), new Route(france, sz13));
-    move(sz13.getUnits().getUnits(), new Route(sz13, sz14, sz15));
-    move(sz15.getUnits().getMatches(Matches.UnitIsInfantry), new Route(sz15, egypt));
-    // ground attack
-    load(libya.getUnits().getMatches(Matches.UnitIsArtillery), new Route(libya, egypt));
-    // air units
-    move(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber), new Route(germany, balkans, sz14, sz15, egypt));
-    moveDelegate(gameData).end();
-    bridge.setStepName("Combat");
-    // cook the dice so that all miss first round,all hit second round
-    bridge.setRandomSource(new ScriptedRandomSource(5, 5, 5, 5, 5, 5, 5, 5, 5, 1, 1, 1, 1, 1, 1, 1, 1, 1));
-    battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
-    battleDelegate(gameData).start();
   }
 
   @Test


### PR DESCRIPTION
Fixes #1954 

Functional Changes
- Battle window now just shows standard withdraw step from air, non-amphib, and standard withdraw while the actual withdraw prompt describes withdraw detail. This was done as this custom step message provides little value and can be incorrect as casualty selection can change which type of withdraw is available. Example is if you had non-amphib attackers so it displays that step text but those are all taken as casualties so its no longer relevant.