### PR TITLE
Remove icons from installation directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,10 +183,6 @@ task allPlatform(type: Zip, group: 'release', dependsOn: [renameShadowJar, updat
             into(folder)
         }
     }
-    from("${assetsDirectory}/icons") {
-        into('icons')
-        exclude("icon.icns")
-    }
     from(gameEnginePropertiesArtifactFile)
     from(renameShadowJar.output) {
         into('bin')

--- a/build.install4j
+++ b/build.install4j
@@ -22,7 +22,6 @@
       <mountPoint id="28" root="" location="assets" mode="755" />
       <mountPoint id="23" root="" location="bin" mode="755" />
       <mountPoint id="27" root="" location="dice_servers" mode="755" />
-      <mountPoint id="26" root="" location="icons" mode="755" />
       <mountPoint id="25" root="" location="old" mode="755" />
       <mountPoint id="22" root="" location="" mode="755" />
     </mountPoints>
@@ -32,9 +31,6 @@
       </dirEntry>
       <fileEntry mountPoint="23" file="build/libs/all/triplea.jar" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" />
       <dirEntry mountPoint="27" file="dice_servers" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="dice_servers" excludeSuffixes="" dirMode="755" overrideDirMode="false">
-        <exclude />
-      </dirEntry>
-      <dirEntry mountPoint="26" file="./build/assets/icons" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="icons" excludeSuffixes="" dirMode="755" overrideDirMode="false">
         <exclude />
       </dirEntry>
       <dirEntry mountPoint="25" file="old" overwriteMode="4" shared="false" fileMode="644" uninstallMode="0" overrideFileMode="false" overrideOverwriteMode="false" overrideUninstallMode="false" entryMode="direct" subDirectory="old" excludeSuffixes="" dirMode="755" overrideDirMode="false">
@@ -856,9 +852,7 @@ return true;</string>
       <excludedLaunchers />
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
-      <exclude>
-        <entry location="build/assets/icons/icon.icns" fileType="regular" />
-      </exclude>
+      <exclude />
       <variables />
       <autoUpdate useMinUpdatableVersion="false" minUpdatableVersion="" useMaxUpdatableVersion="false" maxUpdatableVersion="">
         <commentFiles />
@@ -871,9 +865,7 @@ return true;</string>
       <excludedLaunchers />
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
-      <exclude>
-        <entry location="build/assets/icons/icon.icns" fileType="regular" />
-      </exclude>
+      <exclude />
       <variables />
       <autoUpdate useMinUpdatableVersion="false" minUpdatableVersion="" useMaxUpdatableVersion="false" maxUpdatableVersion="">
         <commentFiles />
@@ -899,9 +891,7 @@ return true;</string>
       <excludedLaunchers />
       <excludedBeans />
       <overriddenPrincipalLanguage id="en" customLocalizationFile="" />
-      <exclude>
-        <entry location="build/assets/icons/icon.icns" fileType="regular" />
-      </exclude>
+      <exclude />
       <variables />
       <autoUpdate useMinUpdatableVersion="false" minUpdatableVersion="" useMaxUpdatableVersion="false" maxUpdatableVersion="">
         <commentFiles />


### PR DESCRIPTION
The icons from the assets repo are only used at build-time to create the installer.  They are not required in the end-user's installation directory.  This PR modifies the installer to no longer include the `icons/` folder in the installation directory.  It is also not required to include this folder in the `all_platforms` zip archive.  (The icons used by the game at runtime come from the classpath, specifically those in `src/main/resources`.)

The only issue I was uncertain about was the use of the macOS ICNS file (`icon.icns`).  I looked through the history of `build.install4j` and cannot find any commit in which the `icnsFile` or `customIcnsFile` attributes were ever set to anything other than an empty string.  The `customIcnsFile` attribute is populated on the following screen, from which you can see it is not specified:

![install4j-icons](https://user-images.githubusercontent.com/4826349/27988365-3868e7b4-63ee-11e7-9138-2e1daeee405b.png)

Unless there's some magic on macOS that allows it to "discover" the ICNS file in the `<installDir>/icons` folder, I don't see how it was ever used.  However, as I'm unable to test the Mac installer, I can modify the install script to keep this one file on macOS if that change is deemed too risky.