### PR TITLE
Checkstyle: Fix recent regressions

### DIFF
--- a/src/main/java/games/strategy/engine/config/client/GameEnginePropertyReader.java
+++ b/src/main/java/games/strategy/engine/config/client/GameEnginePropertyReader.java
@@ -84,6 +84,7 @@ public class GameEnginePropertyReader {
   public boolean useJavaFxUi() {
     return propertyFileReader.readProperty(PropertyKeys.JAVAFX_UI).equalsIgnoreCase(String.valueOf(true));
   }
+
   @VisibleForTesting
   interface PropertyKeys {
     String MAP_LISTING_SOURCE_FILE = "map_list_file";

--- a/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -9,7 +9,9 @@ import javax.swing.JComboBox;
 import javax.swing.JComponent;
 
 /**
- * A String property that uses a list for selecting the value.
+ * A property that uses a list for selecting the value.
+ *
+ * @param <T> The type of the property value.
  */
 public class ComboProperty<T> extends AEditableProperty {
   private static final long serialVersionUID = -3098612299805630587L;
@@ -23,7 +25,7 @@ public class ComboProperty<T> extends AEditableProperty {
    * @param defaultValue
    *        default string value
    * @param possibleValues
-   *        collection of Strings
+   *        collection of values
    */
   public ComboProperty(final String name, final String description, final T defaultValue,
       final Collection<T> possibleValues) {

--- a/src/main/java/games/strategy/triplea/delegate/remote/IAbstractMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/remote/IAbstractMoveDelegate.java
@@ -7,15 +7,16 @@ import games.strategy.engine.message.IRemote;
 
 /**
  * Remote interface for MoveDelegate and PlaceDelegate.
+ *
+ * @param <T> The type of the move (typically {@code UndoableMove} or {@code UndoablePlacement}).
  */
 public interface IAbstractMoveDelegate<T> extends IRemote, IDelegate {
   /**
    * Get the moves already made.
    *
-   * @return a list of UndoableMoves or UndoablePlacements
+   * @return A list of moves already made.
    */
   List<T> getMovesMade();
-
 
   /**
    * @param moveIndex

--- a/src/main/java/games/strategy/util/IntegerMap.java
+++ b/src/main/java/games/strategy/util/IntegerMap.java
@@ -11,6 +11,8 @@ import java.util.Set;
 /**
  * A utility class for mapping Objects to ints. <br>
  * Supports adding and comparing of maps.
+ *
+ * @param <T> The type of the map key.
  */
 public class IntegerMap<T> implements Cloneable, Serializable {
   private static final long serialVersionUID = 6856531659284300930L;

--- a/src/main/java/games/strategy/util/LinkedIntegerMap.java
+++ b/src/main/java/games/strategy/util/LinkedIntegerMap.java
@@ -12,6 +12,8 @@ import java.util.Set;
  * A utility class for mapping Objects to ints. <br>
  * Supports adding and comparing of maps. <br>
  * Uses LinkedHashMap to keep insert order.
+ *
+ * @param <T> The type of the map key.
  */
 public class LinkedIntegerMap<T> implements Cloneable, Serializable {
   private static final long serialVersionUID = 6856531659284300930L;


### PR DESCRIPTION
One regression was due to a merge.  The remaining are from when we enabled the JavadocType rule.