### PR TITLE
Checkstyle: Remove s_ prefix from constants

### DIFF
--- a/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
+++ b/src/main/java/games/strategy/engine/data/CompositeRouteFinder.java
@@ -13,7 +13,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.Match;
 
 public class CompositeRouteFinder {
-  private static final Logger s_logger = Logger.getLogger(CompositeRouteFinder.class.getName());
+  private static final Logger logger = Logger.getLogger(CompositeRouteFinder.class.getName());
 
   private final GameMap m_map;
   private final Map<Match<Territory>, Integer> m_matches;
@@ -35,7 +35,7 @@ public class CompositeRouteFinder {
   public CompositeRouteFinder(final GameMap map, final Map<Match<Territory>, Integer> matches) {
     m_map = map;
     m_matches = matches;
-    s_logger.finer("Initializing CompositeRouteFinderClass...");
+    logger.finer("Initializing CompositeRouteFinderClass...");
   }
 
   Route findRoute(final Territory start, final Territory end) {

--- a/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -103,7 +103,7 @@ public class GameDataExporter {
           for (final TechAdvance tech : frontier.getTechs()) {
             String name = tech.getName();
             final String cat = tech.getProperty();
-            for (final String definedName : TechAdvance.s_allPreDefinedTechnologyNames) {
+            for (final String definedName : TechAdvance.ALL_PREDEFINED_TECHNOLOGY_NAMES) {
               if (definedName.equals(name)) {
                 name = cat;
               }
@@ -127,7 +127,7 @@ public class GameDataExporter {
         final String cat = tech.getProperty();
         // definedAdvances are handled differently by gameparser, they are set in xml with the category as the name but
         // stored in java with the normal category and name, this causes an xml bug when exporting.
-        for (final String definedName : TechAdvance.s_allPreDefinedTechnologyNames) {
+        for (final String definedName : TechAdvance.ALL_PREDEFINED_TECHNOLOGY_NAMES) {
           if (definedName.equals(name)) {
             name = cat;
           }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -43,7 +43,7 @@ import games.strategy.util.Util;
  */
 public class HeadlessGameServer {
 
-  static final Logger s_logger = Logger.getLogger(HeadlessGameServer.class.getName());
+  private static final Logger logger = Logger.getLogger(HeadlessGameServer.class.getName());
   private static HeadlessGameServer s_instance = null;
   private final AvailableGames m_availableGames;
   private final GameSelectorModel m_gameSelectorModel;
@@ -390,7 +390,7 @@ public class HeadlessGameServer {
     }
     s_instance = this;
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-      s_logger.info("Running ShutdownHook.");
+      logger.info("Running ShutdownHook.");
       shutdown();
     }));
     m_availableGames = new AvailableGames();
@@ -432,7 +432,7 @@ public class HeadlessGameServer {
         restartLobbyWatcher(m_setupPanelModel, m_iGame);
       }
     }, reconnect, reconnect, TimeUnit.SECONDS);
-    s_logger.info("Game Server initialized");
+    logger.info("Game Server initialized");
   }
 
   private static synchronized void restartLobbyWatcher(

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -20,7 +20,7 @@ import games.strategy.net.Messengers;
 import games.strategy.util.ThreadUtil;
 
 public class LocalLauncher extends AbstractLauncher {
-  private static final Logger s_logger = Logger.getLogger(ILauncher.class.getName());
+  private static final Logger logger = Logger.getLogger(ILauncher.class.getName());
   private final IRandomSource m_randomSource;
   private final PlayerListing m_playerListing;
 
@@ -57,9 +57,9 @@ public class LocalLauncher extends AbstractLauncher {
     }
     try {
       if (exceptionLoadingGame == null) {
-        s_logger.fine("Game starting");
+        logger.fine("Game starting");
         game.startGame();
-        s_logger.fine("Game over");
+        logger.fine("Game over");
       }
     } finally {
       // todo(kg), this does not occur on the swing thread, and this notifies setupPanel observers

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -49,7 +49,7 @@ import games.strategy.net.Messengers;
 import games.strategy.util.ThreadUtil;
 
 public class ServerLauncher extends AbstractLauncher {
-  private static final Logger s_logger = Logger.getLogger(ServerLauncher.class.getName());
+  private static final Logger logger = Logger.getLogger(ServerLauncher.class.getName());
   public static final String SERVER_ROOT_DIR_PROPERTY = "triplea.server.root.dir";
   private final int m_clientCount;
   private final IRemoteMessenger m_remoteMessenger;
@@ -132,7 +132,7 @@ public class ServerLauncher extends AbstractLauncher {
       }
       m_remoteMessenger.registerRemote(m_serverReady, ClientModel.CLIENT_READY_CHANNEL);
       m_gameData.doPreGameStartDataModifications(m_playerListing);
-      s_logger.fine("Starting server");
+      logger.fine("Starting server");
       m_abortLaunch = testShouldWeAbort();
       byte[] gameDataAsBytes;
       try {

--- a/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -64,7 +64,7 @@ public class ClientModel implements IMessengerErrorListener {
 
   public static final RemoteName CLIENT_READY_CHANNEL =
       new RemoteName("games.strategy.engine.framework.startup.mc.ClientModel.CLIENT_READY_CHANNEL", IServerReady.class);
-  private static final Logger s_logger = Logger.getLogger(ClientModel.class.getName());
+  private static final Logger logger = Logger.getLogger(ClientModel.class.getName());
   private IRemoteModelListener m_listener = IRemoteModelListener.NULL_LISTENER;
   private IChannelMessenger m_channelMessenger;
   private IRemoteMessenger m_remoteMessenger;
@@ -140,7 +140,7 @@ public class ClientModel implements IMessengerErrorListener {
       return false;
     }
     final String name = props.getName();
-    s_logger.log(Level.FINE, "Client playing as:" + name);
+    logger.log(Level.FINE, "Client playing as:" + name);
     // save the name! -- lnxduk
     prefs.put(ServerModel.PLAYERNAME, name);
     final int port = props.getPort();

--- a/src/main/java/games/strategy/engine/lobby/server/AbstractModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/AbstractModeratorController.java
@@ -9,7 +9,7 @@ import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
 
 public abstract class AbstractModeratorController implements IModeratorController {
-  protected static final Logger s_logger = Logger.getLogger(ModeratorController.class.getName());
+  protected static final Logger logger = Logger.getLogger(ModeratorController.class.getName());
   protected final IServerMessenger m_serverMessenger;
   protected final Messengers m_allMessengers;
 

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
@@ -20,7 +20,7 @@ import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 
 class LobbyGameController implements ILobbyGameController {
-  private static final Logger s_logger = Logger.getLogger(LobbyGameController.class.getName());
+  private static final Logger logger = Logger.getLogger(LobbyGameController.class.getName());
   private final Object m_mutex = new Object();
   private final Map<GUID, GameDescription> m_allGames = new HashMap<>();
   private final ILobbyGameBroadcaster m_broadcaster;
@@ -61,7 +61,7 @@ class LobbyGameController implements ILobbyGameController {
   public void postGame(final GUID gameId, final GameDescription description) {
     final INode from = MessageContext.getSender();
     assertCorrectHost(description, from);
-    s_logger.info("Game added:" + description);
+    logger.info("Game added:" + description);
     synchronized (m_mutex) {
       m_allGames.put(gameId, description);
     }
@@ -70,7 +70,7 @@ class LobbyGameController implements ILobbyGameController {
 
   private static void assertCorrectHost(final GameDescription description, final INode from) {
     if (!from.getAddress().getHostAddress().equals(description.getHostedBy().getAddress().getHostAddress())) {
-      s_logger.severe("Game modified from wrong host, from:" + from + " game host:" + description.getHostedBy());
+      logger.severe("Game modified from wrong host, from:" + from + " game host:" + description.getHostedBy());
       throw new IllegalStateException("Game from the wrong host");
     }
   }
@@ -79,8 +79,8 @@ class LobbyGameController implements ILobbyGameController {
   public void updateGame(final GUID gameId, final GameDescription description) {
     final INode from = MessageContext.getSender();
     assertCorrectHost(description, from);
-    if (s_logger.isLoggable(Level.FINE)) {
-      s_logger.fine("Game updated:" + description);
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("Game updated:" + description);
     }
     synchronized (m_mutex) {
       final GameDescription oldDescription = m_allGames.get(gameId);
@@ -123,15 +123,15 @@ class LobbyGameController implements ILobbyGameController {
     assertCorrectHost(description, from);
     final int port = description.getPort();
     final String host = description.getHostedBy().getAddress().getHostAddress();
-    s_logger.fine("Testing game connection on host:" + host + " port:" + port);
+    logger.fine("Testing game connection on host:" + host + " port:" + port);
     final Socket s = new Socket();
     try {
       s.connect(new InetSocketAddress(host, port), 10 * 1000);
       s.close();
-      s_logger.fine("Connection test passed for host:" + host + " port:" + port);
+      logger.fine("Connection test passed for host:" + host + " port:" + port);
       return null;
     } catch (final IOException e) {
-      s_logger.fine("Connection test failed for host:" + host + " port:" + port + " reason:" + e.getMessage());
+      logger.fine("Connection test failed for host:" + host + " port:" + port + " reason:" + e.getMessage());
       return "host:" + host + " " + " port:" + port;
     }
   }

--- a/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/ModeratorController.java
@@ -35,7 +35,7 @@ public class ModeratorController extends AbstractModeratorController {
     final String mac = getNodeMacAddress(node);
     new BannedUsernameController().addBannedUsername(getRealName(node), banExpires);
     final String banUntil = (banExpires == null ? "forever" : banExpires.toString());
-    s_logger.info(String.format(
+    logger.info(String.format(
         "User was banned from the lobby(Username ban). "
             + "Username: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s Expires: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
@@ -75,7 +75,7 @@ public class ModeratorController extends AbstractModeratorController {
     final String mac = getNodeMacAddress(node);
     new BannedMacController().addBannedMac(mac, banExpires);
     final String banUntil = (banExpires == null ? "forever" : banExpires.toString());
-    s_logger.info(String.format(
+    logger.info(String.format(
         "User was banned from the lobby(Mac ban). "
             + "Username: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s Expires: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
@@ -95,7 +95,7 @@ public class ModeratorController extends AbstractModeratorController {
     final INode modNode = MessageContext.getSender();
     new BannedMacController().addBannedMac(hashedMac, banExpires);
     final String banUntil = (banExpires == null ? "forever" : banExpires.toString());
-    s_logger.info(String.format(
+    logger.info(String.format(
         "User was banned from the lobby(Mac ban). "
             + "Username: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s Expires: %s",
         node.getName(), node.getAddress().getHostAddress(), hashedMac, modNode.getName(),
@@ -118,7 +118,7 @@ public class ModeratorController extends AbstractModeratorController {
     new MutedUsernameController().addMutedUsername(realName, muteExpires);
     m_serverMessenger.notifyUsernameMutingOfPlayer(realName, muteExpires);
     final String muteUntil = (muteExpires == null ? "forever" : muteExpires.toString());
-    s_logger.info(String.format(
+    logger.info(String.format(
         "User was muted on the lobby(Username mute). "
             + "Username: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s Expires: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
@@ -140,7 +140,7 @@ public class ModeratorController extends AbstractModeratorController {
     new MutedMacController().addMutedMac(mac, muteExpires);
     m_serverMessenger.notifyMacMutingOfPlayer(mac, muteExpires);
     final String muteUntil = (muteExpires == null ? "forever" : muteExpires.toString());
-    s_logger.info(String.format(
+    logger.info(String.format(
         "User was muted on the lobby(Mac mute). "
             + "Username: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s Expires: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
@@ -157,7 +157,7 @@ public class ModeratorController extends AbstractModeratorController {
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
     m_serverMessenger.removeConnection(node);
-    s_logger.info(String.format(
+    logger.info(String.format(
         "User was booted from the lobby. Username: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
@@ -171,7 +171,7 @@ public class ModeratorController extends AbstractModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    s_logger.info(String.format(
+    logger.info(String.format(
         "Getting salt for Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
@@ -193,7 +193,7 @@ public class ModeratorController extends AbstractModeratorController {
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.getChatLogHeadlessHostBot(hashedPassword, salt);
-    s_logger.info(String.format(
+    logger.info(String.format(
         ((response == null || response.equals("Invalid password!")) ? "Failed" : "Successful")
             + " Remote get Chat Log of Headless HostBot. "
             + "Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
@@ -216,7 +216,7 @@ public class ModeratorController extends AbstractModeratorController {
         (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response =
         remoteHostUtils.mutePlayerHeadlessHostBot(playerNameToBeMuted, minutes, hashedPassword, salt);
-    s_logger.info(String.format(
+    logger.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")") + " Remote Mute of " + playerNameToBeMuted
             + " for " + minutes
             + " minutes In Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
@@ -238,7 +238,7 @@ public class ModeratorController extends AbstractModeratorController {
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.bootPlayerHeadlessHostBot(playerNameToBeBooted, hashedPassword, salt);
-    s_logger.info(String.format(
+    logger.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")") + " Remote Boot of " + playerNameToBeBooted
             + " In Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
@@ -259,7 +259,7 @@ public class ModeratorController extends AbstractModeratorController {
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.banPlayerHeadlessHostBot(playerNameToBeBanned, hours, hashedPassword, salt);
-    s_logger.info(String.format(
+    logger.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")") + " Remote Ban of " + playerNameToBeBanned
             + " for " + hours
             + "hours  In Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
@@ -280,7 +280,7 @@ public class ModeratorController extends AbstractModeratorController {
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.stopGameHeadlessHostBot(hashedPassword, salt);
-    s_logger.info(String.format(
+    logger.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")")
             + " Remote Stopgame of Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
@@ -296,7 +296,7 @@ public class ModeratorController extends AbstractModeratorController {
     }
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
-    s_logger.info(String.format(
+    logger.info(String.format(
         "Started Remote Shutdown of Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
@@ -304,7 +304,7 @@ public class ModeratorController extends AbstractModeratorController {
     final IRemoteHostUtils remoteHostUtils =
         (IRemoteHostUtils) m_allMessengers.getRemoteMessenger().getRemote(remoteName);
     final String response = remoteHostUtils.shutDownHeadlessHostBot(hashedPassword, salt);
-    s_logger.info(String.format(
+    logger.info(String.format(
         (response == null ? "Successful" : "Failed (" + response + ")")
             + " Remote Shutdown of Headless HostBot. "
             + "Username: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",

--- a/src/main/java/games/strategy/engine/lobby/server/UserManager.java
+++ b/src/main/java/games/strategy/engine/lobby/server/UserManager.java
@@ -10,7 +10,7 @@ import games.strategy.engine.message.MessageContext;
 import games.strategy.net.INode;
 
 public class UserManager implements IUserManager {
-  private static final Logger s_logger = Logger.getLogger(UserManager.class.getName());
+  private static final Logger logger = Logger.getLogger(UserManager.class.getName());
 
   public void register(final IRemoteMessenger messenger) {
     messenger.registerRemote(this, IUserManager.USER_MANAGER);
@@ -23,7 +23,7 @@ public class UserManager implements IUserManager {
   public String updateUser(final String userName, final String emailAddress, final String hashedPassword) {
     final INode remote = MessageContext.getSender();
     if (!userName.equals(remote.getName())) {
-      s_logger
+      logger
           .severe("Tried to update user permission, but not correct user, userName:" + userName + " node:" + remote);
       return "Sorry, but I can't let you do that";
     }
@@ -57,7 +57,7 @@ public class UserManager implements IUserManager {
   public DBUser getUserInfo(final String userName) {
     final INode remote = MessageContext.getSender();
     if (!userName.equals(remote.getName())) {
-      s_logger.severe("Tried to get user info, but not correct user, userName:" + userName + " node:" + remote);
+      logger.severe("Tried to get user info, but not correct user, userName:" + userName + " node:" + remote);
       throw new IllegalStateException("Sorry, but I can't let you do that");
     }
     return new DbUserController().getUserByName(userName);

--- a/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
@@ -13,10 +13,10 @@ import java.util.logging.Logger;
  * Utilitiy class to create/read/delete bad words (there is no update).
  */
 public class BadWordController {
-  private static final Logger s_logger = Logger.getLogger(BadWordController.class.getName());
+  private static final Logger logger = Logger.getLogger(BadWordController.class.getName());
 
   public void addBadWord(final String word) {
-    s_logger.fine("Adding bad word word:" + word);
+    logger.fine("Adding bad word word:" + word);
     final Connection con = Database.getDerbyConnection();
     try {
       final PreparedStatement ps = con.prepareStatement("insert into bad_words (word) values (?)");
@@ -28,10 +28,10 @@ public class BadWordController {
       if (sqle.getErrorCode() == 30000) {
         // this is ok
         // the word is bad as expected
-        s_logger.info("Tried to create duplicate banned word:" + word + " error:" + sqle.getMessage());
+        logger.info("Tried to create duplicate banned word:" + word + " error:" + sqle.getMessage());
         return;
       }
-      s_logger.log(Level.SEVERE, "Error inserting banned word:" + word, sqle);
+      logger.log(Level.SEVERE, "Error inserting banned word:" + word, sqle);
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);
@@ -39,7 +39,7 @@ public class BadWordController {
   }
 
   void removeBannedWord(final String word) {
-    s_logger.fine("Removing banned word:" + word);
+    logger.fine("Removing banned word:" + word);
     final Connection con = Database.getDerbyConnection();
     try {
       final PreparedStatement ps = con.prepareStatement("delete from bad_words where word = ?");
@@ -48,7 +48,7 @@ public class BadWordController {
       ps.close();
       con.commit();
     } catch (final SQLException sqle) {
-      s_logger.log(Level.SEVERE, "Error deleting banned word:" + word, sqle);
+      logger.log(Level.SEVERE, "Error deleting banned word:" + word, sqle);
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);
@@ -69,7 +69,7 @@ public class BadWordController {
       ps.close();
       return rVal;
     } catch (final SQLException sqle) {
-      s_logger.info("Error reading bad words error:" + sqle.getMessage());
+      logger.info("Error reading bad words error:" + sqle.getMessage());
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -15,7 +15,7 @@ import games.strategy.util.Tuple;
  * Utilitiy class to create/read/delete banned macs (there is no update).
  */
 public class BannedMacController {
-  private static final Logger s_logger = Logger.getLogger(BannedMacController.class.getName());
+  private static final Logger logger = Logger.getLogger(BannedMacController.class.getName());
 
   /**
    * Ban the mac permanently.
@@ -39,7 +39,7 @@ public class BannedMacController {
     if (banTill != null) {
       banTillTs = new Timestamp(banTill.toEpochMilli());
     }
-    s_logger.fine("Banning mac:" + mac);
+    logger.fine("Banning mac:" + mac);
     final Connection con = Database.getDerbyConnection();
     try {
       final PreparedStatement ps = con.prepareStatement("insert into banned_macs (mac, ban_till) values (?, ?)");
@@ -52,10 +52,10 @@ public class BannedMacController {
       if (sqle.getErrorCode() == 30000) {
         // this is ok
         // the mac is banned as expected
-        s_logger.info("Tried to create duplicate banned mac:" + mac + " error:" + sqle.getMessage());
+        logger.info("Tried to create duplicate banned mac:" + mac + " error:" + sqle.getMessage());
         return;
       }
-      s_logger.log(Level.SEVERE, "Error inserting banned mac:" + mac, sqle);
+      logger.log(Level.SEVERE, "Error inserting banned mac:" + mac, sqle);
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);
@@ -63,7 +63,7 @@ public class BannedMacController {
   }
 
   private void removeBannedMac(final String mac) {
-    s_logger.fine("Removing banned mac:" + mac);
+    logger.fine("Removing banned mac:" + mac);
     final Connection con = Database.getDerbyConnection();
     try {
       final PreparedStatement ps = con.prepareStatement("delete from banned_macs where mac = ?");
@@ -72,7 +72,7 @@ public class BannedMacController {
       ps.close();
       con.commit();
     } catch (final SQLException sqle) {
-      s_logger.log(Level.SEVERE, "Error deleting banned mac:" + mac, sqle);
+      logger.log(Level.SEVERE, "Error deleting banned mac:" + mac, sqle);
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);
@@ -98,14 +98,14 @@ public class BannedMacController {
       if (found) {
         banTill = rs.getTimestamp(2);
         if (banTill != null && banTill.getTime() < System.currentTimeMillis()) {
-          s_logger.fine("Ban expired for:" + mac);
+          logger.fine("Ban expired for:" + mac);
           expired = true;
         }
       }
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      s_logger.info("Error for testing banned mac existence:" + mac + " error:" + sqle.getMessage());
+      logger.info("Error for testing banned mac existence:" + mac + " error:" + sqle.getMessage());
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -15,7 +15,7 @@ import games.strategy.util.Tuple;
  * Utilitiy class to create/read/delete banned usernames (there is no update).
  */
 public class BannedUsernameController {
-  private static final Logger s_logger = Logger.getLogger(BannedUsernameController.class.getName());
+  private static final Logger logger = Logger.getLogger(BannedUsernameController.class.getName());
 
   /**
    * Ban the username permanently.
@@ -39,7 +39,7 @@ public class BannedUsernameController {
     if (banTill != null) {
       banTillTs = new Timestamp(banTill.toEpochMilli());
     }
-    s_logger.fine("Banning username:" + username);
+    logger.fine("Banning username:" + username);
     final Connection con = Database.getDerbyConnection();
     try {
       final PreparedStatement ps =
@@ -53,10 +53,10 @@ public class BannedUsernameController {
       if (sqle.getErrorCode() == 30000) {
         // this is ok
         // the username is banned as expected
-        s_logger.info("Tried to create duplicate banned username:" + username + " error:" + sqle.getMessage());
+        logger.info("Tried to create duplicate banned username:" + username + " error:" + sqle.getMessage());
         return;
       }
-      s_logger.log(Level.SEVERE, "Error inserting banned username:" + username, sqle);
+      logger.log(Level.SEVERE, "Error inserting banned username:" + username, sqle);
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);
@@ -64,7 +64,7 @@ public class BannedUsernameController {
   }
 
   private void removeBannedUsername(final String username) {
-    s_logger.fine("Removing banned username:" + username);
+    logger.fine("Removing banned username:" + username);
     final Connection con = Database.getDerbyConnection();
     try {
       final PreparedStatement ps = con.prepareStatement("delete from banned_usernames where username = ?");
@@ -73,7 +73,7 @@ public class BannedUsernameController {
       ps.close();
       con.commit();
     } catch (final SQLException sqle) {
-      s_logger.log(Level.SEVERE, "Error deleting banned username:" + username, sqle);
+      logger.log(Level.SEVERE, "Error deleting banned username:" + username, sqle);
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);
@@ -99,14 +99,14 @@ public class BannedUsernameController {
       if (found) {
         banTill = rs.getTimestamp(2);
         if (banTill != null && banTill.getTime() < System.currentTimeMillis()) {
-          s_logger.fine("Ban expired for:" + username);
+          logger.fine("Ban expired for:" + username);
           expired = true;
         }
       }
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      s_logger.info("Error for testing banned username existence:" + username + " error:" + sqle.getMessage());
+      logger.info("Error for testing banned username existence:" + username + " error:" + sqle.getMessage());
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);

--- a/src/main/java/games/strategy/engine/lobby/server/db/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/Database.java
@@ -40,8 +40,8 @@ import games.strategy.util.ThreadUtil;
  * </p>
  */
 public class Database {
-  private static final Logger s_logger = Logger.getLogger(Database.class.getName());
-  private static final Object s_dbSetupLock = new Object();
+  private static final Logger logger = Logger.getLogger(Database.class.getName());
+  private static final Object dbSetupLock = new Object();
   private static boolean s_isDbSetup = false;
   private static boolean s_areDBTablesCreated = false;
 
@@ -109,7 +109,7 @@ public class Database {
    * The connection passed in to this method is not closed, except in case of error.
    */
   private static void ensureDbTablesAreCreated(final Connection conn) {
-    synchronized (s_dbSetupLock) {
+    synchronized (dbSetupLock) {
       try {
         if (s_areDBTablesCreated) {
           return;
@@ -176,7 +176,7 @@ public class Database {
         } catch (final SQLException e) {
           // ignore close errors
         }
-        s_logger.log(Level.SEVERE, sqle.getMessage(), sqle);
+        logger.log(Level.SEVERE, sqle.getMessage(), sqle);
         throw new IllegalStateException("Could not create tables");
       }
     }
@@ -186,7 +186,7 @@ public class Database {
    * Set up folders and environment variables for database.
    */
   private static void ensureDbIsSetup() {
-    synchronized (s_dbSetupLock) {
+    synchronized (dbSetupLock) {
       if (s_isDbSetup) {
         return;
       }
@@ -231,10 +231,10 @@ public class Database {
     final File backupRootDir = getBackupDir();
     final File backupDir = new File(backupRootDir, backupDirName);
     if (!backupDir.mkdirs()) {
-      s_logger.severe("Could not create backup dir" + backupDirName);
+      logger.severe("Could not create backup dir" + backupDirName);
       return;
     }
-    s_logger.log(Level.INFO, "Backing up database to " + backupDir.getAbsolutePath());
+    logger.log(Level.INFO, "Backing up database to " + backupDir.getAbsolutePath());
     try (final Connection con = getDerbyConnection()) {
       // http://www-128.ibm.com/developerworks/db2/library/techarticle/dm-0502thalamati/
       final String sqlstmt = "CALL SYSCS_UTIL.SYSCS_BACKUP_DATABASE(?)";
@@ -243,9 +243,9 @@ public class Database {
       cs.execute();
       cs.close();
     } catch (final Exception e) {
-      s_logger.log(Level.SEVERE, "Could not back up database", e);
+      logger.log(Level.SEVERE, "Could not back up database", e);
     }
-    s_logger.log(Level.INFO, "Done backing up database");
+    logger.log(Level.INFO, "Done backing up database");
   }
 
   private static File getBackupDir() {
@@ -257,9 +257,9 @@ public class Database {
       DriverManager.getConnection("jdbc:derby:ta_users;shutdown=true");
     } catch (final SQLException se) {
       if (se.getErrorCode() != 45000) {
-        s_logger.log(Level.WARNING, se.getMessage(), se);
+        logger.log(Level.WARNING, se.getMessage(), se);
       }
     }
-    s_logger.info("Databse shut down");
+    logger.info("Databse shut down");
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/db/DbUtil.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/DbUtil.java
@@ -6,13 +6,13 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 class DbUtil {
-  private static final Logger s_logger = Logger.getLogger(DbUtil.class.getName());
+  private static final Logger logger = Logger.getLogger(DbUtil.class.getName());
 
   static void closeConnection(final Connection con) {
     try {
       con.close();
     } catch (final SQLException e) {
-      s_logger.log(Level.WARNING, "Error closing connection", e);
+      logger.log(Level.WARNING, "Error closing connection", e);
     }
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
  * Utilitiy class to create/read/delete muted macs (there is no update).
  */
 public class MutedMacController {
-  private static final Logger s_logger = Logger.getLogger(MutedMacController.class.getName());
+  private static final Logger logger = Logger.getLogger(MutedMacController.class.getName());
 
   /**
    * Mute the mac permanently.
@@ -37,7 +37,7 @@ public class MutedMacController {
     if (muteTill != null) {
       muteTillTs = new Timestamp(muteTill.toEpochMilli());
     }
-    s_logger.fine("Muting mac:" + mac);
+    logger.fine("Muting mac:" + mac);
     final Connection con = Database.getDerbyConnection();
     try {
       final PreparedStatement ps = con.prepareStatement("insert into muted_macs (mac, mute_till) values (?, ?)");
@@ -50,10 +50,10 @@ public class MutedMacController {
       if (sqle.getErrorCode() == 30000) {
         // this is ok
         // the mac is muted as expected
-        s_logger.info("Tried to create duplicate muted mac:" + mac + " error:" + sqle.getMessage());
+        logger.info("Tried to create duplicate muted mac:" + mac + " error:" + sqle.getMessage());
         return;
       }
-      s_logger.log(Level.SEVERE, "Error inserting muted mac:" + mac, sqle);
+      logger.log(Level.SEVERE, "Error inserting muted mac:" + mac, sqle);
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);
@@ -61,7 +61,7 @@ public class MutedMacController {
   }
 
   private void removeMutedMac(final String mac) {
-    s_logger.fine("Removing muted mac:" + mac);
+    logger.fine("Removing muted mac:" + mac);
     final Connection con = Database.getDerbyConnection();
     try {
       final PreparedStatement ps = con.prepareStatement("delete from muted_macs where mac = ?");
@@ -70,7 +70,7 @@ public class MutedMacController {
       ps.close();
       con.commit();
     } catch (final SQLException sqle) {
-      s_logger.log(Level.SEVERE, "Error deleting muted mac:" + mac, sqle);
+      logger.log(Level.SEVERE, "Error deleting muted mac:" + mac, sqle);
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);
@@ -103,7 +103,7 @@ public class MutedMacController {
         final Timestamp muteTill = rs.getTimestamp(2);
         result = muteTill.getTime();
         if (result < System.currentTimeMillis()) {
-          s_logger.fine("Mute expired for:" + mac);
+          logger.fine("Mute expired for:" + mac);
           expired = true;
         }
       } else {
@@ -112,7 +112,7 @@ public class MutedMacController {
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      s_logger.info("Error for testing muted mac existence:" + mac + " error:" + sqle.getMessage());
+      logger.info("Error for testing muted mac existence:" + mac + " error:" + sqle.getMessage());
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
  * Utilitiy class to create/read/delete muted usernames (there is no update).
  */
 public class MutedUsernameController {
-  private static final Logger s_logger = Logger.getLogger(MutedUsernameController.class.getName());
+  private static final Logger logger = Logger.getLogger(MutedUsernameController.class.getName());
 
   /**
    * Mute the username permanently.
@@ -37,7 +37,7 @@ public class MutedUsernameController {
     if (muteTill != null) {
       muteTillTs = new Timestamp(muteTill.toEpochMilli());
     }
-    s_logger.fine("Muting username:" + username);
+    logger.fine("Muting username:" + username);
     final Connection con = Database.getDerbyConnection();
     try {
       final PreparedStatement ps =
@@ -51,10 +51,10 @@ public class MutedUsernameController {
       if (sqle.getErrorCode() == 30000) {
         // this is ok
         // the username is muted as expected
-        s_logger.info("Tried to create duplicate muted username:" + username + " error:" + sqle.getMessage());
+        logger.info("Tried to create duplicate muted username:" + username + " error:" + sqle.getMessage());
         return;
       }
-      s_logger.log(Level.SEVERE, "Error inserting muted username:" + username, sqle);
+      logger.log(Level.SEVERE, "Error inserting muted username:" + username, sqle);
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);
@@ -62,7 +62,7 @@ public class MutedUsernameController {
   }
 
   private void removeMutedUsername(final String username) {
-    s_logger.fine("Removing muted username:" + username);
+    logger.fine("Removing muted username:" + username);
     final Connection con = Database.getDerbyConnection();
     try {
       final PreparedStatement ps = con.prepareStatement("delete from muted_usernames where username = ?");
@@ -71,7 +71,7 @@ public class MutedUsernameController {
       ps.close();
       con.commit();
     } catch (final SQLException sqle) {
-      s_logger.log(Level.SEVERE, "Error deleting muted username:" + username, sqle);
+      logger.log(Level.SEVERE, "Error deleting muted username:" + username, sqle);
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);
@@ -104,7 +104,7 @@ public class MutedUsernameController {
         final Timestamp muteTill = rs.getTimestamp(2);
         result = muteTill.getTime();
         if (result < System.currentTimeMillis()) {
-          s_logger.fine("Mute expired for:" + username);
+          logger.fine("Mute expired for:" + username);
           expired = true;
         }
       } else {
@@ -113,7 +113,7 @@ public class MutedUsernameController {
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      s_logger.info("Error for testing muted username existence:" + username + " error:" + sqle.getMessage());
+      logger.info("Error for testing muted username existence:" + username + " error:" + sqle.getMessage());
       throw new IllegalStateException(sqle.getMessage());
     } finally {
       DbUtil.closeConnection(con);

--- a/src/main/java/games/strategy/engine/lobby/server/login/AccessLog.java
+++ b/src/main/java/games/strategy/engine/lobby/server/login/AccessLog.java
@@ -8,15 +8,15 @@ import java.util.logging.Logger;
  * be set up to log messages from this class to a seperate access log file.
  */
 class AccessLog {
-  private static final Logger s_logger = Logger.getLogger(AccessLog.class.getName());
+  private static final Logger logger = Logger.getLogger(AccessLog.class.getName());
 
   static void successfulLogin(final String userName, final InetAddress from) {
-    s_logger.info(String.format("LOGIN name: %s, ip: %s",
+    logger.info(String.format("LOGIN name: %s, ip: %s",
         userName, from.getHostAddress()));
   }
 
   static void failedLogin(final String userName, final InetAddress from, final String error) {
-    s_logger.info(String.format("FAILED name: %s, ip: %s",
+    logger.info(String.format("FAILED name: %s, ip: %s",
         userName, from.getHostAddress()));
   }
 }

--- a/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
+++ b/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
@@ -9,13 +9,13 @@ import java.util.logging.Logger;
 import games.strategy.util.Tuple;
 
 class RemoteInterfaceHelper {
-  private static final Logger s_logger = Logger.getLogger(RemoteInterfaceHelper.class.getName());
+  private static final Logger logger = Logger.getLogger(RemoteInterfaceHelper.class.getName());
 
   static int getNumber(final String methodName, final Class<?>[] argTypes, final Class<?> remoteInterface) {
     final Method[] methods = remoteInterface.getMethods();
     Arrays.sort(methods, methodComparator);
-    if (s_logger.isLoggable(Level.FINEST)) {
-      s_logger.fine("Sorted methods:" + Arrays.asList(methods));
+    if (logger.isLoggable(Level.FINEST)) {
+      logger.fine("Sorted methods:" + Arrays.asList(methods));
     }
     for (int i = 0; i < methods.length; i++) {
       if (methods[i].getName().equals(methodName)) {
@@ -43,8 +43,8 @@ class RemoteInterfaceHelper {
   static Tuple<String, Class<?>[]> getMethodInfo(final int methodNumber, final Class<?> remoteInterface) {
     final Method[] methods = remoteInterface.getMethods();
     Arrays.sort(methods, methodComparator);
-    if (s_logger.isLoggable(Level.FINEST)) {
-      s_logger.fine("Sorted methods:" + Arrays.asList(methods));
+    if (logger.isLoggable(Level.FINEST)) {
+      logger.fine("Sorted methods:" + Arrays.asList(methods));
     }
     return Tuple.of(methods[methodNumber].getName(), methods[methodNumber].getParameterTypes());
   }

--- a/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
+++ b/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
@@ -16,7 +16,7 @@ import games.strategy.util.Tuple;
  */
 public class RemoteMethodCall implements Externalizable {
   private static final long serialVersionUID = 4630825927685836207L;
-  private static final Logger s_logger = Logger.getLogger(RemoteMethodCall.class.getName());
+  private static final Logger logger = Logger.getLogger(RemoteMethodCall.class.getName());
   private String m_remoteName;
   private String m_methodName;
   private Object[] m_args;
@@ -45,8 +45,8 @@ public class RemoteMethodCall implements Externalizable {
     m_args = args;
     m_argTypes = classesToString(argTypes, args);
     m_methodNumber = RemoteInterfaceHelper.getNumber(methodName, argTypes, remoteInterface);
-    if (s_logger.isLoggable(Level.FINE)) {
-      s_logger.fine("Remote Method Call:" + debugMethodText());
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("Remote Method Call:" + debugMethodText());
     }
   }
 
@@ -178,8 +178,8 @@ public class RemoteMethodCall implements Externalizable {
     final Tuple<String, Class<?>[]> values = RemoteInterfaceHelper.getMethodInfo(m_methodNumber, remoteType);
     m_methodName = values.getFirst();
     m_argTypes = classesToString(values.getSecond(), m_args);
-    if (s_logger.isLoggable(Level.FINE)) {
-      s_logger.fine("Remote Method for class:" + remoteType.getSimpleName() + " Resolved To:" + debugMethodText());
+    if (logger.isLoggable(Level.FINE)) {
+      logger.fine("Remote Method for class:" + remoteType.getSimpleName() + " Resolved To:" + debugMethodText());
     }
   }
 }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -32,7 +32,7 @@ import games.strategy.util.ThreadUtil;
  * based on it.
  */
 public class UnifiedMessenger {
-  private static final Logger s_logger = Logger.getLogger(UnifiedMessenger.class.getName());
+  private static final Logger logger = Logger.getLogger(UnifiedMessenger.class.getName());
 
   private static final ExecutorService threadPool = Executors.newFixedThreadPool(15);
   // the messenger we are based on
@@ -121,7 +121,7 @@ public class UnifiedMessenger {
     try {
       latch.await();
     } catch (final InterruptedException e) {
-      s_logger.log(Level.WARNING, e.getMessage());
+      logger.log(Level.WARNING, e.getMessage());
     }
 
     synchronized (m_pendingLock) {
@@ -153,7 +153,7 @@ public class UnifiedMessenger {
       for (final RemoteMethodCallResults r : results) {
         if (r.getException() != null) {
           // don't swallow errors
-          s_logger.log(Level.WARNING, r.getException().getMessage(), r.getException());
+          logger.log(Level.WARNING, r.getException().getMessage(), r.getException());
         }
       }
     }

--- a/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
+++ b/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
@@ -13,7 +13,7 @@ import games.strategy.net.MessageHeader;
 import games.strategy.net.Node;
 
 public class ClientQuarantineConversation extends QuarantineConversation {
-  private static final Logger s_logger = Logger.getLogger(ClientQuarantineConversation.class.getName());
+  private static final Logger logger = Logger.getLogger(ClientQuarantineConversation.class.getName());
 
   private enum STEP {
     READ_CHALLENGE, READ_ERROR, READ_NAMES, READ_ADDRESS
@@ -97,8 +97,8 @@ public class ClientQuarantineConversation extends QuarantineConversation {
         case READ_CHALLENGE:
           // read name, send challenge
           final Map<String, String> challenge = (Map<String, String>) o;
-          if (s_logger.isLoggable(Level.FINER)) {
-            s_logger.log(Level.FINER, "read challenge:" + challenge);
+          if (logger.isLoggable(Level.FINER)) {
+            logger.log(Level.FINER, "read challenge:" + challenge);
           }
           if (challenge != null) {
             challengeProperties = challenge;
@@ -111,14 +111,14 @@ public class ClientQuarantineConversation extends QuarantineConversation {
             if (isClosed) {
               return ACTION.NONE;
             }
-            if (s_logger.isLoggable(Level.FINER)) {
-              s_logger.log(Level.FINER, "writing response" + challengeResponse);
+            if (logger.isLoggable(Level.FINER)) {
+              logger.log(Level.FINER, "writing response" + challengeResponse);
             }
             send((Serializable) challengeResponse);
           } else {
             showLatch.countDown();
-            if (s_logger.isLoggable(Level.FINER)) {
-              s_logger.log(Level.FINER, "sending null response");
+            if (logger.isLoggable(Level.FINER)) {
+              logger.log(Level.FINER, "sending null response");
             }
             send(null);
           }
@@ -126,8 +126,8 @@ public class ClientQuarantineConversation extends QuarantineConversation {
           return ACTION.NONE;
         case READ_ERROR:
           if (o != null) {
-            if (s_logger.isLoggable(Level.FINER)) {
-              s_logger.log(Level.FINER, "error:" + o);
+            if (logger.isLoggable(Level.FINER)) {
+              logger.log(Level.FINER, "error:" + o);
             }
             errorMessage = (String) o;
             // acknowledge the error
@@ -138,8 +138,8 @@ public class ClientQuarantineConversation extends QuarantineConversation {
           return ACTION.NONE;
         case READ_NAMES:
           final String[] strings = ((String[]) o);
-          if (s_logger.isLoggable(Level.FINER)) {
-            s_logger.log(Level.FINER, "new local name:" + strings[0]);
+          if (logger.isLoggable(Level.FINER)) {
+            logger.log(Level.FINER, "new local name:" + strings[0]);
           }
           localName = strings[0];
           serverName = strings[1];
@@ -151,11 +151,11 @@ public class ClientQuarantineConversation extends QuarantineConversation {
           // this is the address the server thinks he is
           networkVisibleAddress = address[0];
           serverLocalAddress = address[1];
-          if (s_logger.isLoggable(Level.FINE)) {
-            s_logger.log(Level.FINE, "Server local address:" + serverLocalAddress);
-            s_logger.log(Level.FINE, "channel remote address:" + channel.socket().getRemoteSocketAddress());
-            s_logger.log(Level.FINE, "network visible address:" + networkVisibleAddress);
-            s_logger.log(Level.FINE, "channel local adresss:" + channel.socket().getLocalSocketAddress());
+          if (logger.isLoggable(Level.FINE)) {
+            logger.log(Level.FINE, "Server local address:" + serverLocalAddress);
+            logger.log(Level.FINE, "channel remote address:" + channel.socket().getRemoteSocketAddress());
+            logger.log(Level.FINE, "network visible address:" + networkVisibleAddress);
+            logger.log(Level.FINE, "channel local adresss:" + channel.socket().getLocalSocketAddress());
           }
           return ACTION.UNQUARANTINE;
         default:
@@ -165,7 +165,7 @@ public class ClientQuarantineConversation extends QuarantineConversation {
       isClosed = true;
       showLatch.countDown();
       doneShowLatch.countDown();
-      s_logger.log(Level.SEVERE, "error with connection", t);
+      logger.log(Level.SEVERE, "error with connection", t);
       return ACTION.TERMINATE;
     }
   }

--- a/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/src/main/java/games/strategy/net/nio/Encoder.java
@@ -15,7 +15,7 @@ import games.strategy.net.Node;
  * Encodes data to be written by a writer.
  */
 class Encoder {
-  private static final Logger s_logger = Logger.getLogger(Encoder.class.getName());
+  private static final Logger logger = Logger.getLogger(Encoder.class.getName());
   private final NIOWriter m_writer;
   private final IObjectStreamFactory m_objectStreamFactory;
   private final NIOSocket m_nioSocket;
@@ -27,8 +27,8 @@ class Encoder {
   }
 
   void write(final SocketChannel to, final MessageHeader header) {
-    if (s_logger.isLoggable(Level.FINEST)) {
-      s_logger.log(Level.FINEST, "Encoding msg:" + header + " to:" + to);
+    if (logger.isLoggable(Level.FINEST)) {
+      logger.log(Level.FINEST, "Encoding msg:" + header + " to:" + to);
     }
     if (header.getFrom() == null) {
       throw new IllegalArgumentException("No from node");
@@ -44,11 +44,11 @@ class Encoder {
     } catch (final Exception e) {
       // we arent doing any io, just writing in memory
       // so something is very wrong
-      s_logger.log(Level.SEVERE, "Error writing object:" + header, e);
+      logger.log(Level.SEVERE, "Error writing object:" + header, e);
       return;
     }
-    if (s_logger.isLoggable(Level.FINER)) {
-      s_logger.log(Level.FINER, "encoded  msg:" + header.getMessage() + " size:" + data.size());
+    if (logger.isLoggable(Level.FINER)) {
+      logger.log(Level.FINER, "encoded  msg:" + header.getMessage() + " size:" + data.size());
     }
     m_writer.enque(data, to);
   }

--- a/src/main/java/games/strategy/net/nio/NIOSocket.java
+++ b/src/main/java/games/strategy/net/nio/NIOSocket.java
@@ -19,7 +19,7 @@ import games.strategy.net.MessageHeader;
  * by threads calling this object.
  */
 public class NIOSocket implements IErrorReporter {
-  private static final Logger s_logger = Logger.getLogger(NIOSocket.class.getName());
+  private static final Logger logger = Logger.getLogger(NIOSocket.class.getName());
   private final Encoder m_encoder;
   private final Decoder m_decoder;
   private final NIOWriter m_writer;
@@ -102,7 +102,7 @@ public class NIOSocket implements IErrorReporter {
       }
       channel.close();
     } catch (final IOException e1) {
-      s_logger.log(Level.FINE, "error closing channel", e1);
+      logger.log(Level.FINE, "error closing channel", e1);
     }
     m_decoder.closed(channel);
     m_writer.closed(channel);

--- a/src/main/java/games/strategy/net/nio/SocketWriteData.java
+++ b/src/main/java/games/strategy/net/nio/SocketWriteData.java
@@ -19,11 +19,11 @@ import java.util.logging.Logger;
  * </p>
  */
 class SocketWriteData {
-  private static final Logger s_logger = Logger.getLogger(SocketWriteData.class.getName());
-  private static final AtomicInteger s_counter = new AtomicInteger();
+  private static final Logger logger = Logger.getLogger(SocketWriteData.class.getName());
+  private static final AtomicInteger counter = new AtomicInteger();
   private final ByteBuffer m_size;
   private final ByteBuffer m_content;
-  private final int m_number = s_counter.incrementAndGet();
+  private final int m_number = counter.incrementAndGet();
   // how many times we called write before we finished writing ourselves
   private int m_writeCalls = 0;
 
@@ -58,8 +58,8 @@ class SocketWriteData {
       if (count == -1) {
         throw new IOException("triplea: end of stream detected");
       }
-      if (s_logger.isLoggable(Level.FINEST)) {
-        s_logger.finest("wrote size_buffer bytes:" + count);
+      if (logger.isLoggable(Level.FINEST)) {
+        logger.finest("wrote size_buffer bytes:" + count);
       }
       // we could not write everything
       if (m_size.hasRemaining()) {
@@ -70,8 +70,8 @@ class SocketWriteData {
     if (count == -1) {
       throw new IOException("triplea: end of stream detected");
     }
-    if (s_logger.isLoggable(Level.FINEST)) {
-      s_logger.finest("wrote content bytes:" + count);
+    if (logger.isLoggable(Level.FINEST)) {
+      logger.finest("wrote content bytes:" + count);
     }
     return !m_content.hasRemaining();
   }

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -71,7 +71,7 @@ import games.strategy.util.Tuple;
  */
 public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAPlayer {
 
-  private static final Logger s_logger = Logger.getLogger(AbstractAI.class.getName());
+  private static final Logger logger = Logger.getLogger(AbstractAI.class.getName());
 
   public AbstractAI(final String name, final String type) {
     super(name, type);
@@ -585,7 +585,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
         for (final Territory current : entry.getValue()) {
           final String error = battleDelegate.fightBattle(current, entry.getKey().isBombingRun(), entry.getKey());
           if (error != null) {
-            s_logger.fine(error);
+            logger.fine(error);
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProAI.java
@@ -58,7 +58,7 @@ import games.strategy.util.Tuple;
  */
 public class ProAI extends AbstractAI {
 
-  private static final Logger s_logger = Logger.getLogger(ProAI.class.getName());
+  private static final Logger logger = Logger.getLogger(ProAI.class.getName());
 
   // Odds calculator
   private static final IOddsCalculator concurrentCalc = new ConcurrentOddsCalculator("ProAI");
@@ -114,7 +114,7 @@ public class ProAI extends AbstractAI {
   }
 
   public static Logger getLogger() {
-    return s_logger;
+    return logger;
   }
 
   public static void gameOverClearCache() {

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -45,7 +45,7 @@ import games.strategy.util.Util;
  * A very weak ai, based on some simple rules.<p>
  */
 public class WeakAI extends AbstractAI {
-  private static final Logger s_logger = Logger.getLogger(WeakAI.class.getName());
+  private static final Logger logger = Logger.getLogger(WeakAI.class.getName());
 
   /** Creates new WeakAI. */
   public WeakAI(final String name, final String type) {
@@ -242,7 +242,7 @@ public class WeakAI extends AbstractAI {
       pause();
       if (moveRoutes.get(i) == null || moveRoutes.get(i).getEnd() == null || moveRoutes.get(i).getStart() == null
           || moveRoutes.get(i).hasNoSteps()) {
-        s_logger.fine("Route not valid" + moveRoutes.get(i) + " units:" + moveUnits.get(i));
+        logger.fine("Route not valid" + moveRoutes.get(i) + " units:" + moveUnits.get(i));
         continue;
       }
       final String result;
@@ -252,7 +252,7 @@ public class WeakAI extends AbstractAI {
         result = moveDel.move(moveUnits.get(i), moveRoutes.get(i), transportsToLoad.get(i));
       }
       if (result != null) {
-        s_logger.fine("could not move " + moveUnits.get(i) + " over " + moveRoutes.get(i) + " because : " + result);
+        logger.fine("could not move " + moveUnits.get(i) + " over " + moveRoutes.get(i) + " because : " + result);
       }
     }
   }
@@ -379,7 +379,7 @@ public class WeakAI extends AbstractAI {
           ourStrength += AIUtils.strength(owned.getUnits().getMatches(attackable), true, true);
         }
         if (ourStrength > 1.32 * enemyStrength) {
-          s_logger.fine("Attacking : " + enemy + " our strength:" + ourStrength + " enemy strength" + enemyStrength);
+          logger.fine("Attacking : " + enemy + " our strength:" + ourStrength + " enemy strength" + enemyStrength);
           for (final Territory owned : attackFrom) {
             if (dontMoveFrom.contains(owned)) {
               continue;
@@ -686,7 +686,7 @@ public class WeakAI extends AbstractAI {
               moveRoutes.add(data.getMap().getRoute(owned, enemy));
             }
           }
-          s_logger.fine("Attacking : " + enemy + " our strength:" + ourStrength + " enemy strength" + enemyStrength
+          logger.fine("Attacking : " + enemy + " our strength:" + ourStrength + " enemy strength" + enemyStrength
               + " remaining strength needed " + remainingStrengthNeeded);
         }
       }
@@ -1055,8 +1055,8 @@ public class WeakAI extends AbstractAI {
   private void doPlace(final Territory where, final Collection<Unit> toPlace, final IAbstractPlaceDelegate del) {
     final String message = del.placeUnits(new ArrayList<>(toPlace), where, IAbstractPlaceDelegate.BidMode.NOT_BID);
     if (message != null) {
-      s_logger.fine(message);
-      s_logger.fine("Attempt was at:" + where + " with:" + toPlace);
+      logger.fine(message);
+      logger.fine("Attempt was at:" + where + " with:" + toPlace);
     }
     pause();
   }

--- a/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -54,12 +54,12 @@ public abstract class TechAdvance extends NamedAttachable {
   public static final String TECH_PROPERTY_INDUSTRIAL_TECHNOLOGY = "industrialTechnology";
   public static final String TECH_NAME_DESTROYER_BOMBARD = "Destroyer Bombard";
   public static final String TECH_PROPERTY_DESTROYER_BOMBARD = "destroyerBombard";
-  public static final List<String> s_allPreDefinedTechnologyNames = Collections.unmodifiableList(
+  public static final List<String> ALL_PREDEFINED_TECHNOLOGY_NAMES = Collections.unmodifiableList(
       Arrays.asList(TECH_NAME_SUPER_SUBS, TECH_NAME_JET_POWER, TECH_NAME_IMPROVED_SHIPYARDS, TECH_NAME_AA_RADAR,
           TECH_NAME_LONG_RANGE_AIRCRAFT, TECH_NAME_HEAVY_BOMBER, TECH_NAME_IMPROVED_ARTILLERY_SUPPORT,
           TECH_NAME_ROCKETS, TECH_NAME_PARATROOPERS, TECH_NAME_INCREASED_FACTORY_PRODUCTION, TECH_NAME_WAR_BONDS,
           TECH_NAME_MECHANIZED_INFANTRY, TECH_NAME_INDUSTRIAL_TECHNOLOGY, TECH_NAME_DESTROYER_BOMBARD));
-  private static final Map<String, Class<? extends TechAdvance>> s_allPreDefinedTechnologies =
+  private static final Map<String, Class<? extends TechAdvance>> ALL_PREDEFINED_TECHNOLOGIES =
       createPreDefinedTechnologyMap();
 
   private static Map<String, Class<? extends TechAdvance>> createPreDefinedTechnologyMap() {
@@ -164,7 +164,7 @@ public abstract class TechAdvance extends NamedAttachable {
   }
 
   public static TechAdvance findDefinedAdvanceAndCreateAdvance(final String s, final GameData data) {
-    final Class<? extends TechAdvance> clazz = s_allPreDefinedTechnologies.get(s);
+    final Class<? extends TechAdvance> clazz = ALL_PREDEFINED_TECHNOLOGIES.get(s);
     if (clazz == null) {
       throw new IllegalArgumentException(s + " is not a valid technology");
     }

--- a/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -24,7 +24,7 @@ public class DiceImageFactory {
   public int DIE_HEIGHT = 32;
   private final int m_diceSides;
   private final ResourceLoader m_resourceLoader;
-  private static final Color s_ignored = new Color(100, 100, 100, 200);
+  private static final Color IGNORED = new Color(100, 100, 100, 200);
   // maps Integer -> Image
   private final Map<Integer, Image> m_images = new HashMap<>();
   private final Map<Integer, Image> m_imagesHit = new HashMap<>();
@@ -36,7 +36,7 @@ public class DiceImageFactory {
     m_resourceLoader = loader;
     generateDice(pipSize, Color.black, m_images);
     generateDice(pipSize, Color.red, m_imagesHit);
-    generateDice(pipSize, s_ignored, m_imagesIgnored);
+    generateDice(pipSize, IGNORED, m_imagesIgnored);
   }
 
   private void generateDice(final int pipSize, final Color color, final Map<Integer, Image> images) {
@@ -49,7 +49,7 @@ public class DiceImageFactory {
           img = iFactory.getImage("dice/" + i + ".png", false);
         } else if (color == Color.red) {
           img = iFactory.getImage("dice/" + i + "_hit.png", false);
-        } else if (color == s_ignored) {
+        } else if (color == IGNORED) {
           img = iFactory.getImage("dice/" + i + "_ignored.png", false);
         }
       }
@@ -118,7 +118,7 @@ public class DiceImageFactory {
           graphics.setColor(Color.BLACK);
           break;
         case IGNORED:
-          graphics.setColor(s_ignored);
+          graphics.setColor(IGNORED);
           break;
         default:
           throw new IllegalStateException("??");

--- a/src/main/java/games/strategy/triplea/image/ImageRef.java
+++ b/src/main/java/games/strategy/triplea/image/ImageRef.java
@@ -15,16 +15,16 @@ import games.strategy.debug.ClientLogger;
  * getImage method ensures that the image will be loaded before returning.
  */
 class ImageRef {
-  public static final ReferenceQueue<Image> s_referenceQueue = new ReferenceQueue<>();
-  public static final Logger s_logger = Logger.getLogger(ImageRef.class.getName());
-  private static final AtomicInteger s_imageCount = new AtomicInteger();
+  private static final ReferenceQueue<Image> referenceQueue = new ReferenceQueue<>();
+  private static final Logger logger = Logger.getLogger(ImageRef.class.getName());
+  private static final AtomicInteger imageCount = new AtomicInteger();
 
   static {
     final Runnable r = () -> {
       while (true) {
         try {
-          s_referenceQueue.remove();
-          s_logger.finer("Removed soft reference image. Image count:" + s_imageCount.decrementAndGet());
+          referenceQueue.remove();
+          logger.finer("Removed soft reference image. Image count:" + imageCount.decrementAndGet());
         } catch (final InterruptedException e) {
           ClientLogger.logQuietly(e);
         }
@@ -39,9 +39,9 @@ class ImageRef {
 
   // private final Object m_hardRef;
   public ImageRef(final Image image) {
-    m_image = new SoftReference<>(image, s_referenceQueue);
+    m_image = new SoftReference<>(image, referenceQueue);
     // m_hardRef = image;
-    s_logger.finer("Added soft reference image. Image count:" + s_imageCount.incrementAndGet());
+    logger.finer("Added soft reference image. Image count:" + imageCount.incrementAndGet());
   }
 
   public Image getImage() {

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -41,7 +41,7 @@ public final class TileImageFactory {
   private final Composite composite = AlphaComposite.Src;
   private static GraphicsConfiguration configuration =
       GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
-  private static final Logger s_logger = Logger.getLogger(TileImageFactory.class.getName());
+  private static final Logger logger = Logger.getLogger(TileImageFactory.class.getName());
   private double m_scale = 1;
   // maps image name to ImageRef
   private HashMap<String, ImageRef> m_imageCache = new HashMap<>();
@@ -248,7 +248,7 @@ public final class TileImageFactory {
     // Get buffered images
     try {
       final Stopwatch loadingImages =
-          new Stopwatch(s_logger, Level.FINE, "Loading images:" + urlrelief + " and " + urlBase);
+          new Stopwatch(logger, Level.FINE, "Loading images:" + urlrelief + " and " + urlBase);
       if (urlrelief != null) {
         reliefFile = loadCompatibleImage(urlrelief);
       }
@@ -308,10 +308,10 @@ public final class TileImageFactory {
       final boolean cache, final boolean scale) {
     Image image;
     try {
-      final Stopwatch loadingImages = new Stopwatch(s_logger, Level.FINE, "Loading image:" + imageLocation);
+      final Stopwatch loadingImages = new Stopwatch(logger, Level.FINE, "Loading image:" + imageLocation);
       final BufferedImage fromFile = ImageIO.read(imageLocation);
       loadingImages.done();
-      final Stopwatch copyingImage = new Stopwatch(s_logger, Level.FINE, "Copying image:" + imageLocation);
+      final Stopwatch copyingImage = new Stopwatch(logger, Level.FINE, "Copying image:" + imageLocation);
       // if we dont copy, drawing the tile to the screen takes significantly longer
       // has something to do with the colour model and type of the images
       // some images can be copeid quickly to the screen

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/ConcurrentOddsCalculator.java
@@ -29,7 +29,7 @@ import games.strategy.util.CountUpAndDownLatch;
  * across these workers. This is mainly to be used by AIs since they call the OddsCalculator a lot.
  */
 public class ConcurrentOddsCalculator implements IOddsCalculator {
-  private static final Logger s_logger = Logger.getLogger(ConcurrentOddsCalculator.class.getName());
+  private static final Logger logger = Logger.getLogger(ConcurrentOddsCalculator.class.getName());
   private static final int MAX_THREADS = Math.max(1, Runtime.getRuntime().availableProcessors());
 
   private int currentThreads = MAX_THREADS;
@@ -58,7 +58,7 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
   public ConcurrentOddsCalculator(final String threadNamePrefix) {
     executor = Executors.newFixedThreadPool(MAX_THREADS,
         new DaemonThreadFactory(true, threadNamePrefix + " ConcurrentOddsCalculator Worker"));
-    s_logger.fine("Initialized executor thread pool with size: " + MAX_THREADS);
+    logger.fine("Initialized executor thread pool with size: " + MAX_THREADS);
   }
 
   @Override
@@ -190,7 +190,7 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
     latchWorkerThreadsCreation.countDown();
     // allow calcing and other stuff to go ahead
     latchSetData.countDown();
-    s_logger.fine("Initialized worker thread pool with size: " + workers.size());
+    logger.fine("Initialized worker thread pool with size: " + workers.size());
   }
 
   @Override
@@ -290,7 +290,7 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
       }
       // we don't want to scare the user with 8+ errors all for the same thing
       if (!interruptExceptions.isEmpty()) {
-        s_logger.log(Level.SEVERE, interruptExceptions.size() + " Battle results workers interrupted",
+        logger.log(Level.SEVERE, interruptExceptions.size() + " Battle results workers interrupted",
             interruptExceptions.iterator().next());
       }
       if (!executionExceptions.isEmpty()) {
@@ -298,7 +298,7 @@ public class ConcurrentOddsCalculator implements IOddsCalculator {
         for (final Set<ExecutionException> entry : executionExceptions.values()) {
           if (!entry.isEmpty()) {
             e = entry.iterator().next();
-            s_logger.log(Level.SEVERE, entry.size() + " Battle results workers aborted by exception", e.getCause());
+            logger.log(Level.SEVERE, entry.size() + " Battle results workers aborted by exception", e.getCause());
           }
         }
         if (e != null) {

--- a/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
@@ -21,7 +21,7 @@ import games.strategy.ui.ImageScrollerSmallView;
 import games.strategy.ui.Util;
 
 public class SmallMapImageManager {
-  private static final Logger s_logger = Logger.getLogger(SmallMapImageManager.class.getName());
+  private static final Logger logger = Logger.getLogger(SmallMapImageManager.class.getName());
   private final ImageScrollerSmallView view;
   private static final int UNIT_BOX_SIZE = 4;
   private Image offscreen;
@@ -40,7 +40,7 @@ public class SmallMapImageManager {
   }
 
   public void update(final GameData data, final MapData mapData) {
-    final Stopwatch stopwatch = new Stopwatch(s_logger, Level.FINEST, "Small map updating took");
+    final Stopwatch stopwatch = new Stopwatch(logger, Level.FINEST, "Small map updating took");
     final Graphics onScreenGraphics = view.getOffScreenImage().getGraphics();
     onScreenGraphics.drawImage(offscreen, 0, 0, null);
     for (final UnitsDrawer drawer : new ArrayList<>(tileManager.getUnitDrawables())) {

--- a/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -29,9 +29,9 @@ import games.strategy.triplea.util.Stopwatch;
 import games.strategy.ui.Util;
 
 public class Tile {
-  public static final LockUtil S_TILE_LOCKUTIL = LockUtil.INSTANCE;
+  public static final LockUtil LOCK_UTIL = LockUtil.INSTANCE;
   private static final boolean DRAW_DEBUG = false;
-  private static final Logger s_logger = Logger.getLogger(Tile.class.getName());
+  private static final Logger logger = Logger.getLogger(Tile.class.getName());
 
   // allow the gc to implement memory management
   private SoftReference<Image> imageRef;
@@ -60,11 +60,11 @@ public class Tile {
   }
 
   public void acquireLock() {
-    S_TILE_LOCKUTIL.acquireLock(lock);
+    LOCK_UTIL.acquireLock(lock);
   }
 
   public void releaseLock() {
-    S_TILE_LOCKUTIL.releaseLock(lock);
+    LOCK_UTIL.releaseLock(lock);
   }
 
   public Image getImage(final GameData data, final MapData mapData) {
@@ -121,7 +121,7 @@ public class Tile {
     } else {
       scaled = unscaled;
     }
-    final Stopwatch stopWatch = new Stopwatch(s_logger, Level.FINEST, "Drawing Tile at" + bounds);
+    final Stopwatch stopWatch = new Stopwatch(logger, Level.FINEST, "Drawing Tile at" + bounds);
     // clear
     g.setColor(Color.BLACK);
     g.fill(new Rectangle(0, 0, TileManager.TILE_SIZE, TileManager.TILE_SIZE));

--- a/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -58,7 +58,7 @@ import games.strategy.ui.Util;
 import games.strategy.util.Tuple;
 
 public class TileManager {
-  private static final Logger s_logger = Logger.getLogger(TileManager.class.getName());
+  private static final Logger logger = Logger.getLogger(TileManager.class.getName());
   public static final int TILE_SIZE = 256;
 
   private List<Tile> tiles = new ArrayList<>();
@@ -142,11 +142,11 @@ public class TileManager {
   }
 
   private void acquireLock() {
-    Tile.S_TILE_LOCKUTIL.acquireLock(lock);
+    Tile.LOCK_UTIL.acquireLock(lock);
   }
 
   private void releaseLock() {
-    Tile.S_TILE_LOCKUTIL.releaseLock(lock);
+    Tile.LOCK_UTIL.releaseLock(lock);
   }
 
   Collection<UnitsDrawer> getUnitDrawables() {
@@ -239,7 +239,7 @@ public class TileManager {
     try {
       acquireLock();
       try {
-        s_logger.log(Level.FINER, "Updating " + territory.getName());
+        logger.log(Level.FINER, "Updating " + territory.getName());
         clearTerritory(territory);
         drawTerritory(territory, data, mapData);
       } finally {

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -67,7 +67,7 @@ public class MapPropertiesMaker extends JFrame {
   private static final String TRIPLEA_UNIT_ZOOM = "triplea.unit.zoom";
   private static final String TRIPLEA_UNIT_WIDTH = "triplea.unit.width";
   private static final String TRIPLEA_UNIT_HEIGHT = "triplea.unit.height";
-  private static final MapProperties s_mapProperties = new MapProperties();
+  private static final MapProperties mapProperties = new MapProperties();
   private static JPanel s_playerColorChooser = new JPanel();
 
   public static String[] getProperties() {
@@ -149,7 +149,7 @@ public class MapPropertiesMaker extends JFrame {
     panel.add(new JLabel("The Width in Pixels of your map: "), new GridBagConstraints(0, row, 1, 1, 1, 1,
         GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
     final IntTextField widthField = new IntTextField(0, Integer.MAX_VALUE);
-    widthField.setText("" + s_mapProperties.getMapWidth());
+    widthField.setText("" + mapProperties.getMapWidth());
     widthField.addFocusListener(new FocusListener() {
       @Override
       public void focusGained(final FocusEvent e) {}
@@ -157,11 +157,11 @@ public class MapPropertiesMaker extends JFrame {
       @Override
       public void focusLost(final FocusEvent e) {
         try {
-          s_mapProperties.setMapWidth(Integer.parseInt(widthField.getText()));
+          mapProperties.setMapWidth(Integer.parseInt(widthField.getText()));
         } catch (final Exception ex) {
           // ignore malformed input
         }
-        widthField.setText("" + s_mapProperties.getMapWidth());
+        widthField.setText("" + mapProperties.getMapWidth());
       }
     });
     panel.add(widthField, new GridBagConstraints(1, row++, 1, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
@@ -169,7 +169,7 @@ public class MapPropertiesMaker extends JFrame {
     panel.add(new JLabel("The Height in Pixels of your map: "), new GridBagConstraints(0, row, 1, 1, 1, 1,
         GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
     final IntTextField heightField = new IntTextField(0, Integer.MAX_VALUE);
-    heightField.setText("" + s_mapProperties.getMapHeight());
+    heightField.setText("" + mapProperties.getMapHeight());
     heightField.addFocusListener(new FocusListener() {
       @Override
       public void focusGained(final FocusEvent e) {}
@@ -177,11 +177,11 @@ public class MapPropertiesMaker extends JFrame {
       @Override
       public void focusLost(final FocusEvent e) {
         try {
-          s_mapProperties.setMapHeight(Integer.parseInt(heightField.getText()));
+          mapProperties.setMapHeight(Integer.parseInt(heightField.getText()));
         } catch (final Exception ex) {
           // ignore malformed input
         }
-        heightField.setText("" + s_mapProperties.getMapHeight());
+        heightField.setText("" + mapProperties.getMapHeight());
       }
     });
     panel.add(heightField, new GridBagConstraints(1, row++, 1, 1, 1, 1, GridBagConstraints.WEST,
@@ -192,7 +192,7 @@ public class MapPropertiesMaker extends JFrame {
         new GridBagConstraints(0, row, 1, 1, 1, 1, GridBagConstraints.EAST, GridBagConstraints.NONE,
             new Insets(10, 10, 10, 10), 0, 0));
     final DoubleTextField scaleField = new DoubleTextField(0.1d, 2.0d);
-    scaleField.setText("" + s_mapProperties.getUnitsScale());
+    scaleField.setText("" + mapProperties.getUnitsScale());
     scaleField.addFocusListener(new FocusListener() {
       @Override
       public void focusGained(final FocusEvent e) {}
@@ -200,12 +200,12 @@ public class MapPropertiesMaker extends JFrame {
       @Override
       public void focusLost(final FocusEvent e) {
         try {
-          // s_mapProperties.setUNITS_SCALE(Double.parseDouble(scaleField.getText()));
-          s_mapProperties.setUnitsScale(scaleField.getText());
+          // mapProperties.setUNITS_SCALE(Double.parseDouble(scaleField.getText()));
+          mapProperties.setUnitsScale(scaleField.getText());
         } catch (final Exception ex) {
           // ignore malformed input
         }
-        scaleField.setText("" + s_mapProperties.getUnitsScale());
+        scaleField.setText("" + mapProperties.getUnitsScale());
       }
     });
     panel.add(scaleField, new GridBagConstraints(1, row++, 1, 1, 1, 1, GridBagConstraints.WEST, GridBagConstraints.NONE,
@@ -218,9 +218,9 @@ public class MapPropertiesMaker extends JFrame {
     final JButton showMore = new JButton("Show All Options");
     showMore.addActionListener(SwingAction.of("Show All Options", e -> {
       final Tuple<PropertiesUI, List<MapPropertyWrapper<?>>> propertyWrapperUi =
-          MapPropertiesMaker.s_mapProperties.propertyWrapperUi(true);
+          MapPropertiesMaker.mapProperties.propertyWrapperUi(true);
       JOptionPane.showMessageDialog(MapPropertiesMaker.this, propertyWrapperUi.getFirst());
-      s_mapProperties.writePropertiesToObject(propertyWrapperUi.getSecond());
+      mapProperties.writePropertiesToObject(propertyWrapperUi.getSecond());
       MapPropertiesMaker.this.createPlayerColorChooser();
       MapPropertiesMaker.this.validate();
       MapPropertiesMaker.this.repaint();
@@ -235,7 +235,7 @@ public class MapPropertiesMaker extends JFrame {
     s_playerColorChooser.removeAll();
     s_playerColorChooser.setLayout(new GridBagLayout());
     int row = 0;
-    for (final Entry<String, Color> entry : s_mapProperties.getColorMap().entrySet()) {
+    for (final Entry<String, Color> entry : mapProperties.getColorMap().entrySet()) {
       s_playerColorChooser.add(new JLabel(entry.getKey()), new GridBagConstraints(0, row, 1, 1, 1, 1,
           GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
       final JLabel label = new JLabel(entry.getKey()) {
@@ -254,7 +254,7 @@ public class MapPropertiesMaker extends JFrame {
         public void mouseClicked(final MouseEvent e) {
           System.out.println(label.getBackground());
           final Color color = JColorChooser.showDialog(label, "Choose color", label.getBackground());
-          s_mapProperties.getColorMap().put(label.getText(), color);
+          mapProperties.getColorMap().put(label.getText(), color);
           MapPropertiesMaker.this.createPlayerColorChooser();
           MapPropertiesMaker.this.validate();
           MapPropertiesMaker.this.repaint();
@@ -280,7 +280,7 @@ public class MapPropertiesMaker extends JFrame {
 
         @Override
         public void actionPerformed(final ActionEvent e) {
-          s_mapProperties.getColorMap().remove(removePlayer.getText().replaceFirst("Remove ", ""));
+          mapProperties.getColorMap().remove(removePlayer.getText().replaceFirst("Remove ", ""));
           MapPropertiesMaker.this.createPlayerColorChooser();
           MapPropertiesMaker.this.validate();
           MapPropertiesMaker.this.repaint();
@@ -290,13 +290,13 @@ public class MapPropertiesMaker extends JFrame {
           GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
       row++;
     }
-    final JTextField nameTextField = new JTextField("Player" + (s_mapProperties.getColorMap().size() + 1));
+    final JTextField nameTextField = new JTextField("Player" + (mapProperties.getColorMap().size() + 1));
     final Dimension ourMinimum = new Dimension(150, 30);
     nameTextField.setMinimumSize(ourMinimum);
     nameTextField.setPreferredSize(ourMinimum);
     final JButton addPlayer = new JButton("Add Another Player");
     addPlayer.addActionListener(SwingAction.of("Add Another Player", e -> {
-      s_mapProperties.getColorMap().put(nameTextField.getText(), Color.GREEN);
+      mapProperties.getColorMap().put(nameTextField.getText(), Color.GREEN);
       MapPropertiesMaker.this.createPlayerColorChooser();
       MapPropertiesMaker.this.validate();
       MapPropertiesMaker.this.repaint();
@@ -322,7 +322,7 @@ public class MapPropertiesMaker extends JFrame {
     } catch (final HeadlessException | IOException ex) {
       ClientLogger.logQuietly(ex);
     }
-    for (final Method setter : s_mapProperties.getClass().getMethods()) {
+    for (final Method setter : mapProperties.getClass().getMethods()) {
       final boolean startsWithSet = setter.getName().startsWith("set");
       if (!startsWithSet) {
         continue;
@@ -358,13 +358,13 @@ public class MapPropertiesMaker extends JFrame {
 
   private static String getOutPutString() {
     final StringBuilder outString = new StringBuilder();
-    for (final Method outMethod : s_mapProperties.getClass().getMethods()) {
+    for (final Method outMethod : mapProperties.getClass().getMethods()) {
       final boolean startsWithSet = outMethod.getName().startsWith("out");
       if (!startsWithSet) {
         continue;
       }
       try {
-        outString.append(outMethod.invoke(s_mapProperties));
+        outString.append(outMethod.invoke(mapProperties));
       } catch (final IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
         ClientLogger.logQuietly(e);
       }
@@ -423,8 +423,8 @@ public class MapPropertiesMaker extends JFrame {
     if (zoomString != null && zoomString.length() > 0) {
       try {
         final double unit_zoom_percent = Double.parseDouble(zoomString);
-        // s_mapProperties.setUNITS_SCALE(unit_zoom_percent);
-        s_mapProperties.setUnitsScale(zoomString);
+        // mapProperties.setUNITS_SCALE(unit_zoom_percent);
+        mapProperties.setUnitsScale(zoomString);
         System.out.println("Unit Zoom Percent to use: " + unit_zoom_percent);
       } catch (final Exception ex) {
         System.err.println("Not a decimal percentage: " + zoomString);
@@ -434,8 +434,8 @@ public class MapPropertiesMaker extends JFrame {
     if (widthString != null && widthString.length() > 0) {
       try {
         final int unit_width = Integer.parseInt(widthString);
-        s_mapProperties.setUnitsWidth(unit_width);
-        s_mapProperties.setUnitsCounterOffsetWidth(unit_width / 4);
+        mapProperties.setUnitsWidth(unit_width);
+        mapProperties.setUnitsCounterOffsetWidth(unit_width / 4);
         System.out.println("Unit Width to use: " + unit_width);
       } catch (final Exception ex) {
         System.err.println("Not an integer: " + widthString);
@@ -445,8 +445,8 @@ public class MapPropertiesMaker extends JFrame {
     if (heightString != null && heightString.length() > 0) {
       try {
         final int unit_height = Integer.parseInt(heightString);
-        s_mapProperties.setUnitsHeight(unit_height);
-        s_mapProperties.setUnitsCounterOffsetHeight(unit_height);
+        mapProperties.setUnitsHeight(unit_height);
+        mapProperties.setUnitsCounterOffsetHeight(unit_height);
         System.out.println("Unit Height to use: " + unit_height);
       } catch (final Exception ex) {
         System.err.println("Not an integer: " + heightString);


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule, specifically removing the `s_` prefix from all `static final` fields.  In some cases, I renamed fields from `camelCase` to `UPPER_SNAKE_CASE` if it was clear that the field referenced an immutable value.