### PR TITLE
Checkstyle: Fix member name violations in g.s.triplea.ui.*Panel classes (part 1)

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -49,7 +49,9 @@ public abstract class AbstractMovePanel extends ActionPanel {
       }
     }
   };
-  private final Action DONE_MOVE_ACTION = new WeakAction("Done", doneMove);
+
+  private final Action doneMoveAction = new WeakAction("Done", doneMove);
+
   private final Action cancelMove = new AbstractAction("Cancel") {
     private static final long serialVersionUID = -257745862234175428L;
 
@@ -60,14 +62,14 @@ public abstract class AbstractMovePanel extends ActionPanel {
         frame.clearStatusMessage();
       }
       this.setEnabled(false);
-      CANCEL_MOVE_ACTION.setEnabled(false);
+      cancelMoveAction.setEnabled(false);
     }
   };
 
   protected AbstractMovePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map);
     this.frame = frame;
-    CANCEL_MOVE_ACTION.setEnabled(false);
+    cancelMoveAction.setEnabled(false);
     undoableMoves = Collections.emptyList();
   }
 
@@ -81,7 +83,8 @@ public abstract class AbstractMovePanel extends ActionPanel {
    */
   protected abstract void cancelMoveAction();
 
-  private final AbstractAction CANCEL_MOVE_ACTION = new WeakAction("Cancel", cancelMove);
+  private final AbstractAction cancelMoveAction = new WeakAction("Cancel", cancelMove);
+
   protected AbstractUndoableMovesPanel undoableMovesPanel;
   private IPlayerBridge bridge;
 
@@ -115,7 +118,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
   }
 
   protected final void enableCancelButton() {
-    CANCEL_MOVE_ACTION.setEnabled(true);
+    cancelMoveAction.setEnabled(true);
   }
 
   protected final GameData getGameData() {
@@ -133,7 +136,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
   }
 
   public final void cancelMove() {
-    CANCEL_MOVE_ACTION.actionPerformed(null);
+    cancelMoveAction.actionPerformed(null);
   }
 
   public final String undoMove(final int moveIndex) {
@@ -142,7 +145,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
 
   protected final String undoMove(final int moveIndex, final boolean suppressError) {
     // clean up any state we may have
-    CANCEL_MOVE_ACTION.actionPerformed(null);
+    cancelMoveAction.actionPerformed(null);
     // undo the move
     final String error = getMoveDelegate().undoMove(moveIndex);
     if (error != null && !suppressError) {
@@ -225,13 +228,13 @@ public abstract class AbstractMovePanel extends ActionPanel {
       listening = false;
       cleanUpSpecific();
       bridge = null;
-      CANCEL_MOVE_ACTION.setEnabled(false);
+      cancelMoveAction.setEnabled(false);
       final JComponent rootPane = getRootPane();
       if (rootPane != null) {
         rootPane.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), null);
       }
       removeAll();
-      REFRESH.run();
+      refresh.run();
     });
   }
 
@@ -243,7 +246,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
   @Override
   public final void setActive(final boolean active) {
     super.setActive(active);
-    SwingUtilities.invokeLater(() -> CANCEL_MOVE_ACTION.actionPerformed(null));
+    SwingUtilities.invokeLater(() -> cancelMoveAction.actionPerformed(null));
   }
 
   protected final void display(final PlayerID id, final String actionLabel) {
@@ -253,14 +256,14 @@ public abstract class AbstractMovePanel extends ActionPanel {
       this.actionLabel.setText(id.getName() + actionLabel);
       add(leftBox(this.actionLabel));
       if (setCancelButton()) {
-        add(leftBox(new JButton(CANCEL_MOVE_ACTION)));
+        add(leftBox(new JButton(cancelMoveAction)));
       }
-      add(leftBox(new JButton(DONE_MOVE_ACTION)));
+      add(leftBox(new JButton(doneMoveAction)));
       addAdditionalButtons();
       add(Box.createVerticalStrut(entryPadding));
       add(undoableMovesPanel);
       add(Box.createGlue());
-      SwingUtilities.invokeLater(REFRESH);
+      SwingUtilities.invokeLater(refresh);
     });
   }
 
@@ -287,7 +290,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
       listening = true;
       if (getRootPane() != null) {
         final String key = MOVE_PANEL_CANCEL;
-        getRootPane().getActionMap().put(key, CANCEL_MOVE_ACTION);
+        getRootPane().getActionMap().put(key, cancelMoveAction);
         getRootPane().getInputMap(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
             .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), key);
       }

--- a/src/main/java/games/strategy/triplea/ui/AbstractStatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractStatPanel.java
@@ -56,21 +56,21 @@ public abstract class AbstractStatPanel extends JPanel {
   }
 
   class ResourceStat extends AbstractStat {
-    final Resource m_resource;
+    final Resource resource;
 
     public ResourceStat(final Resource resource) {
       super();
-      m_resource = resource;
+      this.resource = resource;
     }
 
     @Override
     public String getName() {
-      return m_resource.getName();
+      return resource.getName();
     }
 
     @Override
     public double getValue(final PlayerID player, final GameData data) {
-      return player.getResources().getQuantity(m_resource);
+      return player.getResources().getQuantity(resource);
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -173,20 +173,20 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
 
   class UndoMoveActionListener extends AbstractAction {
     private static final long serialVersionUID = -397312652244693138L;
-    private final int m_moveIndex;
+    private final int moveIndex;
 
     public UndoMoveActionListener(final int index) {
       super("Undo");
-      m_moveIndex = index;
+      moveIndex = index;
     }
 
     @Override
     public void actionPerformed(final ActionEvent e) {
       // Record position of scroll bar as percentage.
       scrollBarPreviousValue = scroll.getVerticalScrollBar().getValue();
-      final String error = movePanel.undoMove(m_moveIndex);
+      final String error = movePanel.undoMove(moveIndex);
       if (error == null) {
-        previousVisibleIndex = Math.max(0, m_moveIndex - 1);
+        previousVisibleIndex = Math.max(0, moveIndex - 1);
       } else {
         previousVisibleIndex = null;
       }
@@ -213,20 +213,20 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
 
   class ViewAction extends AbstractAction {
     private static final long serialVersionUID = -6999284663802575467L;
-    private final AbstractUndoableMove m_move;
+    private final AbstractUndoableMove move;
 
     public ViewAction(final AbstractUndoableMove move) {
       super("Show");
-      m_move = move;
+      this.move = move;
     }
 
     @Override
     public void actionPerformed(final ActionEvent e) {
       movePanel.cancelMove();
-      if (!movePanel.getMap().isShowing(m_move.getEnd())) {
-        movePanel.getMap().centerOn(m_move.getEnd());
+      if (!movePanel.getMap().isShowing(move.getEnd())) {
+        movePanel.getMap().centerOn(move.getEnd());
       }
-      specificViewAction(m_move);
+      specificViewAction(move);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -135,7 +135,7 @@ public abstract class ActionPanel extends JPanel {
   /**
    * Refreshes the action panel. Should be run within the swing event queue.
    */
-  protected final Runnable REFRESH = () -> {
+  protected final Runnable refresh = () -> {
     revalidate();
     repaint();
   };

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -132,7 +132,7 @@ public class BattlePanel extends ActionPanel {
           }
         }
         add(panel, BorderLayout.NORTH);
-        SwingUtilities.invokeLater(REFRESH);
+        SwingUtilities.invokeLater(refresh);
       }
 
       private void addBattleActions(final JPanel panel, final Territory territory, final boolean bomb,
@@ -442,11 +442,11 @@ public class BattlePanel extends ActionPanel {
 
   class CenterBattleAction extends AbstractAction {
     private static final long serialVersionUID = -5071133874755970334L;
-    Territory m_territory;
+    Territory battleSite;
 
     CenterBattleAction(final Territory battleSite) {
       super("Center");
-      m_territory = battleSite;
+      this.battleSite = battleSite;
     }
 
     @Override
@@ -457,56 +457,56 @@ public class BattlePanel extends ActionPanel {
       if (oldCenteredTerritory != null) {
         getMap().clearTerritoryOverlay(oldCenteredTerritory);
       }
-      getMap().centerOn(m_territory);
+      getMap().centerOn(battleSite);
       centerBattleActionTimer = new Timer();
-      centerBattleActionTimer.scheduleAtFixedRate(new MyTimerTask(m_territory, centerBattleActionTimer), 150, 150);
-      oldCenteredTerritory = m_territory;
+      centerBattleActionTimer.scheduleAtFixedRate(new MyTimerTask(battleSite, centerBattleActionTimer), 150, 150);
+      oldCenteredTerritory = battleSite;
     }
 
     class MyTimerTask extends TimerTask {
       private final Territory territory;
-      private final Timer m_stopTimer;
-      private int m_count = 0;
+      private final Timer stopTimer;
+      private int count = 0;
 
       MyTimerTask(final Territory battleSite, final Timer stopTimer) {
         territory = battleSite;
-        m_stopTimer = stopTimer;
+        this.stopTimer = stopTimer;
       }
 
       @Override
       public void run() {
-        if (m_count == 5) {
-          m_stopTimer.cancel();
+        if (count == 5) {
+          stopTimer.cancel();
         }
-        if ((m_count % 3) == 0) {
+        if ((count % 3) == 0) {
           getMap().setTerritoryOverlayForBorder(territory, Color.white);
           getMap().paintImmediately(getMap().getBounds());
-          // TODO: getUIContext().getMapData().getBoundingRect(m_territory)); what kind of additional transformation
+          // TODO: getUIContext().getMapData().getBoundingRect(battleSite)); what kind of additional transformation
           // needed here?
           // TODO: setTerritoryOverlayForBorder is causing invalid ordered lock acquire atempt, why?
         } else {
           getMap().clearTerritoryOverlay(territory);
           getMap().paintImmediately(getMap().getBounds());
-          // TODO: getUIContext().getMapData().getBoundingRect(m_territory)); what kind of additional transformation
+          // TODO: getUIContext().getMapData().getBoundingRect(battleSite)); what kind of additional transformation
           // needed here?
           // TODO: setTerritoryOverlayForBorder is causing invalid ordered lock acquire atempt, why?
         }
-        m_count++;
+        count++;
       }
     }
   }
 
   class FightBattleAction extends AbstractAction {
     private static final long serialVersionUID = 5510976406003707776L;
-    Territory m_territory;
-    boolean m_bomb;
-    BattleType m_type;
+    Territory territory;
+    boolean bomb;
+    BattleType battleType;
 
     FightBattleAction(final Territory battleSite, final boolean bomb, final BattleType battleType) {
       super(battleType.toString() + " in " + battleSite.getName() + "...");
-      m_territory = battleSite;
-      m_bomb = bomb;
-      m_type = battleType;
+      territory = battleSite;
+      this.bomb = bomb;
+      this.battleType = battleType;
     }
 
     @Override
@@ -514,7 +514,7 @@ public class BattlePanel extends ActionPanel {
       if (oldCenteredTerritory != null) {
         getMap().clearTerritoryOverlay(oldCenteredTerritory);
       }
-      fightBattleMessage = new FightBattleDetails(m_territory, m_bomb, m_type);
+      fightBattleMessage = new FightBattleDetails(territory, bomb, battleType);
       release();
     }
   }

--- a/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
@@ -44,13 +44,13 @@ public class EconomyPanel extends AbstractStatPanel {
 
   class ResourceTableModel extends AbstractTableModel implements GameDataChangeListener {
     private static final long serialVersionUID = 5197895788633898324L;
-    private boolean m_isDirty = true;
-    private String[][] m_collectedData;
+    private boolean isDirty = true;
+    private String[][] collectedData;
 
     public ResourceTableModel() {
       setResourceCollums();
       gameData.addDataChangeListener(this);
-      m_isDirty = true;
+      isDirty = true;
     }
 
     private void setResourceCollums() {
@@ -66,11 +66,11 @@ public class EconomyPanel extends AbstractStatPanel {
 
     @Override
     public synchronized Object getValueAt(final int row, final int col) {
-      if (m_isDirty) {
+      if (isDirty) {
         loadData();
-        m_isDirty = false;
+        isDirty = false;
       }
-      return m_collectedData[row][col];
+      return collectedData[row][col];
     }
 
     private synchronized void loadData() {
@@ -78,12 +78,12 @@ public class EconomyPanel extends AbstractStatPanel {
       try {
         final List<PlayerID> players = getPlayers();
         final Collection<String> alliances = getAlliances();
-        m_collectedData = new String[players.size() + alliances.size()][statsResource.length + 1];
+        collectedData = new String[players.size() + alliances.size()][statsResource.length + 1];
         int row = 0;
         for (final PlayerID player : players) {
-          m_collectedData[row][0] = player.getName();
+          collectedData[row][0] = player.getName();
           for (int i = 0; i < statsResource.length; i++) {
-            m_collectedData[row][i + 1] =
+            collectedData[row][i + 1] =
                 statsResource[i].getFormatter().format(statsResource[i].getValue(player, gameData));
           }
           row++;
@@ -91,9 +91,9 @@ public class EconomyPanel extends AbstractStatPanel {
         final Iterator<String> allianceIterator = alliances.iterator();
         while (allianceIterator.hasNext()) {
           final String alliance = allianceIterator.next();
-          m_collectedData[row][0] = alliance;
+          collectedData[row][0] = alliance;
           for (int i = 0; i < statsResource.length; i++) {
-            m_collectedData[row][i + 1] =
+            collectedData[row][i + 1] =
                 statsResource[i].getFormatter().format(statsResource[i].getValue(alliance, gameData));
           }
           row++;
@@ -106,7 +106,7 @@ public class EconomyPanel extends AbstractStatPanel {
     @Override
     public void gameDataChanged(final Change change) {
       synchronized (this) {
-        m_isDirty = true;
+        isDirty = true;
       }
       SwingUtilities.invokeLater(() -> repaint());
     }
@@ -126,8 +126,8 @@ public class EconomyPanel extends AbstractStatPanel {
 
     @Override
     public synchronized int getRowCount() {
-      if (!m_isDirty) {
-        return m_collectedData.length;
+      if (!isDirty) {
+        return collectedData.length;
       } else {
         gameData.acquireReadLock();
         try {
@@ -143,7 +143,7 @@ public class EconomyPanel extends AbstractStatPanel {
         gameData.removeDataChangeListener(this);
         gameData = data;
         gameData.addDataChangeListener(this);
-        m_isDirty = true;
+        isDirty = true;
       }
       repaint();
     }

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -100,7 +100,7 @@ class EditPanel extends ActionPanel {
       public void actionPerformed(final ActionEvent event) {
         currentAction = this;
         EditPanel.this.frame.showActionPanelTab();
-        CANCEL_EDIT_ACTION.actionPerformed(null);
+        cancelEditAction.actionPerformed(null);
       }
     };
     addUnitsAction = new AbstractAction("Add Units") {
@@ -158,7 +158,7 @@ class EditPanel extends ActionPanel {
           final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, chooserText,
               JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
           if (option != JOptionPane.OK_OPTION) {
-            CANCEL_EDIT_ACTION.actionPerformed(null);
+            cancelEditAction.actionPerformed(null);
             return;
           }
           bestUnits = chooser.getSelected(true);
@@ -170,7 +170,7 @@ class EditPanel extends ActionPanel {
           JOptionPane.showMessageDialog(getTopLevelAncestor(), result,
               MyFormatter.pluralize("Could not remove unit", selectedUnits.size()), JOptionPane.ERROR_MESSAGE);
         }
-        CANCEL_EDIT_ACTION.actionPerformed(null);
+        cancelEditAction.actionPerformed(null);
       }
     };
     changeTerritoryOwnerAction = new AbstractAction("Change Territory Owner") {
@@ -197,7 +197,7 @@ class EditPanel extends ActionPanel {
         dialog.setVisible(true);
         final PlayerID player = playerChooser.getSelected();
         if (player == null) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         Resource pus = null;
@@ -208,7 +208,7 @@ class EditPanel extends ActionPanel {
           getData().releaseReadLock();
         }
         if (pus == null) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         final int oldTotal = player.getResources().getQuantity(pus);
@@ -218,7 +218,7 @@ class EditPanel extends ActionPanel {
         final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), new JScrollPane(PUsField),
             "Select new number of PUs", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
         if (option != JOptionPane.OK_OPTION) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         try {
@@ -231,7 +231,7 @@ class EditPanel extends ActionPanel {
           JOptionPane.showMessageDialog(getTopLevelAncestor(), result, "Could not perform edit",
               JOptionPane.ERROR_MESSAGE);
         }
-        CANCEL_EDIT_ACTION.actionPerformed(null);
+        cancelEditAction.actionPerformed(null);
       }
     };
     addTechAction = new AbstractAction("Add Technology") {
@@ -247,7 +247,7 @@ class EditPanel extends ActionPanel {
         dialog.setVisible(true);
         final PlayerID player = playerChooser.getSelected();
         if (player == null) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         Vector<TechAdvance> techs = null;
@@ -258,7 +258,7 @@ class EditPanel extends ActionPanel {
           getData().releaseReadLock();
         }
         if (techs == null || techs.isEmpty()) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         final JList<?> techList = new JList<>(techs);
@@ -269,7 +269,7 @@ class EditPanel extends ActionPanel {
         final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), scroll, "Select tech to add",
             JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
         if (option != JOptionPane.OK_OPTION) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         final Set<TechAdvance> advance = new HashSet<>();
@@ -285,7 +285,7 @@ class EditPanel extends ActionPanel {
           JOptionPane.showMessageDialog(getTopLevelAncestor(), result, "Could not perform edit",
               JOptionPane.ERROR_MESSAGE);
         }
-        CANCEL_EDIT_ACTION.actionPerformed(null);
+        cancelEditAction.actionPerformed(null);
       }
     };
     removeTechAction = new AbstractAction("Remove Technology") {
@@ -301,7 +301,7 @@ class EditPanel extends ActionPanel {
         dialog.setVisible(true);
         final PlayerID player = playerChooser.getSelected();
         if (player == null) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         Vector<TechAdvance> techs = null;
@@ -321,7 +321,7 @@ class EditPanel extends ActionPanel {
           getData().releaseReadLock();
         }
         if (techs == null || techs.isEmpty()) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         final JList<?> techList = new JList<>(techs);
@@ -332,7 +332,7 @@ class EditPanel extends ActionPanel {
         final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), scroll, "Select tech to remove",
             JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
         if (option != JOptionPane.OK_OPTION) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         final Set<TechAdvance> advance = new HashSet<>();
@@ -348,7 +348,7 @@ class EditPanel extends ActionPanel {
           JOptionPane.showMessageDialog(getTopLevelAncestor(), result, "Could not perform edit",
               JOptionPane.ERROR_MESSAGE);
         }
-        CANCEL_EDIT_ACTION.actionPerformed(null);
+        cancelEditAction.actionPerformed(null);
       }
     };
     changeUnitHitDamageAction = new AbstractAction("Change Unit Hit Damage") {
@@ -360,13 +360,13 @@ class EditPanel extends ActionPanel {
         setWidgetActivation();
         final List<Unit> units = Match.getMatches(selectedUnits, Matches.UnitHasMoreThanOneHitPointTotal);
         if (units == null || units.isEmpty() || !selectedTerritory.getUnits().getUnits().containsAll(units)) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         // all owned by one player
         units.retainAll(Match.getMatches(units, Matches.unitIsOwnedBy(units.iterator().next().getOwner())));
         if (units.isEmpty()) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         sortUnitsToRemove(units);
@@ -385,7 +385,7 @@ class EditPanel extends ActionPanel {
         final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), scroll, "Change Unit Hit Damage",
             JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
         if (option != JOptionPane.OK_OPTION) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         final IntegerMap<Unit> newDamageMap = unitPanel.getSelected();
@@ -395,7 +395,7 @@ class EditPanel extends ActionPanel {
           JOptionPane.showMessageDialog(getTopLevelAncestor(), result, "Could not perform edit",
               JOptionPane.ERROR_MESSAGE);
         }
-        CANCEL_EDIT_ACTION.actionPerformed(null);
+        cancelEditAction.actionPerformed(null);
       }
     };
     changeUnitBombingDamageAction = new AbstractAction("Change Unit Bombing Damage") {
@@ -407,13 +407,13 @@ class EditPanel extends ActionPanel {
         setWidgetActivation();
         final List<Unit> units = Match.getMatches(selectedUnits, Matches.UnitCanBeDamaged);
         if (units == null || units.isEmpty() || !selectedTerritory.getUnits().getUnits().containsAll(units)) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         // all owned by one player
         units.retainAll(Match.getMatches(units, Matches.unitIsOwnedBy(units.iterator().next().getOwner())));
         if (units.isEmpty()) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         sortUnitsToRemove(units);
@@ -434,7 +434,7 @@ class EditPanel extends ActionPanel {
         final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), scroll, "Change Unit Bombing Damage",
             JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
         if (option != JOptionPane.OK_OPTION) {
-          CANCEL_EDIT_ACTION.actionPerformed(null);
+          cancelEditAction.actionPerformed(null);
           return;
         }
         final IntegerMap<Unit> newDamageMap = unitPanel.getSelected();
@@ -444,7 +444,7 @@ class EditPanel extends ActionPanel {
           JOptionPane.showMessageDialog(getTopLevelAncestor(), result, "Could not perform edit",
               JOptionPane.ERROR_MESSAGE);
         }
-        CANCEL_EDIT_ACTION.actionPerformed(null);
+        cancelEditAction.actionPerformed(null);
       }
     };
     changePoliticalRelationships = new AbstractAction("Change Political Relationships") {
@@ -501,7 +501,7 @@ class EditPanel extends ActionPanel {
             }
           }
         }
-        CANCEL_EDIT_ACTION.actionPerformed(null);
+        cancelEditAction.actionPerformed(null);
       }
     };
     m_actionLabel.setText("Edit Mode Actions");
@@ -613,20 +613,20 @@ class EditPanel extends ActionPanel {
   public void setActive(final boolean active) {
     if (frame.getEditDelegate() == null) {
       // current turn belongs to remote player or AI player
-      getMap().removeMapSelectionListener(MAP_SELECTION_LISTENER);
-      getMap().removeUnitSelectionListener(UNIT_SELECTION_LISTENER);
-      getMap().removeMouseOverUnitListener(MOUSE_OVER_UNIT_LISTENER);
+      getMap().removeMapSelectionListener(mapSelectionListener);
+      getMap().removeUnitSelectionListener(unitSelectionListener);
+      getMap().removeMouseOverUnitListener(mouseOverUnitListener);
       setWidgetActivation();
     } else if (!this.active && active) {
-      getMap().addMapSelectionListener(MAP_SELECTION_LISTENER);
-      getMap().addUnitSelectionListener(UNIT_SELECTION_LISTENER);
-      getMap().addMouseOverUnitListener(MOUSE_OVER_UNIT_LISTENER);
+      getMap().addMapSelectionListener(mapSelectionListener);
+      getMap().addUnitSelectionListener(unitSelectionListener);
+      getMap().addMouseOverUnitListener(mouseOverUnitListener);
       setWidgetActivation();
     } else if (!active && this.active) {
-      getMap().removeMapSelectionListener(MAP_SELECTION_LISTENER);
-      getMap().removeUnitSelectionListener(UNIT_SELECTION_LISTENER);
-      getMap().removeMouseOverUnitListener(MOUSE_OVER_UNIT_LISTENER);
-      CANCEL_EDIT_ACTION.actionPerformed(null);
+      getMap().removeMapSelectionListener(mapSelectionListener);
+      getMap().removeUnitSelectionListener(unitSelectionListener);
+      getMap().removeMouseOverUnitListener(mouseOverUnitListener);
+      cancelEditAction.actionPerformed(null);
     }
     this.active = active;
   }
@@ -636,7 +636,7 @@ class EditPanel extends ActionPanel {
     return active;
   }
 
-  private final UnitSelectionListener UNIT_SELECTION_LISTENER = new UnitSelectionListener() {
+  private final UnitSelectionListener unitSelectionListener = new UnitSelectionListener() {
     @Override
     public void unitsSelected(final List<Unit> units, final Territory t, final MouseDetails md) {
       // check if we can handle this event, are we active?
@@ -660,7 +660,7 @@ class EditPanel extends ActionPanel {
       if (!rightMouse && (currentAction == addUnitsAction)) {
         // clicking on unit or territory selects territory
         selectedTerritory = t;
-        MAP_SELECTION_LISTENER.territorySelected(t, md);
+        mapSelectionListener.territorySelected(t, md);
       } else if (!rightMouse) {
         // delete units
         selectUnitsToRemove(units, t, md);
@@ -693,7 +693,7 @@ class EditPanel extends ActionPanel {
       }
       // nothing left, cancel edit
       if (selectedUnits.isEmpty()) {
-        CANCEL_EDIT_ACTION.actionPerformed(null);
+        cancelEditAction.actionPerformed(null);
       } else {
         getMap().setMouseShadowUnits(selectedUnits);
       }
@@ -724,7 +724,7 @@ class EditPanel extends ActionPanel {
         selectedTerritory = t;
         mouseSelectedPoint = md.getMapPoint();
         mouseCurrentPoint = md.getMapPoint();
-        CANCEL_EDIT_ACTION.setEnabled(true);
+        cancelEditAction.setEnabled(true);
       }
       // select all
       if (md.isShiftDown()) {
@@ -744,7 +744,8 @@ class EditPanel extends ActionPanel {
       getMap().setMouseShadowUnits(selectedUnits);
     }
   };
-  private final MouseOverUnitListener MOUSE_OVER_UNIT_LISTENER = (units, territory, md) -> {
+
+  private final MouseOverUnitListener mouseOverUnitListener = (units, territory, md) -> {
     if (!getActive()) {
       return;
     }
@@ -759,7 +760,8 @@ class EditPanel extends ActionPanel {
       getMap().setUnitHighlight(null);
     }
   };
-  private final MapSelectionListener MAP_SELECTION_LISTENER = new DefaultMapSelectionListener() {
+
+  private final MapSelectionListener mapSelectionListener = new DefaultMapSelectionListener() {
     @Override
     public void territorySelected(final Territory territory, final MouseDetails md) {
       if (territory == null) {
@@ -786,7 +788,7 @@ class EditPanel extends ActionPanel {
                 JOptionPane.ERROR_MESSAGE);
           }
         }
-        SwingUtilities.invokeLater(() -> CANCEL_EDIT_ACTION.actionPerformed(null));
+        SwingUtilities.invokeLater(() -> cancelEditAction.actionPerformed(null));
       } else if (currentAction == addUnitsAction) {
         final boolean allowNeutral = doesPlayerHaveUnitsOnMap(PlayerID.NULL_PLAYERID, getData());
         final PlayerChooser playerChooser =
@@ -814,7 +816,7 @@ class EditPanel extends ActionPanel {
                 JOptionPane.ERROR_MESSAGE);
           }
         }
-        SwingUtilities.invokeLater(() -> CANCEL_EDIT_ACTION.actionPerformed(null));
+        SwingUtilities.invokeLater(() -> cancelEditAction.actionPerformed(null));
       }
     }
 
@@ -842,7 +844,8 @@ class EditPanel extends ActionPanel {
       }
     }
   };
-  private final AbstractAction CANCEL_EDIT_ACTION = new AbstractAction("Cancel") {
+
+  private final AbstractAction cancelEditAction = new AbstractAction("Cancel") {
     private static final long serialVersionUID = 6394987295241603443L;
 
     @Override

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -703,7 +703,7 @@ public class MovePanel extends AbstractMovePanel {
     return chooser.getSelected(false);
   }
 
-  private final UnitSelectionListener UNIT_SELECTION_LISTENER = new UnitSelectionListener() {
+  private final UnitSelectionListener unitSelectionListener = new UnitSelectionListener() {
     @Override
     public void unitsSelected(final List<Unit> units, final Territory t, final MouseDetails me) {
       if (!getListening()) {
@@ -1223,7 +1223,7 @@ public class MovePanel extends AbstractMovePanel {
     return true;
   }
 
-  private final MouseOverUnitListener MOUSE_OVER_UNIT_LISTENER = new MouseOverUnitListener() {
+  private final MouseOverUnitListener mouseOverUnitListener = new MouseOverUnitListener() {
     @Override
     public void mouseEnter(final List<Unit> units, final Territory territory, final MouseDetails me) {
       if (!getListening()) {
@@ -1242,7 +1242,8 @@ public class MovePanel extends AbstractMovePanel {
       }
     }
   };
-  private final MapSelectionListener MAP_SELECTION_LISTENER = new DefaultMapSelectionListener() {
+
+  private final MapSelectionListener mapSelectionListener = new DefaultMapSelectionListener() {
     @Override
     public void territorySelected(final Territory territory, final MouseDetails me) {}
 
@@ -1336,9 +1337,9 @@ public class MovePanel extends AbstractMovePanel {
 
   @Override
   protected final void cleanUpSpecific() {
-    getMap().removeMapSelectionListener(MAP_SELECTION_LISTENER);
-    getMap().removeUnitSelectionListener(UNIT_SELECTION_LISTENER);
-    getMap().removeMouseOverUnitListener(MOUSE_OVER_UNIT_LISTENER);
+    getMap().removeMapSelectionListener(mapSelectionListener);
+    getMap().removeUnitSelectionListener(unitSelectionListener);
+    getMap().removeMouseOverUnitListener(mouseOverUnitListener);
     getMap().setUnitHighlight(null);
     selectedUnits.clear();
     updateRouteAndMouseShadowUnits(null);
@@ -1380,9 +1381,9 @@ public class MovePanel extends AbstractMovePanel {
   protected final void setUpSpecific() {
     setFirstSelectedTerritory(null);
     forced = null;
-    getMap().addMapSelectionListener(MAP_SELECTION_LISTENER);
-    getMap().addUnitSelectionListener(UNIT_SELECTION_LISTENER);
-    getMap().addMouseOverUnitListener(MOUSE_OVER_UNIT_LISTENER);
+    getMap().addMapSelectionListener(mapSelectionListener);
+    getMap().addUnitSelectionListener(unitSelectionListener);
+    getMap().addMouseOverUnitListener(mouseOverUnitListener);
   }
 
   KeyListener getCustomKeyListeners() {

--- a/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -63,11 +63,11 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       removeAll();
       actionLabel.setText(id.getName() + " Pick Territory and Units");
       add(actionLabel);
-      selectTerritoryButton = new JButton(SelectTerritoryAction);
+      selectTerritoryButton = new JButton(selectTerritoryAction);
       add(selectTerritoryButton);
-      selectUnitsButton = new JButton(SelectUnitsAction);
+      selectUnitsButton = new JButton(selectUnitsAction);
       add(selectUnitsButton);
-      doneButton = new JButton(DoneAction);
+      doneButton = new JButton(doneAction);
       add(doneButton);
       SwingUtilities.invokeLater(() -> selectTerritoryButton.requestFocusInWindow());
     });
@@ -89,9 +89,9 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
     }
     SwingUtilities.invokeLater(() -> {
       if (territoryChoices.size() > 1) {
-        SelectTerritoryAction.actionPerformed(null);
+        selectTerritoryAction.actionPerformed(null);
       } else if (unitChoices.size() > 1) {
-        SelectUnitsAction.actionPerformed(null);
+        selectUnitsAction.actionPerformed(null);
       }
     });
     waitForRelease();
@@ -102,23 +102,23 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
     SwingUtilities.invokeLater(() -> {
       if (!getActive()) {
         // current turn belongs to remote player or AI player
-        DoneAction.setEnabled(false);
-        SelectUnitsAction.setEnabled(false);
-        SelectTerritoryAction.setEnabled(false);
+        doneAction.setEnabled(false);
+        selectUnitsAction.setEnabled(false);
+        selectTerritoryAction.setEnabled(false);
       } else {
-        DoneAction.setEnabled(currentAction == null);
-        SelectUnitsAction.setEnabled(currentAction == null);
-        SelectTerritoryAction.setEnabled(currentAction == null);
+        doneAction.setEnabled(currentAction == null);
+        selectUnitsAction.setEnabled(currentAction == null);
+        selectTerritoryAction.setEnabled(currentAction == null);
       }
     });
   }
 
-  private final Action DoneAction = new AbstractAction("Done") {
+  private final Action doneAction = new AbstractAction("Done") {
     private static final long serialVersionUID = -2376988913511268803L;
 
     @Override
     public void actionPerformed(final ActionEvent event) {
-      currentAction = DoneAction;
+      currentAction = doneAction;
       setWidgetActivation();
       if (pickedTerritory == null || !territoryChoices.contains(pickedTerritory)) {
         EventThreadJOptionPane.showMessageDialog(parent, "Must Pick An Unowned Territory",
@@ -173,12 +173,12 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       release();
     }
   };
-  private final Action SelectUnitsAction = new AbstractAction("Select Units") {
+  private final Action selectUnitsAction = new AbstractAction("Select Units") {
     private static final long serialVersionUID = 4745335350716395600L;
 
     @Override
     public void actionPerformed(final ActionEvent event) {
-      currentAction = SelectUnitsAction;
+      currentAction = selectUnitsAction;
       setWidgetActivation();
       final UnitChooser unitChooser = new UnitChooser(unitChoices, Collections.emptyMap(),
           getData(), false, getMap().getUIContext());
@@ -192,23 +192,24 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       setWidgetActivation();
     }
   };
-  private final Action SelectTerritoryAction = new AbstractAction("Select Territory") {
+  private final Action selectTerritoryAction = new AbstractAction("Select Territory") {
     private static final long serialVersionUID = -8003634505955439651L;
 
     @Override
     public void actionPerformed(final ActionEvent event) {
-      currentAction = SelectTerritoryAction;
+      currentAction = selectTerritoryAction;
       setWidgetActivation();
-      getMap().addMapSelectionListener(MAP_SELECTION_LISTENER);
+      getMap().addMapSelectionListener(mapSelectionListener);
     }
   };
-  private final MapSelectionListener MAP_SELECTION_LISTENER = new DefaultMapSelectionListener() {
+
+  private final MapSelectionListener mapSelectionListener = new DefaultMapSelectionListener() {
     @Override
     public void territorySelected(final Territory territory, final MouseDetails md) {
       if (territory == null) {
         return;
       }
-      if (currentAction == SelectTerritoryAction) {
+      if (currentAction == selectTerritoryAction) {
         if (territory == null || !territoryChoices.contains(territory)) {
           EventThreadJOptionPane.showMessageDialog(parent,
               "Must Pick An Unowned Territory (will have a white highlight)", "Must Pick An Unowned Territory",
@@ -217,12 +218,12 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
         }
         pickedTerritory = territory;
         SwingUtilities.invokeLater(() -> {
-          getMap().removeMapSelectionListener(MAP_SELECTION_LISTENER);
+          getMap().removeMapSelectionListener(mapSelectionListener);
           currentAction = null;
           setWidgetActivation();
         });
       } else {
-        System.err.println("Should not be able to select a territory outside of the SelectTerritoryAction.");
+        System.err.println("Should not be able to select a territory outside of the selectTerritoryAction.");
       }
     }
 
@@ -234,7 +235,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       }
       if (territory != null) {
         // highlight territory
-        if (currentAction == SelectTerritoryAction) {
+        if (currentAction == selectTerritoryAction) {
           if (currentHighlightedTerritory != territory) {
             if (currentHighlightedTerritory != null) {
               getMap().clearTerritoryOverlay(currentHighlightedTerritory);

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -72,7 +72,7 @@ public class PlacePanel extends AbstractMovePanel {
     return games.strategy.triplea.Properties.getLHTRCarrierProductionRules(getData());
   }
 
-  private final MapSelectionListener PLACE_MAP_SELECTION_LISTENER = new DefaultMapSelectionListener() {
+  private final MapSelectionListener placeMapSelectionListener = new DefaultMapSelectionListener() {
     @Override
     public void territorySelected(final Territory territory, final MouseDetails e) {
       if (!getActive() || (e.getButton() != MouseEvent.BUTTON1)) {
@@ -182,12 +182,12 @@ public class PlacePanel extends AbstractMovePanel {
 
   @Override
   protected final void cleanUpSpecific() {
-    getMap().removeMapSelectionListener(PLACE_MAP_SELECTION_LISTENER);
+    getMap().removeMapSelectionListener(placeMapSelectionListener);
   }
 
   @Override
   protected final void setUpSpecific() {
-    getMap().addMapSelectionListener(PLACE_MAP_SELECTION_LISTENER);
+    getMap().addMapSelectionListener(placeMapSelectionListener);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -65,10 +65,10 @@ public class PoliticsPanel extends ActionPanel {
       removeAll();
       actionLabel.setText(id.getName() + " Politics");
       add(actionLabel);
-      selectPoliticalActionButton = new JButton(SelectPoliticalActionAction);
+      selectPoliticalActionButton = new JButton(selectPoliticalActionAction);
       selectPoliticalActionButton.setEnabled(false);
       add(selectPoliticalActionButton);
-      doneButton = new JButton(DontBotherAction);
+      doneButton = new JButton(dontBotherAction);
       doneButton.setEnabled(false);
       SwingUtilities.invokeLater(() -> doneButton.requestFocusInWindow());
       add(doneButton);
@@ -99,7 +99,7 @@ public class PoliticsPanel extends ActionPanel {
         selectPoliticalActionButton.setEnabled(true);
         doneButton.setEnabled(true);
         // press the politics button for us.
-        SelectPoliticalActionAction.actionPerformed(null);
+        selectPoliticalActionAction.actionPerformed(null);
       });
     }
     waitForRelease();
@@ -110,7 +110,7 @@ public class PoliticsPanel extends ActionPanel {
    * Fires up a JDialog showing the political landscape and valid actions,
    * choosing an action will release this model and trigger waitForRelease().
    */
-  private final Action SelectPoliticalActionAction = SwingAction.of("Do Politics...", e -> {
+  private final Action selectPoliticalActionAction = SwingAction.of("Do Politics...", e -> {
     final Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
     final int availHeight = screenResolution.height - 96;
     final int availWidth = screenResolution.width - 30;
@@ -192,7 +192,7 @@ public class PoliticsPanel extends ActionPanel {
   /**
    * This will stop the politicsPhase.
    */
-  private final Action DontBotherAction = SwingAction.of("Done", e -> {
+  private final Action dontBotherAction = SwingAction.of("Done", e -> {
     if (!firstRun || youSureDoNothing()) {
       choice = null;
       release();
@@ -233,12 +233,12 @@ public class PoliticsPanel extends ActionPanel {
   }
 
   private static final class PoliticalActionComparator implements Comparator<PoliticalActionAttachment> {
-    private final GameData m_data;
-    private final PlayerID m_player;
+    private final GameData gameData;
+    private final PlayerID player;
 
     PoliticalActionComparator(final PlayerID currentPlayer, final GameData data) {
-      m_data = data;
-      m_player = currentPlayer;
+      gameData = data;
+      player = currentPlayer;
     }
 
     @Override
@@ -249,23 +249,23 @@ public class PoliticsPanel extends ActionPanel {
       final String[] paa1RelationChange = paa1.getRelationshipChange().iterator().next().split(":");
       final String[] paa2RelationChange = paa2.getRelationshipChange().iterator().next().split(":");
       final RelationshipTypeList relationshipTypeList;
-      m_data.acquireReadLock();
+      gameData.acquireReadLock();
       try {
-        relationshipTypeList = m_data.getRelationshipTypeList();
+        relationshipTypeList = gameData.getRelationshipTypeList();
       } finally {
-        m_data.releaseReadLock();
+        gameData.releaseReadLock();
       }
       final RelationshipType paa1NewType = relationshipTypeList.getRelationshipType(paa1RelationChange[2]);
       final RelationshipType paa2NewType = relationshipTypeList.getRelationshipType(paa2RelationChange[2]);
       // sort by player
-      final PlayerID paa1p1 = m_data.getPlayerList().getPlayerID(paa1RelationChange[0]);
-      final PlayerID paa1p2 = m_data.getPlayerList().getPlayerID(paa1RelationChange[1]);
-      final PlayerID paa2p1 = m_data.getPlayerList().getPlayerID(paa2RelationChange[0]);
-      final PlayerID paa2p2 = m_data.getPlayerList().getPlayerID(paa2RelationChange[1]);
-      final PlayerID paa1OtherPlayer = (m_player.equals(paa1p1) ? paa1p2 : paa1p1);
-      final PlayerID paa2OtherPlayer = (m_player.equals(paa2p1) ? paa2p2 : paa2p1);
+      final PlayerID paa1p1 = gameData.getPlayerList().getPlayerID(paa1RelationChange[0]);
+      final PlayerID paa1p2 = gameData.getPlayerList().getPlayerID(paa1RelationChange[1]);
+      final PlayerID paa2p1 = gameData.getPlayerList().getPlayerID(paa2RelationChange[0]);
+      final PlayerID paa2p2 = gameData.getPlayerList().getPlayerID(paa2RelationChange[1]);
+      final PlayerID paa1OtherPlayer = (player.equals(paa1p1) ? paa1p2 : paa1p1);
+      final PlayerID paa2OtherPlayer = (player.equals(paa2p1) ? paa2p2 : paa2p1);
       if (!paa1OtherPlayer.equals(paa2OtherPlayer)) {
-        final int order = new PlayerOrderComparator(m_data).compare(paa1OtherPlayer, paa2OtherPlayer);
+        final int order = new PlayerOrderComparator(gameData).compare(paa1OtherPlayer, paa2OtherPlayer);
         if (order != 0) {
           return order;
         }

--- a/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -181,7 +181,7 @@ public class ProductionRepairPanel extends JPanel {
     }
     add(left, new GridBagConstraints(0, 3, 30, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
         new Insets(8, 8, 0, 12), 0, 0));
-    done = new JButton(done_action);
+    done = new JButton(doneAction);
     add(done, new GridBagConstraints(0, 4, 30, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(0, 0, 8, 0), 0, 0));
   }
@@ -191,7 +191,7 @@ public class ProductionRepairPanel extends JPanel {
     this.left.setText("<html>You have " + left + " left.<br>Out of " + total + "</html>");
   }
 
-  Action done_action = SwingAction.of("Done", e -> dialog.setVisible(false));
+  Action doneAction = SwingAction.of("Done", e -> dialog.setVisible(false));
 
   protected void calculateLimits() {
     // final IntegerMap<Resource> cost;

--- a/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -49,7 +49,7 @@ public class PurchasePanel extends ActionPanel {
     purchasedPreviousRoundsUnits = new SimpleUnitPanel(map.getUIContext());
     purhcasedUnits = new SimpleUnitPanel(map.getUIContext());
     buyButton = new JButton(BUY);
-    buyButton.addActionListener(PURCHASE_ACTION);
+    buyButton.addActionListener(purchaseAction);
     purchasedPreviousRoundsLabel = new JLabel("Unplaced from previous rounds");
   }
 
@@ -65,7 +65,7 @@ public class PurchasePanel extends ActionPanel {
       buyButton.setText(BUY);
       add(buyButton);
 
-      add(new JButton(DoneAction));
+      add(new JButton(doneAction));
 
       add(Box.createVerticalStrut(9));
 
@@ -90,7 +90,7 @@ public class PurchasePanel extends ActionPanel {
         getData().releaseReadLock();
       }
       add(Box.createVerticalGlue());
-      SwingUtilities.invokeLater(REFRESH);
+      SwingUtilities.invokeLater(refresh);
     });
   }
 
@@ -103,12 +103,12 @@ public class PurchasePanel extends ActionPanel {
     this.bid = bid;
     refreshActionLabelText();
     // automatically "click" the buy button for us!
-    SwingUtilities.invokeLater(() -> PURCHASE_ACTION.actionPerformed(null));
+    SwingUtilities.invokeLater(() -> purchaseAction.actionPerformed(null));
     waitForRelease();
     return purchase;
   }
 
-  private final AbstractAction PURCHASE_ACTION = new AbstractAction("Buy") {
+  private final AbstractAction purchaseAction = new AbstractAction("Buy") {
     private static final long serialVersionUID = -2931438906267249990L;
 
     @Override
@@ -143,7 +143,7 @@ public class PurchasePanel extends ActionPanel {
     return totalUnits;
   }
 
-  private final Action DoneAction = new AbstractAction("Done") {
+  private final Action doneAction = new AbstractAction("Done") {
     private static final long serialVersionUID = -209781523508962628L;
 
     @Override

--- a/src/main/java/games/strategy/triplea/ui/RepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/RepairPanel.java
@@ -38,7 +38,7 @@ public class RepairPanel extends ActionPanel {
     super(data, map);
     unitsPanel = new SimpleUnitPanel(map.getUIContext());
     buyButton = new JButton(BUY);
-    buyButton.addActionListener(PURCHASE_ACTION);
+    buyButton.addActionListener(purchaseAction);
   }
 
   @Override
@@ -51,7 +51,7 @@ public class RepairPanel extends ActionPanel {
       buyButton.setText(BUY);
       add(actionLabel);
       add(buyButton);
-      add(new JButton(DoneAction));
+      add(new JButton(doneAction));
       repairdSoFar.setText("");
       add(Box.createVerticalStrut(9));
       add(repairdSoFar);
@@ -59,7 +59,7 @@ public class RepairPanel extends ActionPanel {
       unitsPanel.setUnitsFromRepairRuleMap(new HashMap<>(), id, getData());
       add(unitsPanel);
       add(Box.createVerticalGlue());
-      SwingUtilities.invokeLater(REFRESH);
+      SwingUtilities.invokeLater(refresh);
     });
   }
 
@@ -74,12 +74,12 @@ public class RepairPanel extends ActionPanel {
     this.allowedPlayersToRepair = allowedPlayersToRepair;
     refreshActionLabelText();
     // automatically "click" the buy button for us!
-    SwingUtilities.invokeLater(() -> PURCHASE_ACTION.actionPerformed(null));
+    SwingUtilities.invokeLater(() -> purchaseAction.actionPerformed(null));
     waitForRelease();
     return repair;
   }
 
-  private final AbstractAction PURCHASE_ACTION = new AbstractAction("Buy") {
+  private final AbstractAction purchaseAction = new AbstractAction("Buy") {
     private static final long serialVersionUID = 5572043262815077402L;
 
     @Override
@@ -112,7 +112,7 @@ public class RepairPanel extends ActionPanel {
     return totalValues;
   }
 
-  private final Action DoneAction = new AbstractAction("Done") {
+  private final Action doneAction = new AbstractAction("Done") {
     private static final long serialVersionUID = -2002286381161651398L;
 
     @Override

--- a/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -59,10 +59,10 @@ public class TechPanel extends ActionPanel {
       add(actionLabel);
       if (isWW2V3TechModel()) {
         add(new JButton(getTechTokenAction));
-        add(new JButton(JustRollTech));
+        add(new JButton(justRollTech));
       } else {
         add(new JButton(getTechRollsAction));
-        add(new JButton(DontBother));
+        add(new JButton(dontBother));
       }
     });
   }
@@ -144,10 +144,12 @@ public class TechPanel extends ActionPanel {
     }
     release();
   });
-  private final Action DontBother = SwingAction.of("Done", e -> {
+
+  private final Action dontBother = SwingAction.of("Done", e -> {
     techRoll = null;
     release();
   });
+
   private final Action getTechTokenAction = SwingAction.of("Buy Tech Tokens...", e -> {
     final PlayerID currentPlayer = getCurrentPlayer();
     currTokens = currentPlayer.getResources().getQuantity(Constants.TECH_TOKENS);
@@ -206,7 +208,8 @@ public class TechPanel extends ActionPanel {
 
 
   });
-  private final Action JustRollTech = SwingAction.of("Done/Roll Current Tokens", e -> {
+
+  private final Action justRollTech = SwingAction.of("Done/Roll Current Tokens", e -> {
     currTokens = getCurrentPlayer().getResources().getQuantity(Constants.TECH_TOKENS);
     // If this player has tokens, roll them.
     if (currTokens > 0) {

--- a/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -67,10 +67,10 @@ public class UserActionPanel extends ActionPanel {
       removeAll();
       actionLabel.setText(id.getName() + " Actions and Operations");
       add(actionLabel);
-      selectUserActionButton = new JButton(SelectUserActionAction);
+      selectUserActionButton = new JButton(selectUserActionAction);
       selectUserActionButton.setEnabled(false);
       add(selectUserActionButton);
-      doneButton = new JButton(DontBotherAction);
+      doneButton = new JButton(dontBotherAction);
       doneButton.setEnabled(false);
       SwingUtilities.invokeLater(() -> doneButton.requestFocusInWindow());
       add(doneButton);
@@ -99,7 +99,7 @@ public class UserActionPanel extends ActionPanel {
         selectUserActionButton.setEnabled(true);
         doneButton.setEnabled(true);
         // press the user action button for us.
-        SelectUserActionAction.actionPerformed(null);
+        selectUserActionAction.actionPerformed(null);
       });
     }
     waitForRelease();
@@ -110,7 +110,7 @@ public class UserActionPanel extends ActionPanel {
    * Fires up a JDialog showing valid actions,
    * choosing an action will release this model and trigger waitForRelease().
    */
-  private final Action SelectUserActionAction = new AbstractAction("Take Action...") {
+  private final Action selectUserActionAction = new AbstractAction("Take Action...") {
     private static final long serialVersionUID = 2389485901611958851L;
 
     @Override
@@ -215,7 +215,7 @@ public class UserActionPanel extends ActionPanel {
   /**
    * This will stop the user action Phase.
    */
-  private final Action DontBotherAction = new AbstractAction("Done") {
+  private final Action dontBotherAction = new AbstractAction("Done") {
     private static final long serialVersionUID = 2835948679299520899L;
 
     @Override


### PR DESCRIPTION
This is one part of multiple PRs to fix violations of the Checkstyle MemberName rule in `*Panel` classes within the `g.s.triplea.ui` package.

All member renames were done via automatic refactoring.  The only manual changes in this PR are the insertion of a few additional newlines around affected members where they were a bit cramped with their neighbors.