### PR TITLE
Suppress varargs linter warnings

### DIFF
--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -187,6 +187,7 @@ public abstract class Match<T> {
    * @return A new match; never {@code null}.
    */
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public static <T> Match<T> all(final Match<T>... matches) {
     checkNotNull(matches);
 
@@ -214,6 +215,7 @@ public abstract class Match<T> {
    * @return A new match; never {@code null}.
    */
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public static <T> Match<T> any(final Match<T>... matches) {
     checkNotNull(matches);
 
@@ -241,6 +243,7 @@ public abstract class Match<T> {
    * @return A new composite match builder; never {@code null}.
    */
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public static <T> CompositeBuilder<T> newCompositeBuilder(final Match<T>... matches) {
     checkNotNull(matches);
 


### PR DESCRIPTION
This PR suppresses the compiler's `varargs` linter warning on recently-added `Match` factory methods.  These methods do not perform unsafe operations on their varargs parameters.  They simply pass them on to `Arrays#asList()`, which is varargs safe.

Per this [comment](https://github.com/triplea-game/triplea/pull/1932#issuecomment-309195988), I was originally going to turn off the `varargs` linter warnings in the Gradle build for the reasons given in that comment.  However, upon further research, it appears that the Eclipse team has acknowledged they will support `varargs` linter warnings in the future (see [here](https://bugs.eclipse.org/bugs/show_bug.cgi?id=349669#c21) and [here](https://bugs.eclipse.org/bugs/show_bug.cgi?id=344783)).

In the meantime, Eclipse users will see an "Unsupported @SuppressWarnings("varargs")" warning marker on these lines.  This type of warning can be disabled via **Window > Preferences > Java > Compiler > Errors/Warnings > Annotations > Unhandled token in '@SuppressWarnings'** (set to either `Info` or `Ignore`).