### PR TITLE
Increase icon size on installer interior pages

### DIFF
--- a/build.install4j
+++ b/build.install4j
@@ -98,7 +98,7 @@
             <object class="com.install4j.runtime.beans.applications.InstallerApplication" id="InstallerApplication0">
               <void property="customHeaderImage">
                 <object class="com.install4j.api.beans.ExternalFile">
-                  <string>./build/assets/icons/triplea_icon_16_16.png</string>
+                  <string>./build/assets/icons/triplea_icon_48_48.png</string>
                 </object>
               </void>
               <void property="customIconImageFiles">


### PR DESCRIPTION
#### Before
![installer-icon-before](https://user-images.githubusercontent.com/4826349/27989038-b3b7f0a8-63fe-11e7-8069-662dc667116a.png)

#### After
![installer-icon-after-48](https://user-images.githubusercontent.com/4826349/27989039-b8bb31e6-63fe-11e7-9bce-221519d0f83e.png)

The above version uses the 48x48 icon.  However, install4j recommends an icon size of 60x60, so I also tried the 64x64 icon.  I ultimately thought the 48x48 version looked better because it preserved the original height of the banner title area, but here's the 64x64 version in case anyone disagrees and wants me to use it instead:

![installer-icon-after-64](https://user-images.githubusercontent.com/4826349/27989051-f6340930-63fe-11e7-9314-c5a7ce0895c7.png)