### PR TITLE
Checkstyle: Fix member name violations in g.s.triplea.ui.screen.drawable.* classes

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/BaseMapDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/BaseMapDrawable.java
@@ -11,24 +11,24 @@ public class BaseMapDrawable extends MapTileDrawable {
 
   @Override
   public MapTileDrawable getUnscaledCopy() {
-    final BaseMapDrawable copy = new BaseMapDrawable(m_x, m_y, m_uiContext);
-    copy.m_unscaled = true;
+    final BaseMapDrawable copy = new BaseMapDrawable(x, y, uiContext);
+    copy.unscaled = true;
     return copy;
   }
 
   @Override
   protected Image getImage() {
-    if (m_noImage) {
+    if (noImage) {
       return null;
     }
     Image image;
-    if (m_unscaled) {
-      image = m_uiContext.getTileImageFactory().getUnscaledUncachedBaseTile(m_x, m_y);
+    if (unscaled) {
+      image = uiContext.getTileImageFactory().getUnscaledUncachedBaseTile(x, y);
     } else {
-      image = m_uiContext.getTileImageFactory().getBaseTile(m_x, m_y);
+      image = uiContext.getTileImageFactory().getBaseTile(x, y);
     }
     if (image == null) {
-      m_noImage = true;
+      noImage = true;
     }
     return image;
   }

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
@@ -17,22 +17,22 @@ import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class BattleDrawable extends TerritoryDrawable implements IDrawable {
-  private final String m_territoryName;
+  private final String territoryName;
 
   public BattleDrawable(final String territoryName) {
-    m_territoryName = territoryName;
+    this.territoryName = territoryName;
   }
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
     final Set<PlayerID> players = new HashSet<>();
-    for (final Unit u : data.getMap().getTerritory(m_territoryName).getUnits()) {
+    for (final Unit u : data.getMap().getTerritory(territoryName).getUnits()) {
       if (!TripleAUnit.get(u).getSubmerged()) {
         players.add(u.getOwner());
       }
     }
-    final Territory territory = data.getMap().getTerritory(m_territoryName);
+    final Territory territory = data.getMap().getTerritory(territoryName);
     PlayerID attacker = null;
     boolean draw = false;
     for (final PlayerID p : players) {

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/BlockadeZoneDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/BlockadeZoneDrawable.java
@@ -11,20 +11,18 @@ import games.strategy.triplea.ui.IUIContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class BlockadeZoneDrawable implements IDrawable {
-  private final String m_location;
+  private final String location;
 
-  // private final UIContext m_uiContext;
   public BlockadeZoneDrawable(final Territory location, final IUIContext uiContext) {
     super();
-    m_location = location.getName();
-    // m_uiContext = uiContext;
+    this.location = location.getName();
   }
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
     // Find blockade.png from misc folder
-    final Point point = mapData.getBlockadePlacementPoint(data.getMap().getTerritory(m_location));
+    final Point point = mapData.getBlockadePlacementPoint(data.getMap().getTerritory(location));
     drawImage(graphics, mapData.getBlockadeImage(), point, bounds);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/CapitolMarkerDrawable.java
@@ -13,26 +13,26 @@ import games.strategy.triplea.ui.IUIContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class CapitolMarkerDrawable implements IDrawable {
-  private final String m_player;
-  private final String m_location;
-  private final IUIContext m_uiContext;
+  private final String player;
+  private final String location;
+  private final IUIContext uiContext;
 
   public CapitolMarkerDrawable(final PlayerID player, final Territory location, final IUIContext uiContext) {
     super();
     if (player == null) {
       throw new IllegalStateException("no player for capitol:" + location);
     }
-    m_player = player.getName();
-    m_location = location.getName();
-    m_uiContext = uiContext;
+    this.player = player.getName();
+    this.location = location.getName();
+    this.uiContext = uiContext;
   }
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
     // Changed back to use Large flags
-    final Image img = m_uiContext.getFlagImageFactory().getLargeFlag(data.getPlayerList().getPlayerID(m_player));
-    final Point point = mapData.getCapitolMarkerLocation(data.getMap().getTerritory(m_location));
+    final Image img = uiContext.getFlagImageFactory().getLargeFlag(data.getPlayerList().getPlayerID(player));
+    final Point point = mapData.getCapitolMarkerLocation(data.getMap().getTerritory(location));
     graphics.drawImage(img, point.x - bounds.x, point.y - bounds.y, null);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/ConvoyZoneDrawable.java
@@ -14,15 +14,15 @@ import games.strategy.triplea.ui.mapdata.MapData;
 
 // Rewritten class to use country markers rather than shading for Convoy Centers/Routes.
 public class ConvoyZoneDrawable implements IDrawable {
-  private final String m_player;
-  private final String m_location;
-  private final IUIContext m_uiContext;
+  private final String player;
+  private final String location;
+  private final IUIContext uiContext;
 
   public ConvoyZoneDrawable(final PlayerID player, final Territory location, final IUIContext uiContext) {
     super();
-    m_player = player.getName();
-    m_location = location.getName();
-    m_uiContext = uiContext;
+    this.player = player.getName();
+    this.location = location.getName();
+    this.uiContext = uiContext;
   }
 
   @Override
@@ -30,11 +30,11 @@ public class ConvoyZoneDrawable implements IDrawable {
       final AffineTransform unscaled, final AffineTransform scaled) {
     Image img;
     if (mapData.useNation_convoyFlags()) {
-      img = m_uiContext.getFlagImageFactory().getConvoyFlag(data.getPlayerList().getPlayerID(m_player));
+      img = uiContext.getFlagImageFactory().getConvoyFlag(data.getPlayerList().getPlayerID(player));
     } else {
-      img = m_uiContext.getFlagImageFactory().getFlag(data.getPlayerList().getPlayerID(m_player));
+      img = uiContext.getFlagImageFactory().getFlag(data.getPlayerList().getPlayerID(player));
     }
-    final Point point = mapData.getConvoyMarkerLocation(data.getMap().getTerritory(m_location));
+    final Point point = mapData.getConvoyMarkerLocation(data.getMap().getTerritory(location));
     graphics.drawImage(img, point.x - bounds.x, point.y - bounds.y, null);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/DecoratorDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/DecoratorDrawable.java
@@ -10,19 +10,19 @@ import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class DecoratorDrawable implements IDrawable {
-  private final Point m_point;
-  private final Image m_image;
+  private final Point point;
+  private final Image image;
 
   public DecoratorDrawable(final Point point, final Image image) {
     super();
-    m_point = point;
-    m_image = image;
+    this.point = point;
+    this.image = image;
   }
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
-    graphics.drawImage(m_image, m_point.x - bounds.x, m_point.y - bounds.y, null);
+    graphics.drawImage(image, point.x - bounds.x, point.y - bounds.y, null);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
@@ -15,20 +15,20 @@ import games.strategy.triplea.ui.mapdata.MapData;
 
 // Class to use 'Faded' country markers for Kamikaze Zones.
 public class KamikazeZoneDrawable implements IDrawable {
-  private final String m_location;
-  private final IUIContext m_uiContext;
+  private final String location;
+  private final IUIContext uiContext;
 
-  public KamikazeZoneDrawable(final Territory location, final IUIContext uiContext2) {
+  public KamikazeZoneDrawable(final Territory location, final IUIContext uiContext) {
     super();
-    m_location = location.getName();
-    m_uiContext = uiContext2;
+    this.location = location.getName();
+    this.uiContext = uiContext;
   }
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
     // Change so only original owner gets the kamikazi zone marker
-    final Territory terr = data.getMap().getTerritory(m_location);
+    final Territory terr = data.getMap().getTerritory(location);
     final TerritoryAttachment ta = TerritoryAttachment.get(terr);
     PlayerID owner = null;
     if (games.strategy.triplea.Properties.getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(data)) {
@@ -46,8 +46,8 @@ public class KamikazeZoneDrawable implements IDrawable {
         }
       }
     }
-    final Image img = m_uiContext.getFlagImageFactory().getFadedFlag(owner);
-    final Point point = mapData.getKamikazeMarkerLocation(data.getMap().getTerritory(m_location));
+    final Image img = uiContext.getFlagImageFactory().getFadedFlag(owner);
+    final Point point = mapData.getKamikazeMarkerLocation(data.getMap().getTerritory(location));
     graphics.drawImage(img, point.x - bounds.x, point.y - bounds.y, null);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/LandTerritoryDrawable.java
@@ -11,16 +11,16 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class LandTerritoryDrawable extends TerritoryDrawable implements IDrawable {
-  private final String m_territoryName;
+  private final String territoryName;
 
   public LandTerritoryDrawable(final String territoryName) {
-    m_territoryName = territoryName;
+    this.territoryName = territoryName;
   }
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
-    final Territory territory = data.getMap().getTerritory(m_territoryName);
+    final Territory territory = data.getMap().getTerritory(territoryName);
     Color territoryColor;
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     if (ta != null && ta.getIsImpassable()) {

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
@@ -12,17 +12,17 @@ import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.TileManager;
 
 public abstract class MapTileDrawable implements IDrawable {
-  protected boolean m_noImage = false;
-  protected final int m_x;
-  protected final int m_y;
-  protected final IUIContext m_uiContext;
-  protected boolean m_unscaled;
+  protected boolean noImage = false;
+  protected final int x;
+  protected final int y;
+  protected final IUIContext uiContext;
+  protected boolean unscaled;
 
   protected MapTileDrawable(final int x, final int y, final IUIContext uiContext) {
-    m_x = x;
-    m_y = y;
-    m_uiContext = uiContext;
-    m_unscaled = false;
+    this.x = x;
+    this.y = y;
+    this.uiContext = uiContext;
+    unscaled = false;
   }
 
   public abstract MapTileDrawable getUnscaledCopy();
@@ -46,7 +46,7 @@ public abstract class MapTileDrawable implements IDrawable {
     if (unscaled != null) {
       graphics.setTransform(unscaled);
     }
-    graphics.drawImage(img, m_x * TileManager.TILE_SIZE - bounds.x, m_y * TileManager.TILE_SIZE - bounds.y, null);
+    graphics.drawImage(img, x * TileManager.TILE_SIZE - bounds.x, y * TileManager.TILE_SIZE - bounds.y, null);
     if (unscaled != null) {
       graphics.setTransform(scaled);
     }

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/OptionalExtraTerritoryBordersDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/OptionalExtraTerritoryBordersDrawable.java
@@ -13,18 +13,18 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class OptionalExtraTerritoryBordersDrawable implements IDrawable {
-  private final String m_territoryName;
-  private final OptionalExtraBorderLevel m_level;
+  private final String territoryName;
+  private final OptionalExtraBorderLevel level;
 
   public OptionalExtraTerritoryBordersDrawable(final String territoryName, final OptionalExtraBorderLevel level) {
-    m_territoryName = territoryName;
-    m_level = level;
+    this.territoryName = territoryName;
+    this.level = level;
   }
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
-    final Territory territory = data.getMap().getTerritory(m_territoryName);
+    final Territory territory = data.getMap().getTerritory(territoryName);
     final List<Polygon> polys = mapData.getPolygons(territory);
     final Iterator<Polygon> iter2 = polys.iterator();
     while (iter2.hasNext()) {
@@ -43,7 +43,7 @@ public class OptionalExtraTerritoryBordersDrawable implements IDrawable {
 
   @Override
   public int getLevel() {
-    if (m_level == OptionalExtraBorderLevel.HIGH) {
+    if (level == OptionalExtraBorderLevel.HIGH) {
       return OPTIONAL_EXTRA_TERRITORY_BORDERS_HIGH_LEVEL;
     }
     return OPTIONAL_EXTRA_TERRITORY_BORDERS_MEDIUM_LEVEL;

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/ReliefMapDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/ReliefMapDrawable.java
@@ -12,27 +12,27 @@ public class ReliefMapDrawable extends MapTileDrawable {
 
   @Override
   public MapTileDrawable getUnscaledCopy() {
-    final ReliefMapDrawable copy = new ReliefMapDrawable(m_x, m_y, m_uiContext);
-    copy.m_unscaled = true;
+    final ReliefMapDrawable copy = new ReliefMapDrawable(x, y, uiContext);
+    copy.unscaled = true;
     return copy;
   }
 
   @Override
   protected Image getImage() {
-    if (m_noImage) {
+    if (noImage) {
       return null;
     }
     if (!TileImageFactory.getShowReliefImages()) {
       return null;
     }
     Image image;
-    if (m_unscaled) {
-      image = m_uiContext.getTileImageFactory().getUnscaledUncachedReliefTile(m_x, m_y);
+    if (unscaled) {
+      image = uiContext.getTileImageFactory().getUnscaledUncachedReliefTile(x, y);
     } else {
-      image = m_uiContext.getTileImageFactory().getReliefTile(m_x, m_y);
+      image = uiContext.getTileImageFactory().getReliefTile(x, y);
     }
     if (image == null) {
-      m_noImage = true;
+      noImage = true;
     }
     return image;
   }

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/SeaZoneOutlineDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/SeaZoneOutlineDrawable.java
@@ -13,16 +13,16 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class SeaZoneOutlineDrawable implements IDrawable {
-  private final String m_territoryName;
+  private final String territoryName;
 
   public SeaZoneOutlineDrawable(final String territoryName) {
-    m_territoryName = territoryName;
+    this.territoryName = territoryName;
   }
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
-    final Territory territory = data.getMap().getTerritory(m_territoryName);
+    final Territory territory = data.getMap().getTerritory(territoryName);
     final List<Polygon> polys = mapData.getPolygons(territory);
     final Iterator<Polygon> iter2 = polys.iterator();
     while (iter2.hasNext()) {

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryEffectDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryEffectDrawable.java
@@ -10,19 +10,19 @@ import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class TerritoryEffectDrawable implements IDrawable {
-  private final TerritoryEffect m_effect;
+  private final TerritoryEffect effect;
   private final Point point;
 
   public TerritoryEffectDrawable(final TerritoryEffect te, final Point point) {
     super();
-    m_effect = te;
+    effect = te;
     this.point = point;
   }
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
-    drawImage(graphics, mapData.getTerritoryEffectImage(m_effect.getName()), point, bounds);
+    drawImage(graphics, mapData.getTerritoryEffectImage(effect.getName()), point, bounds);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -20,18 +20,18 @@ import games.strategy.triplea.ui.IUIContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 
 public class TerritoryNameDrawable implements IDrawable {
-  private final String m_territoryName;
-  private final IUIContext m_uiContext;
+  private final String territoryName;
+  private final IUIContext uiContext;
 
-  public TerritoryNameDrawable(final String territoryName, final IUIContext context) {
-    this.m_territoryName = territoryName;
-    this.m_uiContext = context;
+  public TerritoryNameDrawable(final String territoryName, final IUIContext uiContext) {
+    this.territoryName = territoryName;
+    this.uiContext = uiContext;
   }
 
   @Override
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
-    final Territory territory = data.getMap().getTerritory(m_territoryName);
+    final Territory territory = data.getMap().getTerritory(territoryName);
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     final boolean drawFromTopLeft = mapData.drawNamesFromTopLeft();
     final boolean showSeaNames = mapData.drawSeaZoneNames();
@@ -97,7 +97,7 @@ public class TerritoryNameDrawable implements IDrawable {
       }
     }
     // draw territory names
-    if (mapData.drawTerritoryNames() && mapData.shouldDrawTerritoryName(m_territoryName)) {
+    if (mapData.drawTerritoryNames() && mapData.shouldDrawTerritoryName(territoryName)) {
       if (!territory.isWater() || showSeaNames) {
         final Image nameImage = mapData.getTerritoryNameImages().get(territory.getName());
         draw(bounds, graphics, x, y, nameImage, territory.getName(), drawFromTopLeft);
@@ -105,7 +105,7 @@ public class TerritoryNameDrawable implements IDrawable {
     }
     // draw the PUs.
     if (ta != null && ta.getProduction() > 0 && mapData.drawResources()) {
-      final Image img = m_uiContext.getPUImageFactory().getPUImage(ta.getProduction());
+      final Image img = uiContext.getPUImageFactory().getPUImage(ta.getProduction());
       final String prod = Integer.valueOf(ta.getProduction()).toString();
       final Optional<Point> place = mapData.getPUPlacementPoint(territory);
       // if pu_place.txt is specified draw there
@@ -113,7 +113,7 @@ public class TerritoryNameDrawable implements IDrawable {
         draw(bounds, graphics, place.get().x, place.get().y, img, prod, drawFromTopLeft);
       } else {
         // otherwise, draw under the territory name
-        draw(bounds, graphics, x + ((fm.stringWidth(m_territoryName)) >> 1) - ((fm.stringWidth(prod)) >> 1),
+        draw(bounds, graphics, x + ((fm.stringWidth(territoryName)) >> 1) - ((fm.stringWidth(prod)) >> 1),
             y + fm.getLeading() + fm.getAscent(), img, prod, drawFromTopLeft);
       }
     }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName rule in classes within the `g.s.triplea.ui.screen.drawable` package.