### PR TITLE
Delete temporary map download file (#1754)

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 
-import games.strategy.engine.ClientFileSystemHelper;
-
 /**
  * Class that accepts and queues download requests. Download requests are started in background
  * thread, this class ensures N are in progress until all are done.
@@ -61,7 +59,7 @@ public final class DownloadCoordinator {
 
     if (activeDownloads.size() < MAX_CONCURRENT_DOWNLOADS && !pendingDownloads.isEmpty()) {
       final DownloadFile downloadFile = pendingDownloads.remove();
-      downloadFile.startAsyncDownload(ClientFileSystemHelper.createTempFile());
+      downloadFile.startAsyncDownload();
       activeDownloads.add(downloadFile);
     }
   }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Files;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.ClientFileSystemHelper;
 
 /**
  * Keeps track of the state for a file download from a URL.
@@ -33,12 +34,9 @@ final class DownloadFile {
     return download;
   }
 
-  /**
-   * @param fileToDownloadTo The intermediate file to which the download is saved; must not be {@code null}. If the
-   *        download is successful, this file will be moved to the install location. If the download is cancelled, this
-   *        file <strong>WILL NOT</strong> be deleted.
-   */
-  void startAsyncDownload(final File fileToDownloadTo) {
+  void startAsyncDownload() {
+    final File fileToDownloadTo = ClientFileSystemHelper.createTempFile();
+    fileToDownloadTo.deleteOnExit();
     final FileSizeWatcher watcher = new FileSizeWatcher(
         fileToDownloadTo,
         bytesReceived -> downloadListener.downloadUpdated(download, bytesReceived));

--- a/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
@@ -4,9 +4,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -15,9 +13,6 @@ import games.strategy.engine.framework.map.download.DownloadFile.DownloadState;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FileDownloadTest {
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
   @Mock
   private DownloadFileDescription mockDownload;
 
@@ -26,7 +21,7 @@ public class FileDownloadTest {
     final DownloadFile testObj = new DownloadFile(mockDownload, mock(DownloadListener.class));
     assertThat(testObj.getDownloadState(), is(DownloadState.NOT_STARTED));
 
-    testObj.startAsyncDownload(temporaryFolder.newFile());
+    testObj.startAsyncDownload();
     assertThat(testObj.getDownloadState(), is(DownloadState.DOWNLOADING));
 
     testObj.cancelDownload();


### PR DESCRIPTION
This PR addresses the second part of #1754 and ensures the temporary file created during a map download is deleted in the event the download is interrupted (e.g. exiting the application while the download is in progress).

#### Functional changes
* The temporary file created during a map download will be deleted upon VM shutdown if it has not already been moved to the user's map folder (i.e. if the download was interrupted).

#### Functional issues for review
None.

#### Refactoring changes
* I removed the single `File` parameter from `DownloadFile#startAsyncDownload()`.  There is really no need to pass the temporary file location to this method.  This class already does a lot of its own file management, so encapsulating the creation (and deletion) of the temporary file within the class seemed reasonable.

#### Refactoring issues for review
None.

#### Testing

I tested the following scenarios:

* Successful download
    * Start a download.
    * Verify a temporary file is created and its size increases as the download progresses.
    * Wait for download to complete.
    * Exit TripleA.
    * Verify temporary file is no longer present.
    * Verify map file is present in user's map folder.

* Interrupted download
    * Start a download.
    * Verify a temporary file is created and its size increases as the download progresses.
    * Exit TripleA before the download completes.
    * Verify temporary file is no longer present.
    * Verify map file is not present in user's map folder.