### PR TITLE
Remove incremental build support for prepareGameEngineProperties task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,9 +179,6 @@ task prepareGameEngineProperties() {
     group = 'release'
     description = 'Updates the game engine properties with final values for distribution.'
 
-    inputs.file gameEnginePropertiesFile
-    outputs.file gameEnginePropertiesArtifactFile
-
     doLast {
         copy {
             from gameEnginePropertiesFile


### PR DESCRIPTION
The `prepareGameEngineProperties` task not only depends on the `game_engine.properties` file but also the value of the `engineVersion` project property.  The task only tracks the state of the former and not the latter.  Thus, if a dev rebuilds locally with the same `game_engine.properties` file, but a different `engineVersion` project property, the output file will not be regenerated, possibly leading to the wrong engine version in the resulting build artifacts.

This is such a small and fast operation that incremental build support was simply removed, and the task will be run on each build.