### PR TITLE
Re-enable attachment validation tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 checkstyleIntegTestMaxWarnings=0
-checkstyleMainMaxWarnings=3371
+checkstyleMainMaxWarnings=3373
 checkstyleTestMaxWarnings=9

--- a/src/main/java/games/strategy/engine/data/annotations/GameProperty.java
+++ b/src/main/java/games/strategy/engine/data/annotations/GameProperty.java
@@ -36,4 +36,17 @@ public @interface GameProperty {
    * @return true that this property identifies an adder instead of a setter
    */
   boolean adds();
+
+  /**
+   * Indicates the property is virtual and either has no backing field or uses one or more backing fields associated
+   * with other non-virtual properties.
+   *
+   * <p>
+   * A virtual property is typically used for so-called "convenience" properties that are used to initialize multiple
+   * properties at once. Properties of this type are not required to have get, reset, or clear methods.
+   * </p>
+   *
+   * @return {@code true} if the property is virtual; otherwise {@code false}.
+   */
+  boolean virtual() default false;
 }

--- a/src/main/java/games/strategy/engine/xml/TestAttachment.java
+++ b/src/main/java/games/strategy/engine/xml/TestAttachment.java
@@ -3,6 +3,8 @@ package games.strategy.engine.xml;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.annotations.GameProperty;
+import games.strategy.engine.data.annotations.InternalDoNotExport;
 
 public class TestAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 4886924951201479496L;
@@ -18,6 +20,7 @@ public class TestAttachment extends DefaultAttachment {
     return null;
   }
 
+  @InternalDoNotExport
   @Override
   public void setAttachedTo(final Attachable unused) {}
 
@@ -26,15 +29,21 @@ public class TestAttachment extends DefaultAttachment {
     return null;
   }
 
+  @InternalDoNotExport
   @Override
   public void setName(final String name) {}
 
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setValue(final String value) {
     m_value = value;
   }
 
   public String getValue() {
     return m_value;
+  }
+
+  public void resetValue() {
+    m_value = null;
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -299,6 +299,10 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     return m_chance;
   }
 
+  public void resetChance() {
+    m_chance = DEFAULT_CHANCE;
+  }
+
   public int getChanceToHit() {
     return getInt(getChance().split(":")[0]);
   }
@@ -316,6 +320,10 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     return m_chanceIncrementOnFailure;
   }
 
+  public void resetChanceIncrementOnFailure() {
+    m_chanceIncrementOnFailure = 0;
+  }
+
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setChanceDecrementOnSuccess(final String value) {
     m_chanceDecrementOnSuccess = getInt(value);
@@ -323,6 +331,10 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
 
   public int getChanceDecrementOnSuccess() {
     return m_chanceDecrementOnSuccess;
+  }
+
+  public void resetChanceDecrementOnSuccess() {
+    m_chanceDecrementOnSuccess = 0;
   }
 
   public void changeChanceDecrementOrIncrementOnSuccessOrFailure(final IDelegateBridge delegateBridge,

--- a/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -216,7 +216,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
     m_gameProperty = null;
   }
 
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
   public void setRounds(final String rounds) throws GameParseException {
     if (rounds == null) {
       m_turns = null;

--- a/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -152,7 +152,7 @@ public class CanalAttachment extends DefaultAttachment {
     m_excludedUnits = value;
   }
 
-  public HashSet<UnitType> getExcludedUnits(final GameData data) {
+  public HashSet<UnitType> getExcludedUnits() {
     if (m_excludedUnits == null) {
       return new HashSet<>(
           Match.getMatches(getData().getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeIsAir));

--- a/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -120,6 +120,10 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_canMoveAirUnitsOverOwnedLand = canFlyOver;
   }
 
+  public String getCanMoveAirUnitsOverOwnedLand() {
+    return m_canMoveAirUnitsOverOwnedLand;
+  }
+
   /**
    * <strong> EXAMPLE</strong> method on how you could do finegrained authorizations instead of looking at isNeutral,
    * isAllied or isWar();
@@ -127,7 +131,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
    *
    * @return whether in this relationshipType you can fly over other territories
    */
-  public boolean getCanMoveAirUnitsOverOwnedLand() { // War: true, Allied: True, Neutral: false
+  public boolean canMoveAirUnitsOverOwnedLand() { // War: true, Allied: True, Neutral: false
     if (m_canMoveAirUnitsOverOwnedLand.equals(PROPERTY_DEFAULT)) {
       return isWar() || isAllied();
     }
@@ -143,7 +147,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_canMoveLandUnitsOverOwnedLand = canFlyOver;
   }
 
-  public boolean getCanMoveLandUnitsOverOwnedLand() { // War: true, Allied: True, Neutral: false
+  public String getCanMoveLandUnitsOverOwnedLand() {
+    return m_canMoveLandUnitsOverOwnedLand;
+  }
+
+  public boolean canMoveLandUnitsOverOwnedLand() { // War: true, Allied: True, Neutral: false
     if (m_canMoveLandUnitsOverOwnedLand.equals(PROPERTY_DEFAULT)) {
       return isWar() || isAllied();
     }
@@ -159,7 +167,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_canLandAirUnitsOnOwnedLand = canLandAir;
   }
 
-  public boolean getCanLandAirUnitsOnOwnedLand() {
+  public String getCanLandAirUnitsOnOwnedLand() {
+    return m_canLandAirUnitsOnOwnedLand;
+  }
+
+  public boolean canLandAirUnitsOnOwnedLand() {
     // War: false, Allied: true, Neutral: false
     if (m_canLandAirUnitsOnOwnedLand.equals(PROPERTY_DEFAULT)) {
       return isAllied();
@@ -176,7 +188,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_canTakeOverOwnedTerritory = canTakeOver;
   }
 
-  public boolean getCanTakeOverOwnedTerritory() {
+  public String getCanTakeOverOwnedTerritory() {
+    return m_canTakeOverOwnedTerritory;
+  }
+
+  public boolean canTakeOverOwnedTerritory() {
     // War: true, Allied: false, Neutral: false
     if (m_canTakeOverOwnedTerritory.equals(PROPERTY_DEFAULT)) {
       return isWar();
@@ -234,7 +250,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_alliancesCanChainTogether = value;
   }
 
-  public boolean getAlliancesCanChainTogether() {
+  public String getAlliancesCanChainTogether() {
+    return m_alliancesCanChainTogether;
+  }
+
+  public boolean canAlliancesChainTogether() {
     if (m_alliancesCanChainTogether.equals(PROPERTY_DEFAULT) || isWar() || isNeutral()) {
       return false;
     }
@@ -254,7 +274,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_isDefaultWarPosition = value;
   }
 
-  public boolean getIsDefaultWarPosition() {
+  public String getIsDefaultWarPosition() {
+    return m_isDefaultWarPosition;
+  }
+
+  public boolean isDefaultWarPosition() {
     if (m_isDefaultWarPosition.equals(PROPERTY_DEFAULT) || isAllied() || isNeutral()) {
       return false;
     }
@@ -274,7 +298,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_givesBackOriginalTerritories = value;
   }
 
-  public boolean getGivesBackOriginalTerritories() {
+  public String getGivesBackOriginalTerritories() {
+    return m_givesBackOriginalTerritories;
+  }
+
+  public boolean givesBackOriginalTerritories() {
     if (m_givesBackOriginalTerritories.equals(PROPERTY_DEFAULT)) {
       return false;
     }
@@ -294,7 +322,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_canMoveIntoDuringCombatMove = value;
   }
 
-  public boolean getCanMoveIntoDuringCombatMove() {
+  public String getCanMoveIntoDuringCombatMove() {
+    return m_canMoveIntoDuringCombatMove;
+  }
+
+  public boolean canMoveIntoDuringCombatMove() {
     // this property is not affected by any archetype.
     if (m_canMoveIntoDuringCombatMove.equals(PROPERTY_DEFAULT)) {
       return true;
@@ -315,7 +347,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_canMoveThroughCanals = value;
   }
 
-  public boolean getCanMoveThroughCanals() {
+  public String getCanMoveThroughCanals() {
+    return m_canMoveThroughCanals;
+  }
+
+  public boolean canMoveThroughCanals() {
     // only allied can move through canals normally
     if (m_canMoveThroughCanals.equals(PROPERTY_DEFAULT)) {
       return isAllied();
@@ -336,7 +372,11 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
     m_rocketsCanFlyOver = value;
   }
 
-  public boolean getRocketsCanFlyOver() {
+  public String getRocketsCanFlyOver() {
+    return m_rocketsCanFlyOver;
+  }
+
+  public boolean canRocketsFlyOver() {
     // rockets can normally fly over everyone.
     if (m_rocketsCanFlyOver.equals(PROPERTY_DEFAULT)) {
       return true;

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -343,7 +343,7 @@ public class TerritoryAttachment extends DefaultAttachment {
   /**
    * Sets only m_production.
    */
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
   public void setProductionOnly(final String value) {
     m_production = getInt(value);
   }

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -252,6 +252,10 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_isImpassable;
   }
 
+  public void resetIsImpassable() {
+    m_isImpassable = false;
+  }
+
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setCapital(final String value) throws GameParseException {
     if (value == null) {
@@ -299,6 +303,9 @@ public class TerritoryAttachment extends DefaultAttachment {
     return m_originalFactory;
   }
 
+  public void resetOriginalFactory() {
+    m_originalFactory = false;
+  }
 
   /**
    * Sets production and unitProduction (or just "production" in a map xml)
@@ -325,6 +332,15 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   /**
+   * Resets production and unitProduction (or just "production" in a map xml) of a territory to the default value.
+   */
+  public void resetProduction() {
+    m_production = 0;
+    // do NOT remove. unitProduction should always default to production
+    m_unitProduction = m_production;
+  }
+
+  /**
    * Sets only m_production.
    */
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
@@ -335,6 +351,10 @@ public class TerritoryAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setUnitProduction(final String value) {
     m_unitProduction = Integer.parseInt(value);
+  }
+
+  public void resetUnitProduction() {
+    m_unitProduction = 0;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -517,7 +517,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_destroyedWhenCapturedBy = value;
   }
 
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = true)
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = true, virtual = true)
   public void setDestroyedWhenCapturedFrom(String value) throws GameParseException {
     if (!(value.startsWith("BY:") || value.startsWith("FROM:"))) {
       value = "FROM:" + value;
@@ -698,12 +698,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   // DO NOT REMOVE, this is an important convenience method for xmls
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
   public void setIsFactory(final String s) {
     setIsFactory(getBool(s));
   }
 
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
   public void setIsFactory(final Boolean s) {
     setCanBeDamaged(s);
     setIsInfrastructure(s);
@@ -799,7 +799,7 @@ public class UnitAttachment extends DefaultAttachment {
 
   // no m_ variable for this, since it is the inverse of m_unitPlacementRestrictions
   // we might as well just use m_unitPlacementRestrictions
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
   public void setUnitPlacementOnlyAllowedIn(final String value) throws GameParseException {
     final Collection<Territory> allowedTerritories = getListedTerritories(value.split(":"));
     final Collection<Territory> restrictedTerritories = new HashSet<>(getData().getMap().getTerritories());
@@ -1208,10 +1208,8 @@ public class UnitAttachment extends DefaultAttachment {
     m_transportCapacity = -1;
   }
 
-  /**
-   * DO NOT REMOVE.
-   */
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  // DO NOT REMOVE.
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
   public void setIsTwoHit(final String s) {
     m_hitPoints = getBool(s) ? 2 : 1;
   }
@@ -2045,13 +2043,13 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   // Do not delete, we keep this both for backwards compatibility, and for user convenience when making maps
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
   public void setIsAA(final String s) throws GameParseException {
     setIsAA(getBool(s));
   }
 
   // Do not delete, we keep this both for backwards compatibility, and for user convenience when making maps
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
   public void setIsAA(final Boolean s) throws GameParseException {
     setIsAAforCombatOnly(s);
     setIsAAforBombingThisUnitOnly(s);
@@ -2416,12 +2414,12 @@ public class UnitAttachment extends DefaultAttachment {
     m_willNotFireIfPresent = new HashSet<>();
   }
 
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
   public void setIsAAmovement(final String s) throws GameParseException {
     setIsAAmovement(getBool(s));
   }
 
-  @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
+  @GameProperty(xmlProperty = true, gameProperty = true, adds = false, virtual = true)
   public void setIsAAmovement(final Boolean s) throws GameParseException {
     setCanNotMoveDuringCombatMove(s);
     if (s) {

--- a/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -295,6 +295,10 @@ public class UnitAttachment extends DefaultAttachment {
     m_airDefense = value;
   }
 
+  public int getAirDefense() {
+    return m_airDefense;
+  }
+
   public int getAirDefense(final PlayerID player) {
     return (Math.min(getData().getDiceSides(), Math.max(0,
         m_airDefense + TechAbilityAttachment.getAirDefenseBonus((UnitType) this.getAttachedTo(), player, getData()))));
@@ -312,6 +316,10 @@ public class UnitAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setAirAttack(final Integer value) {
     m_airAttack = value;
+  }
+
+  public int getAirAttack() {
+    return m_airAttack;
   }
 
   public int getAirAttack(final PlayerID player) {
@@ -539,6 +547,10 @@ public class UnitAttachment extends DefaultAttachment {
     m_canBlitz = s;
   }
 
+  public boolean getCanBlitz() {
+    return m_canBlitz;
+  }
+
   public boolean getCanBlitz(final PlayerID player) {
     if (m_canBlitz) {
       return true;
@@ -631,6 +643,10 @@ public class UnitAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setCanBombard(final Boolean s) {
     m_canBombard = s;
+  }
+
+  public boolean getCanBombard() {
+    return m_canBombard;
   }
 
   public boolean getCanBombard(final PlayerID player) {
@@ -885,6 +901,10 @@ public class UnitAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setCanInvadeOnlyFrom(final String[] value) {
     m_canInvadeOnlyFrom = value;
+  }
+
+  public String[] getCanInvadeOnlyFrom() {
+    return m_canInvadeOnlyFrom;
   }
 
   public boolean canInvadeFrom(final String transport) {
@@ -1367,7 +1387,7 @@ public class UnitAttachment extends DefaultAttachment {
     m_bombard = s;
   }
 
-  public int getBombard(final PlayerID player) {
+  public int getBombard() {
     return m_bombard > 0 ? m_bombard : m_attack;
   }
 
@@ -1383,6 +1403,10 @@ public class UnitAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setMovement(final Integer s) {
     m_movement = s;
+  }
+
+  public int getMovement() {
+    return m_movement;
   }
 
   public int getMovement(final PlayerID player) {
@@ -1404,14 +1428,14 @@ public class UnitAttachment extends DefaultAttachment {
     m_attack = s;
   }
 
+  public int getAttack() {
+    return m_attack;
+  }
+
   public int getAttack(final PlayerID player) {
     final int attackValue =
         m_attack + TechAbilityAttachment.getAttackBonus((UnitType) this.getAttachedTo(), player, getData());
     return Math.min(getData().getDiceSides(), Math.max(0, attackValue));
-  }
-
-  int getRawAttack() {
-    return m_attack;
   }
 
   public void resetAttack() {
@@ -1426,6 +1450,10 @@ public class UnitAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setAttackRolls(final Integer s) {
     m_attackRolls = s;
+  }
+
+  public int getAttackRolls() {
+    return m_attackRolls;
   }
 
   public int getAttackRolls(final PlayerID player) {
@@ -1447,6 +1475,10 @@ public class UnitAttachment extends DefaultAttachment {
     m_defense = s;
   }
 
+  public int getDefense() {
+    return m_defense;
+  }
+
   public int getDefense(final PlayerID player) {
     int defenseValue =
         m_defense + TechAbilityAttachment.getDefenseBonus((UnitType) this.getAttachedTo(), player, getData());
@@ -1455,10 +1487,6 @@ public class UnitAttachment extends DefaultAttachment {
       defenseValue += bonus;
     }
     return Math.min(getData().getDiceSides(), Math.max(0, defenseValue));
-  }
-
-  int getRawDefense() {
-    return m_defense;
   }
 
   public void resetDefense() {
@@ -1473,6 +1501,10 @@ public class UnitAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setDefenseRolls(final Integer s) {
     m_defenseRolls = s;
+  }
+
+  public int getDefenseRolls() {
+    return m_defenseRolls;
   }
 
   public int getDefenseRolls(final PlayerID player) {
@@ -1977,6 +2009,10 @@ public class UnitAttachment extends DefaultAttachment {
     m_bombingTargets = value;
   }
 
+  public HashSet<UnitType> getBombingTargets() {
+    return m_bombingTargets;
+  }
+
   public HashSet<UnitType> getBombingTargets(final GameData data) {
     if (m_bombingTargets != null) {
       return m_bombingTargets;
@@ -2035,6 +2071,10 @@ public class UnitAttachment extends DefaultAttachment {
     m_attackAA = s;
   }
 
+  public int getAttackAA() {
+    return m_attackAA;
+  }
+
   public int getAttackAA(final PlayerID player) {
     // TODO: this may cause major problems with Low Luck, if they have diceSides equal to something other than 6, or it
     // does not divide
@@ -2055,6 +2095,10 @@ public class UnitAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setOffensiveAttackAA(final Integer s) {
     m_offensiveAttackAA = s;
+  }
+
+  public int getOffensiveAttackAA() {
+    return m_offensiveAttackAA;
   }
 
   public int getOffensiveAttackAA(final PlayerID player) {
@@ -2311,6 +2355,10 @@ public class UnitAttachment extends DefaultAttachment {
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setTargetsAA(final HashSet<UnitType> value) {
     m_targetsAA = value;
+  }
+
+  public HashSet<UnitType> getTargetsAA() {
+    return m_targetsAA;
   }
 
   public HashSet<UnitType> getTargetsAA(final GameData data) {
@@ -3052,8 +3100,8 @@ public class UnitAttachment extends DefaultAttachment {
     if (getIsDestroyer()) {
       stats.append("is Anti-Stealth, ");
     }
-    if (getCanBombard(player) && getBombard(player) > 0) {
-      stats.append(getBombard(player)).append(" Bombard, ");
+    if (getCanBombard(player) && getBombard() > 0) {
+      stats.append(getBombard()).append(" Bombard, ");
     }
     if (getBlockade() > 0) {
       stats.append(getBlockade()).append(" Blockade Loss, ");

--- a/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -111,6 +111,10 @@ public class UnitSupportAttachment extends DefaultAttachment {
     m_unitType = value;
   }
 
+  public void resetUnitType() {
+    m_unitType = null;
+  }
+
   @GameProperty(xmlProperty = true, gameProperty = true, adds = false)
   public void setFaction(final String faction) throws GameParseException {
     m_faction = faction;

--- a/src/main/java/games/strategy/triplea/attachments/UnitTypeComparator.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitTypeComparator.java
@@ -42,8 +42,8 @@ public class UnitTypeComparator implements Comparator<UnitType> {
     if (ua2.getIsSea() && !ua1.getIsSea()) {
       return -1;
     }
-    if (ua1.getRawAttack() != ua2.getRawAttack()) {
-      return ua1.getRawAttack() - ua2.getRawAttack();
+    if (ua1.getAttack() != ua2.getAttack()) {
+      return ua1.getAttack() - ua2.getAttack();
     }
     return u1.getName().compareTo(u2.getName());
   }

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -476,7 +476,7 @@ public class DiceRoll implements Externalizable {
         }
         if (ua.getIsSea() && isAmphibiousBattle && Matches.TerritoryIsLand.match(location)) {
           // change the strength to be bombard, not attack/defense, because this is a
-          strength = ua.getBombard(current.getOwner());
+          strength = ua.getBombard();
           // bombarding naval unit
         }
         strength += getSupport(current, supportRulesFriendly, supportLeftFriendly, supportUnitsLeftFriendly,

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1822,7 +1822,7 @@ public class Matches {
       Match.of(relationship -> relationship.getRelationshipType().getRelationshipTypeAttachment().isWar());
 
   public static final Match<RelationshipType> RelationshipTypeCanMoveLandUnitsOverOwnedLand =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().getCanMoveLandUnitsOverOwnedLand());
+      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveLandUnitsOverOwnedLand());
 
   /**
    * If the territory is not land, returns true. Else, tests relationship of the owners.
@@ -1842,7 +1842,7 @@ public class Matches {
   }
 
   public static final Match<RelationshipType> RelationshipTypeCanMoveAirUnitsOverOwnedLand =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().getCanMoveAirUnitsOverOwnedLand());
+      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveAirUnitsOverOwnedLand());
 
   /**
    * If the territory is not land, returns true. Else, tests relationship of the owners.
@@ -1862,22 +1862,22 @@ public class Matches {
   }
 
   public static final Match<RelationshipType> RelationshipTypeCanLandAirUnitsOnOwnedLand =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().getCanLandAirUnitsOnOwnedLand());
+      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canLandAirUnitsOnOwnedLand());
 
   public static final Match<RelationshipType> RelationshipTypeCanTakeOverOwnedTerritory =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().getCanTakeOverOwnedTerritory());
+      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canTakeOverOwnedTerritory());
 
   public static final Match<RelationshipType> RelationshipTypeGivesBackOriginalTerritories =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().getGivesBackOriginalTerritories());
+      Match.of(relationship -> relationship.getRelationshipTypeAttachment().givesBackOriginalTerritories());
 
   public static final Match<RelationshipType> RelationshipTypeCanMoveIntoDuringCombatMove =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().getCanMoveIntoDuringCombatMove());
+      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveIntoDuringCombatMove());
 
   public static final Match<RelationshipType> RelationshipTypeCanMoveThroughCanals =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().getCanMoveThroughCanals());
+      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveThroughCanals());
 
   public static final Match<RelationshipType> RelationshipTypeRocketsCanFlyOver =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().getRocketsCanFlyOver());
+      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canRocketsFlyOver());
 
   public static Match<String> isValidRelationshipName(final GameData data) {
     return Match.of(relationshipName -> data.getRelationshipTypeList().getRelationshipType(relationshipName) != null);
@@ -2010,11 +2010,11 @@ public class Matches {
   }
 
   public static final Match<RelationshipType> RelationshipTypeIsAlliedAndAlliancesCanChainTogether = Match.of(rt -> {
-    return RelationshipTypeIsAllied.match(rt) && rt.getRelationshipTypeAttachment().getAlliancesCanChainTogether();
+    return RelationshipTypeIsAllied.match(rt) && rt.getRelationshipTypeAttachment().canAlliancesChainTogether();
   });
 
   public static final Match<RelationshipType> RelationshipTypeIsDefaultWarPosition =
-      Match.of(rt -> rt.getRelationshipTypeAttachment().getIsDefaultWarPosition());
+      Match.of(rt -> rt.getRelationshipTypeAttachment().isDefaultWarPosition());
 
   /**
    * If player is null, this match Will return true if ANY of the relationship changes match the conditions. (since

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1296,7 +1296,7 @@ public class MoveValidator {
   private static Optional<String> canPassThroughCanal(final CanalAttachment canalAttachment,
       final Collection<Unit> units, final PlayerID player, final GameData data) {
     if (units != null && !units.isEmpty()
-        && Match.allMatch(units, Matches.unitIsOfTypes(canalAttachment.getExcludedUnits(data)))) {
+        && Match.allMatch(units, Matches.unitIsOfTypes(canalAttachment.getExcludedUnits()))) {
       return Optional.empty();
     }
     for (final Territory borderTerritory : canalAttachment.getLandTerritories()) {

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -518,9 +518,9 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     RelationshipType alliedType = null;
     RelationshipType warType = null;
     for (final RelationshipType type : allTypes) {
-      if (type.getRelationshipTypeAttachment().getIsDefaultWarPosition()) {
+      if (type.getRelationshipTypeAttachment().isDefaultWarPosition()) {
         warType = type;
-      } else if (type.getRelationshipTypeAttachment().getAlliancesCanChainTogether()) {
+      } else if (type.getRelationshipTypeAttachment().canAlliancesChainTogether()) {
         alliedType = type;
       }
     }

--- a/src/main/java/games/strategy/util/PropertyUtil.java
+++ b/src/main/java/games/strategy/util/PropertyUtil.java
@@ -1,5 +1,7 @@
 package games.strategy.util;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
@@ -42,7 +44,7 @@ public class PropertyUtil {
     }
   }
 
-  public static Field getFieldIncludingFromSuperClasses(final Class<?> c, final String name,
+  private static Field getFieldIncludingFromSuperClasses(final Class<?> c, final String name,
       final boolean justFromSuper) {
     if (!justFromSuper) {
       try {
@@ -76,14 +78,27 @@ public class PropertyUtil {
   }
 
   private static Field getPropertyField(final String propertyName, final Object subject) {
+    return getPropertyField(propertyName, subject.getClass());
+  }
+
+  /**
+   * Gets the backing field for the property with the specified name in the specified type.
+   *
+   * @param propertyName The property name.
+   * @param type The type that hosts the property.
+   *
+   * @return The backing field for the specified property.
+   *
+   * @throws IllegalStateException If no backing field for the specified property exists.
+   */
+  public static Field getPropertyField(final String propertyName, final Class<?> type) {
+    checkNotNull(propertyName);
+    checkNotNull(type);
+
     try {
-      return getFieldIncludingFromSuperClasses(subject.getClass(), "m_" + propertyName, false);
-    } catch (final Exception e) {
-      try {
-        return getFieldIncludingFromSuperClasses(subject.getClass(), propertyName, false);
-      } catch (final Exception exception) {
-        throw exception;
-      }
+      return getFieldIncludingFromSuperClasses(type, "m_" + propertyName, false);
+    } catch (final IllegalStateException ignored) {
+      return getFieldIncludingFromSuperClasses(type, propertyName, false);
     }
   }
 

--- a/src/main/java/tools/map/making/MapPropertyWrapper.java
+++ b/src/main/java/tools/map/making/MapPropertyWrapper.java
@@ -140,7 +140,7 @@ public class MapPropertyWrapper<T> extends AEditableProperty {
         continue;
       }
       final String fieldName = Introspector.decapitalize(propertyName);
-      final Field field = PropertyUtil.getFieldIncludingFromSuperClasses(object.getClass(), fieldName, false);
+      final Field field = PropertyUtil.getPropertyField(fieldName, object.getClass());
       final Object currentValue;
       try {
         currentValue = field.get(object);

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -3,7 +3,9 @@ package games.strategy.engine.data.annotations;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.PrintWriter;
@@ -150,6 +152,8 @@ public class ValidateAttachmentsTest {
    */
   @Test
   public void testAllAttachments() throws Exception {
+    assumeFalse("cannot scan for attachments in a headless environment", GraphicsEnvironment.isHeadless());
+
     final File root = getRootClassesFolder();
     final String errors = findAttachmentsAndValidate(root, root);
     if (!errors.isEmpty()) {

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -382,7 +382,7 @@ public class ValidateAttachmentsTest {
           if (!getterValue.equals(fieldValue)) {
             sb.append("Class ").append(clazz.getCanonicalName()).append(", ").append(getterName)
                 .append(" returns type ").append(getterValue.getClass().getName()).append(" but field is of type ")
-                .append(fieldValue.getClass().getName());
+                .append(fieldValue.getClass().getName()).append("\n");
           }
         } catch (final NoSuchMethodException e) {
           sb.append("Warning, Class ").append(clazz.getCanonicalName()).append(" testing '").append(propertyName)

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.IAttachment;
+import games.strategy.engine.data.ResourceCollection;
 import games.strategy.triplea.attachments.CanalAttachment;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
@@ -301,8 +302,10 @@ public class ValidateAttachmentsTest {
         field = PropertyUtil.getPropertyField(propertyName, clazz);
         // adders must have a field of type IntegerMap, or be a collection of sorts
         if (annotation != null && annotation.adds()) {
-          if (!(Collection.class.isAssignableFrom(field.getType()) || Map.class.isAssignableFrom(field.getType())
-              || IntegerMap.class.isAssignableFrom(field.getType()))) {
+          if (!Collection.class.isAssignableFrom(field.getType())
+              && !ResourceCollection.class.isAssignableFrom(field.getType())
+              && !Map.class.isAssignableFrom(field.getType())
+              && !IntegerMap.class.isAssignableFrom(field.getType())) {
             sb.append("Class ").append(clazz.getCanonicalName()).append(" has a setter ").append(setter.getName())
                 .append(" which adds but the field ").append(field.getName())
                 .append(" is not a Collection or Map or IntegerMap\n");

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -15,7 +15,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -23,21 +22,8 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.IAttachment;
 import games.strategy.engine.data.ResourceCollection;
-import games.strategy.triplea.attachments.CanalAttachment;
-import games.strategy.triplea.attachments.PlayerAttachment;
-import games.strategy.triplea.attachments.PoliticalActionAttachment;
-import games.strategy.triplea.attachments.RelationshipTypeAttachment;
-import games.strategy.triplea.attachments.RulesAttachment;
-import games.strategy.triplea.attachments.TechAbilityAttachment;
-import games.strategy.triplea.attachments.TechAttachment;
-import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.TerritoryEffectAttachment;
-import games.strategy.triplea.attachments.TriggerAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.PropertyUtil;
 
@@ -115,21 +101,23 @@ public class ValidateAttachmentsTest {
   }
 
   private static List<Class<? extends IAttachment>> getKnownAttachmentClasses() {
-    final List<Class<? extends IAttachment>> result = new ArrayList<>();
-    result.add(DefaultAttachment.class);
-    result.add(CanalAttachment.class);
-    result.add(PlayerAttachment.class);
-    result.add(PoliticalActionAttachment.class);
-    result.add(RelationshipTypeAttachment.class);
-    result.add(RulesAttachment.class);
-    result.add(TechAttachment.class);
-    result.add(TerritoryAttachment.class);
-    result.add(TerritoryEffectAttachment.class);
-    result.add(TriggerAttachment.class);
-    result.add(UnitAttachment.class);
-    result.add(UnitSupportAttachment.class);
-    result.add(TechAbilityAttachment.class);
-    return result;
+    return Arrays.asList(
+        games.strategy.engine.data.DefaultAttachment.class,
+        games.strategy.engine.data.annotations.ExampleAttachment.class,
+        games.strategy.engine.xml.TestAttachment.class,
+        games.strategy.triplea.attachments.CanalAttachment.class,
+        games.strategy.triplea.attachments.PlayerAttachment.class,
+        games.strategy.triplea.attachments.PoliticalActionAttachment.class,
+        games.strategy.triplea.attachments.RelationshipTypeAttachment.class,
+        games.strategy.triplea.attachments.RulesAttachment.class,
+        games.strategy.triplea.attachments.TechAbilityAttachment.class,
+        games.strategy.triplea.attachments.TechAttachment.class,
+        games.strategy.triplea.attachments.TerritoryAttachment.class,
+        games.strategy.triplea.attachments.TerritoryEffectAttachment.class,
+        games.strategy.triplea.attachments.TriggerAttachment.class,
+        games.strategy.triplea.attachments.UnitAttachment.class,
+        games.strategy.triplea.attachments.UnitSupportAttachment.class,
+        games.strategy.triplea.attachments.UserActionAttachment.class);
   }
 
   /**

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -2,6 +2,7 @@ package games.strategy.engine.data.annotations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -12,7 +13,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -140,8 +140,7 @@ public class ValidateAttachmentsTest {
       sb.append(validateAttachment(clazz));
     }
     if (sb.length() > 0) {
-      System.out.println(sb.toString());
-      // fail(sb.toString());
+      fail("One or more attachments are invalid:\n" + sb.toString());
     }
   }
 
@@ -153,9 +152,8 @@ public class ValidateAttachmentsTest {
   public void testAllAttachments() throws Exception {
     final File root = getRootClassesFolder();
     final String errors = findAttachmentsAndValidate(root, root);
-    if (errors.length() > 0) {
-      System.out.println(errors);
-      // fail("\n" + errors);
+    if (!errors.isEmpty()) {
+      fail("One or more attachments are invalid:\n" + errors);
     }
   }
 

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -289,12 +289,18 @@ public class ValidateAttachmentsTest {
       if (setter.getAnnotation(Deprecated.class) != null) {
         continue;
       }
+
+      // skip the remaining field-related checks if the property is virtual
+      if (annotation != null && annotation.virtual()) {
+        continue;
+      }
+
       // validate that there is a field and a getter
       Field field = null;
       try {
         field = PropertyUtil.getPropertyField(propertyName, clazz);
         // adders must have a field of type IntegerMap, or be a collection of sorts
-        if (annotation.adds()) {
+        if (annotation != null && annotation.adds()) {
           if (!(Collection.class.isAssignableFrom(field.getType()) || Map.class.isAssignableFrom(field.getType())
               || IntegerMap.class.isAssignableFrom(field.getType()))) {
             sb.append("Class ").append(clazz.getCanonicalName()).append(" has a setter ").append(setter.getName())
@@ -335,7 +341,7 @@ public class ValidateAttachmentsTest {
             .append(" doesn't have a valid getter method for property: ").append(propertyName).append("\n");
         continue;
       }
-      if (annotation.adds()) {
+      if (annotation != null && annotation.adds()) {
         // check that there is a clear method
         final String clearName = "clear" + capitalizeFirstLetter(propertyName);
         final Method clearMethod;

--- a/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
+++ b/src/test/java/games/strategy/engine/data/annotations/ValidateAttachmentsTest.java
@@ -292,7 +292,7 @@ public class ValidateAttachmentsTest {
       // validate that there is a field and a getter
       Field field = null;
       try {
-        field = PropertyUtil.getFieldIncludingFromSuperClasses(clazz, propertyName, false);
+        field = PropertyUtil.getPropertyField(propertyName, clazz);
         // adders must have a field of type IntegerMap, or be a collection of sorts
         if (annotation.adds()) {
           if (!(Collection.class.isAssignableFrom(field.getType()) || Map.class.isAssignableFrom(field.getType())


### PR DESCRIPTION
While reviewing [#2112](https://github.com/triplea-game/triplea/pull/2112/files#r128143719), I discovered that, sometime in 2012, the tests in `ValidateAttachmentsTest` were changed to no longer fail when an `IAttachment`-derived class was determined to be invalid, but rather to only report the error(s) to the console.  There are currently about 500 errors being reported, so apparently no one has noticed. :smile:  Therefore, my goal for this PR was to fix the existing errors and re-enable the tests to fail when an invalid attachment is detected.  (Of course, after reviewing this PR, the team may feel this class of tests is not even really necessary, in which case, I'm happy to convert the PR into one that removes this test fixture completely.)

The fixes mostly required adding missing methods that may be invoked via reflection (but, in reality, probably aren't; otherwise someone would have observed the failure and fixed it).  There were other fixes that required some creative changes, which I'll call out in a forthcoming review.

I also fixed the broken `testAllAttachments()` test, which scans the classpath for attachments to validate (as opposed to the `testSpecificAttachments()` test, which uses a hard-coded list of attachments).  There are some issues with `testAllAttachments()` which make me question its usefulness.  See below for a more in-depth discussion.

I think it might be easier to review this PR commit-by-commit, as they are pretty focused, and the commit messages establish the context for the changes.