### PR TITLE
Use strict stubs where possible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     testCompile 'eu.codearte.catch-exception:catch-exception:2.0.0-ALPHA-1'
     testCompile 'org.apache.derby:derby:10.10.1.1'
     testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
-    testCompile 'org.mockito:mockito-core:2.7.22'
+    testCompile 'org.mockito:mockito-core:2.8.47'
     testCompile 'junit:junit:4.12'
 }
 

--- a/src/test/java/games/strategy/engine/config/client/remote/LobbyServerPropertiesFetcherTest.java
+++ b/src/test/java/games/strategy/engine/config/client/remote/LobbyServerPropertiesFetcherTest.java
@@ -17,7 +17,7 @@ import games.strategy.engine.framework.map.download.DownloadUtils;
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.util.Version;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class LobbyServerPropertiesFetcherTest {
 
   private static final Version fakeVersion = new Version("0.0.0.0");

--- a/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
+++ b/src/test/java/games/strategy/engine/data/UnitCollectionTest.java
@@ -20,7 +20,7 @@ import org.mockito.stubbing.Answer;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.IntegerMap;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class UnitCollectionTest {
 
   @Mock

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTests.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadUtilsTests.java
@@ -44,7 +44,7 @@ import games.strategy.engine.framework.map.download.DownloadUtils.DownloadLength
 public final class DownloadUtilsTests {
   private static final String URI = "some://uri";
 
-  @RunWith(MockitoJUnitRunner.class)
+  @RunWith(MockitoJUnitRunner.StrictStubs.class)
   public static final class DownloadToFileTest {
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -123,7 +123,7 @@ public final class DownloadUtilsTests {
     }
   }
 
-  @RunWith(MockitoJUnitRunner.class)
+  @RunWith(MockitoJUnitRunner.StrictStubs.class)
   public static final class GetDownloadLengthFromCacheTest {
     @Mock
     private DownloadLengthSupplier downloadLengthSupplier;
@@ -173,7 +173,7 @@ public final class DownloadUtilsTests {
     }
   }
 
-  @RunWith(MockitoJUnitRunner.class)
+  @RunWith(MockitoJUnitRunner.StrictStubs.class)
   public static final class GetDownloadLengthFromHostTest {
     @Mock
     private CloseableHttpClient client;

--- a/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/FileDownloadTest.java
@@ -11,7 +11,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.framework.map.download.DownloadFile.DownloadState;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class FileDownloadTest {
   @Mock
   private DownloadFileDescription mockDownload;

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTests.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTests.java
@@ -129,7 +129,7 @@ public final class MapDownloadControllerTests {
     }
   }
 
-  @RunWith(MockitoJUnitRunner.class)
+  @RunWith(MockitoJUnitRunner.StrictStubs.class)
   public static final class PreventPromptToDownloadTutorialMapTest {
     @Mock
     private TutorialMapPreferences tutorialMapPreferences;
@@ -146,7 +146,7 @@ public final class MapDownloadControllerTests {
     }
   }
 
-  @RunWith(MockitoJUnitRunner.class)
+  @RunWith(MockitoJUnitRunner.StrictStubs.class)
   public static final class ShouldPromptToDownloadTutorialMapTest {
     @Mock
     private TutorialMapPreferences tutorialMapPreferences;

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -19,7 +19,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import games.strategy.util.Version;
 
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class MapDownloadListTest {
 
 

--- a/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
+++ b/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
@@ -31,7 +31,7 @@ import games.strategy.engine.framework.ui.NewGameChooserEntry;
 import games.strategy.util.Version;
 
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class GameSelectorModelTest {
 
   private static void assertHasEmptyData(final GameSelectorModel objectToCheck) {

--- a/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
+++ b/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
@@ -25,7 +25,7 @@ import games.strategy.net.INode;
 import games.strategy.test.TestUtil;
 import games.strategy.util.Tuple;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class LobbyGameTableModelTest {
 
   private LobbyGameTableModel testObj;

--- a/src/test/java/games/strategy/engine/lobby/server/db/DbUserControllerTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/db/DbUserControllerTest.java
@@ -16,7 +16,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import games.strategy.engine.lobby.server.userDB.DBUser;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class DbUserControllerTest {
 
   private DbUserController testObj;

--- a/src/test/java/games/strategy/engine/pbem/CredentialManagerTest.java
+++ b/src/test/java/games/strategy/engine/pbem/CredentialManagerTest.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public final class CredentialManagerTest {
   private static final char[] MASTER_PASSWORD = "MASTER←PASSWORD↑WITH→UNICODE↓CHARS".toCharArray();
 

--- a/src/test/java/games/strategy/thread/LockUtilTest.java
+++ b/src/test/java/games/strategy/thread/LockUtilTest.java
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public final class LockUtilTest {
   private final LockUtil lockUtil = LockUtil.INSTANCE;
 

--- a/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
@@ -29,7 +29,6 @@ import games.strategy.triplea.TripleAUnit;
 @RunWith(MockitoJUnitRunner.class)
 public class BattleTrackerTest {
 
-
   @Mock
   private IDelegateBridge mockDelegateBridge;
   @Mock
@@ -68,8 +67,7 @@ public class BattleTrackerTest {
     when(mockDelegateBridge.getData()).thenReturn(mockGameData);
     when(mockGameData.getProperties()).thenReturn(mockGameProperties);
     when(mockGameData.getRelationshipTracker()).thenReturn(mockRelationshipTracker);
-    when(mockGameProperties.get(Constants.RAIDS_MAY_BE_PRECEEDED_BY_AIR_BATTLES, false))
-        .thenReturn(true);
+    when(mockGameProperties.get(Constants.RAIDS_MAY_BE_PRECEEDED_BY_AIR_BATTLES, false)).thenReturn(true);
     when(mockGetBattleFunction.apply(territory, IBattle.BattleType.BOMBING_RAID)).thenReturn(mockBattle);
 
     // set up the testObj to have the bombing battle

--- a/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
+++ b/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
@@ -120,9 +120,8 @@ public final class UserActionPanelTest {
 
   @Test
   public void testCanSpendResourcesOnUserActions_ShouldReturnFalseWhenNoUserActionHasCost() {
-    final Collection<UserActionAttachment> userActions = Arrays.asList(
-        createUserActionWithCost(0),
-        createUserActionWithCost(0));
+    final Collection<UserActionAttachment> userActions =
+        Arrays.asList(createUserActionWithCost(0), createUserActionWithCost(0));
 
     final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
 
@@ -131,9 +130,8 @@ public final class UserActionPanelTest {
 
   @Test
   public void testCanSpendResourcesOnUserActions_ShouldReturnTrueWhenAtLeastOneUserActionHasCost() {
-    final Collection<UserActionAttachment> userActions = Arrays.asList(
-        createUserActionWithCost(0),
-        createUserActionWithCost(5));
+    final Collection<UserActionAttachment> userActions =
+        Arrays.asList(createUserActionWithCost(0), createUserActionWithCost(5));
 
     final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
 

--- a/src/test/java/games/strategy/triplea/ui/logic/RouteCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/ui/logic/RouteCalculatorTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class RouteCalculatorTest {
 
   @Test

--- a/src/test/java/games/strategy/ui/SwingWorkerCompletionWaiterTest.java
+++ b/src/test/java/games/strategy/ui/SwingWorkerCompletionWaiterTest.java
@@ -11,26 +11,28 @@ import org.junit.Test;
 
 public final class SwingWorkerCompletionWaiterTest {
 
-	private SwingWorkerCompletionWaiter.ProgressWindow progressWindow = mock(SwingWorkerCompletionWaiter.ProgressWindow.class);
+  private SwingWorkerCompletionWaiter.ProgressWindow progressWindow =
+      mock(SwingWorkerCompletionWaiter.ProgressWindow.class);
 
-	private SwingWorkerCompletionWaiter waiter = new SwingWorkerCompletionWaiter(progressWindow);
+  private SwingWorkerCompletionWaiter waiter = new SwingWorkerCompletionWaiter(progressWindow);
 
-	@Test
-	public void testShouldOpenProgressWindowWhenWorkerStarted() {
-		waiter.propertyChange(newSwingWorkerStateEvent(SwingWorker.StateValue.STARTED));
+  @Test
+  public void testShouldOpenProgressWindowWhenWorkerStarted() {
+    waiter.propertyChange(newSwingWorkerStateEvent(SwingWorker.StateValue.STARTED));
 
-		verify(progressWindow).open();
-	}
+    verify(progressWindow).open();
+  }
 
-	@Test
-	public void testShouldCloseProgressWindowWhenWorkerDone() {
-		waiter.propertyChange(newSwingWorkerStateEvent(SwingWorker.StateValue.DONE));
+  @Test
+  public void testShouldCloseProgressWindowWhenWorkerDone() {
+    waiter.propertyChange(newSwingWorkerStateEvent(SwingWorker.StateValue.DONE));
 
-		verify(progressWindow).close();
-	}
+    verify(progressWindow).close();
+  }
 
-	private static PropertyChangeEvent newSwingWorkerStateEvent(
-			final SwingWorker.StateValue stateValue) {
-		return new PropertyChangeEvent(new Object(), SwingWorkerCompletionWaiter.SWING_WORKER_STATE_PROPERTY_NAME, null, stateValue);
-	}
+  private static PropertyChangeEvent newSwingWorkerStateEvent(
+      final SwingWorker.StateValue stateValue) {
+    return new PropertyChangeEvent(new Object(), SwingWorkerCompletionWaiter.SWING_WORKER_STATE_PROPERTY_NAME, null,
+        stateValue);
+  }
 }

--- a/src/test/java/games/strategy/ui/SwingWorkerCompletionWaiterTest.java
+++ b/src/test/java/games/strategy/ui/SwingWorkerCompletionWaiterTest.java
@@ -1,5 +1,6 @@
 package games.strategy.ui;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.beans.PropertyChangeEvent;
@@ -7,38 +8,29 @@ import java.beans.PropertyChangeEvent;
 import javax.swing.SwingWorker;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
 public final class SwingWorkerCompletionWaiterTest {
-  @InjectMocks
-  private SwingWorkerCompletionWaiter waiter;
 
-  @Mock
-  private SwingWorkerCompletionWaiter.ProgressWindow progressWindow;
+	private SwingWorkerCompletionWaiter.ProgressWindow progressWindow = mock(SwingWorkerCompletionWaiter.ProgressWindow.class);
 
-  @Test
-  public void testShouldOpenProgressWindowWhenWorkerStarted() {
-    waiter.propertyChange(newSwingWorkerStateEvent(SwingWorker.StateValue.STARTED));
+	private SwingWorkerCompletionWaiter waiter = new SwingWorkerCompletionWaiter(progressWindow);
 
-    verify(progressWindow).open();
-  }
+	@Test
+	public void testShouldOpenProgressWindowWhenWorkerStarted() {
+		waiter.propertyChange(newSwingWorkerStateEvent(SwingWorker.StateValue.STARTED));
 
-  @Test
-  public void testShouldCloseProgressWindowWhenWorkerDone() {
-    waiter.propertyChange(newSwingWorkerStateEvent(SwingWorker.StateValue.DONE));
+		verify(progressWindow).open();
+	}
 
-    verify(progressWindow).close();
-  }
+	@Test
+	public void testShouldCloseProgressWindowWhenWorkerDone() {
+		waiter.propertyChange(newSwingWorkerStateEvent(SwingWorker.StateValue.DONE));
 
-  private static PropertyChangeEvent newSwingWorkerStateEvent(final SwingWorker.StateValue stateValue) {
-    return new PropertyChangeEvent(
-        new Object(),
-        SwingWorkerCompletionWaiter.SWING_WORKER_STATE_PROPERTY_NAME,
-        null,
-        stateValue);
-  }
+		verify(progressWindow).close();
+	}
+
+	private static PropertyChangeEvent newSwingWorkerStateEvent(
+			final SwingWorker.StateValue stateValue) {
+		return new PropertyChangeEvent(new Object(), SwingWorkerCompletionWaiter.SWING_WORKER_STATE_PROPERTY_NAME, null, stateValue);
+	}
 }

--- a/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
+++ b/src/test/java/games/strategy/util/EventThreadJOptionPaneTest.java
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public final class EventThreadJOptionPaneTest {
   @Rule
   public final Timeout globalTimeout = new Timeout(5, TimeUnit.SECONDS);

--- a/src/test/java/games/strategy/util/UrlStreamsTest.java
+++ b/src/test/java/games/strategy/util/UrlStreamsTest.java
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class UrlStreamsTest {
 
   private UrlStreams testObj;


### PR DESCRIPTION
Mockito recommends using the StricStub Runner instead of the classic one.
This runner is supposed to detect programming mistakes early on by analyzing the code.
I tried replacing all of the MockitoJUnitRunner usages, but some tests were failing, I reverted this change for the failing classes, because I couldn't figure out why they were failing.
This PR also fixes an issue I had with eclipse, for whatever Reason the SwingWorker Test failed on eclipse but not using gradle. Now they both work fine.

More information: https://github.com/mockito/mockito/issues/769