### PR TITLE
Fix broken moderator commands when connected to old lobby (#2110)

### DIFF
--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -10,6 +10,7 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import javax.swing.Action;
@@ -155,10 +156,10 @@ public class LobbyFrame extends JFrame {
       }
       if (selectedTimeUnit.equals("Forever")) {
         if (selectedBanType.toLowerCase().contains("name")) {
-          controller.zzBanUsername(clickedOn, (Instant) null);
+          controller.banUsername(clickedOn, null);
         }
         if (selectedBanType.toLowerCase().contains("mac")) {
-          controller.zzBanMac(clickedOn, (Instant) null);
+          controller.banMac(clickedOn, null);
         }
         // Should we keep this auto?
         controller.boot(clickedOn);
@@ -189,10 +190,10 @@ public class LobbyFrame extends JFrame {
       }
       final Instant expire = Instant.now().plus(Duration.of(result2, unit));
       if (selectedBanType.toLowerCase().contains("name")) {
-        controller.zzBanUsername(clickedOn, expire);
+        controller.banUsername(clickedOn, Date.from(expire));
       }
       if (selectedBanType.toLowerCase().contains("mac")) {
-        controller.zzBanMac(clickedOn, expire);
+        controller.banMac(clickedOn, Date.from(expire));
       }
       // Should we keep this auto?
       controller.boot(clickedOn);
@@ -232,10 +233,10 @@ public class LobbyFrame extends JFrame {
       }
       if (selectedTimeUnit.equals("Forever")) {
         if (selectedMuteType.toLowerCase().contains("name")) {
-          controller.zzMuteUsername(clickedOn, (Instant) null);
+          controller.muteUsername(clickedOn, null);
         }
         if (selectedMuteType.toLowerCase().contains("mac")) {
-          controller.zzMuteMac(clickedOn, (Instant) null);
+          controller.muteMac(clickedOn, null);
         }
         return;
       }
@@ -264,10 +265,10 @@ public class LobbyFrame extends JFrame {
       }
       final Instant expire = Instant.now().plus(Duration.of(result2, unit));
       if (selectedMuteType.toLowerCase().contains("name")) {
-        controller.zzMuteUsername(clickedOn, expire);
+        controller.muteUsername(clickedOn, Date.from(expire));
       }
       if (selectedMuteType.toLowerCase().contains("mac")) {
-        controller.zzMuteMac(clickedOn, expire);
+        controller.muteMac(clickedOn, Date.from(expire));
       }
     }));
     rVal.add(SwingAction.of("Quick Mute", e -> {
@@ -288,8 +289,8 @@ public class LobbyFrame extends JFrame {
           return;
         }
         final Instant expire = Instant.now().plus(Duration.ofMinutes(resultMuteLengthInMinutes));
-        controller.zzMuteUsername(clickedOn, expire);
-        controller.zzMuteMac(clickedOn, expire);
+        controller.muteUsername(clickedOn, Date.from(expire));
+        controller.muteMac(clickedOn, Date.from(expire));
       }
     }));
     rVal.add(SwingAction.of("Show player information", e -> {

--- a/src/main/java/games/strategy/engine/lobby/server/IModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/IModeratorController.java
@@ -1,12 +1,13 @@
 package games.strategy.engine.lobby.server;
 
-import java.time.Instant;
 import java.util.Date;
 
 import games.strategy.engine.message.IRemote;
 import games.strategy.net.INode;
 
 public interface IModeratorController extends IRemote {
+  // TODO: The methods accepting a Date parameter can be converted to Instant after the next incompatible release.
+
   /**
    * Boot the given INode from the network.
    *
@@ -16,21 +17,10 @@ public interface IModeratorController extends IRemote {
    */
   void boot(INode node);
 
-  // Remove the z Prefix of all methods in the next incompatible release
-
-  /**
-   * @deprecated Kept to maintain backwards compatibility.
-   *             Remove with next incompatible release.
-   */
-  @Deprecated
-  default void banUsername(INode node, Date banExpires) {
-    zzBanUsername(node, banExpires != null ? banExpires.toInstant() : null);
-  }
-
   /**
    * Ban the username of the given INode.
    */
-  void zzBanUsername(INode node, Instant banExpires);
+  void banUsername(INode node, Date banExpires);
 
   /**
    * @deprecated Kept to maintain backwards compatibility.
@@ -40,46 +30,19 @@ public interface IModeratorController extends IRemote {
   default void banIp(INode node, Date banExpires) {}
 
   /**
-   * @deprecated Kept to maintain backwards compatibility.
-   *             Remove with next incompatible release.
-   */
-  @Deprecated
-  default void banMac(INode node, Date banExpires) {
-    zzBanMac(node, banExpires != null ? banExpires.toInstant() : null);
-  }
-
-  /**
-   * @deprecated Kept to maintain backwards compatibility.
-   *             Remove with next incompatible release.
-   */
-  @Deprecated
-  default void banMac(final INode node, final String hashedMac, final Date banExpires) {
-    zzBanMac(node, banExpires != null ? banExpires.toInstant() : null);
-  }
-
-  /**
    * Ban the mac of the given INode.
    */
-  void zzBanMac(INode node, Instant banExpires);
+  void banMac(INode node, Date banExpires);
 
   /**
    * Ban the mac.
    */
-  void zzBanMac(final INode node, final String hashedMac, final Instant banExpires);
-
-  /**
-   * @deprecated Kept to maintain backwards compatibility.
-   *             Remove with next incompatible release.
-   */
-  @Deprecated
-  default void muteUsername(INode node, Date muteExpires) {
-    zzMuteUsername(node, muteExpires != null ? muteExpires.toInstant() : null);
-  }
+  void banMac(INode node, String hashedMac, Date banExpires);
 
   /**
    * Mute the username of the given INode.
    */
-  void zzMuteUsername(INode node, Instant muteExpires);
+  void muteUsername(INode node, Date muteExpires);
 
   /**
    * @deprecated Kept to maintain backwards compatibility.
@@ -89,18 +52,9 @@ public interface IModeratorController extends IRemote {
   default void muteIp(INode node, Date muteExpires) {}
 
   /**
-   * @deprecated Kept to maintain backwards compatibility.
-   *             Remove with next incompatible release.
-   */
-  @Deprecated
-  default void muteMac(INode node, Date muteExpires) {
-    zzMuteMac(node, muteExpires != null ? muteExpires.toInstant() : null);
-  }
-
-  /**
    * Mute the mac of the given INode.
    */
-  void zzMuteMac(INode node, Instant muteExpires);
+  void muteMac(INode node, Date muteExpires);
 
   /**
    * Get list of people in the game.

--- a/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.lobby.server;
 
 import java.time.Instant;
+import java.util.Date;
 
 import games.strategy.engine.lobby.server.db.BannedMacController;
 import games.strategy.engine.lobby.server.db.BannedUsernameController;
@@ -21,7 +22,11 @@ public class ModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void zzBanUsername(final INode node, final Instant banExpires) {
+  public void banUsername(final INode node, final Date banExpires) {
+    banUsername(node, banExpires != null ? banExpires.toInstant() : null);
+  }
+
+  private void banUsername(final INode node, final Instant banExpires) {
     assertUserIsAdmin();
     if (isPlayerAdmin(node)) {
       throw new IllegalStateException("Can't ban an admin");
@@ -57,7 +62,11 @@ public class ModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void zzBanMac(final INode node, final Instant banExpires) {
+  public void banMac(final INode node, final Date banExpires) {
+    banMac(node, banExpires != null ? banExpires.toInstant() : null);
+  }
+
+  private void banMac(final INode node, final Instant banExpires) {
     assertUserIsAdmin();
     if (isPlayerAdmin(node)) {
       throw new IllegalStateException("Can't ban an admin");
@@ -74,7 +83,11 @@ public class ModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void zzBanMac(final INode node, final String hashedMac, final Instant banExpires) {
+  public void banMac(final INode node, final String hashedMac, final Date banExpires) {
+    banMac(node, hashedMac, banExpires != null ? banExpires.toInstant() : null);
+  }
+
+  private void banMac(final INode node, final String hashedMac, final Instant banExpires) {
     assertUserIsAdmin();
     if (isPlayerAdmin(node)) {
       throw new IllegalStateException("Can't ban an admin");
@@ -90,7 +103,11 @@ public class ModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void zzMuteUsername(final INode node, final Instant muteExpires) {
+  public void muteUsername(final INode node, final Date muteExpires) {
+    muteUsername(node, muteExpires != null ? muteExpires.toInstant() : null);
+  }
+
+  private void muteUsername(final INode node, final Instant muteExpires) {
     assertUserIsAdmin();
     if (isPlayerAdmin(node)) {
       throw new IllegalStateException("Can't mute an admin");
@@ -109,7 +126,11 @@ public class ModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void zzMuteMac(final INode node, final Instant muteExpires) {
+  public void muteMac(final INode node, final Date muteExpires) {
+    muteMac(node, muteExpires != null ? muteExpires.toInstant() : null);
+  }
+
+  private void muteMac(final INode node, final Instant muteExpires) {
     assertUserIsAdmin();
     if (isPlayerAdmin(node)) {
       throw new IllegalStateException("Can't mute an admin");

--- a/src/main/java/games/strategy/engine/lobby/server/NullModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/NullModeratorController.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.lobby.server;
 
-import java.time.Instant;
+import java.util.Date;
 
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
@@ -15,12 +15,12 @@ public class NullModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void zzBanMac(final INode node, final String hashedMac, final Instant banExpires) {
+  public void banMac(final INode node, final String hashedMac, final Date banExpires) {
     // nothing
   }
 
   @Override
-  public void zzBanMac(final INode node, final Instant banExpires) {
+  public void banMac(final INode node, final Date banExpires) {
     // nothing
   }
 
@@ -68,17 +68,17 @@ public class NullModeratorController extends AbstractModeratorController {
   }
 
   @Override
-  public void zzBanUsername(final INode node, final Instant banExpires) {
+  public void banUsername(final INode node, final Date banExpires) {
     // nothing
   }
 
   @Override
-  public void zzMuteUsername(final INode node, final Instant muteExpires) {
+  public void muteUsername(final INode node, final Date muteExpires) {
     // nothing
   }
 
   @Override
-  public void zzMuteMac(final INode node, final Instant muteExpires) {
+  public void muteMac(final INode node, final Date muteExpires) {
     // nothing
   }
 

--- a/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -7,6 +7,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import javax.swing.JButton;
@@ -159,7 +160,7 @@ public class LobbyMenu extends JMenuBar {
       final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
           .getRemoteMessenger().getRemote(ModeratorController.getModeratorControllerName());
       try {
-        controller.zzBanUsername(new Node(name1, InetAddress.getByName("0.0.0.0"), 0), expire);
+        controller.banUsername(new Node(name1, InetAddress.getByName("0.0.0.0"), 0), Date.from(expire));
       } catch (final UnknownHostException ex) {
         ClientLogger.logQuietly(ex);
       }
@@ -200,8 +201,8 @@ public class LobbyMenu extends JMenuBar {
       final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
           .getRemoteMessenger().getRemote(ModeratorController.getModeratorControllerName());
       try {
-        controller.zzBanMac(new Node("None (Admin menu originated ban)", InetAddress.getByName("0.0.0.0"), 0), mac,
-            expire);
+        controller.banMac(new Node("None (Admin menu originated ban)", InetAddress.getByName("0.0.0.0"), 0), mac,
+            Date.from(expire));
       } catch (final UnknownHostException ex) {
         ClientLogger.logQuietly(ex);
       }
@@ -228,7 +229,8 @@ public class LobbyMenu extends JMenuBar {
       final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
           .getRemoteMessenger().getRemote(ModeratorController.getModeratorControllerName());
       try {
-        controller.zzBanUsername(new Node(name1, InetAddress.getByName("0.0.0.0"), 0), Instant.ofEpochMilli(0));
+        controller.banUsername(new Node(name1, InetAddress.getByName("0.0.0.0"), 0),
+            Date.from(Instant.ofEpochMilli(0)));
       } catch (final UnknownHostException ex) {
         ClientLogger.logQuietly(ex);
       }
@@ -268,8 +270,8 @@ public class LobbyMenu extends JMenuBar {
       final IModeratorController controller = (IModeratorController) lobbyFrame.getLobbyClient().getMessengers()
           .getRemoteMessenger().getRemote(ModeratorController.getModeratorControllerName());
       try {
-        controller.zzBanMac(new Node("None (Admin menu originated unban)", InetAddress.getByName("0.0.0.0"), 0), mac,
-            Instant.ofEpochMilli(0));
+        controller.banMac(new Node("None (Admin menu originated unban)", InetAddress.getByName("0.0.0.0"), 0), mac,
+            Date.from(Instant.ofEpochMilli(0)));
       } catch (final UnknownHostException ex) {
         ClientLogger.logQuietly(ex);
       }


### PR DESCRIPTION
The new `zz` methods added in #1942 do not exist in the currently-deployed lobby (1.9.0.0.3635).  Therefore, any attempt to run a corresponding moderator command (un/ban username, un/mute username, un/ban MAC, un/mute MAC) from a new client will result in a failure.  The failure is manifest as a freeze in the UI as the call to the associated `IModeratorController` method on the EDT never returns.

This PR fixes the problem by partially reverting the changes in #1942:

* The `IModeratorController` interface is returned to its pre-#1942 state.
* The new `IModeratorController` methods added in #1942 are moved to the implementation class, `ModeratorController`.  The old `Date`-based methods delegate to the new `Instant`-based methods as before.
* All call sites were modified to convert the `Instant` argument to a `Date` via `Date#from()`.

When the next incompatible release is made (and deployed to the lobby), a PR can be submitted to

* Replace all `Date` parameters in `IModeratorController` methods with `Instant`.
* Replace all `Date` parameters in `NullModeratorController` methods with `Instant`.
* Delete the `ModeratorController` methods that take a `Date` parameter.  Modify the methods that take an `Instant` parameter to be public and marked with `@Overload`.
* Modify the applicable `IModeratorController` call sites to remove the `Date#from()` calls.  All previous `Instant` logic remains, so no other changes need to be made.

#### Testing

I tested all admin commands (from the **Admin > Toolbox** menu in the client) in the following scenarios:

Lobby | Admin client
:-- | :--
this branch | this branch
this branch | 1.9.0.0.3635
1.9.0.0.3635 | this branch

In all cases, no UI freezes were observed.  All commands appeared to succeed based on the lobby log output.  No exceptions were observed in either the lobby log nor the client console.