### PR TITLE
Checkstyle: Require Javadocs on public types (#2004)

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -21,6 +21,11 @@
     <property name="severity" value="warning"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
+
+    <module name="SuppressionFilter">
+        <property name="file" value="config/checkstyle/suppressions.xml"/>
+    </module>
+
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
         <module name="FileTabCharacter">
@@ -194,6 +199,9 @@
         <module name="AtclauseOrder">
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocType">
+            <property name="scope" value="public" />
         </module>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://checkstyle.sourceforge.net/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress checks="JavadocType" files=".*Test\.java"/>
+</suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 checkstyleIntegTestMaxWarnings=0
-checkstyleMainMaxWarnings=2856
-checkstyleTestMaxWarnings=29
+checkstyleMainMaxWarnings=3290
+checkstyleTestMaxWarnings=49


### PR DESCRIPTION
This PR modifies the Checkstyle configuration to require Javadocs on public types (excluding test classes).  This PR supercedes #2025.