### PR TITLE
Replace Match.allMatchNotEmpty usage

### DIFF
--- a/src/main/java/games/strategy/engine/data/Route.java
+++ b/src/main/java/games/strategy/engine/data/Route.java
@@ -420,7 +420,7 @@ public class Route implements Serializable, Iterable<Territory> {
     if (!getStart().isWater()) {
       return true;
     }
-    return !Match.allMatchNotEmpty(getAllTerritories(), Matches.TerritoryIsWater);
+    return getAllTerritories().isEmpty() || !Match.allMatch(getAllTerritories(), Matches.TerritoryIsWater);
   }
 
   public int getLargestMovementCost(final Collection<Unit> units) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -491,8 +491,9 @@ class ProNonCombatMoveAI {
       final boolean hasFactory = ProMatches.territoryHasInfraFactoryAndIsLand().match(t);
       final ProBattleResult minResult = patd.getMinBattleResult();
       final int cantMoveUnitValue = BattleCalculator.getTUV(moveMap.get(t).getCantMoveUnits(), ProData.unitValueMap);
+      final List<Unit> maxEnemyUnits = patd.getMaxEnemyUnits();
       final boolean isLandAndCanOnlyBeAttackedByAir =
-          !t.isWater() && Match.allMatchNotEmpty(patd.getMaxEnemyUnits(), Matches.UnitIsAir);
+          !t.isWater() && !maxEnemyUnits.isEmpty() && Match.allMatch(maxEnemyUnits, Matches.UnitIsAir);
       final boolean isNotFactoryAndShouldHold =
           !hasFactory && (minResult.getTUVSwing() <= 0 || !minResult.isHasLandUnitRemaining());
       final boolean canAlreadyBeHeld =

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -1224,7 +1224,8 @@ class ProPurchaseAI {
             result = calc.estimateDefendBattleResults(t, enemyAttackOptions.getMax(t).getMaxUnits(),
                 defendingUnits, enemyAttackOptions.getMax(t).getMaxBombardUnits());
             hasOnlyRetreatingSubs =
-                Properties.getSubRetreatBeforeBattle(data) && !defendingUnits.isEmpty() && Match.allMatch(defendingUnits, Matches.UnitIsSub)
+                Properties.getSubRetreatBeforeBattle(data) && !defendingUnits.isEmpty()
+                    && Match.allMatch(defendingUnits, Matches.UnitIsSub)
                     && Match.noneMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsDestroyer);
           }
         }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -455,7 +455,7 @@ class ProPurchaseAI {
 
         // If it can't currently be held then add to list
         final boolean isLandAndCanOnlyBeAttackedByAir =
-            !t.isWater() && Match.allMatchNotEmpty(enemyAttackingUnits, Matches.UnitIsAir);
+            !t.isWater() && !enemyAttackingUnits.isEmpty() && Match.allMatch(enemyAttackingUnits, Matches.UnitIsAir);
         if ((!t.isWater() && result.isHasLandUnitRemaining()) || result.getTUVSwing() > holdValue
             || (t.equals(ProData.myCapital) && !isLandAndCanOnlyBeAttackedByAir
                 && result.getWinPercentage() > (100 - ProData.winPercentage))) {
@@ -1159,7 +1159,7 @@ class ProPurchaseAI {
             initialDefendingUnits, enemyAttackOptions.getMax(t).getMaxBombardUnits());
         boolean hasOnlyRetreatingSubs =
             Properties.getSubRetreatBeforeBattle(data)
-                && Match.allMatchNotEmpty(initialDefendingUnits, Matches.UnitIsSub)
+                && !initialDefendingUnits.isEmpty() && Match.allMatch(initialDefendingUnits, Matches.UnitIsSub)
                 && Match.noneMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsDestroyer);
         for (final ProPurchaseTerritory purchaseTerritory : selectedPurchaseTerritories) {
 
@@ -1224,7 +1224,7 @@ class ProPurchaseAI {
             result = calc.estimateDefendBattleResults(t, enemyAttackOptions.getMax(t).getMaxUnits(),
                 defendingUnits, enemyAttackOptions.getMax(t).getMaxBombardUnits());
             hasOnlyRetreatingSubs =
-                Properties.getSubRetreatBeforeBattle(data) && Match.allMatchNotEmpty(defendingUnits, Matches.UnitIsSub)
+                Properties.getSubRetreatBeforeBattle(data) && !defendingUnits.isEmpty() && Match.allMatch(defendingUnits, Matches.UnitIsSub)
                     && Match.noneMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsDestroyer);
           }
         }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -369,7 +369,7 @@ public class ProTerritoryManager {
   }
 
   private static int getMaxScrambleCount(final Collection<Unit> airbases) {
-    if (!Match.allMatchNotEmpty(airbases, Match.allOf(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
+    if (airbases.isEmpty() || !Match.allMatch(airbases, Match.allOf(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
       throw new IllegalStateException("All units must be viable airbases");
     }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -369,7 +369,8 @@ public class ProTerritoryManager {
   }
 
   private static int getMaxScrambleCount(final Collection<Unit> airbases) {
-    if (airbases.isEmpty() || !Match.allMatch(airbases, Match.allOf(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
+    if (airbases.isEmpty()
+        || !Match.allMatch(airbases, Match.allOf(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
       throw new IllegalStateException("All units must be viable airbases");
     }
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMoveUtils.java
@@ -80,12 +80,12 @@ public class ProMoveUtils {
           // Sea unit (including carriers with planes)
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,
               ProMatches.territoryCanMoveSeaUnitsThrough(player, data, isCombatMove));
-        } else if (Match.allMatchNotEmpty(unitList, Matches.UnitIsLand)) {
+        } else if (!unitList.isEmpty() && Match.allMatch(unitList, Matches.UnitIsLand)) {
 
           // Land unit
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t, ProMatches
               .territoryCanMoveLandUnitsThrough(player, data, u, startTerritory, isCombatMove, new ArrayList<>()));
-        } else if (Match.allMatchNotEmpty(unitList, Matches.UnitIsAir)) {
+        } else if (!unitList.isEmpty() && Match.allMatch(unitList, Matches.UnitIsAir)) {
 
           // Air unit
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,
@@ -249,7 +249,7 @@ public class ProMoveUtils {
 
         // Determine route and add to move list
         Route route = null;
-        if (Match.allMatchNotEmpty(unitList, ProMatches.unitCanBeMovedAndIsOwnedSea(player, true))) {
+        if (!unitList.isEmpty() && Match.allMatch(unitList, ProMatches.unitCanBeMovedAndIsOwnedSea(player, true))) {
 
           // Naval unit
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, bombardFromTerritory,
@@ -284,7 +284,7 @@ public class ProMoveUtils {
 
         // Determine route and add to move list
         Route route = null;
-        if (Match.allMatchNotEmpty(unitList, Matches.UnitIsAir)) {
+        if (!unitList.isEmpty() && Match.allMatch(unitList, Matches.UnitIsAir)) {
           route = data.getMap().getRoute_IgnoreEnd(startTerritory, t,
               ProMatches.territoryCanMoveAirUnitsAndNoAA(player, data, true));
         }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -67,7 +67,7 @@ public class ProOddsCalculator {
     final double strengthDifference = ProBattleUtils.estimateStrengthDifference(t, attackingUnits, defendingUnits);
     if (strengthDifference > 55) {
       final boolean isLandAndCanOnlyBeAttackedByAir =
-          !t.isWater() && Match.allMatchNotEmpty(attackingUnits, Matches.UnitIsAir);
+          !t.isWater() && !attackingUnits.isEmpty() && Match.allMatch(attackingUnits, Matches.UnitIsAir);
       return new ProBattleResult(100 + strengthDifference, 999 + strengthDifference, !isLandAndCanOnlyBeAttackedByAir,
           attackingUnits, new ArrayList<>(), 1);
     }
@@ -90,14 +90,15 @@ public class ProOddsCalculator {
 
     final boolean hasNoDefenders = Match.noneMatch(defendingUnits, Matches.UnitIsNotInfrastructure);
     final boolean isLandAndCanOnlyBeAttackedByAir =
-        !t.isWater() && Match.allMatchNotEmpty(attackingUnits, Matches.UnitIsAir);
+        !t.isWater() && !attackingUnits.isEmpty() && Match.allMatch(attackingUnits, Matches.UnitIsAir);
     if (attackingUnits.size() == 0) {
       return new ProBattleResult();
     } else if (hasNoDefenders && isLandAndCanOnlyBeAttackedByAir) {
       return new ProBattleResult();
     } else if (hasNoDefenders) {
       return new ProBattleResult(100, 0.1, true, attackingUnits, new ArrayList<>(), 0);
-    } else if (Properties.getSubRetreatBeforeBattle(data) && Match.allMatchNotEmpty(defendingUnits, Matches.UnitIsSub)
+    } else if (Properties.getSubRetreatBeforeBattle(data) && !defendingUnits.isEmpty()
+        && Match.allMatch(defendingUnits, Matches.UnitIsSub)
         && Match.noneMatch(attackingUnits, Matches.UnitIsDestroyer)) {
       return new ProBattleResult();
     }
@@ -157,7 +158,7 @@ public class ProOddsCalculator {
     // Create battle result object
     final List<Territory> tList = new ArrayList<>();
     tList.add(t);
-    if (Match.allMatchNotEmpty(tList, Matches.TerritoryIsLand)) {
+    if (!tList.isEmpty() && Match.allMatch(tList, Matches.TerritoryIsLand)) {
       return new ProBattleResult(winPercentage, tuvSwing,
           Match.anyMatch(averageAttackersRemaining, Matches.UnitIsLand), averageAttackersRemaining,
           averageDefendersRemaining, results.getAverageBattleRoundsFought());

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -806,7 +806,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         }
       }
       // make sure all units are land
-      if (!Match.allMatchNotEmpty(units, Matches.UnitIsNotSea)) {
+      if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsNotSea)) {
         return "Cant place sea units on land";
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -608,7 +608,7 @@ public class AirMovementValidator {
    */
   public static boolean canLand(final Collection<Unit> airUnits, final Territory territory, final PlayerID player,
       final GameData data) {
-    if (!Match.allMatchNotEmpty(airUnits, Matches.UnitIsAir)) {
+    if (airUnits.isEmpty() || !Match.allMatch(airUnits, Matches.UnitIsAir)) {
       throw new IllegalArgumentException("can only test if air will land");
     }
     if (!territory.isWater() && AbstractMoveDelegate.getBattleTracker(data).wasConquered(territory)) {
@@ -616,7 +616,7 @@ public class AirMovementValidator {
     }
     if (territory.isWater()) {
       // if they cant all land on carriers
-      if (!Match.allMatchNotEmpty(airUnits, Matches.UnitCanLandOnCarrier)) {
+      if (airUnits.isEmpty() || !Match.allMatch(airUnits, Matches.UnitCanLandOnCarrier)) {
         return false;
       }
       // when doing the calculation, make sure to include the units

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -1016,7 +1016,8 @@ public class BattleCalculator {
     final LinkedHashMap<PlayerID, Map<UnitType, ResourceCollection>> rVal =
         new LinkedHashMap<>();
     final Map<UnitType, ResourceCollection> average = includeAverageForMissingUnits
-        ? getResourceCostsForTUVForAllPlayersMergedAndAveraged(data) : new HashMap<>();
+        ? getResourceCostsForTUVForAllPlayersMergedAndAveraged(data)
+        : new HashMap<>();
     final List<PlayerID> players = data.getPlayerList().getPlayers();
     players.add(PlayerID.NULL_PLAYERID);
     for (final PlayerID p : players) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -109,7 +109,7 @@ public class BattleCalculator {
     }
     final GameData data = bridge.getData();
     final boolean allowMultipleHitsPerUnit =
-        Match.allMatchNotEmpty(defendingAa, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
+        !defendingAa.isEmpty() && Match.allMatch(defendingAa, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
     if (isChooseAA(data)) {
       final String text = "Select " + dice.getHits() + " casualties from aa fire in " + terr.getName();
       return selectCasualties(null, hitPlayer, planes, allFriendlyUnits, firingPlayer, allEnemyUnits, amphibious,

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -330,8 +330,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         if (m_battleTracker.noBombardAllowedFromHere(neighbor)) {
           continue;
         }
+        final Collection<Unit> neighbourUnits = attackingFromMap.get(neighbor);
         // If all units from a territory are air- no bombard
-        if (Match.allMatchNotEmpty(attackingFromMap.get(neighbor), Matches.UnitIsAir)) {
+        if (!neighbourUnits.isEmpty() && Match.allMatch(neighbourUnits, Matches.UnitIsAir)) {
           continue;
         }
         Collection<IBattle> battles = possibleBombardingTerritories.get(neighbor);
@@ -491,10 +492,12 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         }
       }
       // Reach stalemate if all attacking and defending units are transports
-      if ((ignoreTransports && Match.allMatchNotEmpty(attackingUnits, seaTransports)
-          && Match.allMatchNotEmpty(enemyUnits, seaTransports))
-          || ((Match.allMatchNotEmpty(attackingUnits, Matches.unitHasAttackValueOfAtLeast(1).invert()))
-              && Match.allMatchNotEmpty(enemyUnits, Matches.unitHasDefendValueOfAtLeast(1).invert()))) {
+      if ((ignoreTransports && !attackingUnits.isEmpty() && Match.allMatch(attackingUnits, seaTransports)
+          && !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, seaTransports))
+          || (!attackingUnits.isEmpty()
+              && Match.allMatch(attackingUnits, Matches.unitHasAttackValueOfAtLeast(1).invert())
+              && !enemyUnits.isEmpty()
+              && Match.allMatch(enemyUnits, Matches.unitHasDefendValueOfAtLeast(1).invert()))) {
         final BattleResults results = new BattleResults(battle, WhoWon.DRAW, data);
         battleTracker.getBattleRecords().addResultToBattle(player, battle.getBattleID(), null, 0, 0,
             BattleRecord.BattleResultDescription.STALEMATE, results);
@@ -519,7 +522,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         if (ignoreTransports || ignoreSubs) {
           // TODO check if incoming units can attack before asking
           // if only enemy transports... attack them?
-          if (ignoreTransports && Match.allMatchNotEmpty(enemyUnits, seaTransports)) {
+          if (ignoreTransports && !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, seaTransports)) {
             if (!remotePlayer.selectAttackTransports(territory)) {
               final BattleResults results = new BattleResults(battle, WhoWon.NOTFINISHED, data);
               battleTracker.getBattleRecords().addResultToBattle(player, battle.getBattleID(), null, 0, 0,
@@ -530,7 +533,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             continue;
           }
           // if only enemy subs... attack them?
-          if (ignoreSubs && Match.allMatchNotEmpty(enemyUnits, Matches.UnitIsSub)) {
+          if (ignoreSubs && !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, Matches.UnitIsSub)) {
             if (!remotePlayer.selectAttackSubs(territory)) {
               final BattleResults results = new BattleResults(battle, WhoWon.NOTFINISHED, data);
               battleTracker.getBattleRecords().addResultToBattle(player, battle.getBattleID(), null, 0, 0,
@@ -541,7 +544,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             continue;
           }
           // if only enemy transports and subs... attack them?
-          if (ignoreSubs && ignoreTransports && Match.allMatchNotEmpty(enemyUnits, seaTranportsOrSubs)) {
+          if (ignoreSubs && ignoreTransports && !enemyUnits.isEmpty()
+              && Match.allMatch(enemyUnits, seaTranportsOrSubs)) {
             if (!remotePlayer.selectAttackUnits(territory)) {
               final BattleResults results = new BattleResults(battle, WhoWon.NOTFINISHED, data);
               battleTracker.getBattleRecords().addResultToBattle(player, battle.getBattleID(), null, 0, 0,
@@ -945,7 +949,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   }
 
   public static int getMaxScrambleCount(final Collection<Unit> airbases) {
-    if (!Match.allMatchNotEmpty(airbases, Match.allOf(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
+    if (airbases.isEmpty()
+        || !Match.allMatch(airbases, Match.allOf(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
       throw new IllegalStateException("All units must be viable airbases");
     }
     // find how many is the max this territory can scramble
@@ -1505,7 +1510,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     availableLand.removeAll(canNotLand);
     whereCanLand.addAll(availableLand);
     // now for carrier-air-landing validation
-    if (Match.allMatchNotEmpty(strandedAir, Matches.UnitCanLandOnCarrier)) {
+    if (!strandedAir.isEmpty() && Match.allMatch(strandedAir, Matches.UnitCanLandOnCarrier)) {
       final HashSet<Territory> availableWater = new HashSet<>();
       availableWater.addAll(Match.getMatches(possibleTerrs,
           Match.allOf(

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -865,7 +865,7 @@ public class BattleTracker implements java.io.Serializable {
     }
     // if just an enemy factory &/or AA then no battle
     final Collection<Unit> enemyUnits = Match.getMatches(site.getUnits().getUnits(), Matches.enemyUnit(id, data));
-    if (route.getEnd() != null && Match.allMatchNotEmpty(enemyUnits, Matches.UnitIsInfrastructure)) {
+    if (route.getEnd() != null && !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, Matches.UnitIsInfrastructure)) {
       return ChangeFactory.EMPTY_CHANGE;
     }
     IBattle battle = getPendingBattle(site, false, BattleType.NORMAL);

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -82,17 +82,17 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     final GameData data = getData();
     Map<Unit, Unit> mapLoading = null;
     if (territory.isWater()) {
-      if (!Match.allMatchNotEmpty(units, Matches.UnitIsSea)) {
+      if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsSea)) {
         if (Match.anyMatch(units, Matches.UnitIsLand)) {
           // this should be exact same as the one in the EditValidator
-          if (!Match.allMatchNotEmpty(units, Matches.alliedUnit(player, data))) {
+          if (units.isEmpty() || !Match.allMatch(units, Matches.alliedUnit(player, data))) {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
               Match.allOf(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
-          if (!Match.allMatchNotEmpty(landUnitsToAdd, Matches.UnitCanBeTransported)) {
+          if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.UnitCanBeTransported)) {
             return "Can't add land units that can't be transported, to water";
           }
           seaTransports.addAll(territory.getUnits().getMatches(friendlySeaTransports));

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -68,16 +68,16 @@ class EditValidator {
     final PlayerID player = units.iterator().next().getOwner();
     // check land/water sanity
     if (territory.isWater()) {
-      if (!Match.allMatchNotEmpty(units, Matches.UnitIsSea)) {
+      if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsSea)) {
         if (Match.anyMatch(units, Matches.UnitIsLand)) {
-          if (!Match.allMatchNotEmpty(units, Matches.alliedUnit(player, data))) {
+          if (units.isEmpty() || !Match.allMatch(units, Matches.alliedUnit(player, data))) {
             return "Can't add mixed nationality units to water";
           }
           final Match<Unit> friendlySeaTransports =
               Match.allOf(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
-          if (!Match.allMatchNotEmpty(landUnitsToAdd, Matches.UnitCanBeTransported)) {
+          if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.UnitCanBeTransported)) {
             return "Can't add land units that can't be transported, to water";
           }
           seaTransports.addAll(territory.getUnits().getMatches(friendlySeaTransports));
@@ -222,10 +222,10 @@ class EditValidator {
     }
     final PlayerID player = units.iterator().next().getOwner();
     // all units should be same owner
-    if (!Match.allMatchNotEmpty(units, Matches.unitIsOwnedBy(player))) {
+    if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsOwnedBy(player))) {
       return "Not all units have the same owner";
     }
-    if (!Match.allMatchNotEmpty(units, Matches.UnitHasMoreThanOneHitPointTotal)) {
+    if (units.isEmpty() || !Match.allMatch(units, Matches.UnitHasMoreThanOneHitPointTotal)) {
       return "Not all units have more than one total hitpoints";
     }
     for (final Unit u : units) {
@@ -256,10 +256,10 @@ class EditValidator {
     }
     final PlayerID player = units.iterator().next().getOwner();
     // all units should be same owner
-    if (!Match.allMatchNotEmpty(units, Matches.unitIsOwnedBy(player))) {
+    if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsOwnedBy(player))) {
       return "Not all units have the same owner";
     }
-    if (!Match.allMatchNotEmpty(units, Matches.UnitCanBeDamaged)) {
+    if (units.isEmpty() || !Match.allMatch(units, Matches.UnitCanBeDamaged)) {
       return "Not all units can take bombing damage";
     }
     for (final Unit u : units) {

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -181,7 +181,7 @@ public class MovePerformer implements Serializable {
           if (canCreateAirBattle) {
             allBombingRaidBuilder.add(Matches.unitCanEscort);
           }
-          final boolean allCanBomb = Match.allMatchNotEmpty(arrived, allBombingRaidBuilder.any());
+          final boolean allCanBomb = !arrived.isEmpty() && Match.allMatch(arrived, allBombingRaidBuilder.any());
           final Collection<Unit> enemyTargets =
               Match.getMatches(enemyTargetsTotal,
                   Matches.unitIsOfTypes(UnitAttachment
@@ -189,7 +189,7 @@ public class MovePerformer implements Serializable {
                           data)));
           final boolean targetsOrEscort = !enemyTargets.isEmpty()
               || (!enemyTargetsTotal.isEmpty() && canCreateAirBattle
-                  && Match.allMatchNotEmpty(arrived, Matches.unitCanEscort));
+                  && !arrived.isEmpty() && Match.allMatch(arrived, Matches.unitCanEscort));
           boolean targetedAttack = false;
           // if it's all bombers and there's something to bomb
           if (allCanBomb && targetsOrEscort && GameStepPropertiesHelper.isCombatMove(data)) {
@@ -226,9 +226,9 @@ public class MovePerformer implements Serializable {
           // Ignore Trn on Trn forces.
           if (isIgnoreTransportInMovement(bridge.getData())) {
             final boolean allOwnedTransports =
-                Match.allMatchNotEmpty(arrived, Matches.UnitIsTransportButNotCombatTransport);
+                !arrived.isEmpty() && Match.allMatch(arrived, Matches.UnitIsTransportButNotCombatTransport);
             final boolean allEnemyTransports =
-                Match.allMatchNotEmpty(enemyUnits, Matches.UnitIsTransportButNotCombatTransport);
+                !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, Matches.UnitIsTransportButNotCombatTransport);
             // If everybody is a transport, don't create a battle
             if (allOwnedTransports && allEnemyTransports) {
               ignoreBattle = true;
@@ -257,8 +257,8 @@ public class MovePerformer implements Serializable {
               if (Matches.isTerritoryEnemy(id, data).match(t) || Matches.territoryHasEnemyUnits(id, data).match(t)) {
                 continue;
               }
-              if ((t.equals(route.getEnd()) && Match.allMatchNotEmpty(arrivedCopyForBattles, Matches.UnitIsAir))
-                  || (!t.equals(route.getEnd()) && Match.allMatchNotEmpty(presentFromStartTilEnd, Matches.UnitIsAir))) {
+              if ((t.equals(route.getEnd()) && !arrivedCopyForBattles.isEmpty() && Match.allMatch(arrivedCopyForBattles, Matches.UnitIsAir))
+                  || (!t.equals(route.getEnd()) && !presentFromStartTilEnd.isEmpty() && Match.allMatch(presentFromStartTilEnd, Matches.UnitIsAir))) {
                 continue;
               }
               // createdBattle = true;

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -257,8 +257,10 @@ public class MovePerformer implements Serializable {
               if (Matches.isTerritoryEnemy(id, data).match(t) || Matches.territoryHasEnemyUnits(id, data).match(t)) {
                 continue;
               }
-              if ((t.equals(route.getEnd()) && !arrivedCopyForBattles.isEmpty() && Match.allMatch(arrivedCopyForBattles, Matches.UnitIsAir))
-                  || (!t.equals(route.getEnd()) && !presentFromStartTilEnd.isEmpty() && Match.allMatch(presentFromStartTilEnd, Matches.UnitIsAir))) {
+              if ((t.equals(route.getEnd()) && !arrivedCopyForBattles.isEmpty()
+                  && Match.allMatch(arrivedCopyForBattles, Matches.UnitIsAir))
+                  || (!t.equals(route.getEnd()) && !presentFromStartTilEnd.isEmpty()
+                      && Match.allMatch(presentFromStartTilEnd, Matches.UnitIsAir))) {
                 continue;
               }
               // createdBattle = true;

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -133,14 +133,14 @@ public class MoveValidator {
   static MoveValidationResult validateFirst(final GameData data, final Collection<Unit> units, final Route route,
       final PlayerID player, final MoveValidationResult result) {
     if (!units.isEmpty()
-        && !getEditMode(data)
-        && !Match.allMatchNotEmpty(Match.getMatches(units,
-            Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, route, player, data, true)
-                .invert()),
-            Matches.unitIsOwnedBy(player))) {
-      result.setError("Player, " + player.getName() + ", is not owner of all the units: "
-          + MyFormatter.unitsToTextNoOwner(units));
-      return result;
+        && !getEditMode(data)) {
+      final Collection<Unit> matches = Match.getMatches(units,
+          Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, route, player, data, true).invert());
+      if (matches.isEmpty() || !Match.allMatch(matches, Matches.unitIsOwnedBy(player))) {
+        result.setError("Player, " + player.getName() + ", is not owner of all the units: "
+            + MyFormatter.unitsToTextNoOwner(units));
+        return result;
+      }
     }
     // this should never happen
     if (new HashSet<>(units).size() != units.size()) {
@@ -280,7 +280,7 @@ public class MoveValidator {
         && (route.anyMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
             .isTerritoryEnemy(player, data).invert(), false))) {
       if (!Matches.territoryIsBlitzable(player, data).match(route.getStart())
-          && !Match.allMatchNotEmpty(units, Matches.UnitIsAir)) {
+          && (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir))) {
         return result.setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
       }
       for (final Unit u : Match.getMatches(units, Match.allOf(Matches.UnitCanBlitz.invert(), Matches.UnitIsNotAir))) {
@@ -295,7 +295,7 @@ public class MoveValidator {
         && (route.anyMatch(Matches.isTerritoryEnemy(player, data)) && !route.allMatchMiddleSteps(Matches
             .isTerritoryEnemy(player, data).invert(), false))) {
       if (!Matches.territoryIsBlitzable(player, data).match(route.getStart())
-          && !Match.allMatchNotEmpty(units, Matches.UnitIsAir)) {
+          && (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir))) {
         return result.setErrorReturnResult("Cannot blitz out of a battle into enemy territory");
       }
     }
@@ -308,7 +308,7 @@ public class MoveValidator {
     }
     // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
     if (route.hasNeutralBeforeEnd()) {
-      if (!Match.allMatchNotEmpty(units, Matches.UnitIsAir) && !isNeutralsBlitzable(data)) {
+      if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir) && !isNeutralsBlitzable(data)) {
         return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
       }
     }
@@ -374,7 +374,7 @@ public class MoveValidator {
     // make sure no conquered territories on route
     if (MoveValidator.hasConqueredNonBlitzedNonWaterOnRoute(route, data)) {
       // unless we are all air or we are in non combat OR the route is water (was a bug in convoy zone movement)
-      if (!Match.allMatchNotEmpty(units, Matches.UnitIsAir)) {
+      if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir)) {
         // what if we are paratroopers?
         return result.setErrorReturnResult("Cannot move through newly captured territories");
       }
@@ -382,7 +382,8 @@ public class MoveValidator {
     // See if they've already been in combat
     if (Match.anyMatch(units, Matches.UnitWasInCombat) && Match.anyMatch(units, Matches.UnitWasUnloadedThisTurn)) {
       final Collection<Territory> end = Collections.singleton(route.getEnd());
-      if (Match.allMatchNotEmpty(end, Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data))
+      if (!end.isEmpty()
+          && Match.allMatch(end, Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data))
           && !route.getEnd().getUnits().isEmpty()) {
         return result.setErrorReturnResult("Units cannot participate in multiple battles");
       }
@@ -425,7 +426,7 @@ public class MoveValidator {
       }
     }
     // Subs can't travel under DDs
-    if (isSubmersibleSubsAllowed(data) && Match.allMatchNotEmpty(units, Matches.UnitIsSub)) {
+    if (isSubmersibleSubsAllowed(data) && !units.isEmpty() && Match.allMatch(units, Matches.UnitIsSub)) {
       // this is ok unless there are destroyer on the path
       if (MoveValidator.enemyDestroyerOnPath(route, player, data)) {
         return result.setErrorReturnResult("Cannot move submarines under destroyers");
@@ -437,8 +438,8 @@ public class MoveValidator {
             Matches.enemyUnit(player, data).invert(),
             Matches.UnitIsSubmerged);
         if (!end.getUnits().allMatch(friendlyOrSubmerged)
-            && !(Match.allMatchNotEmpty(units, Matches.UnitIsAir) && end.isWater())) {
-          if (!Match.allMatchNotEmpty(units, Matches.UnitIsSub)
+            && !(!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir) && end.isWater())) {
+          if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsSub)
               || !games.strategy.triplea.Properties.getSubsCanEndNonCombatMoveWithEnemies(data)) {
             return result.setErrorReturnResult("Cannot advance to battle in non combat");
           }
@@ -447,7 +448,7 @@ public class MoveValidator {
     }
     // if there are enemy units on the path blocking us, that is validated elsewhere (validateNonEnemyUnitsOnPath)
     // now check if we can move over neutral or enemies territories in noncombat
-    if (Match.allMatchNotEmpty(units, Matches.UnitIsAir)
+    if (!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir)
         || (Match.noneMatch(units, Matches.UnitIsSea) && !nonParatroopersPresent(player, units))) {
       // if there are non-paratroopers present, then we cannot fly over stuff
       // if there are neutral territories in the middle, we cannot fly over (unless allowed to)
@@ -515,18 +516,19 @@ public class MoveValidator {
       return result;
     }
     // if we are all air, then its ok
-    if (Match.allMatchNotEmpty(units, Matches.UnitIsAir)) {
+    if (!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir)) {
       return result;
     }
     // subs may possibly carry units...
-    if (isSubmersibleSubsAllowed(data)
-        && Match.allMatchNotEmpty(Match.getMatches(units, Matches.unitIsBeingTransported().invert()),
-            Matches.UnitIsSub)) {
-      // this is ok unless there are destroyer on the path
-      if (MoveValidator.enemyDestroyerOnPath(route, player, data)) {
-        return result.setErrorReturnResult("Cannot move submarines under destroyers");
-      } else {
-        return result;
+    if (isSubmersibleSubsAllowed(data)) {
+      final Collection<Unit> matches = Match.getMatches(units, Matches.unitIsBeingTransported().invert());
+      if (!matches.isEmpty() && Match.allMatch(matches, Matches.UnitIsSub)) {
+        // this is ok unless there are destroyer on the path
+        if (MoveValidator.enemyDestroyerOnPath(route, player, data)) {
+          return result.setErrorReturnResult("Cannot move submarines under destroyers");
+        } else {
+          return result;
+        }
       }
     }
     if (onlyIgnoredUnitsOnPath(route, player, data, true)) {
@@ -642,7 +644,7 @@ public class MoveValidator {
       }
       // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
       if (route.hasNeutralBeforeEnd()) {
-        if (!Match.allMatchNotEmpty(units, Matches.UnitIsAir) && !isNeutralsBlitzable(data)) {
+        if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir) && !isNeutralsBlitzable(data)) {
           return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
         }
       }
@@ -943,7 +945,7 @@ public class MoveValidator {
       final List<UndoableMove> undoableMoves, final Collection<Unit> units, final Route route, final PlayerID player,
       final Collection<Unit> transportsToLoad, final MoveValidationResult result) {
     final boolean isEditMode = getEditMode(data);
-    if (Match.allMatchNotEmpty(units, Matches.UnitIsAir)) {
+    if (!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir)) {
       return result;
     }
     if (!route.hasWater()) {
@@ -1160,8 +1162,9 @@ public class MoveValidator {
 
   static boolean allLandUnitsAreBeingParatroopered(final Collection<Unit> units) {
     // some units that can't be paratrooped
-    if (!Match.allMatchNotEmpty(units, Match.anyOf(Matches.UnitIsAirTransportable, Matches.UnitIsAirTransport,
-        Matches.UnitIsAir))) {
+    if (units.isEmpty()
+        || !Match.allMatch(units, Match.anyOf(Matches.UnitIsAirTransportable, Matches.UnitIsAirTransport,
+            Matches.UnitIsAir))) {
       return false;
     }
     // final List<Unit> paratroopsRequiringTransport = getParatroopsRequiringTransport(units, route);
@@ -1186,7 +1189,7 @@ public class MoveValidator {
     if (!TechAttachment.isAirTransportable(player)) {
       return true;
     }
-    if (!Match.allMatchNotEmpty(units, Match.anyOf(Matches.UnitIsAir, Matches.UnitIsLand))) {
+    if (units.isEmpty() || !Match.allMatch(units, Match.anyOf(Matches.UnitIsAir, Matches.UnitIsLand))) {
       return true;
     }
     for (final Unit unit : Match.getMatches(units, Matches.UnitIsNotAirTransportable)) {
@@ -1291,7 +1294,8 @@ public class MoveValidator {
    */
   private static Optional<String> canPassThroughCanal(final CanalAttachment canalAttachment,
       final Collection<Unit> units, final PlayerID player, final GameData data) {
-    if (units != null && Match.allMatchNotEmpty(units, Matches.unitIsOfTypes(canalAttachment.getExcludedUnits(data)))) {
+    if (units != null && !units.isEmpty()
+        && Match.allMatch(units, Matches.unitIsOfTypes(canalAttachment.getExcludedUnits(data)))) {
       return Optional.empty();
     }
     for (final Territory borderTerritory : canalAttachment.getLandTerritories()) {
@@ -1545,8 +1549,9 @@ public class MoveValidator {
           data.getMap().getRoute_IgnoreEnd(start, end, Match.allOf(Matches.TerritoryIsWater, noImpassable));
       if (waterRoute != null
           && ((waterRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
-              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) || (forceLandOrSeaRoute && Match
-                  .anyMatch(unitsWhichAreNotBeingTransportedOrDependent, Matches.UnitIsSea)))) {
+              .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) || (forceLandOrSeaRoute
+                  && Match
+                      .anyMatch(unitsWhichAreNotBeingTransportedOrDependent, Matches.UnitIsSea)))) {
         defaultRoute = waterRoute;
         mustGoSea = true;
       }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -308,7 +308,7 @@ public class MoveValidator {
     }
     // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
     if (route.hasNeutralBeforeEnd()) {
-      if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir) && !isNeutralsBlitzable(data)) {
+      if ((units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir)) && !isNeutralsBlitzable(data)) {
         return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
       }
     }
@@ -448,7 +448,7 @@ public class MoveValidator {
     }
     // if there are enemy units on the path blocking us, that is validated elsewhere (validateNonEnemyUnitsOnPath)
     // now check if we can move over neutral or enemies territories in noncombat
-    if (!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir)
+    if ((!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir))
         || (Match.noneMatch(units, Matches.UnitIsSea) && !nonParatroopersPresent(player, units))) {
       // if there are non-paratroopers present, then we cannot fly over stuff
       // if there are neutral territories in the middle, we cannot fly over (unless allowed to)
@@ -644,7 +644,7 @@ public class MoveValidator {
       }
       // if there is a neutral in the middle must stop unless all are air or getNeutralsBlitzable
       if (route.hasNeutralBeforeEnd()) {
-        if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir) && !isNeutralsBlitzable(data)) {
+        if ((units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir)) && !isNeutralsBlitzable(data)) {
           return result.setErrorReturnResult("Must stop land units when passing through neutral territories");
         }
       }
@@ -1550,8 +1550,7 @@ public class MoveValidator {
       if (waterRoute != null
           && ((waterRoute.getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent) <= defaultRoute
               .getLargestMovementCost(unitsWhichAreNotBeingTransportedOrDependent)) || (forceLandOrSeaRoute
-                  && Match
-                      .anyMatch(unitsWhichAreNotBeingTransportedOrDependent, Matches.UnitIsSea)))) {
+                  && Match.anyMatch(unitsWhichAreNotBeingTransportedOrDependent, Matches.UnitIsSea)))) {
         defaultRoute = waterRoute;
         mustGoSea = true;
       }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -379,15 +379,15 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       // play a sound
       if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSea)
           || Match.anyMatch(m_defendingUnits, Matches.UnitIsSea)) {
-        if (Match.allMatchNotEmpty(m_attackingUnits, Matches.UnitIsSub)
+        if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsSub)
             || (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)
                 && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub))) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_SEA_SUBS, m_attacker);
         } else {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_SEA_NORMAL, m_attacker);
         }
-      } else if (Match.allMatchNotEmpty(m_attackingUnits, Matches.UnitIsAir)
-          && Match.allMatchNotEmpty(m_defendingUnits, Matches.UnitIsAir)) {
+      } else if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)
+          && !m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.UnitIsAir)) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AIR, m_attacker);
       } else {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_LAND, m_attacker);
@@ -876,8 +876,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           endBattle(bridge);
           attackerWins(bridge);
         } else if (shouldEndBattleDueToMaxRounds()
-            || (Match.allMatchNotEmpty(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1).invert())
-                && Match.allMatchNotEmpty(m_defendingUnits, Matches.unitHasDefendValueOfAtLeast(1).invert()))) {
+            || (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1).invert())
+                && !m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.unitHasDefendValueOfAtLeast(1).invert()))) {
           endBattle(bridge);
           nobodyWins(bridge);
         }
@@ -1201,7 +1201,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // non-paratrooper non-amphibious
     // land units.
     // If attacker is all planes, just return collection of current territory
-    if (m_headless || Match.allMatchNotEmpty(m_attackingUnits, Matches.UnitIsAir)
+    if (m_headless || !m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)
         || games.strategy.triplea.Properties.getRetreatingUnitsRemainInPlace(m_data)) {
       final Collection<Territory> oneTerritory = new ArrayList<>(2);
       oneTerritory.add(m_battleSite);
@@ -1227,7 +1227,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (isWW2V2() || isWW2V3()) {
       possible = Match.getMatches(possible, Match.of(t -> {
         final Collection<Unit> units = m_attackingFromMap.get(t);
-        return !Match.allMatchNotEmpty(units, Matches.UnitIsAir);
+        return units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir);
       }));
     }
 
@@ -1266,7 +1266,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!isTransportCasualtiesRestricted()) {
       return false;
     }
-    return Match.allMatchNotEmpty(m_defendingUnits, Matches.UnitIsTransportButNotCombatTransport);
+    return !m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.UnitIsTransportButNotCombatTransport);
   }
 
   private boolean canAttackerRetreatSubs() {
@@ -1811,14 +1811,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    */
   private void submergeSubsVsOnlyAir(final IDelegateBridge bridge) {
     // if All attackers are AIR submerge any defending subs ..m_defendingUnits.removeAll(m_killed);
-    if (Match.allMatchNotEmpty(m_attackingUnits, Matches.UnitIsAir)
+    if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)
         && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub)) {
       // Get all defending subs (including allies) in the territory.
       final List<Unit> defendingSubs = Match.getMatches(m_defendingUnits, Matches.UnitIsSub);
       // submerge defending subs
       submergeUnits(defendingSubs, true, bridge);
       // checking defending air on attacking subs
-    } else if (Match.allMatchNotEmpty(m_defendingUnits, Matches.UnitIsAir)
+    } else if (!m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.UnitIsAir)
         && Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)) {
       // Get all attacking subs in the territory
       final List<Unit> attackingSubs = Match.getMatches(m_attackingUnits, Matches.UnitIsSub);
@@ -2035,7 +2035,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         && Match.anyMatch(attackedDefenders, Matches.UnitIsSub)) {
       attackedDefenders.removeAll(Match.getMatches(attackedDefenders, Matches.UnitIsSub));
     }
-    if (Match.allMatchNotEmpty(suicideAttackers, Matches.UnitIsSub)) {
+    if (!suicideAttackers.isEmpty() && Match.allMatch(suicideAttackers, Matches.UnitIsSub)) {
       attackedDefenders.removeAll(Match.getMatches(attackedDefenders, Matches.UnitIsAir));
     }
     if (suicideAttackers.size() == 0 || attackedDefenders.size() == 0) {
@@ -2066,7 +2066,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         && Match.anyMatch(attackedAttackers, Matches.UnitIsSub)) {
       attackedAttackers.removeAll(Match.getMatches(attackedAttackers, Matches.UnitIsSub));
     }
-    if (Match.allMatchNotEmpty(suicideDefenders, Matches.UnitIsSub)) {
+    if (!suicideDefenders.isEmpty() && Match.allMatch(suicideDefenders, Matches.UnitIsSub)) {
       suicideDefenders.removeAll(Match.getMatches(suicideDefenders, Matches.UnitIsAir));
     }
     if (suicideDefenders.size() == 0 || attackedAttackers.size() == 0) {
@@ -2544,7 +2544,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     if (!m_headless) {
       if (Matches.TerritoryIsWater.match(m_battleSite)) {
-        if (Match.allMatchNotEmpty(m_attackingUnits, Matches.UnitIsAir)) {
+        if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AIR_SUCCESSFUL,
               m_attacker);
         } else {
@@ -2556,7 +2556,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         // no sounds for a successful land battle, because land battle means we are going to capture a territory, and we
         // have capture sounds
         // for that
-        if (Match.allMatchNotEmpty(m_attackingUnits, Matches.UnitIsAir)) {
+        if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_AIR_SUCCESSFUL,
               m_attacker);
         }

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -379,7 +379,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       // play a sound
       if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSea)
           || Match.anyMatch(m_defendingUnits, Matches.UnitIsSea)) {
-        if (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsSub)
+        if ((!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsSub))
             || (Match.anyMatch(m_attackingUnits, Matches.UnitIsSub)
                 && Match.anyMatch(m_defendingUnits, Matches.UnitIsSub))) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_SEA_SUBS, m_attacker);

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -1203,7 +1203,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // non-paratrooper non-amphibious
     // land units.
     // If attacker is all planes, just return collection of current territory
-    if (m_headless || !m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir)
+    if (m_headless || (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.UnitIsAir))
         || games.strategy.triplea.Properties.getRetreatingUnitsRemainInPlace(m_data)) {
       final Collection<Territory> oneTerritory = new ArrayList<>(2);
       oneTerritory.add(m_battleSite);

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -876,8 +876,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           endBattle(bridge);
           attackerWins(bridge);
         } else if (shouldEndBattleDueToMaxRounds()
-            || (!m_attackingUnits.isEmpty() && Match.allMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1).invert())
-                && !m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.unitHasDefendValueOfAtLeast(1).invert()))) {
+            || (!m_attackingUnits.isEmpty()
+                && Match.allMatch(m_attackingUnits, Matches.unitHasAttackValueOfAtLeast(1).invert())
+                && !m_defendingUnits.isEmpty()
+                && Match.allMatch(m_defendingUnits, Matches.unitHasDefendValueOfAtLeast(1).invert()))) {
           endBattle(bridge);
           nobodyWins(bridge);
         }
@@ -1266,7 +1268,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!isTransportCasualtiesRestricted()) {
       return false;
     }
-    return !m_defendingUnits.isEmpty() && Match.allMatch(m_defendingUnits, Matches.UnitIsTransportButNotCombatTransport);
+    return !m_defendingUnits.isEmpty()
+        && Match.allMatch(m_defendingUnits, Matches.UnitIsTransportButNotCombatTransport);
   }
 
   private boolean canAttackerRetreatSubs() {

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -19,6 +19,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.MapSupport;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.delegate.IBattle.BattleType;
@@ -240,14 +241,13 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
       return result;
     }
     final BattleTracker battleTracker = AbstractMoveDelegate.getBattleTracker(data);
-    final boolean onlyWhereUnderAttackAlready =
-        games.strategy.triplea.Properties.getAirborneAttacksOnlyInExistingBattles(data);
-    final boolean onlyEnemyTerritories =
-        games.strategy.triplea.Properties.getAirborneAttacksOnlyInEnemyTerritories(data);
-    if (!Match.allMatchNotEmpty(route.getSteps(), Matches.territoryIsPassableAndNotRestricted(player, data))) {
+    final boolean onlyWhereUnderAttackAlready = Properties.getAirborneAttacksOnlyInExistingBattles(data);
+    final boolean onlyEnemyTerritories = Properties.getAirborneAttacksOnlyInEnemyTerritories(data);
+    final List<Territory> steps = route.getSteps();
+    if (steps.isEmpty() || !Match.allMatch(steps, Matches.territoryIsPassableAndNotRestricted(player, data))) {
       return result.setErrorReturnResult("May Not Fly Over Impassable or Restricted Territories");
     }
-    if (!Match.allMatchNotEmpty(route.getSteps(), Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))) {
+    if (steps.isEmpty() || !Match.allMatch(steps, Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))) {
       return result.setErrorReturnResult("May Only Fly Over Territories Where Air May Move");
     }
     final boolean someLand = Match.anyMatch(airborne, Matches.UnitIsLand);

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -467,7 +467,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     getDisplay(bridge).notifyDice(dice, SELECT_PREFIX + currentTypeAa + CASUALTIES_SUFFIX);
     final boolean isEditMode = BaseEditDelegate.getEditMode(m_data);
     final boolean allowMultipleHitsPerUnit =
-        Match.allMatchNotEmpty(defendingAa, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
+        !defendingAa.isEmpty() && Match.allMatch(defendingAa, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
     if (isEditMode) {
       final String text = currentTypeAa + AA_GUNS_FIRE_SUFFIX;
       final CasualtyDetails casualtySelection = BattleCalculator.selectCasualties(RAID, m_attacker,

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -601,7 +601,7 @@ class DummyPlayer extends AbstractAI {
       if (ourUnits == null || enemyUnits == null) {
         return null;
       }
-      if (Match.allMatchNotEmpty(enemyUnits, planeNotDestroyer) && Match.allMatchNotEmpty(ourUnits, seaSub)) {
+      if (!enemyUnits.isEmpty() && Match.allMatch(enemyUnits, planeNotDestroyer) && !ourUnits.isEmpty() && Match.allMatch(ourUnits, seaSub)) {
         return possibleTerritories.iterator().next();
       }
       return null;

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -503,7 +503,7 @@ class DummyGameModifiedChannel implements IGameModifiedChannel {
 
   @Override
   public void startHistoryEvent(final String event, final Object renderingData) {}
-  
+
   @Override
   public void stepChanged(final String stepName, final String delegateName, final PlayerID player, final int round,
       final String displayName, final boolean loadedFromSavedGame) {}
@@ -601,7 +601,8 @@ class DummyPlayer extends AbstractAI {
       if (ourUnits == null || enemyUnits == null) {
         return null;
       }
-      if (!enemyUnits.isEmpty() && Match.allMatch(enemyUnits, planeNotDestroyer) && !ourUnits.isEmpty() && Match.allMatch(ourUnits, seaSub)) {
+      if (!enemyUnits.isEmpty() && Match.allMatch(enemyUnits, planeNotDestroyer) && !ourUnits.isEmpty()
+          && Match.allMatch(ourUnits, seaSub)) {
         return possibleTerritories.iterator().next();
       }
       return null;

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1264,7 +1264,7 @@ public class MovePanel extends AbstractMovePanel {
             // is the only one for
             // which the route may actually change much)
             if (unitsThatCanMoveOnRoute.size() < selectedUnits.size() && (unitsThatCanMoveOnRoute.size() == 0
-                || !unitsThatCanMoveOnRoute.isEmpty() && Match.allMatch(unitsThatCanMoveOnRoute, Matches.UnitIsAir))) {
+                || (!unitsThatCanMoveOnRoute.isEmpty() && Match.allMatch(unitsThatCanMoveOnRoute, Matches.UnitIsAir)))) {
               final Collection<Unit> airUnits = Match.getMatches(selectedUnits, Matches.UnitIsAir);
               if (airUnits.size() > 0) {
                 route = getRoute(getFirstSelectedTerritory(), territory, airUnits);

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1264,7 +1264,7 @@ public class MovePanel extends AbstractMovePanel {
             // is the only one for
             // which the route may actually change much)
             if (unitsThatCanMoveOnRoute.size() < selectedUnits.size() && (unitsThatCanMoveOnRoute.size() == 0
-                || Match.allMatchNotEmpty(unitsThatCanMoveOnRoute, Matches.UnitIsAir))) {
+                || !unitsThatCanMoveOnRoute.isEmpty() && Match.allMatch(unitsThatCanMoveOnRoute, Matches.UnitIsAir))) {
               final Collection<Unit> airUnits = Match.getMatches(selectedUnits, Matches.UnitIsAir);
               if (airUnits.size() > 0) {
                 route = getRoute(getFirstSelectedTerritory(), territory, airUnits);

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1265,7 +1265,8 @@ public class MovePanel extends AbstractMovePanel {
             // is the only one for
             // which the route may actually change much)
             if (unitsThatCanMoveOnRoute.size() < selectedUnits.size() && (unitsThatCanMoveOnRoute.size() == 0
-                || (!unitsThatCanMoveOnRoute.isEmpty() && Match.allMatch(unitsThatCanMoveOnRoute, Matches.UnitIsAir)))) {
+                || (!unitsThatCanMoveOnRoute.isEmpty()
+                    && Match.allMatch(unitsThatCanMoveOnRoute, Matches.UnitIsAir)))) {
               final Collection<Unit> airUnits = Match.getMatches(selectedUnits, Matches.UnitIsAir);
               if (airUnits.size() > 0) {
                 route = getRoute(getFirstSelectedTerritory(), territory, airUnits);

--- a/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -152,7 +152,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
         if (unitChoices.size() < unitsPerPick) {
           // if we have fewer units than the number we are supposed to pick, set it to all
           pickedUnits.addAll(unitChoices);
-        } else if (Match.allMatchNotEmpty(unitChoices, Matches.unitIsOfType(unitChoices.get(0).getType()))) {
+        } else if (!unitChoices.isEmpty() && Match.allMatch(unitChoices, Matches.unitIsOfType(unitChoices.get(0).getType()))) {
           // if we have only 1 unit type, set it to that
           pickedUnits.clear();
           pickedUnits.addAll(Match.getNMatches(unitChoices, unitsPerPick, Match.always()));

--- a/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -152,7 +152,8 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
         if (unitChoices.size() < unitsPerPick) {
           // if we have fewer units than the number we are supposed to pick, set it to all
           pickedUnits.addAll(unitChoices);
-        } else if (!unitChoices.isEmpty() && Match.allMatch(unitChoices, Matches.unitIsOfType(unitChoices.get(0).getType()))) {
+        } else if (!unitChoices.isEmpty()
+            && Match.allMatch(unitChoices, Matches.unitIsOfType(unitChoices.get(0).getType()))) {
           // if we have only 1 unit type, set it to that
           pickedUnits.clear();
           pickedUnits.addAll(Match.getNMatches(unitChoices, unitsPerPick, Match.always()));

--- a/src/main/java/games/strategy/util/Match.java
+++ b/src/main/java/games/strategy/util/Match.java
@@ -89,17 +89,6 @@ public final class Match<T> {
 
   /**
    * returns true if all elements in the collection match.
-   * returns false if the collection is empty.
-   * 
-   * @deprecated Check if the collection you provided is empty on your own.
-   */
-  @Deprecated
-  public static <T> boolean allMatchNotEmpty(final Collection<T> collection, final Match<T> match) {
-    return !collection.isEmpty() && allMatch(collection, match);
-  }
-
-  /**
-   * returns true if all elements in the collection match.
    */
   public static <T> boolean allMatch(final Collection<T> collection, final Match<T> match) {
     return collection.stream().allMatch(match::match);

--- a/src/test/java/games/strategy/util/MatchTest.java
+++ b/src/test/java/games/strategy/util/MatchTest.java
@@ -106,15 +106,6 @@ public class MatchTest {
   public void testGetNMatches_ShouldThrowExceptionWhenMaxIsNegative() {
     Match.getNMatches(Arrays.asList(-1, 0, 1), -1, Match.always());
   }
-
-  @Test
-  public void testAllMatchNotEmpty() {
-    assertFalse("empty collection", Match.allMatchNotEmpty(Arrays.asList(), IS_ZERO_MATCH));
-    assertFalse("none match", Match.allMatchNotEmpty(Arrays.asList(-1, 1), IS_ZERO_MATCH));
-    assertFalse("some match", Match.allMatchNotEmpty(Arrays.asList(-1, 0, 1), IS_ZERO_MATCH));
-    assertTrue("all match (one element)", Match.allMatchNotEmpty(Arrays.asList(0), IS_ZERO_MATCH));
-    assertTrue("all match (multiple elements)", Match.allMatchNotEmpty(Arrays.asList(0, 0, 0), IS_ZERO_MATCH));
-  }
   
   @Test
   public void testAllMatch() {


### PR DESCRIPTION
This removes the usage of Match.allMatchNotEmpty.
Most of this PR was done using find-and-replace using regex expressions.
I reviewed every change myself afterwards, but it's very likely I overlooked something...