### PR TITLE
Rename someMatch() methods to anyMatch()

### DIFF
--- a/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -154,14 +154,14 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
     boolean hasFactory = false;
     boolean ownsLand = false;
     for (final Territory t : data.getMap().getTerritories()) {
-      if (t.getUnits().someMatch(Match.allOf(Matches.unitIsOwnedBy(this),
+      if (t.getUnits().anyMatch(Match.allOf(Matches.unitIsOwnedBy(this),
           Matches.unitHasAttackValueOfAtLeast(1), Matches.UnitCanMove, Matches.UnitIsLand))) {
         return true;
       }
       if (t.getOwner().equals(this)) {
         ownsLand = true;
       }
-      if (t.getUnits().someMatch(Match.allOf(Matches.unitIsOwnedBy(this), Matches.UnitCanProduceUnits))) {
+      if (t.getUnits().anyMatch(Match.allOf(Matches.unitIsOwnedBy(this), Matches.UnitCanProduceUnits))) {
         hasFactory = true;
       }
       if (ownsLand && hasFactory) {

--- a/src/main/java/games/strategy/engine/data/Route.java
+++ b/src/main/java/games/strategy/engine/data/Route.java
@@ -229,9 +229,9 @@ public class Route implements Serializable, Iterable<Territory> {
   /**
    * @param match
    *        referring match
-   * @return whether some territories in this route match the given match (start territory is not tested).
+   * @return whether any territories in this route match the given match (start territory is not tested).
    */
-  public boolean someMatch(final Match<Territory> match) {
+  public boolean anyMatch(final Match<Territory> match) {
     for (final Territory t : m_steps) {
       if (match.match(t)) {
         return true;
@@ -410,7 +410,7 @@ public class Route implements Serializable, Iterable<Territory> {
     if (getStart().isWater()) {
       return true;
     }
-    return Match.someMatch(getSteps(), Matches.TerritoryIsWater);
+    return Match.anyMatch(getSteps(), Matches.TerritoryIsWater);
   }
 
   /**

--- a/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -218,7 +218,7 @@ public class UnitCollection extends GameDataComponent implements Iterable<Unit> 
     return true;
   }
 
-  public boolean someMatch(final Match<Unit> matcher) {
+  public boolean anyMatch(final Match<Unit> matcher) {
     for (final Unit unit : m_units) {
       if (matcher.match(unit)) {
         return true;

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -131,7 +131,7 @@ public class AIUtils {
   }
 
   static List<Unit> interleaveCarriersAndPlanes(final List<Unit> units, final int planesThatDontNeedToLand) {
-    if (!(Match.someMatch(units, Matches.UnitIsCarrier) && Match.someMatch(units, Matches.UnitCanLandOnCarrier))) {
+    if (!(Match.anyMatch(units, Matches.UnitIsCarrier) && Match.anyMatch(units, Matches.UnitCanLandOnCarrier))) {
       return units;
     }
     // Clone the current list

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -318,7 +318,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
       final List<Territory> notOwned = Match.getMatches(territoryChoices, Matches.isTerritoryOwnedBy(me).invert());
       if (notOwned.isEmpty()) {
         // only owned territories left
-        final boolean nonFactoryUnitsLeft = Match.someMatch(unitChoices, Matches.UnitCanProduceUnits.invert());
+        final boolean nonFactoryUnitsLeft = Match.anyMatch(unitChoices, Matches.UnitCanProduceUnits.invert());
         final Match<Unit> ownedFactories = Match.allOf(Matches.UnitCanProduceUnits, Matches.unitIsOwnedBy(me));
         final List<Territory> capitals = TerritoryAttachment.getAllCapitals(me, data);
         final List<Territory> test = new ArrayList<>(capitals);

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
@@ -297,7 +297,7 @@ public class ProAI extends AbstractAI {
         + attackers.size() + ", defenders=" + defenders.size() + ", submerge=" + submerge + ", attacker=" + isAttacker
         + ", isStrafing=" + isStrafing);
     if ((isStrafing || (isAttacker && strengthDifference > 50))
-        && (battleTerritory.isWater() || Match.someMatch(attackers, Matches.UnitIsLand))) {
+        && (battleTerritory.isWater() || Match.anyMatch(attackers, Matches.UnitIsLand))) {
       return null;
     }
     calc.setData(getGameData());

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -463,7 +463,7 @@ class ProCombatMoveAI {
 
       // Remove empty convoy zones that can't be held
       if (!patd.isCanHold() && enemyAttackOptions.getMax(t) != null && t.isWater()
-          && !t.getUnits().someMatch(Matches.enemyUnit(player, data))) {
+          && !t.getUnits().anyMatch(Matches.enemyUnit(player, data))) {
         ProLogger.debug("Removing convoy zone that can't be held: " + t.getName() + ", enemyAttackers="
             + enemyAttackOptions.getMax(t).getMaxUnits());
         it.remove();
@@ -545,7 +545,7 @@ class ProCombatMoveAI {
     // Find land territories with no can't move units and adjacent to enemy land units
     final List<Unit> alreadyMovedUnits = new ArrayList<>();
     for (final Territory t : ProData.myUnitTerritories) {
-      final boolean hasAlliedLandUnits = Match.someMatch(t.getUnits().getUnits(),
+      final boolean hasAlliedLandUnits = Match.anyMatch(t.getUnits().getUnits(),
           ProMatches.unitCantBeMovedAndIsAlliedDefenderAndNotInfra(player, data, t));
       final Set<Territory> enemyNeighbors = data.getMap().getNeighbors(t,
           Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player, Matches.UnitIsLand));
@@ -719,9 +719,9 @@ class ProCombatMoveAI {
         Optional<Territory> maxBombingTerritory = Optional.empty();
         int maxBombingScore = MIN_BOMBING_SCORE;
         for (final Territory t : bomberMoveMap.get(unit)) {
-          final boolean territoryCanBeBombed = t.getUnits().someMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
+          final boolean territoryCanBeBombed = t.getUnits().anyMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
           if (territoryCanBeBombed && canAirSafelyLandAfterAttack(unit, t)) {
-            final int noAaBombingDefense = t.getUnits().someMatch(Matches.UnitIsAAforBombingThisUnitOnly) ? 0 : 1;
+            final int noAaBombingDefense = t.getUnits().anyMatch(Matches.UnitIsAAforBombingThisUnitOnly) ? 0 : 1;
             int maxDamage = 0;
             final TerritoryAttachment ta = TerritoryAttachment.get(t);
             if (ta != null) {
@@ -776,7 +776,7 @@ class ProCombatMoveAI {
             final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player, data);
             final boolean isOverwhelmingWin =
                 ProBattleUtils.checkForOverwhelmingWin(t, attackingUnits, defendingUnits);
-            final boolean hasAa = Match.someMatch(defendingUnits, Matches.UnitIsAAforAnything);
+            final boolean hasAa = Match.anyMatch(defendingUnits, Matches.UnitIsAAforAnything);
             if (!hasAa && !isOverwhelmingWin) {
               minWinPercentage = result.getWinPercentage();
               minWinTerritory = t;
@@ -1017,7 +1017,7 @@ class ProCombatMoveAI {
 
         // Add destroyer if territory has subs and a destroyer has been already added
         final List<Unit> defendingUnits = attackMap.get(t).getMaxEnemyDefenders(player, data);
-        if (Match.someMatch(defendingUnits, Matches.UnitIsSub)
+        if (Match.anyMatch(defendingUnits, Matches.UnitIsSub)
             && Match.noneMatch(attackMap.get(t).getUnits(), Matches.UnitIsDestroyer)) {
           attackMap.get(t).addUnit(unit);
           it.remove();
@@ -1040,7 +1040,7 @@ class ProCombatMoveAI {
         }
         final List<Unit> defendingUnits = attackMap.get(t).getMaxEnemyDefenders(player, data);
         double estimate = ProBattleUtils.estimateStrengthDifference(t, attackMap.get(t).getUnits(), defendingUnits);
-        final boolean hasAa = Match.someMatch(defendingUnits, Matches.UnitIsAAforAnything);
+        final boolean hasAa = Match.anyMatch(defendingUnits, Matches.UnitIsAAforAnything);
         if (hasAa) {
           estimate -= 10;
         }
@@ -1130,7 +1130,7 @@ class ProCombatMoveAI {
                 Match.noneMatch(defendingUnits, ProMatches.unitIsEnemyAndNotInfa(player, data));
             final boolean isOverwhelmingWin =
                 ProBattleUtils.checkForOverwhelmingWin(t, patd.getUnits(), defendingUnits);
-            final boolean hasAa = Match.someMatch(defendingUnits, Matches.UnitIsAAforAnything);
+            final boolean hasAa = Match.anyMatch(defendingUnits, Matches.UnitIsAAforAnything);
             if (!hasNoDefenders && !isOverwhelmingWin && (!hasAa || result.getWinPercentage() < minWinPercentage)) {
               minWinPercentage = result.getWinPercentage();
               minWinTerritory = t;
@@ -1188,7 +1188,7 @@ class ProCombatMoveAI {
                 Match.noneMatch(defendingUnits, ProMatches.unitIsEnemyAndNotInfa(player, data));
             final boolean isOverwhelmingWin =
                 ProBattleUtils.checkForOverwhelmingWin(t, patd.getUnits(), defendingUnits);
-            final boolean hasAa = Match.someMatch(defendingUnits, Matches.UnitIsAAforAnything);
+            final boolean hasAa = Match.anyMatch(defendingUnits, Matches.UnitIsAAforAnything);
             if (!isAirUnit || (!hasNoDefenders && !isOverwhelmingWin
                 && (!hasAa || result.getWinPercentage() < minWinPercentage))) {
               minWinPercentage = result.getWinPercentage();
@@ -1382,7 +1382,7 @@ class ProCombatMoveAI {
       final Set<Territory> canBombardTerritories = new HashSet<>();
       for (final ProTerritory patd : prioritizedTerritories) {
         final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player, data);
-        final boolean hasDefenders = Match.someMatch(defendingUnits, Matches.UnitIsInfrastructure.invert());
+        final boolean hasDefenders = Match.anyMatch(defendingUnits, Matches.UnitIsInfrastructure.invert());
         if (bombardMap.get(u).contains(patd.getTerritory()) && !patd.getTransportTerritoryMap().isEmpty()
             && hasDefenders && !TransportTracker.isTransporting(u)) {
           canBombardTerritories.add(patd.getTerritory());

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -289,7 +289,7 @@ class ProNonCombatMoveAI {
     final List<Territory> territoriesToDefendWithOneUnit = new ArrayList<>();
     for (final Territory t : moveMap.keySet()) {
       final boolean hasAlliedLandUnits =
-          Match.someMatch(moveMap.get(t).getCantMoveUnits(), ProMatches.unitIsAlliedLandAndNotInfra(player, data));
+          Match.anyMatch(moveMap.get(t).getCantMoveUnits(), ProMatches.unitIsAlliedLandAndNotInfra(player, data));
       if (!t.isWater() && !hasAlliedLandUnits
           && ProMatches
               .territoryHasNeighborOwnedByAndHasLandUnit(data, ProUtils.getPotentialEnemyPlayers(player))
@@ -1344,7 +1344,7 @@ class ProNonCombatMoveAI {
         if (Matches.UnitIsSea.match(u)) {
           for (final Territory t : currentUnitMoveMap.get(u)) {
             if (moveMap.get(t).isCanHold() && !moveMap.get(t).getAllDefenders().isEmpty()
-                && Match.someMatch(moveMap.get(t).getAllDefenders(), ProMatches.unitIsOwnedTransport(player))) {
+                && Match.anyMatch(moveMap.get(t).getAllDefenders(), ProMatches.unitIsOwnedTransport(player))) {
               final List<Unit> defendingUnits =
                   Match.getMatches(moveMap.get(t).getAllDefenders(), Matches.UnitIsNotLand);
               if (moveMap.get(t).getBattleResult() == null) {
@@ -1384,7 +1384,7 @@ class ProNonCombatMoveAI {
         if (Matches.UnitCanLandOnCarrier.match(u)) {
           for (final Territory t : currentUnitMoveMap.get(u)) {
             if (t.isWater() && moveMap.get(t).isCanHold() && !moveMap.get(t).getAllDefenders().isEmpty()
-                && Match.someMatch(moveMap.get(t).getAllDefenders(), ProMatches.unitIsOwnedTransport(player))) {
+                && Match.anyMatch(moveMap.get(t).getAllDefenders(), ProMatches.unitIsOwnedTransport(player))) {
               if (!ProTransportUtils.validateCarrierCapacity(player, t,
                   moveMap.get(t).getAllDefendersForCarrierCalcs(data, player), u)) {
                 continue;
@@ -1789,7 +1789,7 @@ class ProNonCombatMoveAI {
         // Check if number of attack territories and value are max
         final int isntFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t) ? 0 : 1;
         final int hasOwnedCarrier =
-            Match.someMatch(moveMap.get(t).getAllDefenders(), ProMatches.unitIsOwnedCarrier(player)) ? 1 : 0;
+            Match.anyMatch(moveMap.get(t).getAllDefenders(), ProMatches.unitIsOwnedCarrier(player)) ? 1 : 0;
         final double airValue = (200.0 * numSeaAttackTerritories + 100 * numLandAttackTerritories
             + 10 * numEnemyAttackTerritories + numNearbyEnemyTerritories) / (1 + cantHoldWithoutAllies)
             / (1 + cantHoldWithoutAllies * isntFactory) * (1 + hasOwnedCarrier);
@@ -1947,7 +1947,7 @@ class ProNonCombatMoveAI {
           // Find value and try to move to territory that doesn't already have AA
           final List<Unit> units = new ArrayList<>(moveMap.get(t).getCantMoveUnits());
           units.addAll(moveMap.get(t).getUnits());
-          final boolean hasAa = Match.someMatch(units, Matches.UnitIsAAforAnything);
+          final boolean hasAa = Match.anyMatch(units, Matches.UnitIsAAforAnything);
           double value = moveMap.get(t).getValue();
           if (hasAa) {
             value *= 0.01;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -547,7 +547,7 @@ class ProPurchaseAI {
 
       // Determine if need destroyer
       boolean needDestroyer = false;
-      if (Match.someMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsSub)
+      if (Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsSub)
           && Match.noneMatch(ownedLocalUnits, Matches.UnitIsDestroyer)) {
         needDestroyer = true;
       }
@@ -712,9 +712,9 @@ class ProPurchaseAI {
 
       // Check if territory needs AA
       final boolean enemyCanBomb =
-          Match.someMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsStrategicBomber);
-      final boolean territoryCanBeBombed = t.getUnits().someMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
-      final boolean hasAaBombingDefense = t.getUnits().someMatch(Matches.UnitIsAAforBombingThisUnitOnly);
+          Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsStrategicBomber);
+      final boolean territoryCanBeBombed = t.getUnits().anyMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
+      final boolean hasAaBombingDefense = t.getUnits().anyMatch(Matches.UnitIsAAforBombingThisUnitOnly);
       ProLogger.debug(t + ", enemyCanBomb=" + enemyCanBomb + ", territoryCanBeBombed=" + territoryCanBeBombed
           + ", hasAABombingDefense=" + hasAaBombingDefense);
       if (!enemyCanBomb || !territoryCanBeBombed || hasAaBombingDefense) {
@@ -1146,7 +1146,7 @@ class ProPurchaseAI {
       if (enemyAttackOptions.getMax(t) != null) {
 
         // Determine if need destroyer
-        if (Match.someMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsSub)
+        if (Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsSub)
             && Match.noneMatch(t.getUnits().getMatches(Matches.unitIsOwnedBy(player)), Matches.UnitIsDestroyer)) {
           needDestroyer = true;
         }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -407,7 +407,7 @@ final class ProTechAI {
       }
       for (final Territory neighbor : data.getMap().getNeighbors(current)) {
         if (!distance.keySet().contains(neighbor)) {
-          if (!neighbor.getUnits().someMatch(unitCondition)) {
+          if (!neighbor.getUnits().anyMatch(unitCondition)) {
             if (!routeCondition.match(neighbor)) {
               continue;
             }
@@ -675,7 +675,7 @@ final class ProTechAI {
     final List<Territory> shipTerr = new ArrayList<>();
     final Collection<Territory> tNeighbors = data.getMap().getTerritories();
     for (final Territory t2 : tNeighbors) {
-      if (t2.getUnits().someMatch(limitShips)) {
+      if (t2.getUnits().anyMatch(limitShips)) {
         shipTerr.add(t2);
       }
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProOtherMoveOptions.java
@@ -86,8 +86,8 @@ public class ProOtherMoveOptions {
           }
           final double currentStrength =
               ProBattleUtils.estimateStrength(t, new ArrayList<>(currentUnits), new ArrayList<>(), isAttacker);
-          final boolean currentHasLandUnits = Match.someMatch(currentUnits, Matches.UnitIsLand);
-          final boolean maxHasLandUnits = Match.someMatch(maxUnits, Matches.UnitIsLand);
+          final boolean currentHasLandUnits = Match.anyMatch(currentUnits, Matches.UnitIsLand);
+          final boolean maxHasLandUnits = Match.anyMatch(maxUnits, Matches.UnitIsLand);
           if ((currentHasLandUnits && ((!maxHasLandUnits && !t.isWater()) || currentStrength > maxStrength))
               || ((!maxHasLandUnits || t.isWater()) && currentStrength > maxStrength)) {
             result.put(t, moveMap.get(t));

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseTerritory.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseTerritory.java
@@ -40,7 +40,7 @@ public class ProPurchaseTerritory {
       if (ProMatches.territoryHasInfraFactoryAndIsNotConqueredOwnedLand(player, data).match(territory)) {
         for (final Territory t : data.getMap().getNeighbors(territory, Matches.TerritoryIsWater)) {
           if (Properties.getWW2V2(data) || Properties.getUnitPlacementInEnemySeas(data)
-              || !t.getUnits().someMatch(Matches.enemyUnit(player, data))) {
+              || !t.getUnits().anyMatch(Matches.enemyUnit(player, data))) {
             canPlaceTerritories.add(new ProPlaceTerritory(t));
           }
         }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -571,7 +571,7 @@ public class ProTerritoryManager {
             continue;
           }
           if (myRoute.hasMoreThenOneStep()
-              && Match.someMatch(myRoute.getMiddleSteps(), Matches.isTerritoryEnemy(player, data))
+              && Match.anyMatch(myRoute.getMiddleSteps(), Matches.isTerritoryEnemy(player, data))
               && Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesThatLostBlitz(myRoute.getAllTerritories()))
                   .match(myLandUnit)) {
             continue; // If blitzing then make sure none of the territories cause blitz ability to be lost
@@ -632,7 +632,7 @@ public class ProTerritoryManager {
         }
       }
       for (final Territory t : data.getMap().getTerritories()) {
-        if (t.getUnits().someMatch(Matches.unitIsAlliedCarrier(player, data))) {
+        if (t.getUnits().anyMatch(Matches.unitIsAlliedCarrier(player, data))) {
           possibleCarrierTerritories.add(t);
         }
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
@@ -75,7 +75,7 @@ public class ProMoveUtils {
 
         // Determine route and add to move list
         Route route = null;
-        if (Match.someMatch(unitList, Matches.UnitIsSea)) {
+        if (Match.anyMatch(unitList, Matches.UnitIsSea)) {
 
           // Sea unit (including carriers with planes)
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -157,7 +157,7 @@ public class ProOddsCalculator {
     tList.add(t);
     if (Match.allMatch(tList, Matches.TerritoryIsLand)) {
       return new ProBattleResult(winPercentage, tuvSwing,
-          Match.someMatch(averageAttackersRemaining, Matches.UnitIsLand), averageAttackersRemaining,
+          Match.anyMatch(averageAttackersRemaining, Matches.UnitIsLand), averageAttackersRemaining,
           averageDefendersRemaining, results.getAverageBattleRoundsFought());
     } else {
       return new ProBattleResult(winPercentage, tuvSwing, !averageAttackersRemaining.isEmpty(),

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTransportUtils.java
@@ -232,7 +232,7 @@ public class ProTransportUtils {
 
   public static List<Unit> interleaveUnitsCarriersAndPlanes(final List<Unit> units,
       final int planesThatDontNeedToLand) {
-    if (!(Match.someMatch(units, Matches.UnitIsCarrier) && Match.someMatch(units, Matches.UnitCanLandOnCarrier))) {
+    if (!(Match.anyMatch(units, Matches.UnitIsCarrier) && Match.anyMatch(units, Matches.UnitCanLandOnCarrier))) {
       return units;
     }
 

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -107,7 +107,7 @@ class Utils {
     final List<Territory> shipTerr = new ArrayList<>();
     final Collection<Territory> tNeighbors = data.getMap().getTerritories();
     for (final Territory t2 : tNeighbors) {
-      if (t2.getUnits().someMatch(limitShips)) {
+      if (t2.getUnits().anyMatch(limitShips)) {
         shipTerr.add(t2);
       }
     }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -307,7 +307,7 @@ public class WeakAI extends AbstractAI {
       // move sea units to the capitol, unless they are loaded transports
       if (t.isWater()) {
         // land units, move all towards the end point
-        if (t.getUnits().someMatch(Matches.UnitIsLand)) {
+        if (t.getUnits().anyMatch(Matches.UnitIsLand)) {
           // move along amphi route
           if (lastSeaZoneOnAmphib != null) {
             // two move route to end
@@ -319,7 +319,7 @@ public class WeakAI extends AbstractAI {
             }
           }
         }
-        if (nonCombat && t.getUnits().someMatch(ownedAndNotMoved)) {
+        if (nonCombat && t.getUnits().anyMatch(ownedAndNotMoved)) {
           // move toward the start of the amphib route
           if (firstSeaZoneOnAmphib != null) {
             final Route r = getMaxSeaRoute(data, t, firstSeaZoneOnAmphib, player);
@@ -357,7 +357,7 @@ public class WeakAI extends AbstractAI {
       if (!t.isWater()) {
         continue;
       }
-      if (!t.getUnits().someMatch(Matches.enemyUnit(player, data))) {
+      if (!t.getUnits().anyMatch(Matches.enemyUnit(player, data))) {
         continue;
       }
       final Territory enemy = t;
@@ -371,7 +371,7 @@ public class WeakAI extends AbstractAI {
         final Collection<Territory> attackFrom = data.getMap().getNeighbors(enemy, Matches.TerritoryIsWater);
         for (final Territory owned : attackFrom) {
           // dont risk units we are carrying
-          if (owned.getUnits().someMatch(Matches.UnitIsLand)) {
+          if (owned.getUnits().anyMatch(Matches.UnitIsLand)) {
             dontMoveFrom.add(owned);
             continue;
           }
@@ -573,8 +573,8 @@ public class WeakAI extends AbstractAI {
       if (!ta1.isCapital() && ta2.isCapital()) {
         return 1;
       }
-      final boolean factoryInT1 = o1.getUnits().someMatch(Matches.UnitCanProduceUnits);
-      final boolean factoryInT2 = o2.getUnits().someMatch(Matches.UnitCanProduceUnits);
+      final boolean factoryInT1 = o1.getUnits().anyMatch(Matches.UnitCanProduceUnits);
+      final boolean factoryInT2 = o2.getUnits().anyMatch(Matches.UnitCanProduceUnits);
       // next take territories which can produce
       if (factoryInT1 && !factoryInT2) {
         return -1;
@@ -582,8 +582,8 @@ public class WeakAI extends AbstractAI {
       if (!factoryInT1 && factoryInT2) {
         return 1;
       }
-      final boolean infrastructureInT1 = o1.getUnits().someMatch(Matches.UnitIsInfrastructure);
-      final boolean infrastructureInT2 = o2.getUnits().someMatch(Matches.UnitIsInfrastructure);
+      final boolean infrastructureInT1 = o1.getUnits().anyMatch(Matches.UnitIsInfrastructure);
+      final boolean infrastructureInT2 = o2.getUnits().anyMatch(Matches.UnitIsInfrastructure);
       // next take territories with infrastructure
       if (infrastructureInT1 && !infrastructureInT2) {
         return -1;
@@ -1007,7 +1007,7 @@ public class WeakAI extends AbstractAI {
     final List<Territory> randomTerritories = new ArrayList<>(data.getMap().getTerritories());
     Collections.shuffle(randomTerritories);
     for (final Territory t : randomTerritories) {
-      if (t != capitol && t.getOwner().equals(player) && t.getUnits().someMatch(Matches.UnitCanProduceUnits)) {
+      if (t != capitol && t.getOwner().equals(player) && t.getUnits().anyMatch(Matches.UnitCanProduceUnits)) {
         placeAllWeCanOn(data, t, placeDelegate, player);
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -119,12 +119,12 @@ class AAInMoveUtil implements Serializable {
     // AA guns in transports shouldn't be able to fire
     final List<Territory> territoriesWhereAaWillFire = new ArrayList<>();
     for (final Territory current : route.getMiddleSteps()) {
-      if (current.getUnits().someMatch(hasAa)) {
+      if (current.getUnits().anyMatch(hasAa)) {
         territoriesWhereAaWillFire.add(current);
       }
     }
     if (games.strategy.triplea.Properties.getForceAAattacksForLastStepOfFlyOver(data)) {
-      if (route.getEnd().getUnits().someMatch(hasAa)) {
+      if (route.getEnd().getUnits().anyMatch(hasAa)) {
         territoriesWhereAaWillFire.add(route.getEnd());
       }
     } else {
@@ -136,7 +136,7 @@ class AAInMoveUtil implements Serializable {
       // battle.
       // TODO: there is a bug in which if you move an air unit to a battle site in the middle of non combat, it wont
       // fire
-      if (route.getStart().getUnits().someMatch(hasAa) && !getBattleTracker().wasBattleFought(route.getStart())) {
+      if (route.getStart().getUnits().anyMatch(hasAa) && !getBattleTracker().wasBattleFought(route.getStart())) {
         territoriesWhereAaWillFire.add(route.getStart());
       }
     }
@@ -148,7 +148,7 @@ class AAInMoveUtil implements Serializable {
   }
 
   private PlayerID movingPlayer(final Collection<Unit> units) {
-    if (Match.someMatch(units, Matches.unitIsOwnedBy(m_player))) {
+    if (Match.anyMatch(units, Matches.unitIsOwnedBy(m_player))) {
       return m_player;
     }
     if (units != null) {
@@ -248,7 +248,7 @@ class AAInMoveUtil implements Serializable {
       }
       return PlayerID.NULL_PLAYERID;
     } else if (territory != null && territory.getOwner() != null && !territory.getOwner().isNull()
-        && Match.someMatch(defendingUnits, Matches.unitIsOwnedBy(territory.getOwner()))) {
+        && Match.anyMatch(defendingUnits, Matches.unitIsOwnedBy(territory.getOwner()))) {
       return territory.getOwner();
     }
     for (final Unit u : defendingUnits) {

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -215,16 +215,16 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final List<Unit> remainingUnitsToPlace = new ArrayList<>(m_player.getUnits().getUnits());
     remainingUnitsToPlace.removeAll(unitsLeftToPlace);
     final boolean hasRemainingNonConstructionUnitsToPlace =
-        Match.someMatch(remainingUnitsToPlace, Matches.UnitIsNotConstruction);
+        Match.anyMatch(remainingUnitsToPlace, Matches.UnitIsNotConstruction);
     while (!unitsLeftToPlace.isEmpty() && !producers.isEmpty()) {
 
       // Get next producer territory
       Territory producer = producers.get(0);
       final boolean isCarrierLeftAndCanMoveExistingFightersToCarrier =
-          Match.someMatch(unitsLeftToPlace, Matches.UnitIsCarrier) && canMoveExistingFightersToNewCarriers()
+          Match.anyMatch(unitsLeftToPlace, Matches.UnitIsCarrier) && canMoveExistingFightersToNewCarriers()
               && !Properties.getLHTRCarrierProductionRules(getData());
       final boolean cantAdjustUnitPlacements =
-          isUnitPlacementRestrictions() && Match.someMatch(unitsLeftToPlace, Matches.UnitRequiresUnitsOnCreation);
+          isUnitPlacementRestrictions() && Match.anyMatch(unitsLeftToPlace, Matches.UnitRequiresUnitsOnCreation);
       if (producers.size() > 1
           && (isCarrierLeftAndCanMoveExistingFightersToCarrier
               || (hasRemainingProduction && hasRemainingNonConstructionUnitsToPlace && cantAdjustUnitPlacements))) {
@@ -286,11 +286,11 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
 
     // play a sound
-    if (Match.someMatch(units, Matches.UnitIsInfrastructure)) {
+    if (Match.anyMatch(units, Matches.UnitIsInfrastructure)) {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_INFRASTRUCTURE, m_player);
-    } else if (Match.someMatch(units, Matches.UnitIsSea)) {
+    } else if (Match.anyMatch(units, Matches.UnitIsSea)) {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_SEA, m_player);
-    } else if (Match.someMatch(units, Matches.UnitIsAir)) {
+    } else if (Match.anyMatch(units, Matches.UnitIsAir)) {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_AIR, m_player);
     } else {
       m_bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_PLACED_LAND, m_player);
@@ -378,7 +378,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         final Territory placeTerritory = placement.getPlaceTerritory();
         // units with requiresUnits are too difficult to mess with logically, so do not move them around at all
         if (placeTerritory.isWater() && !placeTerritory.equals(producer) && (!isUnitPlacementRestrictions()
-            || !Match.someMatch(placement.getUnits(), Matches.UnitRequiresUnitsOnCreation))) {
+            || !Match.anyMatch(placement.getUnits(), Matches.UnitRequiresUnitsOnCreation))) {
           // found placement move of producer that can be taken over
           // remember move and amount of placements in that territory
           redoPlacements.add(placement);
@@ -511,17 +511,17 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!Matches.TerritoryIsLand.match(producer)) {
       return null;
     }
-    if (!producer.getUnits().someMatch(Matches.UnitCanProduceUnits)) {
+    if (!producer.getUnits().anyMatch(Matches.UnitCanProduceUnits)) {
       return null;
     }
     final Match<Unit> ownedFighters = Match.allOf(Matches.UnitCanLandOnCarrier, Matches.unitIsOwnedBy(player));
-    if (!producer.getUnits().someMatch(ownedFighters)) {
+    if (!producer.getUnits().anyMatch(ownedFighters)) {
       return null;
     }
     if (wasConquered(producer)) {
       return null;
     }
-    if (Match.someMatch(getAlreadyProduced(producer), Matches.UnitCanProduceUnits)) {
+    if (Match.anyMatch(getAlreadyProduced(producer), Matches.UnitCanProduceUnits)) {
       return null;
     }
     final List<Unit> fighters = producer.getUnits().getMatches(ownedFighters);
@@ -640,7 +640,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!producer.getOwner().equals(player)) {
       // sea constructions require either owning the sea zone or owning a surrounding land territory
       if (producer.isWater()
-          && Match.someMatch(testUnits, Match.allOf(Matches.UnitIsSea, Matches.UnitIsConstruction))) {
+          && Match.anyMatch(testUnits, Match.allOf(Matches.UnitIsSea, Matches.UnitIsConstruction))) {
         boolean ownedNeighbor = false;
         for (final Territory current : getData().getMap().getNeighbors(to, Matches.TerritoryIsLand)) {
           if (current.getOwner().equals(player) && (canProduceInConquered || !wasConquered(current))) {
@@ -672,11 +672,11 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     }
     // make sure some unit has fullfilled requiresUnits requirements
     if (isUnitPlacementRestrictions() && !testUnits.isEmpty()
-        && !Match.someMatch(testUnits, unitWhichRequiresUnitsHasRequiredUnits(producer, true))) {
+        && !Match.anyMatch(testUnits, unitWhichRequiresUnitsHasRequiredUnits(producer, true))) {
       return "You do not have the required units to build in " + producer.getName();
     }
     if (to.isWater() && (!isWW2V2() && !isUnitPlacementInEnemySeas())
-        && to.getUnits().someMatch(Matches.enemyUnit(player, getData()))) {
+        && to.getUnits().anyMatch(Matches.enemyUnit(player, getData()))) {
       return "Cannot place sea units with enemy naval units";
     }
     // make sure there is a factory
@@ -684,15 +684,15 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       return null;
     }
     // check to see if we are producing a factory or construction
-    if (Match.someMatch(testUnits, Matches.UnitIsConstruction)) {
+    if (Match.anyMatch(testUnits, Matches.UnitIsConstruction)) {
       if (howManyOfEachConstructionCanPlace(to, producer, testUnits, player).totalValues() > 0) {
         return null;
       }
       return "No more Constructions Allowed in " + producer.getName();
     }
     // check we havent just put a factory there (should we be checking producer?)
-    if (Match.someMatch(getAlreadyProduced(producer), Matches.UnitCanProduceUnits)
-        || Match.someMatch(getAlreadyProduced(to), Matches.UnitCanProduceUnits)) {
+    if (Match.anyMatch(getAlreadyProduced(producer), Matches.UnitCanProduceUnits)
+        || Match.anyMatch(getAlreadyProduced(to), Matches.UnitCanProduceUnits)) {
       return "Factory in " + producer.getName() + " cant produce until 1 turn after it is created";
     }
     return "No Factory in " + producer.getName();
@@ -793,7 +793,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         if (GameStepPropertiesHelper.isBid(getData())) {
           final PlayerAttachment pa = PlayerAttachment.get(to.getOwner());
           if ((pa == null || pa.getGiveUnitControl() == null || !pa.getGiveUnitControl().contains(player))
-              && !to.getUnits().someMatch(Matches.unitIsOwnedBy(player))) {
+              && !to.getUnits().anyMatch(Matches.unitIsOwnedBy(player))) {
             return "You don't own " + to.getName();
           }
         } else {
@@ -877,7 +877,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       final PlayerID player) {
     final boolean water = to.isWater();
     if (water && (!isWW2V2() && !isUnitPlacementInEnemySeas())
-        && to.getUnits().someMatch(Matches.enemyUnit(player, getData()))) {
+        && to.getUnits().anyMatch(Matches.enemyUnit(player, getData()))) {
       return null;
     }
     final Collection<Unit> units = new ArrayList<>(allUnits);
@@ -897,13 +897,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       if (!water) {
         placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.UnitIsNotConstruction)));
       } else if (((isBid || canProduceFightersOnCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
-          && Match.someMatch(allProducedUnits, Matches.UnitIsCarrier))
+          && Match.anyMatch(allProducedUnits, Matches.UnitIsCarrier))
           || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
-              && Match.someMatch(to.getUnits().getUnits(), Matches.UnitIsCarrier))) {
+              && Match.anyMatch(to.getUnits().getUnits(), Matches.UnitIsCarrier))) {
         placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
       }
     }
-    if (Match.someMatch(units, Matches.UnitIsConstruction)) {
+    if (Match.anyMatch(units, Matches.UnitIsConstruction)) {
       final IntegerMap<String> constructionsMap = howManyOfEachConstructionCanPlace(to, to, units, player);
       final Collection<Unit> skipUnits = new ArrayList<>();
       for (final Unit currentUnit : Match.getMatches(units, Matches.UnitIsConstruction)) {
@@ -921,7 +921,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       }
     }
     // remove any units that require other units to be consumed on creation, if we don't have enough to consume (veqryn)
-    if (Match.someMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
+    if (Match.anyMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
       final Collection<Unit> unitsWhichConsume = Match.getMatches(placeableUnits, Matches.UnitConsumesUnitsOnCreation);
       for (final Unit unit : unitsWhichConsume) {
         if (Matches.unitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
@@ -1167,7 +1167,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
           // logically, so we ignore them
           // for our special 'move shit around' methods.
           if (!placeTerritory.isWater() || (isUnitPlacementRestrictions()
-              && Match.someMatch(unitsPlacedByCurrentPlacementMove, Matches.UnitRequiresUnitsOnCreation))) {
+              && Match.anyMatch(unitsPlacedByCurrentPlacementMove, Matches.UnitRequiresUnitsOnCreation))) {
             productionCanNotBeMoved += unitsPlacedByCurrentPlacementMove.size();
           } else {
             final int maxProductionThatCanBeTakenOverFromThisPlacement = unitsPlacedByCurrentPlacementMove.size();
@@ -1250,7 +1250,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       final Collection<Unit> units, final PlayerID player) {
     // constructions can ONLY be produced BY the same territory that they are going into!
     if (!to.equals(producer) || units == null || units.isEmpty()
-        || !Match.someMatch(units, Matches.UnitIsConstruction)) {
+        || !Match.anyMatch(units, Matches.UnitIsConstruction)) {
       return new IntegerMap<>();
     }
     final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
@@ -1307,7 +1307,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         wasOwnedUnitThatCanProduceUnitsOrIsFactoryInTerritoryAtStartOfStep(to, player);
     // build an integer map of each construction unit in the territory
     final IntegerMap<String> unitMapTo = new IntegerMap<>();
-    if (Match.someMatch(unitsInTo, Matches.UnitIsConstruction)) {
+    if (Match.anyMatch(unitsInTo, Matches.UnitIsConstruction)) {
       for (final Unit currentUnit : Match.getMatches(unitsInTo, Matches.UnitIsConstruction)) {
         final UnitAttachment ua = UnitAttachment.get(currentUnit.getUnitType());
         /*
@@ -1407,7 +1407,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   }
 
   private boolean getCanAllUnitsWithRequiresUnitsBePlacedCorrectly(final Collection<Unit> units, final Territory to) {
-    if (!isUnitPlacementRestrictions() || !Match.someMatch(units, Matches.UnitRequiresUnitsOnCreation)) {
+    if (!isUnitPlacementRestrictions() || !Match.anyMatch(units, Matches.UnitRequiresUnitsOnCreation)) {
       return true;
     }
     final IntegerMap<Territory> producersMap = getMaxUnitsToBePlacedMap(units, to, m_player, true);

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -115,7 +115,7 @@ public class AirBattle extends AbstractBattle {
 
   private boolean shouldFightAirBattle() {
     if (m_isBombingRun) {
-      return Match.someMatch(m_attackingUnits, Matches.UnitIsStrategicBomber) && !m_defendingUnits.isEmpty();
+      return Match.anyMatch(m_attackingUnits, Matches.UnitIsStrategicBomber) && !m_defendingUnits.isEmpty();
     } else {
       return !m_attackingUnits.isEmpty() && !m_defendingUnits.isEmpty();
     }
@@ -169,14 +169,14 @@ public class AirBattle extends AbstractBattle {
           if (m_isBombingRun) {
             attackerSuicideBuilder.add(Matches.UnitIsNotStrategicBomber);
           }
-          if (Match.someMatch(m_attackingUnits, attackerSuicideBuilder.all())) {
+          if (Match.anyMatch(m_attackingUnits, attackerSuicideBuilder.all())) {
             final List<Unit> suicideUnits = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);
             m_attackingUnits.removeAll(suicideUnits);
             remove(suicideUnits, bridge, m_battleSite);
             tuvLostAttacker = BattleCalculator.getTUV(suicideUnits, m_attacker, attackerCosts, m_data);
             m_attackerLostTUV += tuvLostAttacker;
           }
-          if (Match.someMatch(m_defendingUnits, Matches.UnitIsSuicide)) {
+          if (Match.anyMatch(m_defendingUnits, Matches.UnitIsSuicide)) {
             final List<Unit> suicideUnits = Match.getMatches(m_defendingUnits, Matches.UnitIsSuicide);
             m_defendingUnits.removeAll(suicideUnits);
             remove(suicideUnits, bridge, m_battleSite);
@@ -347,7 +347,7 @@ public class AirBattle extends AbstractBattle {
     final String text;
     if (!m_attackingUnits.isEmpty()) {
       if (m_isBombingRun) {
-        if (Match.someMatch(m_attackingUnits, Matches.UnitIsStrategicBomber)) {
+        if (Match.anyMatch(m_attackingUnits, Matches.UnitIsStrategicBomber)) {
           m_whoWon = WhoWon.ATTACKER;
           if (m_defendingUnits.isEmpty()) {
             m_battleResultDescription = BattleRecord.BattleResultDescription.WON_WITHOUT_CONQUERING;
@@ -679,11 +679,11 @@ public class AirBattle extends AbstractBattle {
         }
       }
     } else {
-      return territory.getUnits().someMatch(defendingAirMatch);
+      return territory.getUnits().anyMatch(defendingAirMatch);
     }
     // should we check if the territory also has an air base?
-    return territory.getUnits().someMatch(defendingAirMatch)
-        || Match.someMatch(data.getMap().getNeighbors(territory, maxScrambleDistance),
+    return territory.getUnits().anyMatch(defendingAirMatch)
+        || Match.anyMatch(data.getMap().getNeighbors(territory, maxScrambleDistance),
             Matches.territoryHasUnitsThatMatch(defendingAirMatch));
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -41,7 +41,7 @@ public class AirMovementValidator {
       final Route route, final PlayerID player, final MoveValidationResult result) {
     // First check if we even need to check
     if (getEditMode(data) || // Edit Mode, no need to check
-        !Match.someMatch(units, Matches.UnitIsAir) || // No Airunits, nothing to check
+        !Match.anyMatch(units, Matches.UnitIsAir) || // No Airunits, nothing to check
         route.hasNoSteps() || // if there are no steps, we didn't move, so it is always OK!
         // we can land at the end, nothing left to check
         Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data).match(route.getEnd())

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -858,7 +858,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           // refactored.
           final MustFightBattle mfb = (MustFightBattle) battle;
           final Collection<Territory> neighborsLand = data.getMap().getNeighbors(to, Matches.TerritoryIsLand);
-          if (Match.someMatch(attackingUnits, Matches.UnitIsTransport)) {
+          if (Match.anyMatch(attackingUnits, Matches.UnitIsTransport)) {
             // first, we have to reset the "transportedBy" setting for all the land units that were offloaded
             final CompositeChange change1 = new CompositeChange();
             mfb.reLoadTransports(attackingUnits, change1);
@@ -908,7 +908,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
               }
             }
           }
-          if (Match.someMatch(attackingUnits, Matches.UnitIsAir.invert())) {
+          if (Match.anyMatch(attackingUnits, Matches.UnitIsAir.invert())) {
             // TODO: for now, we will hack and say that the attackers came from Everywhere, and hope the user will
             // choose the correct place
             // to retreat to! (TODO: Fix this)

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -288,8 +288,8 @@ public class BattleTracker implements java.io.Serializable {
       if (changeTracker != null) {
         changeTracker.addChange(change);
       }
-      if (games.strategy.util.Match.someMatch(units, Matches.UnitIsLand)
-          || games.strategy.util.Match.someMatch(units, Matches.UnitIsSea)) {
+      if (games.strategy.util.Match.anyMatch(units, Matches.UnitIsLand)
+          || games.strategy.util.Match.anyMatch(units, Matches.UnitIsSea)) {
         addEmptyBattle(route, units, id, bridge, changeTracker, unitsNotUnloadedTilEndOfRoute);
       }
     }
@@ -390,7 +390,7 @@ public class BattleTracker implements java.io.Serializable {
     if (unitsNotUnloadedTilEndOfRoute != null) {
       presentFromStartTilEnd.removeAll(unitsNotUnloadedTilEndOfRoute);
     }
-    final boolean canConquerMiddleSteps = Match.someMatch(presentFromStartTilEnd, Matches.UnitIsNotAir);
+    final boolean canConquerMiddleSteps = Match.anyMatch(presentFromStartTilEnd, Matches.UnitIsNotAir);
     final boolean scramblingEnabled = games.strategy.triplea.Properties.getScramble_Rules_In_Effect(data);
     final Match<Territory> conquerable = Match.allOf(
         Matches.territoryIsEmptyOfCombatUnits(data, id),
@@ -676,7 +676,7 @@ public class BattleTracker implements java.io.Serializable {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_SEA, id);
       } else if (ta != null && ta.getCapital() != null) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_CAPITAL, id);
-      } else if (m_blitzed.contains(territory) && Match.someMatch(arrivedUnits, Matches.UnitCanBlitz)) {
+      } else if (m_blitzed.contains(territory) && Match.anyMatch(arrivedUnits, Matches.UnitCanBlitz)) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_BLITZ, id);
       } else {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_LAND, id);
@@ -684,7 +684,7 @@ public class BattleTracker implements java.io.Serializable {
     }
     // Remove any bombing raids against captured territory
     // TODO: see if necessary
-    if (Match.someMatch(territory.getUnits().getUnits(),
+    if (Match.anyMatch(territory.getUnits().getUnits(),
         Match.allOf(Matches.unitIsEnemyOf(data, id), Matches.UnitCanBeDamaged))) {
       final IBattle bombingBattle = getPendingBattle(territory, true, null);
       if (bombingBattle != null) {
@@ -880,7 +880,7 @@ public class BattleTracker implements java.io.Serializable {
     // make amphibious assaults dependent on possible naval invasions
     // its only a dependency if we are unloading
     final IBattle precede = getDependentAmphibiousAssault(route);
-    if (precede != null && Match.someMatch(units, Matches.UnitIsLand)) {
+    if (precede != null && Match.anyMatch(units, Matches.UnitIsLand)) {
       addDependency(battle, precede);
     }
     // dont let land battles in the same territory occur before bombing

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -36,18 +36,18 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       final PlayerID player) {
     // we can place if no enemy units and its water
     if (to.isWater()) {
-      if (Match.someMatch(units, Matches.UnitIsLand)) {
+      if (Match.anyMatch(units, Matches.UnitIsLand)) {
         return "Cant place land units at sea";
-      } else if (to.getUnits().someMatch(Matches.enemyUnit(player, getData()))) {
+      } else if (to.getUnits().anyMatch(Matches.enemyUnit(player, getData()))) {
         return "Cant place in sea zone containing enemy units";
-      } else if (!to.getUnits().someMatch(Matches.unitIsOwnedBy(player))) {
+      } else if (!to.getUnits().anyMatch(Matches.unitIsOwnedBy(player))) {
         return "Cant place in sea zone that does not contain a unit owned by you";
       } else {
         return null;
       }
     } else {
       // we can place on territories we own
-      if (Match.someMatch(units, Matches.UnitIsSea)) {
+      if (Match.anyMatch(units, Matches.UnitIsSea)) {
         return "Cant place sea units on land";
       } else if (to.getOwner() == null) {
         return "You dont own " + to.getName();
@@ -55,7 +55,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
         final PlayerAttachment pa = PlayerAttachment.get(to.getOwner());
         if (pa != null && pa.getGiveUnitControl() != null && pa.getGiveUnitControl().contains(player)) {
           return null;
-        } else if (to.getUnits().someMatch(Matches.unitIsOwnedBy(player))) {
+        } else if (to.getUnits().anyMatch(Matches.unitIsOwnedBy(player))) {
           return null;
         }
         return "You dont own " + to.getName();
@@ -119,7 +119,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     final Match<Unit> airUnits = Match.allOf(Matches.UnitIsAir, Matches.UnitIsNotConstruction);
     placeableUnits.addAll(Match.getMatches(units, groundUnits));
     placeableUnits.addAll(Match.getMatches(units, airUnits));
-    if (Match.someMatch(units, Matches.UnitIsConstruction)) {
+    if (Match.anyMatch(units, Matches.UnitIsConstruction)) {
       final IntegerMap<String> constructionsMap = howManyOfEachConstructionCanPlace(to, to, units, player);
       final Collection<Unit> skipUnit = new ArrayList<>();
       for (final Unit currentUnit : Match.getMatches(units, Matches.UnitIsConstruction)) {
@@ -137,7 +137,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       }
     }
     // remove any units that require other units to be consumed on creation (veqryn)
-    if (Match.someMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
+    if (Match.anyMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
       final Collection<Unit> unitsWhichConsume = Match.getMatches(placeableUnits, Matches.UnitConsumesUnitsOnCreation);
       for (final Unit unit : unitsWhichConsume) {
         if (Matches.unitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -83,7 +83,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     Map<Unit, Unit> mapLoading = null;
     if (territory.isWater()) {
       if (!Match.allMatch(units, Matches.UnitIsSea)) {
-        if (Match.someMatch(units, Matches.UnitIsLand)) {
+        if (Match.anyMatch(units, Matches.UnitIsLand)) {
           // this should be exact same as the one in the EditValidator
           if (!Match.allMatch(units, Matches.alliedUnit(player, data))) {
             return "Can't add mixed nationality units to water";

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -69,7 +69,7 @@ class EditValidator {
     // check land/water sanity
     if (territory.isWater()) {
       if (!Match.allMatch(units, Matches.UnitIsSea)) {
-        if (Match.someMatch(units, Matches.UnitIsLand)) {
+        if (Match.anyMatch(units, Matches.UnitIsLand)) {
           if (!Match.allMatch(units, Matches.alliedUnit(player, data))) {
             return "Can't add mixed nationality units to water";
           }
@@ -89,8 +89,8 @@ class EditValidator {
             return "Can't add land units to water without enough transports";
           }
         }
-        if (Match.someMatch(units, Matches.UnitIsAir)) {
-          if (Match.someMatch(units, Match.allOf(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier.invert()))) {
+        if (Match.anyMatch(units, Matches.UnitIsAir)) {
+          if (Match.anyMatch(units, Match.allOf(Matches.UnitIsAir, Matches.UnitCanLandOnCarrier.invert()))) {
             return "Cannot add air to water unless it can land on carriers";
           }
           // Set up matches
@@ -113,7 +113,7 @@ class EditValidator {
        * if (Matches.isTerritoryEnemy(player, data).match(territory) && !Matches.TerritoryIsWater.match(territory))
        * return "Can't add units to enemy territory";
        */
-      if (Match.someMatch(units, Matches.UnitIsSea)) {
+      if (Match.anyMatch(units, Matches.UnitIsSea)) {
         return "Can't add sea units to land";
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
@@ -81,7 +81,7 @@ public class FinishedBattle extends AbstractBattle {
     attackingFromMapUnits.addAll(units);
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()
-        && Match.someMatch(units, Matches.UnitIsLand)) {
+        && Match.anyMatch(units, Matches.UnitIsLand)) {
       m_amphibiousAttackFrom.add(route.getTerritoryBeforeEnd());
       m_amphibiousLandAttackers.addAll(Match.getMatches(units, Matches.UnitIsLand));
       m_isAmphibious = true;
@@ -108,7 +108,7 @@ public class FinishedBattle extends AbstractBattle {
     }
     // deal with amphibious assaults
     if (attackingFrom.isWater()) {
-      if (route.getEnd() != null && !route.getEnd().isWater() && Match.someMatch(units, Matches.UnitIsLand)) {
+      if (route.getEnd() != null && !route.getEnd().isWater() && Match.anyMatch(units, Matches.UnitIsLand)) {
         m_amphibiousLandAttackers.removeAll(Match.getMatches(units, Matches.UnitIsLand));
       }
       // if none of the units is a land unit, the attack from

--- a/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -122,7 +122,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
         continue;
       }
       final Collection<Unit> units = current.getUnits().getUnits();
-      if (units.size() == 0 || !Match.someMatch(units, Matches.UnitIsLand)) {
+      if (units.size() == 0 || !Match.anyMatch(units, Matches.UnitIsLand)) {
         continue;
       }
       // map transports, try to fill

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -66,7 +66,7 @@ import games.strategy.util.Util;
  * </p>
  *
  * <pre>
- * boolean hasLand = Match.someMatch(someCollection, Matches.UnitIsAir);
+ * boolean hasLand = Match.anyMatch(someCollection, Matches.UnitIsAir);
  * </pre>
  *
  * <p>
@@ -414,7 +414,7 @@ public class Matches {
       Match.of(unit -> UnitAttachment.get(unit.getType()).getCarrierCapacity() != -1);
 
   static Match<Territory> territoryHasOwnedCarrier(final PlayerID player) {
-    return Match.of(t -> t.getUnits().someMatch(Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier)));
+    return Match.of(t -> t.getUnits().anyMatch(Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsCarrier)));
   }
 
   public static Match<Unit> unitIsAlliedCarrier(final PlayerID player, final GameData data) {
@@ -504,7 +504,7 @@ public class Matches {
           return true;
         }
       }
-      return Match.someMatch(targets, Match.allOf(Matches.UnitIsAirborne,
+      return Match.anyMatch(targets, Match.allOf(Matches.UnitIsAirborne,
           Matches.unitIsOfTypes(airborneTechTargetsAllowed.get(ua.getTypeAA()))));
     });
   }
@@ -832,7 +832,7 @@ public class Matches {
       if (!data.getRelationshipTracker().isAllied(t.getOwner(), player)) {
         return false;
       }
-      return t.getUnits().someMatch(Match.allOf(Matches.alliedUnit(player, data), unitMatch));
+      return t.getUnits().anyMatch(Match.allOf(Matches.alliedUnit(player, data), unitMatch));
     });
   }
 
@@ -842,7 +842,7 @@ public class Matches {
       if (!t.getOwner().equals(player)) {
         return false;
       }
-      return t.getUnits().someMatch(Match.allOf(Matches.unitIsOwnedBy(player), unitMatch));
+      return t.getUnits().anyMatch(Match.allOf(Matches.unitIsOwnedBy(player), unitMatch));
     });
   }
 
@@ -851,7 +851,7 @@ public class Matches {
       if (!t.getOwner().equals(player)) {
         return false;
       }
-      return t.getUnits().someMatch(Matches.UnitCanProduceUnits);
+      return t.getUnits().anyMatch(Matches.UnitCanProduceUnits);
     });
   }
 
@@ -861,7 +861,7 @@ public class Matches {
       if (!t.getOwner().equals(player)) {
         return false;
       }
-      if (!t.getUnits().someMatch(Matches.UnitCanProduceUnits)) {
+      if (!t.getUnits().anyMatch(Matches.UnitCanProduceUnits)) {
         return false;
       }
       final BattleTracker bt = AbstractMoveDelegate.getBattleTracker(data);
@@ -874,7 +874,7 @@ public class Matches {
       if (!isTerritoryAllied(player, data).match(t)) {
         return false;
       }
-      return t.getUnits().someMatch(Matches.UnitCanProduceUnits);
+      return t.getUnits().anyMatch(Matches.UnitCanProduceUnits);
     });
   }
 
@@ -887,7 +887,7 @@ public class Matches {
       if (t.getOwner().isNull()) {
         return false;
       }
-      return t.getUnits().someMatch(Match.allOf(Matches.enemyUnit(player, data), unitMatch));
+      return t.getUnits().anyMatch(Match.allOf(Matches.enemyUnit(player, data), unitMatch));
     });
   }
 
@@ -1329,49 +1329,49 @@ public class Matches {
   }
 
   public static Match<Territory> territoryHasLandUnitsOwnedBy(final PlayerID player) {
-    return Match.of(t -> t.getUnits().someMatch(Match.allOf(unitIsOwnedBy(player), UnitIsLand)));
+    return Match.of(t -> t.getUnits().anyMatch(Match.allOf(unitIsOwnedBy(player), UnitIsLand)));
   }
 
   public static Match<Territory> territoryHasUnitsOwnedBy(final PlayerID player) {
     final Match<Unit> unitOwnedBy = unitIsOwnedBy(player);
-    return Match.of(t -> t.getUnits().someMatch(unitOwnedBy));
+    return Match.of(t -> t.getUnits().anyMatch(unitOwnedBy));
   }
 
   public static Match<Territory> territoryHasUnitsThatMatch(final Match<Unit> cond) {
-    return Match.of(t -> t.getUnits().someMatch(cond));
+    return Match.of(t -> t.getUnits().anyMatch(cond));
   }
 
   public static Match<Territory> territoryHasEnemyAaForAnything(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().someMatch(unitIsEnemyAaForAnything(player, data)));
+    return Match.of(t -> t.getUnits().anyMatch(unitIsEnemyAaForAnything(player, data)));
   }
 
   public static Match<Territory> territoryHasEnemyAaForCombatOnly(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().someMatch(unitIsEnemyAaForCombat(player, data)));
+    return Match.of(t -> t.getUnits().anyMatch(unitIsEnemyAaForCombat(player, data)));
   }
 
   public static Match<Territory> territoryHasNoEnemyUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> !t.getUnits().someMatch(enemyUnit(player, data)));
+    return Match.of(t -> !t.getUnits().anyMatch(enemyUnit(player, data)));
   }
 
   public static Match<Territory> territoryHasAlliedUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().someMatch(alliedUnit(player, data)));
+    return Match.of(t -> t.getUnits().anyMatch(alliedUnit(player, data)));
   }
 
   static Match<Territory> territoryHasNonSubmergedEnemyUnits(final PlayerID player, final GameData data) {
     final Match<Unit> match = Match.allOf(enemyUnit(player, data), UnitIsSubmerged.invert());
-    return Match.of(t -> t.getUnits().someMatch(match));
+    return Match.of(t -> t.getUnits().anyMatch(match));
   }
 
   public static Match<Territory> territoryHasEnemyLandUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().someMatch(Match.allOf(enemyUnit(player, data), UnitIsLand)));
+    return Match.of(t -> t.getUnits().anyMatch(Match.allOf(enemyUnit(player, data), UnitIsLand)));
   }
 
   public static Match<Territory> territoryHasEnemySeaUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().someMatch(Match.allOf(enemyUnit(player, data), UnitIsSea)));
+    return Match.of(t -> t.getUnits().anyMatch(Match.allOf(enemyUnit(player, data), UnitIsSea)));
   }
 
   public static Match<Territory> territoryHasEnemyUnits(final PlayerID player, final GameData data) {
-    return Match.of(t -> t.getUnits().someMatch(enemyUnit(player, data)));
+    return Match.of(t -> t.getUnits().anyMatch(enemyUnit(player, data)));
   }
 
   /**
@@ -1573,7 +1573,7 @@ public class Matches {
       }
       final Match<Unit> repairUnit = Match.allOf(Matches.alliedUnit(player, data),
           Matches.UnitCanRepairOthers, Matches.unitCanRepairThisUnit(damagedUnit));
-      if (Match.someMatch(territory.getUnits().getUnits(), repairUnit)) {
+      if (Match.anyMatch(territory.getUnits().getUnits(), repairUnit)) {
         return true;
       }
       if (Matches.UnitIsSea.match(damagedUnit)) {
@@ -1581,7 +1581,7 @@ public class Matches {
         final List<Territory> neighbors =
             new ArrayList<>(data.getMap().getNeighbors(territory, Matches.TerritoryIsLand));
         for (final Territory current : neighbors) {
-          if (Match.someMatch(current.getUnits().getUnits(), repairUnitLand)) {
+          if (Match.anyMatch(current.getUnits().getUnits(), repairUnitLand)) {
             return true;
           }
         }
@@ -1590,7 +1590,7 @@ public class Matches {
         final List<Territory> neighbors =
             new ArrayList<>(data.getMap().getNeighbors(territory, Matches.TerritoryIsWater));
         for (final Territory current : neighbors) {
-          if (Match.someMatch(current.getUnits().getUnits(), repairUnitSea)) {
+          if (Match.anyMatch(current.getUnits().getUnits(), repairUnitSea)) {
             return true;
           }
         }
@@ -1637,7 +1637,7 @@ public class Matches {
     return Match.of(unitWhichWillGetBonus -> {
       final Match<Unit> givesBonusUnit = Match.allOf(Matches.alliedUnit(player, data),
           unitCanGiveBonusMovementToThisUnit(unitWhichWillGetBonus));
-      if (Match.someMatch(territory.getUnits().getUnits(), givesBonusUnit)) {
+      if (Match.anyMatch(territory.getUnits().getUnits(), givesBonusUnit)) {
         return true;
       }
       if (Matches.UnitIsSea.match(unitWhichWillGetBonus)) {
@@ -1645,7 +1645,7 @@ public class Matches {
         final List<Territory> neighbors =
             new ArrayList<>(data.getMap().getNeighbors(territory, Matches.TerritoryIsLand));
         for (final Territory current : neighbors) {
-          if (Match.someMatch(current.getUnits().getUnits(), givesBonusUnitLand)) {
+          if (Match.anyMatch(current.getUnits().getUnits(), givesBonusUnitLand)) {
             return true;
           }
         }

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -248,7 +248,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       moveableUnitOwnedByMeBuilder.add(Matches.UnitCanNotMoveDuringCombatMove.invert());
     }
     for (final Territory item : getData().getMap().getTerritories()) {
-      if (item.getUnits().someMatch(moveableUnitOwnedByMeBuilder.all())) {
+      if (item.getUnits().anyMatch(moveableUnitOwnedByMeBuilder.all())) {
         return true;
       }
     }
@@ -528,7 +528,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     Collection<Unit> kamikazeUnits = new ArrayList<>();
 
     // confirm kamikaze moves, and remove them from unresolved units
-    if (getKamikazeAir || Match.someMatch(units, Matches.UnitIsKamikaze)) {
+    if (getKamikazeAir || Match.anyMatch(units, Matches.UnitIsKamikaze)) {
       kamikazeUnits = result.getUnresolvedUnits(MoveValidator.NOT_ALL_AIR_UNITS_CAN_LAND);
       if (kamikazeUnits.size() > 0 && getRemotePlayer().confirmMoveKamikaze()) {
         for (final Unit unit : kamikazeUnits) {
@@ -581,7 +581,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     boolean hasProducedCarriers = false;
     for (final PlayerID p : GameStepPropertiesHelper.getCombinedTurns(data, m_player)) {
-      if (p.getUnits().someMatch(Matches.UnitIsCarrier)) {
+      if (p.getUnits().anyMatch(Matches.UnitIsCarrier)) {
         hasProducedCarriers = true;
         break;
       }
@@ -595,7 +595,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       // Check if player still has units to place
       if (!player.equals(m_player)) {
         util.removeAirThatCantLand(player,
-            ((player.getUnits().someMatch(Matches.UnitIsCarrier) || hasProducedCarriers) && lhtrCarrierProd));
+            ((player.getUnits().anyMatch(Matches.UnitIsCarrier) || hasProducedCarriers) && lhtrCarrierProd));
       }
     }
   }

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -164,7 +164,7 @@ public class MovePerformer implements Serializable {
           change.add(markFuelCostResourceChange(units, route, id, data));
         }
         markTransportsMovement(arrived, transporting, route);
-        if (route.someMatch(mustFightThrough) && arrived.size() != 0) {
+        if (route.anyMatch(mustFightThrough) && arrived.size() != 0) {
           boolean bombing = false;
           boolean ignoreBattle = false;
           // could it be a bombing raid
@@ -338,7 +338,7 @@ public class MovePerformer implements Serializable {
     }
     if (routeEnd != null && games.strategy.triplea.Properties.getSubsCanEndNonCombatMoveWithEnemies(data)
         && GameStepPropertiesHelper.isNonCombatMove(data, false) && routeEnd.getUnits()
-            .someMatch(Match.allOf(Matches.unitIsEnemyOf(data, id), Matches.UnitIsDestroyer))) {
+            .anyMatch(Match.allOf(Matches.unitIsEnemyOf(data, id), Matches.UnitIsDestroyer))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we want to make sure we
       // can't keep moving them
       // if there is an enemy destroyer there
@@ -359,7 +359,7 @@ public class MovePerformer implements Serializable {
     }
     final GameData data = m_bridge.getData();
     final Match<Unit> paratroopNAirTransports = Match.anyOf(Matches.UnitIsAirTransport, Matches.UnitIsAirTransportable);
-    final boolean paratroopsLanding = Match.someMatch(arrived, paratroopNAirTransports)
+    final boolean paratroopsLanding = Match.anyMatch(arrived, paratroopNAirTransports)
         && MoveValidator.allLandUnitsAreBeingParatroopered(arrived);
     final Map<Unit, Collection<Unit>> dependentAirTransportableUnits =
         MoveValidator.getDependents(Match.getMatches(arrived, Matches.UnitCanTransport));

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -103,7 +103,7 @@ public class MoveValidator {
     // dont let the user move out of a battle zone
     // the exception is air units and unloading units into a battle zone
     if (AbstractMoveDelegate.getBattleTracker(data).hasPendingBattle(route.getStart(), false)
-        && Match.someMatch(units, Matches.UnitIsNotAir)) {
+        && Match.anyMatch(units, Matches.UnitIsNotAir)) {
       // if the units did not move into the territory, then they can move out
       // this will happen if there is a submerged sub in the area, and
       // a different unit moved into the sea zone setting up a battle
@@ -161,13 +161,13 @@ public class MoveValidator {
       // make sure we avoid land
       // territories owned by nations with these 2 relationship type attachment options
       for (final Territory t : landOnRoute) {
-        if (Match.someMatch(units, Matches.UnitIsLand)) {
+        if (Match.anyMatch(units, Matches.UnitIsLand)) {
           if (!data.getRelationshipTracker().canMoveLandUnitsOverOwnedLand(player, t.getOwner())) {
             result.setError(player.getName() + " may not move land units over land owned by " + t.getOwner().getName());
             return result;
           }
         }
-        if (Match.someMatch(units, Matches.UnitIsAir)) {
+        if (Match.anyMatch(units, Matches.UnitIsAir)) {
           if (!data.getRelationshipTracker().canMoveAirUnitsOverOwnedLand(player, t.getOwner())) {
             result.setError(player.getName() + " may not move air units over land owned by " + t.getOwner().getName());
             return result;
@@ -231,7 +231,7 @@ public class MoveValidator {
     // unit can blitz the current territory.
     if (!route.getStart().isWater()
         && Matches.isAtWar(route.getStart().getOwner(), data).match(player)
-        && (route.someMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
+        && (route.anyMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
             .isTerritoryEnemy(player, data).invert(), false))) {
       if (!Matches.territoryIsBlitzable(player, data).match(route.getStart())
           && !Match.allMatch(units, Matches.UnitIsAir)) {
@@ -246,7 +246,7 @@ public class MoveValidator {
     // blitzable.
     if (!route.getStart().isWater()
         && !Matches.isAtWar(route.getStart().getOwner(), data).match(player)
-        && (route.someMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
+        && (route.anyMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
             .isTerritoryEnemy(player, data).invert(), false))) {
       if (!Matches.territoryIsBlitzable(player, data).match(route.getStart())
           && !Match.allMatch(units, Matches.UnitIsAir)) {
@@ -254,7 +254,7 @@ public class MoveValidator {
       }
     }
     // Don't allow aa guns (and other disallowed units) to move in combat unless they are in a transport
-    if (Match.someMatch(units, Matches.UnitCanNotMoveDuringCombatMove)
+    if (Match.anyMatch(units, Matches.UnitCanNotMoveDuringCombatMove)
         && (!route.getStart().isWater() || !route.getEnd().isWater())) {
       for (final Unit unit : Match.getMatches(units, Matches.UnitCanNotMoveDuringCombatMove)) {
         result.addDisallowedUnit("Cannot move AA guns in combat movement phase", unit);
@@ -266,7 +266,7 @@ public class MoveValidator {
         return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
       }
     }
-    if (Match.someMatch(units, Matches.UnitIsLand) && route.hasSteps()) {
+    if (Match.anyMatch(units, Matches.UnitIsLand) && route.hasSteps()) {
       // check all the territories but the end, if there are enemy territories, make sure they are blitzable
       // if they are not blitzable, or we aren't all blitz units fail
       int enemyCount = 0;
@@ -310,17 +310,17 @@ public class MoveValidator {
             continue;
           }
           final TripleAUnit tAUnit = (TripleAUnit) unit;
-          if (wasStartFoughtOver || tAUnit.getWasInCombat() || route.someMatch(notEndOrFriendlyTerrs)
-              || route.someMatch(notEndWasFought)) {
+          if (wasStartFoughtOver || tAUnit.getWasInCombat() || route.anyMatch(notEndOrFriendlyTerrs)
+              || route.anyMatch(notEndWasFought)) {
             result.addDisallowedUnit(NOT_ALL_UNITS_CAN_BLITZ, unit);
           }
         }
       }
     }
-    if (Match.someMatch(units, Matches.UnitIsAir)) { // check aircraft
+    if (Match.anyMatch(units, Matches.UnitIsAir)) { // check aircraft
       if (route.hasSteps()
           && (!games.strategy.triplea.Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
-        if (Match.someMatch(route.getMiddleSteps(), Matches.TerritoryIsNeutralButNotWater)) {
+        if (Match.anyMatch(route.getMiddleSteps(), Matches.TerritoryIsNeutralButNotWater)) {
           return result.setErrorReturnResult("Air units cannot fly over neutral territories");
         }
       }
@@ -334,7 +334,7 @@ public class MoveValidator {
       }
     }
     // See if they've already been in combat
-    if (Match.someMatch(units, Matches.UnitWasInCombat) && Match.someMatch(units, Matches.UnitWasUnloadedThisTurn)) {
+    if (Match.anyMatch(units, Matches.UnitWasInCombat) && Match.anyMatch(units, Matches.UnitWasUnloadedThisTurn)) {
       final Collection<Territory> end = Collections.singleton(route.getEnd());
       if (Match.allMatch(end, Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data))
           && !route.getEnd().getUnits().isEmpty()) {
@@ -356,10 +356,10 @@ public class MoveValidator {
     if (getEditMode(data)) {
       return result;
     }
-    if (route.someMatch(Matches.TerritoryIsImpassable)) {
+    if (route.anyMatch(Matches.TerritoryIsImpassable)) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_IMPASSABLE);
     }
-    if (!route.someMatch(Matches.territoryIsPassableAndNotRestricted(player, data))) {
+    if (!route.anyMatch(Matches.territoryIsPassableAndNotRestricted(player, data))) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_RESTRICTED);
     }
     final Match<Territory> neutralOrEnemy =
@@ -385,7 +385,7 @@ public class MoveValidator {
         return result.setErrorReturnResult("Cannot move submarines under destroyers");
       }
     }
-    if (end.getUnits().someMatch(Matches.enemyUnit(player, data))) {
+    if (end.getUnits().anyMatch(Matches.enemyUnit(player, data))) {
       if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
         final Match<Unit> friendlyOrSubmerged = Match.anyOf(
             Matches.enemyUnit(player, data).invert(),
@@ -406,21 +406,21 @@ public class MoveValidator {
       // if there are non-paratroopers present, then we cannot fly over stuff
       // if there are neutral territories in the middle, we cannot fly over (unless allowed to)
       // otherwise we can generally fly over anything in noncombat
-      if (route.someMatch(Match.allOf(Matches.TerritoryIsNeutralButNotWater, Matches.TerritoryIsWater.invert()))
+      if (route.anyMatch(Match.allOf(Matches.TerritoryIsNeutralButNotWater, Matches.TerritoryIsWater.invert()))
           && (!games.strategy.triplea.Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
         return result.setErrorReturnResult("Air units cannot fly over neutral territories in non combat");
       }
     // if sea units, or land units moving over/onto sea (ex: loading onto a transport), then only check if old rules
     // stop us
-    } else if (Match.someMatch(units, Matches.UnitIsSea) || route.someMatch(Matches.TerritoryIsWater)) {
+    } else if (Match.anyMatch(units, Matches.UnitIsSea) || route.anyMatch(Matches.TerritoryIsWater)) {
       // if there are neutral or owned territories, we cannot move through them (only under old rules. under new rules
       // we can move through
       // owned sea zones.)
-      if (navalMayNotNonComIntoControlled && route.someMatch(neutralOrEnemy)) {
+      if (navalMayNotNonComIntoControlled && route.anyMatch(neutralOrEnemy)) {
         return result.setErrorReturnResult("Cannot move units through neutral or enemy territories in non combat");
       }
     } else {
-      if (route.someMatch(neutralOrEnemy)) {
+      if (route.anyMatch(neutralOrEnemy)) {
         return result.setErrorReturnResult("Cannot move units through neutral or enemy territories in non combat");
       }
     }
@@ -557,7 +557,7 @@ public class MoveValidator {
             // simple: if it movement group contains an air-transport, then assume we are doing paratroopers. else,
             // assume we are doing
             // mechanized
-            if (Match.someMatch(units, Matches.UnitIsAirTransport)) {
+            if (Match.anyMatch(units, Matches.UnitIsAirTransport)) {
               for (final Unit airTransport : dependencies.keySet()) {
                 if (dependencies.get(airTransport) == null || dependencies.get(airTransport).contains(unit)) {
                   unitOk = true;
@@ -585,7 +585,7 @@ public class MoveValidator {
             mechanizedSupportAvailable--;
           } else if (Matches.unitIsOwnedBy(player).invert().match(unit) && Matches.alliedUnit(player, data).match(unit)
               && Matches.UnitTypeCanLandOnCarrier.match(unit.getType())
-              && Match.someMatch(moveTest, Matches.unitIsAlliedCarrier(unit.getOwner(), data))) {
+              && Match.anyMatch(moveTest, Matches.unitIsAlliedCarrier(unit.getOwner(), data))) {
             // this is so that if the unit is owned by any ally and it is cargo, then it will not count.
             // (shouldn't it be a dependant in this case??)
           } else {
@@ -600,7 +600,7 @@ public class MoveValidator {
         }
       }
       // a territory effect can disallow unit types in
-      if (Match.someMatch(units,
+      if (Match.anyMatch(units,
           Matches.unitIsOfTypes(TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(route.getSteps())))) {
         return result.setErrorReturnResult("Territory Effects disallow some units into "
             + (route.numberOfSteps() > 1 ? "these territories" : "this territory"));
@@ -613,7 +613,7 @@ public class MoveValidator {
       }
     }
     // if we are water make sure no land
-    if (Match.someMatch(units, Matches.UnitIsSea)) {
+    if (Match.anyMatch(units, Matches.UnitIsSea)) {
       if (route.hasLand()) {
         for (final Unit unit : Match.getMatches(units, Matches.UnitIsSea)) {
           result.addDisallowedUnit("Sea units cannot go on land", unit);
@@ -627,7 +627,7 @@ public class MoveValidator {
       for (final Territory t : route.getSteps()) {
         final Collection<Unit> unitsAllowedSoFar = new ArrayList<>();
         if (Matches.isTerritoryEnemyAndNotUnownedWater(player, data).match(t)
-            || t.getUnits().someMatch(Matches.unitIsEnemyOf(data, player))) {
+            || t.getUnits().anyMatch(Matches.unitIsEnemyOf(data, player))) {
           for (final Unit unit : unitsWithStackingLimits) {
             final UnitType ut = unit.getType();
             int maxAllowed =
@@ -664,7 +664,7 @@ public class MoveValidator {
       }
     }
     // don't allow move through impassable territories
-    if (!isEditMode && route.someMatch(Matches.TerritoryIsImpassable)) {
+    if (!isEditMode && route.anyMatch(Matches.TerritoryIsImpassable)) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_IMPASSABLE);
     }
     if (canCrossNeutralTerritory(data, route, player, result).getError() != null) {
@@ -765,7 +765,7 @@ public class MoveValidator {
   private static boolean enemyDestroyerOnPath(final Route route, final PlayerID player, final GameData data) {
     final Match<Unit> enemyDestroyer = Match.allOf(Matches.UnitIsDestroyer, Matches.enemyUnit(player, data));
     for (final Territory current : route.getMiddleSteps()) {
-      if (current.getUnits().someMatch(enemyDestroyer)) {
+      if (current.getUnits().anyMatch(enemyDestroyer)) {
         return true;
       }
     }
@@ -905,7 +905,7 @@ public class MoveValidator {
     // If there are non-sea transports return
     final boolean seaOrNoTransportsPresent =
         transportsToLoad.isEmpty()
-            || Match.someMatch(transportsToLoad, Match.allOf(Matches.UnitIsSea, Matches.UnitCanTransport));
+            || Match.anyMatch(transportsToLoad, Match.allOf(Matches.UnitIsSea, Matches.UnitCanTransport));
     if (!seaOrNoTransportsPresent) {
       return result;
     }
@@ -1038,7 +1038,7 @@ public class MoveValidator {
       }
       final Match<Unit> enemyNonSubmerged =
           Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsSubmerged.invert());
-      if (route.getEnd().getUnits().someMatch(enemyNonSubmerged) && nonParatroopersPresent(player, landAndAir)) {
+      if (route.getEnd().getUnits().anyMatch(enemyNonSubmerged) && nonParatroopersPresent(player, landAndAir)) {
         if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
           if (!AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(player,
               route.getEnd().getUnits().getUnits(), data)) {
@@ -1464,9 +1464,9 @@ public class MoveValidator {
    */
   public static Route getBestRoute(final Territory start, final Territory end, final GameData data,
       final PlayerID player, final Collection<Unit> units, final boolean forceLandOrSeaRoute) {
-    final boolean hasLand = Match.someMatch(units, Matches.UnitIsLand);
-    final boolean hasAir = Match.someMatch(units, Matches.UnitIsAir);
-    // final boolean hasSea = Match.someMatch(units, Matches.UnitIsSea);
+    final boolean hasLand = Match.anyMatch(units, Matches.UnitIsLand);
+    final boolean hasAir = Match.anyMatch(units, Matches.UnitIsAir);
+    // final boolean hasSea = Match.anyMatch(units, Matches.UnitIsSea);
     final boolean isNeutralsImpassable =
         isNeutralsImpassable(data) || (hasAir && !games.strategy.triplea.Properties.getNeutralFlyoverAllowed(data));
     // Ignore the end territory in our tests. it must be in the route, so it shouldn't affect the route choice
@@ -1532,7 +1532,7 @@ public class MoveValidator {
           && ((landRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
               .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent))
               || (forceLandOrSeaRoute
-                  && Match.someMatch(unitsWhichAreNotBeingTransportedOrDependent, Matches.UnitIsLand)))) {
+                  && Match.anyMatch(unitsWhichAreNotBeingTransportedOrDependent, Matches.UnitIsLand)))) {
         defaultRoute = landRoute;
         mustGoLand = true;
       }
@@ -1545,7 +1545,7 @@ public class MoveValidator {
       if (waterRoute != null
           && ((waterRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
               .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) || (forceLandOrSeaRoute && Match
-                  .someMatch(unitsWhichAreNotBeingTransportedOrDependent, Matches.UnitIsSea)))) {
+                  .anyMatch(unitsWhichAreNotBeingTransportedOrDependent, Matches.UnitIsSea)))) {
         defaultRoute = waterRoute;
         mustGoSea = true;
       }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -160,7 +160,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // deal with amphibious assaults
     if (attackingFrom.isWater()) {
-      if (route.getEnd() != null && !route.getEnd().isWater() && Match.someMatch(units, Matches.UnitIsLand)) {
+      if (route.getEnd() != null && !route.getEnd().isWater() && Match.anyMatch(units, Matches.UnitIsLand)) {
         m_amphibiousLandAttackers.removeAll(Match.getMatches(units, Matches.UnitIsLand));
       }
       // if none of the units is a land unit, the attack from
@@ -201,7 +201,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     attackingFromMapUnits.addAll(attackingUnits);
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()
-        && Match.someMatch(attackingUnits, Matches.UnitIsLand)) {
+        && Match.anyMatch(attackingUnits, Matches.UnitIsLand)) {
       getAmphibiousAttackTerritories().add(route.getTerritoryBeforeEnd());
       m_amphibiousLandAttackers.addAll(Match.getMatches(attackingUnits, Matches.UnitIsLand));
       m_isAmphibious = true;
@@ -377,11 +377,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       }
       BattleCalculator.sortPreBattle(m_defendingUnits);
       // play a sound
-      if (Match.someMatch(m_attackingUnits, Matches.UnitIsSea)
-          || Match.someMatch(m_defendingUnits, Matches.UnitIsSea)) {
+      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSea)
+          || Match.anyMatch(m_defendingUnits, Matches.UnitIsSea)) {
         if (Match.allMatch(m_attackingUnits, Matches.UnitIsSub)
-            || (Match.someMatch(m_attackingUnits, Matches.UnitIsSub)
-                && Match.someMatch(m_defendingUnits, Matches.UnitIsSub))) {
+            || (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)
+                && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub))) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_SEA_SUBS, m_attacker);
         } else {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_SEA_NORMAL, m_attacker);
@@ -503,11 +503,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         steps.add(NAVAL_BOMBARDMENT);
         steps.add(SELECT_NAVAL_BOMBARDMENT_CASUALTIES);
       }
-      if (Match.someMatch(m_attackingUnits, Matches.UnitIsSuicide)) {
+      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSuicide)) {
         steps.add(SUICIDE_ATTACK);
         steps.add(m_defender.getName() + SELECT_CASUALTIES_SUICIDE);
       }
-      if (Match.someMatch(m_defendingUnits, Matches.UnitIsSuicide) && !isDefendingSuicideAndMunitionUnitsDoNotFire()) {
+      if (Match.anyMatch(m_defendingUnits, Matches.UnitIsSuicide) && !isDefendingSuicideAndMunitionUnitsDoNotFire()) {
         steps.add(SUICIDE_DEFEND);
         steps.add(m_attacker.getName() + SELECT_CASUALTIES_SUICIDE);
       }
@@ -524,25 +524,25 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // Check if defending subs can submerge before battle
     if (isSubRetreatBeforeBattle()) {
-      if (!Match.someMatch(m_defendingUnits, Matches.UnitIsDestroyer)
-          && Match.someMatch(m_attackingUnits, Matches.UnitIsSub)) {
+      if (!Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer)
+          && Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
         steps.add(m_attacker.getName() + SUBS_SUBMERGE);
       }
-      if (!Match.someMatch(m_attackingUnits, Matches.UnitIsDestroyer)
-          && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
+      if (!Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer)
+          && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
         steps.add(m_defender.getName() + SUBS_SUBMERGE);
       }
     }
     // See if there any unescorted trns
     if (m_battleSite.isWater() && isTransportCasualtiesRestricted()) {
-      if (Match.someMatch(m_attackingUnits, Matches.UnitIsTransport)
-          || Match.someMatch(m_defendingUnits, Matches.UnitIsTransport)) {
+      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsTransport)
+          || Match.anyMatch(m_defendingUnits, Matches.UnitIsTransport)) {
         steps.add(REMOVE_UNESCORTED_TRANSPORTS);
       }
     }
     // if attacker has no sneak attack subs, then defendering sneak attack subs fire first and remove casualties
     final boolean defenderSubsFireFirst = defenderSubsFireFirst();
-    if (defenderSubsFireFirst && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
+    if (defenderSubsFireFirst && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
       steps.add(m_defender.getName() + SUBS_FIRE);
       steps.add(m_attacker.getName() + SELECT_SUB_CASUALTIES);
       steps.add(REMOVE_SNEAK_ATTACK_CASUALTIES);
@@ -552,7 +552,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // attacker subs sneak attack
     // Attacking subs have no sneak attack if Destroyers are present
     if (m_battleSite.isWater()) {
-      if (Match.someMatch(m_attackingUnits, Matches.UnitIsSub)) {
+      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
         steps.add(m_attacker.getName() + SUBS_FIRE);
         steps.add(m_defender.getName() + SELECT_SUB_CASUALTIES);
       }
@@ -568,7 +568,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final boolean defendingSubsFireWithAllDefendersAlways = !defendingSubsSneakAttack3();
     if (m_battleSite.isWater()) {
       if (!defendingSubsFireWithAllDefendersAlways && !defendingSubsFireWithAllDefenders && !defenderSubsFireFirst
-          && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
+          && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
         steps.add(m_defender.getName() + SUBS_FIRE);
         steps.add(m_attacker.getName() + SELECT_SUB_CASUALTIES);
       }
@@ -581,9 +581,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (isAirAttackSubRestricted()) {
       final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
       units.addAll(m_attackingUnits);
-      // if(!Match.someMatch(m_attackingUnits, Matches.UnitIsDestroyer) && Match.allMatch(m_attackingUnits,
+      // if(!Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer) && Match.allMatch(m_attackingUnits,
       // Matches.UnitIsAir))
-      if (Match.someMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
+      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
         steps.add(SUBMERGE_SUBS_VS_AIR_ONLY);
       }
     }
@@ -591,14 +591,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (m_battleSite.isWater() && isAirAttackSubRestricted()) {
       final Collection<Unit> units = new ArrayList<>(m_attackingUnits.size() + m_attackingWaitingToDie.size());
       units.addAll(m_attackingUnits);
-      // if(!Match.someMatch(m_attackingUnits, Matches.UnitIsDestroyer) && Match.someMatch(m_attackingUnits,
+      // if(!Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer) && Match.anyMatch(m_attackingUnits,
       // Matches.UnitIsAir) &&
-      // Match.someMatch(m_defendingUnits, Matches.UnitIsSub))
-      if (Match.someMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
+      // Match.anyMatch(m_defendingUnits, Matches.UnitIsSub))
+      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_defendingUnits, units)) {
         steps.add(AIR_ATTACK_NON_SUBS);
       }
     }
-    if (Match.someMatch(m_attackingUnits, Matches.UnitIsNotSub)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsNotSub)) {
       steps.add(m_attacker.getName() + FIRE);
       steps.add(m_defender.getName() + SELECT_CASUALTIES);
     }
@@ -608,7 +608,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final Collection<Unit> units = new ArrayList<>(m_defendingUnits.size() + m_defendingWaitingToDie.size());
       units.addAll(m_defendingUnits);
       units.addAll(m_defendingWaitingToDie);
-      if (Match.someMatch(units, Matches.UnitIsSub) && !defenderSubsFireFirst
+      if (Match.anyMatch(units, Matches.UnitIsSub) && !defenderSubsFireFirst
           && (defendingSubsFireWithAllDefenders || defendingSubsFireWithAllDefendersAlways)) {
         steps.add(m_defender.getName() + SUBS_FIRE);
         steps.add(m_attacker.getName() + SELECT_SUB_CASUALTIES);
@@ -619,14 +619,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final Collection<Unit> units = new ArrayList<>(m_defendingUnits.size() + m_defendingWaitingToDie.size());
       units.addAll(m_defendingUnits);
       units.addAll(m_defendingWaitingToDie);
-      // if(!Match.someMatch(m_defendingUnits, Matches.UnitIsDestroyer) && Match.someMatch(m_defendingUnits,
+      // if(!Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer) && Match.anyMatch(m_defendingUnits,
       // Matches.UnitIsAir) &&
-      // Match.someMatch(m_attackingUnits, Matches.UnitIsSub))
-      if (Match.someMatch(m_defendingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_attackingUnits, units)) {
+      // Match.anyMatch(m_attackingUnits, Matches.UnitIsSub))
+      if (Match.anyMatch(m_defendingUnits, Matches.UnitIsAir) && !canAirAttackSubs(m_attackingUnits, units)) {
         steps.add(AIR_DEFEND_NON_SUBS);
       }
     }
-    if (Match.someMatch(m_defendingUnits, Matches.UnitIsNotSub)) {
+    if (Match.anyMatch(m_defendingUnits, Matches.UnitIsNotSub)) {
       steps.add(m_defender.getName() + FIRE);
       steps.add(m_attacker.getName() + SELECT_CASUALTIES);
     }
@@ -636,21 +636,21 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (m_battleSite.isWater()) {
       if (canSubsSubmerge()) {
         if (!isSubRetreatBeforeBattle()) {
-          if (Match.someMatch(m_attackingUnits, Matches.UnitIsSub)) {
+          if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
             steps.add(m_attacker.getName() + SUBS_SUBMERGE);
           }
-          if (Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
+          if (Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
             steps.add(m_defender.getName() + SUBS_SUBMERGE);
           }
         }
       } else {
         if (canAttackerRetreatSubs()) {
-          if (Match.someMatch(m_attackingUnits, Matches.UnitIsSub)) {
+          if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
             steps.add(m_attacker.getName() + SUBS_WITHDRAW);
           }
         }
         if (canDefenderRetreatSubs()) {
-          if (Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
+          if (Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
             steps.add(m_defender.getName() + SUBS_WITHDRAW);
           }
         }
@@ -664,7 +664,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // a sea zone, we always have to have the retreat
     // option shown
     // later, if our sea units die, we may ask the user to retreat
-    final boolean someAirAtSea = m_battleSite.isWater() && Match.someMatch(m_attackingUnits, Matches.UnitIsAir);
+    final boolean someAirAtSea = m_battleSite.isWater() && Match.anyMatch(m_attackingUnits, Matches.UnitIsAir);
     if (canAttackerRetreat() || someAirAtSea || canAttackerRetreatPartialAmphib() || canAttackerRetreatPlanes()) {
       steps.add(m_attacker.getName() + ATTACKER_WITHDRAW);
     }
@@ -1135,7 +1135,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private ReturnFire returnFireAgainstAttackingSubs() {
-    final boolean attackingSubsSneakAttack = !Match.someMatch(m_defendingUnits, Matches.UnitIsDestroyer);
+    final boolean attackingSubsSneakAttack = !Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer);
     final boolean defendingSubsSneakAttack = defendingSubsSneakAttack2();
     final ReturnFire returnFireAgainstAttackingSubs;
     if (!attackingSubsSneakAttack) {
@@ -1155,7 +1155,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
      * calculate here, this holds for the fight round, but can't be computed later
      * since destroyers may die
      */
-    final boolean attackingSubsSneakAttack = !Match.someMatch(m_defendingUnits, Matches.UnitIsDestroyer);
+    final boolean attackingSubsSneakAttack = !Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer);
     final boolean defendingSubsSneakAttack = defendingSubsSneakAttack2();
     final ReturnFire returnFireAgainstDefendingSubs;
     if (!defendingSubsSneakAttack) {
@@ -1169,7 +1169,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean defendingSubsSneakAttack2() {
-    return !Match.someMatch(m_attackingUnits, Matches.UnitIsDestroyer) && defendingSubsSneakAttack3();
+    return !Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer) && defendingSubsSneakAttack3();
   }
 
   private boolean defendingSubsSneakAttack3() {
@@ -1178,7 +1178,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   private boolean canAttackerRetreatPlanes() {
     return (isWW2V2() || isAttackerRetreatPlanes() || isPartialAmphibiousRetreat()) && m_isAmphibious
-        && Match.someMatch(m_attackingUnits, Matches.UnitIsAir);
+        && Match.anyMatch(m_attackingUnits, Matches.UnitIsAir);
   }
 
   private boolean canAttackerRetreatPartialAmphib() {
@@ -1242,10 +1242,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // the battle site is in the attacking from
     // if sea units are fighting a submerged sub
     possible.remove(m_battleSite);
-    if (Match.someMatch(m_attackingUnits, Matches.UnitIsLand) && !m_battleSite.isWater()) {
+    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsLand) && !m_battleSite.isWater()) {
       possible = Match.getMatches(possible, Matches.TerritoryIsLand);
     }
-    if (Match.someMatch(m_attackingUnits, Matches.UnitIsSea)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSea)) {
       possible = Match.getMatches(possible, Matches.TerritoryIsWater);
     }
     return possible;
@@ -1270,10 +1270,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean canAttackerRetreatSubs() {
-    if (Match.someMatch(m_defendingUnits, Matches.UnitIsDestroyer)) {
+    if (Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer)) {
       return false;
     }
-    if (Match.someMatch(m_defendingWaitingToDie, Matches.UnitIsDestroyer)) {
+    if (Match.anyMatch(m_defendingWaitingToDie, Matches.UnitIsDestroyer)) {
       return false;
     }
     return canAttackerRetreat() || canSubsSubmerge();
@@ -1307,7 +1307,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Collection<Territory> possible = new ArrayList<>(2);
     possible.add(m_battleSite);
     // retreat planes
-    if (Match.someMatch(m_attackingUnits, Matches.UnitIsAir)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsAir)) {
       queryRetreat(false, RetreatType.PLANES, bridge, possible);
     }
   }
@@ -1318,10 +1318,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean canDefenderRetreatSubs() {
-    if (Match.someMatch(m_attackingUnits, Matches.UnitIsDestroyer)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer)) {
       return false;
     }
-    if (Match.someMatch(m_attackingWaitingToDie, Matches.UnitIsDestroyer)) {
+    if (Match.anyMatch(m_attackingWaitingToDie, Matches.UnitIsDestroyer)) {
       return false;
     }
     return getEmptyOrFriendlySeaNeighbors(m_defender, Match.getMatches(m_defendingUnits, Matches.UnitIsSub)).size() != 0
@@ -1332,7 +1332,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!canAttackerRetreatSubs()) {
       return;
     }
-    if (Match.someMatch(m_attackingUnits, Matches.UnitIsSub)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
       queryRetreat(false, RetreatType.SUBS, bridge, getAttackerRetreatTerritories());
     }
   }
@@ -1341,7 +1341,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!canDefenderRetreatSubs()) {
       return;
     }
-    if (!m_isOver && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
+    if (!m_isOver && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
       queryRetreat(true, RetreatType.SUBS, bridge,
           getEmptyOrFriendlySeaNeighbors(m_defender, Match.getMatches(m_defendingUnits, Matches.UnitIsSub)));
     }
@@ -1397,7 +1397,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     } else if (partialAmphib) {
       units = Match.getMatches(units, Matches.UnitWasNotAmphibious);
     }
-    if (Match.someMatch(units, Matches.UnitIsSea)) {
+    if (Match.anyMatch(units, Matches.UnitIsSea)) {
       availableTerritories = Match.getMatches(availableTerritories, Matches.TerritoryIsWater);
     }
     if (canDefendingSubsSubmergeOrRetreat) {
@@ -1466,9 +1466,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         getDisplay(bridge).notifyRetreat(messageShort, messageShort, step, retreatingPlayer);
       } else if (partialAmphib) {
         if (!m_headless) {
-          if (Match.someMatch(units, Matches.UnitIsSea)) {
+          if (Match.anyMatch(units, Matches.UnitIsSea)) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_SEA, m_attacker);
-          } else if (Match.someMatch(units, Matches.UnitIsLand)) {
+          } else if (Match.anyMatch(units, Matches.UnitIsLand)) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_LAND, m_attacker);
           } else {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_AIR, m_attacker);
@@ -1481,9 +1481,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         getDisplay(bridge).notifyRetreat(messageShort, messageShort, step, retreatingPlayer);
       } else {
         if (!m_headless) {
-          if (Match.someMatch(units, Matches.UnitIsSea)) {
+          if (Match.anyMatch(units, Matches.UnitIsSea)) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_SEA, m_attacker);
-          } else if (Match.someMatch(units, Matches.UnitIsLand)) {
+          } else if (Match.anyMatch(units, Matches.UnitIsLand)) {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_LAND, m_attacker);
           } else {
             bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_RETREAT_AIR, m_attacker);
@@ -1724,7 +1724,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void checkUndefendedTransports(final IDelegateBridge bridge, final PlayerID player) {
     // if we are the attacker, we can retreat instead of dying
     if (player.equals(m_attacker)
-        && (!getAttackerRetreatTerritories().isEmpty() || Match.someMatch(m_attackingUnits, Matches.UnitIsAir))) {
+        && (!getAttackerRetreatTerritories().isEmpty() || Match.anyMatch(m_attackingUnits, Matches.UnitIsAir))) {
       return;
     }
     // Get all allied transports in the territory
@@ -1765,7 +1765,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void checkForUnitsThatCanRollLeft(final IDelegateBridge bridge, final boolean attacker) {
     // if we are the attacker, we can retreat instead of dying
     if (attacker
-        && (!getAttackerRetreatTerritories().isEmpty() || Match.someMatch(m_attackingUnits, Matches.UnitIsAir))) {
+        && (!getAttackerRetreatTerritories().isEmpty() || Match.anyMatch(m_attackingUnits, Matches.UnitIsAir))) {
       return;
     }
     if (m_attackingUnits.isEmpty() || m_defendingUnits.isEmpty()) {
@@ -1782,12 +1782,12 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Collection<Unit> unitsToKill;
     final boolean hasUnitsThatCanRollLeft;
     if (attacker) {
-      hasUnitsThatCanRollLeft = Match.someMatch(m_attackingUnits, Match.allOf(notSubmergedAndType,
+      hasUnitsThatCanRollLeft = Match.anyMatch(m_attackingUnits, Match.allOf(notSubmergedAndType,
           Matches.unitIsSupporterOrHasCombatAbility(attacker)));
       unitsToKill = Match.getMatches(m_attackingUnits,
           Match.allOf(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
     } else {
-      hasUnitsThatCanRollLeft = Match.someMatch(m_defendingUnits, Match.allOf(notSubmergedAndType,
+      hasUnitsThatCanRollLeft = Match.anyMatch(m_defendingUnits, Match.allOf(notSubmergedAndType,
           Matches.unitIsSupporterOrHasCombatAbility(attacker)));
       unitsToKill = Match.getMatches(m_defendingUnits,
           Match.allOf(notSubmergedAndType, Matches.UnitIsNotInfrastructure));
@@ -1795,10 +1795,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final boolean enemy = !attacker;
     final boolean enemyHasUnitsThatCanRollLeft;
     if (enemy) {
-      enemyHasUnitsThatCanRollLeft = Match.someMatch(m_attackingUnits,
+      enemyHasUnitsThatCanRollLeft = Match.anyMatch(m_attackingUnits,
           Match.allOf(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
     } else {
-      enemyHasUnitsThatCanRollLeft = Match.someMatch(m_defendingUnits,
+      enemyHasUnitsThatCanRollLeft = Match.anyMatch(m_defendingUnits,
           Match.allOf(notSubmergedAndType, Matches.unitIsSupporterOrHasCombatAbility(enemy)));
     }
     if (!hasUnitsThatCanRollLeft && enemyHasUnitsThatCanRollLeft) {
@@ -1811,14 +1811,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    */
   private void submergeSubsVsOnlyAir(final IDelegateBridge bridge) {
     // if All attackers are AIR submerge any defending subs ..m_defendingUnits.removeAll(m_killed);
-    if (Match.allMatch(m_attackingUnits, Matches.UnitIsAir) && Match.someMatch(m_defendingUnits, Matches.UnitIsSub)) {
+    if (Match.allMatch(m_attackingUnits, Matches.UnitIsAir) && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
       // Get all defending subs (including allies) in the territory.
       final List<Unit> defendingSubs = Match.getMatches(m_defendingUnits, Matches.UnitIsSub);
       // submerge defending subs
       submergeUnits(defendingSubs, true, bridge);
       // checking defending air on attacking subs
     } else if (Match.allMatch(m_defendingUnits, Matches.UnitIsAir)
-        && Match.someMatch(m_attackingUnits, Matches.UnitIsSub)) {
+        && Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
       // Get all attacking subs in the territory
       final List<Unit> attackingSubs = Match.getMatches(m_attackingUnits, Matches.UnitIsSub);
       // submerge attacking subs
@@ -1872,7 +1872,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean canAirAttackSubs(final Collection<Unit> firedAt, final Collection<Unit> firing) {
-    return !(m_battleSite.isWater() && Match.someMatch(firedAt, Matches.UnitIsSub)
+    return !(m_battleSite.isWater() && Match.anyMatch(firedAt, Matches.UnitIsSub)
         && Match.noneMatch(firing, Matches.UnitIsDestroyer));
   }
 
@@ -2030,8 +2030,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // comparatively simple rules for isSuicide units. if AirAttackSubRestricted and you have no destroyers, you can't
     // attack subs with
     // anything.
-    if (isAirAttackSubRestricted() && !Match.someMatch(m_attackingUnits, Matches.UnitIsDestroyer)
-        && Match.someMatch(attackedDefenders, Matches.UnitIsSub)) {
+    if (isAirAttackSubRestricted() && !Match.anyMatch(m_attackingUnits, Matches.UnitIsDestroyer)
+        && Match.anyMatch(attackedDefenders, Matches.UnitIsSub)) {
       attackedDefenders.removeAll(Match.getMatches(attackedDefenders, Matches.UnitIsSub));
     }
     if (Match.allMatch(suicideAttackers, Matches.UnitIsSub)) {
@@ -2061,8 +2061,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // comparatively simple rules for isSuicide units. if AirAttackSubRestricted and you have no destroyers, you can't
     // attack subs with
     // anything.
-    if (isAirAttackSubRestricted() && !Match.someMatch(m_defendingUnits, Matches.UnitIsDestroyer)
-        && Match.someMatch(attackedAttackers, Matches.UnitIsSub)) {
+    if (isAirAttackSubRestricted() && !Match.anyMatch(m_defendingUnits, Matches.UnitIsDestroyer)
+        && Match.anyMatch(attackedAttackers, Matches.UnitIsSub)) {
       attackedAttackers.removeAll(Match.getMatches(attackedAttackers, Matches.UnitIsSub));
     }
     if (Match.allMatch(suicideDefenders, Matches.UnitIsSub)) {
@@ -2383,7 +2383,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return Collections.emptyList();
     }
     final Collection<Unit> dependents = new ArrayList<>();
-    if (Match.someMatch(targets, Matches.UnitCanTransport)) {
+    if (Match.anyMatch(targets, Matches.UnitCanTransport)) {
       // just worry about transports
       for (final Unit target : targets) {
         dependents.addAll(TransportTracker.transportingAndUnloaded(target));
@@ -2511,7 +2511,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return;
     }
     // do we need to change ownership
-    if (Match.someMatch(m_attackingUnits, Matches.UnitIsNotAir)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsNotAir)) {
       if (Matches.isTerritoryEnemyAndNotUnownedWater(m_attacker, m_data).match(m_battleSite)) {
         m_battleTracker.addToConquered(m_battleSite);
       }

--- a/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -65,7 +65,7 @@ public class NonFightingBattle extends DependentBattle {
     attackingFromMapUnits.addAll(units);
     // are we amphibious
     if (route.getStart().isWater() && route.getEnd() != null && !route.getEnd().isWater()
-        && Match.someMatch(units, Matches.UnitIsLand)) {
+        && Match.anyMatch(units, Matches.UnitIsLand)) {
       getAmphibiousAttackTerritories().add(route.getTerritoryBeforeEnd());
       m_amphibiousLandAttackers.addAll(Match.getMatches(units, Matches.UnitIsLand));
       m_isAmphibious = true;
@@ -103,7 +103,7 @@ public class NonFightingBattle extends DependentBattle {
 
   boolean hasAttackingUnits() {
     final Match<Unit> attackingLand = Match.allOf(Matches.alliedUnit(m_attacker, m_data), Matches.UnitIsLand);
-    return m_battleSite.getUnits().someMatch(attackingLand);
+    return m_battleSite.getUnits().anyMatch(attackingLand);
   }
 
   @Override
@@ -125,7 +125,7 @@ public class NonFightingBattle extends DependentBattle {
     }
     // deal with amphibious assaults
     if (attackingFrom.isWater()) {
-      if (route.getEnd() != null && !route.getEnd().isWater() && Match.someMatch(units, Matches.UnitIsLand)) {
+      if (route.getEnd() != null && !route.getEnd().isWater() && Match.anyMatch(units, Matches.UnitIsLand)) {
         m_amphibiousLandAttackers.removeAll(Match.getMatches(units, Matches.UnitIsLand));
       }
       // if none of the units is a land unit, the attack from

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -136,7 +136,7 @@ public class RocketsFireHelper {
       if (tracker.wasConquered(current)) {
         continue;
       }
-      if (current.getUnits().someMatch(ownedRockets)) {
+      if (current.getUnits().anyMatch(ownedRockets)) {
         territories.add(current);
       }
     }
@@ -163,7 +163,7 @@ public class RocketsFireHelper {
     for (final Territory current : possible) {
       final Route route = data.getMap().getRoute(territory, current, allowedBuilder.all());
       if (route != null && route.numberOfSteps() <= maxDistance) {
-        if (current.getUnits().someMatch(Match.allOf(attackableUnits,
+        if (current.getUnits().anyMatch(Match.allOf(attackableUnits,
             Matches.unitIsAtMaxDamageOrNotCanBeDamaged(current).invert()))) {
           hasFactory.add(current);
         }
@@ -419,7 +419,7 @@ public class RocketsFireHelper {
       }
     }
     // kill any units that can die if they have reached max damage (veqryn)
-    if (Match.someMatch(targets, Matches.UnitCanDieFromReachingMaxDamage)) {
+    if (Match.anyMatch(targets, Matches.UnitCanDieFromReachingMaxDamage)) {
       final List<Unit> unitsCanDie = Match.getMatches(targets, Matches.UnitCanDieFromReachingMaxDamage);
       unitsCanDie
           .retainAll(Match.getMatches(unitsCanDie, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory)));

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -250,8 +250,8 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     if (!Match.allMatch(route.getSteps(), Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))) {
       return result.setErrorReturnResult("May Only Fly Over Territories Where Air May Move");
     }
-    final boolean someLand = Match.someMatch(airborne, Matches.UnitIsLand);
-    final boolean someSea = Match.someMatch(airborne, Matches.UnitIsSea);
+    final boolean someLand = Match.anyMatch(airborne, Matches.UnitIsLand);
+    final boolean someSea = Match.anyMatch(airborne, Matches.UnitIsSea);
     final boolean land = Matches.TerritoryIsLand.match(end);
     final boolean sea = Matches.TerritoryIsWater.match(end);
     if (someLand && someSea) {
@@ -270,9 +270,9 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
         final IBattle battle = battleTracker.getPendingBattle(end, false, BattleType.NORMAL);
         if (battle == null) {
           return result.setErrorReturnResult("Airborne May Only Attack Territories Already Under Assault");
-        } else if (land && someLand && !Match.someMatch(battle.getAttackingUnits(), Matches.UnitIsLand)) {
+        } else if (land && someLand && !Match.anyMatch(battle.getAttackingUnits(), Matches.UnitIsLand)) {
           return result.setErrorReturnResult("Battle Must Have Some Land Units Participating Already");
-        } else if (sea && someSea && !Match.someMatch(battle.getAttackingUnits(), Matches.UnitIsSea)) {
+        } else if (sea && someSea && !Match.anyMatch(battle.getAttackingUnits(), Matches.UnitIsSea)) {
           return result.setErrorReturnResult("Battle Must Have Some Sea Units Participating Already");
         }
       }

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -240,7 +240,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           }
         }
         // kill any suicide attackers (veqryn)
-        if (Match.someMatch(m_attackingUnits, Matches.UnitIsSuicide)) {
+        if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSuicide)) {
           final List<Unit> suicideUnits = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);
           m_attackingUnits.removeAll(suicideUnits);
           final Change removeSuicide = ChangeFactory.removeUnits(m_battleSite, suicideUnits);
@@ -252,7 +252,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           bridge.addChange(removeSuicide);
         }
         // kill any units that can die if they have reached max damage (veqryn)
-        if (Match.someMatch(m_targets.keySet(), Matches.UnitCanDieFromReachingMaxDamage)) {
+        if (Match.anyMatch(m_targets.keySet(), Matches.UnitCanDieFromReachingMaxDamage)) {
           final List<Unit> unitsCanDie = Match.getMatches(m_targets.keySet(), Matches.UnitCanDieFromReachingMaxDamage);
           unitsCanDie
               .retainAll(Match.getMatches(unitsCanDie, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite)));

--- a/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
@@ -39,7 +39,7 @@ public class UnitsThatCantFightUtil {
       if (nonCombatUnits.isEmpty() || nonCombatUnits.size() != countAllOwnedUnits) {
         continue;
       }
-      if (current.getUnits().someMatch(enemyAttackUnits)) {
+      if (current.getUnits().anyMatch(enemyAttackUnits)) {
         cantFight.add(current);
       }
     }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -654,8 +654,8 @@ class DummyPlayer extends AbstractAI {
       final List<Unit> notKilled = new ArrayList<>(selectFrom);
       notKilled.removeAll(rKilled);
       // no land units left, but we have a non land unit to kill and land unit was killed
-      if (!Match.someMatch(notKilled, Matches.UnitIsLand) && Match.someMatch(notKilled, Matches.UnitIsNotLand)
-          && Match.someMatch(rKilled, Matches.UnitIsLand)) {
+      if (!Match.anyMatch(notKilled, Matches.UnitIsLand) && Match.anyMatch(notKilled, Matches.UnitIsNotLand)
+          && Match.anyMatch(rKilled, Matches.UnitIsLand)) {
         final List<Unit> notKilledAndNotLand = Match.getMatches(notKilled, Matches.UnitIsNotLand);
         // sort according to cost
         Collections.sort(notKilledAndNotLand, AIUtils.getCostComparator());

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -526,11 +526,11 @@ class EditPanel extends ActionPanel {
     data.acquireReadLock();
     try {
       final Set<UnitType> allUnitTypes = data.getUnitTypeList().getAllUnitTypes();
-      if (Match.someMatch(allUnitTypes, Matches.UnitTypeHasMoreThanOneHitPointTotal)) {
+      if (Match.anyMatch(allUnitTypes, Matches.UnitTypeHasMoreThanOneHitPointTotal)) {
         add(new JButton(changeUnitHitDamageAction));
       }
       if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
-          && Match.someMatch(allUnitTypes, Matches.UnitTypeCanBeDamaged)) {
+          && Match.anyMatch(allUnitTypes, Matches.UnitTypeCanBeDamaged)) {
         add(new JButton(changeUnitBombingDamageAction));
       }
     } finally {

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -130,7 +130,7 @@ public class MovePanel extends AbstractMovePanel {
 
     final Comparator<Unit> unitComparator;
     // sort units based on which transports are allowed to unload
-    if (route.isUnload() && Match.someMatch(units, Matches.UnitIsLand)) {
+    if (route.isUnload() && Match.anyMatch(units, Matches.UnitIsLand)) {
       unitComparator = UnitComparator.getUnloadableUnitsComparator(units, route, getUnitOwner(units));
     } else {
       unitComparator = UnitComparator.getMovableUnitsComparator(units, route);
@@ -558,7 +558,7 @@ public class MovePanel extends AbstractMovePanel {
     if (!route.isLoad()) {
       return Collections.emptyList();
     }
-    if (Match.someMatch(unitsToLoad, Matches.UnitIsAir)) {
+    if (Match.anyMatch(unitsToLoad, Matches.UnitIsAir)) {
       return Collections.emptyList();
     }
     final Collection<Unit> endOwnedUnits = route.getEnd().getUnits().getUnits();
@@ -842,7 +842,7 @@ public class MovePanel extends AbstractMovePanel {
         // Load Bombers with paratroops
         if ((!nonCombat || isParatroopersCanMoveDuringNonCombat(getData()))
             && TechAttachment.isAirTransportable(getCurrentPlayer())
-            && Match.someMatch(selectedUnits, Match.allOf(Matches.UnitIsAirTransport, Matches.unitHasNotMoved))) {
+            && Match.anyMatch(selectedUnits, Match.allOf(Matches.UnitIsAirTransport, Matches.unitHasNotMoved))) {
           final PlayerID player = getCurrentPlayer();
           // TODO Transporting allied units
           // Get the potential units to load
@@ -1093,14 +1093,14 @@ public class MovePanel extends AbstractMovePanel {
       final Match.CompositeBuilder<Unit> paratroopNBombersBuilder = Match.newCompositeBuilder(
           Matches.UnitIsAirTransport,
           Matches.UnitIsAirTransportable);
-      final boolean paratroopsLanding = Match.someMatch(units, paratroopNBombersBuilder.all());
-      if (route.isLoad() && Match.someMatch(units, Matches.UnitIsLand)) {
+      final boolean paratroopsLanding = Match.anyMatch(units, paratroopNBombersBuilder.all());
+      if (route.isLoad() && Match.anyMatch(units, Matches.UnitIsLand)) {
         transports = getTransportsToLoad(route, units, false);
         if (transports.isEmpty()) {
           cancelMove();
           return;
         }
-      } else if ((route.isUnload() && Match.someMatch(units, Matches.UnitIsLand)) || paratroopsLanding) {
+      } else if ((route.isUnload() && Match.anyMatch(units, Matches.UnitIsLand)) || paratroopsLanding) {
         final List<Unit> unloadAble = Match.getMatches(selectedUnits, getUnloadableMatch());
         final Collection<Unit> canMove = new ArrayList<>(getUnitsToUnload(route, unloadAble));
         canMove.addAll(Match.getMatches(selectedUnits, getUnloadableMatch().invert()));
@@ -1231,7 +1231,7 @@ public class MovePanel extends AbstractMovePanel {
       }
       final PlayerID owner = getUnitOwner(selectedUnits);
       final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(owner), Matches.UnitCanMove);
-      final boolean someOwned = Match.someMatch(units, match);
+      final boolean someOwned = Match.anyMatch(units, match);
       final boolean isCorrectTerritory = firstSelectedTerritory == null || firstSelectedTerritory == territory;
       if (someOwned && isCorrectTerritory) {
         final Map<Territory, List<Unit>> highlight = new HashMap<>();

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -121,7 +121,7 @@ public class PlacePanel extends AbstractMovePanel {
         if (GameStepPropertiesHelper.isBid(getData())) {
           final PlayerAttachment pa = PlayerAttachment.get(territory.getOwner());
           if ((pa == null || pa.getGiveUnitControl() == null || !pa.getGiveUnitControl().contains(getCurrentPlayer()))
-              && !territory.getUnits().someMatch(Matches.unitIsOwnedBy(getCurrentPlayer()))) {
+              && !territory.getUnits().anyMatch(Matches.unitIsOwnedBy(getCurrentPlayer()))) {
             return Collections.emptyList();
           }
         } else {

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -182,7 +182,7 @@ public class StatPanel extends AbstractStatPanel {
 
     public void setStatCollums() {
       stats = new IStat[] {new PUStat(), new ProductionStat(), new UnitsStat(), new TUVStat()};
-      if (Match.someMatch(gameData.getMap().getTerritories(), Matches.TerritoryIsVictoryCity)) {
+      if (Match.anyMatch(gameData.getMap().getTerritories(), Matches.TerritoryIsVictoryCity)) {
         final List<IStat> stats = new ArrayList<>(Arrays.asList(StatPanel.this.stats));
         stats.add(new VictoryCityStat());
         StatPanel.this.stats = stats.toArray(new IStat[stats.size()]);

--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -114,7 +114,7 @@ public final class Match<T> {
   /**
    * Returns true if any matches could be found.
    */
-  public static <T> boolean someMatch(final Collection<T> collection, final Match<T> match) {
+  public static <T> boolean anyMatch(final Collection<T> collection, final Match<T> match) {
     if (collection.isEmpty()) {
       return false;
     }
@@ -130,7 +130,7 @@ public final class Match<T> {
    * Returns true if no matches could be found.
    */
   public static <T> boolean noneMatch(final Collection<T> collection, final Match<T> match) {
-    return !someMatch(collection, match);
+    return !anyMatch(collection, match);
   }
 
   /**

--- a/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
+++ b/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
@@ -408,17 +408,17 @@ public class UnitCollectionTest {
   }
 
   @Test
-  public void someMatch() {
+  public void anyMatch() {
     final UnitCollection defaultPlayerUnitsOfUnitTypeOneUnitCollection =
         addAllDefaultPlayerUnitsOfUnitTypeOneToUnitCollection(unitCollection);
-    assertThat(defaultPlayerUnitsOfUnitTypeOneUnitCollection.someMatch(Matches.unitIsOfType(unitTypeOne)),
+    assertThat(defaultPlayerUnitsOfUnitTypeOneUnitCollection.anyMatch(Matches.unitIsOfType(unitTypeOne)),
         is(equalTo(true)));
-    assertThat(defaultPlayerUnitsOfUnitTypeOneUnitCollection.someMatch(Matches.unitIsOfType(unitTypeTwo)),
+    assertThat(defaultPlayerUnitsOfUnitTypeOneUnitCollection.anyMatch(Matches.unitIsOfType(unitTypeTwo)),
         is(equalTo(false)));
     final UnitCollection allDefaultPlayerUnitCollection =
         addAllDefaultPlayerUnitsOfUnitTypeTwoToUnitCollection(defaultPlayerUnitsOfUnitTypeOneUnitCollection);
-    assertThat(allDefaultPlayerUnitCollection.someMatch(Matches.unitIsOfType(unitTypeOne)), is(equalTo(true)));
-    assertThat(allDefaultPlayerUnitCollection.someMatch(Matches.unitIsOfType(unitTypeTwo)), is(equalTo(true)));
+    assertThat(allDefaultPlayerUnitCollection.anyMatch(Matches.unitIsOfType(unitTypeOne)), is(equalTo(true)));
+    assertThat(allDefaultPlayerUnitCollection.anyMatch(Matches.unitIsOfType(unitTypeTwo)), is(equalTo(true)));
   }
 
   @Test

--- a/src/test/java/games/strategy/triplea/delegate/LHTRTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LHTRTest.java
@@ -69,7 +69,7 @@ public class LHTRTest {
     delegate.end();
     // make sure the fighter is still there
     // in lhtr fighters can hover, and carriers placed beneath them
-    assertTrue(baltic.getUnits().someMatch(Matches.unitIsOfType(fighterType)));
+    assertTrue(baltic.getUnits().anyMatch(Matches.unitIsOfType(fighterType)));
   }
 
   @Test
@@ -93,7 +93,7 @@ public class LHTRTest {
     delegate.end();
     // there is no pending carrier to be placed
     // the fighter cannot hover
-    assertFalse(baltic.getUnits().someMatch(Matches.unitIsOfType(fighterType)));
+    assertFalse(baltic.getUnits().anyMatch(Matches.unitIsOfType(fighterType)));
   }
 
   @Test

--- a/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -113,8 +113,8 @@ public class MoveValidatorTest extends DelegateTest {
   @Test
   public void testHasSomeLand() {
     final Collection<Unit> units = transport.create(3, british);
-    assertTrue(!Match.someMatch(units, Matches.UnitIsLand));
+    assertTrue(!Match.anyMatch(units, Matches.UnitIsLand));
     units.addAll(infantry.create(2, british));
-    assertTrue(Match.someMatch(units, Matches.UnitIsLand));
+    assertTrue(Match.anyMatch(units, Matches.UnitIsLand));
   }
 }

--- a/src/test/java/games/strategy/util/MatchTest.java
+++ b/src/test/java/games/strategy/util/MatchTest.java
@@ -117,13 +117,13 @@ public class MatchTest {
   }
 
   @Test
-  public void testSomeMatch() {
-    assertFalse("empty collection", Match.someMatch(Arrays.asList(), IS_ZERO_MATCH));
-    assertFalse("none match", Match.someMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH));
-    assertTrue("some match (one element)", Match.someMatch(Arrays.asList(0), IS_ZERO_MATCH));
-    assertTrue("some match (multiple elements)", Match.someMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH));
-    assertTrue("all match (one element)", Match.someMatch(Arrays.asList(0), IS_ZERO_MATCH));
-    assertTrue("all match (multiple elements)", Match.someMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH));
+  public void testAnyMatch() {
+    assertFalse("empty collection", Match.anyMatch(Arrays.asList(), IS_ZERO_MATCH));
+    assertFalse("none match", Match.anyMatch(Arrays.asList(-1, 1), IS_ZERO_MATCH));
+    assertTrue("some match (one element)", Match.anyMatch(Arrays.asList(0), IS_ZERO_MATCH));
+    assertTrue("some match (multiple elements)", Match.anyMatch(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH));
+    assertTrue("all match (one element)", Match.anyMatch(Arrays.asList(0), IS_ZERO_MATCH));
+    assertTrue("all match (multiple elements)", Match.anyMatch(Arrays.asList(0, 0, 0), IS_ZERO_MATCH));
   }
 
   @Test


### PR DESCRIPTION
This PR renames all methods named `someMatch()` to `anyMatch()` for consistency with the new `Match` factory methods, as well as JDK conventions.  The following three classes each contained one method named `someMatch()`:

* `g.s.engine.data.Route`
* `g.s.engine.data.UnitCollection`
* `g.s.util.Match`

This is a big change, but everything was done via automated refactoring. No manual code modifications were made (except for one comment which was updated manually).  So it shouldn't require very much scrutiny beyond the name change.