### PR TITLE
Checkstyle: Fix abbreviation violations in g.s.triplea.ui classes

### DIFF
--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -349,7 +349,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     if (airCantLand.isEmpty()) {
       return true;
     } else {
-      return ui.getOKToLetAirDie(getPlayerID(), airCantLand, movePhase);
+      return ui.getOkToLetAirDie(getPlayerID(), airCantLand, movePhase);
     }
   }
 
@@ -366,7 +366,7 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     if (unitsCantFight.isEmpty()) {
       return false;
     } else {
-      return !ui.getOKToLetUnitsDie(unitsCantFight, true);
+      return !ui.getOkToLetUnitsDie(unitsCantFight, true);
     }
   }
 
@@ -647,19 +647,19 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
   public boolean confirmMoveInFaceOfAA(final Collection<Territory> aaFiringTerritories) {
     final String question = "Your units will be fired on in: "
         + MyFormatter.defaultNamedToTextList(aaFiringTerritories, " and ", false) + ".  Do you still want to move?";
-    return ui.getOK(question);
+    return ui.getOk(question);
   }
 
   @Override
   public boolean confirmMoveKamikaze() {
     final String question = "Not all air units in destination territory can land, do you still want to move?";
-    return ui.getOK(question);
+    return ui.getOk(question);
   }
 
   @Override
   public boolean confirmMoveHariKari() {
     final String question = "All units in destination territory will automatically die, do you still want to move?";
-    return ui.getOK(question);
+    return ui.getOk(question);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorDialog.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorDialog.java
@@ -29,13 +29,13 @@ public class OddsCalculatorDialog extends JDialog {
 
   public static void show(final TripleAFrame taFrame, final Territory t) {
     final OddsCalculatorDialog dialog =
-        new OddsCalculatorDialog(taFrame.getGame().getData(), taFrame.getUIContext(), taFrame, t);
+        new OddsCalculatorDialog(taFrame.getGame().getData(), taFrame.getUiContext(), taFrame, t);
     dialog.pack();
     dialog.addWindowListener(new WindowAdapter() {
       @Override
       public void windowClosed(final WindowEvent e) {
-        if (taFrame != null && taFrame.getUIContext() != null && !taFrame.getUIContext().isShutDown()) {
-          taFrame.getUIContext().removeShutdownWindow(dialog);
+        if (taFrame != null && taFrame.getUiContext() != null && !taFrame.getUiContext().isShutDown()) {
+          taFrame.getUiContext().removeShutdownWindow(dialog);
         }
       }
     });
@@ -59,7 +59,7 @@ public class OddsCalculatorDialog extends JDialog {
       dialog.setSize(lastShape);
     }
     dialog.setVisible(true);
-    taFrame.getUIContext().addShutdownWindow(dialog);
+    taFrame.getUiContext().addShutdownWindow(dialog);
   }
 
   OddsCalculatorDialog(final GameData data, final IUIContext context, final JFrame parent, final Territory location) {

--- a/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -132,7 +132,7 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
     while (iter.hasNext()) {
       final UnitCategory category = iter.next();
       final Optional<ImageIcon> icon =
-          movePanel.getMap().getUIContext().getUnitImageFactory().getIcon(category.getType(),
+          movePanel.getMap().getUiContext().getUnitImageFactory().getIcon(category.getType(),
               category.getOwner(), gameData, category.hasDamageOrBombingUnitDamage(), category.getDisabled());
       if (icon.isPresent()) {
         final JLabel label = new JLabel("x" + category.getUnits().size() + " ", icon.get(), SwingConstants.LEFT);

--- a/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -83,7 +83,7 @@ public class ActionButtons extends JPanel {
     // between objects
     // and if there is a memory leak
     // this will minimize the damage
-    map.getUIContext().addActive(() -> {
+    map.getUiContext().addActive(() -> {
       removeAll();
       actionPanel = null;
       battlePanel.removeAll();

--- a/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -69,7 +69,7 @@ public abstract class ActionPanel extends JPanel {
         throw new IllegalStateException("Latch not null");
       }
       latch = new CountDownLatch(1);
-      map.getUIContext().addShutdownLatch(latch);
+      map.getUiContext().addShutdownLatch(latch);
     }
     try {
       latch.await();
@@ -98,7 +98,7 @@ public abstract class ActionPanel extends JPanel {
       if (latch == null) {
         return;
       }
-      map.getUIContext().removeShutdownLatch(latch);
+      map.getUiContext().removeShutdownLatch(latch);
       latch.countDown();
       latch = null;
     }

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -123,15 +123,15 @@ public class BattleDisplay extends JPanel {
     gameData = data;
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(territory);
     defenderModel = new BattleModel(defendingUnits, false, battleType, gameData, location, territoryEffects,
-        isAmphibious, Collections.emptySet(), this.mapPanel.getUIContext());
+        isAmphibious, Collections.emptySet(), this.mapPanel.getUiContext());
     attackerModel = new BattleModel(attackingUnits, true, battleType, gameData, location, territoryEffects,
-        isAmphibious, amphibiousLandAttackers, this.mapPanel.getUIContext());
+        isAmphibious, amphibiousLandAttackers, this.mapPanel.getUiContext());
     defenderModel.setEnemyBattleModel(attackerModel);
     attackerModel.setEnemyBattleModel(defenderModel);
     defenderModel.refresh();
     attackerModel.refresh();
-    uiContext = mapPanel.getUIContext();
-    casualties = new CasualtyNotificationPanel(data, this.mapPanel.getUIContext());
+    uiContext = mapPanel.getUiContext();
+    casualties = new CasualtyNotificationPanel(data, this.mapPanel.getUiContext());
     if (killedUnits != null && attackingWaitingToDie != null && defendingWaitingToDie != null) {
       final Collection<Unit> attackerUnitsKilled = Match.getMatches(killedUnits, Matches.unitIsOwnedBy(attacker));
       attackerUnitsKilled.addAll(attackingWaitingToDie);
@@ -150,7 +150,7 @@ public class BattleDisplay extends JPanel {
   void cleanUp() {
     actionButton.setAction(nullAction);
     steps.deactivate();
-    mapPanel.getUIContext().removeActive(steps);
+    mapPanel.getUiContext().removeActive(steps);
     steps = null;
   }
 
@@ -297,7 +297,7 @@ public class BattleDisplay extends JPanel {
     final CountDownLatch continueLatch = new CountDownLatch(1);
     final AbstractAction buttonAction = SwingAction.of(message, e -> continueLatch.countDown());
     SwingUtilities.invokeLater(() -> actionButton.setAction(buttonAction));
-    mapPanel.getUIContext().addShutdownLatch(continueLatch);
+    mapPanel.getUiContext().addShutdownLatch(continueLatch);
 
     // Set a auto-wait expiration if the option is set.
     if (!getConfirmDefensiveRolls()) {
@@ -320,7 +320,7 @@ public class BattleDisplay extends JPanel {
     } catch (final InterruptedException ie) {
       Thread.currentThread().interrupt();
     } finally {
-      mapPanel.getUIContext().removeShutdownLatch(continueLatch);
+      mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }
     SwingUtilities.invokeLater(() -> actionButton.setAction(nullAction));
   }
@@ -377,13 +377,13 @@ public class BattleDisplay extends JPanel {
     });
     SwingUtilities.invokeLater(() -> actionButton.setAction(action));
     SwingUtilities.invokeLater(() -> action.actionPerformed(null));
-    mapPanel.getUIContext().addShutdownLatch(latch);
+    mapPanel.getUiContext().addShutdownLatch(latch);
     try {
       latch.await();
     } catch (final InterruptedException e1) {
       Thread.currentThread().interrupt();
     } finally {
-      mapPanel.getUIContext().removeShutdownLatch(latch);
+      mapPanel.getUiContext().removeShutdownLatch(latch);
     }
     SwingUtilities.invokeLater(() -> actionButton.setAction(nullAction));
     return retreatTo[0];
@@ -435,13 +435,13 @@ public class BattleDisplay extends JPanel {
     });
     SwingUtilities.invokeLater(() -> actionButton.setAction(action));
     SwingUtilities.invokeLater(() -> action.actionPerformed(null));
-    mapPanel.getUIContext().addShutdownLatch(latch);
+    mapPanel.getUiContext().addShutdownLatch(latch);
     try {
       latch.await();
     } catch (final InterruptedException e1) {
       e1.printStackTrace();
     } finally {
-      mapPanel.getUIContext().removeShutdownLatch(latch);
+      mapPanel.getUiContext().removeShutdownLatch(latch);
     }
     SwingUtilities.invokeLater(() -> actionButton.setAction(nullAction));
     return retreatTo[0];
@@ -519,7 +519,7 @@ public class BattleDisplay extends JPanel {
           final String messageText = message + " " + btnText + ".";
           if (chooser == null || chooserScrollPane == null) {
             chooser = new UnitChooser(selectFrom, defaultCasualties, dependents, gameData, allowMultipleHitsPerUnit,
-                mapPanel.getUIContext());
+                mapPanel.getUiContext());
             chooser.setTitle(messageText);
             if (isEditMode) {
               chooser.setMax(selectFrom.size());
@@ -564,13 +564,13 @@ public class BattleDisplay extends JPanel {
         }
       });
     });
-    mapPanel.getUIContext().addShutdownLatch(continueLatch);
+    mapPanel.getUiContext().addShutdownLatch(continueLatch);
     try {
       continueLatch.await();
     } catch (final InterruptedException ex) {
       ClientLogger.logQuietly(ex);
     } finally {
-      mapPanel.getUIContext().removeShutdownLatch(continueLatch);
+      mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }
     return casualtyDetails.get();
   }
@@ -598,9 +598,9 @@ public class BattleDisplay extends JPanel {
     messagePanel.setLayout(new BorderLayout());
     messagePanel.add(messageLabel, BorderLayout.CENTER);
     steps = new BattleStepsPanel();
-    mapPanel.getUIContext().addActive(steps);
+    mapPanel.getUiContext().addActive(steps);
     steps.setBorder(new EtchedBorder(EtchedBorder.LOWERED));
-    dicePanel = new DicePanel(mapPanel.getUIContext(), gameData);
+    dicePanel = new DicePanel(mapPanel.getUiContext(), gameData);
     actionPanel = new JPanel();
     actionPanel.setLayout(actionLayout);
     actionPanel.add(dicePanel, DICE_KEY);

--- a/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -81,7 +81,7 @@ public class BattlePanel extends ActionPanel {
       }
     };
     battleFrame.setIconImage(GameRunner.getGameIcon(battleFrame));
-    getMap().getUIContext().addShutdownWindow(battleFrame);
+    getMap().getUiContext().addShutdownWindow(battleFrame);
     battleFrame.addWindowListener(new WindowListener() {
       @Override
       public void windowActivated(final WindowEvent e) {
@@ -245,7 +245,7 @@ public class BattlePanel extends ActionPanel {
         cleanUpBattleWindow();
         currentBattleDisplayed = null;
       }
-      if (!getMap().getUIContext().getShowMapOnly()) {
+      if (!getMap().getUiContext().getShowMapOnly()) {
         battleDisplay = new BattleDisplay(getData(), location, attacker, defender, attackingUnits, defendingUnits,
             killedUnits, attackingWaitingToDie, defendingWaitingToDie, BattlePanel.this.getMap(),
             isAmphibious, battleType, amphibiousLandAttackers);
@@ -256,14 +256,14 @@ public class BattlePanel extends ActionPanel {
         battleFrame.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
         PBEMDiceRoller.setFocusWindow(battleFrame);
         boolean foundHumanInBattle = false;
-        for (final IGamePlayer gamePlayer : getMap().getUIContext().getLocalPlayers().getLocalPlayers()) {
+        for (final IGamePlayer gamePlayer : getMap().getUiContext().getLocalPlayers().getLocalPlayers()) {
           if ((gamePlayer.getPlayerID().equals(attacker) && gamePlayer instanceof TripleAPlayer)
               || (gamePlayer.getPlayerID().equals(defender) && gamePlayer instanceof TripleAPlayer)) {
             foundHumanInBattle = true;
             break;
           }
         }
-        if (getMap().getUIContext().getShowBattlesBetweenAIs() || foundHumanInBattle) {
+        if (getMap().getUiContext().getShowBattlesBetweenAIs() || foundHumanInBattle) {
           battleFrame.setVisible(true);
           battleFrame.validate();
           battleFrame.invalidate();
@@ -296,7 +296,7 @@ public class BattlePanel extends ActionPanel {
     int option = JOptionPane.NO_OPTION;
     while (option != JOptionPane.OK_OPTION) {
       option = EventThreadJOptionPane.showConfirmDialog(this, comp, "Bombardment Territory Selection",
-          JOptionPane.OK_OPTION, getMap().getUIContext().getCountDownLatchHandler());
+          JOptionPane.OK_OPTION, getMap().getUiContext().getCountDownLatchHandler());
     }
     return comp.getSelection();
   }
@@ -304,25 +304,25 @@ public class BattlePanel extends ActionPanel {
   public boolean getAttackSubs(final Territory terr) {
     getMap().centerOn(terr);
     return EventThreadJOptionPane.showConfirmDialog(null, "Attack submarines in " + terr.toString() + "?", "Attack",
-        JOptionPane.YES_NO_OPTION, getMap().getUIContext().getCountDownLatchHandler()) == 0;
+        JOptionPane.YES_NO_OPTION, getMap().getUiContext().getCountDownLatchHandler()) == 0;
   }
 
   public boolean getAttackTransports(final Territory terr) {
     getMap().centerOn(terr);
     return EventThreadJOptionPane.showConfirmDialog(null, "Attack transports in " + terr.toString() + "?", "Attack",
-        JOptionPane.YES_NO_OPTION, getMap().getUIContext().getCountDownLatchHandler()) == 0;
+        JOptionPane.YES_NO_OPTION, getMap().getUiContext().getCountDownLatchHandler()) == 0;
   }
 
   public boolean getAttackUnits(final Territory terr) {
     getMap().centerOn(terr);
     return EventThreadJOptionPane.showConfirmDialog(null, "Attack units in " + terr.toString() + "?", "Attack",
-        JOptionPane.YES_NO_OPTION, getMap().getUIContext().getCountDownLatchHandler()) == 0;
+        JOptionPane.YES_NO_OPTION, getMap().getUiContext().getCountDownLatchHandler()) == 0;
   }
 
   public boolean getShoreBombard(final Territory terr) {
     getMap().centerOn(terr);
     return EventThreadJOptionPane.showConfirmDialog(null, "Conduct naval bombard in " + terr.toString() + "?",
-        "Bombard", JOptionPane.YES_NO_OPTION, getMap().getUIContext().getCountDownLatchHandler()) == 0;
+        "Bombard", JOptionPane.YES_NO_OPTION, getMap().getUiContext().getCountDownLatchHandler()) == 0;
   }
 
   public void casualtyNotification(final String step, final DiceRoll dice, final PlayerID player,
@@ -365,7 +365,7 @@ public class BattlePanel extends ActionPanel {
       final CasualtyList defaultCasualties, final GUID battleId, final boolean allowMultipleHitsPerUnit) {
     // if the battle display is null, then this is an aa fire during move
     if (battleId == null) {
-      return getCasualtiesAA(selectFrom, dependents, count, message, dice, hit, defaultCasualties,
+      return getCasualtiesAa(selectFrom, dependents, count, message, dice, hit, defaultCasualties,
           allowMultipleHitsPerUnit);
     } else {
       // something is wong
@@ -378,20 +378,20 @@ public class BattlePanel extends ActionPanel {
     }
   }
 
-  private CasualtyDetails getCasualtiesAA(final Collection<Unit> selectFrom,
+  private CasualtyDetails getCasualtiesAa(final Collection<Unit> selectFrom,
       final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
       final PlayerID hit, final CasualtyList defaultCasualties, final boolean allowMultipleHitsPerUnit) {
     final Task<CasualtyDetails> task = () -> {
       final boolean isEditMode = (dice == null);
       final UnitChooser chooser = new UnitChooser(selectFrom, defaultCasualties, dependents, getData(),
-          allowMultipleHitsPerUnit, getMap().getUIContext());
+          allowMultipleHitsPerUnit, getMap().getUiContext());
       chooser.setTitle(message);
       if (isEditMode) {
         chooser.setMax(selectFrom.size());
       } else {
         chooser.setMax(count);
       }
-      final DicePanel dicePanel = new DicePanel(getMap().getUIContext(), getData());
+      final DicePanel dicePanel = new DicePanel(getMap().getUiContext(), getData());
       if (!isEditMode) {
         dicePanel.setDiceRoll(dice);
       }
@@ -404,7 +404,7 @@ public class BattlePanel extends ActionPanel {
       final String[] options = {"OK"};
       EventThreadJOptionPane.showOptionDialog(getRootPane(), panel, hit.getName() + " select casualties",
           JOptionPane.OK_OPTION, JOptionPane.PLAIN_MESSAGE, null, options, null,
-          getMap().getUIContext().getCountDownLatchHandler());
+          getMap().getUiContext().getCountDownLatchHandler());
       final List<Unit> killed = chooser.getSelected(false);
       final CasualtyDetails response =
           new CasualtyDetails(killed, chooser.getSelectedDamagedMultipleHitPointUnits(), false);

--- a/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -95,7 +95,7 @@ public class CommentPanel extends JPanel {
     // create icon map
     iconMap = new HashMap<>();
     for (final PlayerID playerId : data.getPlayerList().getPlayers()) {
-      iconMap.put(playerId, new ImageIcon(frame.getUIContext().getFlagImageFactory().getSmallFlag(playerId)));
+      iconMap.put(playerId, new ImageIcon(frame.getUiContext().getFlagImageFactory().getSmallFlag(playerId)));
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -154,7 +154,7 @@ class EditPanel extends ActionPanel {
         if (mustChoose) {
           final String chooserText = "Remove units from " + selectedTerritory + ":";
           final UnitChooser chooser = new UnitChooser(allUnits, selectedUnits, mustMoveWithDetails.getMustMoveWith(),
-              true, false, getData(), /* allowTwoHit= */false, getMap().getUIContext());
+              true, false, getData(), /* allowTwoHit= */false, getMap().getUiContext());
           final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, chooserText,
               JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
           if (option != JOptionPane.OK_OPTION) {
@@ -192,7 +192,7 @@ class EditPanel extends ActionPanel {
         currentAction = this;
         setWidgetActivation();
         final PlayerChooser playerChooser =
-            new PlayerChooser(getData().getPlayerList(), getMap().getUIContext(), false);
+            new PlayerChooser(getData().getPlayerList(), getMap().getUiContext(), false);
         final JDialog dialog = playerChooser.createDialog(getTopLevelAncestor(), "Select owner PUs to change");
         dialog.setVisible(true);
         final PlayerID player = playerChooser.getSelected();
@@ -242,7 +242,7 @@ class EditPanel extends ActionPanel {
         currentAction = this;
         setWidgetActivation();
         final PlayerChooser playerChooser =
-            new PlayerChooser(getData().getPlayerList(), getMap().getUIContext(), false);
+            new PlayerChooser(getData().getPlayerList(), getMap().getUiContext(), false);
         final JDialog dialog = playerChooser.createDialog(getTopLevelAncestor(), "Select player to get technology");
         dialog.setVisible(true);
         final PlayerID player = playerChooser.getSelected();
@@ -296,7 +296,7 @@ class EditPanel extends ActionPanel {
         currentAction = this;
         setWidgetActivation();
         final PlayerChooser playerChooser =
-            new PlayerChooser(getData().getPlayerList(), getMap().getUIContext(), false);
+            new PlayerChooser(getData().getPlayerList(), getMap().getUiContext(), false);
         final JDialog dialog = playerChooser.createDialog(getTopLevelAncestor(), "Select player to remove technology");
         dialog.setVisible(true);
         final PlayerID player = playerChooser.getSelected();
@@ -380,7 +380,7 @@ class EditPanel extends ActionPanel {
           currentDamageMap.put(u, Triple.of(UnitAttachment.get(u.getType()).getHitPoints() - 1, 0, u.getHits()));
         }
         final IndividualUnitPanel unitPanel = new IndividualUnitPanel(currentDamageMap, "Change Unit Hit Damage",
-            getData(), getMap().getUIContext(), -1, true, true, null);
+            getData(), getMap().getUiContext(), -1, true, true, null);
         final JScrollPane scroll = new JScrollPane(unitPanel);
         final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), scroll, "Change Unit Hit Damage",
             JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
@@ -429,7 +429,7 @@ class EditPanel extends ActionPanel {
                   ((TripleAUnit) u).getUnitDamage()));
         }
         final IndividualUnitPanel unitPanel = new IndividualUnitPanel(currentDamageMap, "Change Unit Bombing Damage",
-            getData(), getMap().getUIContext(), -1, true, true, null);
+            getData(), getMap().getUiContext(), -1, true, true, null);
         final JScrollPane scroll = new JScrollPane(unitPanel);
         final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), scroll, "Change Unit Bombing Damage",
             JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
@@ -475,7 +475,7 @@ class EditPanel extends ActionPanel {
             + "unintended consequences!</em></html>");
         panel.add(helpText, BorderLayout.NORTH);
         final PoliticalStateOverview pui =
-            new PoliticalStateOverview(getData(), EditPanel.this.frame.getUIContext(), true);
+            new PoliticalStateOverview(getData(), EditPanel.this.frame.getUiContext(), true);
         panel.add(pui, BorderLayout.CENTER);
         final JScrollPane scroll = new JScrollPane(panel);
         scroll.setBorder(BorderFactory.createEmptyBorder());
@@ -708,7 +708,7 @@ class EditPanel extends ActionPanel {
           }
           final String text = "Remove from " + t.getName();
           final UnitChooser chooser = new UnitChooser(unitsToMove, selectedUnits, null, false, false, getData(),
-              false, getMap().getUIContext());
+              false, getMap().getUiContext());
           final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, text,
               JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
           if (option != JOptionPane.OK_OPTION) {
@@ -777,7 +777,7 @@ class EditPanel extends ActionPanel {
         // PlayerID defaultPlayer = TerritoryAttachment.get(territory).getOriginalOwner();
         final PlayerID defaultPlayer = ta.getOriginalOwner();
         final PlayerChooser playerChooser =
-            new PlayerChooser(getData().getPlayerList(), defaultPlayer, getMap().getUIContext(), true);
+            new PlayerChooser(getData().getPlayerList(), defaultPlayer, getMap().getUiContext(), true);
         final JDialog dialog = playerChooser.createDialog(getTopLevelAncestor(), "Select new owner for territory");
         dialog.setVisible(true);
         final PlayerID player = playerChooser.getSelected();
@@ -792,14 +792,14 @@ class EditPanel extends ActionPanel {
       } else if (currentAction == addUnitsAction) {
         final boolean allowNeutral = doesPlayerHaveUnitsOnMap(PlayerID.NULL_PLAYERID, getData());
         final PlayerChooser playerChooser =
-            new PlayerChooser(getData().getPlayerList(), territory.getOwner(), getMap().getUIContext(), allowNeutral);
+            new PlayerChooser(getData().getPlayerList(), territory.getOwner(), getMap().getUiContext(), allowNeutral);
         final JDialog dialog = playerChooser.createDialog(getTopLevelAncestor(), "Select owner for new units");
         dialog.setVisible(true);
         final PlayerID player = playerChooser.getSelected();
         if (player != null) {
           // open production panel for adding new units
           final IntegerMap<ProductionRule> production =
-              EditProductionPanel.getProduction(player, frame, getData(), getMap().getUIContext());
+              EditProductionPanel.getProduction(player, frame, getData(), getMap().getUiContext());
           final Collection<Unit> units = new ArrayList<>();
           for (final ProductionRule productionRule : production.keySet()) {
             final int quantity = production.getInt(productionRule);

--- a/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -803,7 +803,7 @@ public class MapPanel extends ImageScrollerLargeView {
     tileManager.clearTerritoryOverlay(territory, gameData, uiContext.getMapData());
   }
 
-  public IUIContext getUIContext() {
+  public IUIContext getUiContext() {
     return uiContext;
   }
 
@@ -857,7 +857,7 @@ public class MapPanel extends ImageScrollerLargeView {
         final GameData data = mapPanel.getData();
         data.acquireReadLock();
         try {
-          tile.getImage(data, mapPanel.getUIContext().getMapData());
+          tile.getImage(data, mapPanel.getUiContext().getMapData());
         } finally {
           data.releaseReadLock();
         }

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -260,7 +260,7 @@ public class MovePanel extends AbstractMovePanel {
     // Choosing what transports to unload
     final UnitChooser chooser = new UnitChooser(candidateTransports, defaultSelections,
         mustMoveWithDetails.getMustMoveWith(), /* categorizeMovement */true, /* categorizeTransportCost */false,
-        getGameData(), /* allowTwoHit */false, getMap().getUIContext(), transportsToUnloadMatch);
+        getGameData(), /* allowTwoHit */false, getMap().getUiContext(), transportsToUnloadMatch);
     chooser.setTitle("What transports do you want to unload");
     final int option =
         JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, "What transports do you want to unload",
@@ -693,7 +693,7 @@ public class MovePanel extends AbstractMovePanel {
     });
     final UnitChooser chooser = new UnitChooser(candidateTransports, defaultSelections,
         endMustMoveWith.getMustMoveWith(), /* categorizeMovement */true, /* categorizeTransportCost */false,
-        getGameData(), /* allowTwoHit */false, getMap().getUIContext(), transportsToLoadMatch);
+        getGameData(), /* allowTwoHit */false, getMap().getUiContext(), transportsToLoadMatch);
     chooser.setTitle("What transports do you want to load");
     final int option =
         JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, "What transports do you want to load",
@@ -774,11 +774,11 @@ public class MovePanel extends AbstractMovePanel {
             // use matcher to prevent units of different owners being chosen
             chooser = new UnitChooser(unitsToMove, selectedUnits, /* mustMoveWith */null,
                 /* categorizeMovement */false, /* categorizeTransportCost */false, getData(), /* allowTwoHit */false,
-                getMap().getUIContext(), ownerMatch);
+                getMap().getUiContext(), ownerMatch);
           } else {
             chooser =
                 new UnitChooser(unitsToMove, selectedUnits, /* mustMoveWith */null, /* categorizeMovement */false,
-                    /* categorizeTransportCost */false, getData(), /* allowTwoHit */false, getMap().getUIContext());
+                    /* categorizeTransportCost */false, getData(), /* allowTwoHit */false, getMap().getUiContext());
           }
           final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, text,
               JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
@@ -897,7 +897,7 @@ public class MovePanel extends AbstractMovePanel {
       // Allow player to select which to load.
       final UnitChooser chooser = new UnitChooser(candidateAirTransports, defaultSelections, s_dependentUnits,
           /* categorizeMovement */true, /* categorizeTransportCost */false, getGameData(), /* allowTwoHit */false,
-          getMap().getUIContext(), transportsToLoadMatch);
+          getMap().getUiContext(), transportsToLoadMatch);
       chooser.setTitle("Select air transports to load");
       final int option =
           JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, "What transports do you want to load",
@@ -1197,7 +1197,7 @@ public class MovePanel extends AbstractMovePanel {
       sortUnitsToMove(candidateUnits, route);
       final UnitChooser chooser =
           new UnitChooser(candidateUnits, defaultSelections, mustMoveWithDetails.getMustMoveWith(), true, false,
-              getGameData(), false, getMap().getUIContext(), matchCriteria);
+              getGameData(), false, getMap().getUiContext(), matchCriteria);
       final String text = "Select units to move from " + getFirstSelectedTerritory() + ".";
       final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, text,
           JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
@@ -1326,7 +1326,7 @@ public class MovePanel extends AbstractMovePanel {
     // Allow player to select which to load.
     final UnitChooser chooser = new UnitChooser(unitsToLoad, defaultSelections, s_dependentUnits,
         /* categorizeMovement */false, /* categorizeTransportCost */true, getGameData(), /* allowTwoHit */false,
-        getMap().getUIContext(), unitsToLoadMatch);
+        getMap().getUiContext(), unitsToLoadMatch);
     chooser.setTitle(title);
     final int option =
         JOptionPane.showOptionDialog(getTopLevelAncestor(), chooser, "What units do you want to " + action,

--- a/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -182,7 +182,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       currentAction = selectUnitsAction;
       setWidgetActivation();
       final UnitChooser unitChooser = new UnitChooser(unitChoices, Collections.emptyMap(),
-          getData(), false, getMap().getUIContext());
+          getData(), false, getMap().getUiContext());
       unitChooser.setMaxAndShowMaxButton(unitsPerPick);
       if (JOptionPane.OK_OPTION == EventThreadJOptionPane.showConfirmDialog(parent, unitChooser, "Select Units",
           JOptionPane.OK_CANCEL_OPTION, new CountDownLatchHandler(true))) {

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -38,7 +38,7 @@ public class PlacePanel extends AbstractMovePanel {
   public PlacePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map, frame);
     undoableMovesPanel = new UndoablePlacementsPanel(data, this);
-    unitsToPlace = new SimpleUnitPanel(map.getUIContext());
+    unitsToPlace = new SimpleUnitPanel(map.getUiContext());
     leftToPlaceLabel.setText("Units left to place:");
   }
 
@@ -69,7 +69,7 @@ public class PlacePanel extends AbstractMovePanel {
     return Properties.getProduceNewFightersOnOldCarriers(getData());
   }
 
-  private boolean isLHTR_Carrier_Production_Rules() {
+  private boolean isLhtrCarrierProductionRules() {
     return Properties.getLHTRCarrierProductionRules(getData());
   }
 
@@ -85,7 +85,7 @@ public class PlacePanel extends AbstractMovePanel {
         return;
       }
       final UnitChooser chooser =
-          new UnitChooser(units, Collections.emptyMap(), getData(), false, getMap().getUIContext());
+          new UnitChooser(units, Collections.emptyMap(), getData(), false, getMap().getUiContext());
       final String messageText = "Place units in " + territory.getName();
       if (maxUnits[0] >= 0) {
         chooser.setMaxAndShowMaxButton(maxUnits[0]);
@@ -133,7 +133,7 @@ public class PlacePanel extends AbstractMovePanel {
       Collection<Unit> units = getCurrentPlayer().getUnits().getUnits();
       if (territory.isWater()) {
         if (!(canProduceFightersOnCarriers() || canProduceNewFightersOnOldCarriers()
-            || isLHTR_Carrier_Production_Rules() || GameStepPropertiesHelper.isBid(getData()))) {
+            || isLhtrCarrierProductionRules() || GameStepPropertiesHelper.isBid(getData()))) {
           units = Match.getMatches(units, Matches.UnitIsSea);
         } else {
           final Match<Unit> unitIsSeaOrCanLandOnCarrier = Match.anyOf(Matches.UnitIsSea, Matches.UnitCanLandOnCarrier);

--- a/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -51,13 +51,13 @@ public class PoliticalStateOverview extends JPanel {
     this.uic = uiContext;
     this.data = data;
     this.editable = editable;
-    drawPoliticsUI();
+    drawPoliticsUi();
   }
 
   /**
    * does the actual adding of elements to this panel.
    */
-  private void drawPoliticsUI() {
+  private void drawPoliticsUi() {
     this.setLayout(new GridBagLayout());
     // draw horizontal labels
     int currentCell = 1;
@@ -209,7 +209,7 @@ public class PoliticalStateOverview extends JPanel {
    */
   public void redrawPolitics() {
     this.removeAll();
-    this.drawPoliticsUI();
+    this.drawPoliticsUi();
     this.revalidate();
   }
 

--- a/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -121,7 +121,7 @@ public class PoliticsPanel extends ActionPanel {
     final Insets insets = new Insets(1, 1, 1, 1);
     final JPanel politicalChoicePanel = new JPanel();
     politicalChoicePanel.setLayout(new GridBagLayout());
-    final PoliticalStateOverview overview = new PoliticalStateOverview(getData(), getMap().getUIContext(), false);
+    final PoliticalStateOverview overview = new PoliticalStateOverview(getData(), getMap().getUiContext(), false);
     final JScrollPane overviewScroll = new JScrollPane(overview);
     overviewScroll.setBorder(BorderFactory.createEmptyBorder());
     // add 26 to height when the actions are empty, because for some stupid reason java calculates the pack size wrong
@@ -216,7 +216,7 @@ public class PoliticsPanel extends ActionPanel {
   private JPanel getOtherPlayerFlags(final PoliticalActionAttachment paa) {
     final JPanel panel = new JPanel();
     for (final PlayerID p : paa.getOtherPlayers()) {
-      panel.add(new JLabel(new ImageIcon(this.getMap().getUIContext().getFlagImageFactory().getFlag(p))));
+      panel.add(new JLabel(new ImageIcon(this.getMap().getUiContext().getFlagImageFactory().getFlag(p))));
     }
     return panel;
   }

--- a/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -46,8 +46,8 @@ public class PurchasePanel extends ActionPanel {
   /** Creates new PurchasePanel. */
   public PurchasePanel(final GameData data, final MapPanel map) {
     super(data, map);
-    purchasedPreviousRoundsUnits = new SimpleUnitPanel(map.getUIContext());
-    purhcasedUnits = new SimpleUnitPanel(map.getUIContext());
+    purchasedPreviousRoundsUnits = new SimpleUnitPanel(map.getUiContext());
+    purhcasedUnits = new SimpleUnitPanel(map.getUiContext());
     buyButton = new JButton(BUY);
     buyButton.addActionListener(purchaseAction);
     purchasedPreviousRoundsLabel = new JLabel("Unplaced from previous rounds");
@@ -117,10 +117,10 @@ public class PurchasePanel extends ActionPanel {
       final GameData data = getData();
       if (isTabbedProduction()) {
         purchase = TabbedProductionPanel.getProduction(player, (JFrame) getTopLevelAncestor(), data, bid,
-            purchase, getMap().getUIContext());
+            purchase, getMap().getUiContext());
       } else {
         purchase = ProductionPanel.getProduction(player, (JFrame) getTopLevelAncestor(), data, bid, purchase,
-            getMap().getUIContext());
+            getMap().getUiContext());
       }
       purhcasedUnits.setUnitsFromProductionRuleMap(purchase, player, data);
       if (purchase.totalValues() == 0) {

--- a/src/main/java/games/strategy/triplea/ui/RepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/RepairPanel.java
@@ -36,7 +36,7 @@ public class RepairPanel extends ActionPanel {
   /** Creates new RepairPanel. */
   public RepairPanel(final GameData data, final MapPanel map) {
     super(data, map);
-    unitsPanel = new SimpleUnitPanel(map.getUIContext());
+    unitsPanel = new SimpleUnitPanel(map.getUiContext());
     buyButton = new JButton(BUY);
     buyButton.addActionListener(purchaseAction);
   }
@@ -87,7 +87,7 @@ public class RepairPanel extends ActionPanel {
       final PlayerID player = getCurrentPlayer();
       final GameData data = getData();
       repair = ProductionRepairPanel.getProduction(player, allowedPlayersToRepair, (JFrame) getTopLevelAncestor(),
-          data, bid, repair, getMap().getUIContext());
+          data, bid, repair, getMap().getUiContext());
       unitsPanel.setUnitsFromRepairRuleMap(repair, player, data);
       final int totalValues = getTotalValues(repair);
       if (totalValues == 0) {

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -181,7 +181,7 @@ public class StatPanel extends AbstractStatPanel {
     }
 
     public void setStatCollums() {
-      stats = new IStat[] {new PUStat(), new ProductionStat(), new UnitsStat(), new TUVStat()};
+      stats = new IStat[] {new PuStat(), new ProductionStat(), new UnitsStat(), new TuvStat()};
       if (Match.anyMatch(gameData.getMap().getTerritories(), Matches.TerritoryIsVictoryCity)) {
         final List<IStat> stats = new ArrayList<>(Arrays.asList(StatPanel.this.stats));
         stats.add(new VictoryCityStat());
@@ -190,7 +190,7 @@ public class StatPanel extends AbstractStatPanel {
       // only add the vps in pacific
       if (gameData.getProperties().get(Constants.PACIFIC_THEATER, false)) {
         final List<IStat> stats = new ArrayList<>(Arrays.asList(StatPanel.this.stats));
-        stats.add(new VPStat());
+        stats.add(new VpStat());
         StatPanel.this.stats = stats.toArray(new IStat[stats.size()]);
       }
     }
@@ -463,8 +463,8 @@ public class StatPanel extends AbstractStatPanel {
     }
   }
 
-  class PUStat extends ResourceStat {
-    public PUStat() {
+  class PuStat extends ResourceStat {
+    public PuStat() {
       super(getResourcePUs(gameData));
     }
   }
@@ -486,7 +486,7 @@ public class StatPanel extends AbstractStatPanel {
     }
   }
 
-  class TUVStat extends AbstractStat {
+  class TuvStat extends AbstractStat {
     @Override
     public String getName() {
       return "TUV";
@@ -530,7 +530,7 @@ public class StatPanel extends AbstractStatPanel {
     }
   }
 
-  class VPStat extends AbstractStat {
+  class VpStat extends AbstractStat {
     @Override
     public String getName() {
       return "VPs";

--- a/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -58,7 +58,7 @@ public class TabbedProductionPanel extends ProductionPanel {
         new Insets(8, 8, 8, 0), 0, 0));
     final ProductionTabsProperties properties = ProductionTabsProperties.getInstance(id, rules);
     final List<Tuple<String, List<Rule>>> ruleLists = getRuleLists(properties);
-    calculateXY(properties, largestList(ruleLists));
+    calculateRowsAndColumns(properties, largestList(ruleLists));
     for (final Tuple<String, List<Rule>> ruleList : ruleLists) {
       if (ruleList.getSecond().size() > 0) {
         tabs.addTab(ruleList.getFirst(), new JScrollPane(getRulesPanel(ruleList.getSecond())));
@@ -73,7 +73,7 @@ public class TabbedProductionPanel extends ProductionPanel {
     this.validate();
   }
 
-  private void calculateXY(final ProductionTabsProperties properties, final int largestList) {
+  private void calculateRowsAndColumns(final ProductionTabsProperties properties, final int largestList) {
     if (properties == null || properties.getRows() == 0 || properties.getColumns() == 0
         || properties.getRows() * properties.getColumns() < largestList) {
       final int m_maxColumns;

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -218,13 +218,13 @@ public class TripleAFrame extends MainGameFrame {
     messageAndDialogThreadPool = new ThreadPool(1);
     addZoomKeyboardShortcuts();
     this.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-    final WindowListener WINDOW_LISTENER = new WindowAdapter() {
+    final WindowListener windowListener = new WindowAdapter() {
       @Override
       public void windowClosing(final WindowEvent e) {
         leaveGame();
       }
     };
-    this.addWindowListener(WINDOW_LISTENER);
+    this.addWindowListener(windowListener);
     uiContext = new UIContext();
     uiContext.setDefaultMapDir(game.getData());
     uiContext.getMapData().verify(data);
@@ -286,8 +286,8 @@ public class TripleAFrame extends MainGameFrame {
     smallView = new MapPanelSmallView(small, model);
     mapPanel = new MapPanel(data, smallView, uiContext, model, this::computeScrollSpeed);
     mapPanel.addMapSelectionListener(mapSelectionListener);
-    final MouseOverUnitListener MOUSE_OVER_UNIT_LISTENER = (units, territory, me) -> unitsBeingMousedOver = units;
-    mapPanel.addMouseOverUnitListener(MOUSE_OVER_UNIT_LISTENER);
+    final MouseOverUnitListener mouseOverUnitListener = (units, territory, me) -> unitsBeingMousedOver = units;
+    mapPanel.addMouseOverUnitListener(mouseOverUnitListener);
     // link the small and large images
     mapPanel.initSmallMap();
     mapAndChatPanel = new JPanel();
@@ -586,7 +586,7 @@ public class TripleAFrame extends MainGameFrame {
   public void shutdown() {
     final int rVal = EventThreadJOptionPane.showConfirmDialog(this,
         "Are you sure you want to exit TripleA?\nUnsaved game data will be lost.", "Exit Program",
-        JOptionPane.YES_NO_OPTION, getUIContext().getCountDownLatchHandler());
+        JOptionPane.YES_NO_OPTION, getUiContext().getCountDownLatchHandler());
     if (rVal != JOptionPane.OK_OPTION) {
       return;
     }
@@ -598,7 +598,7 @@ public class TripleAFrame extends MainGameFrame {
   public void leaveGame() {
     final int rVal = EventThreadJOptionPane.showConfirmDialog(this,
         "Are you sure you want to leave the current game?\nUnsaved game data will be lost.", "Leave Game",
-        JOptionPane.YES_NO_OPTION, getUIContext().getCountDownLatchHandler());
+        JOptionPane.YES_NO_OPTION, getUiContext().getCountDownLatchHandler());
     if (rVal != JOptionPane.OK_OPTION) {
       return;
     }
@@ -777,7 +777,7 @@ public class TripleAFrame extends MainGameFrame {
       return;
     }
     messageAndDialogThreadPool.runTask(() -> EventThreadJOptionPane.showMessageDialog(TripleAFrame.this, displayMessage,
-        "Error", JOptionPane.ERROR_MESSAGE, true, getUIContext().getCountDownLatchHandler()));
+        "Error", JOptionPane.ERROR_MESSAGE, true, getUiContext().getCountDownLatchHandler()));
   }
 
   /**
@@ -789,30 +789,30 @@ public class TripleAFrame extends MainGameFrame {
     }
     if (title.indexOf(AbstractConditionsAttachment.TRIGGER_CHANCE_FAILURE) != -1
         && message.indexOf(AbstractConditionsAttachment.TRIGGER_CHANCE_FAILURE) != -1
-        && !getUIContext().getShowTriggerChanceFailure()) {
+        && !getUiContext().getShowTriggerChanceFailure()) {
       return;
     }
     if (title.indexOf(AbstractConditionsAttachment.TRIGGER_CHANCE_SUCCESSFUL) != -1
         && message.indexOf(AbstractConditionsAttachment.TRIGGER_CHANCE_SUCCESSFUL) != -1
-        && !getUIContext().getShowTriggerChanceSuccessful()) {
+        && !getUiContext().getShowTriggerChanceSuccessful()) {
       return;
     }
-    if (title.equals(AbstractTriggerAttachment.NOTIFICATION) && !getUIContext().getShowTriggeredNotifications()) {
+    if (title.equals(AbstractTriggerAttachment.NOTIFICATION) && !getUiContext().getShowTriggeredNotifications()) {
       return;
     }
     if (title.indexOf(AbstractEndTurnDelegate.END_TURN_REPORT_STRING) != -1
         && message.indexOf(AbstractEndTurnDelegate.END_TURN_REPORT_STRING) != -1
-        && !getUIContext().getShowEndOfTurnReport()) {
+        && !getUiContext().getShowEndOfTurnReport()) {
       return;
     }
     final String displayMessage = LocalizeHtml.localizeImgLinksInHtml(message);
     if (messageAndDialogThreadPool != null) {
       messageAndDialogThreadPool.runTask(() -> EventThreadJOptionPane.showMessageDialog(TripleAFrame.this,
-          displayMessage, title, JOptionPane.INFORMATION_MESSAGE, true, getUIContext().getCountDownLatchHandler()));
+          displayMessage, title, JOptionPane.INFORMATION_MESSAGE, true, getUiContext().getCountDownLatchHandler()));
     }
   }
 
-  public boolean getOKToLetAirDie(final PlayerID id, final Collection<Territory> airCantLand,
+  public boolean getOkToLetAirDie(final PlayerID id, final Collection<Territory> airCantLand,
       final boolean movePhase) {
     if (airCantLand == null || airCantLand.isEmpty() || messageAndDialogThreadPool == null) {
       return true;
@@ -843,11 +843,11 @@ public class TripleAFrame extends MainGameFrame {
     mapPanel.centerOn(airCantLand.iterator().next());
     final int choice =
         EventThreadJOptionPane.showOptionDialog(this, sb.toString(), "Air cannot land", JOptionPane.YES_NO_OPTION,
-            JOptionPane.WARNING_MESSAGE, null, options, cancel, getUIContext().getCountDownLatchHandler());
+            JOptionPane.WARNING_MESSAGE, null, options, cancel, getUiContext().getCountDownLatchHandler());
     return choice == 1;
   }
 
-  public boolean getOKToLetUnitsDie(final Collection<Territory> unitsCantFight, final boolean movePhase) {
+  public boolean getOkToLetUnitsDie(final Collection<Territory> unitsCantFight, final boolean movePhase) {
     if (unitsCantFight == null || unitsCantFight.isEmpty() || messageAndDialogThreadPool == null) {
       return true;
     }
@@ -860,7 +860,7 @@ public class TripleAFrame extends MainGameFrame {
     this.mapPanel.centerOn(unitsCantFight.iterator().next());
     final int choice =
         EventThreadJOptionPane.showOptionDialog(this, buf.toString(), "Units cannot fight", JOptionPane.YES_NO_OPTION,
-            JOptionPane.WARNING_MESSAGE, null, options, cancel, getUIContext().getCountDownLatchHandler());
+            JOptionPane.WARNING_MESSAGE, null, options, cancel, getUiContext().getCountDownLatchHandler());
     return choice == 1;
   }
 
@@ -872,17 +872,17 @@ public class TripleAFrame extends MainGameFrame {
     messageAndDialogThreadPool.waitForAll();
     final int choice = EventThreadJOptionPane.showConfirmDialog(this, acceptanceQuestion,
         "Accept " + (politics ? "Political " : "") + "Proposal from " + playerSendingProposal.getName() + "?",
-        JOptionPane.YES_NO_OPTION, getUIContext().getCountDownLatchHandler());
+        JOptionPane.YES_NO_OPTION, getUiContext().getCountDownLatchHandler());
     return choice == JOptionPane.YES_OPTION;
   }
 
-  public boolean getOK(final String message) {
+  public boolean getOk(final String message) {
     if (messageAndDialogThreadPool == null) {
       return true;
     }
     messageAndDialogThreadPool.waitForAll();
     final int choice = EventThreadJOptionPane.showConfirmDialog(this, message, message, JOptionPane.OK_CANCEL_OPTION,
-        getUIContext().getCountDownLatchHandler());
+        getUiContext().getCountDownLatchHandler());
     return choice == JOptionPane.OK_OPTION;
   }
 
@@ -897,7 +897,7 @@ public class TripleAFrame extends MainGameFrame {
         displayRef.set(display);
       });
       EventThreadJOptionPane.showOptionDialog(TripleAFrame.this, displayRef.get(), "Tech roll", JOptionPane.OK_OPTION,
-          JOptionPane.PLAIN_MESSAGE, null, new String[] {"OK"}, "OK", getUIContext().getCountDownLatchHandler());
+          JOptionPane.PLAIN_MESSAGE, null, new String[] {"OK"}, "OK", getUiContext().getCountDownLatchHandler());
     });
   }
 
@@ -916,7 +916,7 @@ public class TripleAFrame extends MainGameFrame {
     int choice = -1;
     while (choice < 0 || choice > 1) {
       choice = EventThreadJOptionPane.showOptionDialog(this, message, "Bomb?", JOptionPane.OK_CANCEL_OPTION,
-          JOptionPane.INFORMATION_MESSAGE, null, choices, bomb, getUIContext().getCountDownLatchHandler());
+          JOptionPane.INFORMATION_MESSAGE, null, choices, bomb, getUiContext().getCountDownLatchHandler());
     }
     return choice == JOptionPane.OK_OPTION;
   }
@@ -946,7 +946,7 @@ public class TripleAFrame extends MainGameFrame {
     final JList<?> list = comps.getSecond();
     final String[] options = {"OK"};
     final int selection = EventThreadJOptionPane.showOptionDialog(this, panel, message, JOptionPane.OK_OPTION,
-        JOptionPane.PLAIN_MESSAGE, null, options, null, getUIContext().getCountDownLatchHandler());
+        JOptionPane.PLAIN_MESSAGE, null, options, null, getUiContext().getCountDownLatchHandler());
     if (selection == 0) {
       selected.set((Unit) list.getSelectedValue());
     }
@@ -960,10 +960,10 @@ public class TripleAFrame extends MainGameFrame {
     }
     messageAndDialogThreadPool.waitForAll();
     final DiceChooser chooser =
-        Util.runInSwingEventThread(() -> new DiceChooser(getUIContext(), numDice, hitAt, hitOnlyIfEquals, diceSides));
+        Util.runInSwingEventThread(() -> new DiceChooser(getUiContext(), numDice, hitAt, hitOnlyIfEquals, diceSides));
     do {
       EventThreadJOptionPane.showMessageDialog(null, chooser, title, JOptionPane.PLAIN_MESSAGE,
-          getUIContext().getCountDownLatchHandler());
+          getUiContext().getCountDownLatchHandler());
     } while (chooser.getDice() == null);
     return chooser.getDice();
   }
@@ -998,7 +998,7 @@ public class TripleAFrame extends MainGameFrame {
     final String[] options = {"OK"};
     final String title = "Select territory for air units to land, current territory is " + currentTerritory.getName();
     EventThreadJOptionPane.showOptionDialog(this, panel, title, JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE,
-        null, options, null, getUIContext().getCountDownLatchHandler());
+        null, options, null, getUiContext().getCountDownLatchHandler());
     final Territory selected = (Territory) list.getSelectedValue();
     return selected;
   }
@@ -1130,13 +1130,13 @@ public class TripleAFrame extends MainGameFrame {
 
       }
     });
-    mapPanel.getUIContext().addShutdownLatch(continueLatch);
+    mapPanel.getUiContext().addShutdownLatch(continueLatch);
     try {
       continueLatch.await();
     } catch (final InterruptedException ex) {
       // ignore interrupted exception
     } finally {
-      mapPanel.getUIContext().removeShutdownLatch(continueLatch);
+      mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }
     return selection;
   }
@@ -1222,13 +1222,13 @@ public class TripleAFrame extends MainGameFrame {
         });
       }
     });
-    mapPanel.getUIContext().addShutdownLatch(continueLatch);
+    mapPanel.getUiContext().addShutdownLatch(continueLatch);
     try {
       continueLatch.await();
     } catch (final InterruptedException ex) {
       // ignore interrupted exception
     } finally {
-      mapPanel.getUIContext().removeShutdownLatch(continueLatch);
+      mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }
     return selection;
   }
@@ -1301,13 +1301,13 @@ public class TripleAFrame extends MainGameFrame {
         });
       }
     });
-    mapPanel.getUIContext().addShutdownLatch(continueLatch);
+    mapPanel.getUiContext().addShutdownLatch(continueLatch);
     try {
       continueLatch.await();
     } catch (final InterruptedException ex) {
       ex.printStackTrace();
     } finally {
-      mapPanel.getUIContext().removeShutdownLatch(continueLatch);
+      mapPanel.getUiContext().removeShutdownLatch(continueLatch);
     }
     return selection;
   }
@@ -2032,7 +2032,7 @@ public class TripleAFrame extends MainGameFrame {
     });
     final int option = EventThreadJOptionPane.showOptionDialog(this, panelRef.get(),
         "Move air units to carrier", JOptionPane.PLAIN_MESSAGE, JOptionPane.OK_CANCEL_OPTION, null,
-        new String[] {"OK", "Cancel"}, "OK", getUIContext().getCountDownLatchHandler());
+        new String[] {"OK", "Cancel"}, "OK", getUiContext().getCountDownLatchHandler());
     if (option == JOptionPane.OK_OPTION) {
       return chooserRef.get().getSelected();
     }
@@ -2055,7 +2055,7 @@ public class TripleAFrame extends MainGameFrame {
     return showMapOnlyAction;
   }
 
-  public IUIContext getUIContext() {
+  public IUIContext getUiContext() {
     return uiContext;
   }
 

--- a/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -244,7 +244,7 @@ public class UserActionPanel extends ActionPanel {
   private JPanel getOtherPlayerFlags(final UserActionAttachment uaa) {
     final JPanel panel = new JPanel();
     for (final PlayerID p : uaa.getOtherPlayers()) {
-      panel.add(new JLabel(new ImageIcon(this.getMap().getUIContext().getFlagImageFactory().getFlag(p))));
+      panel.add(new JLabel(new ImageIcon(this.getMap().getUiContext().getFlagImageFactory().getFlag(p))));
     }
     return panel;
   }

--- a/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -79,7 +79,7 @@ public final class ScreenshotExporter {
         round = ((Round) curNode).getRoundNo();
       }
     }
-    final IUIContext iuiContext = frame.getUIContext();
+    final IUIContext iuiContext = frame.getUiContext();
     final double scale = iuiContext.getScale();
     // print map panel to image
     final MapPanel mapPanel = frame.getMapPanel();

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
@@ -58,7 +58,7 @@ public class HistoryDetailsPanel extends JPanel implements IHistoryDetailsPanel 
     if (node instanceof Renderable) {
       final Object details = ((Renderable) node).getRenderingData();
       if (details instanceof DiceRoll) {
-        final DicePanel dicePanel = new DicePanel(mapPanel.getUIContext(), data);
+        final DicePanel dicePanel = new DicePanel(mapPanel.getUiContext(), data);
         dicePanel.setDiceRoll((DiceRoll) details);
         add(dicePanel, mainConstraints);
       } else if (details instanceof MoveDescription) {
@@ -98,7 +98,7 @@ public class HistoryDetailsPanel extends JPanel implements IHistoryDetailsPanel 
 
   private void renderUnits(final GridBagConstraints mainConstraints, final Collection<Unit> units) {
     final Collection<UnitCategory> unitsCategories = UnitSeperator.categorize(units);
-    final SimpleUnitPanel unitsPanel = new SimpleUnitPanel(mapPanel.getUIContext());
+    final SimpleUnitPanel unitsPanel = new SimpleUnitPanel(mapPanel.getUiContext());
     unitsPanel.setUnitsFromCategories(unitsCategories, data);
     add(unitsPanel, mainConstraints);
   }

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -120,7 +120,7 @@ public class HistoryLog extends JFrame {
     }
   }
 
-  private static PlayerID getPlayerID(final HistoryNode printNode) {
+  private static PlayerID getPlayerId(final HistoryNode printNode) {
     DefaultMutableTreeNode curNode = printNode;
     final TreePath parentPath = (new TreePath(printNode.getPath())).getParentPath();
     PlayerID curPlayer = null;
@@ -390,7 +390,7 @@ public class HistoryLog extends JFrame {
 
   public void printTerritorySummary(final HistoryNode printNode, final GameData data) {
     Collection<Territory> territories;
-    final PlayerID player = getPlayerID(printNode);
+    final PlayerID player = getPlayerId(printNode);
     data.acquireReadLock();
     try {
       territories = data.getMap().getTerritories();

--- a/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -574,7 +574,7 @@ public class MapData implements Closeable {
     return getCenter(terr);
   }
 
-  public Point getVCPlacementPoint(final Territory terr) {
+  public Point getVcPlacementPoint(final Territory terr) {
     if (vcPlace.containsKey(terr.getName())) {
       return vcPlace.get(terr.getName());
     }
@@ -588,7 +588,7 @@ public class MapData implements Closeable {
     return getCenter(terr);
   }
 
-  public Optional<Point> getPUPlacementPoint(final Territory terr) {
+  public Optional<Point> getPuPlacementPoint(final Territory terr) {
     return Optional.ofNullable(puPlace.get(terr.getName()));
   }
 
@@ -704,7 +704,7 @@ public class MapData implements Closeable {
     return boundingRect;
   }
 
-  public Optional<Image> getVCImage() {
+  public Optional<Image> getVcImage() {
     return loadImage("misc/vc.png");
   }
 

--- a/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -62,7 +62,7 @@ class ExportMenu {
   ExportMenu(final TripleAMenuBar menuBar, final TripleAFrame frame) {
     this.frame = frame;
     gameData = frame.getGame().getData();
-    iuiContext = frame.getUIContext();
+    iuiContext = frame.getUiContext();
 
     final JMenu menuGame = new JMenu("Export");
     menuGame.setMnemonic(KeyEvent.VK_E);

--- a/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -37,7 +37,7 @@ class FileMenu {
     fileMenu.add(createSaveMenu());
 
     if (PBEMMessagePoster.gameDataHasPlayByEmailOrForumMessengers(gameData)) {
-      fileMenu.add(addPostPBEM());
+      fileMenu.add(addPostPbem());
     }
 
     fileMenu.addSeparator();
@@ -59,7 +59,7 @@ class FileMenu {
     return menuFileSave;
   }
 
-  JMenuItem addPostPBEM() {
+  private JMenuItem addPostPbem() {
     final JMenuItem menuPbem = new JMenuItem(SwingAction.of("Post PBEM/PBF Gamesave", e -> {
       if (gameData == null || !PBEMMessagePoster.gameDataHasPlayByEmailOrForumMessengers(gameData)) {
         return;

--- a/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -51,7 +51,7 @@ class GameMenu {
     this.frame = frame;
     game = frame.getGame();
     gameData = frame.getGame().getData();
-    iuiContext = frame.getUIContext();
+    iuiContext = frame.getUiContext();
 
     menuBar.add(createGameMenu());
   }

--- a/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -139,7 +139,7 @@ public class HelpMenu {
         for (final UnitType ut : entry.getValue()) {
           i++;
           hints.append("<tr").append(((i & 1) == 0) ? " bgcolor=\"" + color1 + "\"" : " bgcolor=\"" + color2 + "\"")
-              .append(">").append("<td>").append(getUnitImageURL(ut, player, iuiContext)).append("</td>").append("<td>")
+              .append(">").append("<td>").append(getUnitImageUrl(ut, player, iuiContext)).append("</td>").append("<td>")
               .append(ut.getName()).append("</td>").append("<td>").append(costs.get(player).get(ut).toStringForHTML())
               .append("</td>").append("<td>").append(ut.getTooltip(player)).append("</td></tr>");
         }
@@ -154,7 +154,7 @@ public class HelpMenu {
     return hints.toString();
   }
 
-  private static String getUnitImageURL(final UnitType unitType, final PlayerID player, final IUIContext iuiContext) {
+  private static String getUnitImageUrl(final UnitType unitType, final PlayerID player, final IUIContext iuiContext) {
     final UnitImageFactory unitImageFactory = iuiContext.getUnitImageFactory();
     if (player == null || unitImageFactory == null) {
       return "no image";

--- a/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -83,7 +83,7 @@ public class TripleAMenuBar extends JMenuBar {
     }
     new WebHelpMenu(this);
     new DebugMenu(this, frame);
-    new HelpMenu(this, frame.getUIContext(), frame.getGame().getData(), getBackground());
+    new HelpMenu(this, frame.getUiContext(), frame.getGame().getData(), getBackground());
   }
 
   private void createLobbyMenu(final JMenuBar menuBar, final InGameLobbyWatcherWrapper watcher) {

--- a/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -67,7 +67,7 @@ class ViewMenu {
 
   ViewMenu(final JMenuBar menuBar, final TripleAFrame frame) {
     this.frame = frame;
-    this.uiContext = frame.getUIContext();
+    this.uiContext = frame.getUiContext();
     gameData = frame.getGame().getData();
 
 

--- a/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -51,7 +51,7 @@ import games.strategy.triplea.ui.screen.drawable.ReliefMapDrawable;
 import games.strategy.triplea.ui.screen.drawable.SeaZoneOutlineDrawable;
 import games.strategy.triplea.ui.screen.drawable.TerritoryEffectDrawable;
 import games.strategy.triplea.ui.screen.drawable.TerritoryNameDrawable;
-import games.strategy.triplea.ui.screen.drawable.VCDrawable;
+import games.strategy.triplea.ui.screen.drawable.VcDrawable;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeperator;
 import games.strategy.ui.Util;
@@ -313,7 +313,7 @@ public class TileManager {
       drawing.add(new CapitolMarkerDrawable(capitalOf, territory, uiContext));
     }
     if (ta != null && (ta.getVictoryCity() != 0)) {
-      drawing.add(new VCDrawable(territory));
+      drawing.add(new VcDrawable(territory));
     }
     // add to the relevant tiles
     final Iterator<Tile> tiles = getTiles(mapData.getBoundingRect(territory.getName())).iterator();

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -107,7 +107,7 @@ public class TerritoryNameDrawable implements IDrawable {
     if (ta != null && ta.getProduction() > 0 && mapData.drawResources()) {
       final Image img = uiContext.getPuImageFactory().getPUImage(ta.getProduction());
       final String prod = Integer.valueOf(ta.getProduction()).toString();
-      final Optional<Point> place = mapData.getPUPlacementPoint(territory);
+      final Optional<Point> place = mapData.getPuPlacementPoint(territory);
       // if pu_place.txt is specified draw there
       if (place.isPresent()) {
         draw(bounds, graphics, place.get().x, place.get().y, img, prod, drawFromTopLeft);

--- a/src/main/java/games/strategy/triplea/ui/screen/drawable/VcDrawable.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/drawable/VcDrawable.java
@@ -9,10 +9,10 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ui.mapdata.MapData;
 
-public class VCDrawable implements IDrawable {
+public class VcDrawable implements IDrawable {
   private final Territory location;
 
-  public VCDrawable(final Territory location) {
+  public VcDrawable(final Territory location) {
     this.location = location;
   }
 
@@ -20,8 +20,8 @@ public class VCDrawable implements IDrawable {
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
 
-    final Point point = mapData.getVCPlacementPoint(location);
-    drawImage(graphics, mapData.getVCImage(), point, bounds);
+    final Point point = mapData.getVcPlacementPoint(location);
+    drawImage(graphics, mapData.getVcImage(), point, bounds);
   }
 
   @Override


### PR DESCRIPTION
This PR fixes violations of the Checkstyle AbbreviationAsWordInName rule in classes within the `g.s.triplea.ui` package.  Many violations were in public methods, so the renames spread out to several other packages.