### PR TITLE
Checkstyle: Fix member name violations in remaining g.s.triplea.ui.* classes

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/MouseDetails.java
+++ b/src/main/java/games/strategy/triplea/ui/MouseDetails.java
@@ -6,57 +6,57 @@ import java.awt.event.MouseEvent;
 import javax.swing.SwingUtilities;
 
 public class MouseDetails {
-  private final MouseEvent m_mouseEvent;
+  private final MouseEvent mouseEvent;
   // the x position of the event on the map
   // this is in absolute pixels of the unscaled map
-  private final double m_x;
+  private final double x;
   // the x position of the event on the map
   // this is in absolute pixels of the unscaled map
-  private final double m_y;
+  private final double y;
 
   MouseDetails(final MouseEvent mouseEvent, final double x, final double y) {
     super();
-    m_mouseEvent = mouseEvent;
-    m_x = x;
-    m_y = y;
+    this.mouseEvent = mouseEvent;
+    this.x = x;
+    this.y = y;
   }
 
   public MouseEvent getMouseEvent() {
-    return m_mouseEvent;
+    return mouseEvent;
   }
 
   public double getX() {
-    return m_x;
+    return x;
   }
 
   public double getY() {
-    return m_y;
+    return y;
   }
 
   public boolean isRightButton() {
-    return SwingUtilities.isRightMouseButton(m_mouseEvent);
+    return SwingUtilities.isRightMouseButton(mouseEvent);
   }
 
   public boolean isControlDown() {
-    return m_mouseEvent.isControlDown();
+    return mouseEvent.isControlDown();
   }
 
   public boolean isShiftDown() {
-    return m_mouseEvent.isShiftDown();
+    return mouseEvent.isShiftDown();
   }
 
   public boolean isAltDown() {
-    return m_mouseEvent.isAltDown();
+    return mouseEvent.isAltDown();
   }
 
   /**
    * @return this point is in the map co-ordinates, unscaled.
    */
   public Point getMapPoint() {
-    return new Point((int) m_x, (int) m_y);
+    return new Point((int) x, (int) y);
   }
 
   public int getButton() {
-    return m_mouseEvent.getButton();
+    return mouseEvent.getButton();
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/NotificationMessages.java
+++ b/src/main/java/games/strategy/triplea/ui/NotificationMessages.java
@@ -16,9 +16,9 @@ public class NotificationMessages {
   // Filename
   private static final String PROPERTY_FILE = "notifications.properties";
   private static final String SOUND_CLIP_SUFFIX = "_sounds";
-  private static NotificationMessages s_nm = null;
-  private static long s_timestamp = 0;
-  private final Properties m_properties = new Properties();
+  private static NotificationMessages nm = null;
+  private static long timestamp = 0;
+  private final Properties properties = new Properties();
 
   protected NotificationMessages() {
     final ResourceLoader loader = AbstractUIContext.getResourceLoader();
@@ -27,7 +27,7 @@ public class NotificationMessages {
       final Optional<InputStream> inputStream = UrlStreams.openStream(url);
       if (inputStream.isPresent()) {
         try {
-          m_properties.load(inputStream.get());
+          properties.load(inputStream.get());
         } catch (final IOException e) {
           ClientLogger.logError("Error reading " + PROPERTY_FILE, e);
         }
@@ -37,24 +37,24 @@ public class NotificationMessages {
 
   public static NotificationMessages getInstance() {
     // cache properties for 10 seconds
-    if (s_nm == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 10000) {
-      s_nm = new NotificationMessages();
-      s_timestamp = Calendar.getInstance().getTimeInMillis();
+    if (nm == null || Calendar.getInstance().getTimeInMillis() > timestamp + 10000) {
+      nm = new NotificationMessages();
+      timestamp = Calendar.getInstance().getTimeInMillis();
     }
-    return s_nm;
+    return nm;
   }
 
   /**
    * Can be null if none exist.
    */
   public String getMessage(final String notificationMessageKey) {
-    return m_properties.getProperty(notificationMessageKey);
+    return properties.getProperty(notificationMessageKey);
   }
 
   /**
    * Can be null if none exist.
    */
   public String getSoundsKey(final String notificationMessageKey) {
-    return m_properties.getProperty(notificationMessageKey + SOUND_CLIP_SUFFIX);
+    return properties.getProperty(notificationMessageKey + SOUND_CLIP_SUFFIX);
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/PlaceData.java
+++ b/src/main/java/games/strategy/triplea/ui/PlaceData.java
@@ -6,19 +6,19 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 
 public class PlaceData {
-  private final Collection<Unit> m_units;
-  private final Territory m_at;
+  private final Collection<Unit> units;
+  private final Territory at;
 
   public PlaceData(final Collection<Unit> units, final Territory at) {
-    m_units = units;
-    m_at = at;
+    this.units = units;
+    this.at = at;
   }
 
   public Territory getAt() {
-    return m_at;
+    return at;
   }
 
   public Collection<Unit> getUnits() {
-    return m_units;
+    return units;
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/PlayerChooser.java
@@ -21,7 +21,7 @@ import games.strategy.ui.Util;
 public class PlayerChooser extends JOptionPane {
   private static final long serialVersionUID = -7272867474891641839L;
   private JList<PlayerID> list;
-  private final PlayerList m_players;
+  private final PlayerList players;
   private final PlayerID defaultPlayer;
   private final IUIContext uiContext;
   private final boolean allowNeutral;
@@ -38,7 +38,7 @@ public class PlayerChooser extends JOptionPane {
     setMessageType(JOptionPane.PLAIN_MESSAGE);
     setOptionType(JOptionPane.OK_CANCEL_OPTION);
     setIcon(null);
-    this.m_players = players;
+    this.players = players;
     this.defaultPlayer = defaultPlayer;
     this.uiContext = uiContext;
     this.allowNeutral = allowNeutral;
@@ -46,7 +46,7 @@ public class PlayerChooser extends JOptionPane {
   }
 
   private void createComponents() {
-    final Collection<PlayerID> players = new ArrayList<>(this.m_players.getPlayers());
+    final Collection<PlayerID> players = new ArrayList<>(this.players.getPlayers());
     if (allowNeutral) {
       players.add(PlayerID.NULL_PLAYERID);
     }
@@ -67,7 +67,7 @@ public class PlayerChooser extends JOptionPane {
     setMessage(SwingComponents.newJScrollPane(list));
 
     final int maxSize = 700;
-    final int suggestedSize = this.m_players.size() * 40;
+    final int suggestedSize = this.players.size() * 40;
     final int actualSize = suggestedSize > maxSize ? maxSize : suggestedSize;
     setPreferredSize(new Dimension(300, actualSize));
   }

--- a/src/main/java/games/strategy/triplea/ui/PoliticsText.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticsText.java
@@ -17,9 +17,9 @@ import games.strategy.util.UrlStreams;
 public class PoliticsText {
   // Filename
   private static final String PROPERTY_FILE = "politicstext.properties";
-  private static PoliticsText s_pt = null;
-  private static long s_timestamp = 0;
-  private final Properties m_properties = new Properties();
+  private static PoliticsText pt = null;
+  private static long timestamp = 0;
+  private final Properties properties = new Properties();
   private static final String BUTTON = "BUTTON";
   private static final String DESCRIPTION = "DESCRIPTION";
   private static final String NOTIFICATION_SUCCESS = "NOTIFICATION_SUCCESS";
@@ -36,7 +36,7 @@ public class PoliticsText {
       final Optional<InputStream> inputStream = UrlStreams.openStream(url);
       if (inputStream.isPresent()) {
         try {
-          m_properties.load(inputStream.get());
+          properties.load(inputStream.get());
         } catch (final IOException e) {
           System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
         }
@@ -46,15 +46,15 @@ public class PoliticsText {
 
   public static PoliticsText getInstance() {
     // cache properties for 10 seconds
-    if (s_pt == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 10000) {
-      s_pt = new PoliticsText();
-      s_timestamp = Calendar.getInstance().getTimeInMillis();
+    if (pt == null || Calendar.getInstance().getTimeInMillis() > timestamp + 10000) {
+      pt = new PoliticsText();
+      timestamp = Calendar.getInstance().getTimeInMillis();
     }
-    return s_pt;
+    return pt;
   }
 
   private String getString(final String value) {
-    return m_properties.getProperty(value, "NO: " + value + " set.");
+    return properties.getProperty(value, "NO: " + value + " set.");
   }
 
   private String getMessage(final String politicsKey, final String messageKey) {

--- a/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
@@ -36,12 +36,12 @@ public class ProductionTabsProperties {
   // The number of columns of units to be used in the panel if rows or columns are "0" the system will calculate based
   // on max units
   private static final String NUMBER_OF_COLUMNS = "production_tabs.columns";
-  private final Properties m_properties = new Properties();
-  private final List<Rule> m_rules;
-  private List<Tuple<String, List<Rule>>> m_ruleLists;
+  private final Properties properties = new Properties();
+  private final List<Rule> rules;
+  private List<Tuple<String, List<Rule>>> ruleLists;
 
   protected ProductionTabsProperties(final PlayerID playerId, final List<Rule> rules) {
-    m_rules = rules;
+    this.rules = rules;
     final ResourceLoader loader = AbstractUIContext.getResourceLoader();
     String propertyFile = PROPERTY_FILE + "." + playerId.getName() + ".properties";
     URL url = loader.getResource(propertyFile);
@@ -53,7 +53,7 @@ public class ProductionTabsProperties {
         final Optional<InputStream> inputStream = UrlStreams.openStream(url);
         if (inputStream.isPresent()) {
           try {
-            m_properties.load(inputStream.get());
+            properties.load(inputStream.get());
           } catch (final IOException e) {
             System.out.println("Error reading " + propertyFile + e);
           }
@@ -67,38 +67,38 @@ public class ProductionTabsProperties {
   }
 
   List<Tuple<String, List<Rule>>> getRuleLists() {
-    if (m_ruleLists != null) {
-      return m_ruleLists;
+    if (ruleLists != null) {
+      return ruleLists;
     }
-    m_ruleLists = new ArrayList<>();
+    ruleLists = new ArrayList<>();
     final int iTabs = getNumberOfTabs();
     for (int i = 1; i <= iTabs; i++) {
-      final String tabName = m_properties.getProperty(TAB_NAME + "." + i);
-      final List<String> tabValues = Arrays.asList(m_properties.getProperty(TAB_UNITS + "." + i).split(":"));
+      final String tabName = properties.getProperty(TAB_NAME + "." + i);
+      final List<String> tabValues = Arrays.asList(properties.getProperty(TAB_UNITS + "." + i).split(":"));
       final List<Rule> ruleList = new ArrayList<>();
-      for (final Rule rule : m_rules) {
+      for (final Rule rule : rules) {
         if (tabValues.contains(rule.getProductionRule().getResults().keySet().iterator().next().getName())) {
           ruleList.add(rule);
         }
       }
-      m_ruleLists.add(Tuple.of(tabName, ruleList));
+      ruleLists.add(Tuple.of(tabName, ruleList));
     }
-    return m_ruleLists;
+    return ruleLists;
   }
 
   private int getNumberOfTabs() {
-    return Integer.valueOf(m_properties.getProperty(NUMBER_OF_TABS, "0"));
+    return Integer.valueOf(properties.getProperty(NUMBER_OF_TABS, "0"));
   }
 
   public boolean useDefaultTabs() {
-    return Boolean.valueOf(m_properties.getProperty(USE_DEFAULT_TABS, "true"));
+    return Boolean.valueOf(properties.getProperty(USE_DEFAULT_TABS, "true"));
   }
 
   public int getRows() {
-    return Integer.valueOf(m_properties.getProperty(NUMBER_OF_ROWS, "0"));
+    return Integer.valueOf(properties.getProperty(NUMBER_OF_ROWS, "0"));
   }
 
   public int getColumns() {
-    return Integer.valueOf(m_properties.getProperty(NUMBER_OF_COLUMNS, "0"));
+    return Integer.valueOf(properties.getProperty(NUMBER_OF_COLUMNS, "0"));
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/RouteDescription.java
+++ b/src/main/java/games/strategy/triplea/ui/RouteDescription.java
@@ -6,23 +6,23 @@ import java.awt.Point;
 import games.strategy.engine.data.Route;
 
 public class RouteDescription {
-  private final Route m_route;
+  private final Route route;
   // this point is in map co-ordinates, un scaled
-  private final Point m_start;
+  private final Point start;
   // this point is in map co-ordinates, un scaled
-  private final Point m_end;
-  private final Image m_cursorImage;
+  private final Point end;
+  private final Image cursorImage;
 
   RouteDescription(final Route route, final Point start, final Point end, final Image cursorImage) {
-    m_route = route;
-    m_start = start;
-    m_end = end;
-    m_cursorImage = cursorImage;
+    this.route = route;
+    this.start = start;
+    this.end = end;
+    this.cursorImage = cursorImage;
   }
 
   @Override
   public int hashCode() {
-    return m_route.hashCode() + m_cursorImage.hashCode();
+    return route.hashCode() + cursorImage.hashCode();
   }
 
   @Override
@@ -34,46 +34,46 @@ public class RouteDescription {
       return false;
     }
     final RouteDescription other = (RouteDescription) o;
-    if (m_start == null && other.m_start != null || other.m_start == null && m_start != null
-        || (m_start != other.m_start && !m_start.equals(other.m_start))) {
+    if (start == null && other.start != null || other.start == null && start != null
+        || (start != other.start && !start.equals(other.start))) {
       return false;
     }
-    if (m_route == null && other.m_route != null || other.m_route == null && m_route != null
-        || (m_route != other.m_route && !m_route.equals(other.m_route))) {
+    if (route == null && other.route != null || other.route == null && route != null
+        || (route != other.route && !route.equals(other.route))) {
       return false;
     }
-    if (m_end == null && other.m_end != null || other.m_end == null && m_end != null) {
+    if (end == null && other.end != null || other.end == null && end != null) {
       return false;
     }
-    if (m_cursorImage != other.m_cursorImage) {
+    if (cursorImage != other.cursorImage) {
       return false;
     }
     // we dont want to be updating for every small change,
     // if the end points are close enough, they are close enough
-    if (other.m_end == null && this.m_end == null) {
+    if (other.end == null && this.end == null) {
       return true;
     }
-    int diffX = m_end.x - other.m_end.x;
+    int diffX = end.x - other.end.x;
     diffX *= diffX;
-    int diffY = m_end.y - other.m_end.y;
+    int diffY = end.y - other.end.y;
     diffY *= diffY;
     final int endDiff = (int) Math.sqrt(diffX + diffY);
     return endDiff < 6;
   }
 
   public Route getRoute() {
-    return m_route;
+    return route;
   }
 
   public Point getStart() {
-    return m_start;
+    return start;
   }
 
   public Point getEnd() {
-    return m_end;
+    return end;
   }
 
   public Image getCursorImage() {
-    return m_cursorImage;
+    return cursorImage;
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
+++ b/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
@@ -18,9 +18,9 @@ public class TooltipProperties {
   // Properties
   private static final String TOOLTIP = "tooltip";
   private static final String UNIT = "unit";
-  private static TooltipProperties s_ttp = null;
-  private static long s_timestamp = 0;
-  private final Properties m_properties = new Properties();
+  private static TooltipProperties ttp = null;
+  private static long timestamp = 0;
+  private final Properties properties = new Properties();
 
   protected TooltipProperties() {
     final ResourceLoader loader = AbstractUIContext.getResourceLoader();
@@ -29,7 +29,7 @@ public class TooltipProperties {
       final Optional<InputStream> inputStream = UrlStreams.openStream(url);
       if (inputStream.isPresent()) {
         try {
-          m_properties.load(inputStream.get());
+          properties.load(inputStream.get());
         } catch (final IOException e) {
           System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
         }
@@ -39,18 +39,18 @@ public class TooltipProperties {
 
   public static TooltipProperties getInstance() {
     // cache properties for 5 seconds
-    if (s_ttp == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 5000) {
-      s_ttp = new TooltipProperties();
-      s_timestamp = Calendar.getInstance().getTimeInMillis();
+    if (ttp == null || Calendar.getInstance().getTimeInMillis() > timestamp + 5000) {
+      ttp = new TooltipProperties();
+      timestamp = Calendar.getInstance().getTimeInMillis();
     }
-    return s_ttp;
+    return ttp;
   }
 
   public String getToolTip(final UnitType ut, final PlayerID playerId) {
-    final String tooltip = m_properties.getProperty(TOOLTIP + "." + UNIT + "." + ut.getName() + "."
+    final String tooltip = properties.getProperty(TOOLTIP + "." + UNIT + "." + ut.getName() + "."
         + (playerId == null ? PlayerID.NULL_PLAYERID.getName() : playerId.getName()), "");
     if (tooltip == null || tooltip.equals("")) {
-      return m_properties.getProperty(TOOLTIP + "." + UNIT + "." + ut.getName(), "");
+      return properties.getProperty(TOOLTIP + "." + UNIT + "." + ut.getName(), "");
     } else {
       return tooltip;
     }

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -285,7 +285,7 @@ public class TripleAFrame extends MainGameFrame {
     final Image small = uiContext.getMapImage().getSmallMapImage();
     smallView = new MapPanelSmallView(small, model);
     mapPanel = new MapPanel(data, smallView, uiContext, model, this::computeScrollSpeed);
-    mapPanel.addMapSelectionListener(MAP_SELECTION_LISTENER);
+    mapPanel.addMapSelectionListener(mapSelectionListener);
     final MouseOverUnitListener MOUSE_OVER_UNIT_LISTENER = (units, territory, me) -> unitsBeingMousedOver = units;
     mapPanel.addMouseOverUnitListener(MOUSE_OVER_UNIT_LISTENER);
     // link the small and large images
@@ -445,9 +445,9 @@ public class TripleAFrame extends MainGameFrame {
       }
     });
     // force a data change event to update the UI for edit mode
-    m_dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
-    data.addDataChangeListener(m_dataChangeListener);
-    game.addGameStepListener(m_stepListener);
+    dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
+    data.addDataChangeListener(dataChangeListener);
+    game.addGameStepListener(stepListener);
     updateStep();
     uiContext.addShutdownWindow(this);
   }
@@ -613,7 +613,7 @@ public class TripleAFrame extends MainGameFrame {
     }
   }
 
-  public MapSelectionListener MAP_SELECTION_LISTENER = new DefaultMapSelectionListener() {
+  public MapSelectionListener mapSelectionListener = new DefaultMapSelectionListener() {
     @Override
     public void mouseEntered(final Territory territory) {
       territoryLastEntered = territory;
@@ -1374,7 +1374,7 @@ public class TripleAFrame extends MainGameFrame {
     return selected.get();
   }
 
-  GameStepListener m_stepListener = (stepName, delegateName, player1, round1, stepDisplayName) -> updateStep();
+  GameStepListener stepListener = (stepName, delegateName, player1, round1, stepDisplayName) -> updateStep();
 
   private void updateStep() {
     final IUIContext context = uiContext;
@@ -1464,7 +1464,7 @@ public class TripleAFrame extends MainGameFrame {
     });
   }
 
-  GameDataChangeListener m_dataChangeListener = new GameDataChangeListener() {
+  GameDataChangeListener dataChangeListener = new GameDataChangeListener() {
     @Override
     public void gameDataChanged(final Change change) {
       try {
@@ -1638,13 +1638,13 @@ public class TripleAFrame extends MainGameFrame {
       if (clonedGameData == null) {
         return;
       }
-      data.removeDataChangeListener(m_dataChangeListener);
+      data.removeDataChangeListener(dataChangeListener);
       clonedGameData.testLocksOnRead();
       if (historySyncher != null) {
         throw new IllegalStateException("Two history synchers?");
       }
       historySyncher = new HistorySynchronizer(clonedGameData, game);
-      clonedGameData.addDataChangeListener(m_dataChangeListener);
+      clonedGameData.addDataChangeListener(dataChangeListener);
     } finally {
       data.releaseReadLock();
     }
@@ -1802,7 +1802,7 @@ public class TripleAFrame extends MainGameFrame {
       }
       historyPanel.goToEnd();
       historyPanel = null;
-      mapPanel.getData().removeDataChangeListener(m_dataChangeListener);
+      mapPanel.getData().removeDataChangeListener(dataChangeListener);
       statsPanel.setGameData(data);
       economyPanel.setGameData(data);
       if (objectivePanel != null && !objectivePanel.isEmpty()) {
@@ -1810,7 +1810,7 @@ public class TripleAFrame extends MainGameFrame {
       }
       details.setGameData(data);
       mapPanel.setGameData(data);
-      data.addDataChangeListener(m_dataChangeListener);
+      data.addDataChangeListener(dataChangeListener);
       tabsPanel.removeAll();
     }
     setWidgetActivation();
@@ -1848,9 +1848,9 @@ public class TripleAFrame extends MainGameFrame {
       }
       historyPanel.goToEnd();
       historyPanel = null;
-      mapPanel.getData().removeDataChangeListener(m_dataChangeListener);
+      mapPanel.getData().removeDataChangeListener(dataChangeListener);
       mapPanel.setGameData(data);
-      data.addDataChangeListener(m_dataChangeListener);
+      data.addDataChangeListener(dataChangeListener);
       gameMainPanel.removeAll();
       gameMainPanel.setLayout(new BorderLayout());
       gameMainPanel.add(mapAndChatPanel, BorderLayout.CENTER);
@@ -1874,13 +1874,13 @@ public class TripleAFrame extends MainGameFrame {
       SwingUtilities.invokeLater(() -> setWidgetActivation());
       return;
     }
-    if (m_showHistoryAction != null) {
-      m_showHistoryAction.setEnabled(!(inHistory || uiContext.getShowMapOnly()));
+    if (showHistoryAction != null) {
+      showHistoryAction.setEnabled(!(inHistory || uiContext.getShowMapOnly()));
     }
-    if (m_showGameAction != null) {
-      m_showGameAction.setEnabled(!inGame);
+    if (showGameAction != null) {
+      showGameAction.setEnabled(!inGame);
     }
-    if (m_showMapOnlyAction != null) {
+    if (showMapOnlyAction != null) {
       // We need to check and make sure there are no local human players
       boolean foundHuman = false;
       for (final IGamePlayer gamePlayer : localPlayers.getLocalPlayers()) {
@@ -1889,9 +1889,9 @@ public class TripleAFrame extends MainGameFrame {
         }
       }
       if (!foundHuman) {
-        m_showMapOnlyAction.setEnabled(inGame || inHistory);
+        showMapOnlyAction.setEnabled(inGame || inHistory);
       } else {
-        m_showMapOnlyAction.setEnabled(false);
+        showMapOnlyAction.setEnabled(false);
       }
     }
     if (editModeButtonModel != null) {
@@ -1907,7 +1907,7 @@ public class TripleAFrame extends MainGameFrame {
   public void setEditDelegate(final IEditDelegate editDelegate) {
     this.editDelegate = editDelegate;
     // force a data change event to update the UI for edit mode
-    m_dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
+    dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
     setWidgetActivation();
   }
 
@@ -1935,16 +1935,17 @@ public class TripleAFrame extends MainGameFrame {
     return isEditMode;
   }
 
-  private final AbstractAction m_showHistoryAction = new AbstractAction("Show history") {
+  private final AbstractAction showHistoryAction = new AbstractAction("Show history") {
     private static final long serialVersionUID = -3960551522512897374L;
 
     @Override
     public void actionPerformed(final ActionEvent e) {
       showHistory();
-      m_dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
+      dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
     }
   };
-  private final AbstractAction m_showGameAction = new AbstractAction("Show current game") {
+
+  private final AbstractAction showGameAction = new AbstractAction("Show current game") {
     private static final long serialVersionUID = -7551760679570164254L;
 
     {
@@ -1954,16 +1955,17 @@ public class TripleAFrame extends MainGameFrame {
     @Override
     public void actionPerformed(final ActionEvent e) {
       showGame();
-      m_dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
+      dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
     }
   };
-  private final AbstractAction m_showMapOnlyAction = new AbstractAction("Show map only") {
+
+  private final AbstractAction showMapOnlyAction = new AbstractAction("Show map only") {
     private static final long serialVersionUID = -6621157075878333141L;
 
     @Override
     public void actionPerformed(final ActionEvent e) {
       showMapOnly();
-      m_dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
+      dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
     }
   };
 
@@ -2042,15 +2044,15 @@ public class TripleAFrame extends MainGameFrame {
   }
 
   public Action getShowGameAction() {
-    return m_showGameAction;
+    return showGameAction;
   }
 
   public Action getShowHistoryAction() {
-    return m_showHistoryAction;
+    return showHistoryAction;
   }
 
   public Action getShowMapOnlyAction() {
-    return m_showMapOnlyAction;
+    return showMapOnlyAction;
   }
 
   public IUIContext getUIContext() {

--- a/src/main/java/games/strategy/triplea/ui/UserActionText.java
+++ b/src/main/java/games/strategy/triplea/ui/UserActionText.java
@@ -16,9 +16,9 @@ import games.strategy.util.UrlStreams;
 public class UserActionText {
   // Filename
   private static final String PROPERTY_FILE = "actionstext.properties";
-  private static UserActionText s_text = null;
-  private static long s_timestamp = 0;
-  private final Properties m_properties = new Properties();
+  private static UserActionText text = null;
+  private static long timestamp = 0;
+  private final Properties properties = new Properties();
   private static final String BUTTON = "BUTTON";
   private static final String DESCRIPTION = "DESCRIPTION";
   private static final String NOTIFICATION_SUCCESS = "NOTIFICATION_SUCCESS";
@@ -34,7 +34,7 @@ public class UserActionText {
       final Optional<InputStream> inputStream = UrlStreams.openStream(url);
       if (inputStream.isPresent()) {
         try {
-          m_properties.load(inputStream.get());
+          properties.load(inputStream.get());
         } catch (final IOException e) {
           System.out.println("Error reading " + PROPERTY_FILE + " : " + e);
         }
@@ -44,15 +44,15 @@ public class UserActionText {
 
   public static UserActionText getInstance() {
     // cache properties for 10 seconds
-    if (s_text == null || Calendar.getInstance().getTimeInMillis() > s_timestamp + 10000) {
-      s_text = new UserActionText();
-      s_timestamp = Calendar.getInstance().getTimeInMillis();
+    if (text == null || Calendar.getInstance().getTimeInMillis() > timestamp + 10000) {
+      text = new UserActionText();
+      timestamp = Calendar.getInstance().getTimeInMillis();
     }
-    return s_text;
+    return text;
   }
 
   private String getString(final String value) {
-    return m_properties.getProperty(value, "NO: " + value + " set.");
+    return properties.getProperty(value, "NO: " + value + " set.");
   }
 
   private String getMessage(final String actionKey, final String messageKey) {

--- a/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
@@ -18,10 +18,10 @@ import games.strategy.triplea.delegate.IBattle.BattleType;
 import games.strategy.triplea.ui.TripleAFrame;
 
 public class TripleADisplay implements ITripleADisplay {
-  private final TripleAFrame m_ui;
+  private final TripleAFrame ui;
 
   public TripleADisplay(final TripleAFrame ui) {
-    m_ui = ui;
+    this.ui = ui;
   }
 
   @Override
@@ -38,57 +38,57 @@ public class TripleADisplay implements ITripleADisplay {
       final Collection<Unit> attackingWaitingToDie, final Collection<Unit> defendingWaitingToDie,
       final Map<Unit, Collection<Unit>> unitDependents, final PlayerID attacker, final PlayerID defender,
       final boolean isAmphibious, final BattleType battleType, final Collection<Unit> amphibiousLandAttackers) {
-    m_ui.getBattlePanel().showBattle(battleId, location, attackingUnits, defendingUnits, killedUnits,
+    ui.getBattlePanel().showBattle(battleId, location, attackingUnits, defendingUnits, killedUnits,
         attackingWaitingToDie, defendingWaitingToDie, attacker, defender, isAmphibious, battleType,
         amphibiousLandAttackers);
   }
 
   @Override
   public void listBattleSteps(final GUID battleId, final List<String> steps) {
-    m_ui.getBattlePanel().listBattle(battleId, steps);
+    ui.getBattlePanel().listBattle(battleId, steps);
   }
 
   @Override
   public void casualtyNotification(final GUID battleId, final String step, final DiceRoll dice, final PlayerID player,
       final Collection<Unit> killed, final Collection<Unit> damaged, final Map<Unit, Collection<Unit>> dependents) {
-    m_ui.getBattlePanel().casualtyNotification(step, dice, player, killed, damaged, dependents);
+    ui.getBattlePanel().casualtyNotification(step, dice, player, killed, damaged, dependents);
   }
 
   @Override
   public void deadUnitNotification(final GUID battleId, final PlayerID player, final Collection<Unit> killed,
       final Map<Unit, Collection<Unit>> dependents) {
-    m_ui.getBattlePanel().deadUnitNotification(player, killed, dependents);
+    ui.getBattlePanel().deadUnitNotification(player, killed, dependents);
   }
 
   @Override
   public void changedUnitsNotification(final GUID battleId, final PlayerID player, final Collection<Unit> removedUnits,
       final Collection<Unit> addedUnits, final Map<Unit, Collection<Unit>> dependents) {
-    m_ui.getBattlePanel().changedUnitsNotification(player, removedUnits, addedUnits, dependents);
+    ui.getBattlePanel().changedUnitsNotification(player, removedUnits, addedUnits, dependents);
   }
 
   @Override
   public void battleEnd(final GUID battleId, final String message) {
-    m_ui.getBattlePanel().battleEndMessage(message);
+    ui.getBattlePanel().battleEndMessage(message);
   }
 
   @Override
   public void bombingResults(final GUID battleId, final List<Die> dice, final int cost) {
-    m_ui.getBattlePanel().bombingResults(battleId, dice, cost);
+    ui.getBattlePanel().bombingResults(battleId, dice, cost);
   }
 
   @Override
   public void notifyRetreat(final String shortMessage, final String message, final String step,
       final PlayerID retreatingPlayer) {
     // we just told the game to retreat, so we already know
-    if (m_ui.getLocalPlayers().playing(retreatingPlayer)) {
+    if (ui.getLocalPlayers().playing(retreatingPlayer)) {
       return;
     }
-    m_ui.getBattlePanel().notifyRetreat(shortMessage, message, step, retreatingPlayer);
+    ui.getBattlePanel().notifyRetreat(shortMessage, message, step, retreatingPlayer);
   }
 
   @Override
   public void notifyRetreat(final GUID battleId, final Collection<Unit> retreating) {
-    m_ui.getBattlePanel().notifyRetreat(retreating);
+    ui.getBattlePanel().notifyRetreat(retreating);
   }
 
   /**
@@ -96,17 +96,17 @@ public class TripleADisplay implements ITripleADisplay {
    */
   @Override
   public void notifyDice(final DiceRoll dice, final String stepName) {
-    m_ui.getBattlePanel().showDice(dice, stepName);
+    ui.getBattlePanel().showDice(dice, stepName);
   }
 
   @Override
   public void gotoBattleStep(final GUID battleId, final String step) {
-    m_ui.getBattlePanel().gotoStep(battleId, step);
+    ui.getBattlePanel().gotoStep(battleId, step);
   }
 
   @Override
   public void shutDown() {
-    m_ui.stopGame();
+    ui.stopGame();
   }
 
   @Override
@@ -120,7 +120,7 @@ public class TripleADisplay implements ITripleADisplay {
       boolean isClient = false;
       boolean isObserver = true;
       if (doNotIncludeHost || doNotIncludeClients || doNotIncludeObservers) {
-        for (final IGamePlayer player : m_ui.getLocalPlayers().getLocalPlayers()) {
+        for (final IGamePlayer player : ui.getLocalPlayers().getLocalPlayers()) {
           // if we have any local players, we are not an observer
           isObserver = false;
           if (player instanceof TripleAPlayer) {
@@ -139,7 +139,7 @@ public class TripleADisplay implements ITripleADisplay {
         return;
       }
     }
-    m_ui.notifyMessage(message, title);
+    ui.notifyMessage(message, title);
   }
 
   @Override
@@ -150,20 +150,20 @@ public class TripleADisplay implements ITripleADisplay {
     }
     if (butNotThesePlayers != null) {
       for (final PlayerID p : butNotThesePlayers) {
-        if (m_ui.getLocalPlayers().playing(p)) {
+        if (ui.getLocalPlayers().playing(p)) {
           return;
         }
       }
     }
     boolean isPlaying = false;
     for (final PlayerID p : playersToSendTo) {
-      if (m_ui.getLocalPlayers().playing(p)) {
+      if (ui.getLocalPlayers().playing(p)) {
         isPlaying = true;
         break;
       }
     }
     if (isPlaying) {
-      m_ui.notifyMessage(message, title);
+      ui.notifyMessage(message, title);
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -42,20 +42,20 @@ import games.strategy.util.IntegerMap;
 
 public class HistoryLog extends JFrame {
   private static final long serialVersionUID = 4880602702815333376L;
-  private final JTextArea m_textArea;
-  private final StringWriter m_stringWriter;
-  private final PrintWriter m_printWriter;
+  private final JTextArea textArea;
+  private final StringWriter stringWriter;
+  private final PrintWriter printWriter;
 
   public HistoryLog() {
-    m_textArea = new JTextArea(40, 80);
-    m_textArea.setEditable(false);
-    final JScrollPane scrollingArea = new JScrollPane(m_textArea);
+    textArea = new JTextArea(40, 80);
+    textArea.setEditable(false);
+    final JScrollPane scrollingArea = new JScrollPane(textArea);
     // ... Get the content pane, set layout, add to center
     final JPanel content = new JPanel();
     content.setLayout(new BorderLayout());
     content.add(scrollingArea, BorderLayout.CENTER);
-    m_stringWriter = new StringWriter();
-    m_printWriter = new PrintWriter(m_stringWriter);
+    stringWriter = new StringWriter();
+    printWriter = new PrintWriter(stringWriter);
     // ... Set window characteristics.
     this.setContentPane(content);
     this.setTitle("History Log");
@@ -64,17 +64,17 @@ public class HistoryLog extends JFrame {
   }
 
   public PrintWriter getWriter() {
-    return m_printWriter;
+    return printWriter;
   }
 
   @Override
   public String toString() {
-    return m_stringWriter.toString();
+    return stringWriter.toString();
   }
 
   public void clear() {
-    m_stringWriter.getBuffer().delete(0, m_stringWriter.getBuffer().length());
-    m_textArea.setText("");
+    stringWriter.getBuffer().delete(0, stringWriter.getBuffer().length());
+    textArea.setText("");
   }
 
   public void printFullTurn(final GameData data, final boolean verbose, final Collection<PlayerID> playersAllowed) {
@@ -155,7 +155,7 @@ public class HistoryLog extends JFrame {
   @SuppressWarnings("unchecked")
   public void printRemainingTurn(final HistoryNode printNode, final boolean verbose, final int diceSides,
       final Collection<PlayerID> playersAllowed) {
-    final PrintWriter logWriter = m_printWriter;
+    final PrintWriter logWriter = printWriter;
     final String moreIndent = "    ";
     // print out the parent nodes
     DefaultMutableTreeNode curNode = printNode;
@@ -385,7 +385,7 @@ public class HistoryLog extends JFrame {
     }
     logWriter.println();
     logWriter.println();
-    m_textArea.setText(m_stringWriter.toString());
+    textArea.setText(stringWriter.toString());
   }
 
   public void printTerritorySummary(final HistoryNode printNode, final GameData data) {
@@ -437,7 +437,7 @@ public class HistoryLog extends JFrame {
     if (players == null || players.isEmpty() || territories == null || territories.isEmpty()) {
       return;
     }
-    final PrintWriter logWriter = m_printWriter;
+    final PrintWriter logWriter = printWriter;
     // print all units in all territories, including "flags"
     logWriter.println("Territory Summary for " + MyFormatter.defaultNamedToTextList(players) + " : \n");
     for (final Territory t : territories) {
@@ -467,11 +467,11 @@ public class HistoryLog extends JFrame {
     }
     logWriter.println();
     logWriter.println();
-    m_textArea.setText(m_stringWriter.toString());
+    textArea.setText(stringWriter.toString());
   }
 
   public void printDiceStatistics(final GameData data, final IRandomStats randomStats) {
-    final PrintWriter logWriter = m_printWriter;
+    final PrintWriter logWriter = printWriter;
     final RandomStatsDetails stats = randomStats.getRandomStats(data.getDiceSides());
     final String diceStats = stats.getAllStatsString("    ");
     if (diceStats.length() > 0) {
@@ -479,11 +479,11 @@ public class HistoryLog extends JFrame {
       logWriter.println();
       logWriter.println();
     }
-    m_textArea.setText(m_stringWriter.toString());
+    textArea.setText(stringWriter.toString());
   }
 
   public void printProductionSummary(final GameData data) {
-    final PrintWriter logWriter = m_printWriter;
+    final PrintWriter logWriter = printWriter;
     Collection<PlayerID> players;
     Resource pus;
     data.acquireReadLock();
@@ -504,7 +504,7 @@ public class HistoryLog extends JFrame {
     }
     logWriter.println();
     logWriter.println();
-    m_textArea.setText(m_stringWriter.toString());
+    textArea.setText(stringWriter.toString());
   }
 
   // copied from StatPanel


### PR DESCRIPTION
This PR fixes the remaining violations of the Checkstyle MemberName rule in classes under the `g.s.triplea.ui` package.

All member renames were done via automated refactoring.  There were a few manual newline insertions to add some whitespace between affected members that were crammed a bit too closely to their neighbors.