### PR TITLE
Fix temporary progress bar reset when download is complete

### DIFF
--- a/src/main/java/games/strategy/engine/framework/map/download/FileSizeWatcher.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/FileSizeWatcher.java
@@ -35,8 +35,4 @@ final class FileSizeWatcher {
       }
     };
   }
-
-  File getFile() {
-    return fileToWatch;
-  }
 }


### PR DESCRIPTION
The download progress bar will temporarily be reset to 0% after the download is complete because the `FileSizeWatcher` is still monitoring the file size when we attempt to move the intermediate file to its final location.  If the `FileSizeWatcher` background thread executes immediately after the move, it will observe a zero file size, and the progress bar is reset to 0% for a short time (hundreds of milliseconds) before it jumps back to 100% when the `downloadStopped()` callback is invoked.

#### Functional changes
Stop the `FileSizeWatcher` immediately after the download so its background thread is no longer running when we attempt to move the file.  Because we don't wait for confirmation that the background thread has exited before proceeding with the file move, there is a very small possibility that it still may see a zero file size causing the progress bar to once again temporarily be set to 0%.  But this is highly unlikely.

#### Functional issues for review
None.

#### Refactoring changes
I used this PR as an opportunity to clean up some of the more convoluted bits in the `DownloadFile` background thread.  This also allowed me to narrow the window in which the `FileSizeWatcher` runs to be as small as possible.  The refactoring is responsible for the vast majority of changes in this PR.

#### Refactoring issues for review
None.

#### Testing
I ran numerous download tests to ensure the progress bar didn't reset to 0% immediately before reaching 100%.  Prior to the final changes, I introduced a 3-second sleep immediately after the file was moved to ensure I wasn't just missing the reset due to a timing issue.