### PR TITLE
Simplify creation of HttpClient in DownloadUtils

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadUtils.java
@@ -14,14 +14,11 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.config.CookieSpecs;
-import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClients;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -101,10 +98,7 @@ public final class DownloadUtils {
   }
 
   private static CloseableHttpClient newHttpClient() {
-    return HttpClients.custom()
-        .setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.IGNORE_COOKIES).build())
-        .setRedirectStrategy(new DefaultRedirectStrategy())
-        .build();
+    return HttpClients.custom().disableCookieManagement().build();
   }
 
   private static HttpRequestBase newHttpHeadRequest(final String uri) {


### PR DESCRIPTION
While updating `TripleAForumPoster` in #2000, I learned a simpler way to disable cookie management when building an `HttpClient`.  This PR applies that simplification to the `HttpClient` creation code in `DownloadUtils`.

It also removes the explicit redirect strategy configuration.  `HttpClientBuilder` automatically uses `DefaultRedirectStrategy` as long `disableRedirectHandling()` is not called on the builder.

I tested downloading a few maps to ensure no cookie errors were reported and redirects were followed.