### PR TITLE
Fix java9 compile errors

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -167,14 +167,13 @@ public class CommentPanel extends JPanel {
   private void loadHistory() {
     final Document doc = text.getDocument();
     final HistoryNode rootNode = (HistoryNode) data.getHistory().getRoot();
-    @SuppressWarnings("unchecked")
-    final Enumeration<HistoryNode> nodeEnum = rootNode.preorderEnumeration();
+    final Enumeration<TreeNode> nodeEnum = rootNode.preorderEnumeration();
     final Pattern p = Pattern.compile("^COMMENT: (.*)");
     String player = "";
     int round = 0;
     Icon icon = null;
     while (nodeEnum.hasMoreElements()) {
-      final HistoryNode node = nodeEnum.nextElement();
+      final HistoryNode node = (HistoryNode) nodeEnum.nextElement();
       if (node instanceof Round) {
         round++;
       } else if (node instanceof Step) {

--- a/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -167,6 +167,7 @@ public class CommentPanel extends JPanel {
   private void loadHistory() {
     final Document doc = text.getDocument();
     final HistoryNode rootNode = (HistoryNode) data.getHistory().getRoot();
+    @SuppressWarnings("unchecked")
     final Enumeration<TreeNode> nodeEnum = rootNode.preorderEnumeration();
     final Pattern p = Pattern.compile("^COMMENT: (.*)");
     String player = "";

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1742,6 +1742,7 @@ public class TripleAFrame extends MainGameFrame {
               // TODO: this could be solved easily if rounds/steps were changes,
               // but that could greatly increase the file size :(
               // TODO: this also does not undo the runcount of each delegate step
+              @SuppressWarnings("unchecked")
               final Enumeration<TreeNode> enumeration =
                   ((DefaultMutableTreeNode) datacopy.getHistory().getRoot()).preorderEnumeration();
               enumeration.nextElement();

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -69,6 +69,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import javax.swing.border.EtchedBorder;
 import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeNode;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
@@ -1741,15 +1742,14 @@ public class TripleAFrame extends MainGameFrame {
               // TODO: this could be solved easily if rounds/steps were changes,
               // but that could greatly increase the file size :(
               // TODO: this also does not undo the runcount of each delegate step
-              @SuppressWarnings("unchecked")
-              final Enumeration<HistoryNode> enumeration =
+              final Enumeration<TreeNode> enumeration =
                   ((DefaultMutableTreeNode) datacopy.getHistory().getRoot()).preorderEnumeration();
               enumeration.nextElement();
               int round = 0;
               String stepDisplayName = datacopy.getSequence().getStep(0).getDisplayName();
               PlayerID currentPlayer = datacopy.getSequence().getStep(0).getPlayerID();
               while (enumeration.hasMoreElements()) {
-                final HistoryNode node = enumeration.nextElement();
+                final HistoryNode node = (HistoryNode) enumeration.nextElement();
                 if (node instanceof Round) {
                   round = Math.max(0, ((Round) node).getRoundNo() - datacopy.getSequence().getRoundOffset());
                   currentPlayer = null;

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -180,7 +180,6 @@ public class HistoryPanel extends JPanel {
     }
     final TreePath path = tree.getSelectionPath();
     final TreeNode selected = (TreeNode) path.getLastPathComponent();
-    @SuppressWarnings("unchecked")
     final Enumeration<TreeNode> nodeEnum =
         ((DefaultMutableTreeNode) tree.getModel().getRoot()).depthFirstEnumeration();
     TreeNode previous = null;
@@ -223,7 +222,6 @@ public class HistoryPanel extends JPanel {
     }
     final TreePath path = tree.getSelectionPath();
     final TreeNode selected = (TreeNode) path.getLastPathComponent();
-    @SuppressWarnings("unchecked")
     final Enumeration<TreeNode> nodeEnum = ((DefaultMutableTreeNode) tree.getModel().getRoot()).preorderEnumeration();
     TreeNode next = null;
     boolean foundSelected = false;

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -180,6 +180,7 @@ public class HistoryPanel extends JPanel {
     }
     final TreePath path = tree.getSelectionPath();
     final TreeNode selected = (TreeNode) path.getLastPathComponent();
+    @SuppressWarnings("unchecked")
     final Enumeration<TreeNode> nodeEnum =
         ((DefaultMutableTreeNode) tree.getModel().getRoot()).depthFirstEnumeration();
     TreeNode previous = null;
@@ -222,6 +223,7 @@ public class HistoryPanel extends JPanel {
     }
     final TreePath path = tree.getSelectionPath();
     final TreeNode selected = (TreeNode) path.getLastPathComponent();
+    @SuppressWarnings("unchecked")
     final Enumeration<TreeNode> nodeEnum = ((DefaultMutableTreeNode) tree.getModel().getRoot()).preorderEnumeration();
     TreeNode next = null;
     boolean foundSelected = false;

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -24,6 +24,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.WindowConstants;
 import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeNode;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
@@ -307,14 +308,12 @@ class ExportMenu {
       }
       text.append("\n");
       clone.getHistory().gotoNode(clone.getHistory().getLastNode());
-      @SuppressWarnings("unchecked")
-      final Enumeration<HistoryNode> nodes =
-          ((DefaultMutableTreeNode) clone.getHistory().getRoot()).preorderEnumeration();
+      final Enumeration<TreeNode> nodes = ((DefaultMutableTreeNode) clone.getHistory().getRoot()).preorderEnumeration();
       PlayerID currentPlayer = null;
       int round = 0;
       while (nodes.hasMoreElements()) {
         // we want to export on change of turn
-        final HistoryNode element = nodes.nextElement();
+        final HistoryNode element = (HistoryNode) nodes.nextElement();
         if (element instanceof Round) {
           round++;
         }

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -308,6 +308,7 @@ class ExportMenu {
       }
       text.append("\n");
       clone.getHistory().gotoNode(clone.getHistory().getLastNode());
+      @SuppressWarnings("unchecked")
       final Enumeration<TreeNode> nodes = ((DefaultMutableTreeNode) clone.getHistory().getRoot()).preorderEnumeration();
       PlayerID currentPlayer = null;
       int round = 0;


### PR DESCRIPTION
preorderNumeration was parameterized in java 9, this caused compile errors to show up