### PR TITLE
Display DownloadMapsWindow on top (#1260)

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -92,6 +92,7 @@ public class DownloadMapsWindow extends JFrame {
         dia.setLocationRelativeTo(null);
         dia.setMinimumSize(new Dimension(200, 200));
         dia.setVisible(true);
+        // ensure Download Maps window is displayed on top (#1260)
         SwingUtilities.invokeLater(() -> {
           dia.requestFocus();
           dia.toFront();

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -92,8 +92,10 @@ public class DownloadMapsWindow extends JFrame {
         dia.setLocationRelativeTo(null);
         dia.setMinimumSize(new Dimension(200, 200));
         dia.setVisible(true);
-        dia.requestFocus();
-        dia.toFront();
+        SwingUtilities.invokeLater(() -> {
+          dia.requestFocus();
+          dia.toFront();
+        });
       });
     };
     final String popupWindowTitle = "Downloading list of available maps...";


### PR DESCRIPTION
For whatever reason this fixes #1260.
I assume somewhere in the code a `mainFrame.requestFocus` is being called after the download maps window is shown...
Adding this requestFocus call at the end of the EventQueue seems to fix this problem.