### PR TITLE
Add Default Option for Set All Player Selection

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -20,6 +20,7 @@ import javax.swing.JLabel;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.TripleA;
 
 class PlayerSelectorRow {
 
@@ -28,7 +29,7 @@ class PlayerSelectorRow {
 
   private final JCheckBox enabledCheckBox;
   private final String playerName;
-  private final boolean isHidden;
+  private final PlayerID player;
   private final JComboBox<String> playerTypes;
   private JComponent incomePercentage;
   private final JLabel incomePercentageLabel;
@@ -47,7 +48,7 @@ class PlayerSelectorRow {
     this.disableable = disableable;
     this.parent = parent;
     playerName = player.getName();
-    isHidden = player.isHidden();
+    this.player = player;
     name = new JLabel(playerName + ":");
 
     enabledCheckBox = new JCheckBox();
@@ -77,12 +78,8 @@ class PlayerSelectorRow {
     }
     if (!(previousSelection.equals("no_one")) && Arrays.asList(types).contains(previousSelection)) {
       playerTypes.setSelectedItem(previousSelection);
-    } else if (PLAYER_TYPE_AI.equals(player.getDefaultType())) {
-      // the 4th in the list should be Pro AI (Hard AI)
-      playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 3))]);
-    } else if (PLAYER_TYPE_DOES_NOTHING.equals(player.getDefaultType())) {
-      // the 5th in the list should be Does Nothing AI
-      playerTypes.setSelectedItem(types[Math.max(0, Math.min(types.length - 1, 4))]);
+    } else {
+      setDefaultPlayerType();
     }
 
     alliances = null;
@@ -164,8 +161,20 @@ class PlayerSelectorRow {
   }
 
   void setPlayerType(final String playerType) {
-    if (enabled && !isHidden) {
+    if (enabled && !player.isHidden()) {
       playerTypes.setSelectedItem(playerType);
+    }
+  }
+
+  void setDefaultPlayerType() {
+    if (enabled && !player.isHidden()) {
+      if (PLAYER_TYPE_AI.equals(player.getDefaultType())) {
+        playerTypes.setSelectedItem(TripleA.PRO_COMPUTER_PLAYER_TYPE);
+      } else if (PLAYER_TYPE_DOES_NOTHING.equals(player.getDefaultType())) {
+        playerTypes.setSelectedItem(TripleA.DOESNOTHINGAI_COMPUTER_PLAYER_TYPE);
+      } else {
+        playerTypes.setSelectedItem(TripleA.HUMAN_PLAYER_TYPE);
+      }
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -24,6 +24,8 @@ import games.strategy.ui.SwingAction;
 
 public abstract class SetupPanel extends JPanel implements ISetupPanel {
   private static final long serialVersionUID = 4001323470187210773L;
+  private static final String SET_ALL_DEFAULT_LABEL = "Default";
+
   private final List<Observer> listeners = new ArrayList<>();
 
   @Override
@@ -111,6 +113,7 @@ public abstract class SetupPanel extends JPanel implements ISetupPanel {
     panel.add(nameLabel, new GridBagConstraints(gridx++, gridy, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(0, 5, 5, 0), 0, 0));
     final JComboBox<String> setAllTypes = new JComboBox<>(playerTypes);
+    setAllTypes.insertItemAt(SET_ALL_DEFAULT_LABEL, 0);
     setAllTypes.setSelectedIndex(-1);
     panel.add(setAllTypes, new GridBagConstraints(gridx, gridy - 1, 1, 1, 0, 0, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(5, 5, 15, 0), 0, 0));
@@ -155,7 +158,12 @@ public abstract class SetupPanel extends JPanel implements ISetupPanel {
     resourceModifiers.setAction(resourceModifiersAction);
 
     final Action setAllTypesAction = SwingAction.of(e -> {
-      playerRows.forEach(row -> row.setPlayerType(setAllTypes.getSelectedItem().toString()));
+      final String selectedType = setAllTypes.getSelectedItem().toString();
+      if (SET_ALL_DEFAULT_LABEL.equals(selectedType)) {
+        playerRows.forEach(row -> row.setDefaultPlayerType());
+      } else {
+        playerRows.forEach(row -> row.setPlayerType(selectedType));
+      }
     });
     setAllTypes.setAction(setAllTypesAction);
 


### PR DESCRIPTION
**Functional Changes**
- Added "Default" option to Set All dropdown on player selection screen which resets all players back to default types defined in XML

**To Test**
- Set 'defaultType' in game XML - optional, default is "Human"; options are "Human", "AI", "DoesNothing"; sets player to this type by default in the player selection window

Examples:
```
<player name="Germans" optional="false" defaultType="AI" />
<player name="Italians" optional="false" defaultType="DoesNothing" />
```