### PR TITLE
Improve Checkstyle threshold update script

### DIFF
--- a/.travis/update_checkstyle_thresholds
+++ b/.travis/update_checkstyle_thresholds
@@ -87,10 +87,13 @@ update_remote_thresholds() {
     \"sha\": \"$old_hash\" \
   }"
   curl \
+      --silent \
+      --show-error \
       -X PUT \
       --header "Accept: application/vnd.github.v3+json" \
       --data "$update_request" \
-      "https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@api.github.com/repos/$TRAVIS_REPO_SLUG/contents/$GRADLE_PROPERTIES"
+      --user ":$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS" \
+      "https://api.github.com/repos/$TRAVIS_REPO_SLUG/contents/$GRADLE_PROPERTIES"
 }
 
 main


### PR DESCRIPTION
This PR makes the following improvements to the `update_checkstyle_thresholds` Travis build script:

* Suppress progress output (`--silent`) while ensuring HTTP errors are still displayed (`--show-error`).
* Passes the GitHub API token via the `--user` switch instead of embedding it within the URL.  This isn't as important now since Travis is scrubbing accidental disclosure of tokens from the build log, but use of `--user` instead of embedding credentials in the URL is probably a best practice we should be using regardless.

I didn't test this specific script, but I tested a similar [script](https://github.com/ssoloff/triplea-game-triplea/blob/remove-push-tag-script/.travis/create_tag#L56-L62) on a different branch that uses the same `--user` switch format, and it worked without any issues (that's how I discovered the required switch value format being `:<token>`).