### PR TITLE
Serialization proxy: Add feature toggle

### DIFF
--- a/src/main/java/games/strategy/engine/config/client/GameEnginePropertyReader.java
+++ b/src/main/java/games/strategy/engine/config/client/GameEnginePropertyReader.java
@@ -85,12 +85,17 @@ public class GameEnginePropertyReader {
     return propertyFileReader.readProperty(PropertyKeys.JAVAFX_UI).equalsIgnoreCase(String.valueOf(true));
   }
 
+  public boolean useNewSaveGameFormat() {
+    return propertyFileReader.readProperty(PropertyKeys.NEW_SAVE_GAME_FORMAT).equalsIgnoreCase(String.valueOf(true));
+  }
+
   @VisibleForTesting
   interface PropertyKeys {
-    String MAP_LISTING_SOURCE_FILE = "map_list_file";
     String ENGINE_VERSION = "engine_version";
-    String LOBBY_PROP_FILE_URL = "lobby_properties_file_url";
-    String LOBBY_BACKUP_HOST_ADDRESS = "lobby_backup_url";
     String JAVAFX_UI = "javafx_ui";
+    String LOBBY_BACKUP_HOST_ADDRESS = "lobby_backup_url";
+    String LOBBY_PROP_FILE_URL = "lobby_properties_file_url";
+    String MAP_LISTING_SOURCE_FILE = "map_list_file";
+    String NEW_SAVE_GAME_FORMAT = "new_save_game_format";
   }
 }

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -12,15 +12,20 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import javax.annotation.Nullable;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 
 import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.commons.io.output.CloseShieldOutputStream;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.ClientContext;
@@ -49,21 +54,76 @@ public final class GameDataManager {
 
   private GameDataManager() {}
 
-  public static GameData loadGame(final File savedGameFile) throws IOException {
-    try (
-        FileInputStream fileInputStream = new FileInputStream(savedGameFile);
-        InputStream input = new BufferedInputStream(fileInputStream)) {
-      String path;
-      try {
-        path = savedGameFile.getCanonicalPath();
-      } catch (final IOException e) {
-        path = savedGameFile.getPath();
-      }
-      return loadGame(input, path);
+  /**
+   * Loads game data from the specified file.
+   *
+   * @param file The file from which the game data will be loaded.
+   *
+   * @return The loaded game data.
+   *
+   * @throws IOException If an error occurs while loading the game.
+   */
+  public static GameData loadGame(final File file) throws IOException {
+    checkNotNull(file);
+
+    try (final FileInputStream fis = new FileInputStream(file);
+        final InputStream is = new BufferedInputStream(fis)) {
+      return loadGame(is, getPath(file));
     }
   }
 
-  public static GameData loadGame(final InputStream inputStream, final String savegamePath) throws IOException {
+  /**
+   * Loads game data from the specified stream.
+   *
+   * @param is The stream from which the game data will be loaded. The caller is responsible for closing this stream; it
+   *        will not be closed when this method returns.
+   * @param path The path to the file from which the game data originated or {@code null} if none.
+   *
+   * @return The loaded game data.
+   *
+   * @throws IOException If an error occurs while loading the game.
+   */
+  public static GameData loadGame(final InputStream is, final @Nullable String path) throws IOException {
+    checkNotNull(is);
+
+    return ClientContext.gameEnginePropertyReader().useNewSaveGameFormat()
+        ? loadGameInNewFormat(is)
+        : loadGameInCurrentFormat(is, path);
+  }
+
+  private static String getPath(final File file) {
+    try {
+      return file.getCanonicalPath();
+    } catch (final IOException e) {
+      return file.getPath();
+    }
+  }
+
+  @VisibleForTesting
+  static GameData loadGameInNewFormat(final InputStream is) throws IOException {
+    return fromMemento(loadMemento(new CloseShieldInputStream(is)));
+  }
+
+  private static Memento loadMemento(final InputStream is) throws IOException {
+    try (final GZIPInputStream gzipis = new GZIPInputStream(is);
+        final ObjectInputStream ois = new ObjectInputStream(gzipis)) {
+      return (Memento) ois.readObject();
+    } catch (final ClassNotFoundException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private static GameData fromMemento(final Memento memento) throws IOException {
+    try {
+      final MementoImporter<GameData> mementoImporter = GameDataMemento.newImporter();
+      return mementoImporter.importMemento(memento);
+    } catch (final MementoImportException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private static GameData loadGameInCurrentFormat(final InputStream inputStream, final @Nullable String savegamePath)
+      throws IOException {
     final ObjectInputStream input = new ObjectInputStream(new GZIPInputStream(inputStream));
     try {
       final Version readVersion = (Version) input.readObject();
@@ -223,11 +283,69 @@ public final class GameDataManager {
     }
   }
 
-  public static void saveGame(final OutputStream sink, final GameData data) throws IOException {
-    saveGame(sink, data, true);
+  /**
+   * Saves the specified game data to the specified stream.
+   *
+   * @param os The stream to which the game data will be saved. The caller is responsible for closing this stream; it
+   *        will not be closed when this method returns.
+   * @param gameData The game data to save.
+   *
+   * @throws IOException If an error occurs while saving the game.
+   */
+  public static void saveGame(final OutputStream os, final GameData gameData) throws IOException {
+    checkNotNull(os);
+    checkNotNull(gameData);
+
+    saveGame(os, gameData, true);
   }
 
-  static void saveGame(final OutputStream sink, final GameData data, final boolean saveDelegateInfo)
+  static void saveGame(
+      final OutputStream os,
+      final GameData gameData,
+      final boolean includeDelegates)
+      throws IOException {
+    if (ClientContext.gameEnginePropertyReader().useNewSaveGameFormat()) {
+      saveGameInNewFormat(
+          os,
+          gameData,
+          Collections.singletonMap(GameDataMemento.ExportOptionName.EXCLUDE_DELEGATES, !includeDelegates));
+    } else {
+      saveGameInCurrentFormat(os, gameData, includeDelegates);
+    }
+  }
+
+  @VisibleForTesting
+  static void saveGameInNewFormat(
+      final OutputStream os,
+      final GameData gameData,
+      final Map<GameDataMemento.ExportOptionName, Object> optionsByName)
+      throws IOException {
+    saveMemento(new CloseShieldOutputStream(os), toMemento(gameData, optionsByName));
+  }
+
+  private static Memento toMemento(
+      final GameData gameData,
+      final Map<GameDataMemento.ExportOptionName, Object> optionsByName)
+      throws IOException {
+    try {
+      final MementoExporter<GameData> mementoExporter = GameDataMemento.newExporter(optionsByName);
+      return mementoExporter.exportMemento(gameData);
+    } catch (final MementoExportException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private static void saveMemento(final OutputStream os, final Memento memento) throws IOException {
+    try (final GZIPOutputStream gzipos = new GZIPOutputStream(os);
+        final ObjectOutputStream oos = new ProxyableObjectOutputStream(gzipos, ProxyRegistries.GAME_DATA_MEMENTO)) {
+      oos.writeObject(memento);
+    }
+  }
+
+  private static void saveGameInCurrentFormat(
+      final OutputStream sink,
+      final GameData data,
+      final boolean saveDelegateInfo)
       throws IOException {
     // write internally first in case of error
     final ByteArrayOutputStream bytes = new ByteArrayOutputStream(25000);
@@ -264,71 +382,5 @@ public final class GameDataManager {
     }
     // mark end of delegate section
     out.writeObject(DELEGATE_LIST_END);
-  }
-
-  /**
-   * Loads game data from the specified stream, which is expected to be in serializable format.
-   *
-   * @param is The stream from which the game data will be loaded. The caller is responsible for closing this stream; it
-   *        will not be closed when this method returns.
-   *
-   * @return The loaded game data.
-   *
-   * @throws IOException If an error occurs while loading the game.
-   */
-  public static GameData loadSerializableGame(final InputStream is) throws IOException {
-    checkNotNull(is);
-
-    return fromMemento(loadMemento(new CloseShieldInputStream(is)));
-  }
-
-  private static Memento loadMemento(final InputStream is) throws IOException {
-    try (final GZIPInputStream gzipis = new GZIPInputStream(is);
-        final ObjectInputStream ois = new ObjectInputStream(gzipis)) {
-      return (Memento) ois.readObject();
-    } catch (final ClassNotFoundException e) {
-      throw new IOException(e);
-    }
-  }
-
-  private static GameData fromMemento(final Memento memento) throws IOException {
-    try {
-      final MementoImporter<GameData> mementoImporter = GameDataMemento.newImporter();
-      return mementoImporter.importMemento(memento);
-    } catch (final MementoImportException e) {
-      throw new IOException(e);
-    }
-  }
-
-  /**
-   * Saves the specified game data to the specified stream in serializable format.
-   *
-   * @param os The stream to which the game data will be saved. The caller is responsible for closing this stream; it
-   *        will not be closed when this method returns.
-   * @param gameData The game data to save.
-   *
-   * @throws IOException If an error occurs while saving the game.
-   */
-  public static void saveSerializableGame(final OutputStream os, final GameData gameData) throws IOException {
-    checkNotNull(os);
-    checkNotNull(gameData);
-
-    saveMemento(new CloseShieldOutputStream(os), toMemento(gameData));
-  }
-
-  private static Memento toMemento(final GameData gameData) throws IOException {
-    try {
-      final MementoExporter<GameData> mementoExporter = GameDataMemento.newExporter();
-      return mementoExporter.exportMemento(gameData);
-    } catch (final MementoExportException e) {
-      throw new IOException(e);
-    }
-  }
-
-  private static void saveMemento(final OutputStream os, final Memento memento) throws IOException {
-    try (final GZIPOutputStream gzipos = new GZIPOutputStream(os);
-        final ObjectOutputStream oos = new ProxyableObjectOutputStream(gzipos, ProxyRegistries.GAME_DATA_MEMENTO)) {
-      oos.writeObject(memento);
-    }
   }
 }

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -40,21 +40,16 @@ import games.strategy.util.memento.MementoImportException;
 import games.strategy.util.memento.MementoImporter;
 
 /**
- * <p>
- * Title: TripleA
- * </p>
- * <p>
- * Description: Responsible for loading saved games, new games from xml, and saving games.
- * </p>
+ * Responsible for loading saved games, new games from xml, and saving games.
  */
-public class GameDataManager {
+public final class GameDataManager {
   private static final String DELEGATE_START = "<DelegateStart>";
   private static final String DELEGATE_DATA_NEXT = "<DelegateData>";
   private static final String DELEGATE_LIST_END = "<EndDelegateList>";
 
-  public GameDataManager() {}
+  private GameDataManager() {}
 
-  public GameData loadGame(final File savedGameFile) throws IOException {
+  public static GameData loadGame(final File savedGameFile) throws IOException {
     try (
         FileInputStream fileInputStream = new FileInputStream(savedGameFile);
         InputStream input = new BufferedInputStream(fileInputStream)) {
@@ -68,7 +63,7 @@ public class GameDataManager {
     }
   }
 
-  public GameData loadGame(final InputStream inputStream, final String savegamePath) throws IOException {
+  public static GameData loadGame(final InputStream inputStream, final String savegamePath) throws IOException {
     final ObjectInputStream input = new ObjectInputStream(new GZIPInputStream(inputStream));
     try {
       final Version readVersion = (Version) input.readObject();
@@ -175,8 +170,11 @@ public class GameDataManager {
    * FYI: Engine version numbers work like this with regards to savegames:
    * Any changes to the first 3 digits means that the savegame is not compatible between different engines.
    * While any change only to the 4th (last) digit means that the savegame must be compatible between different engines.
+   *
+   * @param originalEngineVersion The engine version used to save the specified game data.
+   * @param data The game data to be updated.
    */
-  private void updateDataToBeCompatibleWithNewEngine(final Version originalEngineVersion, final GameData data) {
+  private static void updateDataToBeCompatibleWithNewEngine(final Version originalEngineVersion, final GameData data) {
     // whenever this gets out of date, just comment out (but keep as an example, by commenting out)
     /*
      * example1:
@@ -225,11 +223,12 @@ public class GameDataManager {
     }
   }
 
-  public void saveGame(final OutputStream sink, final GameData data) throws IOException {
+  public static void saveGame(final OutputStream sink, final GameData data) throws IOException {
     saveGame(sink, data, true);
   }
 
-  void saveGame(final OutputStream sink, final GameData data, final boolean saveDelegateInfo) throws IOException {
+  static void saveGame(final OutputStream sink, final GameData data, final boolean saveDelegateInfo)
+      throws IOException {
     // write internally first in case of error
     final ByteArrayOutputStream bytes = new ByteArrayOutputStream(25000);
     final ObjectOutputStream outStream = new ObjectOutputStream(bytes);

--- a/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -20,13 +20,12 @@ public class GameDataUtils {
    */
   public static GameData cloneGameData(final GameData data, final boolean copyDelegates) {
     try {
-      final GameDataManager manager = new GameDataManager();
       ByteArrayOutputStream sink = new ByteArrayOutputStream(10000);
-      manager.saveGame(sink, data, copyDelegates);
+      GameDataManager.saveGame(sink, data, copyDelegates);
       sink.close();
       final ByteArrayInputStream source = new ByteArrayInputStream(sink.toByteArray());
       sink = null;
-      return manager.loadGame(source, null);
+      return GameDataManager.loadGame(source, null);
     } catch (final IOException ex) {
       ClientLogger.logQuietly(ex);
       return null;

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -383,7 +383,7 @@ public class ServerGame extends AbstractGame {
       throw new IOException(ie.getMessage());
     }
     try {
-      new GameDataManager().saveGame(out, m_data);
+      GameDataManager.saveGame(out, m_data);
     } finally {
       m_delegateExecutionManager.resumeDelegateExecution();
     }

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -324,7 +324,7 @@ public class ServerLauncher extends AbstractLauncher {
 
   private static byte[] gameDataToBytes(final GameData data) throws IOException {
     final ByteArrayOutputStream sink = new ByteArrayOutputStream(25000);
-    new GameDataManager().saveGame(sink, data);
+    GameDataManager.saveGame(sink, data);
     sink.flush();
     sink.close();
     return sink.toByteArray();

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -303,7 +303,7 @@ public class ClientModel implements IMessengerErrorListener {
     try {
       // this normally takes a couple seconds, but can take
       // up to 60 seconds for a freaking huge game
-      data = new GameDataManager().loadGame(new ByteArrayInputStream(gameData), null);
+      data = GameDataManager.loadGame(new ByteArrayInputStream(gameData), null);
     } catch (final IOException ex) {
       ClientLogger.logQuietly(ex);
       return;

--- a/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -103,7 +103,6 @@ public class GameSelectorModel extends Observable {
       }
       return;
     }
-    final GameDataManager manager = new GameDataManager();
     GameData newData;
     final AtomicReference<String> gameName = new AtomicReference<>();
     try {
@@ -114,7 +113,7 @@ public class GameSelectorModel extends Observable {
         }
       } else {
         // try to load it as a saved game whatever the extension
-        newData = manager.loadGame(file);
+        newData = GameDataManager.loadGame(file);
       }
       if (newData != null) {
         m_fileName = file.getName();
@@ -137,10 +136,9 @@ public class GameSelectorModel extends Observable {
   }
 
   public GameData getGameData(final InputStream input) {
-    final GameDataManager manager = new GameDataManager();
     GameData newData;
     try {
-      newData = manager.loadGame(input, null);
+      newData = GameDataManager.loadGame(input, null);
       if (newData != null) {
         return newData;
       }

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -337,7 +337,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
 
       byte[] bytes = null;
       try (final ByteArrayOutputStream sink = new ByteArrayOutputStream(5000)) {
-        new GameDataManager().saveGame(sink, data);
+        GameDataManager.saveGame(sink, data);
         bytes = sink.toByteArray();
       } catch (final IOException e) {
         ClientLogger.logQuietly(e);

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1763,7 +1763,7 @@ public class TripleAFrame extends MainGameFrame {
                 }
               }
               datacopy.getSequence().setRoundAndStep(round, stepDisplayName, currentPlayer);
-              new GameDataManager().saveGame(fout, datacopy);
+              GameDataManager.saveGame(fout, datacopy);
               JOptionPane.showMessageDialog(TripleAFrame.this, "Game Saved", "Game Saved",
                   JOptionPane.INFORMATION_MESSAGE);
             } catch (final IOException e) {

--- a/src/test/java/games/strategy/engine/config/client/GameEnginePropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/client/GameEnginePropertyReaderTest.java
@@ -93,6 +93,30 @@ public class GameEnginePropertyReaderTest {
         .thenReturn(TestData.fakeProps);
   }
 
+  @Test
+  public void useNewSaveGameFormat_ShouldReturnTrueWhenPropertyValueIsCaseSensitiveTrue() {
+    when(mockPropertyFileReader.readProperty(GameEnginePropertyReader.PropertyKeys.NEW_SAVE_GAME_FORMAT))
+        .thenReturn("true");
+
+    assertThat(testObj.useNewSaveGameFormat(), is(true));
+  }
+
+  @Test
+  public void useNewSaveGameFormat_ShouldReturnTrueWhenPropertyValueIsCaseInsensitiveTrue() {
+    when(mockPropertyFileReader.readProperty(GameEnginePropertyReader.PropertyKeys.NEW_SAVE_GAME_FORMAT))
+        .thenReturn("True");
+
+    assertThat(testObj.useNewSaveGameFormat(), is(true));
+  }
+
+  @Test
+  public void useNewSaveGameFormat_ShouldReturnFalseWhenPropertyValueIsAbsent() {
+    when(mockPropertyFileReader.readProperty(GameEnginePropertyReader.PropertyKeys.NEW_SAVE_GAME_FORMAT))
+        .thenReturn("");
+
+    assertThat(testObj.useNewSaveGameFormat(), is(false));
+  }
+
   private interface TestData {
     String fakeVersionString = "12.12.12.12";
     Version fakeVersion = new Version(fakeVersionString);

--- a/src/test/java/games/strategy/engine/framework/GameDataFileUtilsTests.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataFileUtilsTests.java
@@ -8,150 +8,267 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
+import games.strategy.engine.framework.GameDataFileUtils.SaveGameFormat;
+
 @RunWith(Enclosed.class)
 public final class GameDataFileUtilsTests {
-  public static final class AddExtensionTest {
-    private static String addExtension(final String fileName) {
-      return GameDataFileUtils.addExtension(fileName);
+  @RunWith(Enclosed.class)
+  public static final class AddExtensionTests {
+    public static final class WhenSaveGameFormatIsCurrentTest {
+      private static String addExtension(final String fileName) {
+        return GameDataFileUtils.addExtension(fileName, SaveGameFormat.CURRENT);
+      }
+
+      @Test
+      public void shouldAddExtensionWhenExtensionAbsent() {
+        assertThat(addExtension("file"), is("file.tsvg"));
+      }
+
+      @Test
+      public void shouldAddExtensionWhenExtensionPresent() {
+        assertThat(addExtension("file.tsvg"), is("file.tsvg.tsvg"));
+      }
     }
 
-    @Test
-    public void shouldAddExtensionWhenExtensionAbsent() {
-      assertThat(addExtension("file"), is("file.tsvg"));
-    }
+    public static final class WhenSaveGameFormatIsNewTest {
+      private static String addExtension(final String fileName) {
+        return GameDataFileUtils.addExtension(fileName, SaveGameFormat.NEW);
+      }
 
-    @Test
-    public void shouldAddExtensionWhenExtensionPresent() {
-      assertThat(addExtension("file.tsvg"), is("file.tsvg.tsvg"));
+      @Test
+      public void shouldAddExtensionWhenExtensionAbsent() {
+        assertThat(addExtension("file"), is("file.tsvgx"));
+      }
+
+      @Test
+      public void shouldAddExtensionWhenExtensionPresent() {
+        assertThat(addExtension("file.tsvgx"), is("file.tsvgx.tsvgx"));
+      }
     }
   }
 
   @RunWith(Enclosed.class)
   public static final class AddExtensionIfAbsentTests {
-    public static final class WhenFileSystemIsCaseSensitiveTest {
-      private static String addExtensionIfAbsent(final String fileName) {
-        return GameDataFileUtils.addExtensionIfAbsent(fileName, IOCase.SENSITIVE);
+    @RunWith(Enclosed.class)
+    public static final class WhenSaveGameFormatIsCurrentTests {
+      public static final class WhenFileSystemIsCaseSensitiveTest {
+        private static String addExtensionIfAbsent(final String fileName) {
+          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.CURRENT, IOCase.SENSITIVE);
+        }
+
+        @Test
+        public void shouldAddExtensionWhenExtensionAbsent() {
+          assertThat(addExtensionIfAbsent("file"), is("file.tsvg"));
+        }
+
+        @Test
+        public void shouldNotAddExtensionWhenSameCasedExtensionPresent() {
+          assertThat(addExtensionIfAbsent("file.tsvg"), is("file.tsvg"));
+        }
+
+        @Test
+        public void shouldAddExtensionWhenDifferentCasedExtensionPresent() {
+          assertThat(addExtensionIfAbsent("file.TSVG"), is("file.TSVG.tsvg"));
+        }
       }
 
-      @Test
-      public void shouldAddExtensionWhenExtensionAbsent() {
-        assertThat(addExtensionIfAbsent("file"), is("file.tsvg"));
-      }
+      public static final class WhenFileSystemIsCaseInsensitiveTest {
+        private static String addExtensionIfAbsent(final String fileName) {
+          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.CURRENT, IOCase.INSENSITIVE);
+        }
 
-      @Test
-      public void shouldNotAddExtensionWhenSameCasedExtensionPresent() {
-        assertThat(addExtensionIfAbsent("file.tsvg"), is("file.tsvg"));
-      }
+        @Test
+        public void shouldAddExtensionWhenExtensionAbsent() {
+          assertThat(addExtensionIfAbsent("file"), is("file.tsvg"));
+        }
 
-      @Test
-      public void shouldAddExtensionWhenDifferentCasedExtensionPresent() {
-        assertThat(addExtensionIfAbsent("file.TSVG"), is("file.TSVG.tsvg"));
+        @Test
+        public void shouldNotAddExtensionWhenSameCasedExtensionPresent() {
+          assertThat(addExtensionIfAbsent("file.tsvg"), is("file.tsvg"));
+        }
+
+        @Test
+        public void shouldNotAddExtensionWhenDifferentCasedExtensionPresent() {
+          assertThat(addExtensionIfAbsent("file.TSVG"), is("file.TSVG"));
+        }
       }
     }
 
-    public static final class WhenFileSystemIsCaseInsensitiveTest {
-      private static String addExtensionIfAbsent(final String fileName) {
-        return GameDataFileUtils.addExtensionIfAbsent(fileName, IOCase.INSENSITIVE);
+    @RunWith(Enclosed.class)
+    public static final class WhenSaveGameFormatIsNewTests {
+      public static final class WhenFileSystemIsCaseSensitiveTest {
+        private static String addExtensionIfAbsent(final String fileName) {
+          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.NEW, IOCase.SENSITIVE);
+        }
+
+        @Test
+        public void shouldAddExtensionWhenExtensionAbsent() {
+          assertThat(addExtensionIfAbsent("file"), is("file.tsvgx"));
+        }
+
+        @Test
+        public void shouldNotAddExtensionWhenSameCasedExtensionPresent() {
+          assertThat(addExtensionIfAbsent("file.tsvgx"), is("file.tsvgx"));
+        }
+
+        @Test
+        public void shouldAddExtensionWhenDifferentCasedExtensionPresent() {
+          assertThat(addExtensionIfAbsent("file.TSVGX"), is("file.TSVGX.tsvgx"));
+        }
       }
 
-      @Test
-      public void shouldAddExtensionWhenExtensionAbsent() {
-        assertThat(addExtensionIfAbsent("file"), is("file.tsvg"));
-      }
+      public static final class WhenFileSystemIsCaseInsensitiveTest {
+        private static String addExtensionIfAbsent(final String fileName) {
+          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.NEW, IOCase.INSENSITIVE);
+        }
 
-      @Test
-      public void shouldNotAddExtensionWhenSameCasedExtensionPresent() {
-        assertThat(addExtensionIfAbsent("file.tsvg"), is("file.tsvg"));
-      }
+        @Test
+        public void shouldAddExtensionWhenExtensionAbsent() {
+          assertThat(addExtensionIfAbsent("file"), is("file.tsvgx"));
+        }
 
-      @Test
-      public void shouldNotAddExtensionWhenDifferentCasedExtensionPresent() {
-        assertThat(addExtensionIfAbsent("file.TSVG"), is("file.TSVG"));
+        @Test
+        public void shouldNotAddExtensionWhenSameCasedExtensionPresent() {
+          assertThat(addExtensionIfAbsent("file.tsvgx"), is("file.tsvgx"));
+        }
+
+        @Test
+        public void shouldNotAddExtensionWhenDifferentCasedExtensionPresent() {
+          assertThat(addExtensionIfAbsent("file.TSVGX"), is("file.TSVGX"));
+        }
       }
     }
   }
 
   @RunWith(Enclosed.class)
   public static final class IsCandidateFileNameTests {
-    public static final class WhenFileSystemIsCaseSensitiveTest {
-      private static boolean isCandidateFileName(final String fileName) {
-        return GameDataFileUtils.isCandidateFileName(fileName, IOCase.SENSITIVE);
+    @RunWith(Enclosed.class)
+    public static final class WhenSaveGameFormatIsCurrentTests {
+      public static final class WhenFileSystemIsCaseSensitiveTest {
+        private static boolean isCandidateFileName(final String fileName) {
+          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.CURRENT, IOCase.SENSITIVE);
+        }
+
+        @Test
+        public void shouldReturnFalseWhenExtensionAbsent() {
+          assertThat(isCandidateFileName("file"), is(false));
+        }
+
+        @Test
+        public void shouldReturnTrueWhenSameCasedPrimaryExtensionPresent() {
+          assertThat(isCandidateFileName("file.tsvg"), is(true));
+        }
+
+        @Test
+        public void shouldReturnFalseWhenDifferentCasedPrimaryExtensionPresent() {
+          assertThat(isCandidateFileName("file.TSVG"), is(false));
+        }
+
+        @Test
+        public void shouldReturnTrueWhenSameCasedLegacyExtensionPresent() {
+          assertThat(isCandidateFileName("file.svg"), is(true));
+        }
+
+        @Test
+        public void shouldReturnFalseWhenDifferentCasedLegacyExtensionPresent() {
+          assertThat(isCandidateFileName("file.SVG"), is(false));
+        }
+
+        @Test
+        public void shouldReturnTrueWhenSameCasedMacOsAlternativeExtensionPresent() {
+          assertThat(isCandidateFileName("filetsvg.gz"), is(true));
+        }
+
+        @Test
+        public void shouldReturnFalseWhenDifferentCasedMacOsAlternativeExtensionPresent() {
+          assertThat(isCandidateFileName("fileTSVG.GZ"), is(false));
+        }
       }
 
-      @Test
-      public void shouldReturnFalseWhenExtensionAbsent() {
-        assertThat(isCandidateFileName("file"), is(false));
-      }
+      public static final class WhenFileSystemIsCaseInsensitiveTest {
+        private static boolean isCandidateFileName(final String fileName) {
+          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.CURRENT, IOCase.INSENSITIVE);
+        }
 
-      @Test
-      public void shouldReturnTrueWhenSameCasedPrimaryExtensionPresent() {
-        assertThat(isCandidateFileName("file.tsvg"), is(true));
-      }
+        @Test
+        public void shouldReturnFalseWhenExtensionAbsent() {
+          assertThat(isCandidateFileName("file"), is(false));
+        }
 
-      @Test
-      public void shouldReturnFalseWhenDifferentCasedPrimaryExtensionPresent() {
-        assertThat(isCandidateFileName("file.TSVG"), is(false));
-      }
+        @Test
+        public void shouldReturnTrueWhenSameCasedPrimaryExtensionPresent() {
+          assertThat(isCandidateFileName("file.tsvg"), is(true));
+        }
 
-      @Test
-      public void shouldReturnTrueWhenSameCasedLegacyExtensionPresent() {
-        assertThat(isCandidateFileName("file.svg"), is(true));
-      }
+        @Test
+        public void shouldReturnTrueWhenDifferentCasedPrimaryExtensionPresent() {
+          assertThat(isCandidateFileName("file.TSVG"), is(true));
+        }
 
-      @Test
-      public void shouldReturnFalseWhenDifferentCasedLegacyExtensionPresent() {
-        assertThat(isCandidateFileName("file.SVG"), is(false));
-      }
+        @Test
+        public void shouldReturnTrueWhenSameCasedLegacyExtensionPresent() {
+          assertThat(isCandidateFileName("file.svg"), is(true));
+        }
 
-      @Test
-      public void shouldReturnTrueWhenSameCasedMacOsAlternativeExtensionPresent() {
-        assertThat(isCandidateFileName("filetsvg.gz"), is(true));
-      }
+        @Test
+        public void shouldReturnTrueWhenDifferentCasedLegacyExtensionPresent() {
+          assertThat(isCandidateFileName("file.SVG"), is(true));
+        }
 
-      @Test
-      public void shouldReturnFalseWhenDifferentCasedMacOsAlternativeExtensionPresent() {
-        assertThat(isCandidateFileName("fileTSVG.GZ"), is(false));
+        @Test
+        public void shouldReturnTrueWhenSameCasedMacOsAlternativeExtensionPresent() {
+          assertThat(isCandidateFileName("filetsvg.gz"), is(true));
+        }
+
+        @Test
+        public void shouldReturnTrueWhenDifferentCasedMacOsAlternativeExtensionPresent() {
+          assertThat(isCandidateFileName("fileTSVG.GZ"), is(true));
+        }
       }
     }
 
-    public static final class WhenFileSystemIsCaseInsensitiveTest {
-      private static boolean isCandidateFileName(final String fileName) {
-        return GameDataFileUtils.isCandidateFileName(fileName, IOCase.INSENSITIVE);
+    @RunWith(Enclosed.class)
+    public static final class WhenSaveGameFormatIsNewTests {
+      public static final class WhenFileSystemIsCaseSensitiveTest {
+        private static boolean isCandidateFileName(final String fileName) {
+          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.NEW, IOCase.SENSITIVE);
+        }
+
+        @Test
+        public void shouldReturnFalseWhenExtensionAbsent() {
+          assertThat(isCandidateFileName("file"), is(false));
+        }
+
+        @Test
+        public void shouldReturnTrueWhenSameCasedExtensionPresent() {
+          assertThat(isCandidateFileName("file.tsvgx"), is(true));
+        }
+
+        @Test
+        public void shouldReturnFalseWhenDifferentCasedExtensionPresent() {
+          assertThat(isCandidateFileName("file.TSVGX"), is(false));
+        }
       }
 
-      @Test
-      public void shouldReturnFalseWhenExtensionAbsent() {
-        assertThat(isCandidateFileName("file"), is(false));
-      }
+      public static final class WhenFileSystemIsCaseInsensitiveTest {
+        private static boolean isCandidateFileName(final String fileName) {
+          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.NEW, IOCase.INSENSITIVE);
+        }
 
-      @Test
-      public void shouldReturnTrueWhenSameCasedPrimaryExtensionPresent() {
-        assertThat(isCandidateFileName("file.tsvg"), is(true));
-      }
+        @Test
+        public void shouldReturnFalseWhenExtensionAbsent() {
+          assertThat(isCandidateFileName("file"), is(false));
+        }
 
-      @Test
-      public void shouldReturnTrueWhenDifferentCasedPrimaryExtensionPresent() {
-        assertThat(isCandidateFileName("file.TSVG"), is(true));
-      }
+        @Test
+        public void shouldReturnTrueWhenSameCasedExtensionPresent() {
+          assertThat(isCandidateFileName("file.tsvgx"), is(true));
+        }
 
-      @Test
-      public void shouldReturnTrueWhenSameCasedLegacyExtensionPresent() {
-        assertThat(isCandidateFileName("file.svg"), is(true));
-      }
-
-      @Test
-      public void shouldReturnTrueWhenDifferentCasedLegacyExtensionPresent() {
-        assertThat(isCandidateFileName("file.SVG"), is(true));
-      }
-
-      @Test
-      public void shouldReturnTrueWhenSameCasedMacOsAlternativeExtensionPresent() {
-        assertThat(isCandidateFileName("filetsvg.gz"), is(true));
-      }
-
-      @Test
-      public void shouldReturnTrueWhenDifferentCasedMacOsAlternativeExtensionPresent() {
-        assertThat(isCandidateFileName("fileTSVG.GZ"), is(true));
+        @Test
+        public void shouldReturnTrueWhenDifferentCasedExtensionPresent() {
+          assertThat(isCandidateFileName("file.TSVGX"), is(true));
+        }
       }
     }
   }

--- a/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -24,10 +24,9 @@ public class GameDataManagerTest {
   @Test
   public void testLoadStoreKeepsGameUuid() throws IOException {
     final GameData data = new GameData();
-    final GameDataManager m = new GameDataManager();
     final ByteArrayOutputStream sink = new ByteArrayOutputStream();
-    m.saveGame(sink, data);
-    final GameData loaded = m.loadGame(new ByteArrayInputStream(sink.toByteArray()), null);
+    GameDataManager.saveGame(sink, data);
+    final GameData loaded = GameDataManager.loadGame(new ByteArrayInputStream(sink.toByteArray()), null);
     assertEquals(loaded.getProperties().get(GameData.GAME_UUID), data.getProperties().get(GameData.GAME_UUID));
   }
 

--- a/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -14,6 +14,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Collections;
 
 import org.junit.Test;
 
@@ -31,49 +32,49 @@ public class GameDataManagerTest {
   }
 
   @Test
-  public void shouldBeAbleToRoundTripSerializableGameData() throws Exception {
+  public void shouldBeAbleToRoundTripGameDataInNewFormat() throws Exception {
     final GameData expected = TestGameDataFactory.newValidGameData();
 
-    final byte[] bytes = saveSerializableGame(expected);
-    final GameData actual = loadSerializableGame(bytes);
+    final byte[] bytes = saveGameInNewFormat(expected);
+    final GameData actual = loadGameInNewFormat(bytes);
 
     assertThat(actual, is(equalToGameData(expected)));
   }
 
-  private static byte[] saveSerializableGame(final GameData gameData) throws Exception {
+  private static byte[] saveGameInNewFormat(final GameData gameData) throws Exception {
     try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-      GameDataManager.saveSerializableGame(baos, gameData);
+      GameDataManager.saveGameInNewFormat(baos, gameData, Collections.emptyMap());
       return baos.toByteArray();
     }
   }
 
-  private static GameData loadSerializableGame(final byte[] bytes) throws Exception {
+  private static GameData loadGameInNewFormat(final byte[] bytes) throws Exception {
     try (final ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
-      return GameDataManager.loadSerializableGame(bais);
+      return GameDataManager.loadGameInNewFormat(bais);
     }
   }
 
   @Test
-  public void loadSerializableGame_ShouldNotCloseInputStream() throws Exception {
-    try (final InputStream is = spy(newSerializableGameInputStream())) {
-      GameDataManager.loadSerializableGame(is);
+  public void loadGameInNewFormat_ShouldNotCloseInputStream() throws Exception {
+    try (final InputStream is = spy(newInputStreamWithGameInNewFormat())) {
+      GameDataManager.loadGameInNewFormat(is);
 
       verify(is, never()).close();
     }
   }
 
-  private static InputStream newSerializableGameInputStream() throws Exception {
+  private static InputStream newInputStreamWithGameInNewFormat() throws Exception {
     final GameData gameData = TestGameDataFactory.newValidGameData();
-    final byte[] bytes = saveSerializableGame(gameData);
+    final byte[] bytes = saveGameInNewFormat(gameData);
     return new ByteArrayInputStream(bytes);
   }
 
   @Test
-  public void saveSerializableGame_ShouldNotCloseOutputStream() throws Exception {
+  public void saveGameInNewFormat_ShouldNotCloseOutputStream() throws Exception {
     final OutputStream os = mock(OutputStream.class);
     final GameData gameData = TestGameDataFactory.newValidGameData();
 
-    GameDataManager.saveSerializableGame(os, gameData);
+    GameDataManager.saveGameInNewFormat(os, gameData, Collections.emptyMap());
 
     verify(os, never()).close();
   }


### PR DESCRIPTION
This PR adds a feature toggle for the new save game format using serialization proxies.  The feature toggle is intended to be used to beta test the new save game format.  The feature toggle, and all supporting code, will be removed when the serialization proxy feature is complete and ready to be deployed in an incompatible release.

#### Functional changes
* The game engine property `new_save_game_format` was defined.  If the value of this property is `true` (case insensitive), the new save game format using serialization proxies will be used.  Otherwise, the current save game format will be used.
* The existing `loadGame()` and `saveGame()` methods in `GameDataManager` were modified to branch based on the feature toggle.  Most (if not all) `GameData` persistence code passes through these methods.  If I encounter others as I work this feature, I will add support for the feature toggle there, as well.
* The `GameDataFileUtils` class was updated to use a different extension (`.tsvgx`) for game data files using the new format.  The purpose of a new extension is to ensure current- and new-format save game files are kept separate while beta testing this feature to avoid confusion.

#### Functional issues for review
* Reviewers should look for cases where the current save game code may not run the same with the addition of the feature toggle (it's not as important for the case when the feature toggle is enabled because this code is effectively broken until all serialization proxies are added).
* I was pretty pedantic about splitting the current- and new-format code into separate methods with clear names (e.g. `XxxInNewFormat`, `XxxInCurrentFormat`) to make code reading easier.  This makes for more verbose code than necessary, but again, all this current/new code split will disappear once the feature is complete and code size should shrink significantly.

#### Refactoring changes
* All `GameDataManager` methods were made static because none of them used any instance state.  This made it cleaner to introduce the feature toggle.
* Some methods were moved around to make code reading easier.  These moves have contributed to the relatively large size of this PR.
* Some whitespace changes were made when updating the tests.  This PR can be more easily reviewed by ignoring whitespace changes (`?w=1`).

#### Testing
I just ran some simple save/load game smoke tests with the feature toggle disabled to ensure there are no regressions when working with the current format.