### PR TITLE
Revert potentially unsafe changes from #1988

### DIFF
--- a/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/src/main/java/games/strategy/engine/chat/Chat.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import games.strategy.engine.chat.IChatController.Tag;
 import games.strategy.engine.message.IChannelMessenger;
@@ -27,7 +28,7 @@ import games.strategy.util.Tuple;
  * </p>
  */
 public class Chat {
-  private final List<IChatListener> listeners = new ArrayList<>();
+  private final List<IChatListener> listeners = new CopyOnWriteArrayList<>();
   private final Messengers messengers;
   private final String chatChannelName;
   private final String chatName;

--- a/src/main/java/games/strategy/engine/chat/StatusManager.java
+++ b/src/main/java/games/strategy/engine/chat/StatusManager.java
@@ -1,15 +1,15 @@
 package games.strategy.engine.chat;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
 
 public class StatusManager {
-  private final List<IStatusListener> listeners = new ArrayList<>();
+  private final List<IStatusListener> listeners = new CopyOnWriteArrayList<>();
   private final Map<INode, String> status = new HashMap<>();
   private final Messengers messengers;
   private final Object mutex = new Object();

--- a/src/main/java/games/strategy/engine/data/GameData.java
+++ b/src/main/java/games/strategy/engine/data/GameData.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -74,9 +75,9 @@ public class GameData implements Serializable {
   private String gameName;
   private Version gameVersion;
   private int diceSides;
-  private transient List<TerritoryListener> territoryListeners = new ArrayList<>();
-  private transient List<GameDataChangeListener> dataChangeListeners = new ArrayList<>();
-  private transient List<GameMapListener> gameMapListeners = new ArrayList<>();
+  private transient List<TerritoryListener> territoryListeners = new CopyOnWriteArrayList<>();
+  private transient List<GameDataChangeListener> dataChangeListeners = new CopyOnWriteArrayList<>();
+  private transient List<GameMapListener> gameMapListeners = new CopyOnWriteArrayList<>();
   private final AllianceTracker alliances = new AllianceTracker();
   // Tracks current relationships between players, this is empty if relationships aren't used
   private final RelationshipTracker relationships = new RelationshipTracker(this);

--- a/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -1,10 +1,10 @@
 package games.strategy.engine.framework;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerID;
@@ -41,7 +41,7 @@ public abstract class AbstractGame implements IGame {
   protected IGameModifiedChannel m_gameModifiedChannel;
   protected final PlayerManager m_playerManager;
   protected boolean m_firstRun = true;
-  protected final List<GameStepListener> gameStepListeners = new ArrayList<>();
+  protected final List<GameStepListener> gameStepListeners = new CopyOnWriteArrayList<>();
 
   protected AbstractGame(final GameData data, final Set<IGamePlayer> gamePlayers,
       final Map<String, INode> remotePlayerMapping, final Messengers messengers) {

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessServerSetup.java
@@ -1,9 +1,9 @@
 package games.strategy.engine.framework.headlessGameServer;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Observer;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.swing.Action;
 
@@ -26,7 +26,7 @@ import games.strategy.util.ThreadUtil;
  */
 public class HeadlessServerSetup implements IRemoteModelListener, ISetupPanel {
   private static final long serialVersionUID = 9021977178348892504L;
-  private final List<Observer> m_listeners = new ArrayList<>();
+  private final List<Observer> m_listeners = new CopyOnWriteArrayList<>();
   private final ServerModel m_model;
   private final GameSelectorModel m_gameSelectorModel;
   private final InGameLobbyWatcherWrapper m_lobbyWatcher = new InGameLobbyWatcherWrapper();

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadCoordinator.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.framework.map.download;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -8,6 +7,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Class that accepts and queues download requests. Download requests are started in background
@@ -22,7 +22,7 @@ public final class DownloadCoordinator {
   private final Set<DownloadFile> activeDownloads = new HashSet<>();
   private final Set<DownloadFile> terminatedDownloads = new HashSet<>();
 
-  private final List<DownloadListener> downloadListeners = new ArrayList<>();
+  private final List<DownloadListener> downloadListeners = new CopyOnWriteArrayList<>();
 
   void addDownloadListener(final DownloadListener downloadListener) {
     downloadListeners.add(downloadListener);

--- a/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/src/main/java/games/strategy/net/ClientMessenger.java
@@ -10,6 +10,7 @@ import java.net.Socket;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 
 import games.strategy.debug.ClientLogger;
@@ -26,8 +27,8 @@ import games.strategy.util.ThreadUtil;
 
 public class ClientMessenger implements IClientMessenger, NIOSocketListener {
   private INode m_node;
-  private final List<IMessageListener> m_listeners = new ArrayList<>();
-  private final List<IMessengerErrorListener> m_errorListeners = new ArrayList<>();
+  private final List<IMessageListener> m_listeners = new CopyOnWriteArrayList<>();
+  private final List<IMessengerErrorListener> m_errorListeners = new CopyOnWriteArrayList<>();
   private final CountDownLatch m_initLatch = new CountDownLatch(1);
   private Exception m_connectionRefusedError;
   private final NIOSocket m_socket;

--- a/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/src/main/java/games/strategy/net/ServerMessenger.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -48,9 +49,9 @@ public class ServerMessenger implements IServerMessenger, NIOSocketListener {
   private final Node node;
   private boolean shutdown = false;
   private final NIOSocket nioSocket;
-  private final List<IMessageListener> listeners = new ArrayList<>();
-  private final List<IMessengerErrorListener> errorListeners = new ArrayList<>();
-  private final List<IConnectionChangeListener> connectionListeners = new ArrayList<>();
+  private final List<IMessageListener> listeners = new CopyOnWriteArrayList<>();
+  private final List<IMessengerErrorListener> errorListeners = new CopyOnWriteArrayList<>();
+  private final List<IConnectionChangeListener> connectionListeners = new CopyOnWriteArrayList<>();
   private boolean acceptNewConnection = false;
   private ILoginValidator loginValidator;
   // all our nodes


### PR DESCRIPTION
As discussed beginning [here](https://github.com/triplea-game/triplea/pull/1988#issuecomment-310908943).

Non-UI classes may be accessed concurrently.  Thus, it may not be safe to change instances of `CopyOnWriteArrayList` to `ArrayList`.  Further review is required to determine if any of the class fields modified in this PR are, in fact, not accessed concurrently, or are protected by a lock if accessed concurrently.  They then can be changed back to instances of `ArrayList` in a future PR.