### PR TITLE
Ignore non-source folders when building Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+bin
+build
+derby_db


### PR DESCRIPTION
This reduces the size of the Docker build context from ~1 GiB to ~228 MiB on a typical dev machine.