### PR TITLE
Checkstyle: Enable additional naming rules

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -108,10 +108,12 @@
              value="Type name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ConstantName">
+            <property name="format" value="^([a-z][a-z0-9][a-zA-Z0-9]*|[A-Z][A-Z0-9]+(_[A-Z0-9]+)*)$"/>
             <message key="name.invalidPattern"
              value="Constant name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="StaticVariableName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
              value="Static variable name ''{0}'' must match pattern ''{1}''."/>
         </module>
@@ -137,6 +139,7 @@
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="LocalFinalVariableName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
              value="Local final variable name ''{0}'' must match pattern ''{1}''."/>
         </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -107,6 +107,14 @@
             <message key="name.invalidPattern"
              value="Type name ''{0}'' must match pattern ''{1}''."/>
         </module>
+        <module name="ConstantName">
+            <message key="name.invalidPattern"
+             value="Constant name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="StaticVariableName">
+            <message key="name.invalidPattern"
+             value="Static variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
         <module name="MemberName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
@@ -127,6 +135,10 @@
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalFinalVariableName">
+            <message key="name.invalidPattern"
+             value="Local final variable name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="ClassTypeParameterName">
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 checkstyleIntegTestMaxWarnings=0
-checkstyleMainMaxWarnings=2835
-checkstyleTestMaxWarnings=10
+checkstyleMainMaxWarnings=3392
+checkstyleTestMaxWarnings=89

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 checkstyleIntegTestMaxWarnings=0
-checkstyleMainMaxWarnings=3392
-checkstyleTestMaxWarnings=89
+checkstyleMainMaxWarnings=3560
+checkstyleTestMaxWarnings=65


### PR DESCRIPTION
For whatever reason, the Google Checkstyle ruleset does not enable the ConstantName, LocalFinalVariableName, and StaticVariableName rules.  This PR enables those rules with the default formats.  However, I think this PR should be discussed a bit just in case the team feels one or more of these rules shouldn't be enabled or one of the default formats should be changed.

These rules are summarized below:

Rule | Applies to | Default format | Notes
:-- | :-- | :-- | :--
ConstantName | `static`, `final` fields | `^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$` |
LocalFinalVariableName | local, `final` variables, including `catch` parameters and resources in `try` statements | `^[a-z][a-zA-Z0-9]*$` | format same as LocalVariableName rule
StaticVariableName | `static`, non-`final` fields | `^[a-z][a-zA-Z0-9]*$` | format same as MemberName rule

Enabling these rules increases the Checkstyle violation counts as follows:

Rule | main | test | integTest | | Total
:-- | :-- | :-- | :-- | :-- | :--
ConstantName | +295 | +34 | 0 | | +329
StaticVariableName | +85 | +5 | 0 | | +90
LocalFinalVariableName | +186 | +40 | 0 | | +226
| | | | |
**Total** | +566 | +79 | 0 | | +645
