### PR TITLE
Remove most checkstyle violations in test code

### DIFF
--- a/src/test/java/games/strategy/engine/data/annotations/ExampleAttachment.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ExampleAttachment.java
@@ -12,12 +12,12 @@ import games.strategy.util.IntegerMap;
  */
 public class ExampleAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -5820318094331518742L;
-  private int m_techCost;
-  private boolean m_heavyBomber;
-  private String m_attribute;
-  private IntegerMap<UnitType> m_givesMovement = new IntegerMap<>();
+  private int techCost;
+  private boolean heavyBomber;
+  private String attribute;
+  private IntegerMap<UnitType> givesMovement = new IntegerMap<>();
   @InternalDoNotExport
-  private String m_notAProperty = "str";
+  private String notAProperty = "str";
 
   public ExampleAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
@@ -25,60 +25,60 @@ public class ExampleAttachment extends DefaultAttachment {
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setTechCost(final String techCost) {
-    m_techCost = getInt(techCost);
+    this.techCost = getInt(techCost);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setTechCost(final int techCost) {
-    m_techCost = techCost;
+    this.techCost = techCost;
   }
 
   public int getTechCost() {
-    return m_techCost;
+    return techCost;
   }
 
   public void resetTechCost() {
-    m_techCost = 5;
+    techCost = 5;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setHeavyBomber(final String heavyBomber) {
-    m_heavyBomber = getBool(heavyBomber);
+    this.heavyBomber = getBool(heavyBomber);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setHeavyBomber(final boolean heavyBomber) {
-    m_heavyBomber = heavyBomber;
+    this.heavyBomber = heavyBomber;
   }
 
   public boolean getHeavyBomber() {
-    return m_heavyBomber;
+    return heavyBomber;
   }
 
   public void resetHeavyBomber() {
-    m_heavyBomber = false;
+    heavyBomber = false;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setAttribute(final String attribute) {
-    m_attribute = attribute;
+    this.attribute = attribute;
   }
 
   public String getAttribute() {
-    return m_attribute;
+    return attribute;
   }
 
   public void resetAttribute() {
-    m_attribute = null;
+    attribute = null;
   }
 
   @InternalDoNotExport
   public void setNotAProperty(final String notAProperty) {
-    m_notAProperty = notAProperty;
+    this.notAProperty = notAProperty;
   }
 
   public String getNotAProperty() {
-    return m_notAProperty;
+    return notAProperty;
   }
 
   /**
@@ -99,24 +99,24 @@ public class ExampleAttachment extends DefaultAttachment {
     }
     // we should allow positive and negative numbers, since you can give bonuses to units or take away a unit's movement
     final int n = getInt(s[0]);
-    m_givesMovement.add(ut, n);
+    givesMovement.add(ut, n);
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setGivesMovement(final IntegerMap<UnitType> value) {
-    m_givesMovement = value;
+    givesMovement = value;
   }
 
   public IntegerMap<UnitType> getGivesMovement() {
-    return m_givesMovement;
+    return givesMovement;
   }
 
   public void clearGivesMovement() {
-    m_givesMovement.clear();
+    givesMovement.clear();
   }
 
   public void resetGivesMovement() {
-    m_givesMovement = new IntegerMap<>();
+    givesMovement = new IntegerMap<>();
   }
 
   @Override

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidClearExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidClearExample.java
@@ -17,7 +17,7 @@ public class InvalidClearExample extends DefaultAttachment {
     super(name, attachable, gameData);
   }
 
-  private final IntegerMap<UnitType> m_givesMovement = new IntegerMap<>();
+  private final IntegerMap<UnitType> givesMovement = new IntegerMap<>();
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
   public void setGivesMovement(final String value) {}
@@ -25,11 +25,11 @@ public class InvalidClearExample extends DefaultAttachment {
   public void resetGivesMovement() {}
 
   public void clearMovement() { // badly named, should cause test to fail
-    m_givesMovement.clear();
+    givesMovement.clear();
   }
 
   public IntegerMap<UnitType> getGivesMovement() {
-    return m_givesMovement;
+    return givesMovement;
   }
 
   @Override

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidFieldNameExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidFieldNameExample.java
@@ -16,15 +16,15 @@ public class InvalidFieldNameExample extends DefaultAttachment {
   }
 
   // should have been prefixed with "m_". Should cause test to fail.
-  private String attribute;
+  private String notAnAttribute;
 
   public String getAttribute() {
-    return attribute;
+    return notAnAttribute;
   }
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setAttribute(final String attribute) {
-    this.attribute = attribute;
+    this.notAnAttribute = attribute;
   }
 
   public void resetAttribute() {}

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidFieldNameExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidFieldNameExample.java
@@ -15,7 +15,7 @@ public class InvalidFieldNameExample extends DefaultAttachment {
     super(name, attachable, gameData);
   }
 
-  // should have been prefixed with "m_". Should cause test to fail.
+  // This attribute with another name than 'attribute' should cause tests to fail.
   private String notAnAttribute;
 
   public String getAttribute() {

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidFieldTypeExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidFieldTypeExample.java
@@ -19,7 +19,7 @@ public class InvalidFieldTypeExample extends DefaultAttachment {
 
   @SuppressWarnings("unused")
   // this should be an integermap, since that is what we are returning. should cause test to fail.
-  private String m_givesMovement;
+  private String givesMovement;
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
   public void setGivesMovement(final String value) {}

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidGetterExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidGetterExample.java
@@ -15,15 +15,15 @@ public class InvalidGetterExample extends DefaultAttachment {
     super(name, attachable, gameData);
   }
 
-  private String m_attribute;
+  private String attribute;
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public String getAttribute() { // annotation put on a getter instead of a setter, should cause test to fail
-    return m_attribute;
+    return attribute;
   }
 
   public void setAttribute(final String attribute) {
-    m_attribute = attribute;
+    this.attribute = attribute;
   }
 
   public void resetAttribute() {}

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidResetExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidResetExample.java
@@ -17,21 +17,21 @@ public class InvalidResetExample extends DefaultAttachment {
     super(name, attachable, gameData);
   }
 
-  private IntegerMap<UnitType> m_givesMovement = new IntegerMap<>();
+  private IntegerMap<UnitType> givesMovement = new IntegerMap<>();
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
   public void setGivesMovement(final String value) {}
 
   public void resetGiveMovement() { // badly named, should cause test to fail
-    m_givesMovement = new IntegerMap<>();
+    givesMovement = new IntegerMap<>();
   }
 
   public void clearGivesMovement() {
-    m_givesMovement.clear();
+    givesMovement.clear();
   }
 
   public IntegerMap<UnitType> getGivesMovement() {
-    return m_givesMovement;
+    return givesMovement;
   }
 
   @Override

--- a/src/test/java/games/strategy/engine/data/annotations/InvalidReturnTypeExample.java
+++ b/src/test/java/games/strategy/engine/data/annotations/InvalidReturnTypeExample.java
@@ -16,7 +16,7 @@ public class InvalidReturnTypeExample extends DefaultAttachment {
   }
 
   @SuppressWarnings("unused")
-  private String m_attribute;
+  private String attribute;
 
   public int getAttribute() { // is not returning our variable, so should cause test to fail
     return 1;
@@ -24,7 +24,7 @@ public class InvalidReturnTypeExample extends DefaultAttachment {
 
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setAttribute(final String attribute) {
-    m_attribute = attribute;
+    this.attribute = attribute;
   }
 
   public void resetAttribute() {}

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -292,7 +292,7 @@ public class ValidateAttachmentsTest {
       // validate that there is a field and a getter
       Field field = null;
       try {
-        field = PropertyUtil.getFieldIncludingFromSuperClasses(clazz, "m_" + propertyName, false);
+        field = PropertyUtil.getFieldIncludingFromSuperClasses(clazz, propertyName, false);
         // adders must have a field of type IntegerMap, or be a collection of sorts
         if (annotation.adds()) {
           if (!(Collection.class.isAssignableFrom(field.getType()) || Map.class.isAssignableFrom(field.getType())

--- a/src/test/java/games/strategy/engine/lobby/server/userDB/DbUserTest.java
+++ b/src/test/java/games/strategy/engine/lobby/server/userDB/DbUserTest.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 
 import org.junit.Test;
 
-public class DBUserTest {
+public class DbUserTest {
 
   private static void verifyValid(final DBUser validDbUser) {
     assertThat("Expecting no validation error messages: " + validDbUser.getValidationErrorMessage(),

--- a/src/test/java/games/strategy/test/TestUtil.java
+++ b/src/test/java/games/strategy/test/TestUtil.java
@@ -8,6 +8,9 @@ import com.google.common.io.Files;
 
 import games.strategy.ui.SwingAction;
 
+/**
+ * A Utility class for test classes.
+ */
 public class TestUtil {
 
   /** Create and returns a simple delete on exit temp file with contents equal to the String parameter. */

--- a/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
+++ b/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
@@ -18,7 +18,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.GameDataTestUtil;
 import games.strategy.triplea.xml.TestMapGameData;
 
-public class AIUtilsTest {
+public class AiUtilsTest {
   private GameData gameData;
 
   @Before

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -367,6 +367,7 @@ public class GameDataTestUtil {
   public static void assertValid(final String string) {
     Assert.assertNull(string, string);
   }
+  
   /**
    * Helper method to check if a String is null and otherwise print the String
    * which doesn't make any sense because the String will then always be null.

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -369,10 +369,10 @@ public class GameDataTestUtil {
   }
   
   /**
-   * Helper method to check if a String is null and otherwise print the String
-   * which doesn't make any sense because the String will then always be null.
+   * Helper method to check if a String is not null.
+   * In this scenario used to verify an error message exists.
    */
   public static void assertError(final String string) {
-    Assert.assertNotNull(string, string);
+    Assert.assertNotNull(string);
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -23,35 +23,70 @@ import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.ui.display.ITripleADisplay;
 import junit.framework.AssertionFailedError;
 
+/**
+ * A utility class for GameData test classes.
+ */
 public class GameDataTestUtil {
+  /**
+   * Get the german PlayerID for the given GameData object.
+   * @return A german PlayerID.
+   */
   public static PlayerID germans(final GameData data) {
     return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_GERMANS);
   }
 
+  /**
+   * Get the italian PlayerID for the given GameData object.
+   * @return A italian PlayerID.
+   */
   public static PlayerID italians(final GameData data) {
     return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_ITALIANS);
   }
 
+  /**
+   * Get the russian PlayerID for the given GameData object.
+   * @return A russian PlayerID.
+   */
   public static PlayerID russians(final GameData data) {
     return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_RUSSIANS);
   }
 
+  /**
+   * Get the american PlayerID for the given GameData object.
+   * @return A american PlayerID.
+   */
   public static PlayerID americans(final GameData data) {
     return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_AMERICANS);
   }
 
+  /**
+   * Get the british PlayerID for the given GameData object.
+   * @return A british PlayerID.
+   */
   public static PlayerID british(final GameData data) {
     return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_BRITISH);
   }
 
+  /**
+   * Get the japanese PlayerID for the given GameData object.
+   * @return A japanese PlayerID.
+   */
   public static PlayerID japanese(final GameData data) {
     return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_JAPANESE);
   }
 
+  /**
+   * Get the chinese PlayerID for the given GameData object.
+   * @return A chinese PlayerID.
+   */
   public static PlayerID chinese(final GameData data) {
     return data.getPlayerList().getPlayerID(Constants.PLAYER_NAME_CHINESE);
   }
 
+  /**
+   * Returns a territory object for the given name in the specified GameData object.
+   * @return A Territory matching the given name if present, otherwise throwing an Exception.
+   */
   public static Territory territory(final String name, final GameData data) {
     final Territory t = data.getMap().getTerritory(name);
     if (t == null) {
@@ -60,112 +95,193 @@ public class GameDataTestUtil {
     return t;
   }
 
+  /**
+   * Returns an armor UnitType object for the specified GameData object.
+   */
   public static UnitType armour(final GameData data) {
     return unitType(Constants.UNIT_TYPE_ARMOUR, data);
   }
 
+  /**
+   * Returns an aaGun UnitType object for the specified GameData object.
+   */
   public static UnitType aaGun(final GameData data) {
     return unitType(Constants.UNIT_TYPE_AAGUN, data);
   }
 
+  /**
+   * Returns a transport UnitType object for the specified GameData object.
+   */
   public static UnitType transport(final GameData data) {
     return unitType(Constants.UNIT_TYPE_TRANSPORT, data);
   }
 
+  /**
+   * Returns a battleship UnitType object for the specified GameData object.
+   */
   public static UnitType battleship(final GameData data) {
     return unitType(Constants.UNIT_TYPE_BATTLESHIP, data);
   }
 
+  /**
+   * Returns a carrier UnitType object for the specified GameData object.
+   */
   public static UnitType carrier(final GameData data) {
     return unitType(Constants.UNIT_TYPE_CARRIER, data);
   }
 
   // Some units hard coded here rather than placed in Constants at the request of community members Ref: Pull Request
   // 1074
+  /**
+   * Returns a tacBomber UnitType object for the specified GameData object.
+   */
   public static UnitType tacBomber(final GameData data) {
     return unitType("tactical_bomber", data);
   }
 
+  /**
+   * Returns an airbase UnitType object for the specified GameData object.
+   */
   public static UnitType airbase(final GameData data) {
     return unitType("airbase", data);
   }
 
+  /**
+   * Returns a harbour UnitType object for the specified GameData object.
+   */
   public static UnitType harbour(final GameData data) {
     return unitType("harbour", data);
   }
 
+  /**
+   * Returns a factoryMajor UnitType object for the specified GameData object.
+   */
   public static UnitType factoryMajor(final GameData data) {
     return unitType("factory_major", data);
   }
 
+  /**
+   * Returns a factoryMinor UnitType object for the specified GameData object.
+   */
   public static UnitType factoryMinor(final GameData data) {
     return unitType("factory_minor", data);
   }
 
+  /**
+   * Returns a fighter UnitType object for the specified GameData object.
+   */
   public static UnitType fighter(final GameData data) {
     return unitType(Constants.UNIT_TYPE_FIGHTER, data);
   }
 
+  /**
+   * Returns a destroyer UnitType object for the specified GameData object.
+   */
   public static UnitType destroyer(final GameData data) {
     return unitType(Constants.UNIT_TYPE_DESTROYER, data);
   }
 
+  /**
+   * Returns a submarine UnitType object for the specified GameData object.
+   */
   public static UnitType submarine(final GameData data) {
     return unitType(Constants.UNIT_TYPE_SUBMARINE, data);
   }
 
+  /**
+   * Returns an infantry UnitType object for the specified GameData object.
+   */
   public static UnitType infantry(final GameData data) {
     return unitType(Constants.UNIT_TYPE_INFANTRY, data);
   }
 
+  /**
+   * Returns a bomber UnitType object for the specified GameData object.
+   */
   public static UnitType bomber(final GameData data) {
     return unitType(Constants.UNIT_TYPE_BOMBER, data);
   }
 
+  /**
+   * Returns a factory UnitType object for the specified GameData object.
+   */
   public static UnitType factory(final GameData data) {
     return unitType(Constants.UNIT_TYPE_FACTORY, data);
   }
 
+  /**
+   * Returns a UnitType object matching the given name for the specified GameData object if present.
+   */
   private static UnitType unitType(final String name, final GameData data) {
     return data.getUnitTypeList().getUnitType(name);
   }
 
+  /**
+   * Removes all units from the given Collection from the given Territory.
+   */
   public static void removeFrom(final Territory t, final Collection<Unit> units) {
     t.getData().performChange(ChangeFactory.removeUnits(t, units));
   }
 
+  /**
+   * Adds all units from the given Collection to the given Territory.
+   */
   public static void addTo(final Territory t, final Collection<Unit> units) {
     t.getData().performChange(ChangeFactory.addUnits(t, units));
   }
 
+  /**
+   * Adds all units from the given Collection to the given PlayerID.
+   */
   public static void addTo(final PlayerID t, final Collection<Unit> units, final GameData data) {
     data.performChange(ChangeFactory.addUnits(t, units));
   }
 
+  /**
+   * Returns a PlaceDelegate from the given GameData object.
+   */
   public static PlaceDelegate placeDelegate(final GameData data) {
     return (PlaceDelegate) data.getDelegateList().getDelegate("place");
   }
 
+  /**
+   * Returns a BattleDelegate from the given GameData object.
+   */
   public static BattleDelegate battleDelegate(final GameData data) {
     return (BattleDelegate) data.getDelegateList().getDelegate("battle");
   }
 
+  /**
+   * Returns a MoveDelegate from the given GameData object.
+   */
   public static MoveDelegate moveDelegate(final GameData data) {
     return (MoveDelegate) data.getDelegateList().getDelegate("move");
   }
 
+  /**
+   * Returns a TechnologyDelegate from the given GameData object.
+   */
   public static TechnologyDelegate techDelegate(final GameData data) {
     return (TechnologyDelegate) data.getDelegateList().getDelegate("tech");
   }
 
+  /**
+   * Returns a PurchaseDelegate from the given GameData object.
+   */
   public static PurchaseDelegate purchaseDelegate(final GameData data) {
     return (PurchaseDelegate) data.getDelegateList().getDelegate("purchase");
   }
 
+  /**
+   * Returns a BidPlaceDelegate from the given GameData object.
+   */
   public static BidPlaceDelegate bidPlaceDelegate(final GameData data) {
     return (BidPlaceDelegate) data.getDelegateList().getDelegate("placeBid");
   }
-
+  
+  /**
+   * Returns a TestDelegateBridge for the given GameData + PlayerID objects.
+   */
   public static ITestDelegateBridge getDelegateBridge(final PlayerID player, final GameData data) {
     return new TestDelegateBridge(data, player, mock(ITripleADisplay.class));
   }
@@ -245,10 +361,16 @@ public class GameDataTestUtil {
     TechAttachment.get(player).setAARadar(Boolean.TRUE.toString());
   }
 
+  /**
+   * Helper method to check if a String is null and otherwise print the String.
+   */
   public static void assertValid(final String string) {
     Assert.assertNull(string, string);
   }
-
+  /**
+   * Helper method to check if a String is null and otherwise print the String
+   * which doesn't make any sense because the String will then always be null.
+   */
   public static void assertError(final String string) {
     Assert.assertNotNull(string, string);
   }

--- a/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -32,7 +32,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.xml.TestMapGameData;
 
-public class LHTRTest {
+public class LhtrTest {
   private GameData gameData;
 
   @Before

--- a/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
@@ -18,7 +18,7 @@ import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.Match;
 
-public class Pact_of_Steel_2_Test {
+public class PactOfSteel2Test {
   private GameData gameData;
 
   @Before

--- a/src/test/java/games/strategy/triplea/delegate/StratBombTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/StratBombTest.java
@@ -74,6 +74,8 @@ public class StratBombTest {
         case "factory_major":
           factory = (TripleAUnit) target;
           break;
+        default:
+          break;
       }
     }
     targets.put(airfield, new HashSet<>(Collections.singleton(tacBomber1)));

--- a/src/test/java/games/strategy/triplea/delegate/WW2V341Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V341Test.java
@@ -95,7 +95,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
-public class WW2V3_41_Test {
+public class WW2V341Test {
   private GameData gameData;
   private final ITripleAPlayer dummyPlayer = mock(ITripleAPlayer.class);
 

--- a/src/test/java/games/strategy/triplea/delegate/WW2V342Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V342Test.java
@@ -32,7 +32,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.xml.TestMapGameData;
 
-public class WW2V3_42_Test {
+public class WW2V342Test {
   private GameData gameData;
 
   @Before

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -95,7 +95,7 @@ import games.strategy.triplea.xml.TestMapGameData;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
-public class WW2V341Test {
+public class WW2V3Year41Test {
   private GameData gameData;
   private final ITripleAPlayer dummyPlayer = mock(ITripleAPlayer.class);
 

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -32,7 +32,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.player.ITripleAPlayer;
 import games.strategy.triplea.xml.TestMapGameData;
 
-public class WW2V342Test {
+public class WW2V3Year42Test {
   private GameData gameData;
 
   @Before

--- a/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -9,6 +9,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParser;
 
+/**
+ * Enum providing all the constants to be used by other tests.
+ */
 public enum TestMapGameData {
   BIG_WORLD_1942("big_world_1942_test.xml"),
   IRON_BLITZ("iron_blitz_test.xml"),

--- a/src/test/java/games/strategy/util/PropertyUtilTest.java
+++ b/src/test/java/games/strategy/util/PropertyUtilTest.java
@@ -113,11 +113,11 @@ public class PropertyUtilTest {
   private static class UnderBarClass {
     
     @SuppressWarnings("unused")
-    private String bar = PropertyUtilTest.DEFAULT;
+    private String m_bar = PropertyUtilTest.DEFAULT;
     
     @SuppressWarnings("unused")
     public void setBar(final String newValue) {
-      bar = newValue;
+      m_bar = newValue;
     }
   }
 }

--- a/src/test/java/games/strategy/util/PropertyUtilTest.java
+++ b/src/test/java/games/strategy/util/PropertyUtilTest.java
@@ -54,7 +54,7 @@ public class PropertyUtilTest {
 
   @Test
   public void testGetFieldWithPrefixedPropertyNames() {
-    assertThat(PropertyUtil.getPropertyFieldObject(BAR, new mUnderBarClass()), is(DEFAULT));
+    assertThat(PropertyUtil.getPropertyFieldObject(BAR, new UnderBarClass()), is(DEFAULT));
   }
 
 
@@ -110,14 +110,14 @@ public class PropertyUtilTest {
     }
   }
 
-  private static class mUnderBarClass {
+  private static class UnderBarClass {
     
     @SuppressWarnings("unused")
-    private String m_bar = PropertyUtilTest.DEFAULT;
+    private String bar = PropertyUtilTest.DEFAULT;
     
     @SuppressWarnings("unused")
     public void setBar(final String newValue) {
-      m_bar = newValue;
+      bar = newValue;
     }
   }
 }

--- a/src/test/java/tools/map/xml/creator/MapXmlCreatorTestBase.java
+++ b/src/test/java/tools/map/xml/creator/MapXmlCreatorTestBase.java
@@ -3,6 +3,9 @@ package tools.map.xml.creator;
 import org.junit.Before;
 import org.junit.Ignore;
 
+/**
+ * Abstract class to be used as base for MapXmlHelperTest.
+ */
 public abstract class MapXmlCreatorTestBase {
 
   private MapXmlCreator mapXmlCreator;


### PR DESCRIPTION
There are only few violations left in the test code.
We don't need to worry about the SHA512 violation, #2101 removes that class.
There is some javadoc needed in the GameDataTestUtil class, I tried adding javadocs as best as I could, but I wasn't able to figure out what some methods do.
Also there are some violations with camelCase package names.
I tried changing those, but this causes errors on case insensitive file systems. (I wasn't able to make eclipse compile triplea)