### PR TITLE
Checkstyle: Fix naming violations in g.s.triplea.util and g.s.util classes

### DIFF
--- a/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/src/main/java/games/strategy/engine/data/UnitType.java
@@ -16,7 +16,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.IUIContext;
 import games.strategy.triplea.ui.TooltipProperties;
-import games.strategy.util.LocalizeHTML;
+import games.strategy.util.LocalizeHtml;
 
 /**
  * A prototype for units.
@@ -83,7 +83,7 @@ public class UnitType extends NamedAttachable {
       return UnitAttachment.get(this).toStringShortAndOnlyImportantDifferences(
           (playerId == null ? PlayerID.NULL_PLAYERID : playerId), true, false);
     } else {
-      return LocalizeHTML.localizeImgLinksInHTML(customTip.trim());
+      return LocalizeHtml.localizeImgLinksInHtml(customTip.trim());
     }
   }
 

--- a/src/main/java/games/strategy/engine/framework/ui/NewGameChooser.java
+++ b/src/main/java/games/strategy/engine/framework/ui/NewGameChooser.java
@@ -24,7 +24,7 @@ import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.util.LocalizeHTML;
+import games.strategy.util.LocalizeHtml;
 
 public class NewGameChooser extends JDialog {
   private static final long serialVersionUID = -3223711652118741132L;
@@ -137,7 +137,7 @@ public class NewGameChooser extends JDialog {
       if (notesProperty != null && notesProperty.trim().length() != 0) {
         // UIContext resource loader should be null (or potentially is still the last game we played's loader),
         // so we send the map dir name so that our localizing of image links can get a new resource loader if needed
-        notes.append(LocalizeHTML.localizeImgLinksInHTML(notesProperty.trim(), null, mapNameDir));
+        notes.append(LocalizeHtml.localizeImgLinksInHtml(notesProperty.trim(), null, mapNameDir));
       }
       notesPanel.setText(notes.toString());
     } else {

--- a/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -30,7 +30,7 @@ import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.util.CountDownLatchHandler;
 import games.strategy.util.EventThreadJOptionPane;
-import games.strategy.util.LocalizeHTML;
+import games.strategy.util.LocalizeHtml;
 import games.strategy.util.Match;
 
 /**
@@ -287,7 +287,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         stopGame = true;
       } else {
         // now tell the HOST, and see if they want to continue the game.
-        String displayMessage = LocalizeHTML.localizeImgLinksInHTML(status);
+        String displayMessage = LocalizeHtml.localizeImgLinksInHtml(status);
         if (displayMessage.endsWith("</body>")) {
           displayMessage = displayMessage.substring(0, displayMessage.length() - "</body>".length())
               + "</br><p>Do you want to continue?</p></body>";

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -154,7 +154,7 @@ import games.strategy.ui.SwingAction;
 import games.strategy.ui.Util;
 import games.strategy.util.EventThreadJOptionPane;
 import games.strategy.util.IntegerMap;
-import games.strategy.util.LocalizeHTML;
+import games.strategy.util.LocalizeHtml;
 import games.strategy.util.Match;
 import games.strategy.util.ThreadUtil;
 import games.strategy.util.Tuple;
@@ -772,7 +772,7 @@ public class TripleAFrame extends MainGameFrame {
    */
   @Override
   public void notifyError(final String message) {
-    final String displayMessage = LocalizeHTML.localizeImgLinksInHTML(message);
+    final String displayMessage = LocalizeHtml.localizeImgLinksInHtml(message);
     if (messageAndDialogThreadPool == null) {
       return;
     }
@@ -805,7 +805,7 @@ public class TripleAFrame extends MainGameFrame {
         && !getUIContext().getShowEndOfTurnReport()) {
       return;
     }
-    final String displayMessage = LocalizeHTML.localizeImgLinksInHTML(message);
+    final String displayMessage = LocalizeHtml.localizeImgLinksInHtml(message);
     if (messageAndDialogThreadPool != null) {
       messageAndDialogThreadPool.runTask(() -> EventThreadJOptionPane.showMessageDialog(TripleAFrame.this,
           displayMessage, title, JOptionPane.INFORMATION_MESSAGE, true, getUIContext().getCountDownLatchHandler()));

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -50,7 +50,7 @@ import games.strategy.triplea.ui.history.HistoryPanel;
 import games.strategy.triplea.util.PlayerOrderComparator;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.IllegalCharacterRemover;
-import games.strategy.util.LocalizeHTML;
+import games.strategy.util.LocalizeHtml;
 
 class ExportMenu {
 
@@ -409,7 +409,7 @@ class ExportMenu {
       try (final FileWriter writer = new FileWriter(chooser.getSelectedFile())) {
         writer.write(
             HelpMenu.getUnitStatsTable(gameData, iuiContext).replaceAll("<p>", "<p>\r\n").replaceAll("</p>", "</p>\r\n")
-                .replaceAll("</tr>", "</tr>\r\n").replaceAll(LocalizeHTML.PATTERN_HTML_IMG_TAG, ""));
+                .replaceAll("</tr>", "</tr>\r\n").replaceAll(LocalizeHtml.PATTERN_HTML_IMG_TAG, ""));
       } catch (final IOException e1) {
         ClientLogger.logQuietly(e1);
       }

--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -38,7 +38,7 @@ import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.IUIContext;
 import games.strategy.ui.SwingAction;
 import games.strategy.ui.SwingComponents;
-import games.strategy.util.LocalizeHTML;
+import games.strategy.util.LocalizeHtml;
 
 public class HelpMenu {
 
@@ -225,7 +225,7 @@ public class HelpMenu {
     // displays whatever is in the notes field in html
     final String notesProperty = gameData.getProperties().get("notes", "");
     if (notesProperty != null && notesProperty.trim().length() != 0) {
-      final String notes = LocalizeHTML.localizeImgLinksInHTML(notesProperty.trim());
+      final String notes = LocalizeHtml.localizeImgLinksInHtml(notesProperty.trim());
       gameNotesPane.setEditable(false);
       gameNotesPane.setContentType("text/html");
       gameNotesPane.setText(notes);

--- a/src/main/java/games/strategy/triplea/util/PlayerOrderComparator.java
+++ b/src/main/java/games/strategy/triplea/util/PlayerOrderComparator.java
@@ -9,10 +9,10 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.delegate.IDelegate;
 
 public class PlayerOrderComparator implements Comparator<PlayerID> {
-  private final GameData m_data;
+  private final GameData gameData;
 
   public PlayerOrderComparator(final GameData data) {
-    m_data = data;
+    gameData = data;
   }
 
   /**
@@ -24,22 +24,22 @@ public class PlayerOrderComparator implements Comparator<PlayerID> {
       return 0;
     }
     final GameSequence sequence;
-    m_data.acquireReadLock();
+    gameData.acquireReadLock();
     try {
-      sequence = m_data.getSequence();
+      sequence = gameData.getSequence();
     } finally {
-      m_data.releaseReadLock();
+      gameData.releaseReadLock();
     }
     for (final GameStep s : sequence) {
       if (s.getPlayerID() == null) {
         continue;
       }
       final IDelegate delegate;
-      m_data.acquireReadLock();
+      gameData.acquireReadLock();
       try {
         delegate = s.getDelegate();
       } finally {
-        m_data.releaseReadLock();
+        gameData.releaseReadLock();
       }
       if (delegate != null && delegate.getClass() != null) {
         final String delegateClassName = delegate.getClass().getName();

--- a/src/main/java/games/strategy/triplea/util/Stopwatch.java
+++ b/src/main/java/games/strategy/triplea/util/Stopwatch.java
@@ -11,20 +11,20 @@ import java.util.logging.Logger;
  * someTask.done();
  */
 public class Stopwatch {
-  private final long m_startTime = System.currentTimeMillis();
-  private final String m_taskDescription;
-  private final Logger m_logger;
-  private final Level m_level;
+  private final long startTime = System.currentTimeMillis();
+  private final String taskDescription;
+  private final Logger logger;
+  private final Level level;
 
   public Stopwatch(final Logger logger, final Level level, final String taskDescription) {
-    m_taskDescription = taskDescription;
-    m_logger = logger;
-    m_level = level;
+    this.taskDescription = taskDescription;
+    this.logger = logger;
+    this.level = level;
   }
 
   public void done() {
-    if (m_logger.isLoggable(m_level)) {
-      m_logger.log(m_level, m_taskDescription + " took " + (System.currentTimeMillis() - m_startTime) + " ms");
+    if (logger.isLoggable(level)) {
+      logger.log(level, taskDescription + " took " + (System.currentTimeMillis() - startTime) + " ms");
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/util/UnitCategory.java
+++ b/src/main/java/games/strategy/triplea/util/UnitCategory.java
@@ -13,74 +13,74 @@ import games.strategy.triplea.attachments.UnitTypeComparator;
 import games.strategy.util.Util;
 
 public class UnitCategory implements Comparable<Object> {
-  private final UnitType m_type;
+  private final UnitType type;
   // Collection of UnitOwners, the type of our dependents, not the dependents
-  private Collection<UnitOwner> m_dependents;
+  private Collection<UnitOwner> dependents;
   // movement of the units
-  private final int m_movement;
+  private final int movement;
   // movement of the units
-  private final int m_transportCost;
+  private final int transportCost;
   // movement of the units
   // private final Territory m_originatingTerr;
-  private final PlayerID m_owner;
+  private final PlayerID owner;
   // the units in the category, may be duplicates.
-  private final List<Unit> m_units = new ArrayList<>();
-  private int m_damaged = 0;
-  private int m_bombingDamage = 0;
-  private boolean m_disabled = false;
+  private final List<Unit> units = new ArrayList<>();
+  private int damaged = 0;
+  private int bombingDamage = 0;
+  private boolean disabled = false;
 
   public UnitCategory(final Unit unit, final Collection<Unit> dependents, final int movement, final int transportCost) {
     this(unit, dependents, movement, 0, 0, false, transportCost);
   }
 
   public UnitCategory(final UnitType type, final PlayerID owner) {
-    m_type = type;
-    m_dependents = Collections.emptyList();
-    m_movement = -1;
-    m_transportCost = -1;
-    m_owner = owner;
+    this.type = type;
+    dependents = Collections.emptyList();
+    movement = -1;
+    transportCost = -1;
+    this.owner = owner;
   }
 
   UnitCategory(final Unit unit, final Collection<Unit> dependents, final int movement, final int damaged,
       final int bombingDamage, final boolean disabled, final int transportCost) {
-    m_type = unit.getType();
-    m_movement = movement;
-    m_transportCost = transportCost;
-    m_owner = unit.getOwner();
-    m_damaged = damaged;
-    m_bombingDamage = bombingDamage;
-    m_disabled = disabled;
-    m_units.add(unit);
+    type = unit.getType();
+    this.movement = movement;
+    this.transportCost = transportCost;
+    owner = unit.getOwner();
+    this.damaged = damaged;
+    this.bombingDamage = bombingDamage;
+    this.disabled = disabled;
+    units.add(unit);
     createDependents(dependents);
   }
 
   public int getDamaged() {
-    return m_damaged;
+    return damaged;
   }
 
   public int getBombingDamage() {
-    return m_bombingDamage;
+    return bombingDamage;
   }
 
   public boolean hasDamageOrBombingUnitDamage() {
-    return m_damaged > 0 || m_bombingDamage > 0;
+    return damaged > 0 || bombingDamage > 0;
   }
 
   public boolean getDisabled() {
-    return m_disabled;
+    return disabled;
   }
 
   public int getHitPoints() {
-    return UnitAttachment.get(m_type).getHitPoints();
+    return UnitAttachment.get(type).getHitPoints();
   }
 
   private void createDependents(final Collection<Unit> dependents) {
-    m_dependents = new ArrayList<>();
+    this.dependents = new ArrayList<>();
     if (dependents == null) {
       return;
     }
     for (final Unit current : dependents) {
-      m_dependents.add(new UnitOwner(current));
+      this.dependents.add(new UnitOwner(current));
     }
   }
 
@@ -94,30 +94,30 @@ public class UnitCategory implements Comparable<Object> {
     }
     final UnitCategory other = (UnitCategory) o;
     // equality of categories does not compare the number
-    // of units in the category, so don't compare on m_units
+    // of units in the category, so don't compare on units
     final boolean equalsIgnoreDamaged = equalsIgnoreDamagedAndBombingDamageAndDisabled(other);
     // return equalsIgnoreDamaged && other.m_damaged == this.m_damaged;
-    return equalsIgnoreDamaged && other.m_damaged == this.m_damaged && other.m_bombingDamage == this.m_bombingDamage
-        && other.m_disabled == this.m_disabled;
+    return equalsIgnoreDamaged && other.damaged == this.damaged && other.bombingDamage == this.bombingDamage
+        && other.disabled == this.disabled;
   }
 
   private boolean equalsIgnoreDamagedAndBombingDamageAndDisabled(final UnitCategory other) {
-    final boolean equalsIgnoreDamaged = other.m_type.equals(this.m_type) && other.m_movement == this.m_movement
-        && other.m_owner.equals(this.m_owner) && Util.equals(this.m_dependents, other.m_dependents);
+    final boolean equalsIgnoreDamaged = other.type.equals(this.type) && other.movement == this.movement
+        && other.owner.equals(this.owner) && Util.equals(this.dependents, other.dependents);
     return equalsIgnoreDamaged;
   }
 
   @Override
   public int hashCode() {
-    return m_type.hashCode() | m_owner.hashCode();
+    return type.hashCode() | owner.hashCode();
   }
 
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder();
-    sb.append("Entry type:").append(m_type.getName()).append(" owner:").append(m_owner.getName()).append(" damaged:")
-        .append(m_damaged).append(" bombingUnitDamage:").append(m_bombingDamage).append(" disabled:").append(m_disabled)
-        .append(" dependents:").append(m_dependents).append(" movement:").append(m_movement);
+    sb.append("Entry type:").append(type.getName()).append(" owner:").append(owner.getName()).append(" damaged:")
+        .append(damaged).append(" bombingUnitDamage:").append(bombingDamage).append(" disabled:").append(disabled)
+        .append(" dependents:").append(dependents).append(" movement:").append(movement);
     return sb.toString();
   }
 
@@ -125,35 +125,35 @@ public class UnitCategory implements Comparable<Object> {
    * Collection of UnitOwners, the type of our dependents, not the dependents.
    */
   public Collection<UnitOwner> getDependents() {
-    return m_dependents;
+    return dependents;
   }
 
   public List<Unit> getUnits() {
-    return m_units;
+    return units;
   }
 
   public int getMovement() {
-    return m_movement;
+    return movement;
   }
 
   public int getTransportCost() {
-    return m_transportCost;
+    return transportCost;
   }
 
   public PlayerID getOwner() {
-    return m_owner;
+    return owner;
   }
 
   public void addUnit(final Unit unit) {
-    m_units.add(unit);
+    units.add(unit);
   }
 
   void removeUnit(final Unit unit) {
-    m_units.remove(unit);
+    units.remove(unit);
   }
 
   public UnitType getType() {
-    return m_type;
+    return type;
   }
 
   @Override
@@ -162,27 +162,27 @@ public class UnitCategory implements Comparable<Object> {
       return -1;
     }
     final UnitCategory other = (UnitCategory) o;
-    if (!other.m_owner.equals(this.m_owner)) {
-      return this.m_owner.getName().compareTo(other.m_owner.getName());
+    if (!other.owner.equals(this.owner)) {
+      return this.owner.getName().compareTo(other.owner.getName());
     }
     final int typeCompare = new UnitTypeComparator().compare(this.getType(), other.getType());
     if (typeCompare != 0) {
       return typeCompare;
     }
-    if (m_movement != other.m_movement) {
-      return m_movement - other.m_movement;
+    if (movement != other.movement) {
+      return movement - other.movement;
     }
-    if (!Util.equals(this.m_dependents, other.m_dependents)) {
-      return m_dependents.toString().compareTo(other.m_dependents.toString());
+    if (!Util.equals(this.dependents, other.dependents)) {
+      return dependents.toString().compareTo(other.dependents.toString());
     }
-    if (this.m_damaged != other.m_damaged) {
-      return this.m_damaged - other.m_damaged;
+    if (this.damaged != other.damaged) {
+      return this.damaged - other.damaged;
     }
-    if (this.m_bombingDamage != other.m_bombingDamage) {
-      return this.m_bombingDamage - other.m_bombingDamage;
+    if (this.bombingDamage != other.bombingDamage) {
+      return this.bombingDamage - other.bombingDamage;
     }
-    if (this.m_disabled != other.m_disabled) {
-      if (m_disabled) {
+    if (this.disabled != other.disabled) {
+      if (disabled) {
         return 1;
       }
       return -1;

--- a/src/main/java/games/strategy/triplea/util/UnitOwner.java
+++ b/src/main/java/games/strategy/triplea/util/UnitOwner.java
@@ -5,17 +5,17 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 
 public class UnitOwner {
-  private final UnitType m_type;
-  private final PlayerID m_owner;
+  private final UnitType type;
+  private final PlayerID owner;
 
   public UnitOwner(final Unit unit) {
-    m_type = unit.getType();
-    m_owner = unit.getOwner();
+    type = unit.getType();
+    owner = unit.getOwner();
   }
 
   public UnitOwner(final UnitType type, final PlayerID owner) {
-    m_type = type;
-    m_owner = owner;
+    this.type = type;
+    this.owner = owner;
   }
 
   @Override
@@ -27,24 +27,24 @@ public class UnitOwner {
       return false;
     }
     final UnitOwner other = (UnitOwner) o;
-    return other.m_type.equals(this.m_type) && other.m_owner.equals(this.m_owner);
+    return other.type.equals(this.type) && other.owner.equals(this.owner);
   }
 
   @Override
   public int hashCode() {
-    return m_type.hashCode() ^ m_owner.hashCode();
+    return type.hashCode() ^ owner.hashCode();
   }
 
   @Override
   public String toString() {
-    return "Unit owner:" + m_owner.getName() + " type:" + m_type.getName();
+    return "Unit owner:" + owner.getName() + " type:" + type.getName();
   }
 
   public UnitType getType() {
-    return m_type;
+    return type;
   }
 
   public PlayerID getOwner() {
-    return m_owner;
+    return owner;
   }
 }

--- a/src/main/java/games/strategy/triplea/util/WrappedInvocationHandler.java
+++ b/src/main/java/games/strategy/triplea/util/WrappedInvocationHandler.java
@@ -5,13 +5,13 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
 public class WrappedInvocationHandler implements InvocationHandler {
-  private final Object m_delegate;
+  private final Object delegate;
 
   public WrappedInvocationHandler(final Object delegate) {
     if (delegate == null) {
       throw new IllegalArgumentException("delegate cant be null");
     }
-    m_delegate = delegate;
+    this.delegate = delegate;
   }
 
   private boolean wrappedEquals(final Object other) {
@@ -20,7 +20,7 @@ public class WrappedInvocationHandler implements InvocationHandler {
     }
     if (Proxy.isProxyClass(other.getClass()) && Proxy.getInvocationHandler(other) instanceof WrappedInvocationHandler) {
       final WrappedInvocationHandler otherWrapped = (WrappedInvocationHandler) Proxy.getInvocationHandler(other);
-      return otherWrapped.m_delegate.equals(m_delegate);
+      return otherWrapped.delegate.equals(delegate);
     }
     return false;
   }
@@ -45,7 +45,7 @@ public class WrappedInvocationHandler implements InvocationHandler {
   }
 
   public int wrappedashCode() {
-    return m_delegate.hashCode();
+    return delegate.hashCode();
   }
 
   @Override

--- a/src/main/java/games/strategy/util/CountDownLatchHandler.java
+++ b/src/main/java/games/strategy/util/CountDownLatchHandler.java
@@ -9,13 +9,13 @@ import java.util.concurrent.CountDownLatch;
  * Is Thread Safe.
  */
 public class CountDownLatchHandler {
-  private final List<CountDownLatch> m_latchesToCloseOnShutdown = new ArrayList<>();
-  private volatile boolean m_isShutDown = false;
-  private final boolean m_releaseLatchOnInterrupt;
+  private final List<CountDownLatch> latchesToCloseOnShutdown = new ArrayList<>();
+  private volatile boolean isShutDown = false;
+  private final boolean releaseLatchOnInterrupt;
 
   public CountDownLatchHandler(final boolean releaseLatchOnInterrupt) {
     super();
-    m_releaseLatchOnInterrupt = releaseLatchOnInterrupt;
+    this.releaseLatchOnInterrupt = releaseLatchOnInterrupt;
   }
 
   /**
@@ -25,8 +25,8 @@ public class CountDownLatchHandler {
    * Otherwise does nothing.
    */
   public void interruptAll() {
-    if (m_releaseLatchOnInterrupt) {
-      for (final CountDownLatch latch : m_latchesToCloseOnShutdown) {
+    if (releaseLatchOnInterrupt) {
+      for (final CountDownLatch latch : latchesToCloseOnShutdown) {
         removeShutdownLatch(latch);
       }
     }
@@ -39,13 +39,13 @@ public class CountDownLatchHandler {
    * Otherwise does nothing.
    */
   public void interruptLatch(final CountDownLatch latch) {
-    if (m_releaseLatchOnInterrupt) {
+    if (releaseLatchOnInterrupt) {
       removeShutdownLatch(latch);
     }
   }
 
   public boolean isShutDown() {
-    return m_isShutDown;
+    return isShutDown;
   }
 
   /**
@@ -53,15 +53,15 @@ public class CountDownLatchHandler {
    */
   public void shutDown() {
     synchronized (this) {
-      if (m_isShutDown) {
+      if (isShutDown) {
         return;
       }
-      m_isShutDown = true;
+      isShutDown = true;
     }
-    for (final CountDownLatch latch : m_latchesToCloseOnShutdown) {
+    for (final CountDownLatch latch : latchesToCloseOnShutdown) {
       releaseLatch(latch);
     }
-    m_latchesToCloseOnShutdown.clear();
+    latchesToCloseOnShutdown.clear();
   }
 
   /**
@@ -82,11 +82,11 @@ public class CountDownLatchHandler {
    */
   public void addShutdownLatch(final CountDownLatch latch) {
     synchronized (this) {
-      if (m_isShutDown) {
+      if (isShutDown) {
         releaseLatch(latch);
         return;
       }
-      m_latchesToCloseOnShutdown.add(latch);
+      latchesToCloseOnShutdown.add(latch);
     }
   }
 
@@ -105,7 +105,7 @@ public class CountDownLatchHandler {
       if (!doNotRelease) {
         releaseLatch(latch);
       }
-      m_latchesToCloseOnShutdown.remove(latch);
+      latchesToCloseOnShutdown.remove(latch);
     }
   }
 }

--- a/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.ui.AbstractUIContext;
 
-public class LocalizeHTML {
+public class LocalizeHtml {
   public static final String ASSET_IMAGE_FOLDER = "doc/images/";
   public static final String ASSET_IMAGE_NOT_FOUND = "notFound.png";
   /*
@@ -57,11 +57,11 @@ public class LocalizeHTML {
    * the last game's
    * resource loader.
    */
-  public static String localizeImgLinksInHTML(final String htmlText) {
-    return localizeImgLinksInHTML(htmlText, AbstractUIContext.getResourceLoader(), null);
+  public static String localizeImgLinksInHtml(final String htmlText) {
+    return localizeImgLinksInHtml(htmlText, AbstractUIContext.getResourceLoader(), null);
   }
 
-  public static String localizeImgLinksInHTML(final String htmlText, final ResourceLoader resourceLoader,
+  public static String localizeImgLinksInHtml(final String htmlText, final ResourceLoader resourceLoader,
       final String mapNameDir) {
     if (htmlText == null || (resourceLoader == null && (mapNameDir == null || mapNameDir.trim().length() == 0))) {
       return htmlText;


### PR DESCRIPTION
This PR fixes violations of the Checkstyle MemberName and AbbreviationAsWordInName rules in non-serializable classes within the `g.s.triplea.util` and `g.s.util` packages.