### PR TITLE
Prevent concurrent display of multiple Download Maps windows (#1923)

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -241,7 +241,7 @@ public class GameRunner {
       mainFrame.toFront();
       mainFrame.setVisible(true);
 
-      SwingComponents.addWindowCloseListener(mainFrame, GameRunner::exitGameIfFinished);
+      SwingComponents.addWindowClosingListener(mainFrame, GameRunner::exitGameIfFinished);
 
       final String fileName = System.getProperty(GameRunner.TRIPLEA_GAME_PROPERTY, "");
       if (fileName.length() > 0) {

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -9,8 +9,6 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.event.ActionListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -164,12 +162,7 @@ public class DownloadMapsWindow extends JFrame {
       assert window == null;
 
       window = new DownloadMapsWindow(mapNames, downloads);
-      window.addWindowListener(new WindowAdapter() {
-        @Override
-        public void windowClosed(final WindowEvent e) {
-          uninitialize();
-        }
-      });
+      SwingComponents.addWindowClosedListener(window, this::uninitialize);
       state = State.INITIALIZED;
 
       show();
@@ -232,7 +225,7 @@ public class DownloadMapsWindow extends JFrame {
 
     final Optional<String> selectedMapName = pendingDownloadMapNames.stream().findFirst();
 
-    SwingComponents.addWindowCloseListener(this, () -> progressPanel.cancel());
+    SwingComponents.addWindowClosingListener(this, progressPanel::cancel);
 
     final JTabbedPane outerTabs = new JTabbedPane();
 

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -2,12 +2,15 @@ package games.strategy.engine.framework.map.download;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -16,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import javax.swing.Box;
@@ -46,13 +50,22 @@ public class DownloadMapsWindow extends JFrame {
   }
 
   private static final long serialVersionUID = -1542210716764178580L;
+  private static final Logger LOGGER = Logger.getLogger(DownloadMapsWindow.class.getName());
   private static final int WINDOW_WIDTH = 1200;
   private static final int WINDOW_HEIGHT = 700;
   private static final int DIVIDER_POSITION = WINDOW_HEIGHT - 150;
+  private static final SingletonManager SINGLETON_MANAGER = new SingletonManager();
 
   private final MapDownloadProgressPanel progressPanel;
 
+  /**
+   * Shows the Download Maps window.
+   *
+   * @throws IllegalStateException If this method is not called from the EDT.
+   */
   public static void showDownloadMapsWindow() {
+    checkState(SwingUtilities.isEventDispatchThread());
+
     showDownloadMapsWindowAndDownload(Collections.emptyList());
   }
 
@@ -64,8 +77,11 @@ public class DownloadMapsWindow extends JFrame {
    * </p>
    *
    * @param mapName The name of the map to download; must not be {@code null}.
+   *
+   * @throws IllegalStateException If this method is not called from the EDT.
    */
   public static void showDownloadMapsWindowAndDownload(final String mapName) {
+    checkState(SwingUtilities.isEventDispatchThread());
     checkNotNull(mapName);
 
     showDownloadMapsWindowAndDownload(Collections.singletonList(mapName));
@@ -79,34 +95,117 @@ public class DownloadMapsWindow extends JFrame {
    * </p>
    *
    * @param mapNames The collection containing the names of the maps to download; must not be {@code null}.
+   *
+   * @throws IllegalStateException If this method is not called from the EDT.
    */
   public static void showDownloadMapsWindowAndDownload(final Collection<String> mapNames) {
+    checkState(SwingUtilities.isEventDispatchThread());
     checkNotNull(mapNames);
 
-    final Runnable downloadAndShowWindow = () -> {
-      final List<DownloadFileDescription> allDownloads = ClientContext.getMapDownloadList();
+    SINGLETON_MANAGER.showAndDownload(mapNames);
+  }
 
-      SwingUtilities.invokeLater(() -> {
-        final DownloadMapsWindow dia = new DownloadMapsWindow(mapNames, allDownloads);
-        dia.setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
-        dia.setLocationRelativeTo(null);
-        dia.setMinimumSize(new Dimension(200, 200));
-        dia.setVisible(true);
-        // ensure Download Maps window is displayed on top (#1260)
-        SwingUtilities.invokeLater(() -> {
-          dia.requestFocus();
-          dia.toFront();
-        });
+  private static final class SingletonManager {
+    private enum State {
+      UNINITIALIZED, INITIALIZING, INITIALIZED;
+    }
+
+    private State state;
+    private DownloadMapsWindow window;
+
+    SingletonManager() {
+      uninitialize();
+    }
+
+    private void uninitialize() {
+      assert SwingUtilities.isEventDispatchThread();
+
+      state = State.UNINITIALIZED;
+      window = null;
+    }
+
+    void showAndDownload(final Collection<String> mapNames) {
+      assert SwingUtilities.isEventDispatchThread();
+
+      switch (state) {
+        case UNINITIALIZED:
+          initialize(mapNames);
+          break;
+
+        case INITIALIZING:
+          logMapDownloadRequestIgnored(mapNames);
+          // do nothing; window will be shown when initialization is complete
+          break;
+
+        case INITIALIZED:
+          logMapDownloadRequestIgnored(mapNames);
+          show();
+          break;
+
+        default:
+          throw new AssertionError("unknown state");
+      }
+    }
+
+    private void initialize(final Collection<String> mapNames) {
+      assert SwingUtilities.isEventDispatchThread();
+      assert state == State.UNINITIALIZED;
+
+      state = State.INITIALIZING;
+      BackgroundTaskRunner.runInBackground("Downloading list of available maps...", () -> {
+        final List<DownloadFileDescription> downloads = ClientContext.getMapDownloadList();
+        SwingUtilities.invokeLater(() -> createAndShow(mapNames, downloads));
       });
-    };
-    final String popupWindowTitle = "Downloading list of available maps...";
-    BackgroundTaskRunner.runInBackground(popupWindowTitle, downloadAndShowWindow);
+    }
+
+    private void createAndShow(final Collection<String> mapNames, final List<DownloadFileDescription> downloads) {
+      assert SwingUtilities.isEventDispatchThread();
+      assert state == State.INITIALIZING;
+      assert window == null;
+
+      window = new DownloadMapsWindow(mapNames, downloads);
+      window.addWindowListener(new WindowAdapter() {
+        @Override
+        public void windowClosed(final WindowEvent e) {
+          uninitialize();
+        }
+      });
+      state = State.INITIALIZED;
+
+      show();
+    }
+
+    private void show() {
+      assert SwingUtilities.isEventDispatchThread();
+      assert state == State.INITIALIZED;
+      assert window != null;
+
+      window.setVisible(true);
+
+      // ensure Download Maps window is displayed on top (#1260)
+      SwingUtilities.invokeLater(() -> {
+        window.requestFocus();
+        window.toFront();
+      });
+    }
+  }
+
+  private static void logMapDownloadRequestIgnored(final Collection<String> mapNames) {
+    if (!mapNames.isEmpty()) {
+      LOGGER.info("ignoring request to download maps because window initialization has already started");
+    }
   }
 
   private DownloadMapsWindow(
       final Collection<String> pendingDownloadMapNames,
       final List<DownloadFileDescription> allDownloads) {
     super("Download Maps");
+
+    setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+    setSize(WINDOW_WIDTH, WINDOW_HEIGHT);
+    setLocationRelativeTo(null);
+    setMinimumSize(new Dimension(200, 200));
+
     setIconImage(GameRunner.getGameIcon(this));
     progressPanel = new MapDownloadProgressPanel();
 

--- a/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/src/main/java/games/strategy/ui/SwingComponents.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import javax.swing.Action;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -223,11 +224,38 @@ public class SwingComponents {
     SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(null, msg));
   }
 
-  public static void addWindowCloseListener(final Window window, final Runnable closeAction) {
+  /**
+   * Executes the specified action when the specified window is in the process of being closed.
+   *
+   * @param window The window to which the action is attached; must not be {@code null}.
+   * @param action The action to execute; must not be {@code null}.
+   */
+  public static void addWindowClosingListener(final Window window, final Runnable action) {
+    checkNotNull(window);
+    checkNotNull(action);
+
     window.addWindowListener(new WindowAdapter() {
       @Override
       public void windowClosing(final WindowEvent e) {
-        closeAction.run();
+        action.run();
+      }
+    });
+  }
+
+  /**
+   * Executes the specified action when the specified window has been closed.
+   *
+   * @param window The window to which the action is attached; must not be {@code null}.
+   * @param action The action to execute; must not be {@code null}.
+   */
+  public static void addWindowClosedListener(final Window window, final Runnable action) {
+    checkNotNull(window);
+    checkNotNull(action);
+
+    window.addWindowListener(new WindowAdapter() {
+      @Override
+      public void windowClosed(final WindowEvent e) {
+        action.run();
       }
     });
   }


### PR DESCRIPTION
This PR addresses #1923 by ensuring that multiple Download Maps windows are not displayed concurrently.

#### Functional changes
* Clicking the **Download Maps** button when the Download Maps window is already open will bring the existing Download Maps window to the foreground.  (:warning: On some operating systems, the window will not be brought to the foreground and clicking the **Download Maps** button will appear to do nothing; this is a separate issue mentioned [here](https://github.com/triplea-game/triplea/issues/1923#issuecomment-309169024).)

#### Functional issues for review
* I essentially introduced a singleton for `DownloadMapsWindow`.  However, because a) the singleton can be created and destroyed multiple times, and b) the singleton requires multi-step initialization (i.e. downloading the maps list is a prerequisite), I had to introduce another abstraction to manage the singleton instance, unimaginatively named `DownloadMapsWindow$SingletonManager`.
    * I originally wanted to locate the singleton in `ClientContext`, but I see no precedent for managing UI classes via `ClientContext`.  Not sure if this should be the first one.  Another alternative would be to have `GameRunner` manage the window, as it recently has taken on some UI responsibilities with the management of the top-level frame window.  (I think access to the top-level frame window is going to be necessary to fix the not-appearing-in-the-foreground issue.)
    * `SingletonManager` smells a bit to me, but I'm not sure what else to do at this point.  The main problem I see in the current code is the multiple locations that attempt to display `DownloadMapsWindow` (the main menu, the tutorial download check, and the map update check).  That makes it difficult to manage the `DownloadMapsWindow` instance "properly."  However, I'm open to any suggestions that improve the architecture.
* If the Download Maps window is open and a request is made to download a map from outside the window (e.g. the map update check calling `showDownloadMapsWindowAndDownload()`), the window will be brought to the foreground, but the map download request will be ignored.  However, this action will be logged at INFO level (which currently causes the console to be displayed).
    * Realistically, this scenario is unlikely to occur in production.  The user would have to click the **Download Maps** button as soon as the main menu appeared in an attempt to win the race with the map update check or the tutorial download check (albeit which is easier on machines with high latency network connections).
    * I view the log as a glorified TODO.  In the future, we should modify `DownloadMapsWindow` to accept out-of-band download requests and not require they be specified at the time the window is created.  However, I think it's best to add this feature when it's actually needed.

#### Refactoring changes
None.

#### Testing
I verified clicking **Download Maps** with a Download Maps window already open brings the existing window into the foreground (Linux only).  After closing that window and clicking **Download Maps** again, I verified a new Download Maps window with all defaults is displayed.

I forced a tutorial download check to trigger and, after answering **Yes** to the prompt, I verified the Download Maps window was displayed and the tutorial download began.  While the download was in progress, I switched back to the main menu and clicked **Download Maps**.  I verified the existing window was brought into the foreground (Linux only).

I forced a map update check to trigger for one map and, after answering **Yes** to the prompt, I verified the Download Maps window was displayed and the map download began.  While the download was in progress, I switched back to the main menu and clicked **Download Maps**.  I verified the existing window was brought into the foreground (Linux only).

Finally, I forced another map update check to trigger for one map.  Before being prompted to update the map, I opened the Download Maps window.  I was then prompted to update the out-of-date map and, after answering **Yes** to the prompt, I verified the existing window was brought into the foreground (Linux only) but the download was not started.  I also verified the console was displayed with a message indicating the map download request was being ignored because the Download Maps window was already initialized.