### PR TITLE
Fix non-deterministic test failure when using @InjectMocks

### DIFF
--- a/src/test/java/games/strategy/ui/SwingWorkerCompletionWaiterTest.java
+++ b/src/test/java/games/strategy/ui/SwingWorkerCompletionWaiterTest.java
@@ -6,19 +6,23 @@ import java.beans.PropertyChangeEvent;
 
 import javax.swing.SwingWorker;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class SwingWorkerCompletionWaiterTest {
-  @InjectMocks
   private SwingWorkerCompletionWaiter waiter;
 
   @Mock
   private SwingWorkerCompletionWaiter.ProgressWindow progressWindow;
+
+  @Before
+  public void setUp() {
+    waiter = new SwingWorkerCompletionWaiter(progressWindow);
+  }
 
   @Test
   public void testShouldOpenProgressWindowWhenWorkerStarted() {


### PR DESCRIPTION
As discussed in [#2071](https://github.com/triplea-game/triplea/pull/2071/files#r126033939).

When using `@InjectMocks` to inject mocks via constructor injection, Mockito will only attempt to use the "biggest" constructor.  This is defined as the constructor with the largest number of parameters.

However, in the case of `SwingWorkerCompletionWaiter`, there are two constructors with an equal number of parameters.  When confronted with this scenario, Mockito does not attempt to use the constructor that is the "best match" (e.g. by looking at the types).  Instead, it simply takes the first one from the list.  The order of the candidate constructor list is determined by `Class#getDeclaredConstructors()`, which does not guarantee an order for the returned collection.  Thus, depending on the environment, the `SwingWorkerCompletionWaiter` constructor chosen by Mockito may be different.

If the chosen constructor is the overload with a `ProgressWindow` parameter, the test is successful.  However, if the chosen constructor is the overload with a `Window` parameter, Mockito believes constructor injection is not possible and moves on to considering other methods of parameter injection.

In the end, Mockito has no choice but to pass null to the constructor overload that accepts a `Window`.  As this constructor requires a non-null argument, it throws a `NullPointerException` and the test errors.

The fix in this case is to simply avoid `@InjectMocks` and manually construct the `SwingWorkerCompletionWaiter` under test.  We could have forced `@InjectMocks` to choose the correct constructor by adding a dummy second parameter for the `ProgressWindow` overload.  However, that seemed like it could be confusing for a future maintainer compared to the chosen solution.