### PR TITLE
Add more test annotations and Remove constructor javadoc requirement in checkstyle

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -201,8 +201,9 @@
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
-            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowedAnnotations" value="Override, Test, BeforeClass, AfterClass, Before, After"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
+            <property name="tokens" value="METHOD_DEF"/>
         </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>


### PR DESCRIPTION
javadocs on @Before methods in test are overkill generally. The point of the method is obvious, we can comment when it is particularly useful.

The public constructor javadoc requirement is not helping a lot:
- not automating a requirement we would ask for otherwise in code review
- encourages not useful comments. eg: "This initializes", "public constructor for ..."    There is no return type on the method and it has a very special place in the class file, it's obvious it is the constructor.  Here is an example I wrote: https://github.com/triplea-game/triplea/blob/master/src/main/java/games/strategy/engine/lobby/server/LobbyServer.java#L26
- can get ridiculous with multiple constructors
- discourages convenience constructors, this leads repetitive and complicated initialization logic that could be instead tucked into a constructor


Removing the javadoc requirement on constructors I think would help. I typically do not ask for javadocs on constructors (though I like seeing them on public methods, and really like seeing them on classes). 

Checkstyle should probably be configured to be required  on classes (as indicated by: https://google.github.io/styleguide/javaguide.html#s7.3-javadoc-where-required), but it does not seem it has the option out of the box...Class javadocs I actually do find very helpful, both as a reader and author. As a reader it gives you a good idea why a class was created, what it is intended to represent and how you would use it. As an author it helps you focus on the responsibility of a class and make sure you can define what it is supposed to represent and what it does. Regardless that does not seem to be an immediate option. In the short term there is some pain since we're having to review and nag each other about the low quality class constructor javadoc commentary we are writing.

