### PR TITLE
Add failure comment

### DIFF
--- a/build.install4j
+++ b/build.install4j
@@ -299,7 +299,7 @@
             <preActivation />
             <postActivation />
             <actions>
-              <action name="" id="263" customizedId="" beanClass="com.install4j.runtime.beans.actions.desktop.CreateFileAssociationAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
+              <action name="" id="263" customizedId="" beanClass="com.install4j.runtime.beans.actions.desktop.CreateFileAssociationAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="Failed to create file association">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
                     <object class="com.install4j.runtime.beans.actions.desktop.CreateFileAssociationAction">


### PR DESCRIPTION
This Pr adds an error message if the file association could not be created. (Currently it is not for whatever reason)
This is probably an install4j bug.
Self-merging to trigger the release build