### PR TITLE
Allow click on alliance label to set current player to all positions 

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -8,8 +8,10 @@ import java.awt.event.ActionListener;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -30,11 +32,12 @@ class PlayerSelectorRow {
   private final JLabel puIncomeBonusLabel;
   private boolean enabled = true;
   private final JLabel name;
-  private final JLabel alliances;
+  private final JButton alliances;
   private final Collection<String> disableable;
   private final SetupPanel parent;
 
-  PlayerSelectorRow(final PlayerID player, final Map<String, String> reloadSelections,
+  PlayerSelectorRow(final List<PlayerSelectorRow> playerRows, final PlayerID player,
+      final Map<String, String> reloadSelections,
       final Collection<String> disableable, final HashMap<String, Boolean> playersEnablementListing,
       final Collection<String> playerAlliances, final String[] types, final SetupPanel parent,
       final GameProperties gameProperties) {
@@ -76,13 +79,20 @@ class PlayerSelectorRow {
     }
 
     // we do not set the default for the combo box because the default is the top item, which in this case is human
-    String alliancesLabelText;
+    final String alliancesLabelText;
     if (playerAlliances.contains(playerName)) {
       alliancesLabelText = "";
     } else {
       alliancesLabelText = playerAlliances.toString();
     }
-    alliances = new JLabel(alliancesLabelText);
+    alliances = new JButton(alliancesLabelText);
+    alliances.setToolTipText("Set all " + alliancesLabelText + " to " + playerTypes.getSelectedItem().toString());
+    alliances.addActionListener(e -> {
+      final String currentType = playerTypes.getSelectedItem().toString();
+      playerRows.stream()
+          .filter(row -> row.alliances.getText().equals(alliancesLabelText))
+          .forEach(row -> row.setPlayerType(currentType));
+    });
 
     // TODO: remove null check for next incompatible release
     incomePercentage = null;
@@ -133,7 +143,7 @@ class PlayerSelectorRow {
     }
   }
 
-  void setResourceModifiersVisble(boolean isVisible) {
+  void setResourceModifiersVisble(final boolean isVisible) {
     // TODO: remove null check for next incompatible release
     if (incomePercentage != null) {
       incomePercentage.setVisible(isVisible);
@@ -146,7 +156,7 @@ class PlayerSelectorRow {
     }
   }
 
-  void setPlayerType(String playerType) {
+  void setPlayerType(final String playerType) {
     playerTypes.setSelectedItem(playerType);
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -137,7 +137,7 @@ public abstract class SetupPanel extends JPanel implements ISetupPanel {
     // Add players in the order they were defined in the XML
     for (final PlayerID player : players) {
       final PlayerSelectorRow selector =
-          new PlayerSelectorRow(player, reloadSelections, disableable, playersEnablementListing,
+          new PlayerSelectorRow(playerRows, player, reloadSelections, disableable, playersEnablementListing,
               data.getAllianceTracker().getAlliancesPlayerIsIn(player), playerTypes, this, data.getProperties());
       playerRows.add(selector);
       if (!player.isHidden()) {


### PR DESCRIPTION
It's a slightly nicer UI when you can click the alliance name to set the entire alliance at once. Means fewer clicks for vs AI games and human vs human games. This may make the set-all combo box button unnecessary (the code inspiration from that made this update very easy :confetti_ball: )

![out](https://user-images.githubusercontent.com/12397753/27614745-871b9224-5b58-11e7-97cd-d056b27e7ee5.gif)
