### PR TITLE
Rename test classes to avoid conflicts with existing tests

### DIFF
--- a/src/integ_test/java/games/strategy/engine/config/client/GameEnginePropertyReaderIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/config/client/GameEnginePropertyReaderIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.notNullValue;
 
 import org.junit.Test;
 
-public class GameEnginePropertyReaderTest {
+public class GameEnginePropertyReaderIntegrationTest {
   @Test
   public void remoteLobbyUrlReaderWorks() {
     final GameEnginePropertyReader testObj = new GameEnginePropertyReader();

--- a/src/integ_test/java/games/strategy/engine/lobby/server/db/DbUserControllerIntegrationTest.java
+++ b/src/integ_test/java/games/strategy/engine/lobby/server/db/DbUserControllerIntegrationTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.util.MD5Crypt;
 
-public class DbUserControllerTest {
+public class DbUserControllerIntegrationTest {
 
   private static final DbTestConnection DERBY =
       new DbTestConnection(Database::getDerbyConnection, new DbUserController());


### PR DESCRIPTION
2 test classes in the integration test and test packages have the same name which is causing an error.