### PR TITLE
Update Default Player Type to String For Flexibility

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -750,9 +750,9 @@ public class GameParser {
       // boolean isOptional = Boolean.getBoolean(current.getAttribute("optional"));
       final boolean isOptional = current.getAttribute("optional").equals("true");
       final boolean canBeDisabled = current.getAttribute("canBeDisabled").equals("true");
-      final boolean isAiDefault = current.getAttribute("isAIDefault").equals("true");
+      final String defaultType = current.getAttribute("defaultType");
       final boolean isHidden = current.getAttribute("isHidden").equals("true");
-      final PlayerID newPlayer = new PlayerID(name, isOptional, canBeDisabled, isAiDefault, isHidden, data);
+      final PlayerID newPlayer = new PlayerID(name, isOptional, canBeDisabled, defaultType, isHidden, data);
       playerList.addPlayerID(newPlayer);
     }
   }

--- a/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -13,7 +13,7 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
   private static final long serialVersionUID = -2284878450555315947L;
   private final boolean m_optional;
   private final boolean m_canBeDisabled;
-  private final boolean isAiDefault;
+  private final String defaultType;
   private final boolean isHidden;
   private boolean m_isDisabled = false;
   private final UnitCollection m_unitsHeld;
@@ -25,16 +25,16 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
 
 
   public PlayerID(final String name, final GameData data) {
-    this(name, false, false, false, false, data);
+    this(name, false, false, null, false, data);
   }
 
   /** Creates new PlayerID. */
-  public PlayerID(final String name, final boolean optional, final boolean canBeDisabled, final boolean isAiDefault,
+  public PlayerID(final String name, final boolean optional, final boolean canBeDisabled, final String defaultType,
       final boolean isHidden, final GameData data) {
     super(name, data);
     m_optional = optional;
     m_canBeDisabled = canBeDisabled;
-    this.isAiDefault = isAiDefault;
+    this.defaultType = defaultType;
     this.isHidden = isHidden;
     m_unitsHeld = new UnitCollection(this, data);
     m_resources = new ResourceCollection(data);
@@ -49,8 +49,8 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
     return m_canBeDisabled;
   }
 
-  public boolean isAiDefault() {
-    return isAiDefault;
+  public String getDefaultType() {
+    return defaultType;
   }
 
   public boolean isHidden() {
@@ -94,7 +94,7 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
   }
 
   public static final PlayerID NULL_PLAYERID =
-      new PlayerID(Constants.PLAYER_NAME_NEUTRAL, true, false, false, false, null) {
+      new PlayerID(Constants.PLAYER_NAME_NEUTRAL, true, false, null, false, null) {
         // compatible with 0.9.0.2 saved games
         private static final long serialVersionUID = -6596127754502509049L;
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -77,10 +77,10 @@ class PlayerSelectorRow {
     }
     if (!(previousSelection.equals("no_one")) && Arrays.asList(types).contains(previousSelection)) {
       playerTypes.setSelectedItem(previousSelection);
-    } else if (player.getDefaultType().equals(PLAYER_TYPE_AI)) {
+    } else if (PLAYER_TYPE_AI.equals(player.getDefaultType())) {
       // the 4th in the list should be Pro AI (Hard AI)
       playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 3))]);
-    } else if (player.getDefaultType().equals(PLAYER_TYPE_DOES_NOTHING)) {
+    } else if (PLAYER_TYPE_DOES_NOTHING.equals(player.getDefaultType())) {
       // the 5th in the list should be Does Nothing AI
       playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 4))]);
     }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -23,8 +23,12 @@ import games.strategy.triplea.Constants;
 
 class PlayerSelectorRow {
 
+  private static final String PLAYER_TYPE_AI = "AI";
+  private static final String PLAYER_TYPE_DOES_NOTHING = "DoesNothing";
+
   private final JCheckBox enabledCheckBox;
   private final String playerName;
+  private final boolean isHidden;
   private final JComboBox<String> playerTypes;
   private JComponent incomePercentage;
   private final JLabel incomePercentageLabel;
@@ -37,13 +41,13 @@ class PlayerSelectorRow {
   private final SetupPanel parent;
 
   PlayerSelectorRow(final List<PlayerSelectorRow> playerRows, final PlayerID player,
-      final Map<String, String> reloadSelections,
-      final Collection<String> disableable, final HashMap<String, Boolean> playersEnablementListing,
-      final Collection<String> playerAlliances, final String[] types, final SetupPanel parent,
-      final GameProperties gameProperties) {
+      final Map<String, String> reloadSelections, final Collection<String> disableable,
+      final HashMap<String, Boolean> playersEnablementListing, final Collection<String> playerAlliances,
+      final String[] types, final SetupPanel parent, final GameProperties gameProperties) {
     this.disableable = disableable;
     this.parent = parent;
     playerName = player.getName();
+    isHidden = player.isHidden();
     name = new JLabel(playerName + ":");
 
     enabledCheckBox = new JCheckBox();
@@ -73,9 +77,12 @@ class PlayerSelectorRow {
     }
     if (!(previousSelection.equals("no_one")) && Arrays.asList(types).contains(previousSelection)) {
       playerTypes.setSelectedItem(previousSelection);
-    } else if (player.isAiDefault()) {
+    } else if (player.getDefaultType().equals(PLAYER_TYPE_AI)) {
       // the 4th in the list should be Pro AI (Hard AI)
       playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 3))]);
+    } else if (player.getDefaultType().equals(PLAYER_TYPE_DOES_NOTHING)) {
+      // the 5th in the list should be Does Nothing AI
+      playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 4))]);
     }
 
     // we do not set the default for the combo box because the default is the top item, which in this case is human
@@ -157,7 +164,9 @@ class PlayerSelectorRow {
   }
 
   void setPlayerType(final String playerType) {
-    playerTypes.setSelectedItem(playerType);
+    if (enabled && !isHidden) {
+      playerTypes.setSelectedItem(playerType);
+    }
   }
 
   String getPlayerName() {

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -36,7 +36,7 @@ class PlayerSelectorRow {
   private final JLabel puIncomeBonusLabel;
   private boolean enabled = true;
   private final JLabel name;
-  private final JButton alliances;
+  private JButton alliances;
   private final Collection<String> disableable;
   private final SetupPanel parent;
 
@@ -85,21 +85,18 @@ class PlayerSelectorRow {
       playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 4))]);
     }
 
-    // we do not set the default for the combo box because the default is the top item, which in this case is human
-    final String alliancesLabelText;
-    if (playerAlliances.contains(playerName)) {
-      alliancesLabelText = "";
-    } else {
-      alliancesLabelText = playerAlliances.toString();
+    alliances = null;
+    if (!playerAlliances.contains(playerName)) {
+      final String alliancesLabelText = playerAlliances.toString();
+      alliances = new JButton(alliancesLabelText);
+      alliances.setToolTipText("Set all " + alliancesLabelText + " to " + playerTypes.getSelectedItem().toString());
+      alliances.addActionListener(e -> {
+        final String currentType = playerTypes.getSelectedItem().toString();
+        playerRows.stream()
+            .filter(row -> row.alliances.getText().equals(alliancesLabelText))
+            .forEach(row -> row.setPlayerType(currentType));
+      });
     }
-    alliances = new JButton(alliancesLabelText);
-    alliances.setToolTipText("Set all " + alliancesLabelText + " to " + playerTypes.getSelectedItem().toString());
-    alliances.addActionListener(e -> {
-      final String currentType = playerTypes.getSelectedItem().toString();
-      playerRows.stream()
-          .filter(row -> row.alliances.getText().equals(alliancesLabelText))
-          .forEach(row -> row.setPlayerType(currentType));
-    });
 
     // TODO: remove null check for next incompatible release
     incomePercentage = null;
@@ -130,8 +127,11 @@ class PlayerSelectorRow {
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     container.add(playerTypes, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
-    container.add(alliances, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
-        GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
+    if (alliances != null) {
+      container.add(alliances, new GridBagConstraints(gridx, row, 1, 1, 0, 0, GridBagConstraints.WEST,
+          GridBagConstraints.NONE, new Insets(0, 7, 5, 5), 0, 0));
+    }
+    gridx++;
     // TODO: remove null check for next incompatible release
     if (incomePercentage != null) {
       container.add(incomePercentage, new GridBagConstraints(gridx++, row, 1, 1, 0, 0, GridBagConstraints.WEST,
@@ -183,7 +183,9 @@ class PlayerSelectorRow {
 
   private void setWidgetActivation() {
     name.setEnabled(enabled);
-    alliances.setEnabled(enabled);
+    if (alliances != null) {
+      alliances.setEnabled(enabled);
+    }
     enabledCheckBox.setEnabled(disableable.contains(playerName));
     // TODO: remove null check for next incompatible release
     if (incomePercentage != null) {

--- a/src/main/resources/games/strategy/engine/xml/game.dtd
+++ b/src/main/resources/games/strategy/engine/xml/game.dtd
@@ -81,8 +81,8 @@
 		name ID #REQUIRED
 		optional (true | false) 'false'
 		canBeDisabled (true | false) 'false'
-		isAIDefault (true | false) 'false'
-		isHidden (true | false) 'false'
+		defaultType (Human | AI | DoesNothing) 'Human'
+		isHidden (true | false) 'false' 
 	>
 	<!ELEMENT alliance EMPTY>
 

--- a/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
+++ b/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
@@ -28,7 +28,7 @@ public class UnitCollectionTest {
   private UnitType unitTypeOne;
   private UnitType unitTypeTwo;
   @Mock
-  private final PlayerID defaultPlayerId = Mockito.spy(new PlayerID("Default Player", true, false, false, false, null));
+  private final PlayerID defaultPlayerId = Mockito.spy(new PlayerID("Default Player", true, false, null, false, null));
   @Mock
   private PlayerID otherPlayerId;
   private UnitCollection unitCollection;


### PR DESCRIPTION
Further addresses: https://forums.triplea-game.org/topic/132/handling-of-ai-players-not-meant-to-be-played-github-request

Functional Changes:
- Game XML player property changed from isAIDefault to defaultType to allow for "Human", "AI", "DoesNothing". Default is still "Human".
- Added checks that player row is enabled and not hidden when using set all player type or player type for alliance functionality
- Only display alliance button if player is in an alliance (don't show empty button)

Examples:
`<player name="Germans" optional="false" defaultType="AI" />`
`<player name="Italians" optional="false" defaultType="DoesNothing" />`