### PR TITLE
Checkstyle: Fix one top-level class violations in UI code

### DIFF
--- a/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
@@ -94,209 +94,208 @@ public class PBEMDiceRoller implements IRandomSource {
   public int getRandom(final int max, final String annotation) throws IllegalStateException {
     return getRandom(max, 1, annotation)[0];
   }
-}
-
-
-/**
- * The dialog that will show while the dice are rolling.
- */
-class HttpDiceRollerDialog extends JDialog {
-  private static final long serialVersionUID = -4802403913826489223L;
-  private final JButton m_exitButton = new JButton("Exit");
-  private final JButton m_reRollButton = new JButton("Roll Again");
-  private final JButton m_okButton = new JButton("OK");
-  private final JTextArea m_text = new JTextArea();
-  private int[] m_diceRoll;
-  private final int m_count;
-  private final int m_sides;
-  private final String m_subjectMessage;
-  private final String m_gameID;
-  private final IRemoteDiceServer m_diceServer;
-  private final String m_gameUUID;
-  private final Object m_lock = new Object();
-  public boolean m_test = false;
-  private final JPanel m_buttons = new JPanel();
-  private Window m_owner;
 
   /**
-   * @param owner
-   *        owner frame.
-   * @param sides
-   *        the number of sides on the dice
-   * @param count
-   *        the number of dice rolled
-   * @param subjectMessage
-   *        the subject for the email the dice roller will send (if it sends emails)
-   * @param diceServer
-   *        the dice server implementation
-   * @param gameUuid
-   *        the TripleA game UUID or null
+   * The dialog that will show while the dice are rolling.
    */
-  public HttpDiceRollerDialog(final Frame owner, final int sides, final int count, final String subjectMessage,
-      final IRemoteDiceServer diceServer, final String gameUuid) {
-    super(owner, "Dice roller", true);
-    m_owner = owner;
-    m_sides = sides;
-    m_count = count;
-    m_subjectMessage = subjectMessage;
-    m_gameID = diceServer.getGameId() == null ? "" : diceServer.getGameId();
-    m_diceServer = diceServer;
-    m_gameUUID = gameUuid;
-    setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-    m_exitButton.addActionListener(e -> System.exit(-1));
-    m_exitButton.setEnabled(false);
-    m_reRollButton.addActionListener(e -> rollInternal());
-    m_okButton.addActionListener(e -> closeAndReturn());
-    m_reRollButton.setEnabled(false);
-    getContentPane().setLayout(new BorderLayout());
-    m_buttons.add(m_exitButton);
-    m_buttons.add(m_reRollButton);
-    getContentPane().add(m_buttons, BorderLayout.SOUTH);
-    getContentPane().add(new JScrollPane(m_text));
-    m_text.setEditable(false);
-    setSize(400, 300);
-    // games.strategy.ui.Util
-    games.strategy.ui.Util.center(this);
-  }
+  private static final class HttpDiceRollerDialog extends JDialog {
+    private static final long serialVersionUID = -4802403913826489223L;
+    private final JButton m_exitButton = new JButton("Exit");
+    private final JButton m_reRollButton = new JButton("Roll Again");
+    private final JButton m_okButton = new JButton("OK");
+    private final JTextArea m_text = new JTextArea();
+    private int[] m_diceRoll;
+    private final int m_count;
+    private final int m_sides;
+    private final String m_subjectMessage;
+    private final String m_gameID;
+    private final IRemoteDiceServer m_diceServer;
+    private final String m_gameUUID;
+    private final Object m_lock = new Object();
+    boolean m_test = false;
+    private final JPanel m_buttons = new JPanel();
+    private Window m_owner;
 
-  /**
-   * There are three differences when we are testing, 1 dont close the window
-   * when we are done 2 remove the exit button 3 add a close button.
-   */
-  public void setTest() {
-    m_test = true;
-    m_buttons.removeAll();
-    m_buttons.add(m_okButton);
-    m_buttons.add(m_reRollButton);
-  }
+    /**
+     * @param owner
+     *        owner frame.
+     * @param sides
+     *        the number of sides on the dice
+     * @param count
+     *        the number of dice rolled
+     * @param subjectMessage
+     *        the subject for the email the dice roller will send (if it sends emails)
+     * @param diceServer
+     *        the dice server implementation
+     * @param gameUuid
+     *        the TripleA game UUID or null
+     */
+    HttpDiceRollerDialog(final Frame owner, final int sides, final int count, final String subjectMessage,
+        final IRemoteDiceServer diceServer, final String gameUuid) {
+      super(owner, "Dice roller", true);
+      m_owner = owner;
+      m_sides = sides;
+      m_count = count;
+      m_subjectMessage = subjectMessage;
+      m_gameID = diceServer.getGameId() == null ? "" : diceServer.getGameId();
+      m_diceServer = diceServer;
+      m_gameUUID = gameUuid;
+      setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+      m_exitButton.addActionListener(e -> System.exit(-1));
+      m_exitButton.setEnabled(false);
+      m_reRollButton.addActionListener(e -> rollInternal());
+      m_okButton.addActionListener(e -> closeAndReturn());
+      m_reRollButton.setEnabled(false);
+      getContentPane().setLayout(new BorderLayout());
+      m_buttons.add(m_exitButton);
+      m_buttons.add(m_reRollButton);
+      getContentPane().add(m_buttons, BorderLayout.SOUTH);
+      getContentPane().add(new JScrollPane(m_text));
+      m_text.setEditable(false);
+      setSize(400, 300);
+      // games.strategy.ui.Util
+      games.strategy.ui.Util.center(this);
+    }
 
-  public void appendText(final String text) {
-    m_text.setText(m_text.getText() + text);
-  }
+    /**
+     * There are three differences when we are testing, 1 dont close the window
+     * when we are done 2 remove the exit button 3 add a close button.
+     */
+    void setTest() {
+      m_test = true;
+      m_buttons.removeAll();
+      m_buttons.add(m_okButton);
+      m_buttons.add(m_reRollButton);
+    }
 
-  public void notifyError() {
-    SwingUtilities.invokeLater(() -> {
-      m_exitButton.setEnabled(true);
-      m_reRollButton.setEnabled(true);
-    });
-  }
+    void appendText(final String text) {
+      m_text.setText(m_text.getText() + text);
+    }
 
-  public int[] getDiceRoll() {
-    return m_diceRoll;
-  }
+    void notifyError() {
+      SwingUtilities.invokeLater(() -> {
+        m_exitButton.setEnabled(true);
+        m_reRollButton.setEnabled(true);
+      });
+    }
 
-  // should only be called if we are not visible
-  // can be called from any thread
-  // wont return until the roll is done.
-  public void roll() throws IllegalStateException {
-    // if we are not the event thread, then start again in the event thread
-    // pausing this thread until we are done
-    if (!SwingUtilities.isEventDispatchThread()) {
-      synchronized (m_lock) {
-        SwingUtilities.invokeLater(() -> roll());
-        try {
-          m_lock.wait();
-        } catch (final InterruptedException e) {
-          ClientLogger.logQuietly(e);
+    int[] getDiceRoll() {
+      return m_diceRoll;
+    }
+
+    // should only be called if we are not visible
+    // can be called from any thread
+    // wont return until the roll is done.
+    void roll() throws IllegalStateException {
+      // if we are not the event thread, then start again in the event thread
+      // pausing this thread until we are done
+      if (!SwingUtilities.isEventDispatchThread()) {
+        synchronized (m_lock) {
+          SwingUtilities.invokeLater(() -> roll());
+          try {
+            m_lock.wait();
+          } catch (final InterruptedException e) {
+            ClientLogger.logQuietly(e);
+          }
+        }
+        return;
+      }
+      rollInternal();
+      setVisible(true);
+    }
+
+    // should be called from the event thread
+    private void rollInternal() throws IllegalStateException {
+      if (!SwingUtilities.isEventDispatchThread()) {
+        throw new IllegalStateException("Wrong thread");
+      }
+      m_reRollButton.setEnabled(false);
+      m_exitButton.setEnabled(false);
+      final Thread t = new Thread("Triplea, roll in seperate thread") {
+        @Override
+        public void run() {
+          rollInSeperateThread();
+        }
+      };
+      t.start();
+    }
+
+    private void closeAndReturn() {
+      // releast any threads waiting on the lock
+      if (m_lock != null) {
+        synchronized (m_lock) {
+          m_lock.notifyAll();
         }
       }
-      return;
+      SwingUtilities.invokeLater(() -> {
+        setVisible(false);
+        m_owner.toFront();
+        m_owner = null;
+        dispose();
+      });
     }
-    rollInternal();
-    setVisible(true);
-  }
 
-  // should be called from the event thread
-  private void rollInternal() throws IllegalStateException {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread");
-    }
-    m_reRollButton.setEnabled(false);
-    m_exitButton.setEnabled(false);
-    final Thread t = new Thread("Triplea, roll in seperate thread") {
-      @Override
-      public void run() {
-        rollInSeperateThread();
+    /**
+     * should be called from a thread other than the event thread after we are
+     * open (or at least in the process of opening) will close the window and
+     * notify any waiting threads when completed successfully.
+     * Before contacting Irony Dice Server, check if email has a reasonable
+     * valid syntax.
+     */
+    private void rollInSeperateThread() throws IllegalStateException {
+      if (SwingUtilities.isEventDispatchThread()) {
+        throw new IllegalStateException("Wrong thread");
       }
-    };
-    t.start();
-  }
-
-  private void closeAndReturn() {
-    // releast any threads waiting on the lock
-    if (m_lock != null) {
-      synchronized (m_lock) {
-        m_lock.notifyAll();
+      while (!isVisible()) {
+        Thread.yield();
       }
-    }
-    SwingUtilities.invokeLater(() -> {
-      setVisible(false);
-      m_owner.toFront();
-      m_owner = null;
-      dispose();
-    });
-  }
-
-  /**
-   * should be called from a thread other than the event thread after we are
-   * open (or at least in the process of opening) will close the window and
-   * notify any waiting threads when completed successfully.
-   * Before contacting Irony Dice Server, check if email has a reasonable
-   * valid syntax.
-   */
-  private void rollInSeperateThread() throws IllegalStateException {
-    if (SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread");
-    }
-    while (!isVisible()) {
-      Thread.yield();
-    }
-    appendText(m_subjectMessage + "\n");
-    appendText("Contacting  " + m_diceServer.getDisplayName() + "\n");
-    String text = null;
-    try {
-      text = m_diceServer.postRequest(m_sides, m_count, m_subjectMessage, m_gameID, m_gameUUID);
-      if (text.length() == 0) {
-        appendText("Nothing could be read from dice server\n");
-        appendText("Please check your firewall settings");
+      appendText(m_subjectMessage + "\n");
+      appendText("Contacting  " + m_diceServer.getDisplayName() + "\n");
+      String text = null;
+      try {
+        text = m_diceServer.postRequest(m_sides, m_count, m_subjectMessage, m_gameID, m_gameUUID);
+        if (text.length() == 0) {
+          appendText("Nothing could be read from dice server\n");
+          appendText("Please check your firewall settings");
+          notifyError();
+        }
+        if (!m_test) {
+          appendText("Contacted :" + text + "\n");
+        }
+        m_diceRoll = m_diceServer.getDice(text, m_count);
+        appendText("Success!");
+        if (!m_test) {
+          closeAndReturn();
+        }
+      } catch (final SocketException ex) { // an error in networking
+        appendText("Connection failure:" + ex.getMessage() + "\n"
+            + "Please ensure your Internet connection is working, and try again.");
+        notifyError();
+      } catch (final InvocationTargetException e) {
+        appendText("\nError:" + e.getMessage() + "\n\n");
+        appendText("Text from dice server:\n" + text + "\n");
+        notifyError();
+      } catch (final IOException ex) {
+        try {
+          appendText("An error has occured!\n");
+          appendText("Possible reasons the error could have happened:\n");
+          appendText("  1: An invalid e-mail address\n");
+          appendText("  2: Firewall could be blocking TripleA from connecting to the Dice Server\n");
+          appendText("  3: The e-mail address does not exist\n");
+          appendText("  4: An unknown error, please see the error console and consult the forums for help\n");
+          appendText("     Visit https://forums.triplea-game.org  for extra help\n");
+          if (text != null) {
+            appendText("Text from dice server:\n" + text + "\n");
+          }
+          final StringWriter writer = new StringWriter();
+          ex.printStackTrace(new PrintWriter(writer));
+          writer.close();
+          appendText(writer.toString());
+        } catch (final IOException ex1) {
+          ex1.printStackTrace();
+        }
         notifyError();
       }
-      if (!m_test) {
-        appendText("Contacted :" + text + "\n");
-      }
-      m_diceRoll = m_diceServer.getDice(text, m_count);
-      appendText("Success!");
-      if (!m_test) {
-        closeAndReturn();
-      }
-    } catch (final SocketException ex) { // an error in networking
-      appendText("Connection failure:" + ex.getMessage() + "\n"
-          + "Please ensure your Internet connection is working, and try again.");
-      notifyError();
-    } catch (final InvocationTargetException e) {
-      appendText("\nError:" + e.getMessage() + "\n\n");
-      appendText("Text from dice server:\n" + text + "\n");
-      notifyError();
-    } catch (final IOException ex) {
-      try {
-        appendText("An error has occured!\n");
-        appendText("Possible reasons the error could have happened:\n");
-        appendText("  1: An invalid e-mail address\n");
-        appendText("  2: Firewall could be blocking TripleA from connecting to the Dice Server\n");
-        appendText("  3: The e-mail address does not exist\n");
-        appendText("  4: An unknown error, please see the error console and consult the forums for help\n");
-        appendText("     Visit https://forums.triplea-game.org  for extra help\n");
-        if (text != null) {
-          appendText("Text from dice server:\n" + text + "\n");
-        }
-        final StringWriter writer = new StringWriter();
-        ex.printStackTrace(new PrintWriter(writer));
-        writer.close();
-        appendText(writer.toString());
-      } catch (final IOException ex1) {
-        ex1.printStackTrace();
-      }
-      notifyError();
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -710,282 +710,277 @@ public class BattleDisplay extends JPanel {
     g.dispose();
     return new JLabel(new ImageIcon(finalImage));
   }
-}
 
+  private static final class BattleTable extends JTable {
+    private static final long serialVersionUID = 6737857639382012817L;
 
-class BattleTable extends JTable {
-  private static final long serialVersionUID = 6737857639382012817L;
-
-  BattleTable(final BattleModel model) {
-    super(model);
-    setDefaultRenderer(Object.class, new Renderer());
-    setRowHeight(UnitImageFactory.DEFAULT_UNIT_ICON_SIZE + 5);
-    setBackground(new JButton().getBackground());
-    setShowHorizontalLines(false);
-    getTableHeader().setReorderingAllowed(false);
-    // getTableHeader().setResizingAllowed(false);
-  }
-}
-
-
-class BattleModel extends DefaultTableModel {
-  private static final long serialVersionUID = 6913324191512043963L;
-  private final IUIContext m_uiContext;
-  private final GameData m_data;
-  // is the player the aggressor?
-  private final boolean m_attack;
-  private final Collection<Unit> m_units;
-  private final Territory m_location;
-  private final BattleType m_battleType;
-  private final Collection<TerritoryEffect> m_territoryEffects;
-  private final boolean m_isAmphibious;
-  private final Collection<Unit> m_amphibiousLandAttackers;
-  private BattleModel m_enemyBattleModel = null;
-
-  private static String[] varDiceArray(final GameData data) {
-    // TODO Soft set the maximum bonus to-hit plus 1 for 0 based count(+2 total currently)
-    final String[] diceColumns = new String[data.getDiceSides() + 1];
-    {
-      for (int i = 0; i < diceColumns.length; i++) {
-        if (i == 0) {
-          diceColumns[i] = " ";
-        } else {
-          diceColumns[i] = Integer.toString(i);
-        }
-      }
+    BattleTable(final BattleModel model) {
+      super(model);
+      setDefaultRenderer(Object.class, new Renderer());
+      setRowHeight(UnitImageFactory.DEFAULT_UNIT_ICON_SIZE + 5);
+      setBackground(new JButton().getBackground());
+      setShowHorizontalLines(false);
+      getTableHeader().setReorderingAllowed(false);
+      // getTableHeader().setResizingAllowed(false);
     }
-    return diceColumns;
   }
 
-  BattleModel(final Collection<Unit> units, final boolean attack, final BattleType battleType,
-      final GameData data, final Territory battleLocation, final Collection<TerritoryEffect> territoryEffects,
-      final boolean isAmphibious, final Collection<Unit> amphibiousLandAttackers, final IUIContext uiContext) {
-    super(new Object[0][0], varDiceArray(data));
-    m_uiContext = uiContext;
-    m_data = data;
-    m_attack = attack;
-    // were going to modify the units
-    m_units = new ArrayList<>(units);
-    m_location = battleLocation;
-    m_battleType = battleType;
-    m_territoryEffects = territoryEffects;
-    m_isAmphibious = isAmphibious;
-    m_amphibiousLandAttackers = amphibiousLandAttackers;
-  }
+  private static final class BattleModel extends DefaultTableModel {
+    private static final long serialVersionUID = 6913324191512043963L;
+    private final IUIContext m_uiContext;
+    private final GameData m_data;
+    // is the player the aggressor?
+    private final boolean m_attack;
+    private final Collection<Unit> m_units;
+    private final Territory m_location;
+    private final BattleType m_battleType;
+    private final Collection<TerritoryEffect> m_territoryEffects;
+    private final boolean m_isAmphibious;
+    private final Collection<Unit> m_amphibiousLandAttackers;
+    private BattleModel m_enemyBattleModel = null;
 
-  public void setEnemyBattleModel(final BattleModel enemyBattleModel) {
-    m_enemyBattleModel = enemyBattleModel;
-  }
-
-  public void notifyRetreat(final Collection<Unit> retreating) {
-    m_units.removeAll(retreating);
-    refresh();
-  }
-
-  public void removeCasualties(final Collection<Unit> killed) {
-    m_units.removeAll(killed);
-    refresh();
-  }
-
-  public void addUnits(final Collection<Unit> units) {
-    m_units.addAll(units);
-    refresh();
-  }
-
-  Collection<Unit> getUnits() {
-    return m_units;
-  }
-
-  /**
-   * refresh the model from m_units.
-   */
-  public void refresh() {
-    // TODO Soft set the maximum bonus to-hit plus 1 for 0 based count(+2 total currently)
-    // Soft code the # of columns
-
-    final List<List<TableData>> columns = new ArrayList<>(m_data.getDiceSides() + 1);
-    for (int i = 0; i <= m_data.getDiceSides(); i++) {
-      columns.add(i, new ArrayList<>());
-    }
-    final List<Unit> units = new ArrayList<>(m_units);
-    DiceRoll.sortByStrength(units, !m_attack);
-    final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap;
-    m_data.acquireReadLock();
-    try {
-      if (m_battleType.isAirPreBattleOrPreRaid()) {
-        unitPowerAndRollsMap = null;
-      } else {
-        unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(units,
-            new ArrayList<>(m_enemyBattleModel.getUnits()), !m_attack, false, m_data, m_location,
-            m_territoryEffects, m_isAmphibious, m_amphibiousLandAttackers);
-      }
-    } finally {
-      m_data.releaseReadLock();
-    }
-    final int diceSides = m_data.getDiceSides();
-    final Collection<UnitCategory> unitCategories = UnitSeperator.categorize(units, null, false, false, false);
-    for (final UnitCategory category : unitCategories) {
-      int strength;
-      final UnitAttachment attachment = UnitAttachment.get(category.getType());
-      final int[] shift = new int[m_data.getDiceSides() + 1];
-      for (final Unit current : category.getUnits()) {
-        if (m_battleType.isAirPreBattleOrPreRaid()) {
-          if (m_attack) {
-            strength = attachment.getAirAttack(category.getOwner());
+    private static String[] varDiceArray(final GameData data) {
+      // TODO Soft set the maximum bonus to-hit plus 1 for 0 based count(+2 total currently)
+      final String[] diceColumns = new String[data.getDiceSides() + 1];
+      {
+        for (int i = 0; i < diceColumns.length; i++) {
+          if (i == 0) {
+            diceColumns[i] = " ";
           } else {
-            strength = attachment.getAirDefense(category.getOwner());
+            diceColumns[i] = Integer.toString(i);
           }
-        } else {
-          // normal battle
-          strength = unitPowerAndRollsMap.get(current).getFirst();
         }
-        strength = Math.min(Math.max(strength, 0), diceSides);
-        shift[strength]++;
       }
+      return diceColumns;
+    }
+
+    BattleModel(final Collection<Unit> units, final boolean attack, final BattleType battleType,
+        final GameData data, final Territory battleLocation, final Collection<TerritoryEffect> territoryEffects,
+        final boolean isAmphibious, final Collection<Unit> amphibiousLandAttackers, final IUIContext uiContext) {
+      super(new Object[0][0], varDiceArray(data));
+      m_uiContext = uiContext;
+      m_data = data;
+      m_attack = attack;
+      // were going to modify the units
+      m_units = new ArrayList<>(units);
+      m_location = battleLocation;
+      m_battleType = battleType;
+      m_territoryEffects = territoryEffects;
+      m_isAmphibious = isAmphibious;
+      m_amphibiousLandAttackers = amphibiousLandAttackers;
+    }
+
+    void setEnemyBattleModel(final BattleModel enemyBattleModel) {
+      m_enemyBattleModel = enemyBattleModel;
+    }
+
+    void notifyRetreat(final Collection<Unit> retreating) {
+      m_units.removeAll(retreating);
+      refresh();
+    }
+
+    void removeCasualties(final Collection<Unit> killed) {
+      m_units.removeAll(killed);
+      refresh();
+    }
+
+    void addUnits(final Collection<Unit> units) {
+      m_units.addAll(units);
+      refresh();
+    }
+
+    Collection<Unit> getUnits() {
+      return m_units;
+    }
+
+    /**
+     * refresh the model from m_units.
+     */
+    void refresh() {
+      // TODO Soft set the maximum bonus to-hit plus 1 for 0 based count(+2 total currently)
+      // Soft code the # of columns
+
+      final List<List<TableData>> columns = new ArrayList<>(m_data.getDiceSides() + 1);
       for (int i = 0; i <= m_data.getDiceSides(); i++) {
-        if (shift[i] > 0) {
-          columns.get(i).add(new TableData(category.getOwner(), shift[i], category.getType(), m_data,
-              category.hasDamageOrBombingUnitDamage(), category.getDisabled(), m_uiContext));
-        }
+        columns.add(i, new ArrayList<>());
       }
-      // TODO Kev determine if we need to identify if the unit is hit/disabled
-    }
-    // find the number of rows
-    // this will be the size of the largest column
-    int rowCount = 1;
-    for (final List<TableData> column : columns) {
-      rowCount = Math.max(rowCount, column.size());
-    }
-    setNumRows(rowCount);
-    for (int row = 0; row < rowCount; row++) {
-      for (int column = 0; column < columns.size(); column++) {
-        // if the column has that many items, add to the table, else add null
-        if (columns.get(column).size() > row) {
-          setValueAt(columns.get(column).get(row), row, column);
+      final List<Unit> units = new ArrayList<>(m_units);
+      DiceRoll.sortByStrength(units, !m_attack);
+      final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap;
+      m_data.acquireReadLock();
+      try {
+        if (m_battleType.isAirPreBattleOrPreRaid()) {
+          unitPowerAndRollsMap = null;
         } else {
-          setValueAt(TableData.NULL, row, column);
+          unitPowerAndRollsMap = DiceRoll.getUnitPowerAndRollsForNormalBattles(units,
+              new ArrayList<>(m_enemyBattleModel.getUnits()), !m_attack, false, m_data, m_location,
+              m_territoryEffects, m_isAmphibious, m_amphibiousLandAttackers);
+        }
+      } finally {
+        m_data.releaseReadLock();
+      }
+      final int diceSides = m_data.getDiceSides();
+      final Collection<UnitCategory> unitCategories = UnitSeperator.categorize(units, null, false, false, false);
+      for (final UnitCategory category : unitCategories) {
+        int strength;
+        final UnitAttachment attachment = UnitAttachment.get(category.getType());
+        final int[] shift = new int[m_data.getDiceSides() + 1];
+        for (final Unit current : category.getUnits()) {
+          if (m_battleType.isAirPreBattleOrPreRaid()) {
+            if (m_attack) {
+              strength = attachment.getAirAttack(category.getOwner());
+            } else {
+              strength = attachment.getAirDefense(category.getOwner());
+            }
+          } else {
+            // normal battle
+            strength = unitPowerAndRollsMap.get(current).getFirst();
+          }
+          strength = Math.min(Math.max(strength, 0), diceSides);
+          shift[strength]++;
+        }
+        for (int i = 0; i <= m_data.getDiceSides(); i++) {
+          if (shift[i] > 0) {
+            columns.get(i).add(new TableData(category.getOwner(), shift[i], category.getType(), m_data,
+                category.hasDamageOrBombingUnitDamage(), category.getDisabled(), m_uiContext));
+          }
+        }
+        // TODO Kev determine if we need to identify if the unit is hit/disabled
+      }
+      // find the number of rows
+      // this will be the size of the largest column
+      int rowCount = 1;
+      for (final List<TableData> column : columns) {
+        rowCount = Math.max(rowCount, column.size());
+      }
+      setNumRows(rowCount);
+      for (int row = 0; row < rowCount; row++) {
+        for (int column = 0; column < columns.size(); column++) {
+          // if the column has that many items, add to the table, else add null
+          if (columns.get(column).size() > row) {
+            setValueAt(columns.get(column).get(row), row, column);
+          } else {
+            setValueAt(TableData.NULL, row, column);
+          }
+        }
+      }
+    }
+
+    @Override
+    public boolean isCellEditable(final int row, final int column) {
+      return false;
+    }
+  }
+
+  private static final class Renderer implements TableCellRenderer {
+    JLabel m_stamp = new JLabel();
+
+    @Override
+    public Component getTableCellRendererComponent(final JTable table, final Object value, final boolean isSelected,
+        final boolean hasFocus, final int row, final int column) {
+      ((TableData) value).updateStamp(m_stamp);
+      return m_stamp;
+    }
+  }
+
+  private static final class TableData {
+    static final TableData NULL = new TableData();
+    private int m_count;
+    private Optional<ImageIcon> m_icon;
+
+    private TableData() {}
+
+    TableData(final PlayerID player, final int count, final UnitType type, final GameData data, final boolean damaged,
+        final boolean disabled, final IUIContext uiContext) {
+      m_count = count;
+      m_icon = uiContext.getUnitImageFactory().getIcon(type, player, data, damaged, disabled);
+    }
+
+    void updateStamp(final JLabel stamp) {
+      if (m_count == 0) {
+        stamp.setText("");
+        stamp.setIcon(null);
+      } else {
+        stamp.setText("x" + m_count);
+        if (m_icon.isPresent()) {
+          stamp.setIcon(m_icon.get());
         }
       }
     }
   }
 
-  @Override
-  public boolean isCellEditable(final int row, final int column) {
-    return false;
-  }
-}
+  private static final class CasualtyNotificationPanel extends JPanel {
+    private static final long serialVersionUID = -8254027929090027450L;
+    private final DicePanel dice;
+    private final JPanel killed = new JPanel();
+    private final JPanel damaged = new JPanel();
+    private final GameData data;
+    private final IUIContext uiContext;
 
+    CasualtyNotificationPanel(final GameData data, final IUIContext uiContext) {
+      this.data = data;
+      this.uiContext = uiContext;
+      dice = new DicePanel(uiContext, data);
+      setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+      add(dice);
+      add(killed);
+      add(damaged);
+    }
 
-class Renderer implements TableCellRenderer {
-  JLabel m_stamp = new JLabel();
-
-  @Override
-  public Component getTableCellRendererComponent(final JTable table, final Object value, final boolean isSelected,
-      final boolean hasFocus, final int row, final int column) {
-    ((TableData) value).updateStamp(m_stamp);
-    return m_stamp;
-  }
-}
-
-
-class TableData {
-  static final TableData NULL = new TableData();
-  private int m_count;
-  private Optional<ImageIcon> m_icon;
-
-  private TableData() {}
-
-  TableData(final PlayerID player, final int count, final UnitType type, final GameData data, final boolean damaged,
-      final boolean disabled, final IUIContext uiContext) {
-    m_count = count;
-    m_icon = uiContext.getUnitImageFactory().getIcon(type, player, data, damaged, disabled);
-  }
-
-  public void updateStamp(final JLabel stamp) {
-    if (m_count == 0) {
-      stamp.setText("");
-      stamp.setIcon(null);
-    } else {
-      stamp.setText("x" + m_count);
-      if (m_icon.isPresent()) {
-        stamp.setIcon(m_icon.get());
+    void setNotification(final DiceRoll dice, final Collection<Unit> killed,
+        final Collection<Unit> damaged, final Map<Unit, Collection<Unit>> dependents) {
+      final boolean isEditMode = (dice == null);
+      if (!isEditMode) {
+        this.dice.setDiceRoll(dice);
       }
-    }
-  }
-}
-
-
-class CasualtyNotificationPanel extends JPanel {
-  private static final long serialVersionUID = -8254027929090027450L;
-  private final DicePanel dice;
-  private final JPanel killed = new JPanel();
-  private final JPanel damaged = new JPanel();
-  private final GameData data;
-  private final IUIContext uiContext;
-
-  public CasualtyNotificationPanel(final GameData data, final IUIContext uiContext) {
-    this.data = data;
-    this.uiContext = uiContext;
-    dice = new DicePanel(uiContext, data);
-    setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-    add(dice);
-    add(killed);
-    add(damaged);
-  }
-
-  protected void setNotification(final DiceRoll dice, final Collection<Unit> killed,
-      final Collection<Unit> damaged, final Map<Unit, Collection<Unit>> dependents) {
-    final boolean isEditMode = (dice == null);
-    if (!isEditMode) {
-      this.dice.setDiceRoll(dice);
-    }
-    this.killed.removeAll();
-    this.damaged.removeAll();
-    if (!killed.isEmpty()) {
-      this.killed.add(new JLabel("Killed"));
-    }
-    final Iterator<UnitCategory> killedIter = UnitSeperator.categorize(killed, dependents, false, false).iterator();
-    categorizeUnits(killedIter, false, false);
-    damaged.removeAll(killed);
-    if (!damaged.isEmpty()) {
-      this.damaged.add(new JLabel("Damaged"));
-    }
-    final Iterator<UnitCategory> damagedIter = UnitSeperator.categorize(damaged, dependents, false, false).iterator();
-    categorizeUnits(damagedIter, true, true);
-    invalidate();
-    validate();
-  }
-
-  protected void setNotificationShort(final Collection<Unit> killed, final Map<Unit, Collection<Unit>> dependents) {
-    this.killed.removeAll();
-    if (!killed.isEmpty()) {
-      this.killed.add(new JLabel("Killed"));
-    }
-    final Iterator<UnitCategory> killedIter = UnitSeperator.categorize(killed, dependents, false, false).iterator();
-    categorizeUnits(killedIter, false, false);
-    invalidate();
-    validate();
-  }
-
-  private void categorizeUnits(final Iterator<UnitCategory> categoryIter, final boolean damaged,
-      final boolean disabled) {
-    while (categoryIter.hasNext()) {
-      final UnitCategory category = categoryIter.next();
-      final JPanel panel = new JPanel();
-      // TODO Kev determine if we need to identify if the unit is hit/disabled
-      final Optional<ImageIcon> unitImage =
-          uiContext.getUnitImageFactory().getIcon(category.getType(), category.getOwner(), data,
-              damaged && category.hasDamageOrBombingUnitDamage(), disabled && category.getDisabled());
-      final JLabel unit = unitImage.isPresent() ? new JLabel(unitImage.get()) : new JLabel();
-      panel.add(unit);
-      for (final UnitOwner owner : category.getDependents()) {
-        unit.add(uiContext.createUnitImageJLabel(owner.getType(), owner.getOwner(), data));
+      this.killed.removeAll();
+      this.damaged.removeAll();
+      if (!killed.isEmpty()) {
+        this.killed.add(new JLabel("Killed"));
       }
-      panel.add(new JLabel("x " + category.getUnits().size()));
-      if (damaged) {
-        this.damaged.add(panel);
-      } else {
-        killed.add(panel);
+      final Iterator<UnitCategory> killedIter = UnitSeperator.categorize(killed, dependents, false, false).iterator();
+      categorizeUnits(killedIter, false, false);
+      damaged.removeAll(killed);
+      if (!damaged.isEmpty()) {
+        this.damaged.add(new JLabel("Damaged"));
+      }
+      final Iterator<UnitCategory> damagedIter = UnitSeperator.categorize(damaged, dependents, false, false).iterator();
+      categorizeUnits(damagedIter, true, true);
+      invalidate();
+      validate();
+    }
+
+    void setNotificationShort(final Collection<Unit> killed, final Map<Unit, Collection<Unit>> dependents) {
+      this.killed.removeAll();
+      if (!killed.isEmpty()) {
+        this.killed.add(new JLabel("Killed"));
+      }
+      final Iterator<UnitCategory> killedIter = UnitSeperator.categorize(killed, dependents, false, false).iterator();
+      categorizeUnits(killedIter, false, false);
+      invalidate();
+      validate();
+    }
+
+    private void categorizeUnits(final Iterator<UnitCategory> categoryIter, final boolean damaged,
+        final boolean disabled) {
+      while (categoryIter.hasNext()) {
+        final UnitCategory category = categoryIter.next();
+        final JPanel panel = new JPanel();
+        // TODO Kev determine if we need to identify if the unit is hit/disabled
+        final Optional<ImageIcon> unitImage =
+            uiContext.getUnitImageFactory().getIcon(category.getType(), category.getOwner(), data,
+                damaged && category.hasDamageOrBombingUnitDamage(), disabled && category.getDisabled());
+        final JLabel unit = unitImage.isPresent() ? new JLabel(unitImage.get()) : new JLabel();
+        panel.add(unit);
+        for (final UnitOwner owner : category.getDependents()) {
+          unit.add(uiContext.createUnitImageJLabel(owner.getType(), owner.getOwner(), data));
+        }
+        panel.add(new JLabel("x " + category.getUnits().size()));
+        if (damaged) {
+          this.damaged.add(panel);
+        } else {
+          killed.add(panel);
+        }
       }
     }
   }

--- a/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
@@ -182,20 +182,19 @@ class BattleStepsPanel extends JPanel implements Active {
     }
     waitThenWalk();
   }
-}
 
+  /**
+   * Doesnt allow the user to change the selection, must be done through
+   * hiddenSetSelectionInterval.
+   */
+  private static final class MyListSelectionModel extends DefaultListSelectionModel {
+    private static final long serialVersionUID = -4359950441657840015L;
 
-/**
- * Doesnt allow the user to change the selection, must be done through
- * hiddenSetSelectionInterval.
- */
-class MyListSelectionModel extends DefaultListSelectionModel {
-  private static final long serialVersionUID = -4359950441657840015L;
+    @Override
+    public void setSelectionInterval(final int index0, final int index1) {}
 
-  @Override
-  public void setSelectionInterval(final int index0, final int index1) {}
-
-  public void hiddenSetSelectionInterval(final int index) {
-    super.setSelectionInterval(index, index);
+    void hiddenSetSelectionInterval(final int index) {
+      super.setSelectionInterval(index, index);
+    }
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
@@ -221,86 +221,86 @@ public class IndividualUnitPanel extends JPanel {
       }
     }
   }
-}
 
+  private static final class SingleUnitPanel extends JPanel {
+    private static final long serialVersionUID = 5034287842323633030L;
+    private final Unit unit;
+    private final ScrollableTextField textField;
+    private static final Insets nullInsets = new Insets(0, 0, 0, 0);
+    private final ScrollableTextFieldListener countTextFieldListener;
 
-class SingleUnitPanel extends JPanel {
-  private static final long serialVersionUID = 5034287842323633030L;
-  private final Unit unit;
-  private final ScrollableTextField textField;
-  private static final Insets nullInsets = new Insets(0, 0, 0, 0);
-  private final ScrollableTextFieldListener countTextFieldListener;
-
-  public SingleUnitPanel(final Unit unit, final GameData data, final IUIContext uiContext,
-      final ScrollableTextFieldListener textFieldListener, final int max, final int min, final boolean showMaxAndMin) {
-    this(unit, data, uiContext, textFieldListener, max, min, 0, showMaxAndMin);
-  }
-
-  public SingleUnitPanel(final Unit unit, final GameData data, final IUIContext context,
-      final ScrollableTextFieldListener textFieldListener, final int max, final int min, final int currentValue,
-      final boolean showMaxAndMin) {
-    this.unit = unit;
-    final GameData m_data = data;
-    final IUIContext m_context = context;
-    countTextFieldListener = textFieldListener;
-    textField = new ScrollableTextField(0, 512);
-    if (max >= 0) {
-      setMax(max);
+    SingleUnitPanel(final Unit unit, final GameData data, final IUIContext uiContext,
+        final ScrollableTextFieldListener textFieldListener, final int max, final int min,
+        final boolean showMaxAndMin) {
+      this(unit, data, uiContext, textFieldListener, max, min, 0, showMaxAndMin);
     }
-    setMin(min);
-    textField.setShowMaxAndMin(showMaxAndMin);
-    final TripleAUnit taUnit = TripleAUnit.get(unit);
+
+    SingleUnitPanel(final Unit unit, final GameData data, final IUIContext context,
+        final ScrollableTextFieldListener textFieldListener, final int max, final int min, final int currentValue,
+        final boolean showMaxAndMin) {
+      this.unit = unit;
+      final GameData m_data = data;
+      final IUIContext m_context = context;
+      countTextFieldListener = textFieldListener;
+      textField = new ScrollableTextField(0, 512);
+      if (max >= 0) {
+        setMax(max);
+      }
+      setMin(min);
+      textField.setShowMaxAndMin(showMaxAndMin);
+      final TripleAUnit taUnit = TripleAUnit.get(unit);
 
 
-    setCount(currentValue);
-    setLayout(new GridBagLayout());
+      setCount(currentValue);
+      setLayout(new GridBagLayout());
 
-    final boolean isDamaged = taUnit.getUnitDamage() > 0 || taUnit.getHits() > 0;
-    final JLabel label = m_context.createUnitImageJLabel(this.unit.getType(), this.unit.getOwner(), m_data,
-        isDamaged ? IUIContext.UnitDamage.DAMAGED : IUIContext.UnitDamage.NOT_DAMAGED,
-        taUnit.getDisabled() ? IUIContext.UnitEnable.DISABLED : IUIContext.UnitEnable.ENABLED);
+      final boolean isDamaged = taUnit.getUnitDamage() > 0 || taUnit.getHits() > 0;
+      final JLabel label = m_context.createUnitImageJLabel(this.unit.getType(), this.unit.getOwner(), m_data,
+          isDamaged ? IUIContext.UnitDamage.DAMAGED : IUIContext.UnitDamage.NOT_DAMAGED,
+          taUnit.getDisabled() ? IUIContext.UnitEnable.DISABLED : IUIContext.UnitEnable.ENABLED);
 
-    add(label, new GridBagConstraints(0, 0, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
-        new Insets(0, 0, 0, 10), 0, 0));
-    add(textField, new GridBagConstraints(1, 0, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
-        new Insets(0, 0, 0, 0), 0, 0));
-  }
+      add(label, new GridBagConstraints(0, 0, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
+          new Insets(0, 0, 0, 10), 0, 0));
+      add(textField, new GridBagConstraints(1, 0, 1, 1, 0, 0, GridBagConstraints.EAST, GridBagConstraints.NONE,
+          new Insets(0, 0, 0, 0), 0, 0));
+    }
 
-  public int getCount() {
-    return textField.getValue();
-  }
+    int getCount() {
+      return textField.getValue();
+    }
 
-  public void setCount(final int value) {
-    textField.setValue(value);
-  }
+    void setCount(final int value) {
+      textField.setValue(value);
+    }
 
-  public void selectAll() {
-    textField.setValue(textField.getMax());
-  }
+    void selectAll() {
+      textField.setValue(textField.getMax());
+    }
 
-  public void selectNone() {
-    textField.setValue(0);
-  }
+    void selectNone() {
+      textField.setValue(0);
+    }
 
-  public void setMax(final int value) {
-    textField.setMax(value);
-  }
+    void setMax(final int value) {
+      textField.setMax(value);
+    }
 
-  public int getMax() {
-    return textField.getMax();
-  }
+    int getMax() {
+      return textField.getMax();
+    }
 
-  public void setMin(final int value) {
-    textField.setMin(value);
-  }
+    void setMin(final int value) {
+      textField.setMin(value);
+    }
 
-  public Unit getUnit() {
-    return unit;
-  }
+    Unit getUnit() {
+      return unit;
+    }
 
-  public void createComponents(final JPanel panel, final int rowIndex) {
-    panel.add(this, new GridBagConstraints(0, rowIndex, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.HORIZONTAL, nullInsets, 0, 0));
-    textField.addChangeListener(countTextFieldListener);
+    void createComponents(final JPanel panel, final int rowIndex) {
+      panel.add(this, new GridBagConstraints(0, rowIndex, 1, 1, 0, 0, GridBagConstraints.WEST,
+          GridBagConstraints.HORIZONTAL, nullInsets, 0, 0));
+      textField.addChangeListener(countTextFieldListener);
+    }
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
@@ -84,26 +84,25 @@ public class PlayerChooser extends JOptionPane {
     }
     return null;
   }
-}
 
+  private static final class PlayerChooserRenderer extends DefaultListCellRenderer {
+    private static final long serialVersionUID = -2185921124436293304L;
+    private final IUIContext uiContext;
 
-class PlayerChooserRenderer extends DefaultListCellRenderer {
-  private static final long serialVersionUID = -2185921124436293304L;
-  private final IUIContext uiContext;
-
-  PlayerChooserRenderer(final IUIContext uiContext) {
-    this.uiContext = uiContext;
-  }
-
-  @Override
-  public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
-      final boolean isSelected, final boolean cellHasFocus) {
-    super.getListCellRendererComponent(list, ((PlayerID) value).getName(), index, isSelected, cellHasFocus);
-    if (uiContext == null || value == PlayerID.NULL_PLAYERID) {
-      setIcon(new ImageIcon(Util.createImage(32, 32, true)));
-    } else {
-      setIcon(new ImageIcon(uiContext.getFlagImageFactory().getFlag((PlayerID) value)));
+    PlayerChooserRenderer(final IUIContext uiContext) {
+      this.uiContext = uiContext;
     }
-    return this;
+
+    @Override
+    public Component getListCellRendererComponent(final JList<?> list, final Object value, final int index,
+        final boolean isSelected, final boolean cellHasFocus) {
+      super.getListCellRendererComponent(list, ((PlayerID) value).getName(), index, isSelected, cellHasFocus);
+      if (uiContext == null || value == PlayerID.NULL_PLAYERID) {
+        setIcon(new ImageIcon(Util.createImage(32, 32, true)));
+      } else {
+        setIcon(new ImageIcon(uiContext.getFlagImageFactory().getFlag((PlayerID) value)));
+      }
+      return this;
+    }
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -266,212 +266,211 @@ public class TechPanel extends ActionPanel {
     }
     return strTechCategory.toString();
   }
-}
 
+  private static final class TechRollPanel extends JPanel {
+    private static final long serialVersionUID = -3794742986339086059L;
+    int pus;
+    PlayerID player;
+    JLabel left = new JLabel();
+    ScrollableTextField textField;
 
-class TechRollPanel extends JPanel {
-  private static final long serialVersionUID = -3794742986339086059L;
-  int pus;
-  PlayerID player;
-  JLabel left = new JLabel();
-  ScrollableTextField textField;
-
-  TechRollPanel(final int pus, final PlayerID player) {
-    setLayout(new GridBagLayout());
-    this.pus = pus;
-    this.player = player;
-    final JLabel title = new JLabel("Select the number of tech rolls:");
-    title.setBorder(new EmptyBorder(5, 5, 5, 5));
-    textField = new ScrollableTextField(0, pus / TechTracker.getTechCost(player));
-    final ScrollableTextFieldListener m_listener =
-        stf -> setLabel(this.pus - (TechTracker.getTechCost(this.player) * textField.getValue()));
-    textField.addChangeListener(m_listener);
-    final JLabel costLabel = new JLabel("x" + TechTracker.getTechCost(this.player));
-    setLabel(pus);
-    final int space = 0;
-    add(title, new GridBagConstraints(0, 0, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(5, 5, space, space), 0, 0));
-    add(textField, new GridBagConstraints(0, 1, 1, 1, 0.5, 1, GridBagConstraints.EAST, GridBagConstraints.NONE,
-        new Insets(8, 10, space, space), 0, 0));
-    add(costLabel, new GridBagConstraints(1, 1, 1, 1, 0.5, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(8, 5, space, 2), 0, 0));
-    add(left, new GridBagConstraints(0, 2, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(10, 5, space, space), 0, 0));
-  }
-
-  private void setLabel(final int pus) {
-    left.setText("Left to spend:" + pus);
-  }
-
-  public int getValue() {
-    return textField.getValue();
-  }
-}
-
-
-class TechTokenPanel extends JPanel {
-  private static final long serialVersionUID = 332026624893335993L;
-  int totalPus;
-  int playerPus;
-  final ScrollableTextField playerPuField;
-  PlayerID player;
-  JLabel left = new JLabel();
-  JLabel right = new JLabel();
-  JLabel totalCost = new JLabel();
-  ScrollableTextField textField;
-  HashMap<PlayerID, ScrollableTextField> whoPaysTextFields = null;
-
-  TechTokenPanel(final int pus, final int currTokens, final PlayerID player, final Collection<PlayerID> helpPay) {
-    playerPus = pus;
-    totalPus = pus;
-    if (helpPay != null && !helpPay.isEmpty()) {
-      helpPay.remove(player);
-      for (final PlayerID p : helpPay) {
-        totalPus += p.getResources().getQuantity(Constants.PUS);
-      }
+    TechRollPanel(final int pus, final PlayerID player) {
+      setLayout(new GridBagLayout());
+      this.pus = pus;
+      this.player = player;
+      final JLabel title = new JLabel("Select the number of tech rolls:");
+      title.setBorder(new EmptyBorder(5, 5, 5, 5));
+      textField = new ScrollableTextField(0, pus / TechTracker.getTechCost(player));
+      final ScrollableTextFieldListener m_listener =
+          stf -> setLabel(this.pus - (TechTracker.getTechCost(this.player) * textField.getValue()));
+      textField.addChangeListener(m_listener);
+      final JLabel costLabel = new JLabel("x" + TechTracker.getTechCost(this.player));
+      setLabel(pus);
+      final int space = 0;
+      add(title, new GridBagConstraints(0, 0, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
+          new Insets(5, 5, space, space), 0, 0));
+      add(textField, new GridBagConstraints(0, 1, 1, 1, 0.5, 1, GridBagConstraints.EAST, GridBagConstraints.NONE,
+          new Insets(8, 10, space, space), 0, 0));
+      add(costLabel, new GridBagConstraints(1, 1, 1, 1, 0.5, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
+          new Insets(8, 5, space, 2), 0, 0));
+      add(left, new GridBagConstraints(0, 2, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
+          new Insets(10, 5, space, space), 0, 0));
     }
-    playerPuField = new ScrollableTextField(0, totalPus);
-    playerPuField.setEnabled(false);
-    setLayout(new GridBagLayout());
-    this.player = player;
-    final JLabel title = new JLabel("Select the number of tech tokens to purchase:");
-    title.setBorder(new EmptyBorder(5, 5, 5, 5));
-    final int techCost = TechTracker.getTechCost(this.player);
-    textField = new ScrollableTextField(0, totalPus / techCost);
-    final ScrollableTextFieldListener m_listener = stf -> {
-      setLabel(TechTracker.getTechCost(this.player) * textField.getValue());
-      setWidgetActivation();
-    };
-    textField.addChangeListener(m_listener);
-    final JLabel costLabel = new JLabel("x" + techCost + " cost per token");
-    setLabel(0);
-    setTokens(currTokens);
-    final int space = 0;
-    add(title, new GridBagConstraints(0, 0, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(5, 5, space, space), 0, 0));
-    add(textField, new GridBagConstraints(0, 1, 1, 1, 0.5, 1, GridBagConstraints.EAST, GridBagConstraints.NONE,
-        new Insets(8, 10, space, space), 0, 0));
-    add(costLabel, new GridBagConstraints(1, 1, 1, 1, 0.5, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(8, 5, space, 2), 0, 0));
-    add(left, new GridBagConstraints(0, 2, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(10, 5, space, space), 0, 0));
-    add(right, new GridBagConstraints(0, 2, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(10, 130, space, space), 0, 0));
-    add(totalCost, new GridBagConstraints(0, 3, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
-        new Insets(10, 5, space, space), 0, 0));
-    if (helpPay != null && !helpPay.isEmpty()) {
-      if (whoPaysTextFields == null) {
-        whoPaysTextFields = new HashMap<>();
+
+    private void setLabel(final int pus) {
+      left.setText("Left to spend:" + pus);
+    }
+
+    int getValue() {
+      return textField.getValue();
+    }
+  }
+
+  private static final class TechTokenPanel extends JPanel {
+    private static final long serialVersionUID = 332026624893335993L;
+    int totalPus;
+    int playerPus;
+    final ScrollableTextField playerPuField;
+    PlayerID player;
+    JLabel left = new JLabel();
+    JLabel right = new JLabel();
+    JLabel totalCost = new JLabel();
+    ScrollableTextField textField;
+    HashMap<PlayerID, ScrollableTextField> whoPaysTextFields = null;
+
+    TechTokenPanel(final int pus, final int currTokens, final PlayerID player, final Collection<PlayerID> helpPay) {
+      playerPus = pus;
+      totalPus = pus;
+      if (helpPay != null && !helpPay.isEmpty()) {
+        helpPay.remove(player);
+        for (final PlayerID p : helpPay) {
+          totalPus += p.getResources().getQuantity(Constants.PUS);
+        }
       }
-      helpPay.remove(player);
-      int row = 4;
-      add(new JLabel("Nations Paying How Much:"), new GridBagConstraints(0, row, 1, 1, 0.5, 1, GridBagConstraints.EAST,
-          GridBagConstraints.NONE, new Insets(30, 6, 6, 6), 0, 0));
-      row++;
-      add(new JLabel(player.getName()), new GridBagConstraints(0, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
-          GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
-      add(playerPuField, new GridBagConstraints(1, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
-          GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
-      add(new JLabel("PUs"), new GridBagConstraints(2, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
-          GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
-      row++;
-      for (final PlayerID p : helpPay) {
-        final int helperPUs = p.getResources().getQuantity(Constants.PUS);
-        if (helperPUs > 0) {
-          final ScrollableTextField whoPaysTextField = new ScrollableTextField(0, helperPUs);
-          whoPaysTextField.addChangeListener(setWidgetAction());
-          whoPaysTextFields.put(p, whoPaysTextField);
-          // TODO: force players to pay if it goes above the cost m_player can afford.
-          add(new JLabel(p.getName()), new GridBagConstraints(0, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
-              GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
-          add(whoPaysTextField, new GridBagConstraints(1, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
-              GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
-          add(new JLabel("PUs"), new GridBagConstraints(2, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
-              GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
-          row++;
+      playerPuField = new ScrollableTextField(0, totalPus);
+      playerPuField.setEnabled(false);
+      setLayout(new GridBagLayout());
+      this.player = player;
+      final JLabel title = new JLabel("Select the number of tech tokens to purchase:");
+      title.setBorder(new EmptyBorder(5, 5, 5, 5));
+      final int techCost = TechTracker.getTechCost(this.player);
+      textField = new ScrollableTextField(0, totalPus / techCost);
+      final ScrollableTextFieldListener m_listener = stf -> {
+        setLabel(TechTracker.getTechCost(this.player) * textField.getValue());
+        setWidgetActivation();
+      };
+      textField.addChangeListener(m_listener);
+      final JLabel costLabel = new JLabel("x" + techCost + " cost per token");
+      setLabel(0);
+      setTokens(currTokens);
+      final int space = 0;
+      add(title, new GridBagConstraints(0, 0, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
+          new Insets(5, 5, space, space), 0, 0));
+      add(textField, new GridBagConstraints(0, 1, 1, 1, 0.5, 1, GridBagConstraints.EAST, GridBagConstraints.NONE,
+          new Insets(8, 10, space, space), 0, 0));
+      add(costLabel, new GridBagConstraints(1, 1, 1, 1, 0.5, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
+          new Insets(8, 5, space, 2), 0, 0));
+      add(left, new GridBagConstraints(0, 2, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
+          new Insets(10, 5, space, space), 0, 0));
+      add(right, new GridBagConstraints(0, 2, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
+          new Insets(10, 130, space, space), 0, 0));
+      add(totalCost, new GridBagConstraints(0, 3, 3, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
+          new Insets(10, 5, space, space), 0, 0));
+      if (helpPay != null && !helpPay.isEmpty()) {
+        if (whoPaysTextFields == null) {
+          whoPaysTextFields = new HashMap<>();
+        }
+        helpPay.remove(player);
+        int row = 4;
+        add(new JLabel("Nations Paying How Much:"),
+            new GridBagConstraints(0, row, 1, 1, 0.5, 1, GridBagConstraints.EAST,
+                GridBagConstraints.NONE, new Insets(30, 6, 6, 6), 0, 0));
+        row++;
+        add(new JLabel(player.getName()), new GridBagConstraints(0, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
+            GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
+        add(playerPuField, new GridBagConstraints(1, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
+            GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
+        add(new JLabel("PUs"), new GridBagConstraints(2, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
+            GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
+        row++;
+        for (final PlayerID p : helpPay) {
+          final int helperPUs = p.getResources().getQuantity(Constants.PUS);
+          if (helperPUs > 0) {
+            final ScrollableTextField whoPaysTextField = new ScrollableTextField(0, helperPUs);
+            whoPaysTextField.addChangeListener(setWidgetAction());
+            whoPaysTextFields.put(p, whoPaysTextField);
+            // TODO: force players to pay if it goes above the cost m_player can afford.
+            add(new JLabel(p.getName()), new GridBagConstraints(0, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
+                GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
+            add(whoPaysTextField, new GridBagConstraints(1, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
+                GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
+            add(new JLabel("PUs"), new GridBagConstraints(2, row, 1, 1, 0.5, 1, GridBagConstraints.CENTER,
+                GridBagConstraints.NONE, new Insets(6, 6, 6, 6), 0, 0));
+            row++;
+          }
         }
       }
     }
-  }
 
-  private void setWidgetActivation() {
-    if (whoPaysTextFields == null || whoPaysTextFields.isEmpty()) {
-      return;
-    }
-    final int cost = TechTracker.getTechCost(player) * textField.getValue();
-    int totalPaidByOthers = 0;
-    for (final Entry<PlayerID, ScrollableTextField> entry : whoPaysTextFields.entrySet()) {
-      totalPaidByOthers += Math.max(0, entry.getValue().getValue());
-    }
-    final int totalPaidByPlayer = Math.max(0, cost - totalPaidByOthers);
-    int amountOver = -1 * (playerPus - totalPaidByPlayer);
-    final Iterator<Entry<PlayerID, ScrollableTextField>> otherPayers = whoPaysTextFields.entrySet().iterator();
-    while (amountOver > 0 && otherPayers.hasNext()) {
-      final Entry<PlayerID, ScrollableTextField> entry = otherPayers.next();
-      int current = entry.getValue().getValue();
-      final int max = entry.getValue().getMax();
-      if (current < max) {
-        final int canAdd = Math.min(max - current, amountOver);
-        amountOver -= canAdd;
-        current += canAdd;
-        entry.getValue().setValue(current);
+    private void setWidgetActivation() {
+      if (whoPaysTextFields == null || whoPaysTextFields.isEmpty()) {
+        return;
       }
-    }
-    // now check if we are negative
-    totalPaidByOthers = 0;
-    for (final Entry<PlayerID, ScrollableTextField> entry : whoPaysTextFields.entrySet()) {
-      totalPaidByOthers += Math.max(0, entry.getValue().getValue());
-    }
-    int amountUnder = -1 * (cost - totalPaidByOthers);
-    final Iterator<Entry<PlayerID, ScrollableTextField>> otherPayers2 = whoPaysTextFields.entrySet().iterator();
-    while (amountUnder > 0 && otherPayers2.hasNext()) {
-      final Entry<PlayerID, ScrollableTextField> entry = otherPayers2.next();
-      int current = entry.getValue().getValue();
-      if (current > 0) {
-        final int canSubtract = Math.min(current, amountUnder);
-        amountUnder -= canSubtract;
-        current -= canSubtract;
-        entry.getValue().setValue(current);
-      }
-    }
-    playerPuField.setValue(Math.max(0, Math.min(playerPus, totalPaidByPlayer)));
-  }
-
-  private void setLabel(final int cost) {
-    left.setText("Left to Spend:  " + (totalPus - cost));
-    totalCost.setText("Total Cost:  " + cost);
-  }
-
-  private void setTokens(final int tokens) {
-    right.setText("Current token count:  " + tokens);
-  }
-
-  private ScrollableTextFieldListener setWidgetAction() {
-    return stf -> setWidgetActivation();
-  }
-
-  public int getValue() {
-    return textField.getValue();
-  }
-
-  public IntegerMap<PlayerID> getWhoPaysHowMuch() {
-    final int techCost = TechTracker.getTechCost(player);
-    final int numberOfTechRolls = getValue();
-    final int totalCost = numberOfTechRolls * techCost;
-    final IntegerMap<PlayerID> whoPaysHowMuch = new IntegerMap<>();
-    if (whoPaysTextFields == null || whoPaysTextFields.isEmpty()) {
-      whoPaysHowMuch.put(player, totalCost);
-    } else {
-      int runningTotal = 0;
+      final int cost = TechTracker.getTechCost(player) * textField.getValue();
+      int totalPaidByOthers = 0;
       for (final Entry<PlayerID, ScrollableTextField> entry : whoPaysTextFields.entrySet()) {
-        final int value = entry.getValue().getValue();
-        whoPaysHowMuch.put(entry.getKey(), value);
-        runningTotal += value;
+        totalPaidByOthers += Math.max(0, entry.getValue().getValue());
       }
-      if (!whoPaysTextFields.containsKey(player)) {
-        whoPaysHowMuch.put(player, Math.max(0, totalCost - runningTotal));
+      final int totalPaidByPlayer = Math.max(0, cost - totalPaidByOthers);
+      int amountOver = -1 * (playerPus - totalPaidByPlayer);
+      final Iterator<Entry<PlayerID, ScrollableTextField>> otherPayers = whoPaysTextFields.entrySet().iterator();
+      while (amountOver > 0 && otherPayers.hasNext()) {
+        final Entry<PlayerID, ScrollableTextField> entry = otherPayers.next();
+        int current = entry.getValue().getValue();
+        final int max = entry.getValue().getMax();
+        if (current < max) {
+          final int canAdd = Math.min(max - current, amountOver);
+          amountOver -= canAdd;
+          current += canAdd;
+          entry.getValue().setValue(current);
+        }
       }
+      // now check if we are negative
+      totalPaidByOthers = 0;
+      for (final Entry<PlayerID, ScrollableTextField> entry : whoPaysTextFields.entrySet()) {
+        totalPaidByOthers += Math.max(0, entry.getValue().getValue());
+      }
+      int amountUnder = -1 * (cost - totalPaidByOthers);
+      final Iterator<Entry<PlayerID, ScrollableTextField>> otherPayers2 = whoPaysTextFields.entrySet().iterator();
+      while (amountUnder > 0 && otherPayers2.hasNext()) {
+        final Entry<PlayerID, ScrollableTextField> entry = otherPayers2.next();
+        int current = entry.getValue().getValue();
+        if (current > 0) {
+          final int canSubtract = Math.min(current, amountUnder);
+          amountUnder -= canSubtract;
+          current -= canSubtract;
+          entry.getValue().setValue(current);
+        }
+      }
+      playerPuField.setValue(Math.max(0, Math.min(playerPus, totalPaidByPlayer)));
     }
-    return whoPaysHowMuch;
+
+    private void setLabel(final int cost) {
+      left.setText("Left to Spend:  " + (totalPus - cost));
+      totalCost.setText("Total Cost:  " + cost);
+    }
+
+    private void setTokens(final int tokens) {
+      right.setText("Current token count:  " + tokens);
+    }
+
+    private ScrollableTextFieldListener setWidgetAction() {
+      return stf -> setWidgetActivation();
+    }
+
+    int getValue() {
+      return textField.getValue();
+    }
+
+    IntegerMap<PlayerID> getWhoPaysHowMuch() {
+      final int techCost = TechTracker.getTechCost(player);
+      final int numberOfTechRolls = getValue();
+      final int totalCost = numberOfTechRolls * techCost;
+      final IntegerMap<PlayerID> whoPaysHowMuch = new IntegerMap<>();
+      if (whoPaysTextFields == null || whoPaysTextFields.isEmpty()) {
+        whoPaysHowMuch.put(player, totalCost);
+      } else {
+        int runningTotal = 0;
+        for (final Entry<PlayerID, ScrollableTextField> entry : whoPaysTextFields.entrySet()) {
+          final int value = entry.getValue().getValue();
+          whoPaysHowMuch.put(entry.getKey(), value);
+          runningTotal += value;
+        }
+        if (!whoPaysTextFields.containsKey(player)) {
+          whoPaysHowMuch.put(player, Math.max(0, totalCost - runningTotal));
+        }
+      }
+      return whoPaysHowMuch;
+    }
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -323,223 +323,209 @@ public class UnitChooser extends JPanel {
       }
     }
   };
-}
 
+  private static final class ChooserEntry {
+    private final UnitCategory m_category;
+    private final ScrollableTextFieldListener m_hitTextFieldListener;
+    private final GameData m_data;
+    private final boolean m_hasMultipleHits;
+    private final List<Integer> m_defaultHits;
+    private final List<ScrollableTextField> m_hitTexts;
+    private final List<JLabel> m_hitLabel = new ArrayList<>();
+    private int m_leftToSelect = 0;
+    private static Insets nullInsets = new Insets(0, 0, 0, 0);
+    private final IUIContext m_uiContext;
 
-class ChooserEntry {
-  private final UnitCategory m_category;
-  private final ScrollableTextFieldListener m_hitTextFieldListener;
-  private final GameData m_data;
-  private final boolean m_hasMultipleHits;
-  private final List<Integer> m_defaultHits;
-  private final List<ScrollableTextField> m_hitTexts;
-  private final List<JLabel> m_hitLabel = new ArrayList<>();
-  private int m_leftToSelect = 0;
-  private static Insets nullInsets = new Insets(0, 0, 0, 0);
-  private final IUIContext m_uiContext;
-
-  ChooserEntry(final UnitCategory category, final int leftToSelect, final ScrollableTextFieldListener listener,
-      final GameData data, final boolean allowTwoHit, final int defaultValue, final IUIContext uiContext) {
-    m_hitTextFieldListener = listener;
-    m_data = data;
-    m_category = category;
-    m_leftToSelect = leftToSelect < 0 ? category.getUnits().size() : leftToSelect;
-    m_hasMultipleHits =
-        allowTwoHit && category.getHitPoints() > 1 && category.getDamaged() < category.getHitPoints() - 1;
-    m_hitTexts = new ArrayList<>(Math.max(1, category.getHitPoints() - category.getDamaged()));
-    m_defaultHits = new ArrayList<>(Math.max(1, category.getHitPoints() - category.getDamaged()));
-    final int numUnits = category.getUnits().size();
-    int hitsUsedSoFar = 0;
-    for (int i = 0; i < Math.max(1, category.getHitPoints() - category.getDamaged()); i++) {
-      // TODO: check if default value includes damaged points or not
-      final int hitsToUse = Math.min(numUnits, (defaultValue - hitsUsedSoFar));
-      hitsUsedSoFar += hitsToUse;
-      m_defaultHits.add(hitsToUse);
+    ChooserEntry(final UnitCategory category, final int leftToSelect, final ScrollableTextFieldListener listener,
+        final GameData data, final boolean allowTwoHit, final int defaultValue, final IUIContext uiContext) {
+      m_hitTextFieldListener = listener;
+      m_data = data;
+      m_category = category;
+      m_leftToSelect = leftToSelect < 0 ? category.getUnits().size() : leftToSelect;
+      m_hasMultipleHits =
+          allowTwoHit && category.getHitPoints() > 1 && category.getDamaged() < category.getHitPoints() - 1;
+      m_hitTexts = new ArrayList<>(Math.max(1, category.getHitPoints() - category.getDamaged()));
+      m_defaultHits = new ArrayList<>(Math.max(1, category.getHitPoints() - category.getDamaged()));
+      final int numUnits = category.getUnits().size();
+      int hitsUsedSoFar = 0;
+      for (int i = 0; i < Math.max(1, category.getHitPoints() - category.getDamaged()); i++) {
+        // TODO: check if default value includes damaged points or not
+        final int hitsToUse = Math.min(numUnits, (defaultValue - hitsUsedSoFar));
+        hitsUsedSoFar += hitsToUse;
+        m_defaultHits.add(hitsToUse);
+      }
+      m_uiContext = uiContext;
     }
-    m_uiContext = uiContext;
-  }
 
-  public void createComponents(final JPanel panel, final int rowIndex) {
-    int gridx = 0;
-    for (int i =
-        0; i < (m_hasMultipleHits ? Math.max(1, m_category.getHitPoints() - m_category.getDamaged()) : 1); i++) {
-      final ScrollableTextField scroll = new ScrollableTextField(0, m_category.getUnits().size());
-      m_hitTexts.add(scroll);
-      scroll.setValue(m_defaultHits.get(i));
-      scroll.addChangeListener(m_hitTextFieldListener);
-      final JLabel label = new JLabel("x" + m_category.getUnits().size());
-      m_hitLabel.add(label);
-      panel.add(new UnitChooserEntryIcon(i > 0, m_uiContext), new GridBagConstraints(gridx++, rowIndex, 1, 1, 0, 0,
-          GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(0, (i == 0 ? 0 : 8), 0, 0), 0, 0));
-      if (i == 0) {
-        if (m_category.getMovement() != -1) {
-          panel.add(new JLabel("mvt " + m_category.getMovement()), new GridBagConstraints(gridx, rowIndex, 1, 1, 0, 0,
-              GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(0, 4, 0, 4), 0, 0));
+    void createComponents(final JPanel panel, final int rowIndex) {
+      int gridx = 0;
+      for (int i =
+          0; i < (m_hasMultipleHits ? Math.max(1, m_category.getHitPoints() - m_category.getDamaged()) : 1); i++) {
+        final ScrollableTextField scroll = new ScrollableTextField(0, m_category.getUnits().size());
+        m_hitTexts.add(scroll);
+        scroll.setValue(m_defaultHits.get(i));
+        scroll.addChangeListener(m_hitTextFieldListener);
+        final JLabel label = new JLabel("x" + m_category.getUnits().size());
+        m_hitLabel.add(label);
+        panel.add(new UnitChooserEntryIcon(i > 0, m_uiContext), new GridBagConstraints(gridx++, rowIndex, 1, 1, 0, 0,
+            GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(0, (i == 0 ? 0 : 8), 0, 0), 0, 0));
+        if (i == 0) {
+          if (m_category.getMovement() != -1) {
+            panel.add(new JLabel("mvt " + m_category.getMovement()), new GridBagConstraints(gridx, rowIndex, 1, 1, 0, 0,
+                GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(0, 4, 0, 4), 0, 0));
+          }
+          if (m_category.getTransportCost() != -1) {
+            panel.add(new JLabel("cst " + m_category.getTransportCost()),
+                new GridBagConstraints(gridx, rowIndex, 1, 1, 0,
+                    0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(0, 4, 0, 4), 0, 0));
+          }
+          gridx++;
         }
-        if (m_category.getTransportCost() != -1) {
-          panel.add(new JLabel("cst " + m_category.getTransportCost()), new GridBagConstraints(gridx, rowIndex, 1, 1, 0,
-              0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(0, 4, 0, 4), 0, 0));
+        panel.add(label, new GridBagConstraints(gridx++, rowIndex, 1, 1, 0, 0, GridBagConstraints.WEST,
+            GridBagConstraints.HORIZONTAL, nullInsets, 0, 0));
+        panel.add(scroll, new GridBagConstraints(gridx++, rowIndex, 1, 1, 0, 0, GridBagConstraints.WEST,
+            GridBagConstraints.HORIZONTAL, new Insets(0, 4, 0, 0), 0, 0));
+        scroll.addChangeListener(field -> updateLeftToSelect());
+      }
+      updateLeftToSelect();
+    }
+
+    int getMax() {
+      return m_hitTexts.get(0).getMax();
+    }
+
+    void set(final int value) {
+      m_hitTexts.get(0).setValue(value);
+    }
+
+    UnitCategory getCategory() {
+      return m_category;
+    }
+
+    void selectAll() {
+      m_hitTexts.get(0).setValue(m_hitTexts.get(0).getMax());
+    }
+
+    void selectNone() {
+      m_hitTexts.get(0).setValue(0);
+    }
+
+    void setLeftToSelect(final int leftToSelect) {
+      m_leftToSelect = leftToSelect < 0 ? m_category.getUnits().size() : leftToSelect;
+      updateLeftToSelect();
+    }
+
+    private void updateLeftToSelect() {
+      int previousMax = m_category.getUnits().size();
+      for (int i = 0; i < m_hitTexts.size(); i++) {
+        final int newMax = m_leftToSelect + getHits(i);
+        final ScrollableTextField text = m_hitTexts.get(i);
+        if (i > 0 && !m_hasMultipleHits) {
+          text.setMax(0);
+        } else {
+          text.setMax(Math.min(newMax, previousMax));
         }
-        gridx++;
-      }
-      panel.add(label, new GridBagConstraints(gridx++, rowIndex, 1, 1, 0, 0, GridBagConstraints.WEST,
-          GridBagConstraints.HORIZONTAL, nullInsets, 0, 0));
-      panel.add(scroll, new GridBagConstraints(gridx++, rowIndex, 1, 1, 0, 0, GridBagConstraints.WEST,
-          GridBagConstraints.HORIZONTAL, new Insets(0, 4, 0, 0), 0, 0));
-      scroll.addChangeListener(field -> updateLeftToSelect());
-    }
-    updateLeftToSelect();
-  }
-
-  public int getMax() {
-    return m_hitTexts.get(0).getMax();
-  }
-
-  public void set(final int value) {
-    m_hitTexts.get(0).setValue(value);
-  }
-
-  public UnitCategory getCategory() {
-    return m_category;
-  }
-
-  public void selectAll() {
-    m_hitTexts.get(0).setValue(m_hitTexts.get(0).getMax());
-  }
-
-  public void selectAllMultipleHitPoints() {
-    for (final ScrollableTextField t : m_hitTexts) {
-      t.setValue(t.getMax());
-    }
-  }
-
-  public void selectNone() {
-    m_hitTexts.get(0).setValue(0);
-  }
-
-  public void setLeftToSelect(final int leftToSelect) {
-    m_leftToSelect = leftToSelect < 0 ? m_category.getUnits().size() : leftToSelect;
-    updateLeftToSelect();
-  }
-
-  private void updateLeftToSelect() {
-    int previousMax = m_category.getUnits().size();
-    for (int i = 0; i < m_hitTexts.size(); i++) {
-      final int newMax = m_leftToSelect + getHits(i);
-      final ScrollableTextField text = m_hitTexts.get(i);
-      if (i > 0 && !m_hasMultipleHits) {
-        text.setMax(0);
-      } else {
-        text.setMax(Math.min(newMax, previousMax));
-      }
-      if (text.getValue() < 0 || text.getValue() > text.getMax()) {
-        text.setValue(Math.max(0, Math.min(text.getMax(), text.getValue())));
-      }
-      m_hitLabel.get(i).setText("x" + (i == 0 ? m_category.getUnits().size() : text.getMax()));
-      previousMax = text.getValue();
-    }
-  }
-
-  public int getTotalHits() {
-    int hits = 0;
-    for (int i = 0; i < m_hitTexts.size(); i++) {
-      hits += getHits(i);
-    }
-    return hits;
-  }
-
-  public int getHits(final int zeroBasedHitsPosition) {
-    if (zeroBasedHitsPosition < 0 || zeroBasedHitsPosition > m_hitTexts.size() - 1) {
-      throw new IllegalArgumentException("Index out of range");
-    }
-    if (!m_hasMultipleHits && zeroBasedHitsPosition > 0) {
-      return 0;
-    }
-    return m_hitTexts.get(zeroBasedHitsPosition).getValue();
-  }
-
-  public int getFinalHit() {
-    return getHits(m_hitTexts.size() - 1);
-  }
-
-  public int getAllButFinalHit() {
-    int hits = 0;
-    for (int i = 0; i < m_hitTexts.size() - 1; i++) {
-      hits += getHits(i);
-    }
-    return hits;
-  }
-
-  public int size() {
-    return m_hitTexts.size();
-  }
-
-  public boolean hasMultipleHitPoints() {
-    return m_hasMultipleHits;
-  }
-
-  private class UnitChooserEntryIcon extends JComponent {
-    private static final long serialVersionUID = 591598594559651745L;
-    private final boolean forceDamaged;
-    private final IUIContext uiContext;
-
-    UnitChooserEntryIcon(final boolean forceDamaged, final IUIContext uiContext) {
-      this.forceDamaged = forceDamaged;
-      this.uiContext = uiContext;
-    }
-
-    @Override
-    public void paint(final Graphics g) {
-      super.paint(g);
-      final Optional<Image> image =
-          uiContext.getUnitImageFactory().getImage(m_category.getType(), m_category.getOwner(), m_data,
-              forceDamaged || m_category.hasDamageOrBombingUnitDamage(), m_category.getDisabled());
-      if (image.isPresent()) {
-        g.drawImage(image.get(), 0, 0, this);
-      }
-
-      final Iterator<UnitOwner> iter = m_category.getDependents().iterator();
-      int index = 1;
-      while (iter.hasNext()) {
-        final UnitOwner holder = iter.next();
-        final int x = uiContext.getUnitImageFactory().getUnitImageWidth() * index;
-        final Optional<Image> unitImg =
-            uiContext.getUnitImageFactory().getImage(holder.getType(), holder.getOwner(), m_data, false, false);
-        if (unitImg.isPresent()) {
-          g.drawImage(unitImg.get(), x, 0, this);
+        if (text.getValue() < 0 || text.getValue() > text.getMax()) {
+          text.setValue(Math.max(0, Math.min(text.getMax(), text.getValue())));
         }
-        index++;
+        m_hitLabel.get(i).setText("x" + (i == 0 ? m_category.getUnits().size() : text.getMax()));
+        previousMax = text.getValue();
       }
     }
 
-    @Override
-    public int getWidth() {
-      // we draw a unit symbol for each dependent
-      return uiContext.getUnitImageFactory().getUnitImageWidth() * (1 + m_category.getDependents().size());
+    int getTotalHits() {
+      int hits = 0;
+      for (int i = 0; i < m_hitTexts.size(); i++) {
+        hits += getHits(i);
+      }
+      return hits;
     }
 
-    @Override
-    public int getHeight() {
-      return uiContext.getUnitImageFactory().getUnitImageHeight();
+    int getHits(final int zeroBasedHitsPosition) {
+      if (zeroBasedHitsPosition < 0 || zeroBasedHitsPosition > m_hitTexts.size() - 1) {
+        throw new IllegalArgumentException("Index out of range");
+      }
+      if (!m_hasMultipleHits && zeroBasedHitsPosition > 0) {
+        return 0;
+      }
+      return m_hitTexts.get(zeroBasedHitsPosition).getValue();
     }
 
-    @Override
-    public Dimension getMaximumSize() {
-      return getDimension();
+    int getFinalHit() {
+      return getHits(m_hitTexts.size() - 1);
     }
 
-    @Override
-    public Dimension getMinimumSize() {
-      return getDimension();
+    int size() {
+      return m_hitTexts.size();
     }
 
-    @Override
-    public Dimension getPreferredSize() {
-      return getDimension();
+    boolean hasMultipleHitPoints() {
+      return m_hasMultipleHits;
     }
 
-    public Dimension getDimension() {
-      return new Dimension(getWidth(), getHeight());
+    private class UnitChooserEntryIcon extends JComponent {
+      private static final long serialVersionUID = 591598594559651745L;
+      private final boolean forceDamaged;
+      private final IUIContext uiContext;
+
+      UnitChooserEntryIcon(final boolean forceDamaged, final IUIContext uiContext) {
+        this.forceDamaged = forceDamaged;
+        this.uiContext = uiContext;
+      }
+
+      @Override
+      public void paint(final Graphics g) {
+        super.paint(g);
+        final Optional<Image> image =
+            uiContext.getUnitImageFactory().getImage(m_category.getType(), m_category.getOwner(), m_data,
+                forceDamaged || m_category.hasDamageOrBombingUnitDamage(), m_category.getDisabled());
+        if (image.isPresent()) {
+          g.drawImage(image.get(), 0, 0, this);
+        }
+
+        final Iterator<UnitOwner> iter = m_category.getDependents().iterator();
+        int index = 1;
+        while (iter.hasNext()) {
+          final UnitOwner holder = iter.next();
+          final int x = uiContext.getUnitImageFactory().getUnitImageWidth() * index;
+          final Optional<Image> unitImg =
+              uiContext.getUnitImageFactory().getImage(holder.getType(), holder.getOwner(), m_data, false, false);
+          if (unitImg.isPresent()) {
+            g.drawImage(unitImg.get(), x, 0, this);
+          }
+          index++;
+        }
+      }
+
+      @Override
+      public int getWidth() {
+        // we draw a unit symbol for each dependent
+        return uiContext.getUnitImageFactory().getUnitImageWidth() * (1 + m_category.getDependents().size());
+      }
+
+      @Override
+      public int getHeight() {
+        return uiContext.getUnitImageFactory().getUnitImageHeight();
+      }
+
+      @Override
+      public Dimension getMaximumSize() {
+        return getDimension();
+      }
+
+      @Override
+      public Dimension getMinimumSize() {
+        return getDimension();
+      }
+
+      @Override
+      public Dimension getPreferredSize() {
+        return getDimension();
+      }
+
+      Dimension getDimension() {
+        return new Dimension(getWidth(), getHeight());
+      }
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -396,38 +396,37 @@ public class HistoryPanel extends JPanel {
     mouseWasOverPanel = mouseOverPanel;
     lastParent = parent;
   }
-}
 
+  private static final class HistoryTreeCellRenderer extends DefaultTreeCellRenderer {
+    private static final long serialVersionUID = -72258573320689596L;
+    private final ImageIcon icon = new ImageIcon();
+    private final IUIContext uiContext;
 
-class HistoryTreeCellRenderer extends DefaultTreeCellRenderer {
-  private static final long serialVersionUID = -72258573320689596L;
-  private final ImageIcon icon = new ImageIcon();
-  private final IUIContext uiContext;
+    HistoryTreeCellRenderer(final IUIContext uiContext) {
+      this.uiContext = uiContext;
+    }
 
-  public HistoryTreeCellRenderer(final IUIContext uiContext) {
-    this. uiContext = uiContext;
-  }
-
-  @Override
-  public Component getTreeCellRendererComponent(final JTree tree, final Object value, final boolean sel,
-      final boolean expanded, final boolean leaf, final int row, final boolean haveFocus) {
-    if (value instanceof Step) {
-      final PlayerID player = ((Step) value).getPlayerID();
-      if (player != null) {
-        if (uiContext != null) {
-          super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, haveFocus);
-          icon.setImage(uiContext.getFlagImageFactory().getSmallFlag(player));
-          setIcon(icon);
+    @Override
+    public Component getTreeCellRendererComponent(final JTree tree, final Object value, final boolean sel,
+        final boolean expanded, final boolean leaf, final int row, final boolean haveFocus) {
+      if (value instanceof Step) {
+        final PlayerID player = ((Step) value).getPlayerID();
+        if (player != null) {
+          if (uiContext != null) {
+            super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, haveFocus);
+            icon.setImage(uiContext.getFlagImageFactory().getSmallFlag(player));
+            setIcon(icon);
+          } else {
+            final String text = value.toString() + " (" + player.getName() + ")";
+            super.getTreeCellRendererComponent(tree, text, sel, expanded, leaf, row, haveFocus);
+          }
         } else {
-          final String text = value.toString() + " (" + player.getName() + ")";
-          super.getTreeCellRendererComponent(tree, text, sel, expanded, leaf, row, haveFocus);
+          super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, haveFocus);
         }
       } else {
         super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, haveFocus);
       }
-    } else {
-      super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, haveFocus);
+      return this;
     }
-    return this;
   }
 }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle OneTopLevelClass rule in UI code.

In all cases, the top-level package-private classes were made nested private classes within the only type that used them.  This allowed the static analyzer to identify methods which had no callers, and they were subsequently removed.  I also removed unnecessary access modifiers after moving a class.

This PR looks bigger than it actually is.  It is more easily reviewed by ignoring whitespace changes (`?w=1`).