### PR TITLE
Unify testLogging configuration for all Test tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,10 +106,6 @@ dependencies {
 
 test {
     exclude '**/*Tests.class'
-
-    testLogging {
-        exceptionFormat = 'full'
-    }
 }
 
 task integTest(type: Test) {
@@ -124,10 +120,6 @@ task integTest(type: Test) {
     reports {
         reports.html.destination = file("${reports.html.destination}/$name")
         reports.junitXml.destination = file("${reports.junitXml.destination}/$name")
-    }
-
-    testLogging {
-        exceptionFormat = 'full'
     }
 
     mustRunAfter tasks.test
@@ -264,6 +256,12 @@ gradle.taskGraph.whenReady { graph ->
             it.project.install4j.installDir = file(project.install4jHomeDir)
         }
     })
+}
+
+tasks.withType(Test) {
+    testLogging {
+        exceptionFormat = 'full'
+    }
 }
 
 check {


### PR DESCRIPTION
This PR is a follow-on to #2134.  It simply extracts the `testLogging` configuration to a single location to avoid duplication now and in the future.