### PR TITLE
Improve game loading

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -235,19 +235,19 @@ public class GameRunner {
    */
   public static void showMainFrame() {
     SwingUtilities.invokeLater(() -> {
-      gameSelectorModel.loadDefaultGame(mainFrame);
-
       mainFrame.requestFocus();
       mainFrame.toFront();
       mainFrame.setVisible(true);
-
       SwingComponents.addWindowCloseListener(mainFrame, GameRunner::exitGameIfFinished);
+      
+      new Thread(() -> {
+        gameSelectorModel.loadDefaultGame(mainFrame, false);
+        final String fileName = System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY, "");
+        if (fileName.length() > 0) {
+          gameSelectorModel.load(new File(fileName), mainFrame);
+        }
+      }).start();
 
-      final String fileName = System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY, "");
-      if (fileName.length() > 0) {
-        new Thread(() -> gameSelectorModel.load(new File(fileName), mainFrame)).start();
-      }
-      mainFrame.setVisible(true);
       if (System.getProperty(GameRunner.TRIPLEA_SERVER_PROPERTY, "false").equals("true")) {
         setupPanelModel.showServer(mainFrame);
       } else if (System.getProperty(GameRunner.TRIPLEA_CLIENT_PROPERTY, "false").equals("true")) {

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -245,8 +245,7 @@ public class GameRunner {
 
       final String fileName = System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY, "");
       if (fileName.length() > 0) {
-        final File f = new File(fileName);
-        gameSelectorModel.load(f, mainFrame);
+        new Thread(() -> gameSelectorModel.load(new File(fileName), mainFrame)).start();
       }
       mainFrame.setVisible(true);
       if (System.getProperty(GameRunner.TRIPLEA_SERVER_PROPERTY, "false").equals("true")) {

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -44,6 +44,7 @@ import games.strategy.engine.framework.systemcheck.LocalSystemChecker;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.net.Messengers;
+import games.strategy.triplea.ai.proAI.ProAI;
 import games.strategy.triplea.settings.SystemPreferenceKey;
 import games.strategy.triplea.settings.SystemPreferences;
 import games.strategy.ui.ProgressWindow;
@@ -242,6 +243,7 @@ public class GameRunner {
       SwingComponents.addWindowClosingListener(mainFrame, GameRunner::exitGameIfFinished);
       
       new Thread(() -> {
+        ProAI.gameOverClearCache();
         gameSelectorModel.loadDefaultGame(mainFrame, false);
         final String fileName = System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY, "");
         if (fileName.length() > 0) {

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -242,8 +242,8 @@ public class GameRunner {
 
       SwingComponents.addWindowClosingListener(mainFrame, GameRunner::exitGameIfFinished);
       
+      ProAI.gameOverClearCache();
       new Thread(() -> {
-        ProAI.gameOverClearCache();
         gameSelectorModel.loadDefaultGame(mainFrame, false);
         final String fileName = System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY, "");
         if (fileName.length() > 0) {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -99,7 +99,7 @@ public class GameSelectorModel extends Observable {
     return null;
   }
 
-  public synchronized void load(final File file, final Component ui) {
+  public void load(final File file, final Component ui) {
     if (!file.exists()) {
       if (ui == null) {
         System.out.println("Could not find file:" + file);
@@ -272,7 +272,7 @@ public class GameSelectorModel extends Observable {
    *        we only call with
    *        'true' if loading the user preferred map failed).
    */
-  private synchronized void loadDefaultGame(final Component ui, final boolean forceFactoryDefault) {
+  public void loadDefaultGame(final Component ui, final boolean forceFactoryDefault) {
     // load the previously saved value
     final Preferences prefs = Preferences.userNodeForPackage(this.getClass());
     if (forceFactoryDefault) {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -12,6 +12,7 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientFileSystemHelper;
@@ -154,8 +155,9 @@ public class GameSelectorModel extends Observable {
   }
 
   private static void error(final String message, final Component ui) {
-    JOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(ui), message, "Could not load Game",
-        JOptionPane.ERROR_MESSAGE);
+    SwingUtilities.invokeLater(
+        () -> JOptionPane.showMessageDialog(JOptionPane.getFrameForComponent(ui), message, "Could not load Game",
+            JOptionPane.ERROR_MESSAGE));
   }
 
   public synchronized GameData getGameData() {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -99,7 +99,7 @@ public class GameSelectorModel extends Observable {
     return null;
   }
 
-  public void load(final File file, final Component ui) {
+  public synchronized void load(final File file, final Component ui) {
     if (!file.exists()) {
       if (ui == null) {
         System.out.println("Could not find file:" + file);
@@ -123,7 +123,7 @@ public class GameSelectorModel extends Observable {
       // if the file name is xml, load it as a new game
       if (file.getName().toLowerCase().endsWith("xml")) {
         try (FileInputStream fis = new FileInputStream(file)) {
-          newData = (new GameParser(file.getAbsolutePath())).parse(fis, gameName, false);
+          newData = new GameParser(file.getAbsolutePath()).parse(fis, gameName, false);
         }
       } else {
         // try to load it as a saved game whatever the extension
@@ -262,7 +262,7 @@ public class GameSelectorModel extends Observable {
     // clear out ai cached properties (this ended up being the best place to put it, as we have definitely left a game
     // at this point)
     ProAI.gameOverClearCache();
-    loadDefaultGame(ui, false);
+    new Thread(() -> loadDefaultGame(ui, false)).start();
   }
 
   /**
@@ -272,7 +272,7 @@ public class GameSelectorModel extends Observable {
    *        we only call with
    *        'true' if loading the user preferred map failed).
    */
-  private void loadDefaultGame(final Component ui, final boolean forceFactoryDefault) {
+  private synchronized void loadDefaultGame(final Component ui, final boolean forceFactoryDefault) {
     // load the previously saved value
     final Preferences prefs = Preferences.userNodeForPackage(this.getClass());
     if (forceFactoryDefault) {


### PR DESCRIPTION
FIxes #2038
### What caused this problem:
`GameSelectorModel#loadDefaultGame` was called in a new Thread which lead to the case that the savegame was parsed faster than the default game, which made triplea load the default game instead.
### Why did this problem happen?
I'm not 100% sure, but this is my theory:
Default Game Loading is invoked before savegame loading as some sort of "fallback" if savegame loading fails.
When loading a savegame, the map loading is invoked before "applying" the game history, when the default game is the same game the savegame requires, everything of course works fine, because when the savegame is parsed, the "original map" it needs is already partially loaded and the savegame waits for the loading to end in order to apply its history (which is not the case if it's a completely different base map).
Therefore savegame loading should sometimes work in cases, where the default map takes less time to parse than the basemap for a savegame, but either did I always pic the wrong maps, which does indeed work when trying to load a WAT savegame with a Minimap default game, but not in most cases for whatever reason...