### PR TITLE
Fix Travis build break [High Priority]

### DIFF
--- a/.travis/install_install4j
+++ b/.travis/install_install4j
@@ -14,7 +14,7 @@ mkdir -p ~/.install4j6/jres
 echo "Downloading and installing install4j"
 wget --no-verbose -O install4j_unix.sh https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_unix_6_1_6.sh
 chmod +x install4j_unix.sh
-./install4j_unix.sh -q
+./install4j_unix.sh -q -dir ~/install4j6
 
 mkdir -p ~/.gradle
 


### PR DESCRIPTION
We do not specify an installation directory for install4j, therefore the "default" installation directory is used.  On the previously-used Precise image, this apparently was "~/install4j6".  However, after upgrading to the Trusty image, it is now "/opt/install4j6".  Our scripts are hard-coded to expect the former location.

The fix employed in this change is to explicitly specify the install4j installation folder via the "-dir" command line switch.

Regression caused by #2033.