### PR TITLE
Improve End Turn Report by Consolidating Some of the Messages

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -43,7 +43,7 @@ import games.strategy.util.Tuple;
  * At the end of the turn collect income.
  */
 public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implements IAbstractForumPosterDelegate {
-  public static final String END_TURN_REPORT_STRING = "End of Turn Report for ";
+  public static final String END_TURN_REPORT_STRING = "Income Summary for ";
   private static final int CONVOY_BLOCKADE_DICE_SIDES = 6;
   private boolean m_needToInitialize = true;
   private boolean m_hasPostedTurnSummary = false;

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import games.strategy.engine.data.GameData;
@@ -17,7 +16,6 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.RelationshipTracker;
 import games.strategy.engine.data.RelationshipTracker.Relationship;
 import games.strategy.engine.data.RelationshipType;
-import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
@@ -2220,6 +2218,7 @@ public class Matches {
       return (ua.getCreatesUnitsList() != null && ua.getCreatesUnitsList().size() > 0);
     }
   };
+
   public static final Match<Unit> UnitCreatesResources = new Match<Unit>() {
     @Override
     public boolean match(final Unit unit) {
@@ -2230,46 +2229,7 @@ public class Matches {
       return (ua.getCreatesResourcesList() != null && ua.getCreatesResourcesList().size() > 0);
     }
   };
-  /** Any unit that creates at least a single positive resource. */
-  public static final Match<Unit> UnitCreatesResourcesPositive = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      if (!UnitCreatesResources.match(unit)) {
-        return false;
-      }
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      if (ua == null || ua.getCreatesResourcesList() == null) {
-        return false;
-      }
-      final IntegerMap<Resource> resources = ua.getCreatesResourcesList();
-      for (final Entry<Resource, Integer> entry : resources.entrySet()) {
-        if (entry.getValue() > 0) {
-          return true;
-        }
-      }
-      return false;
-    }
-  };
-  /** Any unit that does not create a single positive resource, but does create at least a single negative resource. */
-  public static final Match<Unit> UnitCreatesResourcesNegative = new Match<Unit>() {
-    @Override
-    public boolean match(final Unit unit) {
-      if (!UnitCreatesResources.match(unit) || UnitCreatesResourcesPositive.match(unit)) {
-        return false;
-      }
-      final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      if (ua == null || ua.getCreatesResourcesList() == null) {
-        return false;
-      }
-      final IntegerMap<Resource> resources = ua.getCreatesResourcesList();
-      for (final Entry<Resource, Integer> entry : resources.entrySet()) {
-        if (entry.getValue() < 0) {
-          return true;
-        }
-      }
-      return false;
-    }
-  };
+
   public static final Match<UnitType> UnitTypeConsumesUnitsOnCreation = new Match<UnitType>() {
     @Override
     public boolean match(final UnitType obj) {
@@ -2281,6 +2241,7 @@ public class Matches {
       return (ua.getConsumesUnits() != null && ua.getConsumesUnits().size() > 0);
     }
   };
+
   public static final Match<Unit> UnitConsumesUnitsOnCreation = new Match<Unit>() {
     @Override
     public boolean match(final Unit obj) {


### PR DESCRIPTION
Addresses some forum feedback: https://forums.triplea-game.org/topic/128/resource-system-assessment-and-improvements

Functional Changes
- Instead of showing individual lines for every unit that creates resources, group all of the unit generated resources by resource type
- Rename popup to "Income Summary" instead of "End of Turn Report"

Code Changes
- Lots of refactoring
- The existing structure did all positive changes then all negative changes since each individual change was checking if it would make total go below 0. This was updated to add all the changes up (positive & negative) then just check the sum against the total.