### PR TITLE
Increase icon size on uninstaller interior pages

### DIFF
--- a/build.install4j
+++ b/build.install4j
@@ -616,7 +616,7 @@ return true;</string>
             <object class="com.install4j.runtime.beans.applications.UninstallerApplication" id="UninstallerApplication0">
               <void property="customHeaderImage">
                 <object class="com.install4j.api.beans.ExternalFile">
-                  <string>./build/assets/icons/triplea_icon_16_16.png</string>
+                  <string>./build/assets/icons/triplea_icon_48_48.png</string>
                 </object>
               </void>
               <void property="customIconImageFiles">


### PR DESCRIPTION
This should have been part of #2084.  I didn't realize there were separate configuration blocks for the installer and uninstaller (and the uninstaller runs so fast that I didn't notice that the icon size was still the same).