### PR TITLE
Prevent subclassing of Match

### DIFF
--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -26,9 +26,18 @@ import java.util.function.Predicate;
  * count the number of matches, see if any elements match etc.
  * </p>
  *
+ * <p>
+ * Instances of this class are immutable.
+ * </p>
+ *
  * @param <T> The type of object that is tested by the match condition.
  */
-public abstract class Match<T> {
+public final class Match<T> {
+  private final Predicate<T> condition;
+
+  private Match(final Predicate<T> condition) {
+    this.condition = condition;
+  }
 
   /**
    * Returns a match whose condition is always satisfied.
@@ -154,13 +163,14 @@ public abstract class Match<T> {
   }
 
   /**
-   * Subclasses must override this method.
    * Returns true if the object matches some condition.
    */
-  public abstract boolean match(T o);
+  public boolean match(final T value) {
+    return condition.test(value);
+  }
 
-  public final Match<T> invert() {
-    return Match.of(not(this::match));
+  public Match<T> invert() {
+    return Match.of(not(condition));
   }
 
   /**
@@ -173,12 +183,7 @@ public abstract class Match<T> {
   public static <T> Match<T> of(final Predicate<T> condition) {
     checkNotNull(condition);
 
-    return new Match<T>() {
-      @Override
-      public boolean match(final T value) {
-        return condition.test(value);
-      }
-    };
+    return new Match<>(condition);
   }
 
   /**

--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -89,6 +89,8 @@ public abstract class Match<T> {
    * returns true if all elements in the collection match.
    */
   public static <T> boolean allMatch(final Collection<T> collection, final Match<T> match) {
+    // XXX: This method should probably return true when the collection is empty to be consistent with Stream#allMatch
+    // (i.e. the match is vacuously satisfied)
     if (collection.isEmpty()) {
       return false;
     }

--- a/src/test/java/games/strategy/util/MatchTest.java
+++ b/src/test/java/games/strategy/util/MatchTest.java
@@ -7,31 +7,20 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Test;
 
 public class MatchTest {
+  private static final Match<Integer> IS_ZERO_MATCH = Match.of(it -> it == 0);
+
   private static final Object VALUE = new Object();
 
-  private final Collection<Integer> ints = Arrays.asList(-1, -2, -3, 0, 1, 2, 3);
-  private final Match<Integer> pos = Match.of(it -> it > 0);
-  private final Match<Integer> neg = Match.of(it -> it < 0);
-  private final Match<Integer> zero = Match.of(it -> it == 0);
-
   @Test
-  public void testNever() {
-    assertFalse(Match.someMatch(ints, Match.never()));
-    assertFalse(Match.allMatch(ints, Match.never()));
-  }
-
-  @Test
-  public void testMatches() {
-    assertTrue(pos.match(1));
-    assertTrue(!pos.match(-1));
-    assertTrue(neg.match(-1));
-    assertTrue(!neg.match(1));
-    assertTrue(zero.match(0));
-    assertTrue(!zero.match(1));
+  public void testMatch() {
+    assertFalse(IS_ZERO_MATCH.match(-1));
+    assertTrue(IS_ZERO_MATCH.match(0));
+    assertFalse(IS_ZERO_MATCH.match(1));
   }
 
   @Test
@@ -42,8 +31,12 @@ public class MatchTest {
 
   @Test
   public void testAlways() {
-    assertTrue(Match.someMatch(ints, Match.always()));
-    assertTrue(Match.allMatch(ints, Match.always()));
+    assertTrue(Match.always().match(VALUE));
+  }
+
+  @Test
+  public void testNever() {
+    assertFalse(Match.never().match(VALUE));
   }
 
   @Test
@@ -74,20 +67,92 @@ public class MatchTest {
 
   @Test
   public void testGetMatches() {
-    assertEquals(Arrays.asList(), Match.getMatches(Arrays.asList(), Match.always()));
-
     final Collection<Integer> input = Arrays.asList(-1, 0, 1);
-    assertEquals(Arrays.asList(), Match.getMatches(input, Match.never()));
-    assertEquals(Arrays.asList(-1, 0, 1), Match.getMatches(input, Match.always()));
-    assertEquals(Arrays.asList(-1, 1), Match.getMatches(input, Match.of(value -> value != 0)));
+
+    assertEquals("empty collection", Arrays.asList(), Match.getMatches(Arrays.asList(), Match.always()));
+    assertEquals("none match", Arrays.asList(), Match.getMatches(input, Match.never()));
+    assertEquals("some match", Arrays.asList(-1, 1), Match.getMatches(input, IS_ZERO_MATCH.invert()));
+    assertEquals("all match", Arrays.asList(-1, 0, 1), Match.getMatches(input, Match.always()));
   }
 
   @Test
-  public void testMap() {
-    final HashMap<String, String> map = new HashMap<>();
+  public void testGetNMatches() {
+    final Collection<Integer> input = Arrays.asList(-1, 0, 1);
+
+    assertEquals("empty collection", Arrays.asList(), Match.getNMatches(Arrays.asList(), 999, Match.always()));
+    assertEquals("max = 0", Arrays.asList(), Match.getNMatches(input, 0, Match.never()));
+    assertEquals("none match", Arrays.asList(), Match.getNMatches(input, input.size(), Match.never()));
+    assertEquals("some match; max < count",
+        Arrays.asList(0),
+        Match.getNMatches(Arrays.asList(-1, 0, 0, 1), 1, IS_ZERO_MATCH));
+    assertEquals("some match; max = count",
+        Arrays.asList(0, 0),
+        Match.getNMatches(Arrays.asList(-1, 0, 0, 1), 2, IS_ZERO_MATCH));
+    assertEquals("some match; max > count",
+        Arrays.asList(0, 0),
+        Match.getNMatches(Arrays.asList(-1, 0, 0, 1), 3, IS_ZERO_MATCH));
+    assertEquals("all match; max < count",
+        Arrays.asList(-1, 0),
+        Match.getNMatches(input, input.size() - 1, Match.always()));
+    assertEquals("all match; max = count",
+        Arrays.asList(-1, 0, 1),
+        Match.getNMatches(input, input.size(), Match.always()));
+    assertEquals("all match; max > count",
+        Arrays.asList(-1, 0, 1),
+        Match.getNMatches(input, input.size() + 1, Match.always()));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetNMatches_ShouldThrowExceptionWhenMaxIsNegative() {
+    Match.getNMatches(Arrays.asList(-1, 0, 1), -1, Match.always());
+  }
+
+  @Test
+  public void testAllMatch() {
+    assertFalse("empty collection", Match.allMatch(Arrays.asList(), IS_ZERO_MATCH));
+    assertFalse("none match", Match.allMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH));
+    assertFalse("some match", Match.allMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH));
+    assertTrue("all match (one element)", Match.allMatch(Arrays.asList(0), IS_ZERO_MATCH));
+    assertTrue("all match (multiple elements)", Match.allMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH));
+  }
+
+  @Test
+  public void testSomeMatch() {
+    assertFalse("empty collection", Match.someMatch(Arrays.asList(), IS_ZERO_MATCH));
+    assertFalse("none match", Match.someMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH));
+    assertTrue("some match (one element)", Match.someMatch(Arrays.asList(0), IS_ZERO_MATCH));
+    assertTrue("some match (multiple elements)", Match.someMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH));
+    assertTrue("all match (one element)", Match.someMatch(Arrays.asList(0), IS_ZERO_MATCH));
+    assertTrue("all match (multiple elements)", Match.someMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH));
+  }
+
+  @Test
+  public void testNoneMatch() {
+    assertTrue("empty collection", Match.noneMatch(Arrays.asList(), IS_ZERO_MATCH));
+    assertTrue("none match (one element)", Match.noneMatch(Arrays.asList(-1), IS_ZERO_MATCH));
+    assertTrue("none match (multiple elements)", Match.noneMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH));
+    assertFalse("some match", Match.noneMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH));
+    assertFalse("all match", Match.noneMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH));
+  }
+
+  @Test
+  public void testCountMatches() {
+    assertEquals(0, Match.countMatches(Arrays.asList(), IS_ZERO_MATCH));
+
+    assertEquals(1, Match.countMatches(Arrays.asList(0), IS_ZERO_MATCH));
+    assertEquals(1, Match.countMatches(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH));
+
+    assertEquals(2, Match.countMatches(Arrays.asList(0, 0), IS_ZERO_MATCH));
+    assertEquals(2, Match.countMatches(Arrays.asList(-1, 0, 1, 0), IS_ZERO_MATCH));
+  }
+
+  @Test
+  public void testGetKeysWhereValueMatch() {
+    final Map<String, String> map = new HashMap<>();
     map.put("a", "b");
     map.put("b", "c");
     map.put("c", "d");
+
     assertEquals(3, Match.getKeysWhereValueMatch(map, Match.always()).size());
     assertEquals(0, Match.getKeysWhereValueMatch(map, Match.never()).size());
   }


### PR DESCRIPTION
Now that there are no longer any concrete nor anonymous subclasses of `Match`, there is no need to be able to subclass `Match`, and it can be implemented in terms of a single `Predicate` field.  I also took the opportunity to write unit tests for all of the uncovered `Match` methods (probably the majority of this change).

One consequence of writing these tests was that I discovered that the logic of `Match#allMatch()` may be incorrect from an algorithmic perspective when the input collection is empty.  However, I didn't change the logic because there may be a lot of code that depends on the current behavior.  I did note the issue with a comment and added a unit test to capture the current behavior.