### PR TITLE
Rename Match factory methods

### DIFF
--- a/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -40,7 +40,7 @@ public class CompositeRouteFinder {
 
   Route findRoute(final Territory start, final Territory end) {
     final Set<Territory> allMatchingTers =
-        new HashSet<>(Match.getMatches(m_map.getTerritories(), Match.any(m_matches.keySet())));
+        new HashSet<>(Match.getMatches(m_map.getTerritories(), Match.anyOf(m_matches.keySet())));
     final Map<Territory, Integer> terScoreMap = createScoreMap();
     final Map<Territory, Integer> routeScoreMap = new HashMap<>();
     int bestRouteToEndScore = Integer.MAX_VALUE;

--- a/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/src/main/java/games/strategy/engine/data/GameMap.java
@@ -392,7 +392,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   public Route getRoute_IgnoreEnd(final Territory t1, final Territory t2, final Match<Territory> match) {
-    return getRoute(t1, t2, Match.any(Matches.territoryIs(t2), match));
+    return getRoute(t1, t2, Match.anyOf(Matches.territoryIs(t2), match));
   }
 
   /**
@@ -419,7 +419,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     if (t1 == t2) {
       return new Route(t1);
     }
-    final Match<Territory> allCond = Match.any(matches.keySet());
+    final Match<Territory> allCond = Match.anyOf(matches.keySet());
     if (getNeighbors(t1, allCond).contains(t2)) {
       return new Route(t1, t2);
     }
@@ -497,7 +497,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    *         or -1 if they are not connected. (Distance includes to the end)
    */
   public int getDistance_IgnoreEndForCondition(final Territory t1, final Territory t2, final Match<Territory> cond) {
-    return getDistance(t1, t2, Match.any(Matches.territoryIs(t2), cond));
+    return getDistance(t1, t2, Match.anyOf(Matches.territoryIs(t2), cond));
   }
 
   /**

--- a/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -154,14 +154,14 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
     boolean hasFactory = false;
     boolean ownsLand = false;
     for (final Territory t : data.getMap().getTerritories()) {
-      if (t.getUnits().someMatch(Match.all(Matches.unitIsOwnedBy(this),
+      if (t.getUnits().someMatch(Match.allOf(Matches.unitIsOwnedBy(this),
           Matches.unitHasAttackValueOfAtLeast(1), Matches.UnitCanMove, Matches.UnitIsLand))) {
         return true;
       }
       if (t.getOwner().equals(this)) {
         ownsLand = true;
       }
-      if (t.getUnits().someMatch(Match.all(Matches.unitIsOwnedBy(this), Matches.UnitCanProduceUnits))) {
+      if (t.getUnits().someMatch(Match.allOf(Matches.unitIsOwnedBy(this), Matches.UnitCanProduceUnits))) {
         hasFactory = true;
       }
       if (ownsLand && hasFactory) {

--- a/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
@@ -46,7 +46,7 @@ class RelationshipChange extends Change {
     // now redraw territories in case of new hostility
     if (Matches.RelationshipTypeIsAtWar.match(data.getRelationshipTypeList().getRelationshipType(m_NewRelation))) {
       for (final Territory t : Match.getMatches(data.getMap().getTerritories(),
-          Match.all(
+          Match.allOf(
               Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerID(m_player1)),
               Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerID(m_player2))))) {
         t.notifyChanged();

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -387,7 +387,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
         && !id.getRepairFrontier().getRules().isEmpty()) {
       final GameData data = getGameData();
       if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
-        final Match<Unit> myDamaged = Match.all(Matches.unitIsOwnedBy(id), Matches.UnitHasTakenSomeBombingUnitDamage);
+        final Match<Unit> myDamaged = Match.allOf(Matches.unitIsOwnedBy(id), Matches.UnitHasTakenSomeBombingUnitDamage);
         final Collection<Unit> damagedUnits = new ArrayList<>();
         for (final Territory t : data.getMap().getTerritories()) {
           damagedUnits.addAll(Match.getMatches(t.getUnits().getUnits(), myDamaged));

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -157,7 +157,7 @@ public class AIUtils {
         // If this is the first carrier seek
         if (seekedCarrier == null) {
           final int seekedCarrierIndex = getIndexOfLastUnitMatching(result,
-              Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+              Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
           if (seekedCarrierIndex == -1) {
             // No carriers left
             break;
@@ -186,7 +186,7 @@ public class AIUtils {
             filledCarriers.add(seekedCarrier);
             // Find the next carrier
             seekedCarrier = getLastUnitMatching(result,
-                Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               // No carriers left
               break;
@@ -224,7 +224,7 @@ public class AIUtils {
             }
             // Find the next carrier
             seekedCarrier = getLastUnitMatching(result,
-                Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               // No carriers left
               break;

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -319,7 +319,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
       if (notOwned.isEmpty()) {
         // only owned territories left
         final boolean nonFactoryUnitsLeft = Match.someMatch(unitChoices, Matches.UnitCanProduceUnits.invert());
-        final Match<Unit> ownedFactories = Match.all(Matches.UnitCanProduceUnits, Matches.unitIsOwnedBy(me));
+        final Match<Unit> ownedFactories = Match.allOf(Matches.UnitCanProduceUnits, Matches.unitIsOwnedBy(me));
         final List<Territory> capitals = TerritoryAttachment.getAllCapitals(me, data);
         final List<Territory> test = new ArrayList<>(capitals);
         test.retainAll(territoryChoices);
@@ -331,7 +331,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
             picked = test.get(0);
           } else {
             if (capitals.isEmpty()) {
-              capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.all(
+              capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.allOf(
                   Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.TerritoryIsLand)));
             }
             final List<Territory> doesNotHaveFactoryYet =
@@ -362,7 +362,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
             picked = test.get(0);
           } else {
             if (capitals.isEmpty()) {
-              capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.all(
+              capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.allOf(
                   Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.TerritoryIsLand)));
             }
             if (capitals.isEmpty()) {
@@ -393,7 +393,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
           picked = test.get(0);
         } else {
           if (capitals.isEmpty()) {
-            capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.all(
+            capitals.addAll(Match.getMatches(data.getMap().getTerritories(), Match.allOf(
                 Matches.isTerritoryOwnedBy(me), Matches.territoryHasUnitsOwnedBy(me), Matches.TerritoryIsLand)));
           }
           if (capitals.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -1217,7 +1217,7 @@ class ProNonCombatMoveAI {
           final Set<Territory> cantHoldTerritories = new HashSet<>();
           while (true) {
             final Match<Territory> match =
-                Match.all(ProMatches.territoryCanMoveSeaUnitsThrough(player, data, false),
+                Match.allOf(ProMatches.territoryCanMoveSeaUnitsThrough(player, data, false),
                     Matches.territoryIsInList(cantHoldTerritories).invert());
             final Route route = data.getMap().getRoute_IgnoreEnd(currentTerritory, patd.getTerritory(), match);
             if (route == null

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
@@ -50,7 +50,7 @@ class ProPoliticsAI {
         AIPoliticalUtils.getPoliticalActionsTowardsWar(player, politicsDelegate.getTestedConditions(), data);
     ProLogger.trace("War options: " + actionChoicesTowardsWar);
     final List<PoliticalActionAttachment> validWarActions =
-        Match.getMatches(actionChoicesTowardsWar, Match.all(
+        Match.getMatches(actionChoicesTowardsWar, Match.allOf(
             Matches.abstractUserActionAttachmentCanBeAttempted(politicsDelegate.getTestedConditions())));
     ProLogger.trace("Valid War options: " + validWarActions);
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -73,7 +73,7 @@ class ProPurchaseAI {
     // Current data at the start of combat move
     this.data = data;
     this.player = player;
-    final Match<Unit> ourFactories = Match.all(Matches.unitIsOwnedBy(player),
+    final Match<Unit> ourFactories = Match.allOf(Matches.unitIsOwnedBy(player),
         Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
     final List<Territory> rfactories = Match.getMatches(data.getMap().getTerritories(),
         ProMatches.territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data));

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -107,19 +107,19 @@ final class ProTechAI {
       float strength = 0.0F;
       float airStrength = 0.0F;
       enemyPlayer = playerIter.next();
-      final Match<Unit> enemyPlane = Match.all(
+      final Match<Unit> enemyPlane = Match.allOf(
           Matches.UnitIsAir,
           Matches.unitIsOwnedBy(enemyPlayer),
           Matches.UnitCanMove);
-      final Match<Unit> enemyTransport = Match.all(Matches.unitIsOwnedBy(enemyPlayer),
+      final Match<Unit> enemyTransport = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
           Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
-      final Match<Unit> enemyShip = Match.all(
+      final Match<Unit> enemyShip = Match.allOf(
           Matches.unitIsOwnedBy(enemyPlayer),
           Matches.UnitIsSea,
           Matches.UnitCanMove);
-      final Match<Unit> enemyTransportable = Match.all(Matches.unitIsOwnedBy(enemyPlayer),
+      final Match<Unit> enemyTransportable = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
           Matches.UnitCanBeTransported, Matches.UnitIsNotAA, Matches.UnitCanMove);
-      final Match<Unit> aTransport = Match.all(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
+      final Match<Unit> aTransport = Match.allOf(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
       final List<Territory> eFTerrs = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0;
       int maxBomberDistance = 0;
@@ -373,8 +373,8 @@ final class ProTechAI {
     final HashSet<Integer> ignore = new HashSet<>();
     ignore.add(1);
     final Match<Unit> blitzUnit =
-        Match.all(Matches.unitIsOwnedBy(enemyPlayer), Matches.UnitCanBlitz, Matches.UnitCanMove);
-    final Match<Territory> validBlitzRoute = Match.all(
+        Match.allOf(Matches.unitIsOwnedBy(enemyPlayer), Matches.UnitCanBlitz, Matches.UnitCanMove);
+    final Match<Territory> validBlitzRoute = Match.allOf(
         Matches.territoryHasNoEnemyUnits(enemyPlayer, data),
         Matches.territoryIsNotImpassableToLandUnits(enemyPlayer, data));
     final List<Route> routes = new ArrayList<>();
@@ -468,9 +468,9 @@ final class ProTechAI {
     final Queue<Territory> q = new LinkedList<>();
     Territory lz = null;
     Territory ac = null;
-    final Match<Unit> enemyPlane = Match.all(Matches.UnitIsAir, Matches.unitIsOwnedBy(player), Matches.UnitCanMove);
+    final Match<Unit> enemyPlane = Match.allOf(Matches.UnitIsAir, Matches.unitIsOwnedBy(player), Matches.UnitCanMove);
     final Match<Unit> enemyCarrier =
-        Match.all(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player), Matches.UnitCanMove);
+        Match.allOf(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player), Matches.UnitCanMove);
     q.add(start);
     Territory current = null;
     distance.put(start, 0);
@@ -541,8 +541,8 @@ final class ProTechAI {
     if (start == null || destination == null || !start.isWater() || !destination.isWater()) {
       return null;
     }
-    final Match<Unit> sub = Match.all(Matches.UnitIsSub.invert());
-    final Match<Unit> transport = Match.all(Matches.UnitIsTransport.invert(), Matches.UnitIsLand.invert());
+    final Match<Unit> sub = Match.allOf(Matches.UnitIsSub.invert());
+    final Match<Unit> transport = Match.allOf(Matches.UnitIsTransport.invert(), Matches.UnitIsLand.invert());
     final Match.CompositeBuilder<Unit> unitCondBuilder = Match.newCompositeBuilder(
         Matches.UnitIsInfrastructure.invert(),
         Matches.alliedUnit(player, data).invert());
@@ -552,12 +552,12 @@ final class ProTechAI {
     if (Properties.getIgnoreSubInMovement(data)) {
       unitCondBuilder.add(sub);
     }
-    final Match<Territory> routeCond = Match.all(
+    final Match<Territory> routeCond = Match.allOf(
         Matches.territoryHasUnitsThatMatch(unitCondBuilder.all()).invert(),
         Matches.TerritoryIsWater);
     final Match<Territory> routeCondition;
     if (attacking) {
-      routeCondition = Match.any(Matches.territoryIs(destination), routeCond);
+      routeCondition = Match.anyOf(Matches.territoryIs(destination), routeCond);
     } else {
       routeCondition = routeCond;
     }
@@ -570,7 +570,7 @@ final class ProTechAI {
     // if we fail due to canal, then don't go near any enemy canals
     if (MoveValidator.validateCanal(r, null, player, data) != null) {
       r = data.getMap().getRoute(start, destination,
-          Match.all(routeCondition, Matches.territoryHasNonAllowedCanal(player, null, data).invert()));
+          Match.allOf(routeCondition, Matches.territoryHasNonAllowedCanal(player, null, data).invert()));
     }
     if (r == null || r.getEnd() == null) {
       return null;
@@ -632,7 +632,7 @@ final class ProTechAI {
    */
   private static List<Territory> findFontier(final Territory start, final Match<Territory> endCondition,
       final Match<Territory> routeCondition, final int distance, final GameData data) {
-    final Match<Territory> canGo = Match.any(endCondition, routeCondition);
+    final Match<Territory> canGo = Match.anyOf(endCondition, routeCondition);
     final IntegerMap<Territory> visited = new IntegerMap<>();
     final Queue<Territory> q = new LinkedList<>();
     final List<Territory> frontier = new ArrayList<>();
@@ -671,7 +671,7 @@ final class ProTechAI {
    */
   private static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units
-    final Match<Unit> limitShips = Match.all(unitCondition);
+    final Match<Unit> limitShips = Match.allOf(unitCondition);
     final List<Territory> shipTerr = new ArrayList<>();
     final Collection<Territory> tNeighbors = data.getMap().getTerritories();
     for (final Territory t2 : tNeighbors) {
@@ -745,6 +745,6 @@ final class ProTechAI {
    * Assumes that water is passable to air units always.
    */
   private static Match<Territory> territoryIsImpassableToAirUnits() {
-    return Match.all(Matches.TerritoryIsLand, Matches.TerritoryIsImpassable);
+    return Match.allOf(Matches.TerritoryIsLand, Matches.TerritoryIsImpassable);
   }
 }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -185,13 +185,13 @@ public class ProTerritoryManager {
         maxScrambleDistance = ua.getMaxScrambleDistance();
       }
     }
-    final Match<Unit> airbasesCanScramble = Match.all(Matches.unitIsEnemyOf(data, player),
+    final Match<Unit> airbasesCanScramble = Match.allOf(Matches.unitIsEnemyOf(data, player),
         Matches.UnitIsAirBase, Matches.UnitIsNotDisabled, Matches.unitIsBeingTransported().invert());
     final Match.CompositeBuilder<Territory> canScrambleBuilder = Match.newCompositeBuilder(
-        Match.any(
+        Match.anyOf(
             Matches.TerritoryIsWater,
             Matches.isTerritoryEnemy(player, data)),
-        Matches.territoryHasUnitsThatMatch(Match.all(
+        Matches.territoryHasUnitsThatMatch(Match.allOf(
             Matches.UnitCanScramble,
             Matches.unitIsEnemyOf(data, player),
             Matches.UnitIsNotDisabled)),
@@ -224,7 +224,7 @@ public class ProTerritoryManager {
         final int maxCanScramble = getMaxScrambleCount(airbases);
         final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.TerritoryIsNotImpassable);
         List<Unit> canScrambleAir = from.getUnits()
-            .getMatches(Match.all(Matches.unitIsEnemyOf(data, player), Matches.UnitCanScramble,
+            .getMatches(Match.allOf(Matches.unitIsEnemyOf(data, player), Matches.UnitCanScramble,
                 Matches.UnitIsNotDisabled, Matches.UnitWasScrambled.invert(),
                 Matches.unitCanScrambleOnRouteDistance(toBattleRoute)));
 
@@ -247,7 +247,7 @@ public class ProTerritoryManager {
   }
 
   private static int getMaxScrambleCount(final Collection<Unit> airbases) {
-    if (!Match.allMatch(airbases, Match.all(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
+    if (!Match.allMatch(airbases, Match.allOf(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
       throw new IllegalStateException("All units must be viable airbases");
     }
 
@@ -739,10 +739,10 @@ public class ProTerritoryManager {
       // Find my transports and amphibious units that have movement left
       final List<Unit> myTransportUnits =
           myUnitTerritory.getUnits().getMatches(ProMatches.unitCanBeMovedAndIsOwnedTransport(player, isCombatMove));
-      Match<Territory> unloadAmphibTerritoryMatch = Match.all(
+      Match<Territory> unloadAmphibTerritoryMatch = Match.allOf(
           ProMatches.territoryCanMoveLandUnits(player, data, isCombatMove), moveAmphibToTerritoryMatch);
       if (isIgnoringRelationships) {
-        unloadAmphibTerritoryMatch = Match.all(
+        unloadAmphibTerritoryMatch = Match.allOf(
             ProMatches.territoryCanPotentiallyMoveLandUnits(player, data), moveAmphibToTerritoryMatch);
       }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -22,8 +22,8 @@ public class ProMatches {
 
   public static Match<Territory> territoryCanLandAirUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove, final List<Territory> enemyTerritories, final List<Territory> alliedTerritories) {
-    return Match.any(Matches.territoryIsInList(alliedTerritories),
-        Match.all(Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data),
+    return Match.anyOf(Matches.territoryIsInList(alliedTerritories),
+        Match.allOf(Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data),
             Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false,
                 false, true, true),
             Matches.territoryIsInList(enemyTerritories).invert()));
@@ -31,26 +31,26 @@ public class ProMatches {
 
   public static Match<Territory> territoryCanMoveAirUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
-    return Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+    return Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
         Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, false,
             true, false));
   }
 
   public static Match<Territory> territoryCanPotentiallyMoveAirUnits(final PlayerID player, final GameData data) {
-    return Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+    return Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
         Matches.territoryIsPassableAndNotRestricted(player, data));
   }
 
   public static Match<Territory> territoryCanMoveAirUnitsAndNoAA(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
-    return Match.all(ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove),
+    return Match.allOf(ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove),
         Matches.territoryHasEnemyAaForAnything(player, data).invert());
   }
 
   public static Match<Territory> territoryCanMoveSpecificLandUnit(final PlayerID player, final GameData data,
       final boolean isCombatMove, final Unit u) {
     return Match.of(t -> {
-      final Match<Territory> territoryMatch = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+      final Match<Territory> territoryMatch = Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
           Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
               false, false));
       final Match<Unit> unitMatch =
@@ -62,7 +62,7 @@ public class ProMatches {
   public static Match<Territory> territoryCanPotentiallyMoveSpecificLandUnit(final PlayerID player, final GameData data,
       final Unit u) {
     return Match.of(t -> {
-      final Match<Territory> territoryMatch = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+      final Match<Territory> territoryMatch = Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
           Matches.territoryIsPassableAndNotRestricted(player, data));
       final Match<Unit> unitMatch =
           Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t)).invert();
@@ -72,18 +72,18 @@ public class ProMatches {
 
   public static Match<Territory> territoryCanMoveLandUnits(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
-    return Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+    return Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
         Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, true, false,
             false, false));
   }
 
   public static Match<Territory> territoryCanPotentiallyMoveLandUnits(final PlayerID player, final GameData data) {
-    return Match.all(Matches.TerritoryIsLand,
+    return Match.allOf(Matches.TerritoryIsLand,
         Matches.territoryDoesNotCostMoneyToEnter(data), Matches.territoryIsPassableAndNotRestricted(player, data));
   }
 
   public static Match<Territory> territoryCanMoveLandUnitsAndIsAllied(final PlayerID player, final GameData data) {
-    return Match.all(Matches.isTerritoryAllied(player, data),
+    return Match.allOf(Matches.isTerritoryAllied(player, data),
         territoryCanMoveLandUnits(player, data, false));
   }
 
@@ -92,15 +92,15 @@ public class ProMatches {
       final List<Territory> enemyTerritories) {
     return Match.of(t -> {
       Match<Territory> match =
-          Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
+          Match.allOf(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
               Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data),
               Matches.territoryIsInList(enemyTerritories).invert());
       if (isCombatMove && Matches.UnitCanBlitz.match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
-        final Match<Territory> alliedWithNoEnemiesMatch = Match.all(
+        final Match<Territory> alliedWithNoEnemiesMatch = Match.allOf(
             Matches.isTerritoryAllied(player, data), Matches.territoryHasNoEnemyUnits(player, data));
         final Match<Territory> alliedOrBlitzableMatch =
-            Match.any(alliedWithNoEnemiesMatch, territoryIsBlitzable(player, data, u));
-        match = Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
+            Match.anyOf(alliedWithNoEnemiesMatch, territoryIsBlitzable(player, data, u));
+        match = Match.allOf(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
             alliedOrBlitzableMatch, Matches.territoryIsInList(enemyTerritories).invert());
       }
       return match.match(t);
@@ -110,13 +110,13 @@ public class ProMatches {
   public static Match<Territory> territoryCanMoveLandUnitsThroughIgnoreEnemyUnits(final PlayerID player,
       final GameData data, final Unit u, final Territory startTerritory, final boolean isCombatMove,
       final List<Territory> blockedTerritories, final List<Territory> clearedTerritories) {
-    Match<Territory> alliedMatch = Match.any(Matches.isTerritoryAllied(player, data),
+    Match<Territory> alliedMatch = Match.anyOf(Matches.isTerritoryAllied(player, data),
         Matches.territoryIsInList(clearedTerritories));
     if (isCombatMove && Matches.UnitCanBlitz.match(u) && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
-      alliedMatch = Match.any(Matches.isTerritoryAllied(player, data),
+      alliedMatch = Match.anyOf(Matches.isTerritoryAllied(player, data),
           Matches.territoryIsInList(clearedTerritories), territoryIsBlitzable(player, data, u));
     }
-    return Match.all(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
+    return Match.allOf(ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u),
         alliedMatch, Matches.territoryIsInList(blockedTerritories).invert());
   }
 
@@ -134,7 +134,7 @@ public class ProMatches {
           && Matches.isTerritoryEnemyAndNotUnownedWater(player, data).match(t)) {
         return false;
       }
-      final Match<Territory> match = Match.all(Matches.territoryDoesNotCostMoneyToEnter(data),
+      final Match<Territory> match = Match.allOf(Matches.territoryDoesNotCostMoneyToEnter(data),
           Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false, true,
               false, false));
       return match.match(t);
@@ -143,28 +143,28 @@ public class ProMatches {
 
   public static Match<Territory> territoryCanMoveSeaUnitsThrough(final PlayerID player, final GameData data,
       final boolean isCombatMove) {
-    return Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
+    return Match.allOf(territoryCanMoveSeaUnits(player, data, isCombatMove),
         territoryHasOnlyIgnoredUnits(player, data));
   }
 
   public static Match<Territory> territoryCanMoveSeaUnitsAndNotInList(final PlayerID player, final GameData data,
       final boolean isCombatMove, final List<Territory> notTerritories) {
-    return Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
+    return Match.allOf(territoryCanMoveSeaUnits(player, data, isCombatMove),
         Matches.territoryIsNotInList(notTerritories));
   }
 
   public static Match<Territory> territoryCanMoveSeaUnitsThroughOrClearedAndNotInList(final PlayerID player,
       final GameData data, final boolean isCombatMove, final List<Territory> clearedTerritories,
       final List<Territory> notTerritories) {
-    final Match<Territory> onlyIgnoredOrClearedMatch = Match.any(
+    final Match<Territory> onlyIgnoredOrClearedMatch = Match.anyOf(
         territoryHasOnlyIgnoredUnits(player, data), Matches.territoryIsInList(clearedTerritories));
-    return Match.all(territoryCanMoveSeaUnits(player, data, isCombatMove),
+    return Match.allOf(territoryCanMoveSeaUnits(player, data, isCombatMove),
         onlyIgnoredOrClearedMatch, Matches.territoryIsNotInList(notTerritories));
   }
 
   private static Match<Territory> territoryHasOnlyIgnoredUnits(final PlayerID player, final GameData data) {
     return Match.of(t -> {
-      final Match<Unit> subOnly = Match.any(Matches.UnitIsInfrastructure, Matches.UnitIsSub,
+      final Match<Unit> subOnly = Match.anyOf(Matches.UnitIsInfrastructure, Matches.UnitIsSub,
           Matches.enemyUnit(player, data).invert());
       return (Properties.getIgnoreSubInMovement(data) && t.getUnits().allMatch(subOnly))
           || Matches.territoryHasNoEnemyUnits(player, data).match(t);
@@ -173,150 +173,150 @@ public class ProMatches {
 
   public static Match<Territory> territoryHasEnemyUnitsOrCantBeHeld(final PlayerID player, final GameData data,
       final List<Territory> territoriesThatCantBeHeld) {
-    return Match.any(Matches.territoryHasEnemyUnits(player, data),
+    return Match.anyOf(Matches.territoryHasEnemyUnits(player, data),
         Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
   public static Match<Territory> territoryHasPotentialEnemyUnits(final PlayerID player, final GameData data,
       final List<PlayerID> players) {
-    return Match.any(Matches.territoryHasEnemyUnits(player, data),
+    return Match.anyOf(Matches.territoryHasEnemyUnits(player, data),
         Matches.territoryHasUnitsThatMatch(Matches.unitOwnedBy(players)));
   }
 
   public static Match<Territory> territoryHasNoEnemyUnitsOrCleared(final PlayerID player, final GameData data,
       final List<Territory> clearedTerritories) {
-    return Match.any(Matches.territoryHasNoEnemyUnits(player, data), Matches.territoryIsInList(clearedTerritories));
+    return Match.anyOf(Matches.territoryHasNoEnemyUnits(player, data), Matches.territoryIsInList(clearedTerritories));
   }
 
   public static Match<Territory> territoryIsEnemyOrHasEnemyUnitsOrCantBeHeld(final PlayerID player, final GameData data,
       final List<Territory> territoriesThatCantBeHeld) {
-    return Match.any(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
+    return Match.anyOf(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
         Matches.territoryHasEnemyUnits(player, data), Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsLand() {
-    final Match<Unit> infraFactoryMatch = Match.all(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
-    return Match.all(Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
+    final Match<Unit> infraFactoryMatch = Match.allOf(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+    return Match.allOf(Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsEnemyLand(final PlayerID player, final GameData data) {
-    return Match.all(territoryHasInfraFactoryAndIsLand(), Matches.isTerritoryEnemy(player, data));
+    return Match.allOf(territoryHasInfraFactoryAndIsLand(), Matches.isTerritoryEnemy(player, data));
   }
 
   static Match<Territory> territoryHasInfraFactoryAndIsOwnedByPlayersOrCantBeHeld(final PlayerID player,
       final List<PlayerID> players, final List<Territory> territoriesThatCantBeHeld) {
-    final Match<Territory> ownedAndCantBeHeld = Match.all(Matches.isTerritoryOwnedBy(player),
+    final Match<Territory> ownedAndCantBeHeld = Match.allOf(Matches.isTerritoryOwnedBy(player),
         Matches.territoryIsInList(territoriesThatCantBeHeld));
     final Match<Territory> enemyOrOwnedCantBeHeld =
-        Match.any(Matches.isTerritoryOwnedBy(players), ownedAndCantBeHeld);
-    return Match.all(territoryHasInfraFactoryAndIsLand(), enemyOrOwnedCantBeHeld);
+        Match.anyOf(Matches.isTerritoryOwnedBy(players), ownedAndCantBeHeld);
+    return Match.allOf(territoryHasInfraFactoryAndIsLand(), enemyOrOwnedCantBeHeld);
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
       final GameData data) {
-    return Match.all(territoryIsNotConqueredOwnedLand(player, data),
+    return Match.allOf(territoryIsNotConqueredOwnedLand(player, data),
         territoryHasInfraFactoryAndIsOwnedLand(player));
   }
 
   public static Match<Territory> territoryHasNonMobileInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
       final GameData data) {
-    return Match.all(territoryHasNonMobileInfraFactory(),
+    return Match.allOf(territoryHasNonMobileInfraFactory(),
         territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data));
   }
 
   private static Match<Territory> territoryHasNonMobileInfraFactory() {
-    final Match<Unit> nonMobileInfraFactoryMatch = Match.all(Matches.UnitCanProduceUnits,
+    final Match<Unit> nonMobileInfraFactoryMatch = Match.allOf(Matches.UnitCanProduceUnits,
         Matches.UnitIsInfrastructure, Matches.unitHasMovementLeft.invert());
     return Matches.territoryHasUnitsThatMatch(nonMobileInfraFactoryMatch);
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsOwnedLand(final PlayerID player) {
-    final Match<Unit> infraFactoryMatch = Match.all(Matches.unitIsOwnedBy(player),
+    final Match<Unit> infraFactoryMatch = Match.allOf(Matches.unitIsOwnedBy(player),
         Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
-    return Match.all(Matches.isTerritoryOwnedBy(player),
+    return Match.allOf(Matches.isTerritoryOwnedBy(player),
         Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsAlliedLand(final PlayerID player, final GameData data) {
-    final Match<Unit> infraFactoryMatch = Match.all(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
-    return Match.all(Matches.isTerritoryAllied(player, data),
+    final Match<Unit> infraFactoryMatch = Match.allOf(Matches.UnitCanProduceUnits, Matches.UnitIsInfrastructure);
+    return Match.allOf(Matches.isTerritoryAllied(player, data),
         Matches.TerritoryIsLand, Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
 
   public static Match<Territory> territoryHasInfraFactoryAndIsOwnedLandAdjacentToSea(final PlayerID player,
       final GameData data) {
-    return Match.all(territoryHasInfraFactoryAndIsOwnedLand(player),
+    return Match.allOf(territoryHasInfraFactoryAndIsOwnedLand(player),
         Matches.territoryHasNeighborMatching(data, Matches.TerritoryIsWater));
   }
 
   public static Match<Territory> territoryHasNoInfraFactoryAndIsNotConqueredOwnedLand(final PlayerID player,
       final GameData data) {
-    return Match.all(territoryIsNotConqueredOwnedLand(player, data),
+    return Match.allOf(territoryIsNotConqueredOwnedLand(player, data),
         territoryHasInfraFactoryAndIsOwnedLand(player).invert());
   }
 
   public static Match<Territory> territoryHasNeighborOwnedByAndHasLandUnit(final GameData data,
       final List<PlayerID> players) {
-    final Match<Territory> territoryMatch = Match.all(Matches.isTerritoryOwnedBy(players),
+    final Match<Territory> territoryMatch = Match.allOf(Matches.isTerritoryOwnedBy(players),
         Matches.territoryHasUnitsThatMatch(Matches.UnitIsLand));
     return Matches.territoryHasNeighborMatching(data, territoryMatch);
   }
 
   static Match<Territory> territoryIsAlliedLandAndHasNoEnemyNeighbors(final PlayerID player, final GameData data) {
-    final Match<Territory> alliedLand = Match.all(territoryCanMoveLandUnits(player, data, false),
+    final Match<Territory> alliedLand = Match.allOf(territoryCanMoveLandUnits(player, data, false),
         Matches.isTerritoryAllied(player, data));
     final Match<Territory> hasNoEnemyNeighbors = Matches
         .territoryHasNeighborMatching(data, ProMatches.territoryIsEnemyNotNeutralLand(player, data)).invert();
-    return Match.all(alliedLand, hasNoEnemyNeighbors);
+    return Match.allOf(alliedLand, hasNoEnemyNeighbors);
   }
 
   public static Match<Territory> territoryIsEnemyLand(final PlayerID player, final GameData data) {
-    return Match.all(territoryCanMoveLandUnits(player, data, false),
+    return Match.allOf(territoryCanMoveLandUnits(player, data, false),
         Matches.isTerritoryEnemy(player, data));
   }
 
   public static Match<Territory> territoryIsEnemyNotNeutralLand(final PlayerID player, final GameData data) {
-    return Match.all(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
+    return Match.allOf(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
   }
 
   public static Match<Territory> territoryIsOrAdjacentToEnemyNotNeutralLand(final PlayerID player,
       final GameData data) {
     final Match<Territory> isMatch =
-        Match.all(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
-    final Match<Territory> adjacentMatch = Match.all(territoryCanMoveLandUnits(player, data, false),
+        Match.allOf(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
+    final Match<Territory> adjacentMatch = Match.allOf(territoryCanMoveLandUnits(player, data, false),
         Matches.territoryHasNeighborMatching(data, isMatch));
-    return Match.any(isMatch, adjacentMatch);
+    return Match.anyOf(isMatch, adjacentMatch);
   }
 
   public static Match<Territory> territoryIsEnemyNotNeutralOrAllied(final PlayerID player, final GameData data) {
-    final Match<Territory> alliedLand = Match.all(Matches.TerritoryIsLand, Matches.isTerritoryAllied(player, data));
-    return Match.any(territoryIsEnemyNotNeutralLand(player, data), alliedLand);
+    final Match<Territory> alliedLand = Match.allOf(Matches.TerritoryIsLand, Matches.isTerritoryAllied(player, data));
+    return Match.anyOf(territoryIsEnemyNotNeutralLand(player, data), alliedLand);
   }
 
   public static Match<Territory> territoryIsEnemyOrCantBeHeld(final PlayerID player, final GameData data,
       final List<Territory> territoriesThatCantBeHeld) {
-    return Match.any(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
+    return Match.anyOf(Matches.isTerritoryEnemyAndNotUnownedWater(player, data),
         Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
   public static Match<Territory> territoryIsPotentialEnemy(final PlayerID player, final GameData data,
       final List<PlayerID> players) {
-    return Match.any(Matches.isTerritoryEnemyAndNotUnownedWater(player, data), Matches.isTerritoryOwnedBy(players));
+    return Match.anyOf(Matches.isTerritoryEnemyAndNotUnownedWater(player, data), Matches.isTerritoryOwnedBy(players));
   }
 
   public static Match<Territory> territoryIsPotentialEnemyOrHasPotentialEnemyUnits(final PlayerID player,
       final GameData data, final List<PlayerID> players) {
-    return Match.any(territoryIsPotentialEnemy(player, data, players),
+    return Match.anyOf(territoryIsPotentialEnemy(player, data, players),
         territoryHasPotentialEnemyUnits(player, data, players));
   }
 
   public static Match<Territory> territoryIsEnemyOrCantBeHeldAndIsAdjacentToMyLandUnits(final PlayerID player,
       final GameData data, final List<Territory> territoriesThatCantBeHeld) {
-    final Match<Unit> myUnitIsLand = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsLand);
+    final Match<Unit> myUnitIsLand = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsLand);
     final Match<Territory> territoryIsLandAndAdjacentToMyLandUnits =
-        Match.all(Matches.TerritoryIsLand,
+        Match.allOf(Matches.TerritoryIsLand,
             Matches.territoryHasNeighborMatching(data, Matches.territoryHasUnitsThatMatch(myUnitIsLand)));
-    return Match.all(territoryIsLandAndAdjacentToMyLandUnits,
+    return Match.allOf(territoryIsLandAndAdjacentToMyLandUnits,
         territoryIsEnemyOrCantBeHeld(player, data, territoriesThatCantBeHeld));
   }
 
@@ -325,7 +325,7 @@ public class ProMatches {
       if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
         return false;
       }
-      final Match<Territory> match = Match.all(Matches.isTerritoryAllied(player, data), Matches.TerritoryIsLand);
+      final Match<Territory> match = Match.allOf(Matches.isTerritoryAllied(player, data), Matches.TerritoryIsLand);
       return match.match(t);
     });
   }
@@ -335,7 +335,7 @@ public class ProMatches {
       if (AbstractMoveDelegate.getBattleTracker(data).wasConquered(t)) {
         return false;
       }
-      final Match<Territory> match = Match.all(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
+      final Match<Territory> match = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
       return match.match(t);
     });
   }
@@ -343,11 +343,11 @@ public class ProMatches {
   public static Match<Territory> territoryIsWaterAndAdjacentToOwnedFactory(final PlayerID player, final GameData data) {
     final Match<Territory> hasOwnedFactoryNeighbor =
         Matches.territoryHasNeighborMatching(data, ProMatches.territoryHasInfraFactoryAndIsOwnedLand(player));
-    return Match.all(hasOwnedFactoryNeighbor, ProMatches.territoryCanMoveSeaUnits(player, data, true));
+    return Match.allOf(hasOwnedFactoryNeighbor, ProMatches.territoryCanMoveSeaUnits(player, data, true));
   }
 
   private static Match<Unit> unitCanBeMovedAndIsOwned(final PlayerID player) {
-    return Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft);
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft);
   }
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedAir(final PlayerID player, final boolean isCombatMove) {
@@ -355,7 +355,7 @@ public class ProMatches {
       if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsAir);
+      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsAir);
       return match.match(u);
     });
   }
@@ -365,7 +365,7 @@ public class ProMatches {
       if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsLand,
+      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsLand,
           Matches.unitIsBeingTransported().invert());
       return match.match(u);
     });
@@ -376,7 +376,7 @@ public class ProMatches {
       if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsSea);
+      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsSea);
       return match.match(u);
     });
   }
@@ -386,7 +386,7 @@ public class ProMatches {
       if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.UnitIsTransport);
+      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsTransport);
       return match.match(u);
     });
   }
@@ -396,68 +396,68 @@ public class ProMatches {
       if (Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.all(unitCanBeMovedAndIsOwned(player), Matches.unitCanBombard(player));
+      final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitCanBombard(player));
       return match.match(u);
     });
   }
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedNonCombatInfra(final PlayerID player) {
-    return Match.all(unitCanBeMovedAndIsOwned(player),
+    return Match.allOf(unitCanBeMovedAndIsOwned(player),
         Matches.UnitCanNotMoveDuringCombatMove, Matches.UnitIsInfrastructure);
   }
 
   public static Match<Unit> unitCantBeMovedAndIsAlliedDefender(final PlayerID player, final GameData data,
       final Territory t) {
     final Match<Unit> myUnitHasNoMovementMatch =
-        Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft.invert());
+        Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft.invert());
     final Match<Unit> alliedUnitMatch =
-        Match.all(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data),
+        Match.allOf(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data),
             Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(t.getUnits().getUnits(), null, player,
                 data, false).invert());
-    return Match.any(myUnitHasNoMovementMatch, alliedUnitMatch);
+    return Match.anyOf(myUnitHasNoMovementMatch, alliedUnitMatch);
   }
 
   public static Match<Unit> unitCantBeMovedAndIsAlliedDefenderAndNotInfra(final PlayerID player, final GameData data,
       final Territory t) {
-    return Match.all(unitCantBeMovedAndIsAlliedDefender(player, data, t),
+    return Match.allOf(unitCantBeMovedAndIsAlliedDefender(player, data, t),
         Matches.UnitIsNotInfrastructure);
   }
 
   public static Match<Unit> unitIsAlliedLandAndNotInfra(final PlayerID player, final GameData data) {
-    return Match.all(Matches.UnitIsLand, Matches.isUnitAllied(player, data),
+    return Match.allOf(Matches.UnitIsLand, Matches.isUnitAllied(player, data),
         Matches.UnitIsNotInfrastructure);
   }
 
   public static Match<Unit> unitIsAlliedNotOwned(final PlayerID player, final GameData data) {
-    return Match.all(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data));
+    return Match.allOf(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data));
   }
 
   public static Match<Unit> unitIsAlliedNotOwnedAir(final PlayerID player, final GameData data) {
-    return Match.all(unitIsAlliedNotOwned(player, data), Matches.UnitIsAir);
+    return Match.allOf(unitIsAlliedNotOwned(player, data), Matches.UnitIsAir);
   }
 
   static Match<Unit> unitIsAlliedAir(final PlayerID player, final GameData data) {
-    return Match.all(Matches.isUnitAllied(player, data), Matches.UnitIsAir);
+    return Match.allOf(Matches.isUnitAllied(player, data), Matches.UnitIsAir);
   }
 
   public static Match<Unit> unitIsEnemyAir(final PlayerID player, final GameData data) {
-    return Match.all(Matches.enemyUnit(player, data), Matches.UnitIsAir);
+    return Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsAir);
   }
 
   public static Match<Unit> unitIsEnemyAndNotAA(final PlayerID player, final GameData data) {
-    return Match.all(Matches.enemyUnit(player, data), Matches.UnitIsAAforAnything.invert());
+    return Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsAAforAnything.invert());
   }
 
   public static Match<Unit> unitIsEnemyAndNotInfa(final PlayerID player, final GameData data) {
-    return Match.all(Matches.enemyUnit(player, data), Matches.UnitIsNotInfrastructure);
+    return Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsNotInfrastructure);
   }
 
   public static Match<Unit> unitIsEnemyNotLand(final PlayerID player, final GameData data) {
-    return Match.all(Matches.enemyUnit(player, data), Matches.UnitIsNotLand);
+    return Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsNotLand);
   }
 
   static Match<Unit> unitIsEnemyNotNeutral(final PlayerID player, final GameData data) {
-    return Match.all(Matches.enemyUnit(player, data), unitIsNeutral().invert());
+    return Match.allOf(Matches.enemyUnit(player, data), unitIsNeutral().invert());
   }
 
   private static Match<Unit> unitIsNeutral() {
@@ -465,17 +465,17 @@ public class ProMatches {
   }
 
   static Match<Unit> unitIsOwnedAir(final PlayerID player) {
-    return Match.all(Matches.unitOwnedBy(player), Matches.UnitIsAir);
+    return Match.allOf(Matches.unitOwnedBy(player), Matches.UnitIsAir);
   }
 
   public static Match<Unit> unitIsOwnedAndMatchesTypeAndIsTransporting(final PlayerID player, final UnitType unitType) {
-    return Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
         Matches.unitIsTransporting());
   }
 
   public static Match<Unit> unitIsOwnedAndMatchesTypeAndNotTransporting(final PlayerID player,
       final UnitType unitType) {
-    return Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(unitType),
         Matches.unitIsTransporting().invert());
   }
 
@@ -485,19 +485,19 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsOwnedNotLand(final PlayerID player) {
-    return Match.all(Matches.UnitIsNotLand, Matches.unitIsOwnedBy(player));
+    return Match.allOf(Matches.UnitIsNotLand, Matches.unitIsOwnedBy(player));
   }
 
   public static Match<Unit> unitIsOwnedTransport(final PlayerID player) {
-    return Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsTransport);
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsTransport);
   }
 
   public static Match<Unit> unitIsOwnedTransportableUnit(final PlayerID player) {
-    return Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported, Matches.UnitCanMove);
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported, Matches.UnitCanMove);
   }
 
   public static Match<Unit> unitIsOwnedCombatTransportableUnit(final PlayerID player) {
-    return Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported,
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported,
         Matches.UnitCanNotMoveDuringCombatMove.invert(), Matches.UnitCanMove);
   }
 
@@ -507,7 +507,7 @@ public class ProMatches {
       if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.all(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved,
+      final Match<Unit> match = Match.allOf(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved,
           Matches.unitHasMovementLeft, Matches.unitIsBeingTransported().invert());
       return match.match(u);
     });

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -100,7 +100,7 @@ public class ProPurchaseUtils {
 
         // Find number of unit type that are already built and about to be placed
         int currentlyBuilt = 0;
-        final Match<Unit> unitTypeOwnedBy = Match.all(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(player));
+        final Match<Unit> unitTypeOwnedBy = Match.allOf(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(player));
         final List<Territory> allTerritories = data.getMap().getTerritories();
         for (final Territory t : allTerritories) {
           currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
@@ -258,7 +258,7 @@ public class ProTransportUtils {
         // If this is the first carrier seek and not last unit
         if (seekedCarrier == null && i > 0) {
           final int seekedCarrierIndex = AIUtils.getIndexOfLastUnitMatching(result,
-              Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+              Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
           if (seekedCarrierIndex == -1) {
             break; // No carriers left
           }
@@ -288,7 +288,7 @@ public class ProTransportUtils {
 
             // Find the next carrier
             seekedCarrier = AIUtils.getLastUnitMatching(result,
-                Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               break; // No carriers left
             }
@@ -331,7 +331,7 @@ public class ProTransportUtils {
 
             // Find the next carrier
             seekedCarrier = AIUtils.getLastUnitMatching(result,
-                Match.all(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
+                Match.allOf(Matches.UnitIsCarrier, Matches.isNotInList(filledCarriers)), result.size() - 1);
             if (seekedCarrier == null) {
               break; // No carriers left
             }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -61,7 +61,7 @@ class Utils {
     Route shortestRoute = null;
     for (final Territory t : data.getMap().getTerritories()) {
       if (endCondition.match(t)) {
-        final Match<Territory> routeOrEnd = Match.any(routeCondition, Matches.territoryIs(t));
+        final Match<Territory> routeOrEnd = Match.anyOf(routeCondition, Matches.territoryIs(t));
         final Route r = data.getMap().getRoute(start, t, routeOrEnd);
         if (r != null) {
           if (shortestRoute == null || r.numberOfSteps() < shortestRoute.numberOfSteps()) {
@@ -103,7 +103,7 @@ class Utils {
    */
   static List<Territory> findUnitTerr(final GameData data, final Match<Unit> unitCondition) {
     // Return territories containing a certain unit or set of Units
-    final Match<Unit> limitShips = Match.all(unitCondition);
+    final Match<Unit> limitShips = Match.allOf(unitCondition);
     final List<Territory> shipTerr = new ArrayList<>();
     final Collection<Territory> tNeighbors = data.getMap().getTerritories();
     for (final Territory t2 : tNeighbors) {

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -64,7 +64,7 @@ public class WeakAI extends AbstractAI {
       return !impassable && !o.isWater() && Utils.hasLandRouteToEnemyOwnedCapitol(o, player, data);
     });
     final Match<Territory> routeCond =
-        Match.all(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
+        Match.allOf(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
     final Route withNoEnemy = Utils.findNearest(ourCapitol, endMatch, routeCond, data);
     if (withNoEnemy != null && withNoEnemy.numberOfSteps() > 0) {
       return withNoEnemy;
@@ -86,7 +86,7 @@ public class WeakAI extends AbstractAI {
     // find a land route to an enemy territory from our capitol
     final Route invasionRoute =
         Utils.findNearest(capitol, Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data),
-            Match.all(Matches.TerritoryIsLand, Matches.TerritoryIsNeutralButNotWater.invert()), data);
+            Match.allOf(Matches.TerritoryIsLand, Matches.TerritoryIsNeutralButNotWater.invert()), data);
     return invasionRoute == null;
   }
 
@@ -212,7 +212,7 @@ public class WeakAI extends AbstractAI {
     }
     final Territory lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     final Territory landOn = amphibRoute.getEnd();
-    final Match<Unit> landAndOwned = Match.all(Matches.UnitIsLand, Matches.unitIsOwnedBy(player));
+    final Match<Unit> landAndOwned = Match.allOf(Matches.UnitIsLand, Matches.unitIsOwnedBy(player));
     final List<Unit> units = lastSeaZoneOnAmphib.getUnits().getMatches(landAndOwned);
     if (units.size() > 0) {
       // just try to make the move, the engine will stop us if it doesnt work
@@ -271,7 +271,7 @@ public class WeakAI extends AbstractAI {
     firstSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(0);
     lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     final Match<Unit> ownedAndNotMoved =
-        Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved, Transporting);
+        Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved, Transporting);
     final List<Unit> unitsToMove = new ArrayList<>();
     final List<Unit> transports = firstSeaZoneOnAmphib.getUnits().getMatches(ownedAndNotMoved);
     if (transports.size() <= maxTrans) {
@@ -302,7 +302,7 @@ public class WeakAI extends AbstractAI {
       firstSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(1);
       lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     }
-    final Match<Unit> ownedAndNotMoved = Match.all(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved);
+    final Match<Unit> ownedAndNotMoved = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved);
     for (final Territory t : data.getMap()) {
       // move sea units to the capitol, unless they are loaded transports
       if (t.isWater()) {
@@ -334,7 +334,7 @@ public class WeakAI extends AbstractAI {
   private static Route getMaxSeaRoute(final GameData data, final Territory start, final Territory destination,
       final PlayerID player) {
     final Match<Territory> routeCond =
-        Match.all(Matches.TerritoryIsWater, Matches.territoryHasEnemyUnits(player, data).invert(),
+        Match.allOf(Matches.TerritoryIsWater, Matches.territoryHasEnemyUnits(player, data).invert(),
             Matches.territoryHasNonAllowedCanal(player, null, data).invert());
     Route r = data.getMap().getRoute(start, destination, routeCond);
     if (r == null) {
@@ -364,7 +364,7 @@ public class WeakAI extends AbstractAI {
       final float enemyStrength = AIUtils.strength(enemy.getUnits().getUnits(), false, true);
       if (enemyStrength > 0) {
         final Match<Unit> attackable =
-            Match.all(Matches.unitIsOwnedBy(player), Match.of(o -> !unitsAlreadyMoved.contains(o)));
+            Match.allOf(Matches.unitIsOwnedBy(player), Match.of(o -> !unitsAlreadyMoved.contains(o)));
         final Set<Territory> dontMoveFrom = new HashSet<>();
         // find our strength that we can attack with
         int ourStrength = 0;
@@ -399,10 +399,10 @@ public class WeakAI extends AbstractAI {
       return null;
     }
     final Match<Territory> routeCondition =
-        Match.all(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
+        Match.allOf(Matches.TerritoryIsWater, Matches.territoryHasNoEnemyUnits(player, data));
     // should select all territories with loaded transports
     final Match<Territory> transportOnSea =
-        Match.all(Matches.TerritoryIsWater, Matches.territoryHasLandUnitsOwnedBy(player));
+        Match.allOf(Matches.TerritoryIsWater, Matches.territoryHasLandUnitsOwnedBy(player));
     Route altRoute = null;
     final int length = Integer.MAX_VALUE;
     for (final Territory t : data.getMap()) {
@@ -410,9 +410,9 @@ public class WeakAI extends AbstractAI {
         continue;
       }
       final Match<Unit> ownedTransports =
-          Match.all(Matches.UnitCanTransport, Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved);
+          Match.allOf(Matches.UnitCanTransport, Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved);
       final Match<Territory> enemyTerritory =
-          Match.all(Matches.isTerritoryEnemy(player, data), Matches.TerritoryIsLand,
+          Match.allOf(Matches.isTerritoryEnemy(player, data), Matches.TerritoryIsLand,
               Matches.TerritoryIsNeutralButNotWater.invert(), Matches.TerritoryIsEmpty);
       final int trans = t.getUnits().countMatches(ownedTransports);
       if (trans > 0) {
@@ -444,7 +444,7 @@ public class WeakAI extends AbstractAI {
         }
       }
       // these are the units we can move
-      final Match<Unit> moveOfType = Match.all(
+      final Match<Unit> moveOfType = Match.allOf(
           Matches.unitIsOwnedBy(player),
           Matches.UnitIsNotAA,
           // we can never move factories
@@ -452,7 +452,7 @@ public class WeakAI extends AbstractAI {
           Matches.UnitIsNotInfrastructure,
           Matches.UnitIsLand);
       final Match<Territory> moveThrough =
-          Match.all(Matches.TerritoryIsImpassable.invert(),
+          Match.allOf(Matches.TerritoryIsImpassable.invert(),
               Matches.TerritoryIsNeutralButNotWater.invert(), Matches.TerritoryIsLand);
       final List<Unit> units = t.getUnits().getMatches(moveOfType);
       if (units.size() == 0) {
@@ -486,7 +486,7 @@ public class WeakAI extends AbstractAI {
         }
       } else { // if we cant move to a capitol, move towards the enemy
         final Match<Territory> routeCondition =
-            Match.all(Matches.TerritoryIsLand, Matches.TerritoryIsImpassable.invert());
+            Match.allOf(Matches.TerritoryIsLand, Matches.TerritoryIsImpassable.invert());
         Route newRoute = Utils.findNearest(t, Matches.territoryHasEnemyLandUnits(player, data), routeCondition, data);
         // move to any enemy territory
         if (newRoute == null) {
@@ -510,15 +510,16 @@ public class WeakAI extends AbstractAI {
     final IMoveDelegate delegateRemote = (IMoveDelegate) getPlayerBridge().getRemoteDelegate();
     // this works because we are on the server
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
-    final Match<Territory> canLand =
-        Match.all(Matches.isTerritoryAllied(player, data), Match.of(o -> !delegate.getBattleTracker().wasConquered(o)));
-    final Match<Territory> routeCondition = Match.all(
+    final Match<Territory> canLand = Match.allOf(
+        Matches.isTerritoryAllied(player, data),
+        Match.of(o -> !delegate.getBattleTracker().wasConquered(o)));
+    final Match<Territory> routeCondition = Match.allOf(
         Matches.territoryHasEnemyAaForCombatOnly(player, data).invert(), Matches.TerritoryIsImpassable.invert());
     for (final Territory t : delegateRemote.getTerritoriesWhereAirCantLand()) {
       final Route noAaRoute = Utils.findNearest(t, canLand, routeCondition, data);
       final Route aaRoute = Utils.findNearest(t, canLand, Matches.TerritoryIsImpassable.invert(), data);
       final Collection<Unit> airToLand =
-          t.getUnits().getMatches(Match.all(Matches.UnitIsAir, Matches.unitIsOwnedBy(player)));
+          t.getUnits().getMatches(Match.allOf(Matches.UnitIsAir, Matches.unitIsOwnedBy(player)));
       // dont bother to see if all the air units have enough movement points
       // to move without aa guns firing
       // simply move first over no aa, then with aa
@@ -536,7 +537,7 @@ public class WeakAI extends AbstractAI {
     final Collection<Unit> unitsAlreadyMoved = new HashSet<>();
     // find the territories we can just walk into
     final Match<Territory> walkInto =
-        Match.any(Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data),
+        Match.anyOf(Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data),
             Matches.isTerritoryFreeNeutral(data));
     final List<Territory> enemyOwned = Match.getMatches(data.getMap().getTerritories(), walkInto);
     Collections.shuffle(enemyOwned);
@@ -609,7 +610,7 @@ public class WeakAI extends AbstractAI {
           final List<Unit> unitsSortedByCost = new ArrayList<>(attackFrom.getUnits().getUnits());
           Collections.sort(unitsSortedByCost, AIUtils.getCostComparator());
           for (final Unit unit : unitsSortedByCost) {
-            final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsLand,
+            final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsLand,
                 Matches.UnitIsNotInfrastructure, Matches.UnitCanMove, Matches.UnitIsNotAA,
                 Matches.UnitCanNotMoveDuringCombatMove.invert());
             if (!unitsAlreadyMoved.contains(unit) && match.match(unit)) {
@@ -637,7 +638,7 @@ public class WeakAI extends AbstractAI {
     for (final Territory enemy : enemyOwned) {
       final float enemyStrength = AIUtils.strength(enemy.getUnits().getUnits(), false, false);
       if (enemyStrength > 0) {
-        final Match<Unit> attackable = Match.all(
+        final Match<Unit> attackable = Match.allOf(
             Matches.unitIsOwnedBy(player),
             Matches.UnitIsStrategicBomber.invert(),
             Match.of(o -> !unitsAlreadyMoved.contains(o)),
@@ -695,7 +696,7 @@ public class WeakAI extends AbstractAI {
       final List<Route> moveRoutes, final PlayerID player) {
     final Match<Territory> enemyFactory = Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player,
         Matches.UnitCanProduceUnitsAndCanBeDamaged);
-    final Match<Unit> ownBomber = Match.all(Matches.UnitIsStrategicBomber, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownBomber = Match.allOf(Matches.UnitIsStrategicBomber, Matches.unitIsOwnedBy(player));
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> bombers = t.getUnits().getMatches(ownBomber);
       if (bombers.isEmpty()) {
@@ -709,7 +710,7 @@ public class WeakAI extends AbstractAI {
   }
 
   private static int countTransports(final GameData data, final PlayerID player) {
-    final Match<Unit> ownedTransport = Match.all(Matches.UnitIsTransport, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedTransport = Match.allOf(Matches.UnitIsTransport, Matches.unitIsOwnedBy(player));
     int sum = 0;
     for (final Territory t : data.getMap()) {
       sum += t.getUnits().countMatches(ownedTransport);
@@ -718,7 +719,7 @@ public class WeakAI extends AbstractAI {
   }
 
   private static int countLandUnits(final GameData data, final PlayerID player) {
-    final Match<Unit> ownedLandUnit = Match.all(Matches.UnitIsLand, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedLandUnit = Match.allOf(Matches.UnitIsLand, Matches.unitIsOwnedBy(player));
     int sum = 0;
     for (final Territory t : data.getMap()) {
       sum += t.getUnits().countMatches(ownedLandUnit);
@@ -790,7 +791,7 @@ public class WeakAI extends AbstractAI {
     final List<ProductionRule> rules = player.getProductionFrontier().getRules();
     final IntegerMap<ProductionRule> purchase = new IntegerMap<>();
     List<RepairRule> rrules = Collections.emptyList();
-    final Match<Unit> ourFactories = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCanProduceUnits);
+    final Match<Unit> ourFactories = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitCanProduceUnits);
     final List<Territory> rfactories =
         Match.getMatches(Utils.findUnitTerr(data, ourFactories), Matches.isTerritoryOwnedBy(player));
     // figure out if anything needs to be repaired

--- a/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -141,7 +141,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
       return new ArrayList<>();
     }
     return Match.getMatches(getPoliticalActionAttachments(player),
-        Match.all(
+        Match.allOf(
             Matches.abstractUserActionAttachmentCanBeAttempted(testedConditions),
             Matches.politicalActionAffectsAtLeastOneAlivePlayer(player, data)));
   }

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -1008,7 +1008,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         allUnits.retainAll(Match.getMatches(allUnits, Matches.enemyUnitOfAnyOfThesePlayers(players, data)));
       } else if (exclType.equals("enemy_surface")) { // any enemy units (not trn/sub) in the territory
         allUnits.retainAll(
-            Match.getMatches(allUnits, Match.all(Matches.enemyUnitOfAnyOfThesePlayers(players, data),
+            Match.getMatches(allUnits, Match.allOf(Matches.enemyUnitOfAnyOfThesePlayers(players, data),
                 Matches.UnitIsNotSub, Matches.UnitIsNotTransportButCouldBeCombatTransport)));
       } else {
         return false;

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1268,7 +1268,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allJets = Match.getMatches(data.getUnitTypeList().getAllUnitTypes(),
-              Match.all(Matches.UnitTypeIsAir, Matches.UnitTypeIsStrategicBomber.invert()));
+              Match.allOf(Matches.UnitTypeIsAir, Matches.UnitTypeIsStrategicBomber.invert()));
           final boolean ww2v3TechModel = games.strategy.triplea.Properties.getWW2V3TechModel(data);
           for (final UnitType jet : allJets) {
             if (ww2v3TechModel) {

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1502,7 +1502,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     for (final UnitType ut : utMap.keySet()) {
       final int removeNum = utMap.getInt(ut);
       final Collection<Unit> toRemove = Match.getNMatches(terr.getUnits().getUnits(), removeNum,
-          Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(ut)));
+          Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(ut)));
       if (!toRemove.isEmpty()) {
         totalRemoved.addAll(toRemove);
         change.add(ChangeFactory.removeUnits(terr, toRemove));

--- a/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -173,7 +173,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
    */
   public static Collection<UserActionAttachment> getValidActions(final PlayerID player,
       final HashMap<ICondition, Boolean> testedConditions, final GameData data) {
-    return Match.getMatches(getUserActionAttachments(player), Match.all(
+    return Match.getMatches(getUserActionAttachments(player), Match.allOf(
         Matches.abstractUserActionAttachmentCanBeAttempted(testedConditions)));
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -183,8 +183,8 @@ class AAInMoveUtil implements Serializable {
           UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAA(getData());
       final Set<UnitType> airborneTypesTargettedToo = airborneTechTargetsAllowed.get(currentTypeAa);
       final Collection<Unit> validTargetedUnitsForThisRoll =
-          Match.getMatches(units, Match.any(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
-              Match.all(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
+          Match.getMatches(units, Match.anyOf(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
+              Match.allOf(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
       // once we fire the AA guns, we can't undo
       // otherwise you could keep undoing and redoing
       // until you got the roll you wanted

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -306,7 +306,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
           if (PossibleNewOwners.contains(terrNewOwner)) {
             // PlayerOwnerChange
             final Collection<Unit> units =
-                currTerritory.getUnits().getMatches(Match.all(Matches.unitOwnedBy(Player),
+                currTerritory.getUnits().getMatches(Match.allOf(Matches.unitOwnedBy(Player),
                     Matches.unitCanBeGivenByTerritoryTo(terrNewOwner)));
             if (!units.isEmpty()) {
               change.add(ChangeFactory.changeOwner(units, terrNewOwner, currTerritory));
@@ -367,7 +367,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     if (blockable.isEmpty()) {
       return 0;
     }
-    final Match<Unit> enemyUnits = Match.all(Matches.enemyUnit(player, data));
+    final Match<Unit> enemyUnits = Match.allOf(Matches.enemyUnit(player, data));
     int totalLoss = 0;
     final boolean rollDiceForBlockadeDamage = games.strategy.triplea.Properties.getConvoyBlockadesRollDiceForCost(data);
     final Collection<String> transcripts = new ArrayList<>();
@@ -377,7 +377,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     for (final Territory b : blockable) {
       // match will check for land, convoy zones, and also contested territories
       final List<Territory> viableNeighbors =
-          Match.getMatches(map.getNeighbors(b), Match.all(Matches.isTerritoryOwnedBy(player),
+          Match.getMatches(map.getNeighbors(b), Match.allOf(Matches.isTerritoryOwnedBy(player),
               Matches.territoryCanCollectIncomeFrom(player, data)));
       final int maxLoss = getProduction(viableNeighbors);
       if (maxLoss <= 0) {

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -514,7 +514,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!producer.getUnits().someMatch(Matches.UnitCanProduceUnits)) {
       return null;
     }
-    final Match<Unit> ownedFighters = Match.all(Matches.UnitCanLandOnCarrier, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedFighters = Match.allOf(Matches.UnitCanLandOnCarrier, Matches.unitIsOwnedBy(player));
     if (!producer.getUnits().someMatch(ownedFighters)) {
       return null;
     }
@@ -640,7 +640,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!producer.getOwner().equals(player)) {
       // sea constructions require either owning the sea zone or owning a surrounding land territory
       if (producer.isWater()
-          && Match.someMatch(testUnits, Match.all(Matches.UnitIsSea, Matches.UnitIsConstruction))) {
+          && Match.someMatch(testUnits, Match.allOf(Matches.UnitIsSea, Matches.UnitIsConstruction))) {
         boolean ownedNeighbor = false;
         for (final Territory current : getData().getMap().getNeighbors(to, Matches.TerritoryIsLand)) {
           if (current.getOwner().equals(player) && (canProduceInConquered || !wasConquered(current))) {
@@ -893,14 +893,14 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     // we add factories and constructions later
     if (water || wasFactoryThereAtStart || (!water && isPlayerAllowedToPlacementAnyTerritoryOwnedLand(player))) {
       final Match<Unit> seaOrLandMatch = water ? Matches.UnitIsSea : Matches.UnitIsLand;
-      placeableUnits.addAll(Match.getMatches(units, Match.all(seaOrLandMatch, Matches.UnitIsNotConstruction)));
+      placeableUnits.addAll(Match.getMatches(units, Match.allOf(seaOrLandMatch, Matches.UnitIsNotConstruction)));
       if (!water) {
-        placeableUnits.addAll(Match.getMatches(units, Match.all(Matches.UnitIsAir, Matches.UnitIsNotConstruction)));
+        placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.UnitIsNotConstruction)));
       } else if (((isBid || canProduceFightersOnCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
           && Match.someMatch(allProducedUnits, Matches.UnitIsCarrier))
           || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
               && Match.someMatch(to.getUnits().getUnits(), Matches.UnitIsCarrier))) {
-        placeableUnits.addAll(Match.getMatches(units, Match.all(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
+        placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
       }
     }
     if (Match.someMatch(units, Matches.UnitIsConstruction)) {
@@ -992,7 +992,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       final Collection<UnitType> requiredUnits = requiredUnitsMap.keySet();
       for (final UnitType ut : requiredUnits) {
         final int requiredNumber = requiredUnitsMap.getInt(ut);
-        final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.all(
+        final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.allOf(
             Matches.unitIsOwnedBy(unit.getOwner()), Matches.unitIsOfType(ut),
             Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.UnitHasNotTakenAnyDamage, Matches.UnitIsNotDisabled);
         final Collection<Unit> unitsBeingRemoved =

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -304,7 +304,7 @@ public class AirBattle extends AbstractBattle {
       if (!bombers.isEmpty()) {
         HashMap<Unit, HashSet<Unit>> targets = null;
         final Collection<Unit> enemyTargetsTotal = m_battleSite.getUnits()
-            .getMatches(Match.all(Matches.enemyUnit(bridge.getPlayerID(), m_data),
+            .getMatches(Match.allOf(Matches.enemyUnit(bridge.getPlayerID(), m_data),
                 Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
                 Matches.unitIsBeingTransported().invert()));
         for (final Unit unit : bombers) {

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -59,7 +59,7 @@ public class AirMovementValidator {
     final Territory routeEnd = route.getEnd();
     final Territory routeStart = route.getStart();
     // we cannot forget to account for allied air at our location already
-    final Match<Unit> airAlliedNotOwned = Match.all(Matches.unitIsOwnedBy(player).invert(),
+    final Match<Unit> airAlliedNotOwned = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
     final HashSet<Unit> airThatMustLandOnCarriersHash = new HashSet<>();
     airThatMustLandOnCarriersHash.addAll(Match.getMatches(routeEnd.getUnits().getUnits(), airAlliedNotOwned));
@@ -158,7 +158,7 @@ public class AirMovementValidator {
       final List<Territory> landingSpots, final Map<Unit, Collection<Unit>> movedCarriersAndTheirFighters,
       final PlayerID player, final GameData data) {
     final IntegerMap<Territory> startingSpace = new IntegerMap<>();
-    final Match<Unit> carrierAlliedNotOwned = Match.all(Matches.unitIsOwnedBy(player).invert(),
+    final Match<Unit> carrierAlliedNotOwned = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsCarrier);
     // final Match<Unit> airAlliedNotOwned = new CompositeMatchAnd<Unit>(Matches.unitIsOwnedBy(player).invert(),
     // Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
@@ -196,12 +196,12 @@ public class AirMovementValidator {
       final List<Territory> landingSpots, final Collection<Territory> potentialCarrierOrigins,
       final Map<Unit, Collection<Unit>> movedCarriersAndTheirFighters, final Collection<Unit> airThatMustLandOnCarriers,
       final Collection<Unit> airNotToConsider, final PlayerID player, final Route route, final GameData data) {
-    final Match<Unit> ownedCarrierMatch = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier);
+    final Match<Unit> ownedCarrierMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier);
     final Match<Unit> ownedAirMatch =
-        Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
-    final Match<Unit> alliedNotOwnedAirMatch = Match.all(Matches.unitIsOwnedBy(player).invert(),
+        Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
+    final Match<Unit> alliedNotOwnedAirMatch = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
-    final Match<Unit> alliedNotOwnedCarrierMatch = Match.all(Matches.unitIsOwnedBy(player).invert(),
+    final Match<Unit> alliedNotOwnedCarrierMatch = Match.allOf(Matches.unitIsOwnedBy(player).invert(),
         Matches.isUnitAllied(player, data), Matches.UnitIsCarrier);
     final Territory routeEnd = route.getEnd();
     final boolean areNeutralsPassableByAir = areNeutralsPassableByAir(data);
@@ -462,7 +462,7 @@ public class AirMovementValidator {
 
   private static int maxMovementLeftForAllOwnedCarriers(final PlayerID player, final GameData data) {
     int max = 0;
-    final Match<Unit> ownedCarrier = Match.all(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player));
+    final Match<Unit> ownedCarrier = Match.allOf(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player));
     for (final Territory t : data.getMap().getTerritories()) {
       for (final Unit carrier : t.getUnits().getMatches(ownedCarrier)) {
         max = Math.max(max, ((TripleAUnit) carrier).getMovementLeft());
@@ -518,7 +518,7 @@ public class AirMovementValidator {
   private static List<Unit> getAirUnitsToValidate(final Collection<Unit> units, final Route route,
       final PlayerID player) {
     final Match<Unit> ownedAirMatch =
-        Match.all(Matches.UnitIsAir, Matches.unitOwnedBy(player), Matches.UnitIsKamikaze.invert());
+        Match.allOf(Matches.UnitIsAir, Matches.unitOwnedBy(player), Matches.UnitIsKamikaze.invert());
     final List<Unit> ownedAir = new ArrayList<>();
     ownedAir.addAll(Match.getMatches(route.getEnd().getUnits().getUnits(), ownedAirMatch));
     ownedAir.addAll(Match.getMatches(units, ownedAirMatch));
@@ -678,7 +678,7 @@ public class AirMovementValidator {
         if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER).match(unit)) {
           int cargo = 0;
           final Collection<Unit> airCargo = territoryUnitsAreCurrentlyIn.getUnits()
-              .getMatches(Match.all(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier));
+              .getMatches(Match.allOf(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier));
           for (final Unit airUnit : airCargo) {
             final TripleAUnit taUnit = (TripleAUnit) airUnit;
             if (taUnit.getTransportedBy() != null && taUnit.getTransportedBy().equals(unit)) {

--- a/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -40,7 +40,7 @@ public class AirThatCantLandUtil {
     final Iterator<Territory> territories = data.getMap().getTerritories().iterator();
     while (territories.hasNext()) {
       final Territory current = territories.next();
-      final Match<Unit> ownedAir = Match.all(Matches.UnitIsAir, Matches.unitIsOwnedBy(player));
+      final Match<Unit> ownedAir = Match.allOf(Matches.UnitIsAir, Matches.unitIsOwnedBy(player));
       final Collection<Unit> air = current.getUnits().getMatches(ownedAir);
       if (air.size() != 0 && !AirMovementValidator.canLand(air, current, player, data)) {
         cantLand.add(current);
@@ -55,7 +55,7 @@ public class AirThatCantLandUtil {
     final Iterator<Territory> territories = getTerritoriesWhereAirCantLand(player).iterator();
     while (territories.hasNext()) {
       final Territory current = territories.next();
-      final Match<Unit> ownedAir = Match.all(Matches.UnitIsAir, Matches.alliedUnit(player, data));
+      final Match<Unit> ownedAir = Match.allOf(Matches.UnitIsAir, Matches.alliedUnit(player, data));
       final Collection<Unit> air = current.getUnits().getMatches(ownedAir);
       final boolean hasNeighboringFriendlyFactory =
           map.getNeighbors(current, Matches.territoryHasAlliedIsFactoryOrCanProduceUnits(data, player)).size() > 0;

--- a/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -88,7 +88,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
     if (games.strategy.triplea.Properties.getTriggers(data)) {
       final String stepName = data.getSequence().getStep().getName();
       // we use AND in order to make sure there are uses and when is set correctly.
-      final Match<TriggerAttachment> baseDelegateWhenTriggerMatch = Match.all(
+      final Match<TriggerAttachment> baseDelegateWhenTriggerMatch = Match.allOf(
           TriggerAttachment.availableUses, TriggerAttachment.whenOrDefaultMatch(beforeOrAfter, stepName));
       TriggerAttachment.collectAndFireTriggers(new HashSet<>(data.getPlayerList().getPlayers()),
           baseDelegateWhenTriggerMatch, m_bridge, beforeOrAfter, stepName);

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -593,7 +593,7 @@ public class BattleCalculator {
     final Collection<Unit> killedNonAmphibUnits = new ArrayList<>();
     final Collection<UnitType> amphibTypes = new ArrayList<>();
     // Get a list of all selected killed units that are NOT amphibious
-    final Match<Unit> aMatch = Match.all(Matches.UnitIsLand, Matches.UnitWasNotAmphibious);
+    final Match<Unit> aMatch = Match.allOf(Matches.UnitIsLand, Matches.UnitWasNotAmphibious);
     killedNonAmphibUnits.addAll(Match.getMatches(killed, aMatch));
     // If all killed units are amphibious, just return them
     if (killedNonAmphibUnits.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -257,7 +257,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final PlayerID attacker = m_bridge.getPlayerID();
     final ITripleAPlayer remotePlayer = getRemotePlayer();
     final Match<Unit> ownedAndCanBombard =
-        Match.all(Matches.unitCanBombard(attacker), Matches.unitIsOwnedBy(attacker));
+        Match.allOf(Matches.unitCanBombard(attacker), Matches.unitIsOwnedBy(attacker));
     final Map<Territory, Collection<IBattle>> adjBombardment = getPossibleBombardingTerritories();
     final Iterator<Territory> territories = adjBombardment.keySet().iterator();
     final boolean shoreBombardPerGroundUnitRestricted = isShoreBombardPerGroundUnitRestricted(getData());
@@ -419,15 +419,15 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final GameData data = bridge.getData();
     final boolean ignoreTransports = isIgnoreTransportInMovement(data);
     final boolean ignoreSubs = isIgnoreSubInMovement(data);
-    final Match<Unit> seaTransports = Match.all(Matches.UnitIsTransportButNotCombatTransport, Matches.UnitIsSea);
-    final Match<Unit> seaTranportsOrSubs = Match.any(seaTransports, Matches.UnitIsSub);
+    final Match<Unit> seaTransports = Match.allOf(Matches.UnitIsTransportButNotCombatTransport, Matches.UnitIsSea);
+    final Match<Unit> seaTranportsOrSubs = Match.anyOf(seaTransports, Matches.UnitIsSub);
     // we want to match all sea zones with our units and enemy units
-    final Match<Territory> anyTerritoryWithOwnAndEnemy = Match.all(
+    final Match<Territory> anyTerritoryWithOwnAndEnemy = Match.allOf(
         Matches.territoryHasUnitsOwnedBy(player), Matches.territoryHasEnemyUnits(player, data));
-    final Match<Territory> enemyTerritoryAndOwnUnits = Match.all(
+    final Match<Territory> enemyTerritoryAndOwnUnits = Match.allOf(
         Matches.isTerritoryEnemyAndNotUnownedWater(player, data), Matches.territoryHasUnitsOwnedBy(player));
     final Match<Territory> enemyUnitsOrEnemyTerritory =
-        Match.any(anyTerritoryWithOwnAndEnemy, enemyTerritoryAndOwnUnits);
+        Match.anyOf(anyTerritoryWithOwnAndEnemy, enemyTerritoryAndOwnUnits);
     final Iterator<Territory> battleTerritories =
         Match.getMatches(data.getMap().getTerritories(), enemyUnitsOrEnemyTerritory).iterator();
     while (battleTerritories.hasNext()) {
@@ -597,7 +597,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         enemyPlayers.add(u.getOwner());
       }
       for (final PlayerID p : enemyPlayers) {
-        final Match<Unit> canPreventCapture = Match.all(Matches.unitIsEnemyOf(data, p),
+        final Match<Unit> canPreventCapture = Match.allOf(Matches.unitIsEnemyOf(data, p),
             Matches.UnitIsNotAir, Matches.UnitIsNotInfrastructure);
         enemyUnitsOfAbandonedToUnits.addAll(territory.getUnits().getMatches(canPreventCapture));
       }
@@ -641,13 +641,13 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         maxScrambleDistance = ua.getMaxScrambleDistance();
       }
     }
-    final Match<Unit> airbasesCanScramble = Match.all(Matches.unitIsEnemyOf(data, m_player),
+    final Match<Unit> airbasesCanScramble = Match.allOf(Matches.unitIsEnemyOf(data, m_player),
         Matches.UnitIsAirBase, Matches.UnitIsNotDisabled, Matches.unitIsBeingTransported().invert());
     final Match.CompositeBuilder<Territory> canScrambleBuilder = Match.newCompositeBuilder(
-        Match.any(
+        Match.anyOf(
             Matches.TerritoryIsWater,
             Matches.isTerritoryEnemy(m_player, data)),
-        Matches.territoryHasUnitsThatMatch(Match.all(
+        Matches.territoryHasUnitsThatMatch(Match.allOf(
             Matches.UnitCanScramble,
             Matches.unitIsEnemyOf(data, m_player),
             Matches.UnitIsNotDisabled)),
@@ -728,7 +728,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         final int maxCanScramble = getMaxScrambleCount(airbases);
         final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.TerritoryIsNotImpassable);
         final Collection<Unit> canScrambleAir = from.getUnits()
-            .getMatches(Match.all(Matches.unitIsEnemyOf(data, m_player), Matches.UnitCanScramble,
+            .getMatches(Match.allOf(Matches.unitIsEnemyOf(data, m_player), Matches.UnitCanScramble,
                 Matches.UnitIsNotDisabled, Matches.UnitWasScrambled.invert(),
                 Matches.unitCanScrambleOnRouteDistance(toBattleRoute)));
         if (maxCanScramble > 0 && !canScrambleAir.isEmpty()) {
@@ -945,7 +945,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   }
 
   public static int getMaxScrambleCount(final Collection<Unit> airbases) {
-    if (!Match.allMatch(airbases, Match.all(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
+    if (!Match.allMatch(airbases, Match.allOf(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
       throw new IllegalStateException("All units must be viable airbases");
     }
     // find how many is the max this territory can scramble
@@ -1056,7 +1056,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final Map<Territory, Collection<Unit>> defendingAirThatCanNotLand = m_battleTracker.getDefendingAirThatCanNotLand();
     final boolean isWW2v2orIsSurvivingAirMoveToLand = games.strategy.triplea.Properties.getWW2V2(data)
         || games.strategy.triplea.Properties.getSurvivingAirMoveToLand(data);
-    final Match<Unit> alliedDefendingAir = Match.all(Matches.UnitIsAir, Matches.UnitWasScrambled.invert());
+    final Match<Unit> alliedDefendingAir = Match.allOf(Matches.UnitIsAir, Matches.UnitWasScrambled.invert());
     for (final Entry<Territory, Collection<Unit>> entry : defendingAirThatCanNotLand.entrySet()) {
       final Territory battleSite = entry.getKey();
       final Collection<Unit> defendingAir = entry.getValue();
@@ -1071,18 +1071,18 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // Get all land territories where we can land
       final Set<Territory> neighbors = data.getMap().getNeighbors(battleSite);
       final Match<Territory> alliedLandTerritories =
-          Match.all(Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(defender, data));
+          Match.allOf(Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(defender, data));
       // Get those that are neighbors
       final Collection<Territory> canLandHere = Match.getMatches(neighbors, alliedLandTerritories);
       // Get all sea territories where there are allies
       final Match<Territory> neighboringSeaZonesWithAlliedUnits =
-          Match.all(Matches.TerritoryIsWater, Matches.territoryHasAlliedUnits(defender, data));
+          Match.allOf(Matches.TerritoryIsWater, Matches.territoryHasAlliedUnits(defender, data));
       // Get those that are neighbors
       final Collection<Territory> areSeaNeighbors = Match.getMatches(neighbors, neighboringSeaZonesWithAlliedUnits);
       // Set up match criteria for allied carriers
-      final Match<Unit> alliedCarrier = Match.all(Matches.UnitIsCarrier, Matches.alliedUnit(defender, data));
+      final Match<Unit> alliedCarrier = Match.allOf(Matches.UnitIsCarrier, Matches.alliedUnit(defender, data));
       // Set up match criteria for allied planes
-      final Match<Unit> alliedPlane = Match.all(Matches.UnitIsAir, Matches.alliedUnit(defender, data));
+      final Match<Unit> alliedPlane = Match.allOf(Matches.UnitIsAir, Matches.alliedUnit(defender, data));
       // See if neighboring carriers have any capacity available
       for (final Territory currentTerritory : areSeaNeighbors) {
         // get the capacity of the carriers and cost of fighters
@@ -1203,7 +1203,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     if (enemies.isEmpty()) {
       return;
     }
-    final Match<Unit> canBeAttackedDefault = Match.all(Matches.unitIsOwnedBy(m_player),
+    final Match<Unit> canBeAttackedDefault = Match.allOf(Matches.unitIsOwnedBy(m_player),
         Matches.UnitIsSea, Matches.UnitIsNotTransportButCouldBeCombatTransport, Matches.UnitIsNotSub);
     final boolean onlyWhereThereAreBattlesOrAmphibious =
         games.strategy.triplea.Properties.getKamikazeSuicideAttacksOnlyWhereBattlesAre(data);
@@ -1287,7 +1287,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       Match<Unit> canBeAttacked = canBeAttackedDefault;
       final Set<UnitType> suicideAttackTargets = pa.getSuicideAttackTargets();
       if (suicideAttackTargets != null) {
-        canBeAttacked = Match.all(Matches.unitIsOwnedBy(m_player), Matches.unitIsOfTypes(suicideAttackTargets));
+        canBeAttacked = Match.allOf(Matches.unitIsOwnedBy(m_player), Matches.unitIsOfTypes(suicideAttackTargets));
       }
       // See if the player has any attack tokens
       final IntegerMap<Resource> resourcesAndAttackValues = pa.getSuicideAttackResources();
@@ -1501,14 +1501,14 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     possibleTerrs.add(currentTerr);
     final HashSet<Territory> availableLand = new HashSet<>();
     availableLand.addAll(Match.getMatches(possibleTerrs,
-        Match.all(Matches.isTerritoryAllied(alliedPlayer, data), Matches.TerritoryIsLand)));
+        Match.allOf(Matches.isTerritoryAllied(alliedPlayer, data), Matches.TerritoryIsLand)));
     availableLand.removeAll(canNotLand);
     whereCanLand.addAll(availableLand);
     // now for carrier-air-landing validation
     if (Match.allMatch(strandedAir, Matches.UnitCanLandOnCarrier)) {
       final HashSet<Territory> availableWater = new HashSet<>();
       availableWater.addAll(Match.getMatches(possibleTerrs,
-          Match.all(
+          Match.allOf(
               Matches.territoryHasUnitsThatMatch(Matches.unitIsAlliedCarrier(alliedPlayer, data)),
               Matches.TerritoryIsWater)));
       availableWater.removeAll(battleTracker.getPendingBattleSites(false));
@@ -1521,7 +1521,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             .carrierCapacity(t.getUnits().getMatches(Matches.unitIsAlliedCarrier(alliedPlayer, data)), t);
         if (!t.equals(currentTerr)) {
           carrierCapacity -= AirMovementValidator.carrierCost(t.getUnits().getMatches(
-              Match.all(Matches.UnitCanLandOnCarrier, Matches.alliedUnit(alliedPlayer, data))));
+              Match.allOf(Matches.UnitCanLandOnCarrier, Matches.alliedUnit(alliedPlayer, data))));
         } else {
           carrierCapacity -= carrierCostForCurrentTerr;
         }

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -392,9 +392,9 @@ public class BattleTracker implements java.io.Serializable {
     }
     final boolean canConquerMiddleSteps = Match.someMatch(presentFromStartTilEnd, Matches.UnitIsNotAir);
     final boolean scramblingEnabled = games.strategy.triplea.Properties.getScramble_Rules_In_Effect(data);
-    final Match<Territory> conquerable = Match.all(
+    final Match<Territory> conquerable = Match.allOf(
         Matches.territoryIsEmptyOfCombatUnits(data, id),
-        Match.any(
+        Match.anyOf(
             Matches.territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(id),
             Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(id, data)));
     final Collection<Territory> conquered = new ArrayList<>();
@@ -498,7 +498,7 @@ public class BattleTracker implements java.io.Serializable {
           - Match.countMatches(arrivedUnits, Matches.UnitIsAir)
           - Match.countMatches(arrivedUnits, Matches.UnitIsSubmerged);
       // If transports are restricted from controlling sea zones, subtract them
-      final Match<Unit> transportsCanNotControl = Match.all(
+      final Match<Unit> transportsCanNotControl = Match.allOf(
           Matches.UnitIsTransportAndNotDestroyer,
           Matches.UnitIsTransportButNotCombatTransport);
       if (!games.strategy.triplea.Properties.getTransportControlSeaZone(data)) {
@@ -685,7 +685,7 @@ public class BattleTracker implements java.io.Serializable {
     // Remove any bombing raids against captured territory
     // TODO: see if necessary
     if (Match.someMatch(territory.getUnits().getUnits(),
-        Match.all(Matches.unitIsEnemyOf(data, id), Matches.UnitCanBeDamaged))) {
+        Match.allOf(Matches.unitIsEnemyOf(data, id), Matches.UnitCanBeDamaged))) {
       final IBattle bombingBattle = getPendingBattle(territory, true, null);
       if (bombingBattle != null) {
         final BattleResults results = new BattleResults(bombingBattle, WhoWon.DRAW, data);
@@ -743,7 +743,7 @@ public class BattleTracker implements java.io.Serializable {
     // destroy any units that should be destroyed on capture
     if (games.strategy.triplea.Properties.getUnitsCanBeDestroyedInsteadOfCaptured(data)) {
       final Match<Unit> enemyToBeDestroyed =
-          Match.all(Matches.enemyUnit(id, data), Matches.unitDestroyedWhenCapturedByOrFrom(id));
+          Match.allOf(Matches.enemyUnit(id, data), Matches.unitDestroyedWhenCapturedByOrFrom(id));
       final Collection<Unit> destroyed = territory.getUnits().getMatches(enemyToBeDestroyed);
       if (!destroyed.isEmpty()) {
         final Change destroyUnits = ChangeFactory.removeUnits(territory, destroyed);
@@ -769,7 +769,7 @@ public class BattleTracker implements java.io.Serializable {
       }
     }
     // destroy any disabled units owned by the enemy that are NOT infrastructure or factories
-    final Match<Unit> enemyToBeDestroyed = Match.all(Matches.enemyUnit(id, data),
+    final Match<Unit> enemyToBeDestroyed = Match.allOf(Matches.enemyUnit(id, data),
         Matches.UnitIsDisabled, Matches.UnitIsInfrastructure.invert());
     final Collection<Unit> destroyed = territory.getUnits().getMatches(enemyToBeDestroyed);
     if (!destroyed.isEmpty()) {
@@ -781,8 +781,8 @@ public class BattleTracker implements java.io.Serializable {
       }
     }
     // take over non combatants
-    final Match<Unit> enemyNonCom = Match.all(Matches.enemyUnit(id, data), Matches.UnitIsInfrastructure);
-    final Match<Unit> willBeCaptured = Match.any(enemyNonCom,
+    final Match<Unit> enemyNonCom = Match.allOf(Matches.enemyUnit(id, data), Matches.UnitIsInfrastructure);
+    final Match<Unit> willBeCaptured = Match.anyOf(enemyNonCom,
         Matches.unitCanBeCapturedOnEnteringToInThisTerritory(id, territory, data));
     final Collection<Unit> nonCom = territory.getUnits().getMatches(willBeCaptured);
     // change any units that change unit types on capture

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -115,8 +115,8 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     final Collection<Unit> placeableUnits = new ArrayList<>();
     final Match<Unit> groundUnits =
         // we add factories and constructions later
-        Match.all(Matches.UnitIsLand, Matches.UnitIsNotConstruction);
-    final Match<Unit> airUnits = Match.all(Matches.UnitIsAir, Matches.UnitIsNotConstruction);
+        Match.allOf(Matches.UnitIsLand, Matches.UnitIsNotConstruction);
+    final Match<Unit> airUnits = Match.allOf(Matches.UnitIsAir, Matches.UnitIsNotConstruction);
     placeableUnits.addAll(Match.getMatches(units, groundUnits));
     placeableUnits.addAll(Match.getMatches(units, airUnits));
     if (Match.someMatch(units, Matches.UnitIsConstruction)) {

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -645,7 +645,7 @@ public class DiceRoll implements Externalizable {
       if (!((allies && rule.getAllied()) || (!allies && rule.getEnemy()))) {
         continue;
       }
-      final Match<Unit> canSupport = Match.all(
+      final Match<Unit> canSupport = Match.allOf(
           Matches.unitIsOfType((UnitType) rule.getAttachedTo()), Matches.unitOwnedBy(rule.getPlayers()));
       final List<Unit> supporters = Match.getMatches(unitsGivingTheSupport, canSupport);
       int numSupport = supporters.size();

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -89,7 +89,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
-              Match.all(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
+              Match.allOf(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
           if (!Match.allMatch(landUnitsToAdd, Matches.UnitCanBeTransported)) {
@@ -149,7 +149,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
         m_bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
       }
     } else {
-      final Match<Unit> enemyNonCom = Match.all(Matches.UnitIsInfrastructure, Matches.enemyUnit(player, data));
+      final Match<Unit> enemyNonCom = Match.allOf(Matches.UnitIsInfrastructure, Matches.enemyUnit(player, data));
       final Collection<Unit> units = territory.getUnits().getMatches(enemyNonCom);
       // mark no movement for enemy units
       m_bridge.addChange(ChangeFactory.markNoMovementChange(units));

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -74,7 +74,7 @@ class EditValidator {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
-              Match.all(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
+              Match.allOf(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
           if (!Match.allMatch(landUnitsToAdd, Matches.UnitCanBeTransported)) {
@@ -90,12 +90,12 @@ class EditValidator {
           }
         }
         if (Match.someMatch(units, Matches.UnitIsAir)) {
-          if (Match.someMatch(units, Match.all(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier.invert()))) {
+          if (Match.someMatch(units, Match.allOf(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier.invert()))) {
             return "Cannot add air to water unless it can land on carriers";
           }
           // Set up matches
-          final Match<Unit> friendlyCarriers = Match.all(Matches.UnitIsCarrier, Matches.alliedUnit(player, data));
-          final Match<Unit> friendlyAirUnits = Match.all(Matches.UnitIsAir, Matches.alliedUnit(player, data));
+          final Match<Unit> friendlyCarriers = Match.allOf(Matches.UnitIsCarrier, Matches.alliedUnit(player, data));
+          final Match<Unit> friendlyAirUnits = Match.allOf(Matches.UnitIsAir, Matches.alliedUnit(player, data));
           // Determine transport capacity
           final int carrierCapacityTotal =
               AirMovementValidator.carrierCapacity(territory.getUnits().getMatches(friendlyCarriers), territory)

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -106,8 +106,8 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
       final Match<TriggerAttachment> endRoundDelegateTriggerMatch =
-          Match.all(AbstractTriggerAttachment.availableUses,
-              AbstractTriggerAttachment.whenOrDefaultMatch(null, null), Match.any(
+          Match.allOf(AbstractTriggerAttachment.availableUses,
+              AbstractTriggerAttachment.whenOrDefaultMatch(null, null), Match.anyOf(
                   TriggerAttachment.activateTriggerMatch(), TriggerAttachment.victoryMatch()));
       // get all possible triggers based on this match.
       final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -74,7 +74,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final StringBuilder endTurnReport = new StringBuilder();
     final GameData data = getData();
     final PlayerID player = data.getSequence().getStep().getPlayerID();
-    final Match<Unit> myCreatorsMatch = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCreatesUnits);
+    final Match<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitCreatesUnits);
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> myCreators = Match.getMatches(t.getUnits().getUnits(), myCreatorsMatch);
@@ -106,7 +106,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           change.add(place);
         }
         if (!toAddSea.isEmpty()) {
-          final Match<Territory> myTerrs = Match.all(Matches.TerritoryIsWater);
+          final Match<Territory> myTerrs = Match.allOf(Matches.TerritoryIsWater);
           final Collection<Territory> waterNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (waterNeighbors != null && !waterNeighbors.isEmpty()) {
             final Territory tw = getRandomTerritory(waterNeighbors, bridge);
@@ -119,7 +119,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
           }
         }
         if (!toAddLand.isEmpty()) {
-          final Match<Territory> myTerrs = Match.all(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
+          final Match<Territory> myTerrs = Match.allOf(Matches.isTerritoryOwnedBy(player), Matches.TerritoryIsLand);
           final Collection<Territory> landNeighbors = data.getMap().getNeighbors(t, myTerrs);
           if (landNeighbors != null && !landNeighbors.isEmpty()) {
             final Territory tl = getRandomTerritory(landNeighbors, bridge);
@@ -165,7 +165,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     // Find total unit generated resources for all owned units
     final GameData data = getData();
     final PlayerID player = data.getSequence().getStep().getPlayerID();
-    final Match<Unit> myCreatorsMatch = Match.all(Matches.unitIsOwnedBy(player), Matches.UnitCreatesResources);
+    final Match<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitCreatesResources);
     final IntegerMap<Resource> resourceTotalsMap = new IntegerMap<>();
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> myCreators = Match.getMatches(t.getUnits().getUnits(), myCreatorsMatch);
@@ -217,9 +217,9 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final boolean useTriggers = games.strategy.triplea.Properties.getTriggers(data);
     if (useTriggers) {
       // add conditions required for triggers
-      final Match<TriggerAttachment> endTurnDelegateTriggerMatch = Match.all(
+      final Match<TriggerAttachment> endTurnDelegateTriggerMatch = Match.allOf(
           AbstractTriggerAttachment.availableUses, AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
-          Match.any(TriggerAttachment.resourceMatch()));
+          Match.anyOf(TriggerAttachment.resourceMatch()));
       toFirePossible.addAll(TriggerAttachment.collectForAllTriggersMatching(
           new HashSet<>(Collections.singleton(player)), endTurnDelegateTriggerMatch, bridge));
       allConditionsNeeded.addAll(

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -98,13 +98,13 @@ public class Fire implements IExecutable {
     final int hitCount = m_dice.getHits();
     AbstractBattle.getDisplay(bridge).notifyDice(m_dice, m_stepName);
     final int countTransports =
-        Match.countMatches(m_attackableUnits, Match.all(Matches.UnitIsTransport, Matches.UnitIsSea));
+        Match.countMatches(m_attackableUnits, Match.allOf(Matches.UnitIsTransport, Matches.UnitIsSea));
     if (countTransports > 0 && isTransportCasualtiesRestricted(bridge.getData())) {
       final CasualtyDetails message;
       final Collection<Unit> nonTransports = Match.getMatches(m_attackableUnits,
-          Match.any(Matches.UnitIsNotTransportButCouldBeCombatTransport, Matches.UnitIsNotSea));
+          Match.anyOf(Matches.UnitIsNotTransportButCouldBeCombatTransport, Matches.UnitIsNotSea));
       final Collection<Unit> transportsOnly = Match.getMatches(m_attackableUnits,
-          Match.all(Matches.UnitIsTransportButNotCombatTransport, Matches.UnitIsSea));
+          Match.allOf(Matches.UnitIsTransportButNotCombatTransport, Matches.UnitIsSea));
       final int numPossibleHits = AbstractBattle.getMaxHits(nonTransports);
       // more hits than combat units
       if (hitCount > numPossibleHits) {
@@ -120,7 +120,7 @@ public class Fire implements IExecutable {
         // Leave enough transports for each defender for overlfows so they can select who loses them.
         while (playerIter.hasNext()) {
           final PlayerID player = playerIter.next();
-          final Match<Unit> match = Match.all(
+          final Match<Unit> match = Match.allOf(
               Matches.UnitIsTransportButNotCombatTransport,
               Matches.unitIsOwnedBy(player));
           final Collection<Unit> playerTransports = Match.getMatches(transportsOnly, match);

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -239,7 +239,7 @@ public class Matches {
   }
 
   static Match<Unit> unitDestroyedWhenCapturedByOrFrom(final PlayerID playerBy) {
-    return Match.any(unitDestroyedWhenCapturedBy(playerBy), unitDestroyedWhenCapturedFrom());
+    return Match.anyOf(unitDestroyedWhenCapturedBy(playerBy), unitDestroyedWhenCapturedFrom());
   }
 
   private static Match<Unit> unitDestroyedWhenCapturedBy(final PlayerID playerBy) {
@@ -414,7 +414,7 @@ public class Matches {
       Match.of(unit -> UnitAttachment.get(unit.getType()).getCarrierCapacity() != -1);
 
   static Match<Territory> territoryHasOwnedCarrier(final PlayerID player) {
-    return Match.of(t -> t.getUnits().someMatch(Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier)));
+    return Match.of(t -> t.getUnits().someMatch(Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier)));
   }
 
   public static Match<Unit> unitIsAlliedCarrier(final PlayerID player, final GameData data) {
@@ -504,7 +504,7 @@ public class Matches {
           return true;
         }
       }
-      return Match.someMatch(targets, Match.all(Matches.UnitIsAirborne,
+      return Match.someMatch(targets, Match.allOf(Matches.UnitIsAirborne,
           Matches.unitIsOfTypes(airborneTechTargetsAllowed.get(ua.getTypeAA()))));
     });
   }
@@ -542,7 +542,7 @@ public class Matches {
   static Match<Unit> unitIsAaThatCanFire(final Collection<Unit> unitsMovingOrAttacking,
       final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed, final PlayerID playerMovingOrAttacking,
       final Match<Unit> typeOfAa, final int battleRoundNumber, final boolean defending, final GameData data) {
-    return Match.all(Matches.enemyUnit(playerMovingOrAttacking, data),
+    return Match.allOf(Matches.enemyUnit(playerMovingOrAttacking, data),
         Matches.unitIsBeingTransported().invert(),
         Matches.unitIsAaThatCanHitTheseUnits(unitsMovingOrAttacking, typeOfAa, airborneTechTargetsAllowed),
         Matches.unitIsAaThatWillNotFireIfPresentEnemyUnits(unitsMovingOrAttacking).invert(),
@@ -735,7 +735,7 @@ public class Matches {
       // CompositeMatchAnd<Territory>(Matches.TerritoryIsPassableAndNotRestricted(player),
       // Matches.territoryHasEnemyLandNeighbor(data,
       // player));
-      final Match<Territory> condition = Match.all(Matches.TerritoryIsLand,
+      final Match<Territory> condition = Match.allOf(Matches.TerritoryIsLand,
           Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data));
       return data.getMap().getNeighbors(t, condition).size() > 0;
     });
@@ -832,7 +832,7 @@ public class Matches {
       if (!data.getRelationshipTracker().isAllied(t.getOwner(), player)) {
         return false;
       }
-      return t.getUnits().someMatch(Match.all(Matches.alliedUnit(player, data), unitMatch));
+      return t.getUnits().someMatch(Match.allOf(Matches.alliedUnit(player, data), unitMatch));
     });
   }
 
@@ -842,7 +842,7 @@ public class Matches {
       if (!t.getOwner().equals(player)) {
         return false;
       }
-      return t.getUnits().someMatch(Match.all(Matches.unitIsOwnedBy(player), unitMatch));
+      return t.getUnits().someMatch(Match.allOf(Matches.unitIsOwnedBy(player), unitMatch));
     });
   }
 
@@ -887,13 +887,13 @@ public class Matches {
       if (t.getOwner().isNull()) {
         return false;
       }
-      return t.getUnits().someMatch(Match.all(Matches.enemyUnit(player, data), unitMatch));
+      return t.getUnits().someMatch(Match.allOf(Matches.enemyUnit(player, data), unitMatch));
     });
   }
 
   static Match<Territory> territoryIsEmptyOfCombatUnits(final GameData data, final PlayerID player) {
     return Match.of(t -> {
-      final Match<Unit> nonCom = Match.any(UnitIsInfrastructure, enemyUnit(player, data).invert());
+      final Match<Unit> nonCom = Match.anyOf(UnitIsInfrastructure, enemyUnit(player, data).invert());
       return t.getUnits().allMatch(nonCom);
     });
   }
@@ -1187,11 +1187,11 @@ public class Matches {
   }
 
   private static Match<Unit> unitIsEnemyAaForAnything(final PlayerID player, final GameData data) {
-    return Match.all(UnitIsAAforAnything, enemyUnit(player, data));
+    return Match.allOf(UnitIsAAforAnything, enemyUnit(player, data));
   }
 
   private static Match<Unit> unitIsEnemyAaForCombat(final PlayerID player, final GameData data) {
-    return Match.all(UnitIsAAforCombatOnly, enemyUnit(player, data));
+    return Match.allOf(UnitIsAAforCombatOnly, enemyUnit(player, data));
   }
 
   static Match<Unit> unitIsInTerritory(final Territory territory) {
@@ -1329,7 +1329,7 @@ public class Matches {
   }
 
   public static Match<Territory> territoryHasLandUnitsOwnedBy(final PlayerID player) {
-    return Match.of(t -> t.getUnits().someMatch(Match.all(unitIsOwnedBy(player), UnitIsLand)));
+    return Match.of(t -> t.getUnits().someMatch(Match.allOf(unitIsOwnedBy(player), UnitIsLand)));
   }
 
   public static Match<Territory> territoryHasUnitsOwnedBy(final PlayerID player) {
@@ -1358,16 +1358,16 @@ public class Matches {
   }
 
   static Match<Territory> territoryHasNonSubmergedEnemyUnits(final PlayerID player, final GameData data) {
-    final Match<Unit> match = Match.all(enemyUnit(player, data), UnitIsSubmerged.invert());
+    final Match<Unit> match = Match.allOf(enemyUnit(player, data), UnitIsSubmerged.invert());
     return Match.of(t -> t.getUnits().someMatch(match));
   }
 
   public static Match<Territory> territoryHasEnemyLandUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().someMatch(Match.all(enemyUnit(player, data), UnitIsLand)));
+    return Match.of(t -> t.getUnits().someMatch(Match.allOf(enemyUnit(player, data), UnitIsLand)));
   }
 
   public static Match<Territory> territoryHasEnemySeaUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().someMatch(Match.all(enemyUnit(player, data), UnitIsSea)));
+    return Match.of(t -> t.getUnits().someMatch(Match.allOf(enemyUnit(player, data), UnitIsSea)));
   }
 
   public static Match<Territory> territoryHasEnemyUnits(final PlayerID player, final GameData data) {
@@ -1390,7 +1390,7 @@ public class Matches {
       }
       final Set<PlayerID> enemies = new HashSet<>();
       for (final Unit u : t.getUnits()
-          .getMatches(Match.all(enemyUnit(player, data), UnitIsNotAir, UnitIsNotInfrastructure))) {
+          .getMatches(Match.allOf(enemyUnit(player, data), UnitIsNotAir, UnitIsNotInfrastructure))) {
         enemies.add(u.getOwner());
       }
       return (Matches.isAtWarWithAnyOfThesePlayers(enemies, data)).match(t.getOwner());
@@ -1476,9 +1476,9 @@ public class Matches {
     });
   }
 
-  public static final Match<Unit> UnitIsLand = Match.all(UnitIsNotSea, UnitIsNotAir);
+  public static final Match<Unit> UnitIsLand = Match.allOf(UnitIsNotSea, UnitIsNotAir);
 
-  public static final Match<UnitType> UnitTypeIsLand = Match.all(UnitTypeIsNotSea, UnitTypeIsNotAir);
+  public static final Match<UnitType> UnitTypeIsLand = Match.allOf(UnitTypeIsNotSea, UnitTypeIsNotAir);
 
   public static final Match<Unit> UnitIsNotLand = UnitIsLand.invert();
 
@@ -1513,9 +1513,9 @@ public class Matches {
   }
 
   public static Match<Territory> territoryIsBlockedSea(final PlayerID player, final GameData data) {
-    final Match<Unit> sub = Match.all(Matches.UnitIsSub.invert());
+    final Match<Unit> sub = Match.allOf(Matches.UnitIsSub.invert());
     final Match<Unit> transport =
-        Match.all(Matches.UnitIsTransportButNotCombatTransport.invert(), Matches.UnitIsLand.invert());
+        Match.allOf(Matches.UnitIsTransportButNotCombatTransport.invert(), Matches.UnitIsLand.invert());
     final Match.CompositeBuilder<Unit> unitCondBuilder = Match.newCompositeBuilder(
         Matches.UnitIsInfrastructure.invert(),
         Matches.alliedUnit(player, data).invert());
@@ -1525,7 +1525,7 @@ public class Matches {
     if (Properties.getIgnoreSubInMovement(data)) {
       unitCondBuilder.add(sub);
     }
-    return Match.all(
+    return Match.allOf(
         Matches.territoryHasUnitsThatMatch(unitCondBuilder.all()).invert(),
         Matches.TerritoryIsWater);
   }
@@ -1567,17 +1567,17 @@ public class Matches {
   public static Match<Unit> unitCanBeRepairedByFacilitiesInItsTerritory(final Territory territory,
       final PlayerID player, final GameData data) {
     return Match.of(damagedUnit -> {
-      final Match<Unit> damaged = Match.all(Matches.UnitHasMoreThanOneHitPointTotal, Matches.UnitHasTakenSomeDamage);
+      final Match<Unit> damaged = Match.allOf(Matches.UnitHasMoreThanOneHitPointTotal, Matches.UnitHasTakenSomeDamage);
       if (!damaged.match(damagedUnit)) {
         return false;
       }
-      final Match<Unit> repairUnit = Match.all(Matches.alliedUnit(player, data),
+      final Match<Unit> repairUnit = Match.allOf(Matches.alliedUnit(player, data),
           Matches.UnitCanRepairOthers, Matches.unitCanRepairThisUnit(damagedUnit));
       if (Match.someMatch(territory.getUnits().getUnits(), repairUnit)) {
         return true;
       }
       if (Matches.UnitIsSea.match(damagedUnit)) {
-        final Match<Unit> repairUnitLand = Match.all(repairUnit, Matches.UnitIsLand);
+        final Match<Unit> repairUnitLand = Match.allOf(repairUnit, Matches.UnitIsLand);
         final List<Territory> neighbors =
             new ArrayList<>(data.getMap().getNeighbors(territory, Matches.TerritoryIsLand));
         for (final Territory current : neighbors) {
@@ -1586,7 +1586,7 @@ public class Matches {
           }
         }
       } else if (Matches.UnitIsLand.match(damagedUnit)) {
-        final Match<Unit> repairUnitSea = Match.all(repairUnit, Matches.UnitIsSea);
+        final Match<Unit> repairUnitSea = Match.allOf(repairUnit, Matches.UnitIsSea);
         final List<Territory> neighbors =
             new ArrayList<>(data.getMap().getNeighbors(territory, Matches.TerritoryIsWater));
         for (final Territory current : neighbors) {
@@ -1635,13 +1635,13 @@ public class Matches {
   public static Match<Unit> unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(final Territory territory,
       final PlayerID player, final GameData data) {
     return Match.of(unitWhichWillGetBonus -> {
-      final Match<Unit> givesBonusUnit = Match.all(Matches.alliedUnit(player, data),
+      final Match<Unit> givesBonusUnit = Match.allOf(Matches.alliedUnit(player, data),
           unitCanGiveBonusMovementToThisUnit(unitWhichWillGetBonus));
       if (Match.someMatch(territory.getUnits().getUnits(), givesBonusUnit)) {
         return true;
       }
       if (Matches.UnitIsSea.match(unitWhichWillGetBonus)) {
-        final Match<Unit> givesBonusUnitLand = Match.all(givesBonusUnit, Matches.UnitIsLand);
+        final Match<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, Matches.UnitIsLand);
         final List<Territory> neighbors =
             new ArrayList<>(data.getMap().getNeighbors(territory, Matches.TerritoryIsLand));
         for (final Territory current : neighbors) {
@@ -1696,7 +1696,7 @@ public class Matches {
       final Collection<UnitType> requiredUnits = requiredUnitsMap.keySet();
       boolean canBuild = true;
       for (final UnitType ut : requiredUnits) {
-        final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.all(
+        final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.allOf(
             Matches.unitIsOwnedBy(unitWhichRequiresUnits.getOwner()), Matches.unitIsOfType(ut),
             Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.UnitHasNotTakenAnyDamage, Matches.UnitIsNotDisabled);
         final int requiredNumber = requiredUnitsMap.getInt(ut);
@@ -1727,7 +1727,7 @@ public class Matches {
       if (!Matches.UnitRequiresUnitsOnCreation.match(unitWhichRequiresUnits)) {
         return true;
       }
-      final Match<Unit> unitIsOwnedByAndNotDisabled = Match.all(
+      final Match<Unit> unitIsOwnedByAndNotDisabled = Match.allOf(
           Matches.unitIsOwnedBy(unitWhichRequiresUnits.getOwner()), Matches.UnitIsNotDisabled);
       unitsInTerritoryAtStartOfTurn
           .retainAll(Match.getMatches(unitsInTerritoryAtStartOfTurn, unitIsOwnedByAndNotDisabled));
@@ -1779,13 +1779,13 @@ public class Matches {
   public static final Match<Unit> UnitIsNotConstruction = UnitIsConstruction.invert();
 
   public static final Match<Unit> UnitCanProduceUnitsAndIsConstruction =
-      Match.all(UnitCanProduceUnits, UnitIsConstruction);
+      Match.allOf(UnitCanProduceUnits, UnitIsConstruction);
   public static final Match<UnitType> UnitTypeCanProduceUnitsAndIsConstruction =
-      Match.all(UnitTypeCanProduceUnits, UnitTypeIsConstruction);
+      Match.allOf(UnitTypeCanProduceUnits, UnitTypeIsConstruction);
   public static final Match<Unit> UnitCanProduceUnitsAndIsInfrastructure =
-      Match.all(UnitCanProduceUnits, UnitIsInfrastructure);
+      Match.allOf(UnitCanProduceUnits, UnitIsInfrastructure);
   public static final Match<Unit> UnitCanProduceUnitsAndCanBeDamaged =
-      Match.all(UnitCanProduceUnits, UnitCanBeDamaged);
+      Match.allOf(UnitCanProduceUnits, UnitCanBeDamaged);
 
   /**
    * See if a unit can invade. Units with canInvadeFrom not set, or set to "all", can invade from any other unit.
@@ -2162,7 +2162,7 @@ public class Matches {
       supportOrNotInfrastructureOrAa.add(Matches.UnitTypeIsInfrastructure.invert());
       supportOrNotInfrastructureOrAa.add(Matches.unitTypeIsSupporterOrHasCombatAbility(attack, player));
       if (!doNotIncludeAa) {
-        supportOrNotInfrastructureOrAa.add(Match.all(Matches.UnitTypeIsAAforCombatOnly,
+        supportOrNotInfrastructureOrAa.add(Match.allOf(Matches.UnitTypeIsAAforCombatOnly,
             Matches.unitTypeIsAaThatCanFireOnRound(battleRound)));
       }
       canBeInBattle.add(supportOrNotInfrastructureOrAa.any());

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -77,17 +77,17 @@ public class MoveDelegate extends AbstractMoveDelegate {
       // OR. use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
       HashMap<ICondition, Boolean> testedConditions = null;
       final Match<TriggerAttachment> moveCombatDelegateBeforeBonusTriggerMatch =
-          Match.all(AbstractTriggerAttachment.availableUses,
+          Match.allOf(AbstractTriggerAttachment.availableUses,
               AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
-              Match.any(AbstractTriggerAttachment.notificationMatch(),
+              Match.anyOf(AbstractTriggerAttachment.notificationMatch(),
                   TriggerAttachment.playerPropertyMatch(), TriggerAttachment.relationshipTypePropertyMatch(),
                   TriggerAttachment.territoryPropertyMatch(), TriggerAttachment.territoryEffectPropertyMatch(),
                   TriggerAttachment.removeUnitsMatch(), TriggerAttachment.changeOwnershipMatch()));
       final Match<TriggerAttachment> moveCombatDelegateAfterBonusTriggerMatch =
-          Match.all(AbstractTriggerAttachment.availableUses,
+          Match.allOf(AbstractTriggerAttachment.availableUses,
               AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
-              Match.any(TriggerAttachment.placeMatch()));
-      final Match<TriggerAttachment> moveCombatDelegateAllTriggerMatch = Match.any(
+              Match.anyOf(TriggerAttachment.placeMatch()));
+      final Match<TriggerAttachment> moveCombatDelegateAllTriggerMatch = Match.anyOf(
           moveCombatDelegateBeforeBonusTriggerMatch, moveCombatDelegateAfterBonusTriggerMatch);
       if (GameStepPropertiesHelper.isCombatMove(data) && games.strategy.triplea.Properties.getTriggers(data)) {
         final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
@@ -237,9 +237,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
         Matches.unitIsOwnedBy(m_player));
 
     // right now, land units on transports have movement taken away when they their transport moves
-    moveableUnitOwnedByMeBuilder.add(Match.any(
+    moveableUnitOwnedByMeBuilder.add(Match.anyOf(
         Matches.unitHasMovementLeft,
-        Match.all(
+        Match.allOf(
             Matches.UnitIsLand,
             Matches.unitIsBeingTransported())));
 
@@ -320,11 +320,11 @@ public class MoveDelegate extends AbstractMoveDelegate {
   private static void removeMovementFromAirOnDamagedAlliedCarriers(final IDelegateBridge bridge,
       final PlayerID player) {
     final GameData data = bridge.getData();
-    final Match<Unit> crippledAlliedCarriersMatch = Match.all(Matches.isUnitAllied(player, data),
+    final Match<Unit> crippledAlliedCarriersMatch = Match.allOf(Matches.isUnitAllied(player, data),
         Matches.unitIsOwnedBy(player).invert(), Matches.UnitIsCarrier,
         Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
     final Match<Unit> ownedFightersMatch =
-        Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsAir,
+        Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsAir,
             Matches.UnitCanLandOnCarrier, Matches.unitHasMovementLeft);
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
@@ -362,18 +362,18 @@ public class MoveDelegate extends AbstractMoveDelegate {
           }
           int bonusMovement = Integer.MIN_VALUE;
           final Collection<Unit> givesBonusUnits = new ArrayList<>();
-          final Match<Unit> givesBonusUnit = Match.all(Matches.alliedUnit(player, data),
+          final Match<Unit> givesBonusUnit = Match.allOf(Matches.alliedUnit(player, data),
               Matches.unitCanGiveBonusMovementToThisUnit(u));
           givesBonusUnits.addAll(Match.getMatches(t.getUnits().getUnits(), givesBonusUnit));
           if (Matches.UnitIsSea.match(u)) {
-            final Match<Unit> givesBonusUnitLand = Match.all(givesBonusUnit, Matches.UnitIsLand);
+            final Match<Unit> givesBonusUnitLand = Match.allOf(givesBonusUnit, Matches.UnitIsLand);
             final List<Territory> neighbors =
                 new ArrayList<>(data.getMap().getNeighbors(t, Matches.TerritoryIsLand));
             for (final Territory current : neighbors) {
               givesBonusUnits.addAll(Match.getMatches(current.getUnits().getUnits(), givesBonusUnitLand));
             }
           } else if (Matches.UnitIsLand.match(u)) {
-            final Match<Unit> givesBonusUnitSea = Match.all(givesBonusUnit, Matches.UnitIsSea);
+            final Match<Unit> givesBonusUnitSea = Match.allOf(givesBonusUnit, Matches.UnitIsSea);
             final List<Territory> neighbors =
                 new ArrayList<>(data.getMap().getNeighbors(t, Matches.TerritoryIsWater));
             for (final Territory current : neighbors) {
@@ -401,8 +401,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final boolean repairOnlyOwn =
         games.strategy.triplea.Properties.getBattleshipsRepairAtBeginningOfRound(bridge.getData());
     final Match<Unit> damagedUnits =
-        Match.all(Matches.UnitHasMoreThanOneHitPointTotal, Matches.UnitHasTakenSomeDamage);
-    final Match<Unit> damagedUnitsOwned = Match.all(damagedUnits, Matches.unitIsOwnedBy(player));
+        Match.allOf(Matches.UnitHasMoreThanOneHitPointTotal, Matches.UnitHasTakenSomeDamage);
+    final Match<Unit> damagedUnitsOwned = Match.allOf(damagedUnits, Matches.unitIsOwnedBy(player));
     final Map<Territory, Set<Unit>> damagedMap = new HashMap<>();
     final Iterator<Territory> iterTerritories = data.getMap().getTerritories().iterator();
     while (iterTerritories.hasNext()) {
@@ -417,7 +417,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
           damaged = new HashSet<>(current.getUnits().getMatches(damagedUnits));
         }
       } else {
-        damaged = new HashSet<>(current.getUnits().getMatches(Match.all(damagedUnitsOwned,
+        damaged = new HashSet<>(current.getUnits().getMatches(Match.allOf(damagedUnitsOwned,
             Matches.unitCanBeRepairedByFacilitiesInItsTerritory(current, player, data))));
       }
       if (!damaged.isEmpty()) {
@@ -476,18 +476,18 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
     final Set<Unit> repairUnitsForThisUnit = new HashSet<>();
     final PlayerID owner = unitToBeRepaired.getOwner();
-    final Match<Unit> repairUnit = Match.all(Matches.alliedUnit(owner, data),
+    final Match<Unit> repairUnit = Match.allOf(Matches.alliedUnit(owner, data),
         Matches.UnitCanRepairOthers, Matches.unitCanRepairThisUnit(unitToBeRepaired));
     repairUnitsForThisUnit.addAll(territoryUnitIsIn.getUnits().getMatches(repairUnit));
     if (Matches.UnitIsSea.match(unitToBeRepaired)) {
-      final Match<Unit> repairUnitLand = Match.all(repairUnit, Matches.UnitIsLand);
+      final Match<Unit> repairUnitLand = Match.allOf(repairUnit, Matches.UnitIsLand);
       final List<Territory> neighbors =
           new ArrayList<>(data.getMap().getNeighbors(territoryUnitIsIn, Matches.TerritoryIsLand));
       for (final Territory current : neighbors) {
         repairUnitsForThisUnit.addAll(current.getUnits().getMatches(repairUnitLand));
       }
     } else if (Matches.UnitIsLand.match(unitToBeRepaired)) {
-      final Match<Unit> repairUnitSea = Match.all(repairUnit, Matches.UnitIsSea);
+      final Match<Unit> repairUnitSea = Match.allOf(repairUnit, Matches.UnitIsSea);
       final List<Territory> neighbors =
           new ArrayList<>(data.getMap().getNeighbors(territoryUnitIsIn, Matches.TerritoryIsWater));
       for (final Territory current : neighbors) {
@@ -570,7 +570,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
   }
 
   static Collection<Territory> getEmptyNeutral(final Route route) {
-    final Match<Territory> emptyNeutral = Match.all(Matches.TerritoryIsEmpty, Matches.TerritoryIsNeutralButNotWater);
+    final Match<Territory> emptyNeutral = Match.allOf(Matches.TerritoryIsEmpty, Matches.TerritoryIsNeutralButNotWater);
     final Collection<Territory> neutral = route.getMatches(emptyNeutral);
     return neutral;
   }

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -170,7 +170,7 @@ public class MovePerformer implements Serializable {
           // could it be a bombing raid
           final Collection<Unit> enemyUnits = route.getEnd().getUnits().getMatches(Matches.enemyUnit(id, data));
           final Collection<Unit> enemyTargetsTotal = Match.getMatches(enemyUnits,
-              Match.all(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(route.getEnd()).invert(),
+              Match.allOf(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(route.getEnd()).invert(),
                   Matches.unitIsBeingTransported().invert()));
           final Match.CompositeBuilder<Unit> allBombingRaidBuilder = Match.newCompositeBuilder(
               Matches.UnitIsStrategicBomber);
@@ -246,7 +246,7 @@ public class MovePerformer implements Serializable {
             // could get really
             // difficult if we want these recorded in battle records).
             for (final Territory t : route
-                .getMatches(Match.all(
+                .getMatches(Match.allOf(
                     Matches
                         .territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(
                             id),
@@ -287,7 +287,7 @@ public class MovePerformer implements Serializable {
   }
 
   private static Match<Territory> getMustFightThroughMatch(final PlayerID id, final GameData data) {
-    return Match.any(
+    return Match.anyOf(
         Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(id, data),
         Matches.territoryHasNonSubmergedEnemyUnits(id, data),
         Matches.territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(id));
@@ -338,11 +338,11 @@ public class MovePerformer implements Serializable {
     }
     if (routeEnd != null && games.strategy.triplea.Properties.getSubsCanEndNonCombatMoveWithEnemies(data)
         && GameStepPropertiesHelper.isNonCombatMove(data, false) && routeEnd.getUnits()
-            .someMatch(Match.all(Matches.unitIsEnemyOf(data, id), Matches.UnitIsDestroyer))) {
+            .someMatch(Match.allOf(Matches.unitIsEnemyOf(data, id), Matches.UnitIsDestroyer))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we want to make sure we
       // can't keep moving them
       // if there is an enemy destroyer there
-      for (final Unit unit : Match.getMatches(units, Match.all(Matches.UnitIsSub, Matches.UnitIsAir.invert()))) {
+      for (final Unit unit : Match.getMatches(units, Match.allOf(Matches.UnitIsSub, Matches.UnitIsAir.invert()))) {
         change.add(ChangeFactory.markNoMovementChange(Collections.singleton(unit)));
       }
     }
@@ -358,7 +358,7 @@ public class MovePerformer implements Serializable {
       return;
     }
     final GameData data = m_bridge.getData();
-    final Match<Unit> paratroopNAirTransports = Match.any(Matches.UnitIsAirTransport, Matches.UnitIsAirTransportable);
+    final Match<Unit> paratroopNAirTransports = Match.anyOf(Matches.UnitIsAirTransport, Matches.UnitIsAirTransportable);
     final boolean paratroopsLanding = Match.someMatch(arrived, paratroopNAirTransports)
         && MoveValidator.allLandUnitsAreBeingParatroopered(arrived);
     final Map<Unit, Collection<Unit>> dependentAirTransportableUnits =

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -237,7 +237,7 @@ public class MoveValidator {
           && !Match.allMatch(units, Matches.UnitIsAir)) {
         return result.setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
       }
-      for (final Unit u : Match.getMatches(units, Match.all(Matches.UnitCanBlitz.invert(), Matches.UnitIsNotAir))) {
+      for (final Unit u : Match.getMatches(units, Match.allOf(Matches.UnitCanBlitz.invert(), Matches.UnitIsNotAir))) {
         result.addDisallowedUnit("Not all units can blitz out of empty enemy territory", u);
       }
     }
@@ -286,16 +286,16 @@ public class MoveValidator {
           return result.setErrorReturnResult("Cannot blitz on that route");
         }
       } else if (allEnemyBlitzable && !(route.getStart().isWater() || route.getEnd().isWater())) {
-        final Match<Unit> blitzingUnit = Match.any(Matches.UnitCanBlitz, Matches.UnitIsAir);
+        final Match<Unit> blitzingUnit = Match.anyOf(Matches.UnitCanBlitz, Matches.UnitIsAir);
         final Match<Unit> nonBlitzing = blitzingUnit.invert();
         final Collection<Unit> nonBlitzingUnits = Match.getMatches(units, nonBlitzing);
         // remove any units that gain blitz due to certain abilities
         nonBlitzingUnits.removeAll(UnitAttachment.getUnitsWhichReceivesAbilityWhenWith(units, "canBlitz", data));
         final Match<Territory> territoryIsNotEnd = Matches.territoryIs(route.getEnd()).invert();
         final Match<Territory> nonFriendlyTerritories = Matches.isTerritoryFriendly(player, data).invert();
-        final Match<Territory> notEndOrFriendlyTerrs = Match.all(nonFriendlyTerritories, territoryIsNotEnd);
+        final Match<Territory> notEndOrFriendlyTerrs = Match.allOf(nonFriendlyTerritories, territoryIsNotEnd);
         final Match<Territory> foughtOver = Matches.territoryWasFoughOver(AbstractMoveDelegate.getBattleTracker(data));
-        final Match<Territory> notEndWasFought = Match.all(territoryIsNotEnd, foughtOver);
+        final Match<Territory> notEndWasFought = Match.allOf(territoryIsNotEnd, foughtOver);
         final boolean wasStartFoughtOver =
             AbstractMoveDelegate.getBattleTracker(data).wasConquered(route.getStart())
                 || AbstractMoveDelegate.getBattleTracker(data).wasBlitzed(route.getStart());
@@ -363,7 +363,7 @@ public class MoveValidator {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_RESTRICTED);
     }
     final Match<Territory> neutralOrEnemy =
-        Match.any(Matches.TerritoryIsNeutralButNotWater,
+        Match.anyOf(Matches.TerritoryIsNeutralButNotWater,
             Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data));
     // final CompositeMatch<Unit> transportsCanNotControl = new
     // CompositeMatchAnd<Unit>(Matches.UnitIsTransportAndNotDestroyer,
@@ -387,7 +387,7 @@ public class MoveValidator {
     }
     if (end.getUnits().someMatch(Matches.enemyUnit(player, data))) {
       if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
-        final Match<Unit> friendlyOrSubmerged = Match.any(
+        final Match<Unit> friendlyOrSubmerged = Match.anyOf(
             Matches.enemyUnit(player, data).invert(),
             Matches.UnitIsSubmerged);
         if (!end.getUnits().allMatch(friendlyOrSubmerged)
@@ -406,7 +406,7 @@ public class MoveValidator {
       // if there are non-paratroopers present, then we cannot fly over stuff
       // if there are neutral territories in the middle, we cannot fly over (unless allowed to)
       // otherwise we can generally fly over anything in noncombat
-      if (route.someMatch(Match.all(Matches.TerritoryIsNeutralButNotWater, Matches.TerritoryIsWater.invert()))
+      if (route.someMatch(Match.allOf(Matches.TerritoryIsNeutralButNotWater, Matches.TerritoryIsWater.invert()))
           && (!games.strategy.triplea.Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
         return result.setErrorReturnResult("Air units cannot fly over neutral territories in non combat");
       }
@@ -623,7 +623,7 @@ public class MoveValidator {
     // test for stack limits per unit
     if (route.getEnd() != null) {
       final Collection<Unit> unitsWithStackingLimits =
-          Match.getMatches(units, Match.any(Matches.UnitHasMovementLimit, Matches.UnitHasAttackingLimit));
+          Match.getMatches(units, Match.anyOf(Matches.UnitHasMovementLimit, Matches.UnitHasAttackingLimit));
       for (final Territory t : route.getSteps()) {
         final Collection<Unit> unitsAllowedSoFar = new ArrayList<>();
         if (Matches.isTerritoryEnemyAndNotUnownedWater(player, data).match(t)
@@ -680,7 +680,7 @@ public class MoveValidator {
   private static int getMechanizedSupportAvail(final Collection<Unit> units, final PlayerID player) {
     int mechanizedSupportAvailable = 0;
     if (TechAttachment.isMechanizedInfantry(player)) {
-      final Match<Unit> transportLand = Match.all(Matches.UnitIsLandTransport, Matches.unitIsOwnedBy(player));
+      final Match<Unit> transportLand = Match.allOf(Matches.UnitIsLandTransport, Matches.unitIsOwnedBy(player));
       mechanizedSupportAvailable = Match.countMatches(units, transportLand);
     }
     return mechanizedSupportAvailable;
@@ -703,7 +703,7 @@ public class MoveValidator {
    */
   static boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final PlayerID player, final GameData data) {
     final Match<Unit> alliedOrNonCombat =
-        Match.any(Matches.UnitIsInfrastructure, Matches.enemyUnit(player, data).invert(), Matches.UnitIsSubmerged);
+        Match.anyOf(Matches.UnitIsInfrastructure, Matches.enemyUnit(player, data).invert(), Matches.UnitIsSubmerged);
     // Submerged units do not interfere with movement
     for (final Territory current : route.getMiddleSteps()) {
       if (!current.getUnits().allMatch(alliedOrNonCombat)) {
@@ -720,12 +720,12 @@ public class MoveValidator {
   static boolean onlyIgnoredUnitsOnPath(final Route route, final PlayerID player, final GameData data,
       final boolean ignoreRouteEnd) {
     final Match<Unit> subOnly =
-        Match.any(Matches.UnitIsInfrastructure, Matches.UnitIsSub, Matches.enemyUnit(player, data).invert());
+        Match.anyOf(Matches.UnitIsInfrastructure, Matches.UnitIsSub, Matches.enemyUnit(player, data).invert());
     final Match<Unit> transportOnly =
-        Match.any(Matches.UnitIsInfrastructure, Matches.UnitIsTransportButNotCombatTransport,
+        Match.anyOf(Matches.UnitIsInfrastructure, Matches.UnitIsTransportButNotCombatTransport,
             Matches.UnitIsLand, Matches.enemyUnit(player, data).invert());
     final Match<Unit> transportOrSubOnly =
-        Match.any(Matches.UnitIsInfrastructure, Matches.UnitIsTransportButNotCombatTransport,
+        Match.anyOf(Matches.UnitIsInfrastructure, Matches.UnitIsTransportButNotCombatTransport,
             Matches.UnitIsLand, Matches.UnitIsSub, Matches.enemyUnit(player, data).invert());
     final boolean getIgnoreTransportInMovement = isIgnoreTransportInMovement(data);
     final boolean getIgnoreSubInMovement = isIgnoreSubInMovement(data);
@@ -763,7 +763,7 @@ public class MoveValidator {
   }
 
   private static boolean enemyDestroyerOnPath(final Route route, final PlayerID player, final GameData data) {
-    final Match<Unit> enemyDestroyer = Match.all(Matches.UnitIsDestroyer, Matches.enemyUnit(player, data));
+    final Match<Unit> enemyDestroyer = Match.allOf(Matches.UnitIsDestroyer, Matches.enemyUnit(player, data));
     for (final Territory current : route.getMiddleSteps()) {
       if (current.getUnits().someMatch(enemyDestroyer)) {
         return true;
@@ -799,9 +799,9 @@ public class MoveValidator {
     if (checkForAlreadyTransported) {
       // TODO Leaving UnitIsTransport for potential use with amphib transports (hovercraft, ducks, etc...)
       final List<Unit> transports =
-          Match.getMatches(units, Match.any(Matches.UnitIsTransport, Matches.UnitIsAirTransport));
+          Match.getMatches(units, Match.anyOf(Matches.UnitIsTransport, Matches.UnitIsAirTransport));
       final List<Unit> transportable =
-          Match.getMatches(units, Match.any(Matches.UnitCanBeTransported, Matches.UnitIsAirTransportable));
+          Match.getMatches(units, Match.anyOf(Matches.UnitCanBeTransported, Matches.UnitIsAirTransportable));
       // Check if there are transports in the group to be checked
       if (alreadyLoaded.keySet().containsAll(transports)) {
         // Check each transportable unit -vs those already loaded.
@@ -841,7 +841,7 @@ public class MoveValidator {
   }
 
   private static Collection<Unit> getNonLand(final Collection<Unit> units) {
-    return Match.getMatches(units, Match.any(Matches.UnitIsAir, Matches.UnitIsSea));
+    return Match.getMatches(units, Match.anyOf(Matches.UnitIsAir, Matches.UnitIsSea));
   }
 
   public static int getMaxMovement(final Collection<Unit> units) {
@@ -905,7 +905,7 @@ public class MoveValidator {
     // If there are non-sea transports return
     final boolean seaOrNoTransportsPresent =
         transportsToLoad.isEmpty()
-            || Match.someMatch(transportsToLoad, Match.all(Matches.UnitIsSea, Matches.UnitCanTransport));
+            || Match.someMatch(transportsToLoad, Match.allOf(Matches.UnitIsSea, Matches.UnitCanTransport));
     if (!seaOrNoTransportsPresent) {
       return result;
     }
@@ -929,9 +929,9 @@ public class MoveValidator {
               || games.strategy.triplea.Properties.getUseKamikazeSuicideAttacks(data);
       final boolean submarinesPreventUnescortedAmphibAssaults =
           games.strategy.triplea.Properties.getSubmarinesPreventUnescortedAmphibiousAssaults(data);
-      final Match<Unit> enemySubmarineMatch = Match.all(Matches.unitIsEnemyOf(data, player), Matches.UnitIsSub);
+      final Match<Unit> enemySubmarineMatch = Match.allOf(Matches.unitIsEnemyOf(data, player), Matches.UnitIsSub);
       final Match<Unit> ownedSeaNonTransportMatch =
-          Match.all(Matches.unitIsOwnedBy(player), Matches.UnitIsSea,
+          Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsSea,
               Matches.UnitIsNotTransportButCouldBeCombatTransport);
       for (final Unit transport : transports) {
         if (!isNonCombat && route.numberOfStepsIncludingStart() == 2) {
@@ -988,7 +988,7 @@ public class MoveValidator {
     // if we are land make sure no water in route except for transport
     // situations
     final Collection<Unit> land = Match.getMatches(units, Matches.UnitIsLand);
-    final Collection<Unit> landAndAir = Match.getMatches(units, Match.any(Matches.UnitIsLand, Matches.UnitIsAir));
+    final Collection<Unit> landAndAir = Match.getMatches(units, Match.anyOf(Matches.UnitIsLand, Matches.UnitIsAir));
     // make sure we can be transported
     final Match<Unit> cantBeTransported = Matches.UnitCanBeTransported.invert();
     for (final Unit unit : Match.getMatches(land, cantBeTransported)) {
@@ -1037,7 +1037,7 @@ public class MoveValidator {
         return result.setErrorReturnResult("Units cannot move before loading onto transports");
       }
       final Match<Unit> enemyNonSubmerged =
-          Match.all(Matches.enemyUnit(player, data), Matches.UnitIsSubmerged.invert());
+          Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsSubmerged.invert());
       if (route.getEnd().getUnits().someMatch(enemyNonSubmerged) && nonParatroopersPresent(player, landAndAir)) {
         if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
           if (!AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(player,
@@ -1113,7 +1113,7 @@ public class MoveValidator {
 
   static boolean allLandUnitsAreBeingParatroopered(final Collection<Unit> units) {
     // some units that can't be paratrooped
-    if (!Match.allMatch(units, Match.any(Matches.UnitIsAirTransportable, Matches.UnitIsAirTransport,
+    if (!Match.allMatch(units, Match.anyOf(Matches.UnitIsAirTransportable, Matches.UnitIsAirTransport,
         Matches.UnitIsAir))) {
       return false;
     }
@@ -1139,7 +1139,7 @@ public class MoveValidator {
     if (!TechAttachment.isAirTransportable(player)) {
       return true;
     }
-    if (!Match.allMatch(units, Match.any(Matches.UnitIsAir, Matches.UnitIsLand))) {
+    if (!Match.allMatch(units, Match.anyOf(Matches.UnitIsAir, Matches.UnitIsLand))) {
       return true;
     }
     for (final Unit unit : Match.getMatches(units, Matches.UnitIsNotAirTransportable)) {
@@ -1151,7 +1151,7 @@ public class MoveValidator {
   }
 
   private static List<Unit> getParatroopsRequiringTransport(final Collection<Unit> units, final Route route) {
-    return Match.getMatches(units, Match.all(Matches.UnitIsAirTransportable, Match.of(u -> {
+    return Match.getMatches(units, Match.allOf(Matches.UnitIsAirTransportable, Match.of(u -> {
       return TripleAUnit.get(u).getMovementLeft() < route.getMovementCost(u) || route.crossesWater()
           || route.getEnd().isWater();
     })));
@@ -1393,7 +1393,7 @@ public class MoveValidator {
       final Collection<Unit> startUnits, final GameData data, final PlayerID player) {
     // we want to get all air units that are owned by our allies
     // but not us that can land on a carrier
-    final Match<Unit> friendlyNotOwnedAir = Match.all(
+    final Match<Unit> friendlyNotOwnedAir = Match.allOf(
         Matches.alliedUnit(player, data),
         Matches.unitIsOwnedBy(player).invert(),
         Matches.UnitCanLandOnCarrier);
@@ -1402,7 +1402,7 @@ public class MoveValidator {
       return Collections.emptyMap();
     }
     // remove air that can be carried by allied
-    final Match<Unit> friendlyNotOwnedCarrier = Match.all(
+    final Match<Unit> friendlyNotOwnedCarrier = Match.allOf(
         Matches.UnitIsCarrier,
         Matches.alliedUnit(player, data),
         Matches.unitIsOwnedBy(player).invert());
@@ -1419,7 +1419,7 @@ public class MoveValidator {
     final Map<Unit, Collection<Unit>> mapping = new HashMap<>();
     // get air that must be carried by our carriers
     final Collection<Unit> ownedCarrier =
-        Match.getMatches(units, Match.all(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player)));
+        Match.getMatches(units, Match.allOf(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player)));
     final Iterator<Unit> ownedCarrierIter = ownedCarrier.iterator();
     while (ownedCarrierIter.hasNext()) {
       final Unit carrier = ownedCarrierIter.next();
@@ -1492,7 +1492,7 @@ public class MoveValidator {
     // now find the default route
     Route defaultRoute;
     if (isNeutralsImpassable) {
-      defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end, Match.all(noNeutral, noImpassable));
+      defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end, Match.allOf(noNeutral, noImpassable));
     } else {
       defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end, noImpassable);
     }
@@ -1502,7 +1502,7 @@ public class MoveValidator {
       // at least try for a route without impassable territories, but allowing restricted territories, since there is a
       // chance politics may change in the future.
       defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-          (isNeutralsImpassable ? Match.all(noNeutral, Matches.TerritoryIsImpassable)
+          (isNeutralsImpassable ? Match.allOf(noNeutral, Matches.TerritoryIsImpassable)
               : Matches.TerritoryIsImpassable));
       // ok, so there really is nothing, so just return any route, without conditions
       if (defaultRoute == null) {
@@ -1523,10 +1523,10 @@ public class MoveValidator {
       Route landRoute;
       if (isNeutralsImpassable) {
         landRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-            Match.all(Matches.TerritoryIsLand, noNeutral, noImpassable));
+            Match.allOf(Matches.TerritoryIsLand, noNeutral, noImpassable));
       } else {
         landRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-            Match.all(Matches.TerritoryIsLand, noImpassable));
+            Match.allOf(Matches.TerritoryIsLand, noImpassable));
       }
       if (landRoute != null
           && ((landRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
@@ -1541,7 +1541,7 @@ public class MoveValidator {
     // dont force a water route, since planes may be moving
     if (start.isWater() && end.isWater()) {
       final Route waterRoute =
-          data.getMap().getRoute_IgnoreEnd(start, end, Match.all(Matches.TerritoryIsWater, noImpassable));
+          data.getMap().getRoute_IgnoreEnd(start, end, Match.allOf(Matches.TerritoryIsWater, noImpassable));
       if (waterRoute != null
           && ((waterRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
               .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) || (forceLandOrSeaRoute && Match
@@ -1556,26 +1556,26 @@ public class MoveValidator {
     if (isNeutralsImpassable) {
       tests = new ArrayList<>(Arrays.asList(
           // best if no enemy and no neutral
-          Match.all(noEnemy, noNeutral),
+          Match.allOf(noEnemy, noNeutral),
           // we will be satisfied if no aa and no neutral
-          Match.all(noAa, noNeutral)));
+          Match.allOf(noAa, noNeutral)));
     } else {
       tests = new ArrayList<>(Arrays.asList(
           // best if no enemy and no neutral
-          Match.all(noEnemy, noNeutral),
+          Match.allOf(noEnemy, noNeutral),
           // we will be satisfied if no aa and no neutral
-          Match.all(noAa, noNeutral),
+          Match.allOf(noAa, noNeutral),
           // single matches
           noEnemy, noAa, noNeutral));
     }
     for (final Match<Territory> t : tests) {
       Match<Territory> testMatch = null;
       if (mustGoLand) {
-        testMatch = Match.all(t, Matches.TerritoryIsLand, noImpassable);
+        testMatch = Match.allOf(t, Matches.TerritoryIsLand, noImpassable);
       } else if (mustGoSea) {
-        testMatch = Match.all(t, Matches.TerritoryIsWater, noImpassable);
+        testMatch = Match.allOf(t, Matches.TerritoryIsWater, noImpassable);
       } else {
-        testMatch = Match.all(t, noImpassable);
+        testMatch = Match.allOf(t, noImpassable);
       }
       final Route testRoute = data.getMap().getRoute_IgnoreEnd(start, end, testMatch);
       if (testRoute != null

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -845,7 +845,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
             defenderWins(bridge);
           } else {
             // Get all allied transports in the territory
-            final Match<Unit> matchAllied = Match.all(
+            final Match<Unit> matchAllied = Match.allOf(
                 Matches.UnitIsTransport,
                 Matches.UnitIsNotCombatTransport,
                 Matches.isUnitAllied(m_attacker, m_data));
@@ -1232,9 +1232,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
 
     // the air unit may have come from a conquered or enemy territory, don't allow retreating
-    final Match<Territory> conqueuredOrEnemy = Match.any(
+    final Match<Territory> conqueuredOrEnemy = Match.anyOf(
         Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(m_attacker, m_data),
-        Match.all(
+        Match.allOf(
             // Matches.TerritoryIsLand,
             Matches.TerritoryIsWater, Matches.territoryWasFoughOver(m_battleTracker)));
     possible.removeAll(Match.getMatches(possible, conqueuredOrEnemy));
@@ -1360,7 +1360,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       r.add(t);
       return MoveValidator.validateCanal(r, unitsToRetreat, m_defender, m_data) == null;
     });
-    final Match<Territory> match = Match.all(
+    final Match<Territory> match = Match.allOf(
         Matches.TerritoryIsWater,
         Matches.territoryHasNoEnemyUnits(player, m_data),
         canalMatch);
@@ -1608,7 +1608,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final IDelegateBridge bridge) {
     retreating.addAll(getDependentUnits(retreating));
     // our own air units dont retreat with land units
-    final Match<Unit> notMyAir = Match.any(Matches.UnitIsNotAir, Matches.unitIsOwnedBy(m_attacker).invert());
+    final Match<Unit> notMyAir = Match.anyOf(Matches.UnitIsNotAir, Matches.unitIsOwnedBy(m_attacker).invert());
     retreating = Match.getMatches(retreating, notMyAir);
     final String transcriptText;
     // in WW2V1, defending subs can retreat so show owner
@@ -1657,7 +1657,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // retreating.addAll(getDependentUnits(retreating));
     retreating.addAll(getDependentUnits(units));
     // our own air units dont retreat with land units
-    final Match<Unit> notMyAir = Match.any(Matches.UnitIsNotAir, Matches.unitIsOwnedBy(m_attacker).invert());
+    final Match<Unit> notMyAir = Match.anyOf(Matches.UnitIsNotAir, Matches.unitIsOwnedBy(m_attacker).invert());
     final Collection<Unit> nonAirRetreating = Match.getMatches(retreating, notMyAir);
     final String transcriptText = MyFormatter.unitsToTextNoOwner(nonAirRetreating) + " retreated to " + to.getName();
     bridge.getHistoryWriter().addChildToEvent(transcriptText, new ArrayList<>(nonAirRetreating));
@@ -1728,7 +1728,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return;
     }
     // Get all allied transports in the territory
-    final Match<Unit> matchAllied = Match.all(
+    final Match<Unit> matchAllied = Match.allOf(
         Matches.UnitIsTransport,
         Matches.UnitIsNotCombatTransport,
         Matches.isUnitAllied(player, m_data),
@@ -1739,7 +1739,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return;
     }
     // Get all ALLIED, sea & air units in the territory (that are NOT submerged)
-    final Match<Unit> alliedUnitsMatch = Match.all(
+    final Match<Unit> alliedUnitsMatch = Match.allOf(
         Matches.isUnitAllied(player, m_data),
         Matches.UnitIsNotLand,
         Matches.UnitIsSubmerged.invert());
@@ -1747,7 +1747,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // If transports are unescorted, check opposing forces to see if the Trns die automatically
     if (alliedTransports.size() == alliedUnits.size()) {
       // Get all the ENEMY sea and air units (that can attack) in the territory
-      final Match<Unit> enemyUnitsMatch = Match.all(
+      final Match<Unit> enemyUnitsMatch = Match.allOf(
           Matches.UnitIsNotLand,
           Matches.UnitIsSubmerged.invert(),
           Matches.unitCanAttack(player));
@@ -1782,24 +1782,24 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Collection<Unit> unitsToKill;
     final boolean hasUnitsThatCanRollLeft;
     if (attacker) {
-      hasUnitsThatCanRollLeft = Match.someMatch(m_attackingUnits, Match.all(notSubmergedAndType,
+      hasUnitsThatCanRollLeft = Match.someMatch(m_attackingUnits, Match.allOf(notSubmergedAndType,
           Matches.unitIsSupporterOrHasCombatAbility(attacker)));
       unitsToKill = Match.getMatches(m_attackingUnits,
-          Match.all(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
+          Match.allOf(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
     } else {
-      hasUnitsThatCanRollLeft = Match.someMatch(m_defendingUnits, Match.all(notSubmergedAndType,
+      hasUnitsThatCanRollLeft = Match.someMatch(m_defendingUnits, Match.allOf(notSubmergedAndType,
           Matches.unitIsSupporterOrHasCombatAbility(attacker)));
       unitsToKill = Match.getMatches(m_defendingUnits,
-          Match.all(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
+          Match.allOf(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
     }
     final boolean enemy = !attacker;
     final boolean enemyHasUnitsThatCanRollLeft;
     if (enemy) {
       enemyHasUnitsThatCanRollLeft = Match.someMatch(m_attackingUnits,
-          Match.all(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
+          Match.allOf(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
     } else {
       enemyHasUnitsThatCanRollLeft = Match.someMatch(m_defendingUnits,
-          Match.all(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
+          Match.allOf(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
     }
     if (!hasUnitsThatCanRollLeft && enemyHasUnitsThatCanRollLeft) {
       remove(unitsToKill, bridge, m_battleSite, !attacker);
@@ -2022,7 +2022,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   private void fireSuicideUnitsAttack() {
     // TODO: add a global toggle for returning fire (Veqryn)
-    final Match<Unit> attackableUnits = Match.all(
+    final Match<Unit> attackableUnits = Match.allOf(
         Matches.unitIsNotInfrastructureAndNotCapturedOnEntering(m_attacker, m_battleSite, m_data),
         Matches.UnitIsSuicide.invert(), Matches.unitIsBeingTransported().invert());
     final Collection<Unit> suicideAttackers = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);
@@ -2054,7 +2054,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return;
     }
     // TODO: add a global toggle for returning fire (Veqryn)
-    final Match<Unit> attackableUnits = Match.all(Matches.UnitIsNotInfrastructure,
+    final Match<Unit> attackableUnits = Match.allOf(Matches.UnitIsNotInfrastructure,
         Matches.UnitIsSuicide.invert(), Matches.unitIsBeingTransported().invert());
     final Collection<Unit> suicideDefenders = Match.getMatches(m_defendingUnits, Matches.UnitIsSuicide);
     final Collection<Unit> attackedAttackers = Match.getMatches(m_attackingUnits, attackableUnits);
@@ -2162,8 +2162,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
                 : new HashSet<>();
         final Collection<Unit> validAttackingUnitsForThisRoll =
             Match.getMatches((m_defending ? m_attackingUnits : m_defendingUnits),
-                Match.any(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
-                    Match.all(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
+                Match.anyOf(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
+                    Match.allOf(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         final IExecutable rollDice = new IExecutable() {
           private static final long serialVersionUID = 6435935558879109347L;
 
@@ -2314,7 +2314,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     unitList.removeAll(Match.getMatches(unitList,
         Matches.unitCanBeCapturedOnEnteringToInThisTerritory(m_attacker, m_battleSite, m_data)));
     // remove any allied air units that are stuck on damaged carriers (veqryn)
-    unitList.removeAll(Match.getMatches(unitList, Match.all(Matches.unitIsBeingTransported(),
+    unitList.removeAll(Match.getMatches(unitList, Match.allOf(Matches.unitIsBeingTransported(),
         Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
     // remove any units that were in air combat (veqryn)
     unitList.removeAll(Match.getMatches(unitList, Matches.UnitWasInAirBattle));
@@ -2578,7 +2578,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // TODO: why do we keep checking throughout this entire class if the units in m_defendingUnits are allied with
     // defender, and if the
     // units in m_attackingUnits are allied with the attacker? Does it really matter?
-    final Match<Unit> alliedDefendingAir = Match.all(Matches.UnitIsAir, Matches.UnitWasScrambled.invert());
+    final Match<Unit> alliedDefendingAir = Match.allOf(Matches.UnitIsAir, Matches.UnitWasScrambled.invert());
     final Collection<Unit> m_defendingAir = Match.getMatches(m_defendingUnits, alliedDefendingAir);
     // no planes, exit
     if (m_defendingAir.isEmpty()) {
@@ -2620,7 +2620,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // carrier unit
     final Collection<Unit> carriers = Match.getMatches(attackingUnits, Matches.UnitIsCarrier);
     if (!carriers.isEmpty() && !games.strategy.triplea.Properties.getAlliedAirIndependent(data)) {
-      final Match<Unit> alliedFighters = Match.all(Matches.isUnitAllied(attacker, data),
+      final Match<Unit> alliedFighters = Match.allOf(Matches.isUnitAllied(attacker, data),
           Matches.unitIsOwnedBy(attacker).invert(), Matches.UnitIsAir, Matches.UnitCanLandOnCarrier);
       final Collection<Unit> alliedAirInTerr = Match.getMatches(attackingUnits, alliedFighters);
       for (final Unit fighter : alliedAirInTerr) {

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -102,7 +102,7 @@ public class NonFightingBattle extends DependentBattle {
   }
 
   boolean hasAttackingUnits() {
-    final Match<Unit> attackingLand = Match.all(Matches.alliedUnit(m_attacker, m_data), Matches.UnitIsLand);
+    final Match<Unit> attackingLand = Match.allOf(Matches.alliedUnit(m_attacker, m_data), Matches.UnitIsLand);
     return m_battleSite.getUnits().someMatch(attackingLand);
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -57,9 +57,9 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-      final Match<TriggerAttachment> politicsDelegateTriggerMatch = Match.all(
+      final Match<TriggerAttachment> politicsDelegateTriggerMatch = Match.allOf(
           TriggerAttachment.availableUses, TriggerAttachment.whenOrDefaultMatch(null, null),
-          Match.any(TriggerAttachment.relationshipChangeMatch()));
+          Match.anyOf(TriggerAttachment.relationshipChangeMatch()));
       // get all possible triggers based on this match.
       final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
           new HashSet<>(Collections.singleton(m_player)), politicsDelegateTriggerMatch, m_bridge);
@@ -174,7 +174,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   private boolean actionIsAccepted(final PoliticalActionAttachment paa) {
     final GameData data = getData();
     final Match<PoliticalActionAttachment> intoAlliedChainOrIntoOrOutOfWar =
-        Match.any(
+        Match.anyOf(
             Matches.politicalActionIsRelationshipChangeOf(null,
                 Matches.RelationshipTypeIsAlliedAndAlliancesCanChainTogether.invert(),
                 Matches.RelationshipTypeIsAlliedAndAlliancesCanChainTogether, data),

--- a/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -63,9 +63,9 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
         // First set up a match for what we want to have fire as a default in this delegate. List out as a composite
         // match OR.
         // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-        final Match<TriggerAttachment> purchaseDelegateTriggerMatch = Match.all(
+        final Match<TriggerAttachment> purchaseDelegateTriggerMatch = Match.allOf(
             AbstractTriggerAttachment.availableUses, AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
-            Match.any(TriggerAttachment.prodMatch(),
+            Match.anyOf(TriggerAttachment.prodMatch(),
                 TriggerAttachment.prodFrontierEditMatch(), TriggerAttachment.purchaseMatch()));
         // get all possible triggers based on this match.
         final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
@@ -173,7 +173,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
           // count how many units are yet to be placed or are in the field
           int currentlyBuilt = m_player.getUnits().countMatches(Matches.unitIsOfType(type));
 
-          final Match<Unit> unitTypeOwnedBy = Match.all(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(m_player));
+          final Match<Unit> unitTypeOwnedBy = Match.allOf(Matches.unitIsOfType(type), Matches.unitIsOwnedBy(m_player));
           final Collection<Territory> allTerrs = getData().getMap().getTerritories();
           for (final Territory t : allTerrs) {
             currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -220,7 +220,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
   }
 
   public Match<Territory> getTerritoryPickableMatch() {
-    return Match.all(Matches.TerritoryIsLand, Matches.TerritoryIsNotImpassable,
+    return Match.allOf(Matches.TerritoryIsLand, Matches.TerritoryIsNotImpassable,
         Matches.isTerritoryOwnedBy(PlayerID.NULL_PLAYERID), Matches.TerritoryIsEmpty);
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -144,7 +144,7 @@ public class RocketsFireHelper {
   }
 
   Match<Unit> rocketMatch(final PlayerID player, final GameData data) {
-    return Match.all(Matches.UnitIsRocket, Matches.unitIsOwnedBy(player), Matches.UnitIsNotDisabled,
+    return Match.allOf(Matches.UnitIsRocket, Matches.unitIsOwnedBy(player), Matches.UnitIsNotDisabled,
         Matches.unitIsBeingTransported().invert(), Matches.UnitIsSubmerged.invert(), Matches.unitHasNotMoved);
   }
 
@@ -159,11 +159,11 @@ public class RocketsFireHelper {
       allowedBuilder.add(Matches.TerritoryIsNotImpassable);
     }
     final Match<Unit> attackableUnits =
-        Match.all(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert());
+        Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert());
     for (final Territory current : possible) {
       final Route route = data.getMap().getRoute(territory, current, allowedBuilder.all());
       if (route != null && route.numberOfSteps() <= maxDistance) {
-        if (current.getUnits().someMatch(Match.all(attackableUnits,
+        if (current.getUnits().someMatch(Match.allOf(attackableUnits,
             Matches.unitIsAtMaxDamageOrNotCanBeDamaged(current).invert()))) {
           hasFactory.add(current);
         }
@@ -186,7 +186,7 @@ public class RocketsFireHelper {
     final boolean DamageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
     // unit damage vs territory damage
     final Collection<Unit> enemyUnits = attackedTerritory.getUnits().getMatches(
-        Match.all(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
+        Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
     final Collection<Unit> enemyTargetsTotal =
         Match.getMatches(enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).invert());
     final Collection<Unit> targets = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -291,7 +291,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   }
 
   private static Match<Unit> getAirborneMatch(final Set<UnitType> types, final Collection<PlayerID> unitOwners) {
-    return Match.all(Matches.unitIsOwnedByOfAnyOfThesePlayers(unitOwners),
+    return Match.allOf(Matches.unitIsOwnedByOfAnyOfThesePlayers(unitOwners),
         Matches.unitIsOfTypes(types), Matches.UnitIsNotDisabled, Matches.unitHasNotMoved,
         Matches.UnitIsAirborne.invert());
   }

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -91,8 +91,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     // fill in defenders
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
-    final Match<Unit> defenders = Match.all(Matches.enemyUnit(m_attacker, m_data),
-        Match.any(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
+    final Match<Unit> defenders = Match.allOf(Matches.enemyUnit(m_attacker, m_data),
+        Match.anyOf(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
             Matches.unitIsAaThatCanFire(m_attackingUnits, airborneTechTargetsAllowed, m_attacker,
                 Matches.UnitIsAAforBombingThisUnitOnly, m_round, true, m_data)));
     if (m_targets.isEmpty()) {
@@ -355,9 +355,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         final Set<UnitType> airborneTypesTargettedToo =
             TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data).get(currentTypeAa);
         if (determineAttackers) {
-          validAttackingUnitsForThisRoll = Match.getMatches(m_attackingUnits, Match.any(
+          validAttackingUnitsForThisRoll = Match.getMatches(m_attackingUnits, Match.anyOf(
               Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
-              Match.all(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
+              Match.allOf(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         }
 
         final IExecutable roll = new IExecutable() {

--- a/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -57,9 +57,9 @@ public class TechActivationDelegate extends BaseTripleADelegate {
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-      final Match<TriggerAttachment> techActivationDelegateTriggerMatch = Match.all(
+      final Match<TriggerAttachment> techActivationDelegateTriggerMatch = Match.allOf(
           TriggerAttachment.availableUses, TriggerAttachment.whenOrDefaultMatch(null, null),
-          Match.any(TriggerAttachment.unitPropertyMatch(), TriggerAttachment.techMatch(),
+          Match.anyOf(TriggerAttachment.unitPropertyMatch(), TriggerAttachment.techMatch(),
               TriggerAttachment.supportMatch()));
       // get all possible triggers based on this match.
       final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -77,9 +77,9 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       // First set up a match for what we want to have fire as a default in this delegate. List out as a composite match
       // OR.
       // use 'null, null' because this is the Default firing location for any trigger that does NOT have 'when' set.
-      final Match<TriggerAttachment> technologyDelegateTriggerMatch = Match.all(
+      final Match<TriggerAttachment> technologyDelegateTriggerMatch = Match.allOf(
           AbstractTriggerAttachment.availableUses, AbstractTriggerAttachment.whenOrDefaultMatch(null, null),
-          Match.any(TriggerAttachment.techAvailableMatch()));
+          Match.anyOf(TriggerAttachment.techAvailableMatch()));
       // get all possible triggers based on this match.
       final HashSet<TriggerAttachment> toFirePossible = TriggerAttachment.collectForAllTriggersMatching(
           new HashSet<>(Collections.singleton(m_player)), technologyDelegateTriggerMatch, m_bridge);

--- a/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -126,7 +126,7 @@ public class UndoableMove extends AbstractUndoableMove {
           if (routeUnitUsedToMove != null && routeUnitUsedToMove.getEnd() != null) {
             final Territory end = routeUnitUsedToMove.getEnd();
             final Collection<Unit> enemyTargetsTotal = end.getUnits()
-                .getMatches(Match.all(Matches.enemyUnit(bridge.getPlayerID(), data),
+                .getMatches(Match.allOf(Matches.enemyUnit(bridge.getPlayerID(), data),
                     Matches.unitIsAtMaxDamageOrNotCanBeDamaged(end).invert(),
                     Matches.unitIsBeingTransported().invert()));
             final Collection<Unit> enemyTargets = Match.getMatches(enemyTargetsTotal,

--- a/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
@@ -21,7 +21,7 @@ public class UnitsThatCantFightUtil {
 
   // TODO Used to notify of kamikazi attacks
   Collection<Territory> getTerritoriesWhereUnitsCantFight(final PlayerID player) {
-    final Match<Unit> enemyAttackUnits = Match.all(Matches.enemyUnit(player, m_data), Matches.unitCanAttack(player));
+    final Match<Unit> enemyAttackUnits = Match.allOf(Matches.enemyUnit(player, m_data), Matches.unitCanAttack(player));
     final Collection<Territory> cantFight = new ArrayList<>();
     for (final Territory current : m_data.getMap()) {
       // get all owned non-combat units

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -596,8 +596,8 @@ class DummyPlayer extends AbstractAI {
     }
     if (submerge) {
       // submerge if all air vs subs
-      final Match<Unit> seaSub = Match.all(Matches.UnitIsSea, Matches.UnitIsSub);
-      final Match<Unit> planeNotDestroyer = Match.all(Matches.UnitIsAir, Matches.UnitIsDestroyer.invert());
+      final Match<Unit> seaSub = Match.allOf(Matches.UnitIsSea, Matches.UnitIsSub);
+      final Match<Unit> planeNotDestroyer = Match.allOf(Matches.UnitIsAir, Matches.UnitIsDestroyer.invert());
       final List<Unit> ourUnits = getOurUnits();
       final List<Unit> enemyUnits = getEnemyUnits();
       if (ourUnits == null || enemyUnits == null) {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -892,7 +892,7 @@ class OddsCalculatorPanel extends JPanel {
         if (defender) {
           predicate = Matches.UnitTypeIsNotSea;
         } else {
-          predicate = Match.any(Matches.UnitTypeIsNotSea, Matches.unitTypeCanBombard(id));
+          predicate = Match.anyOf(Matches.UnitTypeIsNotSea, Matches.unitTypeCanBombard(id));
         }
       } else {
         predicate = Matches.UnitTypeIsSeaOrAir;

--- a/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -207,7 +207,7 @@ public class ExtendedStats extends StatPanel {
     @Override
     public double getValue(final PlayerID player, final GameData data) {
       int matchCount = 0;
-      final Match<Unit> ownedBy = Match.all(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(m_ut));
+      final Match<Unit> ownedBy = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(m_ut));
       for (final Territory place : data.getMap().getTerritories()) {
         matchCount += place.getUnits().countMatches(ownedBy);
       }

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -322,7 +322,7 @@ public class MovePanel extends AbstractMovePanel {
   }
 
   private Match<Unit> getUnloadableMatch(final Route route, final Collection<Unit> units) {
-    return Match.all(getMovableMatch(route, units), Matches.UnitIsLand);
+    return Match.allOf(getMovableMatch(route, units), Matches.UnitIsLand);
   }
 
   private Match<Unit> getMovableMatch(final Route route, final Collection<Unit> units) {
@@ -348,8 +348,8 @@ public class MovePanel extends AbstractMovePanel {
         return TripleAUnit.get(u).getMovementLeft() >= route.getMovementCost(u);
       });
       if (route.isUnload()) {
-        final Match<Unit> notLandAndCanMove = Match.all(enoughMovement, Matches.UnitIsNotLand);
-        final Match<Unit> landOrCanMove = Match.any(Matches.UnitIsLand, notLandAndCanMove);
+        final Match<Unit> notLandAndCanMove = Match.allOf(enoughMovement, Matches.UnitIsNotLand);
+        final Match<Unit> landOrCanMove = Match.anyOf(Matches.UnitIsLand, notLandAndCanMove);
         movableBuilder.add(landOrCanMove);
       } else {
         movableBuilder.add(enoughMovement);
@@ -450,7 +450,7 @@ public class MovePanel extends AbstractMovePanel {
     Collection<Unit> transportsToLoad = Collections.emptyList();
     if (MoveValidator.isLoad(units, s_dependentUnits, route, getData(), getCurrentPlayer())) {
       transportsToLoad = route.getEnd().getUnits().getMatches(
-          Match.all(Matches.UnitIsTransport, Matches.alliedUnit(getCurrentPlayer(), getData())));
+          Match.allOf(Matches.UnitIsTransport, Matches.alliedUnit(getCurrentPlayer(), getData())));
     }
     List<Unit> best = new ArrayList<>(units);
     // if the player selects a land unit and other units
@@ -569,7 +569,7 @@ public class MovePanel extends AbstractMovePanel {
     for (final Unit unit : unitsToLoad) {
       minTransportCost = Math.min(minTransportCost, UnitAttachment.get(unit.getType()).getTransportCost());
     }
-    final Match<Unit> candidateTransportsMatch = Match.all(
+    final Match<Unit> candidateTransportsMatch = Match.allOf(
         Matches.UnitIsTransport,
         Matches.alliedUnit(unitOwner, getGameData()));
     final List<Unit> candidateTransports = Match.getMatches(endOwnedUnits, candidateTransportsMatch);
@@ -842,7 +842,7 @@ public class MovePanel extends AbstractMovePanel {
         // Load Bombers with paratroops
         if ((!nonCombat || isParatroopersCanMoveDuringNonCombat(getData()))
             && TechAttachment.isAirTransportable(getCurrentPlayer())
-            && Match.someMatch(selectedUnits, Match.all(Matches.UnitIsAirTransport, Matches.unitHasNotMoved))) {
+            && Match.someMatch(selectedUnits, Match.allOf(Matches.UnitIsAirTransport, Matches.unitHasNotMoved))) {
           final PlayerID player = getCurrentPlayer();
           // TODO Transporting allied units
           // Get the potential units to load
@@ -1230,7 +1230,7 @@ public class MovePanel extends AbstractMovePanel {
         return;
       }
       final PlayerID owner = getUnitOwner(selectedUnits);
-      final Match<Unit> match = Match.all(Matches.unitIsOwnedBy(owner), Matches.UnitCanMove);
+      final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(owner), Matches.UnitCanMove);
       final boolean someOwned = Match.someMatch(units, match);
       final boolean isCorrectTerritory = firstSelectedTerritory == null || firstSelectedTerritory == territory;
       if (someOwned && isCorrectTerritory) {

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -135,7 +135,7 @@ public class PlacePanel extends AbstractMovePanel {
             || isLHTR_Carrier_Production_Rules() || GameStepPropertiesHelper.isBid(getData()))) {
           units = Match.getMatches(units, Matches.UnitIsSea);
         } else {
-          final Match<Unit> unitIsSeaOrCanLandOnCarrier = Match.any(Matches.UnitIsSea, Matches.UnitCanLandOnCarrier);
+          final Match<Unit> unitIsSeaOrCanLandOnCarrier = Match.anyOf(Matches.UnitIsSea, Matches.UnitCanLandOnCarrier);
           units = Match.getMatches(units, unitIsSeaOrCanLandOnCarrier);
         }
       } else {

--- a/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -124,7 +124,7 @@ public class ProductionRepairPanel extends JPanel {
       this.id = player;
       this.allowedPlayersToRepair = allowedPlayersToRepair;
       final Match<Unit> myDamagedUnits =
-          Match.all(Matches.unitIsOwnedByOfAnyOfThesePlayers(this.allowedPlayersToRepair),
+          Match.allOf(Matches.unitIsOwnedByOfAnyOfThesePlayers(this.allowedPlayersToRepair),
               Matches.UnitHasTakenSomeBombingUnitDamage);
       final Collection<Territory> terrsWithPotentiallyDamagedUnits =
           Match.getMatches(data.getMap().getTerritories(), Matches.territoryHasUnitsThatMatch(myDamagedUnits));

--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -195,10 +195,10 @@ public final class Match<T> {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <T> Match<T> all(final Match<T>... matches) {
+  public static <T> Match<T> allOf(final Match<T>... matches) {
     checkNotNull(matches);
 
-    return all(Arrays.asList(matches));
+    return allOf(Arrays.asList(matches));
   }
 
   /**
@@ -208,7 +208,7 @@ public final class Match<T> {
    *
    * @return A new match; never {@code null}.
    */
-  public static <T> Match<T> all(final Collection<Match<T>> matches) {
+  public static <T> Match<T> allOf(final Collection<Match<T>> matches) {
     checkNotNull(matches);
 
     return Match.of(value -> matches.stream().allMatch(match -> match.match(value)));
@@ -223,10 +223,10 @@ public final class Match<T> {
    */
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public static <T> Match<T> any(final Match<T>... matches) {
+  public static <T> Match<T> anyOf(final Match<T>... matches) {
     checkNotNull(matches);
 
-    return any(Arrays.asList(matches));
+    return anyOf(Arrays.asList(matches));
   }
 
   /**
@@ -236,7 +236,7 @@ public final class Match<T> {
    *
    * @return A new match; never {@code null}.
    */
-  public static <T> Match<T> any(final Collection<Match<T>> matches) {
+  public static <T> Match<T> anyOf(final Collection<Match<T>> matches) {
     checkNotNull(matches);
 
     return Match.of(value -> matches.stream().anyMatch(match -> match.match(value)));
@@ -294,7 +294,7 @@ public final class Match<T> {
      * @return A new match; never {@code null}.
      */
     public Match<T> all() {
-      return Match.all(matches);
+      return Match.allOf(matches);
     }
 
     /**
@@ -304,7 +304,7 @@ public final class Match<T> {
      * @return A new match; never {@code null}.
      */
     public Match<T> any() {
-      return Match.any(matches);
+      return Match.anyOf(matches);
     }
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -564,7 +564,7 @@ public class MoveDelegateTest extends DelegateTest {
     route3.setStart(japanSeaZone);
     route3.add(sfeSeaZone);
     final Collection<Unit> remainingTrns = Match.getMatches(japanSeaZone.getUnits().getUnits(),
-        Match.all(Matches.unitHasNotMoved, Matches.UnitWasNotLoadedThisTurn));
+        Match.allOf(Matches.unitHasNotMoved, Matches.UnitWasNotLoadedThisTurn));
     results = delegate.move(remainingTrns, route3);
     assertNull(results);
   }

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -539,7 +539,7 @@ public class RevisedTest {
     eeToSz5.add(sz5);
     // load the transport in the baltic
     final List<Unit> infantry = eastEurope.getUnits()
-        .getMatches(Match.all(Matches.unitIsOfType(infantryType), Matches.unitIsOwnedBy(japanese)));
+        .getMatches(Match.allOf(Matches.unitIsOfType(infantryType), Matches.unitIsOwnedBy(japanese)));
     assertEquals(1, infantry.size());
     final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.UnitIsTransport).get(0);
     String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
@@ -725,7 +725,7 @@ public class RevisedTest {
     sz45To50.setStart(sz45);
     sz45To50.add(sz50);
     final List<Unit> japSub =
-        sz45.getUnits().getMatches(Match.all(Matches.UnitIsSub, Matches.unitIsOwnedBy(japanese)));
+        sz45.getUnits().getMatches(Match.allOf(Matches.UnitIsSub, Matches.unitIsOwnedBy(japanese)));
     error = moveDelegate.move(japSub, sz45To50);
     // make sure no error
     assertNull(error);
@@ -1382,7 +1382,7 @@ public class RevisedTest {
     load(germany.getUnits().getMatches(Matches.UnitCanBlitz).subList(0, 1), new Route(germany, sz5));
     load(germany.getUnits().getMatches(Matches.UnitCanBlitz).subList(0, 1), new Route(germany, sz5));
     // attack sz 6
-    move(sz5.getUnits().getMatches(Match.any(Matches.UnitCanBlitz, Matches.UnitIsTransport)), new Route(sz5, sz6));
+    move(sz5.getUnits().getMatches(Match.anyOf(Matches.UnitCanBlitz, Matches.UnitIsTransport)), new Route(sz5, sz6));
     // unload transports, 1 each to a different country
     // this move is illegal now
     assertMoveError(sz6.getUnits().getMatches(Matches.UnitCanBlitz).subList(0, 1), new Route(sz6, norway));

--- a/src/test/java/games/strategy/util/MatchTest.java
+++ b/src/test/java/games/strategy/util/MatchTest.java
@@ -40,29 +40,29 @@ public class MatchTest {
   }
 
   @Test
-  public void testAll() {
-    assertTrue(Match.all().match(VALUE));
+  public void testAllOf() {
+    assertTrue(Match.allOf().match(VALUE));
 
-    assertTrue(Match.all(Match.always()).match(VALUE));
-    assertFalse(Match.all(Match.never()).match(VALUE));
+    assertTrue(Match.allOf(Match.always()).match(VALUE));
+    assertFalse(Match.allOf(Match.never()).match(VALUE));
 
-    assertTrue(Match.all(Match.always(), Match.always()).match(VALUE));
-    assertFalse(Match.all(Match.always(), Match.never()).match(VALUE));
-    assertFalse(Match.all(Match.never(), Match.always()).match(VALUE));
-    assertFalse(Match.all(Match.never(), Match.never()).match(VALUE));
+    assertTrue(Match.allOf(Match.always(), Match.always()).match(VALUE));
+    assertFalse(Match.allOf(Match.always(), Match.never()).match(VALUE));
+    assertFalse(Match.allOf(Match.never(), Match.always()).match(VALUE));
+    assertFalse(Match.allOf(Match.never(), Match.never()).match(VALUE));
   }
 
   @Test
-  public void testAny() {
-    assertFalse(Match.any().match(VALUE));
+  public void testAnyOf() {
+    assertFalse(Match.anyOf().match(VALUE));
 
-    assertTrue(Match.any(Match.always()).match(VALUE));
-    assertFalse(Match.any(Match.never()).match(VALUE));
+    assertTrue(Match.anyOf(Match.always()).match(VALUE));
+    assertFalse(Match.anyOf(Match.never()).match(VALUE));
 
-    assertTrue(Match.any(Match.always(), Match.always()).match(VALUE));
-    assertTrue(Match.any(Match.always(), Match.never()).match(VALUE));
-    assertTrue(Match.any(Match.never(), Match.always()).match(VALUE));
-    assertFalse(Match.any(Match.never(), Match.never()).match(VALUE));
+    assertTrue(Match.anyOf(Match.always(), Match.always()).match(VALUE));
+    assertTrue(Match.anyOf(Match.always(), Match.never()).match(VALUE));
+    assertTrue(Match.anyOf(Match.never(), Match.always()).match(VALUE));
+    assertFalse(Match.anyOf(Match.never(), Match.never()).match(VALUE));
   }
 
   @Test


### PR DESCRIPTION
In the middle of the `Match` refactoring, I questioned my choice of names for the `all()` and `any()` factory methods.  Looking around the JDK, factory methods from newer releases seem to include "of" in their name (e.g. [`EnumSet`](https://docs.oracle.com/javase/8/docs/api/java/util/EnumSet.html), [`CompletableFuture`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html), [`Arrays`](https://docs.oracle.com/javase/8/docs/api/java/util/Arrays.html), etc.).  While I did this for the single-argument `of()` factory method, I was inconsistent when naming `all()` and `any()`.  This PR renames those methods as follows:

* `all()` --> `allOf()`
* `any()` --> `anyOf()`

It should also help to distinguish them from the similarly-named `allMatch()` and `someMatch()` methods.  (I plan on submitting a separate PR to rename `someMatch()` to `anyMatch()` for consistency, so they will be even more similar.)

I did not rename the corresponding `CompositeBuilder` methods because I haven't seen examples of such builder methods including "of" in their name.

This is a big change, but everything was done via automated refactoring except for reformatting a single long line at `WeakAI.java:513`.  So it shouldn't require very much scrutiny beyond the name change.

Please feel free to close this PR if it seems of no value.