### PR TITLE
Enable Mockito strict mode

### DIFF
--- a/src/test/java/games/strategy/engine/config/client/GameEnginePropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/client/GameEnginePropertyReaderTest.java
@@ -3,13 +3,14 @@ package games.strategy.engine.config.client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -19,31 +20,20 @@ import games.strategy.engine.config.client.remote.LobbyServerPropertiesFetcher;
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.util.Version;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class GameEnginePropertyReaderTest {
-
 
   @Mock
   private PropertyFileReader mockPropertyFileReader;
+
   @Mock
   private LobbyServerPropertiesFetcher mockLobbyServerPropertiesFetcher;
+
   @Mock
   private BackupPropertyFetcher mockBackupPropertyFetcher;
 
+  @InjectMocks
   private GameEnginePropertyReader testObj;
-
-
-
-  /**
-   * Sets up a test object with mocked dependencies.
-   */
-  @Before
-  public void setup() {
-    testObj = new GameEnginePropertyReader(
-        mockPropertyFileReader,
-        mockLobbyServerPropertiesFetcher,
-        mockBackupPropertyFetcher);
-  }
 
   @Test
   public void engineVersion() {
@@ -75,11 +65,10 @@ public class GameEnginePropertyReaderTest {
   }
 
   private void givenSuccessfullyParsedPropertiesUrl() {
-    when(mockPropertyFileReader.readProperty(GameEnginePropertyReader.PropertyKeys.LOBBY_PROP_FILE_URL))
-        .thenReturn(TestData.fakePropUrl);
-
-    when(mockPropertyFileReader.readProperty(GameEnginePropertyReader.PropertyKeys.ENGINE_VERSION))
-        .thenReturn(TestData.fakeVersionString);
+    doReturn(TestData.fakePropUrl)
+        .when(mockPropertyFileReader).readProperty(GameEnginePropertyReader.PropertyKeys.LOBBY_PROP_FILE_URL);
+    doReturn(TestData.fakeVersionString)
+        .when(mockPropertyFileReader).readProperty(GameEnginePropertyReader.PropertyKeys.ENGINE_VERSION);
   }
 
   @Test
@@ -91,15 +80,14 @@ public class GameEnginePropertyReaderTest {
 
     givenSuccessfullyParsedBackupValues();
 
-
     final LobbyServerProperties result = testObj.fetchLobbyServerProperties();
 
     assertThat(result, sameInstance(TestData.fakeProps));
   }
 
   private void givenSuccessfullyParsedBackupValues() {
-    when(mockPropertyFileReader.readProperty(GameEnginePropertyReader.PropertyKeys.LOBBY_BACKUP_HOST_ADDRESS))
-        .thenReturn(TestData.backupAddress);
+    doReturn(TestData.backupAddress)
+        .when(mockPropertyFileReader).readProperty(GameEnginePropertyReader.PropertyKeys.LOBBY_BACKUP_HOST_ADDRESS);
 
     when(mockBackupPropertyFetcher.parseBackupValuesFromEngineConfig(TestData.backupAddress))
         .thenReturn(TestData.fakeProps);
@@ -112,5 +100,4 @@ public class GameEnginePropertyReaderTest {
     String backupAddress = "backup";
     LobbyServerProperties fakeProps = new LobbyServerProperties("host", 123);
   }
-
 }

--- a/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTests.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/MapDownloadControllerTests.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,7 +29,7 @@ import games.strategy.util.Version;
 
 @RunWith(Enclosed.class)
 public final class MapDownloadControllerTests {
-  @RunWith(MockitoJUnitRunner.class)
+  @RunWith(MockitoJUnitRunner.StrictStubs.class)
   public static final class GetOutOfDateMapNamesTest {
     private static final String MAP_NAME = "myMap";
 
@@ -75,8 +76,8 @@ public final class MapDownloadControllerTests {
 
     private void givenDownloadedMapVersionIs(final Version version) {
       when(downloadedMaps.getZipFileCandidates(MAP_NAME)).thenReturn(Arrays.asList(MAP_ZIP_FILE_1, MAP_ZIP_FILE_2));
-      when(downloadedMaps.getVersionForZipFile(MAP_ZIP_FILE_1)).thenReturn(Optional.empty());
-      when(downloadedMaps.getVersionForZipFile(MAP_ZIP_FILE_2)).thenReturn(Optional.of(version));
+      doReturn(Optional.empty()).when(downloadedMaps).getVersionForZipFile(MAP_ZIP_FILE_1);
+      doReturn(Optional.of(version)).when(downloadedMaps).getVersionForZipFile(MAP_ZIP_FILE_2);
     }
 
     private Collection<String> getOutOfDateMapNames(final Collection<DownloadFileDescription> downloads) {

--- a/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
@@ -1,6 +1,6 @@
 package games.strategy.triplea.delegate;
 
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -26,28 +25,28 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public class BattleTrackerTest {
 
   @Mock
   private IDelegateBridge mockDelegateBridge;
+
   @Mock
   private GameData mockGameData;
+
   @Mock
   private GameProperties mockGameProperties;
+
   @Mock
   private RelationshipTracker mockRelationshipTracker;
+
   @Mock
   private BiFunction<Territory, IBattle.BattleType, IBattle> mockGetBattleFunction;
+
   @Mock
   private IBattle mockBattle;
 
-  private BattleTracker testObj;
-
-  @Before
-  public void setup() {
-    testObj = new BattleTracker();
-  }
+  private final BattleTracker testObj = new BattleTracker();
 
   @Test
   public void verifyRaidsWithNoBattles() {
@@ -56,19 +55,20 @@ public class BattleTrackerTest {
 
   @Test
   public void verifyRaids() {
-    Territory territory = new Territory("terrName", mockGameData);
+    final Territory territory = new Territory("terrName", mockGameData);
     final Route route = new Route(territory);
-    PlayerID playerId = new PlayerID("name", mockGameData);
+    final PlayerID playerId = new PlayerID("name", mockGameData);
 
     // need at least one attacker for there to be considered a battle.
-    Unit unit = new TripleAUnit(new UnitType("unit", mockGameData), playerId, mockGameData);
+    final Unit unit = new TripleAUnit(new UnitType("unit", mockGameData), playerId, mockGameData);
     final List<Unit> attackers = Collections.singletonList(unit);
 
     when(mockDelegateBridge.getData()).thenReturn(mockGameData);
     when(mockGameData.getProperties()).thenReturn(mockGameProperties);
     when(mockGameData.getRelationshipTracker()).thenReturn(mockRelationshipTracker);
     when(mockGameProperties.get(Constants.RAIDS_MAY_BE_PRECEEDED_BY_AIR_BATTLES, false)).thenReturn(true);
-    when(mockGetBattleFunction.apply(territory, IBattle.BattleType.BOMBING_RAID)).thenReturn(mockBattle);
+    doReturn(null).when(mockGetBattleFunction).apply(territory, IBattle.BattleType.AIR_RAID);
+    doReturn(mockBattle).when(mockGetBattleFunction).apply(territory, IBattle.BattleType.BOMBING_RAID);
 
     // set up the testObj to have the bombing battle
     testObj.addBombingBattle(route, attackers, playerId, mockDelegateBridge, null, null);
@@ -76,6 +76,6 @@ public class BattleTrackerTest {
     testObj.fightAirRaidsAndStrategicBombing(mockDelegateBridge, () -> Collections.singleton(territory),
         mockGetBattleFunction);
 
-    verify(mockBattle, times(1)).fight(mockDelegateBridge);
+    verify(mockBattle).fight(mockDelegateBridge);
   }
 }

--- a/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
+++ b/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.ui;
 
-import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -23,43 +22,23 @@ import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.ResourceList;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UserActionAttachment;
-import games.strategy.util.IntegerMap;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
 public final class UserActionPanelTest {
   @Mock
   private GameData data;
 
   private Resource pus;
 
-  private Resource techTokens;
-
-  private Resource vps;
-
   @Before
   public void setUp() {
-    pus = createResource(Constants.PUS);
-    techTokens = createResource(Constants.TECH_TOKENS);
-    vps = createResource(Constants.VPS);
-    setGameResources(pus, techTokens, vps);
-  }
-
-  private Resource createResource(final String name) {
-    return new Resource(name, data);
-  }
-
-  private void setGameResources(final Resource... resources) {
-    final ResourceList gameResources = mock(ResourceList.class);
-    for (final Resource resource : resources) {
-      when(gameResources.getResource(resource.getName())).thenReturn(resource);
-    }
-
-    when(data.getResourceList()).thenReturn(gameResources);
+    pus = new Resource(Constants.PUS, data);
   }
 
   @Test
   public void testCanPlayerAffordUserAction_ShouldReturnFalseWhenUserActionCostGreaterThanPlayerPUs() {
-    final PlayerID player = createPlayerWithResources(pus);
+    givenGameHasPuResource();
+    final PlayerID player = createPlayer();
     final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus) + 1);
 
     final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
@@ -67,9 +46,15 @@ public final class UserActionPanelTest {
     assertThat(canAffordUserAction, is(false));
   }
 
-  private PlayerID createPlayerWithResources(final Resource... resources) {
+  private void givenGameHasPuResource() {
+    final ResourceList gameResources = mock(ResourceList.class);
+    when(gameResources.getResource(pus.getName())).thenReturn(pus);
+    when(data.getResourceList()).thenReturn(gameResources);
+  }
+
+  private PlayerID createPlayer() {
     final PlayerID player = new PlayerID("player", data);
-    player.getResources().add(new IntegerMap<>(Arrays.stream(resources).collect(toList()), 42));
+    player.getResources().addResource(pus, 42);
     return player;
   }
 
@@ -81,7 +66,8 @@ public final class UserActionPanelTest {
 
   @Test
   public void testCanPlayerAffordUserAction_ShouldReturnTrueWhenUserActionCostEqualToPlayerPUs() {
-    final PlayerID player = createPlayerWithResources(pus);
+    givenGameHasPuResource();
+    final PlayerID player = createPlayer();
     final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus));
 
     final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
@@ -91,7 +77,8 @@ public final class UserActionPanelTest {
 
   @Test
   public void testCanPlayerAffordUserAction_ShouldReturnTrueWhenUserActionCostLessThanPlayerPUs() {
-    final PlayerID player = createPlayerWithResources(pus);
+    givenGameHasPuResource();
+    final PlayerID player = createPlayer();
     final UserActionAttachment userAction = createUserActionWithCost(player.getResources().getQuantity(pus) - 1);
 
     final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);
@@ -101,7 +88,8 @@ public final class UserActionPanelTest {
 
   @Test
   public void testCanPlayerAffordUserAction_ShouldReturnTrueWhenUserActionCostIsZeroAndPlayerPUsIsZero() {
-    final PlayerID player = createPlayerWithResources();
+    givenGameHasPuResource();
+    final PlayerID player = createPlayer();
     final UserActionAttachment userAction = createUserActionWithCost(0);
 
     final boolean canAffordUserAction = UserActionPanel.canPlayerAffordUserAction(player, userAction);


### PR DESCRIPTION
This is a follow-up to #2071.  It completes the conversion of all tests that use `MockitoJUnitRunner` to strict mode.  It also includes a few improvements unrelated to strict mode, which I'll call out in a review.  All files were pumped through Clean Up, so there was some formatting changes and other changes (e.g. addition of `final` where possible) that I won't bother to point out.

The changes fell into two categories:

##### Unnecessary stubbing
This was usually due to stubs being set up in `@Before` but only being used by a subset of the tests.  In these cases, I moved the stub definitions from `@Before` to the tests that required them (preferably encapsulated within a helper method).

##### Multiple stubs for a single method with different arguments
In strict mode, using `when(obj.doSomething(arg)).thenReturn(value)` is discouraged in the case where multiple stubs are specified for a single method where only the argument(s) differ.  Mockito recommends using `doReturn(value).when(obj).doSomething(arg)` instead.