### PR TITLE
Simplify the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .project
 .settings
+.checkstyle
 
 *.backup
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,128 +1,13 @@
-### Project specific files
-bin/
-derby_db/
-access_logs/
-logs/
-release/
-apidoc/
-classes/
-temp/
-temp-build/
-testclasses/
-test-results/
-savedGames/
-
-## Derby
-derby.log
-ta_users/
-
-### JetBrains template
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion
-
-*.iml
-
-## Directory-based project format:
-.idea/
-# if you remove the above rule, at least ignore the following:
-
-# User-specific stuff:
-# .idea/workspace.xml
-# .idea/tasks.xml
-# .idea/dictionaries
-
-# Sensitive or high-churn files:
-# .idea/dataSources.ids
-# .idea/dataSources.xml
-# .idea/sqlDataSources.xml
-# .idea/dynamic.xml
-# .idea/uiDesigner.xml
-
-# Gradle:
-# .idea/gradle.xml
-# .idea/libraries
-
-# Mongo Explorer plugin:
-# .idea/mongoSettings.xml
-
-## File-based project format:
-*.ipr
-*.iws
-
-## Plugin-specific files:
-
-# IntelliJ
-/out/
-
-### Eclipse template
-*.pydevproject
-.metadata
-.gradle
-bin/
-tmp/
-*.tmp
-*.bak
-*.swp
-*~.nib
-local.properties
-.settings/
-.loadpath
-temp_eclipse/
-classes.jar
-
-# Vi tmp files
-*~
-
-# Eclipse Core
-.project
-
-# External tool builders
-.externalToolBuilders/
-
-# CDT-specific
-.cproject
-
-# JDT-specific (Eclipse Java Development Tools)
 .classpath
-
-# Java annotation processor (APT)
-.factorypath
-
-# PDT-specific
-.buildpath
-
-# Checkstyle plugin
-.checkstyle
-
-# sbteclipse plugin
-.target
-
-# TeXlipse plugin
-.texlipse
-
-
-### Java template
-*.class
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.ear
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-
-
-### Gradle template
 .gradle
-build/
-
-# Ignore Gradle GUI config
-gradle-app.setting
-
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
+.idea
+.project
+.settings
 
 *.backup
+*.swp
+
+bin/
+build/
+derby_db/
+


### PR DESCRIPTION
Not sure how many rules accumulated in .gitignore. I pruned them all back and added back in to get to a fresh git status on master. We can add in more rules as needed, for the meantime this prunes down our rules to what we use.

Note: no new rules, the ordering may have changed, it was easier to group the shortened files (grouped by: specific files, file globs, then folders)