### PR TITLE
Update checkstyle to require javadocs on public classes, interfaces and enums

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -195,6 +195,9 @@
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
+        <module name="JavadocType">
+            <property name="scope" value="public" />
+        </module>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
             <property name="allowMissingParamTags" value="true"/>


### PR DESCRIPTION
Submitting first without updating thresholds. The gradle.properties would probably get merge conflicted almost right away. So please approve, once approved I'll fix the threshold to pass the build and merge. (I've found gradle.properties is really a very not nice filed to have in a branch updated, so many conflicts..)