### PR TITLE
Extract method GameDataTestUtil#getUnits()

### DIFF
--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -1,9 +1,11 @@
 package games.strategy.triplea.delegate;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.mockito.Mockito.mock;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 
@@ -14,6 +16,7 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TestDelegateBridge;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitHolder;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.data.properties.BooleanProperty;
@@ -21,6 +24,7 @@ import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.ui.display.ITripleADisplay;
+import games.strategy.util.IntegerMap;
 import junit.framework.AssertionFailedError;
 
 /**
@@ -29,6 +33,7 @@ import junit.framework.AssertionFailedError;
 public class GameDataTestUtil {
   /**
    * Get the german PlayerID for the given GameData object.
+   *
    * @return A german PlayerID.
    */
   public static PlayerID germans(final GameData data) {
@@ -37,6 +42,7 @@ public class GameDataTestUtil {
 
   /**
    * Get the italian PlayerID for the given GameData object.
+   *
    * @return A italian PlayerID.
    */
   public static PlayerID italians(final GameData data) {
@@ -45,6 +51,7 @@ public class GameDataTestUtil {
 
   /**
    * Get the russian PlayerID for the given GameData object.
+   *
    * @return A russian PlayerID.
    */
   public static PlayerID russians(final GameData data) {
@@ -53,6 +60,7 @@ public class GameDataTestUtil {
 
   /**
    * Get the american PlayerID for the given GameData object.
+   *
    * @return A american PlayerID.
    */
   public static PlayerID americans(final GameData data) {
@@ -61,6 +69,7 @@ public class GameDataTestUtil {
 
   /**
    * Get the british PlayerID for the given GameData object.
+   *
    * @return A british PlayerID.
    */
   public static PlayerID british(final GameData data) {
@@ -69,6 +78,7 @@ public class GameDataTestUtil {
 
   /**
    * Get the japanese PlayerID for the given GameData object.
+   *
    * @return A japanese PlayerID.
    */
   public static PlayerID japanese(final GameData data) {
@@ -77,6 +87,7 @@ public class GameDataTestUtil {
 
   /**
    * Get the chinese PlayerID for the given GameData object.
+   *
    * @return A chinese PlayerID.
    */
   public static PlayerID chinese(final GameData data) {
@@ -85,6 +96,7 @@ public class GameDataTestUtil {
 
   /**
    * Returns a territory object for the given name in the specified GameData object.
+   *
    * @return A Territory matching the given name if present, otherwise throwing an Exception.
    */
   public static Territory territory(final String name, final GameData data) {
@@ -278,7 +290,7 @@ public class GameDataTestUtil {
   public static BidPlaceDelegate bidPlaceDelegate(final GameData data) {
     return (BidPlaceDelegate) data.getDelegateList().getDelegate("placeBid");
   }
-  
+
   /**
    * Returns a TestDelegateBridge for the given GameData + PlayerID objects.
    */
@@ -367,12 +379,31 @@ public class GameDataTestUtil {
   public static void assertValid(final String string) {
     Assert.assertNull(string, string);
   }
-  
+
   /**
    * Helper method to check if a String is not null.
    * In this scenario used to verify an error message exists.
    */
   public static void assertError(final String string) {
     Assert.assertNotNull(string);
+  }
+
+  /**
+   * Gets a collection of units from the specified unit holder (e.g. territory, player, etc.) consisting of up to the
+   * specified maximum count of each specified unit type.
+   *
+   * @param maxUnitCountsByType The maximum count of each type of unit to include in the returned collection. The key is
+   *        the unit type. The value is the maximum unit count.
+   * @param from The territory from which the units are to be collected.
+   *
+   * @return A collection of units from the specified unit holder.
+   */
+  public static Collection<Unit> getUnits(final IntegerMap<UnitType> maxUnitCountsByType, final UnitHolder from) {
+    checkNotNull(maxUnitCountsByType);
+    checkNotNull(from);
+
+    return maxUnitCountsByType.entrySet().stream()
+        .flatMap(entry -> from.getUnits().getUnits(entry.getKey(), entry.getValue()).stream())
+        .collect(Collectors.toList());
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import org.junit.Before;
@@ -18,7 +17,6 @@ import games.strategy.engine.data.Change;
 import games.strategy.engine.data.ITestDelegateBridge;
 import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.data.Route;
-import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
@@ -46,16 +44,6 @@ public class MoveDelegateTest extends DelegateTest {
     delegate.initialize("MoveDelegate", "MoveDelegate");
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
-  }
-
-  private static Collection<Unit> getUnits(final IntegerMap<UnitType> unitCountsByType, final Territory from) {
-    final Iterator<UnitType> iter = unitCountsByType.keySet().iterator();
-    final Collection<Unit> units = new ArrayList<>(unitCountsByType.totalValues());
-    while (iter.hasNext()) {
-      final UnitType type = iter.next();
-      units.addAll(from.getUnits().getUnits(type, unitCountsByType.getInt(type)));
-    }
-    return units;
   }
 
   @Test
@@ -91,7 +79,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     assertEquals(1, algeria.getUnits().size());
     assertEquals(0, libya.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(1, algeria.getUnits().size());
     assertEquals(0, libya.getUnits().size());
@@ -106,7 +94,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(eastAfrica);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(2, eastAfrica.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(4, eastAfrica.getUnits().size());
@@ -122,7 +110,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(kenya);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(0, kenya.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(2, kenya.getUnits().size());
@@ -136,7 +124,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.setStart(congoSeaZone);
     route.add(southAtlantic);
     route.add(antarticSea);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -153,7 +141,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(redSea);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(6, redSea.getUnits().size());
@@ -173,7 +161,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(mozambiqueSeaZone);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
@@ -192,7 +180,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(redSea);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
@@ -208,7 +196,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(eastMediteranean);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(0, eastMediteranean.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(0, eastMediteranean.getUnits().size());
@@ -224,7 +212,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(mozambiqueSeaZone);
     assertEquals(4, redSea.getUnits().size());
     assertEquals(0, mozambiqueSeaZone.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(2, redSea.getUnits().size());
     assertEquals(2, mozambiqueSeaZone.getUnits().size());
@@ -240,7 +228,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(egypt);
     assertEquals(4, redSea.getUnits().size());
     assertEquals(18, egypt.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(4, redSea.getUnits().size());
     assertEquals(18, egypt.getUnits().size());
@@ -257,7 +245,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(congoSeaZone);
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(11, congoSeaZone.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(11, congoSeaZone.getUnits().size());
@@ -272,7 +260,7 @@ public class MoveDelegateTest extends DelegateTest {
     // exast movement to force landing
     route.add(redSea);
     route.add(syria);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -287,7 +275,7 @@ public class MoveDelegateTest extends DelegateTest {
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, redSea.getUnits().size());
     final String results =
-        delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(6, redSea.getUnits().size());
@@ -304,7 +292,7 @@ public class MoveDelegateTest extends DelegateTest {
     assertEquals(18, egypt.getUnits().size());
     assertEquals(1, algeria.getUnits().size());
     assertEquals(libya.getOwner(), japanese);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(3, algeria.getUnits().size());
@@ -320,7 +308,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     // Disable canBlitz attachment
     gameData.performChange(ChangeFactory.attachmentPropertyChange(UnitAttachment.get(armour), "false", "canBlitz"));
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Validate move happened
     assertEquals(1, libya.getUnits().size());
@@ -330,7 +318,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.setStart(libya);
     route.add(algeria);
     // Fail because not 'canBlitz'
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -344,7 +332,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(algeria);
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(1, algeria.getUnits().size());
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(1, algeria.getUnits().size());
@@ -361,7 +349,7 @@ public class MoveDelegateTest extends DelegateTest {
     assertEquals(0, westAfrica.getUnits().size());
     assertEquals(westAfrica.getOwner(), PlayerID.NULL_PLAYERID);
     assertEquals(35, british.getResources().getQuantity(pus));
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(2, equatorialAfrica.getUnits().size());
     assertEquals(2, westAfrica.getUnits().size());
@@ -378,7 +366,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     route.add(algeria);
     route.add(equatorialAfrica);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -389,14 +377,14 @@ public class MoveDelegateTest extends DelegateTest {
     Route route = new Route();
     route.setStart(equatorialAfrica);
     route.add(westAfrica);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     map = new IntegerMap<>();
     map.put(armour, 2);
     route = new Route();
     route.setStart(westAfrica);
     route.add(equatorialAfrica);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -409,7 +397,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(kenya);
     assertEquals(2, eastAfrica.getUnits().size());
     assertEquals(0, kenya.getUnits().size());
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(0, eastAfrica.getUnits().size());
     assertEquals(2, kenya.getUnits().size());
@@ -418,7 +406,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(egypt);
     assertEquals(2, kenya.getUnits().size());
     assertEquals(18, egypt.getUnits().size());
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
     assertEquals(2, kenya.getUnits().size());
     assertEquals(18, egypt.getUnits().size());
@@ -434,7 +422,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(equatorialAfrica);
     assertEquals(18, egypt.getUnits().size());
     assertEquals(4, equatorialAfrica.getUnits().size());
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(16, egypt.getUnits().size());
     assertEquals(6, equatorialAfrica.getUnits().size());
@@ -447,7 +435,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(eastAfrica);
     assertEquals(6, equatorialAfrica.getUnits().size());
     assertEquals(2, eastAfrica.getUnits().size());
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     assertEquals(4, equatorialAfrica.getUnits().size());
     assertEquals(4, eastAfrica.getUnits().size());
@@ -460,14 +448,15 @@ public class MoveDelegateTest extends DelegateTest {
     Route route = new Route();
     route.setStart(egypt);
     route.add(redSea);
-    String results = delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+    String results =
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     map = new IntegerMap<>();
     map.put(transport, 2);
     route = new Route();
     route.setStart(redSea);
     route.add(indianOcean);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -478,14 +467,15 @@ public class MoveDelegateTest extends DelegateTest {
     Route route = new Route();
     route.setStart(egypt);
     route.add(redSea);
-    String results = delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+    String results =
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     map = new IntegerMap<>();
     map.put(armour, 2);
     route = new Route();
     route.setStart(redSea);
     route.add(indianOcean);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -496,7 +486,7 @@ public class MoveDelegateTest extends DelegateTest {
     final Route route = new Route();
     route.setStart(congoSeaZone);
     route.add(equatorialAfrica);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -576,7 +566,7 @@ public class MoveDelegateTest extends DelegateTest {
     Route route = new Route();
     route.setStart(congoSeaZone);
     route.add(equatorialAfrica);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     map = new IntegerMap<>();
     // only 2 originially, would have to move the 2 we just unloaded
@@ -586,7 +576,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.setStart(equatorialAfrica);
     route.add(egypt);
     // units were unloaded, shouldnt be able to move any more
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -597,7 +587,7 @@ public class MoveDelegateTest extends DelegateTest {
     Route route = new Route();
     route.setStart(congoSeaZone);
     route.add(equatorialAfrica);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     map = new IntegerMap<>();
     map.put(transport, 2);
@@ -605,7 +595,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.setStart(congoSeaZone);
     route.add(westAfricaSeaZone);
     // the transports unloaded so they cant move
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -617,7 +607,8 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(redSea);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
-    String results = delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+    String results =
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     // move two infantry to red sea
     route = new Route();
@@ -625,7 +616,8 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(redSea);
     map = new IntegerMap<>();
     map.put(infantry, 2);
-    results = delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+    results =
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     // try to move 1 transport to indian ocean with 1 tank
     route = new Route();
@@ -634,7 +626,7 @@ public class MoveDelegateTest extends DelegateTest {
     map = new IntegerMap<>();
     map.put(armour, 1);
     map.put(transport, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // move the other transport to west compass
     route = new Route();
@@ -643,7 +635,7 @@ public class MoveDelegateTest extends DelegateTest {
     map = new IntegerMap<>();
     map.put(infantry, 2);
     map.put(transport, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -656,7 +648,7 @@ public class MoveDelegateTest extends DelegateTest {
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(transport, 1);
     map.put(infantry, 2);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // move transport back
     route = new Route();
@@ -665,7 +657,7 @@ public class MoveDelegateTest extends DelegateTest {
     map = new IntegerMap<>();
     map.put(transport, 1);
     map.put(infantry, 2);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // move the other transport south, should
     // figure out that only 1 can move
@@ -676,7 +668,7 @@ public class MoveDelegateTest extends DelegateTest {
     map = new IntegerMap<>();
     map.put(infantry, 2);
     map.put(transport, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -693,7 +685,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(southAfrica);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 2);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -705,7 +697,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(southAfrica);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 2);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -717,7 +709,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(westAfrica);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     assertTrue(DelegateFinder.battleDelegate(gameData).getBattleTracker().wasConquered(westAfrica));
     assertTrue(!DelegateFinder.battleDelegate(gameData).getBattleTracker().wasBlitzed(westAfrica));
@@ -732,13 +724,13 @@ public class MoveDelegateTest extends DelegateTest {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(infantry, 2);
     map.put(transport, 1);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // move again
     route = new Route();
     route.setStart(southAtlantic);
     route.add(angolaSeaZone);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -750,7 +742,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(westAfrica);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // make sure we cant move through it by land
     route = new Route();
@@ -759,7 +751,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(algeria);
     map = new IntegerMap<>();
     map.put(armour, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
     // make sure we can still move units to the territory
     route = new Route();
@@ -767,7 +759,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(westAfrica);
     map = new IntegerMap<>();
     map.put(armour, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // make sure air can though
     route = new Route();
@@ -777,7 +769,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(equatorialAfrica);
     map = new IntegerMap<>();
     map.put(fighter, 3);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -789,7 +781,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(infantry, 1);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // make sure we can still blitz through it
     route = new Route();
@@ -798,7 +790,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(algeria);
     map = new IntegerMap<>();
     map.put(armour, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -811,7 +803,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(southAfrica);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // move carriers to ensure they can't go anywhere
     route = new Route();
@@ -842,7 +834,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(southAfricaSeaZone);
     map = new IntegerMap<>();
     map.put(fighter, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -855,14 +847,14 @@ public class MoveDelegateTest extends DelegateTest {
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(transport, 1);
     map.put(infantry, 2);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     route = new Route();
     route.setStart(westAfricaSeaZone);
     route.add(westAfrica);
     map = new IntegerMap<>();
     map.put(infantry, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -874,7 +866,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(bomber, 1);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     route = new Route();
     route.setStart(libya);
@@ -882,7 +874,7 @@ public class MoveDelegateTest extends DelegateTest {
     // planes cannot leave a battle zone, but the territory was empty so no battle occurred
     map = new IntegerMap<>();
     map.put(bomber, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -895,7 +887,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(bomber, 1);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -910,7 +902,7 @@ public class MoveDelegateTest extends DelegateTest {
     map.put(bomber, 6);
     map.put(fighter, 6);
     map.put(armour, 6);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -923,7 +915,7 @@ public class MoveDelegateTest extends DelegateTest {
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(transport, 2);
     map.put(infantry, 4);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // try to unload transports
     route = new Route();
@@ -931,7 +923,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(brazil);
     map = new IntegerMap<>();
     map.put(infantry, 4);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     final IBattle inBrazil =
         DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(brazil, false, null);
@@ -954,7 +946,7 @@ public class MoveDelegateTest extends DelegateTest {
     map.put(transport, 1);
     map.put(infantry, 2);
     // Move from the NorthSea to the BalticSea and validate the move
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Unload transports into Finland and validate
     route = new Route();
@@ -962,7 +954,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(finlandNorway);
     map = new IntegerMap<>();
     map.put(infantry, 2);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits = new ArrayList<>();
@@ -1016,7 +1008,7 @@ public class MoveDelegateTest extends DelegateTest {
     map.put(transport, 1);
     map.put(infantry, 2);
     // Move from the NorthSea to the BalticSea and validate the move
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Unload transports into Finland and validate
     route = new Route();
@@ -1024,7 +1016,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(finlandNorway);
     map = new IntegerMap<>();
     map.put(infantry, 2);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits = new ArrayList<>();
@@ -1078,7 +1070,7 @@ public class MoveDelegateTest extends DelegateTest {
     map.put(transport, 1);
     map.put(infantry, 2);
     // Move from the NorthSea to the BalticSea and validate the move
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Unload transports into Finland and validate
     route = new Route();
@@ -1086,7 +1078,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(karelia);
     map = new IntegerMap<>();
     map.put(infantry, 2);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits = new ArrayList<>();
@@ -1134,7 +1126,7 @@ public class MoveDelegateTest extends DelegateTest {
     map.put(transport, 1);
     map.put(infantry, 2);
     // Move from the NorthSea to the BalticSea and validate the move
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Unload transports into Finland and validate
     route = new Route();
@@ -1142,7 +1134,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(karelia);
     map = new IntegerMap<>();
     map.put(infantry, 2);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits = new ArrayList<>();
@@ -1187,7 +1179,7 @@ public class MoveDelegateTest extends DelegateTest {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 3);
     map.put(bomber, 3);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -1201,7 +1193,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(algeria);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 2);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -1215,7 +1207,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(westAfrica);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 2);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -1227,7 +1219,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // go to non combat
     bridge.setStepName("britishNonCombatMove");
@@ -1239,7 +1231,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     map = new IntegerMap<>();
     map.put(armour, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -1254,14 +1246,14 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(kenya);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 2);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     final BattleTracker tracker = DelegateFinder.battleDelegate(gameData).getBattleTracker();
     assertTrue(tracker.wasBlitzed(kenya));
     assertTrue(tracker.wasConquered(kenya));
     map.clear();
     map.put(aaGun, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -1272,19 +1264,19 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(westAfrica);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(infantry, 1);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     final BattleTracker tracker = DelegateFinder.battleDelegate(gameData).getBattleTracker();
     assertTrue(!tracker.wasBlitzed(westAfrica));
     assertTrue(tracker.wasConquered(westAfrica));
     map.clear();
     map.put(armour, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     route = new Route();
     route.setStart(westAfrica);
     route.add(algeria);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
   }
 
@@ -1299,7 +1291,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(libya);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(infantry, 1);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     final BattleTracker tracker = DelegateFinder.battleDelegate(gameData).getBattleTracker();
     assertTrue(tracker.wasBlitzed(libya));
@@ -1316,7 +1308,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(blackSea);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -1333,7 +1325,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(angolaSeaZone);
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    String results = delegate.move(getUnits(map, route.getStart()), route);
+    String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     route = new Route();
     route.setStart(congoSeaZone);
@@ -1342,7 +1334,7 @@ public class MoveDelegateTest extends DelegateTest {
     route.add(angolaSeaZone);
     map = new IntegerMap<>();
     map.put(fighter, 1);
-    results = delegate.move(getUnits(map, route.getStart()), route);
+    results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 

--- a/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -2,9 +2,7 @@ package games.strategy.triplea.delegate;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import org.junit.Before;
@@ -103,16 +101,6 @@ public class PacificTest extends DelegateTest {
     delegate.start();
   }
 
-  private static Collection<Unit> getUnits(final IntegerMap<UnitType> unitCountsByType, final Territory from) {
-    final Iterator<UnitType> iter = unitCountsByType.keySet().iterator();
-    final Collection<Unit> units = new ArrayList<>(unitCountsByType.totalValues());
-    while (iter.hasNext()) {
-      final UnitType type = iter.next();
-      units.addAll(from.getUnits().getUnits(type, unitCountsByType.getInt(type)));
-    }
-    return units;
-  }
-
   @Override
   protected ITestDelegateBridge getDelegateBridge(final PlayerID player) {
     return GameDataTestUtil.getDelegateBridge(player, gameData);
@@ -200,7 +188,7 @@ public class PacificTest extends DelegateTest {
     route.add(newBritain);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -216,7 +204,7 @@ public class PacificTest extends DelegateTest {
     route.add(midway);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // assertError( results);
   }
@@ -233,7 +221,7 @@ public class PacificTest extends DelegateTest {
     route.add(midway);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -247,7 +235,7 @@ public class PacificTest extends DelegateTest {
     route.add(sz20);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(fighter, 1);
-    final String results = delegate.move(getUnits(map, route.getStart()), route);
+    final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
   }
 
@@ -270,7 +258,7 @@ public class PacificTest extends DelegateTest {
     assertEquals(1, sz24.getUnits().size());
     // validate movement
     final String results =
-        delegate.move(getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
     assertValid(results);
     // verify unit counts after move
     assertEquals(1, bonin.getUnits().size());

--- a/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -3,10 +3,8 @@ package games.strategy.triplea.delegate;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.junit.Before;
@@ -41,21 +39,12 @@ public class PlaceDelegateTest extends DelegateTest {
     delegate.start();
   }
 
-  private static Collection<Unit> getUnits(final IntegerMap<UnitType> unitCountsByType, final PlayerID from) {
-    final Iterator<UnitType> iter = unitCountsByType.keySet().iterator();
-    final Collection<Unit> units = new ArrayList<>(unitCountsByType.totalValues());
-    while (iter.hasNext()) {
-      final UnitType type = iter.next();
-      units.addAll(from.getUnits().getUnits(type, unitCountsByType.getInt(type)));
-    }
-    return units;
-  }
-
   @Test
   public void testValid() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = delegate.placeUnits(getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    final String response =
+        delegate.placeUnits(GameDataTestUtil.getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
   }
 
@@ -70,7 +59,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testOnlySeaInSeaZone() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = delegate.canUnitsBePlaced(northSea, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(northSea, GameDataTestUtil.getUnits(map, british), british);
     assertError(response);
   }
 
@@ -78,7 +67,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testSeaCanGoInSeaZone() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(transport, 2);
-    final String response = delegate.canUnitsBePlaced(northSea, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(northSea, GameDataTestUtil.getUnits(map, british), british);
     assertValid(response);
   }
 
@@ -86,7 +75,8 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testLandCanGoInLandZone() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = delegate.placeUnits(getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    final String response =
+        delegate.placeUnits(GameDataTestUtil.getUnits(map, british), uk, IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
   }
 
@@ -94,7 +84,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testSeaCantGoInSeaInLandZone() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(transport, 2);
-    final String response = delegate.canUnitsBePlaced(uk, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(uk, GameDataTestUtil.getUnits(map, british), british);
     assertError(response);
   }
 
@@ -102,7 +92,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testNoGoIfOpposingTroopsSea() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(transport, 2);
-    final String response = delegate.canUnitsBePlaced(northSea, getUnits(map, japanese), japanese);
+    final String response = delegate.canUnitsBePlaced(northSea, GameDataTestUtil.getUnits(map, japanese), japanese);
     assertError(response);
   }
 
@@ -110,7 +100,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testNoGoIfOpposingTroopsLand() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = delegate.canUnitsBePlaced(japan, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(japan, GameDataTestUtil.getUnits(map, british), british);
     assertError(response);
   }
 
@@ -118,7 +108,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testOnlyOneFactoryPlaced() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(factory, 1);
-    final String response = delegate.canUnitsBePlaced(uk, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(uk, GameDataTestUtil.getUnits(map, british), british);
     assertError(response);
   }
 
@@ -126,7 +116,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testCantPlaceAaWhenOneAlreadyThere() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(aaGun, 1);
-    final String response = delegate.canUnitsBePlaced(uk, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(uk, GameDataTestUtil.getUnits(map, british), british);
     assertError(response);
   }
 
@@ -134,7 +124,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testCantPlaceTwoAa() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(aaGun, 2);
-    final String response = delegate.canUnitsBePlaced(westCanada, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(westCanada, GameDataTestUtil.getUnits(map, british), british);
     assertError(response);
   }
 
@@ -142,7 +132,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testProduceFactory() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(factory, 1);
-    final String response = delegate.canUnitsBePlaced(egypt, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(egypt, GameDataTestUtil.getUnits(map, british), british);
     assertValid(response);
   }
 
@@ -150,7 +140,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testMustOwnToPlace() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final String response = delegate.canUnitsBePlaced(germany, getUnits(map, british), british);
+    final String response = delegate.canUnitsBePlaced(germany, GameDataTestUtil.getUnits(map, british), british);
     assertError(response);
   }
 
@@ -158,7 +148,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testCanProduce() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 2);
-    final PlaceableUnits response = delegate.getPlaceableUnits(getUnits(map, british), westCanada);
+    final PlaceableUnits response = delegate.getPlaceableUnits(GameDataTestUtil.getUnits(map, british), westCanada);
     assertFalse(response.isError());
   }
 
@@ -166,7 +156,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testCanProduceInSea() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(transport, 2);
-    final PlaceableUnits response = delegate.getPlaceableUnits(getUnits(map, british), northSea);
+    final PlaceableUnits response = delegate.getPlaceableUnits(GameDataTestUtil.getUnits(map, british), northSea);
     assertFalse(response.isError());
   }
 
@@ -174,7 +164,7 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testCanNotProduceThatManyUnits() {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(infantry, 3);
-    final PlaceableUnits response = delegate.getPlaceableUnits(getUnits(map, british), westCanada);
+    final PlaceableUnits response = delegate.getPlaceableUnits(GameDataTestUtil.getUnits(map, british), westCanada);
     assertTrue(response.getMaxUnits() == 2);
   }
 
@@ -185,7 +175,7 @@ public class PlaceDelegateTest extends DelegateTest {
     alreadyProduced.put(westCanada, getInfantry(2, british));
     delegate.setProduced(alreadyProduced);
     map.add(infantry, 1);
-    final PlaceableUnits response = delegate.getPlaceableUnits(getUnits(map, british), westCanada);
+    final PlaceableUnits response = delegate.getPlaceableUnits(GameDataTestUtil.getUnits(map, british), westCanada);
     assertTrue(response.getMaxUnits() == 0);
   }
 
@@ -193,13 +183,13 @@ public class PlaceDelegateTest extends DelegateTest {
   public void testMultipleFactories() {
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(factory, 1);
-    String response = delegate.canUnitsBePlaced(egypt, getUnits(map, british), british);
+    String response = delegate.canUnitsBePlaced(egypt, GameDataTestUtil.getUnits(map, british), british);
     // we can place 1 factory
     assertValid(response);
     // we cant place 2
     map = new IntegerMap<>();
     map.add(factory, 2);
-    response = delegate.canUnitsBePlaced(egypt, getUnits(map, british), british);
+    response = delegate.canUnitsBePlaced(egypt, GameDataTestUtil.getUnits(map, british), british);
     assertError(response);
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -501,7 +501,8 @@ public class WW2V3Year41Test {
     placeDelegate.setDelegateBridgeAndPlayer(getDelegateBridge(germans(gameData)));
     placeDelegate.start();
     addTo(germans(gameData), aaGun(gameData).create(1, germans(gameData)), gameData);
-    errorResults = placeDelegate.placeUnits(getUnits(map, germans), germany, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    errorResults = placeDelegate.placeUnits(GameDataTestUtil.getUnits(map, germans), germany,
+        IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(errorResults);
     assertEquals(germany.getUnits().getUnitCount(), preCount + 3);
   }
@@ -617,7 +618,7 @@ public class WW2V3Year41Test {
     map.add(factoryType, 1);
     addTo(british(gameData), factory(gameData).create(1, british(gameData)), gameData);
     // Place the factory
-    final String response = placeDelegate.placeUnits(getUnits(map, british), egypt);
+    final String response = placeDelegate.placeUnits(GameDataTestUtil.getUnits(map, british), egypt);
     assertValid(response);
     // placeUnits performPlace
     // get production and unit production values
@@ -666,7 +667,8 @@ public class WW2V3Year41Test {
     // Get the number of units before placing
     int preCount = kiangsu.getUnits().getUnitCount();
     // Place the infantry
-    String response = placeDelegate.placeUnits(getUnits(map, chinese), kiangsu, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    String response = placeDelegate.placeUnits(GameDataTestUtil.getUnits(map, chinese), kiangsu,
+        IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
     assertEquals(preCount + 1, kiangsu.getUnits().getUnitCount());
     /*
@@ -679,7 +681,8 @@ public class WW2V3Year41Test {
     // Get the number of units before placing
     preCount = yunnan.getUnits().getUnitCount();
     // Place the infantry
-    response = placeDelegate.placeUnits(getUnits(map, chinese), yunnan, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    response = placeDelegate.placeUnits(GameDataTestUtil.getUnits(map, chinese), yunnan,
+        IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
     final int midCount = yunnan.getUnits().getUnitCount();
     // Make sure they were all placed
@@ -690,7 +693,8 @@ public class WW2V3Year41Test {
     map = new IntegerMap<>();
     map.add(infantryType, 1);
     addTo(chinese(gameData), infantry(gameData).create(1, chinese(gameData)), gameData);
-    response = placeDelegate.placeUnits(getUnits(map, chinese), yunnan, IAbstractPlaceDelegate.BidMode.NOT_BID);
+    response = placeDelegate.placeUnits(GameDataTestUtil.getUnits(map, chinese), yunnan,
+        IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertError(response);
     // Make sure none were placed
     final int postCount = yunnan.getUnits().getUnitCount();
@@ -719,7 +723,7 @@ public class WW2V3Year41Test {
     map.add(transportType, 1);
     addTo(germans(gameData), transport(gameData).create(1, germans(gameData)), gameData);
     // Place it
-    final String response = placeDelegate.placeUnits(getUnits(map, germans), sz5);
+    final String response = placeDelegate.placeUnits(GameDataTestUtil.getUnits(map, germans), sz5);
     assertValid(response);
   }
 
@@ -1635,22 +1639,6 @@ public class WW2V3Year41Test {
     move(armour, new Route(libya, morrocco));
   }
 
-  /*
-   * Add Utilities here
-   */
-  private static Collection<Unit> getUnits(final IntegerMap<UnitType> unitCountsByType, final PlayerID from) {
-    final Iterator<UnitType> iter = unitCountsByType.keySet().iterator();
-    final Collection<Unit> units = new ArrayList<>(unitCountsByType.totalValues());
-    while (iter.hasNext()) {
-      final UnitType type = iter.next();
-      units.addAll(from.getUnits().getUnits(type, unitCountsByType.getInt(type)));
-    }
-    return units;
-  }
-
-  /*
-   * Add assertions here
-   */
   public void assertValid(final String string) {
     assertNull(string, string);
   }


### PR DESCRIPTION
I recently noticed some test utility code that was duplicated across several fixtures related to getting a subset of units from either a territory or a player (i.e. a `UnitHolder`).  This PR extracts the duplicated code to `GameDataTestUtil#getUnits()` so it can be reused.  After extracting the method, I refactored it to remove some of the legacy Java cruft.

There were some unrelated whitespace changes due to applying Clean Up to `GameDataTestUtil`.