### PR TITLE
Fix ban/mute when using weeks, months, or years (#2117)

### DIFF
--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -6,8 +6,10 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.ZoneOffset;
+import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -24,6 +26,7 @@ import javax.swing.JSplitPane;
 import javax.swing.JTextPane;
 import javax.swing.SpinnerNumberModel;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 import games.strategy.engine.ClientContext;
@@ -44,6 +47,16 @@ import games.strategy.util.EventThreadJOptionPane;
 
 public class LobbyFrame extends JFrame {
   private static final long serialVersionUID = -388371674076362572L;
+
+  @VisibleForTesting
+  interface TimeUnitNames {
+    String MINUTE = "Minute";
+    String HOUR = "Hour";
+    String DAY = "Day";
+    String WEEK = "Week";
+    String MONTH = "Month";
+    String YEAR = "Year";
+  }
 
   private static final List<String> banOrMuteOptions = ImmutableList.of(
       "Mac Address Only",
@@ -136,12 +149,12 @@ public class LobbyFrame extends JFrame {
         return;
       }
       final List<String> timeUnits = new ArrayList<>();
-      timeUnits.add("Minute");
-      timeUnits.add("Hour");
-      timeUnits.add("Day");
-      timeUnits.add("Week");
-      timeUnits.add("Month");
-      timeUnits.add("Year");
+      timeUnits.add(TimeUnitNames.MINUTE);
+      timeUnits.add(TimeUnitNames.HOUR);
+      timeUnits.add(TimeUnitNames.DAY);
+      timeUnits.add(TimeUnitNames.WEEK);
+      timeUnits.add(TimeUnitNames.MONTH);
+      timeUnits.add(TimeUnitNames.YEAR);
       timeUnits.add("Forever");
       timeUnits.add("Cancel");
       final int resultTimespanUnit = JOptionPane.showOptionDialog(LobbyFrame.this, "Select the unit of measurement: ",
@@ -174,21 +187,7 @@ public class LobbyFrame extends JFrame {
       if (result2 < 0) {
         return;
       }
-      TemporalUnit unit = null;
-      if (selectedTimeUnit.equals("Minute")) {
-        unit = ChronoUnit.MINUTES;
-      } else if (selectedTimeUnit.equals("Hour")) {
-        unit = ChronoUnit.HOURS;
-      } else if (selectedTimeUnit.equals("Day")) {
-        unit = ChronoUnit.DAYS;
-      } else if (selectedTimeUnit.equals("Week")) {
-        unit = ChronoUnit.WEEKS;
-      } else if (selectedTimeUnit.equals("Month")) {
-        unit = ChronoUnit.MONTHS;
-      } else if (selectedTimeUnit.equals("Year")) {
-        unit = ChronoUnit.YEARS;
-      }
-      final Instant expire = Instant.now().plus(Duration.of(result2, unit));
+      final Instant expire = addDuration(Instant.now(), result2, selectedTimeUnit);
       if (selectedBanType.toLowerCase().contains("name")) {
         controller.banUsername(clickedOn, Date.from(expire));
       }
@@ -198,7 +197,6 @@ public class LobbyFrame extends JFrame {
       // Should we keep this auto?
       controller.boot(clickedOn);
     }));
-
 
     rVal.add(SwingAction.of("Mute Player", e -> {
       final int resultMuteType = JOptionPane.showOptionDialog(LobbyFrame.this,
@@ -213,12 +211,12 @@ public class LobbyFrame extends JFrame {
         return;
       }
       final List<String> timeUnits = new ArrayList<>();
-      timeUnits.add("Minute");
-      timeUnits.add("Hour");
-      timeUnits.add("Day");
-      timeUnits.add("Week");
-      timeUnits.add("Month");
-      timeUnits.add("Year");
+      timeUnits.add(TimeUnitNames.MINUTE);
+      timeUnits.add(TimeUnitNames.HOUR);
+      timeUnits.add(TimeUnitNames.DAY);
+      timeUnits.add(TimeUnitNames.WEEK);
+      timeUnits.add(TimeUnitNames.MONTH);
+      timeUnits.add(TimeUnitNames.YEAR);
       timeUnits.add("Forever");
       timeUnits.add("Cancel");
       final int resultTimespanUnit = JOptionPane.showOptionDialog(LobbyFrame.this, "Select the unit of measurement: ",
@@ -249,21 +247,7 @@ public class LobbyFrame extends JFrame {
       if (result2 < 0) {
         return;
       }
-      TemporalUnit unit = null;
-      if (selectedTimeUnit.equals("Minute")) {
-        unit = ChronoUnit.MINUTES;
-      } else if (selectedTimeUnit.equals("Hour")) {
-        unit = ChronoUnit.HOURS;
-      } else if (selectedTimeUnit.equals("Day")) {
-        unit = ChronoUnit.DAYS;
-      } else if (selectedTimeUnit.equals("Week")) {
-        unit = ChronoUnit.WEEKS;
-      } else if (selectedTimeUnit.equals("Month")) {
-        unit = ChronoUnit.MONTHS;
-      } else if (selectedTimeUnit.equals("Year")) {
-        unit = ChronoUnit.YEARS;
-      }
-      final Instant expire = Instant.now().plus(Duration.of(result2, unit));
+      final Instant expire = addDuration(Instant.now(), result2, selectedTimeUnit);
       if (selectedMuteType.toLowerCase().contains("name")) {
         controller.muteUsername(clickedOn, Date.from(expire));
       }
@@ -301,7 +285,32 @@ public class LobbyFrame extends JFrame {
       JOptionPane.showMessageDialog(null, textPane, "Player Info", JOptionPane.INFORMATION_MESSAGE);
     }));
     return rVal;
+  }
 
+  @VisibleForTesting
+  static Instant addDuration(final Instant start, final long amountInUnits, final String unitName) {
+    return LocalDateTime.ofInstant(start, ZoneOffset.UTC)
+        .plus(toTemporalAmount(amountInUnits, unitName))
+        .toInstant(ZoneOffset.UTC);
+  }
+
+  private static TemporalAmount toTemporalAmount(final long amountInUnits, final String unitName) {
+    switch (unitName) {
+      case TimeUnitNames.MINUTE:
+        return Duration.ofMinutes(amountInUnits);
+      case TimeUnitNames.HOUR:
+        return Duration.ofHours(amountInUnits);
+      case TimeUnitNames.DAY:
+        return Duration.ofDays(amountInUnits);
+      case TimeUnitNames.WEEK:
+        return Period.ofWeeks((int) amountInUnits);
+      case TimeUnitNames.MONTH:
+        return Period.ofMonths((int) amountInUnits);
+      case TimeUnitNames.YEAR:
+        return Period.ofYears((int) amountInUnits);
+      default:
+        throw new IllegalArgumentException(String.format("unknown temporal unit name (%s)", unitName));
+    }
   }
 
   private boolean confirm(final String question) {

--- a/src/test/java/games/strategy/engine/lobby/client/ui/LobbyFrameTest.java
+++ b/src/test/java/games/strategy/engine/lobby/client/ui/LobbyFrameTest.java
@@ -1,0 +1,91 @@
+package games.strategy.engine.lobby.client.ui;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+import games.strategy.engine.lobby.client.ui.LobbyFrame.TimeUnitNames;
+
+public final class LobbyFrameTest {
+  private static final long SECONDS_PER_MINUTE = 60L;
+  private static final long MINUTES_PER_HOUR = 60L;
+  private static final long HOURS_PER_DAY = 24L;
+  private static final long SECONDS_PER_DAY = SECONDS_PER_MINUTE * MINUTES_PER_HOUR * HOURS_PER_DAY;
+
+  @Test
+  public void addDuration_ShouldBeAbleToAddDurationInMinutes() {
+    final long minutes = 2L;
+
+    final Instant end = LobbyFrame.addDuration(Instant.EPOCH, minutes, TimeUnitNames.MINUTE);
+
+    assertThat(end, is(Instant.ofEpochSecond(SECONDS_PER_MINUTE * minutes)));
+  }
+
+  @Test
+  public void addDuration_ShouldBeAbleToAddDurationInHours() {
+    final long hours = 2L;
+
+    final Instant end = LobbyFrame.addDuration(Instant.EPOCH, hours, TimeUnitNames.HOUR);
+
+    assertThat(end, is(Instant.ofEpochSecond(SECONDS_PER_MINUTE * MINUTES_PER_HOUR * hours)));
+  }
+
+  @Test
+  public void addDuration_ShouldBeAbleToAddDurationInDays() {
+    final long days = 2L;
+
+    final Instant end = LobbyFrame.addDuration(Instant.EPOCH, days, TimeUnitNames.DAY);
+
+    assertThat(end, is(Instant.ofEpochSecond(SECONDS_PER_DAY * days)));
+  }
+
+  @Test
+  public void addDuration_ShouldBeAbleToAddDurationInWeeks() {
+    final long daysPerWeek = 7L;
+    final long weeks = 2L;
+
+    final Instant end = LobbyFrame.addDuration(Instant.EPOCH, weeks, TimeUnitNames.WEEK);
+
+    assertThat(end, is(Instant.ofEpochSecond(SECONDS_PER_DAY * daysPerWeek * weeks)));
+  }
+
+  @Test
+  public void addDuration_ShouldBeAbleToAddDurationInMonths() {
+    final long daysInJan1970 = 31L;
+    final long daysInFeb1970 = 28L;
+    final long months = 2L;
+
+    final Instant end = LobbyFrame.addDuration(Instant.EPOCH, months, TimeUnitNames.MONTH);
+
+    assertThat(end, is(Instant.ofEpochSecond(SECONDS_PER_DAY * (daysInJan1970 + daysInFeb1970))));
+  }
+
+  @Test
+  public void addDuration_ShouldBeAbleToAddDurationInYears() {
+    final long daysIn1970 = 365L;
+    final long daysIn1971 = 365L;
+    final long years = 2L;
+
+    final Instant end = LobbyFrame.addDuration(Instant.EPOCH, years, TimeUnitNames.YEAR);
+
+    assertThat(end, is(Instant.ofEpochSecond(SECONDS_PER_DAY * (daysIn1970 + daysIn1971))));
+  }
+
+  @Test
+  public void addDuration_ShouldThrowExceptionWhenUnitNameIsUnknown() {
+    catchException(() -> LobbyFrame.addDuration(Instant.EPOCH, 1L, "unknown"));
+
+    assertThat(caughtException(), allOf(
+        is(instanceOf(IllegalArgumentException.class)),
+        hasMessageThat(containsString("unknown temporal unit name"))));
+  }
+}


### PR DESCRIPTION
This PR addresses the inability of an admin to ban/mute a lobby player using a duration in units of weeks, months, or years, as reported in #2117.

The `Duration#plus()` method does not support units that have an estimated duration, which include weeks, months, and years.  This caused an exception to be raised when any of these units were specified to a lobby admin ban/mute action.

The fix is to convert `Instant` to `LocalDateTime` (in UTC) before adding the ban/mute duration because `LocalDateTime` does support units that have an estimated duration.

#### Refactoring changes
I extracted the method `LobbyFrame#addDuration()` so that I could unit test it.  I also extracted constants for the various ban/mute time unit names to avoid duplication in both the tests and production code.

#### Testing
In addition to the new unit tests, I manually tested the Ban Player and Mute Player context menu actions from the lobby players list.  I tried both exact (e.g. minute) and estimated (e.g. week) units and verified the targeted player was banned/muted appropriately.  When using a shorter duration (e.g. 1 minute), I verified the ban/mute expired at the correct time, and the targeted player was once again allowed to login/chat.