### PR TITLE
Get engine version from Gradle project property instead of environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ after_success:
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
 before_deploy:
 - ./.travis/install_install4j
-- ENGINE_VERSION=$(grep "engine_version" game_engine.properties | sed 's/.*= *//g')
-- TAGGED_VERSION="$ENGINE_VERSION.$TRAVIS_BUILD_NUMBER"
-- TAGGED_VERSION="$TAGGED_VERSION" ./gradlew release
-- ./.travis/push_tag $TAGGED_VERSION
+- ENGINE_VERSION="$(grep engine_version game_engine.properties | sed 's/.*= *//g').$TRAVIS_BUILD_NUMBER"
+- ./gradlew -PengineVersion="$ENGINE_VERSION" release
+- ./.travis/push_tag $ENGINE_VERSION
 - ./.travis/push_maps
 deploy:
   provider: releases
@@ -30,13 +29,13 @@ deploy:
     secure: nxaqYrkXLGL3W20/eCnf63DLjMrQAhEuW44jggh1/nI383goa+u6w0bBtWCxRdVzos7t4dpVfS6+kv6oIHacm9zVA+RYrqy5opzCJhq8lmXVVRijbALzUeiFif2HURMaKWj0ynRNVlAyBHzazPTLZVWywifpdSubSkuMWkl20cmuKu/Hg3c1EC9se3OYhhTHx3Hya7xSrctrDEYLsEBAUZzkKfscqRVqwwltS88CgIMtRISDpSBGrtH0t1uAH6NitTSguGgb+QEpqnELcRLymX2G1yzMA4Xr5c/L34MfbBKf8vIuG9t411xYuLoyKoUbroTWxSnPwlSy6PHz+QJ7UCXbDkATOGO3chxlKxglppvI/G3n2YP5Zf2dAaDlHblpvarh55i/4i4sKB2AbvvzkIHrQJwUgmLCbpN8/Vp9GWcGkd6i5U7F8tNInCs6ttX3oGvGOfYEXs02Ctyiea4LAqk4S7GZTuV2QXqxXglL4eRIwZ4UETiwgoAAtHma63Eq7+9t2ykMlk7zAK96FGwJrB97wa08aPuSxL94IYEBmn9Ht/vKXRiNQMvpnfp4rWQtL3cqbVyYAg5EjKb4PsBmnb91+RXtnWFOY1RpZGt8sPXYd+KZYzN1BXTFJEpaLLsIDN6r7nMcAvJDUmucaM+m7giPXz1ZBGAic3UBM1qMCgI=
   ## This is the list of files to be deployed to github releases
   file:
-    - build/libs/triplea-${TAGGED_VERSION}-all.jar
-    - build/releases/TripleA_${TAGGED_VERSION}_windows-64bit.exe
-    - build/releases/TripleA_${TAGGED_VERSION}_windows-32bit.exe
-    - build/releases/TripleA_${TAGGED_VERSION}_macos.dmg
-    - build/releases/TripleA_${TAGGED_VERSION}_unix.sh
-    - build/distributions/triplea-${TAGGED_VERSION}-all_platforms.zip
-    - build/distributions/triplea-${TAGGED_VERSION}-server.zip
+    - build/libs/triplea-${ENGINE_VERSION}-all.jar
+    - build/releases/TripleA_${ENGINE_VERSION}_windows-64bit.exe
+    - build/releases/TripleA_${ENGINE_VERSION}_windows-32bit.exe
+    - build/releases/TripleA_${ENGINE_VERSION}_macos.dmg
+    - build/releases/TripleA_${ENGINE_VERSION}_unix.sh
+    - build/distributions/triplea-${ENGINE_VERSION}-all_platforms.zip
+    - build/distributions/triplea-${ENGINE_VERSION}-server.zip
   skip_cleanup: true
   prerelease: true
   on:

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ plugins {
 
 apply from: 'gradle/scripts/yaml.gradle'
 
-version = System.getenv("TAGGED_VERSION") ?: ""
 group = 'triplea'
 description = 'TripleA is a free online turn based strategy game and board game engine, similar to such board games as Axis & Allies or Risk.'
 mainClassName = "games.strategy.engine.framework.GameRunner"
@@ -24,6 +23,24 @@ ext {
     gameEnginePropertiesFile = file('game_engine.properties')
     gameEnginePropertiesArtifactFile = file("$rootFilesDir/${gameEnginePropertiesFile.name}")
 }
+
+def getEngineVersion() {
+    if (project.hasProperty('engineVersion')) {
+        return project.engineVersion
+    }
+
+    def props = new Properties()
+    gameEnginePropertiesFile.withInputStream { props.load(it) }
+    def devEngineVersion = props.getProperty('engine_version')
+    if (devEngineVersion) {
+        return "${devEngineVersion}.dev"
+    }
+
+    throw new GradleException("unable to determine engine version: "
+        + "you must define either the project property 'engineVersion' or the game engine property 'engine_version'")
+}
+
+version = getEngineVersion()
 
 compileJava {
     options.encoding = 'UTF-8'


### PR DESCRIPTION
Based on this [thread](https://github.com/triplea-game/triplea/pull/2085#discussion_r126321471) in #2085.  This PR changes the dependency of `build.gradle` on the environment variable `TAGGED_VERSION` to an equivalent Gradle project property.  There were some other changes made in this PR, as well, which are discussed below.

I'm happy to change any names that may be confusing or just closing this PR outright if it's deemed unnecessary after the discussion in #2085.

##### Change from environment variable to Gradle project property

In order to avoid the syntax of defining an environment variable for a child process, the engine version is now passed as a Gradle project property.  That is, instead of

```shell
$ TAGGED_VERSION="$TAGGED_VERSION" ./gradlew release
```

we now use

```shell
$ ./gradlew -PengineVersion="$ENGINE_VERSION" release
```

(See next item for why `ENGINE_VERSION` is used instead of `TAGGED_VERSION`.)

##### Rename `TAGGED_VERSION` shell variable to `ENGINE_VERSION`

We previously had two separate shell variables: `ENGINE_VERSION` was the value read directly from `game_engine.properties`, while `TAGGED_VERSION` was the concatenation of `ENGINE_VERSION` with the build number.  I got rid of the intermediate `ENGINE_VERSION` variable (which wasn't used for anything else), and renamed `TAGGED_VERSION` to `ENGINE_VERSION`.

The reason I did this is to avoid confusion.  The engine version from `game_engine.properties` stored in Git is really a partial value and not the true engine version from an end user's perspective.

It also aligns with the name of the new `engineVersion` Gradle project property.

##### Default engine version

Previously, if the `TAGGED_VERSION` environment variable was not defined, the build used an empty string for the version.  If you actually build the `all_platforms` zip archive or an installer with this default value, the resulting application will be broken (at startup, the engine throws exceptions due to the inability to parse an empty string as a `Version`).  It's kind of annoying to go through this process only to discover you forgot to specify the version.

I changed this so that if the `engineVersion` property is not defined, the build will now use the current `engine_version` value from `game_engine.properties`.  In order to make it clear that the application (most likely) came from a local developer build, I appended the qualifier ".dev" to this unqualified engine version.  That is, for the current repo state, the engine version would end up being `1.9.0.0.dev`.  (Note that this is purely optional, and I can just leave it as `1.9.0.0` if anyone thinks the `dev` qualifier is useless.)

Finally, if, for some reason, neither `engineVersion` is provided nor `engine_version` is defined in `game_engine.properties`, I fail the build immediately informing the user they need to define one or the other instead of silently generating an application that will fail when installed.