### PR TITLE
Fix undesirable UI artifacts when displaying instances of WaitDialog

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -42,6 +42,7 @@ import games.strategy.engine.framework.startup.ui.ServerSetupPanel;
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.engine.framework.systemcheck.LocalSystemChecker;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
+import games.strategy.engine.framework.ui.background.WaitDialog;
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.net.Messengers;
 import games.strategy.triplea.settings.SystemPreferenceKey;
@@ -195,6 +196,10 @@ public class GameRunner {
 
   public static ProgressWindow newProgressWindow(final String title) {
     return new ProgressWindow(mainFrame, title);
+  }
+
+  public static WaitDialog newWaitDialog(final String message) {
+    return new WaitDialog(mainFrame, message);
   }
 
   /**

--- a/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -11,6 +11,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 
 import games.strategy.debug.ClientLogger;
+import games.strategy.engine.framework.GameRunner;
 
 /**
  * Provides methods for running tasks in the background to avoid blocking the UI.
@@ -45,7 +46,7 @@ public final class BackgroundTaskRunner {
     checkNotNull(backgroundAction);
     checkNotNull(completionAction);
 
-    final WaitDialog waitDialog = new WaitDialog(null, message);
+    final WaitDialog waitDialog = GameRunner.newWaitDialog(message);
     final SwingWorker<T, Void> worker = new SwingWorker<T, Void>() {
       @Override
       protected T doInBackground() {
@@ -68,8 +69,6 @@ public final class BackgroundTaskRunner {
     };
     worker.execute();
 
-    waitDialog.setLocationRelativeTo(null);
-    waitDialog.pack();
     waitDialog.setVisible(true);
   }
 }

--- a/src/main/java/games/strategy/engine/framework/ui/background/WaitDialog.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/WaitDialog.java
@@ -8,7 +8,11 @@ import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 
-public class WaitDialog extends JDialog {
+/**
+ * A dialog that can be displayed during a long-running operation that optionally provides the user with the ability to
+ * cancel the operation.
+ */
+public final class WaitDialog extends JDialog {
   private static final long serialVersionUID = 7433959812027467868L;
 
   public WaitDialog(final Component parent, final String waitMessage) {
@@ -25,5 +29,8 @@ public class WaitDialog extends JDialog {
       cancelButton.addActionListener(cancelAction);
       getContentPane().add(cancelButton, BorderLayout.SOUTH);
     }
+
+    pack();
+    setLocationRelativeTo(parent);
   }
 }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -363,8 +363,6 @@ class OddsCalculatorPanel extends JPanel {
         });
     final AtomicReference<Collection<Unit>> defenders = new AtomicReference<>();
     final AtomicReference<Collection<Unit>> attackers = new AtomicReference<>();
-    dialog.pack();
-    dialog.setLocationRelativeTo(this);
     final Thread calcThread = new Thread(() -> {
       try {
         // find a territory to fight in


### PR DESCRIPTION
This PR fixes several undesirable UI artifacts that occur when displaying instances of `WaitDialog`.

#### Functional changes

* The item that appears in the system tray when an instance of `WaitDialog` is displayed has been removed.
* The application icon in the system menu bar (Linux and presumably OSX) is no longer changed when a `WaitDialog` has focus.
* Instances of `WaitDialog` are now centered relative to their parent rather than the screen.

##### Before
![wait-dialog-before](https://user-images.githubusercontent.com/4826349/27988717-201c97e2-63f7-11e7-9d51-69aca5a4f059.png)

##### After
![wait-dialog-after](https://user-images.githubusercontent.com/4826349/27988732-8be22d7a-63f7-11e7-8ed2-ba93fe048050.png)

#### Functional issues for review
None.

#### Refactoring changes
* The new `GameRunner#newWaitDialog()` method was extracted to provide access to the main frame window when there's a need to create an instance of `WaitDialog` and a parent component is not available.  This is probably not the best solution, but it builds on the pattern of the recently-added `GameRunner` `newProgressWindow()` and `newFileDialog()` methods.

#### Refactoring issues for review
None.