### PR TITLE
Simplify - Use String.format in AccessLog.java and remove redundant date

### DIFF
--- a/src/main/java/games/strategy/engine/lobby/server/login/AccessLog.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/AccessLog.java
@@ -1,23 +1,22 @@
 package games.strategy.engine.lobby.server.login;
 
 import java.net.InetAddress;
-import java.util.Date;
 import java.util.logging.Logger;
 
 /**
  * This class is used to allow an access log to be easily created. The log settings should
  * be set up to log messages from this class to a seperate access log file.
  */
-public class AccessLog {
+class AccessLog {
   private static final Logger s_logger = Logger.getLogger(AccessLog.class.getName());
 
-  public static void successfulLogin(final String userName, final InetAddress from) {
-    s_logger.info("LOGIN name:" + userName + " ip:" + from.getHostAddress() + " time_ms:" + System.currentTimeMillis()
-        + " time:" + new Date());
+  static void successfulLogin(final String userName, final InetAddress from) {
+    s_logger.info(String.format("LOGIN name: %s, ip: %s",
+        userName, from.getHostAddress()));
   }
 
-  public static void failedLogin(final String userName, final InetAddress from, final String error) {
-    s_logger.info("FAILED name:" + userName + " ip:" + from.getHostAddress() + " time_ms:" + System.currentTimeMillis()
-        + " error:" + error + " time:" + new Date());
+  static void failedLogin(final String userName, final InetAddress from, final String error) {
+    s_logger.info(String.format("FAILED name: %s, ip: %s",
+        userName, from.getHostAddress()));
   }
 }


### PR DESCRIPTION
The server logger will give us a datestamp already, no need to log one.