### PR TITLE
Fix race condition in BackgroundTaskRunner#runInBackground() (#1260)

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -150,10 +150,10 @@ public class DownloadMapsWindow extends JFrame {
       assert state == State.UNINITIALIZED;
 
       state = State.INITIALIZING;
-      BackgroundTaskRunner.runInBackground("Downloading list of available maps...", () -> {
-        final List<DownloadFileDescription> downloads = ClientContext.getMapDownloadList();
-        SwingUtilities.invokeLater(() -> createAndShow(mapNames, downloads));
-      });
+      BackgroundTaskRunner.runInBackground(
+          "Downloading list of available maps...",
+          ClientContext::getMapDownloadList,
+          downloads -> createAndShow(mapNames, downloads));
     }
 
     private void createAndShow(final Collection<String> mapNames, final List<DownloadFileDescription> downloads) {
@@ -174,12 +174,8 @@ public class DownloadMapsWindow extends JFrame {
       assert window != null;
 
       window.setVisible(true);
-
-      // ensure Download Maps window is displayed on top (#1260)
-      SwingUtilities.invokeLater(() -> {
-        window.requestFocus();
-        window.toFront();
-      });
+      window.requestFocus();
+      window.toFront();
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -1,33 +1,75 @@
 package games.strategy.engine.framework.ui.background;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
 
-public class BackgroundTaskRunner {
-  /** Non-blocking. */
-  public static void runInBackground(final String waitMessage, final Runnable r) {
-    SwingUtilities.invokeLater(() -> {
-      final WaitDialog window = new WaitDialog(null, waitMessage);
-      // this will center the window
-      window.setLocationRelativeTo(null);
-      final AtomicBoolean doneWait = new AtomicBoolean(false);
-      new Thread(() -> {
-        try {
-          r.run();
-        } finally {
-          // clean up the window
-          SwingUtilities.invokeLater(() -> {
-            doneWait.set(true);
-            window.setVisible(false);
-            window.dispose();
-          });
-        }
-      }).start();
-      if (!doneWait.get()) {
-        window.pack();
-        window.setVisible(true);
+import games.strategy.debug.ClientLogger;
+
+/**
+ * Provides methods for running tasks in the background to avoid blocking the UI.
+ */
+public final class BackgroundTaskRunner {
+  private BackgroundTaskRunner() {}
+
+  /**
+   * Runs the specified action in the background without blocking the UI.
+   *
+   * <p>
+   * {@code backgroundAction} is run on a background (non-UI) thread. While the background action is running, a dialog
+   * is displayed with the specified message. When the background action is complete, the dialog is removed and
+   * {@code completionAction} is run on the UI thread. {@code completionAction} will consume the value supplied by
+   * {@code backgroundAction}.
+   * </p>
+   *
+   * @param <T> The type of value supplied by the background action.
+   *
+   * @param message The message displayed to the user while the background action is running; may be {@code null}.
+   * @param backgroundAction The action to run in the background; must not be {@code null}.
+   * @param completionAction The action to run in the foreground upon completion of {@code backgroundAction}; must not
+   *        be {@code null}.
+   *
+   * @throws IllegalStateException If this method is not called from the EDT.
+   */
+  public static <T> void runInBackground(
+      final String message,
+      final Supplier<T> backgroundAction,
+      final Consumer<T> completionAction) {
+    checkState(SwingUtilities.isEventDispatchThread());
+    checkNotNull(backgroundAction);
+    checkNotNull(completionAction);
+
+    final WaitDialog waitDialog = new WaitDialog(null, message);
+    final SwingWorker<T, Void> worker = new SwingWorker<T, Void>() {
+      @Override
+      protected T doInBackground() {
+        return backgroundAction.get();
       }
-    });
+
+      @Override
+      protected void done() {
+        waitDialog.setVisible(false);
+        waitDialog.dispose();
+
+        try {
+          completionAction.accept(get());
+        } catch (final ExecutionException e) {
+          ClientLogger.logError(e.getCause());
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    };
+    worker.execute();
+
+    waitDialog.setLocationRelativeTo(null);
+    waitDialog.pack();
+    waitDialog.setVisible(true);
   }
 }


### PR DESCRIPTION
Thanks to @RoiEXLab's research in #2059, I was able to track down the root cause of the Download Maps window appearing behind the main frame.  This PR fixes the root cause and reverts the workaround used in #2059.

The root cause is a race condition in the `BackgroundTaskRunner#runInBackground()` method between the caller's completion action that must be run on the EDT and the method's own completion action that must be run on the EDT.  In the scenario described by #1260, the caller's completion action is to display the Download Maps window in the foreground, while the method's completion action is to hide the progress dialog (which has the side effect of returning focus to the main frame).  When the caller's completion action wins the race (i.e. it's executed first), the following actions occur on the EDT in the specified order:

1. Show Download Maps window
1. Give focus to Download Maps window and bring it to the foreground
1. Hide progress dialog
1. Give focus to main frame and bring it to the foreground

When `runInBackground()`'s completion action wins the race, the action sequence on the EDT changes to the following:

1. Hide progress dialog
1. Give focus to main frame and bring it to the foreground
1. Show Download Maps window
1. Give focus to Download Maps window and bring it to the foreground

(Just for completeness, the workaround employed in #2059 resulted in the following action sequence on the EDT:

1. Show Download Maps window
1. Hide progress dialog
1. Give focus to main frame and bring it to the foreground
1. Give focus to Download Maps window and bring it to the foreground

)

In my observations, the caller's completion action wins the race consistently on my physical Windows box using the Oracle JRE.  However, `runInBackground()`'s completion action wins the race consistently on my Linux VM using either the Oracle or OpenJDK JREs.  I suspect the speed of the VM relative to the physical machine causes the difference in who wins the race.

The fix was to break out any completion action the caller needs to run on the EDT from the background action.  This completion action is passed as a new parameter to `runInBackground()`.  This allows the caller to avoid calling `SwingUtilities#invokeLater()` from the background thread before `runInBackground()` has the opportunity to schedule its own completion action.  Basically, the new code ensures the `runInBackground()` completion action (hiding the progress dialog) always runs before the caller's completion action (showing the Download Maps window).

#### Functional changes
None.

#### Refactoring changes
* `BackgroundTaskRunner#runInBackground()` was modified to accept a third argument that represents the completion action to run on the EDT when the background task is complete.  This action is now always invoked after the progress dialog has been hidden and focus has returned to the main frame (parent) window.

#### Refactoring issues for review
None.

#### Testing
I tested on both Windows and Linux and verified the Download Maps window is consistently displayed in front of the main frame.

@RoiEXLab I'd appreciate if you could run a quick test on Windows since you consistently observed this behavior on your machine, as well.