### PR TITLE
Set full logging Level for integTests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,10 @@ task integTest(type: Test) {
         reports.junitXml.destination = file("${reports.junitXml.destination}/$name")
     }
 
+    testLogging {
+        exceptionFormat = 'full'
+    }
+
     mustRunAfter tasks.test
 }
 


### PR DESCRIPTION
This sets the same full logging level for integTests as normal tests.
Self merging, as I need this change for output logs of #2101 