### PR TITLE
Save 1 change later to avoid retriggering end turn on load

### DIFF
--- a/src/main/java/games/strategy/engine/history/History.java
+++ b/src/main/java/games/strategy/engine/history/History.java
@@ -131,7 +131,7 @@ public class History extends DefaultTreeModel {
     assertCorrectThread();
     getGameData().acquireWriteLock();
     try {
-      final int lastChange = getLastChange(removeAfterNode);
+      final int lastChange = getLastChange(removeAfterNode) + 1;
       while (m_changes.size() > lastChange) {
         m_changes.remove(lastChange);
       }


### PR DESCRIPTION
Fixes #1961 

This pushes the save up one step to avoid re-triggering the end turn phase and giving double income.