### PR TITLE
Serialization proxy: Add dice sides to game data memento

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameData.java
+++ b/src/main/java/games/strategy/engine/data/GameData.java
@@ -509,7 +509,9 @@ public class GameData implements Serializable {
   public String toString() {
     final StringBuilder sb = new StringBuilder();
     sb.append("GameData[");
-    sb.append("gameName=");
+    sb.append("diceSides=");
+    sb.append(diceSides);
+    sb.append(", gameName=");
     sb.append(gameName);
     sb.append(", gameVersion=");
     sb.append(gameVersion);

--- a/src/main/java/games/strategy/engine/data/GameDataMemento.java
+++ b/src/main/java/games/strategy/engine/data/GameDataMemento.java
@@ -36,6 +36,7 @@ public final class GameDataMemento {
 
   @VisibleForTesting
   interface PropertyNames {
+    String DICE_SIDES = "diceSides";
     String NAME = "name";
     String VERSION = "version";
   }
@@ -51,7 +52,7 @@ public final class GameDataMemento {
    * @return A new game data memento exporter.
    */
   public static MementoExporter<GameData> newExporter() {
-    return newExporter(DEFAULT_EXPORT_OPTIONS_BY_NAME);
+    return newExporterInternal();
   }
 
   /**
@@ -64,6 +65,16 @@ public final class GameDataMemento {
   public static MementoExporter<GameData> newExporter(final Map<ExportOptionName, Object> optionsByName) {
     checkNotNull(optionsByName);
 
+    return newExporterInternal(optionsByName);
+  }
+
+  @VisibleForTesting
+  static PropertyBagMementoExporter<GameData> newExporterInternal() {
+    return newExporterInternal(DEFAULT_EXPORT_OPTIONS_BY_NAME);
+  }
+
+  @VisibleForTesting
+  static PropertyBagMementoExporter<GameData> newExporterInternal(final Map<ExportOptionName, Object> optionsByName) {
     return new PropertyBagMementoExporter<>(SCHEMA_ID, new ExportHandler(optionsByName));
   }
 
@@ -88,6 +99,7 @@ public final class GameDataMemento {
 
     @Override
     public void exportProperties(final GameData gameData, final Map<String, Object> propertiesByName) {
+      propertiesByName.put(PropertyNames.DICE_SIDES, gameData.getDiceSides());
       propertiesByName.put(PropertyNames.NAME, gameData.getGameName());
       propertiesByName.put(PropertyNames.VERSION, gameData.getGameVersion());
       // TODO: handle remaining properties
@@ -107,6 +119,7 @@ public final class GameDataMemento {
     @Override
     public GameData importProperties(final Map<String, Object> propertiesByName) throws MementoImportException {
       final GameData gameData = new GameData();
+      gameData.setDiceSides(getRequiredProperty(propertiesByName, PropertyNames.DICE_SIDES, Integer.class));
       gameData.setGameName(getRequiredProperty(propertiesByName, PropertyNames.NAME, String.class));
       gameData.setGameVersion(getRequiredProperty(propertiesByName, PropertyNames.VERSION, Version.class));
       // TODO: handle remaining properties

--- a/src/test/java/games/strategy/engine/data/GameDataMementoTest.java
+++ b/src/test/java/games/strategy/engine/data/GameDataMementoTest.java
@@ -33,7 +33,7 @@ public final class GameDataMementoTest {
   }
 
   @Test
-  public void mementoImporter_ShouldThrowExceptionWhenRequiredPropertyIsAbsent() {
+  public void mementoImporter_ShouldThrowExceptionWhenRequiredPropertyIsAbsent() throws Exception {
     final Memento memento = TestGameDataMementoFactory.newMementoWithoutProperty(GameDataMemento.PropertyNames.VERSION);
 
     catchException(() -> mementoImporter.importMemento(memento));
@@ -46,7 +46,7 @@ public final class GameDataMementoTest {
   }
 
   @Test
-  public void mementoImporter_ShouldThrowExceptionWhenPropertyValueHasWrongType() {
+  public void mementoImporter_ShouldThrowExceptionWhenPropertyValueHasWrongType() throws Exception {
     final Memento memento =
         TestGameDataMementoFactory.newMementoWithProperty(GameDataMemento.PropertyNames.VERSION, "1.2.3.4");
 

--- a/src/test/java/games/strategy/engine/data/Matchers.java
+++ b/src/test/java/games/strategy/engine/data/Matchers.java
@@ -44,7 +44,8 @@ public final class Matchers {
 
     @Override
     protected boolean matchesSafely(final GameData actual) {
-      return Objects.equals(expected.getGameName(), actual.getGameName())
+      return (expected.getDiceSides() == actual.getDiceSides())
+          && Objects.equals(expected.getGameName(), actual.getGameName())
           && Objects.equals(expected.getGameVersion(), actual.getGameVersion());
       // TODO: include remaining fields
     }

--- a/src/test/java/games/strategy/engine/data/TestGameDataFactory.java
+++ b/src/test/java/games/strategy/engine/data/TestGameDataFactory.java
@@ -15,6 +15,7 @@ public final class TestGameDataFactory {
    */
   public static GameData newValidGameData() {
     final GameData gameData = new GameData();
+    gameData.setDiceSides(42);
     gameData.setGameName("name");
     gameData.setGameVersion(new Version(1, 2, 3, 4));
     // TODO: initialize other attributes

--- a/src/test/java/games/strategy/engine/data/TestGameDataMementoFactory.java
+++ b/src/test/java/games/strategy/engine/data/TestGameDataMementoFactory.java
@@ -6,9 +6,6 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-
 import games.strategy.util.memento.Memento;
 import games.strategy.util.memento.PropertyBagMemento;
 
@@ -25,8 +22,10 @@ public final class TestGameDataMementoFactory {
    * @param value The property value.
    *
    * @return A new game data memento.
+   *
+   * @throws Exception If the game data memento cannot be created.
    */
-  public static Memento newMementoWithProperty(final String name, final @Nullable Object value) {
+  public static Memento newMementoWithProperty(final String name, final @Nullable Object value) throws Exception {
     checkNotNull(name);
 
     final Map<String, Object> propertiesByName = newValidMementoPropertiesByName();
@@ -34,13 +33,10 @@ public final class TestGameDataMementoFactory {
     return newMementoWithProperties(propertiesByName);
   }
 
-  private static Map<String, Object> newValidMementoPropertiesByName() {
-    final GameData gameData = TestGameDataFactory.newValidGameData();
-    return Maps.newHashMap(ImmutableMap.<String, Object>builder()
-        .put(GameDataMemento.PropertyNames.NAME, gameData.getGameName())
-        .put(GameDataMemento.PropertyNames.VERSION, gameData.getGameVersion())
-        // TODO: handle other properties
-        .build());
+  private static Map<String, Object> newValidMementoPropertiesByName() throws Exception {
+    return GameDataMemento.newExporterInternal()
+        .exportMemento(TestGameDataFactory.newValidGameData())
+        .getPropertiesByName();
   }
 
   private static PropertyBagMemento newMementoWithProperties(final Map<String, Object> propertiesByName) {
@@ -53,8 +49,10 @@ public final class TestGameDataMementoFactory {
    * @param name The property name.
    *
    * @return A new game data memento.
+   *
+   * @throws Exception If the game data memento cannot be created.
    */
-  public static Memento newMementoWithoutProperty(final String name) {
+  public static Memento newMementoWithoutProperty(final String name) throws Exception {
     checkNotNull(name);
 
     final Map<String, Object> propertiesByName = newValidMementoPropertiesByName();


### PR DESCRIPTION
This PR adds the game dice sides property to the `GameData` memento.  No serialization proxy is required because `Integer` is naturally `Serializable`.