### PR TITLE
Checkstyle: Fix generic type name violations

### DIFF
--- a/src/main/java/games/strategy/triplea/player/AbstractHumanPlayer.java
+++ b/src/main/java/games/strategy/triplea/player/AbstractHumanPlayer.java
@@ -6,8 +6,8 @@ import games.strategy.triplea.ui.MainGameFrame;
  * As a rule, nothing that changes GameData should be in here (it should be in a delegate, and done through an IDelegate
  * using a change).
  */
-public abstract class AbstractHumanPlayer<CustomGameFrame extends MainGameFrame> extends AbstractBasePlayer {
-  protected CustomGameFrame ui;
+public abstract class AbstractHumanPlayer<T extends MainGameFrame> extends AbstractBasePlayer {
+  protected T ui;
 
   /**
    * @param name
@@ -17,7 +17,7 @@ public abstract class AbstractHumanPlayer<CustomGameFrame extends MainGameFrame>
     super(name, type);
   }
 
-  public final void setFrame(final CustomGameFrame frame) {
+  public final void setFrame(final T frame) {
     ui = frame;
   }
 }

--- a/src/main/java/games/strategy/triplea/player/AbstractHumanPlayer.java
+++ b/src/main/java/games/strategy/triplea/player/AbstractHumanPlayer.java
@@ -5,6 +5,8 @@ import games.strategy.triplea.ui.MainGameFrame;
 /**
  * As a rule, nothing that changes GameData should be in here (it should be in a delegate, and done through an IDelegate
  * using a change).
+ *
+ * @param <T> The type of the frame window associated with the player.
  */
 public abstract class AbstractHumanPlayer<T extends MainGameFrame> extends AbstractBasePlayer {
   protected T ui;

--- a/src/main/java/games/strategy/triplea/settings/SettingInputComponent.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingInputComponent.java
@@ -3,6 +3,8 @@ package games.strategy.triplea.settings;
 /**
  * Wrapper API around a 'settings' object, allows for a GUI interface that allows a user to read descriptions about
  * each setting in the object, and to update the value.
+ *
+ * @param <T> The type of the object that contains the settings data.
  */
 public interface SettingInputComponent<T extends HasDefaults> {
 

--- a/src/main/java/games/strategy/triplea/settings/SettingInputComponent.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingInputComponent.java
@@ -4,7 +4,7 @@ package games.strategy.triplea.settings;
  * Wrapper API around a 'settings' object, allows for a GUI interface that allows a user to read descriptions about
  * each setting in the object, and to update the value.
  */
-public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
+public interface SettingInputComponent<T extends HasDefaults> {
 
   /**
    * @return Short two or three word label of the user setting. Use 'getDescription' to provide more detail.
@@ -36,7 +36,7 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
    *
    * @param toUpdate The 'Settings' data object to be updated.
    */
-  boolean updateSettings(SettingsObjectType toUpdate);
+  boolean updateSettings(T toUpdate);
 
   /**
    * Method to read the settings value from the SettingsObject that has the value saved.
@@ -44,7 +44,7 @@ public interface SettingInputComponent<SettingsObjectType extends HasDefaults> {
    * @param settingsType Settings object which has the current stored user setting value
    * @return An extracted value corresponding to the current setting from the 'settings' object.
    */
-  String getValue(SettingsObjectType settingsType);
+  String getValue(T settingsType);
 
   /**
    * In cases where we try to update to an invalid value, set Value is called to restore the default/previous valid

--- a/src/main/java/games/strategy/triplea/settings/SettingInputComponentFactory.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingInputComponentFactory.java
@@ -132,17 +132,15 @@ public final class SettingInputComponentFactory {
     }
   }
 
-  private static class SettingsModelReaderWriter<Type extends HasDefaults> {
-    private final Function<Type, String> settingsReader;
-    private final BiConsumer<Type, String> settingsWriter;
+  private static class SettingsModelReaderWriter<T extends HasDefaults> {
+    private final Function<T, String> settingsReader;
+    private final BiConsumer<T, String> settingsWriter;
 
-    SettingsModelReaderWriter(Function<Type, String> settingsReader,
-        BiConsumer<Type, String> settingsWriter) {
+    SettingsModelReaderWriter(Function<T, String> settingsReader,
+        BiConsumer<T, String> settingsWriter) {
       this.settingsWriter = settingsWriter;
       this.settingsReader = settingsReader;
     }
-
-
   }
 
   private static <T extends HasDefaults> SettingInputComponent<T> build(

--- a/src/main/java/games/strategy/triplea/settings/SettingsTab.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingsTab.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import games.strategy.ui.SwingComponents;
 
+/**
+ * @param <T> The type of the object that contains the settings data.
+ */
 public interface SettingsTab<T extends HasDefaults> {
   String getTabTitle();
 

--- a/src/main/java/games/strategy/triplea/settings/SettingsTab.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingsTab.java
@@ -5,14 +5,14 @@ import java.util.List;
 
 import games.strategy.ui.SwingComponents;
 
-public interface SettingsTab<SettingsModelType extends HasDefaults> {
+public interface SettingsTab<T extends HasDefaults> {
   String getTabTitle();
 
-  List<SettingInputComponent<SettingsModelType>> getInputs();
+  List<SettingInputComponent<T>> getInputs();
 
-  SettingsModelType getSettingsObject();
+  T getSettingsObject();
 
-  default void updateSettings(final List<SettingInputComponent<SettingsModelType>> inputs) {
+  default void updateSettings(final List<SettingInputComponent<T>> inputs) {
     final StringBuilder msg = new StringBuilder();
     final StringBuilder failMsg = new StringBuilder();
 
@@ -21,8 +21,8 @@ public interface SettingsTab<SettingsModelType extends HasDefaults> {
     boolean somethingInvalid = false;
 
     final List<String> invalidValues = new ArrayList<>();
-    for (final SettingInputComponent<SettingsModelType> input : inputs) {
-      final SettingsModelType settingsObject = getSettingsObject();
+    for (final SettingInputComponent<T> input : inputs) {
+      final T settingsObject = getSettingsObject();
 
       final String oldValue = input.getValue(settingsObject);
 


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ClassTypeParameterName and InterfaceTypeParameterName rules.  It also fixes the corresponding JavadocType rule violations for missing generic type parameter `@param` tags in the Javadocs.