### PR TITLE
Speed up RsaAuthenticator test

### DIFF
--- a/src/main/java/games/strategy/engine/lobby/server/login/RsaAuthenticator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/RsaAuthenticator.java
@@ -3,6 +3,7 @@ package games.strategy.engine.lobby.server.login;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
+import java.security.Key;
 import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -13,6 +14,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -22,7 +24,6 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
@@ -86,15 +87,40 @@ public class RsaAuthenticator {
       final KeyPairGenerator keyGen = KeyPairGenerator.getInstance(RSA);
       keyGen.initialize(4096);
       return keyGen.generateKeyPair();
-    } catch (NoSuchAlgorithmException e) {
+    } catch (final NoSuchAlgorithmException e) {
       throw new IllegalStateException(RSA + " is an invalid algorithm!", e);
     }
   }
 
-  private static String decryptPassword(final String encryptedPassword, final PrivateKey privateKey,
+
+  /**
+   * Looks up a public key from the 'challenge' param map that was original sent to the client, and
+   * then we return any matching private keys stored under that public key. If we find a private key,
+   * it is purged from cache before being returned.
+   */
+  static Optional<PrivateKey> getPrivateKey(final Map<String, String> challenge) {
+    final String publicKey = challenge.get(RSA_PUBLIC_KEY);
+    final PrivateKey privateKey = rsaKeyMap.getIfPresent(publicKey);
+    rsaKeyMap.invalidate(publicKey);
+    return Optional.ofNullable(privateKey);
+
+  }
+
+  /**
+   * Attempts to decrypt the given password using the challenge and response parameters.
+   * 
+   * @param privateKey PrivateKey that was used to encrypted the password stored in the response param.
+   * @param response The response map containing the encrypte password.
+   * @param successfullDecryptionAction A {@link Function} which is executed if the password is successfully
+   *        encrypted. This methods returns the result of the given Function.
+   */
+  static String decryptPasswordForAction(
+      final Key privateKey,
+      final Map<String, String> response,
       final Function<String, String> successfullDecryptionAction) {
-    Preconditions.checkNotNull(encryptedPassword);
-    Preconditions.checkNotNull(privateKey);
+
+    final String encryptedPassword = response.get(ENCRYPTED_PASSWORD_KEY);
+
     try {
       final Cipher cipher = Cipher.getInstance(RSA_ECB_OAEPP);
       cipher.init(Cipher.DECRYPT_MODE, privateKey);
@@ -107,36 +133,14 @@ public class RsaAuthenticator {
     }
   }
 
-  /**
-   * Attempts to decrypt the given password using the challenge and response parameters.
-   * 
-   * @param challenge The original challenge map containing the required Base64 encoded public key.
-   * @param response The response map containing the encrypte password.
-   * @param successfullDecryptionAction A {@link Function} which is executed if the password is successfully
-   *        encrypted. This methods returns the result of the given Function.
-   */
-  public static String decryptPasswordForAction(final Map<String, String> challenge, final Map<String, String> response,
-      final Function<String, String> successfullDecryptionAction) {
-    final String publicKey = challenge.get(RSA_PUBLIC_KEY);
-    final PrivateKey privateKey = rsaKeyMap.getIfPresent(publicKey);
-    if (privateKey == null) {
-      return "Login timeout, try again!";
-    } else {
-      rsaKeyMap.invalidate(publicKey);
-    }
-    return decryptPassword(response.get(ENCRYPTED_PASSWORD_KEY), privateKey, successfullDecryptionAction);
-  }
-
-
-  @VisibleForTesting
-  static String encryptPassword(final String publicKeyString, final String password) {
+  private static String encryptPassword(final String publicKeyString, final String password) {
     try {
       final PublicKey publicKey = KeyFactory.getInstance(RSA)
           .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyString)));
       final Cipher cipher = Cipher.getInstance(RSA_ECB_OAEPP);
       cipher.init(Cipher.ENCRYPT_MODE, publicKey);
       return Base64.getEncoder().encodeToString(cipher.doFinal(getHashedBytes(password)));
-    } catch (GeneralSecurityException e) {
+    } catch (final GeneralSecurityException e) {
       throw new IllegalStateException(e);
     }
   }
@@ -171,8 +175,21 @@ public class RsaAuthenticator {
     return Collections.singletonMap(ENCRYPTED_PASSWORD_KEY, encryptPassword(challenge.get(RSA_PUBLIC_KEY), password));
   }
 
+  /**
+   * This method exists only to help support test.
+   * @deprecated Avoid calling this method, instead we should rework how this class is structured
+   */
   @VisibleForTesting
   static void invalidateAll() {
     rsaKeyMap.invalidateAll();
+  }
+
+  /**
+   * This method exists only to help support test.
+   * @deprecated Avoid calling this method, instead we should rework how this class is structured
+   */
+  @VisibleForTesting
+  static void putKey(final String publicKey, final PrivateKey privateKey) {
+    rsaKeyMap.put(publicKey, privateKey);
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/login/RsaAuthenticator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/RsaAuthenticator.java
@@ -178,6 +178,7 @@ public class RsaAuthenticator {
    * This method exists only to help support test.
    * @deprecated Avoid calling this method, instead we should rework how this class is structured
    */
+  @Deprecated
   @VisibleForTesting
   static void invalidateAll() {
     rsaKeyMap.invalidateAll();
@@ -187,6 +188,7 @@ public class RsaAuthenticator {
    * This method exists only to help support test.
    * @deprecated Avoid calling this method, instead we should rework how this class is structured
    */
+  @Deprecated
   @VisibleForTesting
   static void putKey(final String publicKey, final PrivateKey privateKey) {
     rsaKeyMap.put(publicKey, privateKey);

--- a/src/main/java/games/strategy/engine/lobby/server/login/RsaAuthenticator.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/RsaAuthenticator.java
@@ -103,7 +103,6 @@ public class RsaAuthenticator {
     final PrivateKey privateKey = rsaKeyMap.getIfPresent(publicKey);
     rsaKeyMap.invalidate(publicKey);
     return Optional.ofNullable(privateKey);
-
   }
 
   /**


### PR DESCRIPTION
Remove a slow call generating test data, speed up test to millisecond runtime. By breaking up private key lookup, we can keep the same focus of our tests and test coverage without then needing to generate a valid RSA key. Once we've avoided the slow call to create the RSA key, the test runs fast.

Note: the login failed message is now updated, it would now always say invalid username + password and no longer has the case where it would show  " login timeout, please try again!"