### PR TITLE
Move '@RunWith(Mockito..)' annotation to the child classes of an abstract class.

### DIFF
--- a/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginValidatorTests.java
+++ b/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginValidatorTests.java
@@ -27,7 +27,6 @@ public final class ClientLoginValidatorTests {
 
   @RunWith(Enclosed.class)
   public static final class GetChallengePropertiesTests {
-    @RunWith(MockitoJUnitRunner.StrictStubs.class)
     public abstract static class AbstractTestCase {
       @InjectMocks
       ClientLoginValidator clientLoginValidator;
@@ -43,6 +42,7 @@ public final class ClientLoginValidatorTests {
       }
     }
 
+    @RunWith(MockitoJUnitRunner.StrictStubs.class)
     public static final class WhenPasswordSetTest extends AbstractTestCase {
       @Before
       public void givenPasswordSet() {
@@ -64,6 +64,7 @@ public final class ClientLoginValidatorTests {
       }
     }
 
+    @RunWith(MockitoJUnitRunner.StrictStubs.class)
     public static final class WhenPasswordNotSetTest extends AbstractTestCase {
       @Before
       public void givenPasswordNotSet() {


### PR DESCRIPTION
 With the annotation on an abstract class, without any test methods in that abstract class, depending on how initialization occurs we can get an error in the mockito framework that ensures at least one '@Test' method is present. Moving the '@RunWith' annotation to the concrete child classes that do contain '@Test' annotated methods would ensure that we avoid this problem.

------------

When running all tests (IntelliJ, Ubuntu), I kept getting an initialization error consistently:
![test_fail](https://user-images.githubusercontent.com/12397753/28688062-7762d1a6-72c5-11e7-8933-17e3986e184a.png)

Running the test individually was okay. Seems to reveal an initialization issue, I found that moving the 'RunWith' annotation fixed the problem.

