### PR TITLE
Remove enabled and hidden check for setting default player type

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -167,14 +167,12 @@ class PlayerSelectorRow {
   }
 
   void setDefaultPlayerType() {
-    if (enabled && !player.isHidden()) {
-      if (PLAYER_TYPE_AI.equals(player.getDefaultType())) {
-        playerTypes.setSelectedItem(TripleA.PRO_COMPUTER_PLAYER_TYPE);
-      } else if (PLAYER_TYPE_DOES_NOTHING.equals(player.getDefaultType())) {
-        playerTypes.setSelectedItem(TripleA.DOESNOTHINGAI_COMPUTER_PLAYER_TYPE);
-      } else {
-        playerTypes.setSelectedItem(TripleA.HUMAN_PLAYER_TYPE);
-      }
+    if (PLAYER_TYPE_AI.equals(player.getDefaultType())) {
+      playerTypes.setSelectedItem(TripleA.PRO_COMPUTER_PLAYER_TYPE);
+    } else if (PLAYER_TYPE_DOES_NOTHING.equals(player.getDefaultType())) {
+      playerTypes.setSelectedItem(TripleA.DOESNOTHINGAI_COMPUTER_PLAYER_TYPE);
+    } else {
+      playerTypes.setSelectedItem(TripleA.HUMAN_PLAYER_TYPE);
     }
   }
 


### PR DESCRIPTION
Fixes issue mentioned here: https://forums.triplea-game.org/topic/132/handling-of-ai-players-not-meant-to-be-played-github-request/30

For players, if you set defaultType and isHidden=true in the XML then it was ignoring defaultType. Hidden players should always get set to defaultType.