### PR TITLE
Checkstyle: Fix member name violations in g.s.triplea.ui.*Panel classes (part 2)

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -154,38 +154,38 @@ public class ExtendedStats extends StatPanel {
   }
 
   class GenericResourceStat extends AbstractStat {
-    private String m_name = null;
+    private String name = null;
 
     public void init(final String name) {
-      m_name = name;
+      this.name = name;
     }
 
     @Override
     public String getName() {
-      return "Resource: " + m_name;
+      return "Resource: " + name;
     }
 
     @Override
     public double getValue(final PlayerID player, final GameData data) {
-      return player.getResources().getQuantity(m_name);
+      return player.getResources().getQuantity(name);
     }
   }
 
   class GenericTechNameStat extends AbstractStat {
-    private TechAdvance m_ta = null;
+    private TechAdvance ta = null;
 
     public void init(final TechAdvance ta) {
-      m_ta = ta;
+      this.ta = ta;
     }
 
     @Override
     public String getName() {
-      return "TechAdvance: " + m_ta.getName();
+      return "TechAdvance: " + ta.getName();
     }
 
     @Override
     public double getValue(final PlayerID player, final GameData data) {
-      if (m_ta.hasTech(TechAttachment.get(player))) {
+      if (ta.hasTech(TechAttachment.get(player))) {
         return 1;
       }
       return 0;
@@ -193,21 +193,21 @@ public class ExtendedStats extends StatPanel {
   }
 
   class GenericUnitNameStat extends AbstractStat {
-    private UnitType m_ut = null;
+    private UnitType ut = null;
 
     public void init(final UnitType ut) {
-      m_ut = ut;
+      this.ut = ut;
     }
 
     @Override
     public String getName() {
-      return "UnitType: " + m_ut.getName();
+      return "UnitType: " + ut.getName();
     }
 
     @Override
     public double getValue(final PlayerID player, final GameData data) {
       int matchCount = 0;
-      final Match<Unit> ownedBy = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(m_ut));
+      final Match<Unit> ownedBy = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitIsOfType(ut));
       for (final Territory place : data.getMap().getTerritories()) {
         matchCount += place.getUnits().countMatches(ownedBy);
       }

--- a/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -73,7 +73,7 @@ public class MapPanel extends ImageScrollerLargeView {
   private final List<MapSelectionListener> mapSelectionListeners = new ArrayList<>();
   private final List<UnitSelectionListener> unitSelectionListeners = new ArrayList<>();
   private final List<MouseOverUnitListener> mouseOverUnitsListeners = new ArrayList<>();
-  private GameData m_data;
+  private GameData gameData;
   // the territory that the mouse is
   private Territory currentTerritory;
   // currently over
@@ -155,7 +155,7 @@ public class MapPanel extends ImageScrollerLargeView {
           return;
         }
         if (!unitSelectionListeners.isEmpty()) {
-          Tuple<Territory, List<Unit>> tuple = tileManager.getUnitsAtPoint(x, y, m_data);
+          Tuple<Territory, List<Unit>> tuple = tileManager.getUnitsAtPoint(x, y, gameData);
           if (tuple == null) {
             tuple = Tuple.of(getTerritory(x, y), new ArrayList<Unit>(0));
           }
@@ -205,7 +205,7 @@ public class MapPanel extends ImageScrollerLargeView {
           notifyMouseEntered(terr);
         }
         notifyMouseMoved(terr, md);
-        final Tuple<Territory, List<Unit>> tuple = tileManager.getUnitsAtPoint(x, y, m_data);
+        final Tuple<Territory, List<Unit>> tuple = tileManager.getUnitsAtPoint(x, y, gameData);
         if (unitsChanged(tuple)) {
           currentUnits = tuple;
           if (tuple == null) {
@@ -237,14 +237,14 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   GameData getData() {
-    return m_data;
+    return gameData;
   }
 
   // Beagle Code used to chnage map skin
   void changeImage(final Dimension newDimensions) {
     model.setMaxBounds((int) newDimensions.getWidth(), (int) newDimensions.getHeight());
-    tileManager.createTiles(new Rectangle(newDimensions), m_data, uiContext.getMapData());
-    tileManager.resetTiles(m_data, uiContext.getMapData());
+    tileManager.createTiles(new Rectangle(newDimensions), gameData, uiContext.getMapData());
+    tileManager.resetTiles(gameData, uiContext.getMapData());
   }
 
   @Override
@@ -367,7 +367,7 @@ public class MapPanel extends ImageScrollerLargeView {
     if (name == null) {
       return null;
     }
-    return m_data.getMap().getTerritory(name);
+    return gameData.getMap().getTerritory(name);
   }
 
   private double normalizeX(double x) {
@@ -397,7 +397,7 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   public void resetMap() {
-    tileManager.resetTiles(m_data, uiContext.getMapData());
+    tileManager.resetTiles(gameData, uiContext.getMapData());
     SwingUtilities.invokeLater(this::repaint);
     initSmallMap();
   }
@@ -419,8 +419,8 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   public void updateCountries(final Collection<Territory> countries) {
-    tileManager.updateTerritories(countries, m_data, uiContext.getMapData());
-    smallMapImageManager.update(m_data, uiContext.getMapData());
+    tileManager.updateTerritories(countries, gameData, uiContext.getMapData());
+    smallMapImageManager.update(gameData, uiContext.getMapData());
     SwingUtilities.invokeLater(() -> {
       smallView.repaint();
       repaint();
@@ -429,15 +429,15 @@ public class MapPanel extends ImageScrollerLargeView {
 
   void setGameData(final GameData data) {
     // clean up any old listeners
-    if (m_data != null) {
-      m_data.removeTerritoryListener(territoryListener);
-      m_data.removeDataChangeListener(techUpdateListener);
+    if (gameData != null) {
+      gameData.removeTerritoryListener(territoryListener);
+      gameData.removeDataChangeListener(techUpdateListener);
     }
-    m_data = data;
-    m_data.addTerritoryListener(territoryListener);
-    m_data.addDataChangeListener(techUpdateListener);
+    gameData = data;
+    gameData.addTerritoryListener(territoryListener);
+    gameData.addDataChangeListener(techUpdateListener);
     clearUndrawn();
-    tileManager.resetTiles(m_data, uiContext.getMapData());
+    tileManager.resetTiles(gameData, uiContext.getMapData());
   }
 
   private final TerritoryListener territoryListener = new TerritoryListener() {
@@ -449,7 +449,7 @@ public class MapPanel extends ImageScrollerLargeView {
 
     @Override
     public void ownerChanged(final Territory territory) {
-      smallMapImageManager.updateTerritoryOwner(territory, m_data, uiContext.getMapData());
+      smallMapImageManager.updateTerritoryOwner(territory, gameData, uiContext.getMapData());
       updateCountries(Collections.singleton(territory));
       SwingUtilities.invokeLater(() -> repaint());
     }
@@ -469,7 +469,7 @@ public class MapPanel extends ImageScrollerLargeView {
       if (playersWithTechChange.isEmpty()) {
         return;
       }
-      tileManager.resetTiles(m_data, uiContext.getMapData());
+      tileManager.resetTiles(gameData, uiContext.getMapData());
       SwingUtilities.invokeLater(() -> repaint());
     }
 
@@ -507,7 +507,7 @@ public class MapPanel extends ImageScrollerLargeView {
   public void drawMapImage(final Graphics g) {
     final Graphics2D g2d = (Graphics2D) checkNotNull(g);
     // make sure we use the same data for the entire print
-    final GameData gameData = m_data;
+    final GameData gameData = this.gameData;
     gameData.acquireReadLock();
     try {
       final Rectangle2D.Double bounds = new Rectangle2D.Double(0, 0, getImageWidth(), getImageHeight());
@@ -541,7 +541,7 @@ public class MapPanel extends ImageScrollerLargeView {
     final List<Tile> undrawnTiles = new ArrayList<>();
     final Stopwatch stopWatch = new Stopwatch(logger, Level.FINER, "Paint");
     // make sure we use the same data for the entire paint
-    final GameData data = m_data;
+    final GameData data = gameData;
     // if the map fits on screen, dont draw any overlap
     final boolean fitAxisX = !mapWidthFitsOnScreen() && uiContext.getMapData().scrollWrapX();
     final boolean fitAxisY = !mapHeightFitsOnScreen() && uiContext.getMapData().scrollWrapY();
@@ -595,13 +595,13 @@ public class MapPanel extends ImageScrollerLargeView {
           if (territoryUnitsOfSameCategory.isEmpty()) {
             continue;
           }
-          final Rectangle r = tileManager.getUnitRect(territoryUnitsOfSameCategory, m_data);
+          final Rectangle r = tileManager.getUnitRect(territoryUnitsOfSameCategory, gameData);
           if (r == null) {
             continue;
           }
 
           final Optional<Image> image = uiContext.getUnitImageFactory().getHighlightImage(category.getType(),
-              category.getOwner(), m_data, category.hasDamageOrBombingUnitDamage(), category.getDisabled());
+              category.getOwner(), gameData, category.hasDamageOrBombingUnitDamage(), category.getDisabled());
           if (image.isPresent()) {
             final AffineTransform t = new AffineTransform();
             t.translate(normalizeX(r.getX() - getXOffset()) * scale, normalizeY(r.getY() - getYOffset()) * scale);
@@ -698,7 +698,7 @@ public class MapPanel extends ImageScrollerLargeView {
   Image getTerritoryImage(final Territory territory) {
     getData().acquireReadLock();
     try {
-      return tileManager.createTerritoryImage(territory, m_data, uiContext.getMapData());
+      return tileManager.createTerritoryImage(territory, gameData, uiContext.getMapData());
     } finally {
       getData().releaseReadLock();
     }
@@ -707,7 +707,7 @@ public class MapPanel extends ImageScrollerLargeView {
   Image getTerritoryImage(final Territory territory, final Territory focusOn) {
     getData().acquireReadLock();
     try {
-      return tileManager.createTerritoryImage(territory, focusOn, m_data, uiContext.getMapData());
+      return tileManager.createTerritoryImage(territory, focusOn, gameData, uiContext.getMapData());
     } finally {
       getData().releaseReadLock();
     }
@@ -740,10 +740,10 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   void initSmallMap() {
-    for (final Territory territory : m_data.getMap().getTerritories()) {
-      smallMapImageManager.updateTerritoryOwner(territory, m_data, uiContext.getMapData());
+    for (final Territory territory : gameData.getMap().getTerritories()) {
+      smallMapImageManager.updateTerritoryOwner(territory, gameData, uiContext.getMapData());
     }
-    smallMapImageManager.update(m_data, uiContext.getMapData());
+    smallMapImageManager.update(gameData, uiContext.getMapData());
   }
 
   void changeSmallMapOffscreenMap() {
@@ -780,7 +780,7 @@ public class MapPanel extends ImageScrollerLargeView {
         final UnitsDrawer drawer = new UnitsDrawer(category.getUnits().size(), category.getType().getName(),
             category.getOwner().getName(), place, category.getDamaged(), category.getBombingDamage(),
             category.getDisabled(), false, "", uiContext);
-        drawer.draw(bounds, m_data, g, uiContext.getMapData(), null, null);
+        drawer.draw(bounds, gameData, g, uiContext.getMapData(), null, null);
         i++;
       }
     } finally {
@@ -792,15 +792,15 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   void setTerritoryOverlay(final Territory territory, final Color color, final int alpha) {
-    tileManager.setTerritoryOverlay(territory, color, alpha, m_data, uiContext.getMapData());
+    tileManager.setTerritoryOverlay(territory, color, alpha, gameData, uiContext.getMapData());
   }
 
   void setTerritoryOverlayForBorder(final Territory territory, final Color color) {
-    tileManager.setTerritoryOverlayForBorder(territory, color, m_data, uiContext.getMapData());
+    tileManager.setTerritoryOverlayForBorder(territory, color, gameData, uiContext.getMapData());
   }
 
   void clearTerritoryOverlay(final Territory territory) {
-    tileManager.clearTerritoryOverlay(territory, m_data, uiContext.getMapData());
+    tileManager.clearTerritoryOverlay(territory, gameData, uiContext.getMapData());
   }
 
   public IUIContext getUIContext() {

--- a/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -163,7 +163,7 @@ public class ProductionPanel extends JPanel {
     // final int startY = m_rules.size() / rows;
     this.add(left, new GridBagConstraints(0, 2, 30, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
         new Insets(8, 8, 0, 12), 0, 0));
-    done = new JButton(done_action);
+    done = new JButton(doneAction);
     this.add(done, new GridBagConstraints(0, 3, 30, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(0, 0, 8, 0), 0, 0));
     this.setMaximumSize(new Dimension(availWidth, availHeight));
@@ -176,7 +176,7 @@ public class ProductionPanel extends JPanel {
         totalUnits, ResourceCollectionUtils.getProductionResources(left)));
   }
 
-  Action done_action = SwingAction.of("Done", e -> dialog.setVisible(false));
+  Action doneAction = SwingAction.of("Done", e -> dialog.setVisible(false));
 
   // This method can be overridden by subclasses
   protected void calculateLimits() {
@@ -219,23 +219,23 @@ public class ProductionPanel extends JPanel {
   }
 
   class Rule {
-    private final IntegerMap<Resource> m_cost;
-    private int m_quantity;
-    private final ProductionRule m_rule;
+    private final IntegerMap<Resource> cost;
+    private int quantity;
+    private final ProductionRule rule;
     private final PlayerID id;
-    private final Set<ScrollableTextField> m_textFields = new HashSet<>();
+    private final Set<ScrollableTextField> textFields = new HashSet<>();
 
     protected JPanel getPanelComponent() {
       final JPanel panel = new JPanel();
       final ScrollableTextField i_text = new ScrollableTextField(0, Integer.MAX_VALUE);
-      i_text.setValue(m_quantity);
+      i_text.setValue(quantity);
       panel.setLayout(new GridBagLayout());
       final JLabel info = new JLabel("  ");
       final JLabel name = new JLabel("  ");
       final Color defaultForegroundLabelColor = name.getForeground();
       Optional<ImageIcon> icon = Optional.empty();
       final StringBuilder tooltip = new StringBuilder();
-      final Set<NamedAttachable> results = new HashSet<>(m_rule.getResults().keySet());
+      final Set<NamedAttachable> results = new HashSet<>(rule.getResults().keySet());
       final Iterator<NamedAttachable> iter = results.iterator();
       while (iter.hasNext()) {
         final NamedAttachable resourceOrUnit = iter.next();
@@ -268,13 +268,13 @@ public class ProductionPanel extends JPanel {
           tooltip.append("<br /><br /><br /><br />");
         }
       }
-      final int numberOfUnitsGiven = m_rule.getResults().totalValues();
+      final int numberOfUnitsGiven = rule.getResults().totalValues();
       String text;
       if (numberOfUnitsGiven > 1) {
-        text = "<html> x " + ResourceCollection.toStringForHTML(m_cost, data) + "<br>" + "for " + numberOfUnitsGiven
+        text = "<html> x " + ResourceCollection.toStringForHTML(cost, data) + "<br>" + "for " + numberOfUnitsGiven
             + "<br>" + " units</html>";
       } else {
-        text = "<html> x " + ResourceCollection.toStringForHTML(m_cost, data) + "</html>";
+        text = "<html> x " + ResourceCollection.toStringForHTML(cost, data) + "</html>";
       }
       final JLabel label =
           icon.isPresent() ? new JLabel(text, icon.get(), SwingConstants.LEFT) : new JLabel(text, SwingConstants.LEFT);
@@ -291,29 +291,29 @@ public class ProductionPanel extends JPanel {
           new Insets(5, space, space, space), 0, 0));
       panel.add(i_text, new GridBagConstraints(0, 3, 1, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.NONE,
           new Insets(10, space, space, space), 0, 0));
-      i_text.addChangeListener(m_listener);
-      m_textFields.add(i_text);
+      i_text.addChangeListener(listener);
+      textFields.add(i_text);
       panel.setBorder(new EtchedBorder());
       return panel;
     }
 
     Rule(final ProductionRule rule, final PlayerID id) {
-      m_rule = rule;
-      m_cost = rule.getCosts();
+      this.rule = rule;
+      cost = rule.getCosts();
       this.id = id;
     }
 
     IntegerMap<Resource> getCost() {
-      return m_cost;
+      return cost;
     }
 
     int getQuantity() {
-      return m_quantity;
+      return quantity;
     }
 
     void setQuantity(final int quantity) {
-      m_quantity = quantity;
-      for (final ScrollableTextField textField : m_textFields) {
+      this.quantity = quantity;
+      for (final ScrollableTextField textField : textFields) {
         if (textField.getValue() != quantity) {
           textField.setValue(quantity);
         }
@@ -321,24 +321,24 @@ public class ProductionPanel extends JPanel {
     }
 
     ProductionRule getProductionRule() {
-      return m_rule;
+      return rule;
     }
 
     void setMax(final int max) {
-      for (final ScrollableTextField textField : m_textFields) {
+      for (final ScrollableTextField textField : textFields) {
         textField.setMax(max);
       }
     }
 
-    private final ScrollableTextFieldListener m_listener = new ScrollableTextFieldListener() {
+    private final ScrollableTextFieldListener listener = new ScrollableTextFieldListener() {
       @Override
       public void changedValue(final ScrollableTextField stf) {
-        if (stf.getValue() != m_quantity) {
-          m_quantity = stf.getValue();
+        if (stf.getValue() != quantity) {
+          quantity = stf.getValue();
           calculateLimits();
-          for (final ScrollableTextField textField : m_textFields) {
+          for (final ScrollableTextField textField : textFields) {
             if (!stf.equals(textField)) {
-              textField.setValue(m_quantity);
+              textField.setValue(quantity);
             }
           }
         }

--- a/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -66,7 +66,7 @@ public class TabbedProductionPanel extends ProductionPanel {
     }
     add(left, new GridBagConstraints(0, 2, 1, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
         new Insets(8, 8, 0, 12), 0, 0));
-    done = new JButton(done_action);
+    done = new JButton(doneAction);
     add(done, new GridBagConstraints(0, 3, 1, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(0, 0, 8, 0), 0, 0));
     tabs.validate();

--- a/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -100,14 +100,14 @@ public class UnitChooser extends JPanel {
    */
   public void setMax(final int max) {
     total = max;
-    m_textFieldListener.changedValue(null);
+    textFieldListener.changedValue(null);
     autoSelectButton.setVisible(false);
     selectNoneButton.setVisible(false);
   }
 
   void setMaxAndShowMaxButton(final int max) {
     total = max;
-    m_textFieldListener.changedValue(null);
+    textFieldListener.changedValue(null);
     autoSelectButton.setText("Max");
   }
 
@@ -190,7 +190,7 @@ public class UnitChooser extends JPanel {
   }
 
   private void addCategory(final UnitCategory category, final int defaultValue) {
-    final ChooserEntry entry = new ChooserEntry(category, total, m_textFieldListener, data, allowMultipleHits,
+    final ChooserEntry entry = new ChooserEntry(category, total, textFieldListener, data, allowMultipleHits,
         defaultValue, uiContext);
     entries.add(entry);
   }
@@ -313,7 +313,7 @@ public class UnitChooser extends JPanel {
     }
   }
 
-  private final ScrollableTextFieldListener m_textFieldListener = new ScrollableTextFieldListener() {
+  private final ScrollableTextFieldListener textFieldListener = new ScrollableTextFieldListener() {
     @Override
     public void changedValue(final ScrollableTextField field) {
       if (match != null) {
@@ -325,57 +325,57 @@ public class UnitChooser extends JPanel {
   };
 
   private static final class ChooserEntry {
-    private final UnitCategory m_category;
-    private final ScrollableTextFieldListener m_hitTextFieldListener;
-    private final GameData m_data;
-    private final boolean m_hasMultipleHits;
-    private final List<Integer> m_defaultHits;
-    private final List<ScrollableTextField> m_hitTexts;
-    private final List<JLabel> m_hitLabel = new ArrayList<>();
-    private int m_leftToSelect = 0;
+    private final UnitCategory category;
+    private final ScrollableTextFieldListener hitTextFieldListener;
+    private final GameData gameData;
+    private final boolean hasMultipleHits;
+    private final List<Integer> defaultHits;
+    private final List<ScrollableTextField> hitTexts;
+    private final List<JLabel> hitLabel = new ArrayList<>();
+    private int leftToSelect = 0;
     private static Insets nullInsets = new Insets(0, 0, 0, 0);
-    private final IUIContext m_uiContext;
+    private final IUIContext uiContext;
 
     ChooserEntry(final UnitCategory category, final int leftToSelect, final ScrollableTextFieldListener listener,
         final GameData data, final boolean allowTwoHit, final int defaultValue, final IUIContext uiContext) {
-      m_hitTextFieldListener = listener;
-      m_data = data;
-      m_category = category;
-      m_leftToSelect = leftToSelect < 0 ? category.getUnits().size() : leftToSelect;
-      m_hasMultipleHits =
+      hitTextFieldListener = listener;
+      gameData = data;
+      this.category = category;
+      this.leftToSelect = leftToSelect < 0 ? category.getUnits().size() : leftToSelect;
+      hasMultipleHits =
           allowTwoHit && category.getHitPoints() > 1 && category.getDamaged() < category.getHitPoints() - 1;
-      m_hitTexts = new ArrayList<>(Math.max(1, category.getHitPoints() - category.getDamaged()));
-      m_defaultHits = new ArrayList<>(Math.max(1, category.getHitPoints() - category.getDamaged()));
+      hitTexts = new ArrayList<>(Math.max(1, category.getHitPoints() - category.getDamaged()));
+      defaultHits = new ArrayList<>(Math.max(1, category.getHitPoints() - category.getDamaged()));
       final int numUnits = category.getUnits().size();
       int hitsUsedSoFar = 0;
       for (int i = 0; i < Math.max(1, category.getHitPoints() - category.getDamaged()); i++) {
         // TODO: check if default value includes damaged points or not
         final int hitsToUse = Math.min(numUnits, (defaultValue - hitsUsedSoFar));
         hitsUsedSoFar += hitsToUse;
-        m_defaultHits.add(hitsToUse);
+        defaultHits.add(hitsToUse);
       }
-      m_uiContext = uiContext;
+      this.uiContext = uiContext;
     }
 
     void createComponents(final JPanel panel, final int rowIndex) {
       int gridx = 0;
       for (int i =
-          0; i < (m_hasMultipleHits ? Math.max(1, m_category.getHitPoints() - m_category.getDamaged()) : 1); i++) {
-        final ScrollableTextField scroll = new ScrollableTextField(0, m_category.getUnits().size());
-        m_hitTexts.add(scroll);
-        scroll.setValue(m_defaultHits.get(i));
-        scroll.addChangeListener(m_hitTextFieldListener);
-        final JLabel label = new JLabel("x" + m_category.getUnits().size());
-        m_hitLabel.add(label);
-        panel.add(new UnitChooserEntryIcon(i > 0, m_uiContext), new GridBagConstraints(gridx++, rowIndex, 1, 1, 0, 0,
+          0; i < (hasMultipleHits ? Math.max(1, category.getHitPoints() - category.getDamaged()) : 1); i++) {
+        final ScrollableTextField scroll = new ScrollableTextField(0, category.getUnits().size());
+        hitTexts.add(scroll);
+        scroll.setValue(defaultHits.get(i));
+        scroll.addChangeListener(hitTextFieldListener);
+        final JLabel label = new JLabel("x" + category.getUnits().size());
+        hitLabel.add(label);
+        panel.add(new UnitChooserEntryIcon(i > 0, uiContext), new GridBagConstraints(gridx++, rowIndex, 1, 1, 0, 0,
             GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(0, (i == 0 ? 0 : 8), 0, 0), 0, 0));
         if (i == 0) {
-          if (m_category.getMovement() != -1) {
-            panel.add(new JLabel("mvt " + m_category.getMovement()), new GridBagConstraints(gridx, rowIndex, 1, 1, 0, 0,
+          if (category.getMovement() != -1) {
+            panel.add(new JLabel("mvt " + category.getMovement()), new GridBagConstraints(gridx, rowIndex, 1, 1, 0, 0,
                 GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(0, 4, 0, 4), 0, 0));
           }
-          if (m_category.getTransportCost() != -1) {
-            panel.add(new JLabel("cst " + m_category.getTransportCost()),
+          if (category.getTransportCost() != -1) {
+            panel.add(new JLabel("cst " + category.getTransportCost()),
                 new GridBagConstraints(gridx, rowIndex, 1, 1, 0,
                     0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(0, 4, 0, 4), 0, 0));
           }
@@ -391,36 +391,36 @@ public class UnitChooser extends JPanel {
     }
 
     int getMax() {
-      return m_hitTexts.get(0).getMax();
+      return hitTexts.get(0).getMax();
     }
 
     void set(final int value) {
-      m_hitTexts.get(0).setValue(value);
+      hitTexts.get(0).setValue(value);
     }
 
     UnitCategory getCategory() {
-      return m_category;
+      return category;
     }
 
     void selectAll() {
-      m_hitTexts.get(0).setValue(m_hitTexts.get(0).getMax());
+      hitTexts.get(0).setValue(hitTexts.get(0).getMax());
     }
 
     void selectNone() {
-      m_hitTexts.get(0).setValue(0);
+      hitTexts.get(0).setValue(0);
     }
 
     void setLeftToSelect(final int leftToSelect) {
-      m_leftToSelect = leftToSelect < 0 ? m_category.getUnits().size() : leftToSelect;
+      this.leftToSelect = leftToSelect < 0 ? category.getUnits().size() : leftToSelect;
       updateLeftToSelect();
     }
 
     private void updateLeftToSelect() {
-      int previousMax = m_category.getUnits().size();
-      for (int i = 0; i < m_hitTexts.size(); i++) {
-        final int newMax = m_leftToSelect + getHits(i);
-        final ScrollableTextField text = m_hitTexts.get(i);
-        if (i > 0 && !m_hasMultipleHits) {
+      int previousMax = category.getUnits().size();
+      for (int i = 0; i < hitTexts.size(); i++) {
+        final int newMax = leftToSelect + getHits(i);
+        final ScrollableTextField text = hitTexts.get(i);
+        if (i > 0 && !hasMultipleHits) {
           text.setMax(0);
         } else {
           text.setMax(Math.min(newMax, previousMax));
@@ -428,39 +428,39 @@ public class UnitChooser extends JPanel {
         if (text.getValue() < 0 || text.getValue() > text.getMax()) {
           text.setValue(Math.max(0, Math.min(text.getMax(), text.getValue())));
         }
-        m_hitLabel.get(i).setText("x" + (i == 0 ? m_category.getUnits().size() : text.getMax()));
+        hitLabel.get(i).setText("x" + (i == 0 ? category.getUnits().size() : text.getMax()));
         previousMax = text.getValue();
       }
     }
 
     int getTotalHits() {
       int hits = 0;
-      for (int i = 0; i < m_hitTexts.size(); i++) {
+      for (int i = 0; i < hitTexts.size(); i++) {
         hits += getHits(i);
       }
       return hits;
     }
 
     int getHits(final int zeroBasedHitsPosition) {
-      if (zeroBasedHitsPosition < 0 || zeroBasedHitsPosition > m_hitTexts.size() - 1) {
+      if (zeroBasedHitsPosition < 0 || zeroBasedHitsPosition > hitTexts.size() - 1) {
         throw new IllegalArgumentException("Index out of range");
       }
-      if (!m_hasMultipleHits && zeroBasedHitsPosition > 0) {
+      if (!hasMultipleHits && zeroBasedHitsPosition > 0) {
         return 0;
       }
-      return m_hitTexts.get(zeroBasedHitsPosition).getValue();
+      return hitTexts.get(zeroBasedHitsPosition).getValue();
     }
 
     int getFinalHit() {
-      return getHits(m_hitTexts.size() - 1);
+      return getHits(hitTexts.size() - 1);
     }
 
     int size() {
-      return m_hitTexts.size();
+      return hitTexts.size();
     }
 
     boolean hasMultipleHitPoints() {
-      return m_hasMultipleHits;
+      return hasMultipleHits;
     }
 
     private class UnitChooserEntryIcon extends JComponent {
@@ -477,19 +477,19 @@ public class UnitChooser extends JPanel {
       public void paint(final Graphics g) {
         super.paint(g);
         final Optional<Image> image =
-            uiContext.getUnitImageFactory().getImage(m_category.getType(), m_category.getOwner(), m_data,
-                forceDamaged || m_category.hasDamageOrBombingUnitDamage(), m_category.getDisabled());
+            uiContext.getUnitImageFactory().getImage(category.getType(), category.getOwner(), gameData,
+                forceDamaged || category.hasDamageOrBombingUnitDamage(), category.getDisabled());
         if (image.isPresent()) {
           g.drawImage(image.get(), 0, 0, this);
         }
 
-        final Iterator<UnitOwner> iter = m_category.getDependents().iterator();
+        final Iterator<UnitOwner> iter = category.getDependents().iterator();
         int index = 1;
         while (iter.hasNext()) {
           final UnitOwner holder = iter.next();
           final int x = uiContext.getUnitImageFactory().getUnitImageWidth() * index;
           final Optional<Image> unitImg =
-              uiContext.getUnitImageFactory().getImage(holder.getType(), holder.getOwner(), m_data, false, false);
+              uiContext.getUnitImageFactory().getImage(holder.getType(), holder.getOwner(), gameData, false, false);
           if (unitImg.isPresent()) {
             g.drawImage(unitImg.get(), x, 0, this);
           }
@@ -500,7 +500,7 @@ public class UnitChooser extends JPanel {
       @Override
       public int getWidth() {
         // we draw a unit symbol for each dependent
-        return uiContext.getUnitImageFactory().getUnitImageWidth() * (1 + m_category.getDependents().size());
+        return uiContext.getUnitImageFactory().getUnitImageWidth() * (1 + category.getDependents().size());
       }
 
       @Override


### PR DESCRIPTION
This is the final part of multiple PRs to fix violations of the Checkstyle MemberName rule in `*Panel` classes within the `g.s.triplea.ui` package.  (Note that some `JPanel`-derived classes modified in this PR are not necessarily named with a `Panel` suffix, e.g. `UnitChooser`.)

All member renames were done via automatic refactoring.