### PR TITLE
Upgrade install4j to 6.1.6

### DIFF
--- a/.travis/install_install4j
+++ b/.travis/install_install4j
@@ -12,7 +12,7 @@ fi
 mkdir -p ~/.install4j6/jres
 
 echo "Downloading and installing install4j"
-wget -O install4j_unix.sh https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_unix_6_1_5.sh
+wget -O install4j_unix.sh https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_unix_6_1_6.sh
 chmod +x install4j_unix.sh
 ./install4j_unix.sh -q
 

--- a/.travis/install_install4j
+++ b/.travis/install_install4j
@@ -12,7 +12,7 @@ fi
 mkdir -p ~/.install4j6/jres
 
 echo "Downloading and installing install4j"
-wget -O install4j_unix.sh https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_unix_6_1_6.sh
+wget --no-verbose -O install4j_unix.sh https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_unix_6_1_6.sh
 chmod +x install4j_unix.sh
 ./install4j_unix.sh -q
 


### PR DESCRIPTION
This PR is a follow-up to #2031 and completes the upgrade to install4j 6.1.6.

It also suppresses progress output when downloading the install4j installer, which reduces the log size by about 800 lines.

[Tested](https://travis-ci.org/ssoloff/triplea-game-triplea/builds/248856479) on Travis.