### PR TITLE
Nest DummyPlayer directly under OddsCalculator

### DIFF
--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -46,7 +46,6 @@ import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
 import games.strategy.triplea.delegate.remote.ITechDelegate;
-import games.strategy.triplea.oddsCalculator.ta.OddsCalculator.DummyGameModifiedChannel.DummyPlayer;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
 import games.strategy.triplea.ui.display.ITripleADisplay;
 import games.strategy.util.Match;
@@ -487,8 +486,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
     }
   }
 
-
-  static class DummyGameModifiedChannel implements IGameModifiedChannel {
+  private static class DummyGameModifiedChannel implements IGameModifiedChannel {
     @Override
     public void addChildToEvent(final String text, final Object renderingData) {}
 
@@ -508,208 +506,207 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
     @Override
     public void stepChanged(final String stepName, final String delegateName, final PlayerID player, final int round,
         final String displayName, final boolean loadedFromSavedGame) {}
+  }
 
-    static class DummyPlayer extends AbstractAI {
-      private final boolean keepAtLeastOneLand;
-      // negative = do not retreat
-      private final int retreatAfterRound;
-      // negative = do not retreat
-      private final int retreatAfterXUnitsLeft;
-      private final boolean retreatWhenOnlyAirLeft;
-      private final DummyDelegateBridge bridge;
-      private final boolean isAttacker;
-      private final List<Unit> orderOfLosses;
+  private static class DummyPlayer extends AbstractAI {
+    private final boolean keepAtLeastOneLand;
+    // negative = do not retreat
+    private final int retreatAfterRound;
+    // negative = do not retreat
+    private final int retreatAfterXUnitsLeft;
+    private final boolean retreatWhenOnlyAirLeft;
+    private final DummyDelegateBridge bridge;
+    private final boolean isAttacker;
+    private final List<Unit> orderOfLosses;
 
-      public DummyPlayer(final DummyDelegateBridge dummyDelegateBridge, final boolean attacker, final String name,
-          final String type, final List<Unit> orderOfLosses, final boolean keepAtLeastOneLand,
-          final int retreatAfterRound,
-          final int retreatAfterXUnitsLeft, final boolean retreatWhenOnlyAirLeft) {
-        super(name, type);
-        this.keepAtLeastOneLand = keepAtLeastOneLand;
-        this.retreatAfterRound = retreatAfterRound;
-        this.retreatAfterXUnitsLeft = retreatAfterXUnitsLeft;
-        this.retreatWhenOnlyAirLeft = retreatWhenOnlyAirLeft;
-        bridge = dummyDelegateBridge;
-        isAttacker = attacker;
-        this.orderOfLosses = orderOfLosses;
+    public DummyPlayer(final DummyDelegateBridge dummyDelegateBridge, final boolean attacker, final String name,
+        final String type, final List<Unit> orderOfLosses, final boolean keepAtLeastOneLand,
+        final int retreatAfterRound,
+        final int retreatAfterXUnitsLeft, final boolean retreatWhenOnlyAirLeft) {
+      super(name, type);
+      this.keepAtLeastOneLand = keepAtLeastOneLand;
+      this.retreatAfterRound = retreatAfterRound;
+      this.retreatAfterXUnitsLeft = retreatAfterXUnitsLeft;
+      this.retreatWhenOnlyAirLeft = retreatWhenOnlyAirLeft;
+      bridge = dummyDelegateBridge;
+      isAttacker = attacker;
+      this.orderOfLosses = orderOfLosses;
+    }
+
+    private MustFightBattle getBattle() {
+      return bridge.getBattle();
+    }
+
+    private List<Unit> getOurUnits() {
+      final MustFightBattle battle = getBattle();
+      if (battle == null) {
+        return null;
       }
+      return new ArrayList<>((isAttacker ? battle.getAttackingUnits() : battle.getDefendingUnits()));
+    }
 
-      private MustFightBattle getBattle() {
-        return bridge.getBattle();
+    private List<Unit> getEnemyUnits() {
+      final MustFightBattle battle = getBattle();
+      if (battle == null) {
+        return null;
       }
+      return new ArrayList<>((isAttacker ? battle.getDefendingUnits() : battle.getAttackingUnits()));
+    }
 
-      private List<Unit> getOurUnits() {
+    @Override
+    protected void move(final boolean nonCombat, final IMoveDelegate moveDel, final GameData data,
+        final PlayerID player) {}
+
+    @Override
+    protected void place(final boolean placeForBid, final IAbstractPlaceDelegate placeDelegate, final GameData data,
+        final PlayerID player) {}
+
+    @Override
+    protected void purchase(final boolean purcahseForBid, final int pusToSpend,
+        final IPurchaseDelegate purchaseDelegate,
+        final GameData data, final PlayerID player) {}
+
+    @Override
+    protected void tech(final ITechDelegate techDelegate, final GameData data, final PlayerID player) {}
+
+    @Override
+    public boolean confirmMoveInFaceOfAA(final Collection<Territory> aaFiringTerritories) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<Unit> getNumberOfFightersToMoveToNewCarrier(final Collection<Unit> fightersThatCanBeMoved,
+        final Territory from) {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * The battle calc doesn't actually care if you have available territories to retreat to or not.
+     * It will always let you retreat to the 'current' territory (the battle territory), even if that is illegal.
+     * This is because the battle calc does not know where the attackers are actually coming from.
+     */
+    @Override
+    public Territory retreatQuery(final GUID battleId, final boolean submerge, final Territory battleSite,
+        final Collection<Territory> possibleTerritories, final String message) {
+      // null = do not retreat
+      if (possibleTerritories.isEmpty()) {
+        return null;
+      }
+      if (submerge) {
+        // submerge if all air vs subs
+        final Match<Unit> seaSub = Match.allOf(Matches.UnitIsSea, Matches.UnitIsSub);
+        final Match<Unit> planeNotDestroyer = Match.allOf(Matches.UnitIsAir, Matches.UnitIsDestroyer.invert());
+        final List<Unit> ourUnits = getOurUnits();
+        final List<Unit> enemyUnits = getEnemyUnits();
+        if (ourUnits == null || enemyUnits == null) {
+          return null;
+        }
+        if (!enemyUnits.isEmpty() && Match.allMatch(enemyUnits, planeNotDestroyer) && !ourUnits.isEmpty()
+            && Match.allMatch(ourUnits, seaSub)) {
+          return possibleTerritories.iterator().next();
+        }
+        return null;
+      } else {
         final MustFightBattle battle = getBattle();
         if (battle == null) {
           return null;
         }
-        return new ArrayList<>((isAttacker ? battle.getAttackingUnits() : battle.getDefendingUnits()));
-      }
-
-      private List<Unit> getEnemyUnits() {
-        final MustFightBattle battle = getBattle();
-        if (battle == null) {
+        if (retreatAfterRound > -1 && battle.getBattleRound() >= retreatAfterRound) {
+          return possibleTerritories.iterator().next();
+        }
+        if (!retreatWhenOnlyAirLeft && retreatAfterXUnitsLeft <= -1) {
           return null;
         }
-        return new ArrayList<>((isAttacker ? battle.getDefendingUnits() : battle.getAttackingUnits()));
-      }
-
-      @Override
-      protected void move(final boolean nonCombat, final IMoveDelegate moveDel, final GameData data,
-          final PlayerID player) {}
-
-      @Override
-      protected void place(final boolean placeForBid, final IAbstractPlaceDelegate placeDelegate, final GameData data,
-          final PlayerID player) {}
-
-      @Override
-      protected void purchase(final boolean purcahseForBid, final int pusToSpend,
-          final IPurchaseDelegate purchaseDelegate,
-          final GameData data, final PlayerID player) {}
-
-      @Override
-      protected void tech(final ITechDelegate techDelegate, final GameData data, final PlayerID player) {}
-
-      @Override
-      public boolean confirmMoveInFaceOfAA(final Collection<Territory> aaFiringTerritories) {
-        throw new UnsupportedOperationException();
-      }
-
-      @Override
-      public Collection<Unit> getNumberOfFightersToMoveToNewCarrier(final Collection<Unit> fightersThatCanBeMoved,
-          final Territory from) {
-        throw new UnsupportedOperationException();
-      }
-
-      /**
-       * The battle calc doesn't actually care if you have available territories to retreat to or not.
-       * It will always let you retreat to the 'current' territory (the battle territory), even if that is illegal.
-       * This is because the battle calc does not know where the attackers are actually coming from.
-       */
-      @Override
-      public Territory retreatQuery(final GUID battleId, final boolean submerge, final Territory battleSite,
-          final Collection<Territory> possibleTerritories, final String message) {
-        // null = do not retreat
-        if (possibleTerritories.isEmpty()) {
-          return null;
-        }
-        if (submerge) {
-          // submerge if all air vs subs
-          final Match<Unit> seaSub = Match.allOf(Matches.UnitIsSea, Matches.UnitIsSub);
-          final Match<Unit> planeNotDestroyer = Match.allOf(Matches.UnitIsAir, Matches.UnitIsDestroyer.invert());
-          final List<Unit> ourUnits = getOurUnits();
-          final List<Unit> enemyUnits = getEnemyUnits();
-          if (ourUnits == null || enemyUnits == null) {
-            return null;
+        final Collection<Unit> unitsLeft = isAttacker ? battle.getAttackingUnits() : battle.getDefendingUnits();
+        final Collection<Unit> airLeft = Match.getMatches(unitsLeft, Matches.UnitIsAir);
+        if (retreatWhenOnlyAirLeft) {
+          // lets say we have a bunch of 3 attack air unit, and a 4 attack non-air unit,
+          // and we want to retreat when we have all air units left + that 4 attack non-air (cus it gets taken
+          // casualty
+          // last)
+          // then we add the number of air, to the retreat after X left number (which we would set to '1')
+          int retreatNum = airLeft.size();
+          if (retreatAfterXUnitsLeft > 0) {
+            retreatNum += retreatAfterXUnitsLeft;
           }
-          if (!enemyUnits.isEmpty() && Match.allMatch(enemyUnits, planeNotDestroyer) && !ourUnits.isEmpty()
-              && Match.allMatch(ourUnits, seaSub)) {
+          if (retreatNum >= unitsLeft.size()) {
             return possibleTerritories.iterator().next();
           }
-          return null;
-        } else {
-          final MustFightBattle battle = getBattle();
-          if (battle == null) {
-            return null;
-          }
-          if (retreatAfterRound > -1 && battle.getBattleRound() >= retreatAfterRound) {
-            return possibleTerritories.iterator().next();
-          }
-          if (!retreatWhenOnlyAirLeft && retreatAfterXUnitsLeft <= -1) {
-            return null;
-          }
-          final Collection<Unit> unitsLeft = isAttacker ? battle.getAttackingUnits() : battle.getDefendingUnits();
-          final Collection<Unit> airLeft = Match.getMatches(unitsLeft, Matches.UnitIsAir);
-          if (retreatWhenOnlyAirLeft) {
-            // lets say we have a bunch of 3 attack air unit, and a 4 attack non-air unit,
-            // and we want to retreat when we have all air units left + that 4 attack non-air (cus it gets taken
-            // casualty
-            // last)
-            // then we add the number of air, to the retreat after X left number (which we would set to '1')
-            int retreatNum = airLeft.size();
-            if (retreatAfterXUnitsLeft > 0) {
-              retreatNum += retreatAfterXUnitsLeft;
-            }
-            if (retreatNum >= unitsLeft.size()) {
-              return possibleTerritories.iterator().next();
-            }
-          }
-          if (retreatAfterXUnitsLeft > -1 && retreatAfterXUnitsLeft >= unitsLeft.size()) {
-            return possibleTerritories.iterator().next();
-          }
-          return null;
+        }
+        if (retreatAfterXUnitsLeft > -1 && retreatAfterXUnitsLeft >= unitsLeft.size()) {
+          return possibleTerritories.iterator().next();
+        }
+        return null;
+      }
+    }
+
+    // Added new collection autoKilled to handle killing units prior to casualty selection
+    @Override
+    public CasualtyDetails selectCasualties(final Collection<Unit> selectFrom,
+        final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
+        final PlayerID hit, final Collection<Unit> friendlyUnits, final PlayerID enemyPlayer,
+        final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
+        final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
+        final boolean allowMultipleHitsPerUnit) {
+      final List<Unit> rDamaged = new ArrayList<>(defaultCasualties.getDamaged());
+      final List<Unit> rKilled = new ArrayList<>(defaultCasualties.getKilled());
+      if (keepAtLeastOneLand) {
+        final List<Unit> notKilled = new ArrayList<>(selectFrom);
+        notKilled.removeAll(rKilled);
+        // no land units left, but we have a non land unit to kill and land unit was killed
+        if (!Match.anyMatch(notKilled, Matches.UnitIsLand) && Match.anyMatch(notKilled, Matches.UnitIsNotLand)
+            && Match.anyMatch(rKilled, Matches.UnitIsLand)) {
+          final List<Unit> notKilledAndNotLand = Match.getMatches(notKilled, Matches.UnitIsNotLand);
+          // sort according to cost
+          Collections.sort(notKilledAndNotLand, AIUtils.getCostComparator());
+          // remove the last killed unit, this should be the strongest
+          rKilled.remove(rKilled.size() - 1);
+          // add the cheapest unit
+          rKilled.add(notKilledAndNotLand.get(0));
         }
       }
-
-      // Added new collection autoKilled to handle killing units prior to casualty selection
-      @Override
-      public CasualtyDetails selectCasualties(final Collection<Unit> selectFrom,
-          final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
-          final PlayerID hit, final Collection<Unit> friendlyUnits, final PlayerID enemyPlayer,
-          final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
-          final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
-          final boolean allowMultipleHitsPerUnit) {
-        final List<Unit> rDamaged = new ArrayList<>(defaultCasualties.getDamaged());
-        final List<Unit> rKilled = new ArrayList<>(defaultCasualties.getKilled());
-        if (keepAtLeastOneLand) {
-          final List<Unit> notKilled = new ArrayList<>(selectFrom);
-          notKilled.removeAll(rKilled);
-          // no land units left, but we have a non land unit to kill and land unit was killed
-          if (!Match.anyMatch(notKilled, Matches.UnitIsLand) && Match.anyMatch(notKilled, Matches.UnitIsNotLand)
-              && Match.anyMatch(rKilled, Matches.UnitIsLand)) {
-            final List<Unit> notKilledAndNotLand = Match.getMatches(notKilled, Matches.UnitIsNotLand);
-            // sort according to cost
-            Collections.sort(notKilledAndNotLand, AIUtils.getCostComparator());
-            // remove the last killed unit, this should be the strongest
-            rKilled.remove(rKilled.size() - 1);
-            // add the cheapest unit
-            rKilled.add(notKilledAndNotLand.get(0));
+      if (orderOfLosses != null && !orderOfLosses.isEmpty() && !rKilled.isEmpty()) {
+        final List<Unit> orderOfLosses = new ArrayList<>(this.orderOfLosses);
+        orderOfLosses.retainAll(selectFrom);
+        if (!orderOfLosses.isEmpty()) {
+          int killedSize = rKilled.size();
+          rKilled.clear();
+          while (killedSize > 0 && !orderOfLosses.isEmpty()) {
+            rKilled.add(orderOfLosses.get(0));
+            orderOfLosses.remove(0);
+            killedSize--;
           }
-        }
-        if (orderOfLosses != null && !orderOfLosses.isEmpty() && !rKilled.isEmpty()) {
-          final List<Unit> orderOfLosses = new ArrayList<>(this.orderOfLosses);
-          orderOfLosses.retainAll(selectFrom);
-          if (!orderOfLosses.isEmpty()) {
-            int killedSize = rKilled.size();
-            rKilled.clear();
-            while (killedSize > 0 && !orderOfLosses.isEmpty()) {
-              rKilled.add(orderOfLosses.get(0));
-              orderOfLosses.remove(0);
+          if (killedSize > 0) {
+            final List<Unit> defaultKilled = new ArrayList<>(defaultCasualties.getKilled());
+            defaultKilled.removeAll(rKilled);
+            while (killedSize > 0) {
+              rKilled.add(defaultKilled.get(0));
+              defaultKilled.remove(0);
               killedSize--;
             }
-            if (killedSize > 0) {
-              final List<Unit> defaultKilled = new ArrayList<>(defaultCasualties.getKilled());
-              defaultKilled.removeAll(rKilled);
-              while (killedSize > 0) {
-                rKilled.add(defaultKilled.get(0));
-                defaultKilled.remove(0);
-                killedSize--;
-              }
-            }
           }
         }
-        final CasualtyDetails casualtyDetails = new CasualtyDetails(rKilled, rDamaged, false);
-        return casualtyDetails;
       }
+      final CasualtyDetails casualtyDetails = new CasualtyDetails(rKilled, rDamaged, false);
+      return casualtyDetails;
+    }
 
-      @Override
-      public Territory selectTerritoryForAirToLand(final Collection<Territory> candidates,
-          final Territory currentTerritory,
-          final String unitMessage) {
-        throw new UnsupportedOperationException();
-      }
+    @Override
+    public Territory selectTerritoryForAirToLand(final Collection<Territory> candidates,
+        final Territory currentTerritory,
+        final String unitMessage) {
+      throw new UnsupportedOperationException();
+    }
 
-      @Override
-      public boolean shouldBomberBomb(final Territory territory) {
-        throw new UnsupportedOperationException();
-      }
+    @Override
+    public boolean shouldBomberBomb(final Territory territory) {
+      throw new UnsupportedOperationException();
+    }
 
-      @Override
-      public Unit whatShouldBomberBomb(final Territory territory, final Collection<Unit> potentialTargets,
-          final Collection<Unit> bombers) {
-        throw new UnsupportedOperationException();
-      }
-
+    @Override
+    public Unit whatShouldBomberBomb(final Territory territory, final Collection<Unit> potentialTargets,
+        final Collection<Unit> bombers) {
+      throw new UnsupportedOperationException();
     }
   }
 }


### PR DESCRIPTION
It appears that the `DummyPlayer` class used by `OddsCalculator` was accidentally nested under `OddsCalculator$DummyGameModifiedChannel` during conflict resolution in merge commit 1c76cb9.  This PR simply moves this class so it is nested directly under `OddsCalculator`, which was the original intent per c3ccc6c.

I also reduced the visibility of all nested types in this file to private.

This PR is more easily reviewed when ignoring whitespace changes (`?w=1`).