### PR TITLE
Use Postgres 9.5 in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+dist: trusty
+sudo: false
 language: java
 jdk:
 - oraclejdk8
 addons:
+  postgresql: "9.5"
   apt:
     packages:
       # python for map file splitter


### PR DESCRIPTION
This is a follow-up to the closed/unmerged #2020.

The piece we were missing is that Travis defaults to using the container-based Precise image.  According to [this information](https://docs.travis-ci.com/user/database-setup/#Using-a-different-PostgreSQL-Version), Postgres 9.5 is not available in the Precise container.  Instead, we have to upgrade to the Trusty container to get Postgres 9.5.

See [here](https://docs.travis-ci.com/user/trusty-ci-environment/) for more information on the Trusty environment in Travis.