### PR TITLE
Checkstyle: Remove s_ prefix from static variables

### DIFF
--- a/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -26,7 +26,7 @@ import games.strategy.net.IMessenger;
  */
 public class ChatPanel extends JPanel implements IChatPanel {
   private static final long serialVersionUID = -6177517517279779486L;
-  static int s_divider_size = 5;
+  private static final int DIVIDER_SIZE = 5;
   private ChatPlayerPanel chatPlayerPanel;
   private ChatMessagePanel chatMessagePanel;
 
@@ -89,7 +89,7 @@ public class ChatPanel extends JPanel implements IChatPanel {
     split.setLeftComponent(chatMessagePanel);
     split.setRightComponent(chatPlayerPanel);
     split.setOneTouchExpandable(false);
-    split.setDividerSize(s_divider_size);
+    split.setDividerSize(DIVIDER_SIZE);
     split.setResizeWeight(1);
     content.add(split, BorderLayout.CENTER);
   }

--- a/src/main/java/games/strategy/engine/data/Unit.java
+++ b/src/main/java/games/strategy/engine/data/Unit.java
@@ -147,11 +147,11 @@ public class Unit extends GameDataComponent {
    * TODO: fix the root cause of this deserialization issue (probably a circular dependency somewhere)
    */
   public static class UnitDeserializationErrorLazyMessage {
-    private static transient boolean s_shownError = false;
+    private static boolean shownError = false;
 
     private static void printError(final String errorMessage) {
-      if (s_shownError == false) {
-        s_shownError = true;
+      if (shownError == false) {
+        shownError = true;
         System.err.println(errorMessage);
       }
     }

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -44,7 +44,7 @@ import games.strategy.util.Util;
 public class HeadlessGameServer {
 
   private static final Logger logger = Logger.getLogger(HeadlessGameServer.class.getName());
-  private static HeadlessGameServer s_instance = null;
+  private static HeadlessGameServer instance = null;
   private final AvailableGames m_availableGames;
   private final GameSelectorModel m_gameSelectorModel;
   private SetupPanelModel m_setupPanelModel = null;
@@ -54,7 +54,7 @@ public class HeadlessGameServer {
   private final String startDate = TimeManager.getFullUtcString(Instant.now());
 
   public static synchronized HeadlessGameServer getInstance() {
-    return s_instance;
+    return instance;
   }
 
   public static synchronized boolean headless() {
@@ -385,10 +385,10 @@ public class HeadlessGameServer {
 
   private HeadlessGameServer() {
     super();
-    if (s_instance != null) {
+    if (instance != null) {
       throw new IllegalStateException("Instance already exists");
     }
-    s_instance = this;
+    instance = this;
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
       logger.info("Running ShutdownHook.");
       shutdown();
@@ -543,7 +543,7 @@ public class HeadlessGameServer {
     } catch (final Exception e) {
       ClientLogger.logQuietly(e);
     }
-    s_instance = null;
+    instance = null;
     m_setupPanelModel = null;
     m_iGame = null;
     System.out.println("Shutdown Script Finished.");

--- a/src/main/java/games/strategy/engine/lobby/server/db/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/Database.java
@@ -42,8 +42,8 @@ import games.strategy.util.ThreadUtil;
 public class Database {
   private static final Logger logger = Logger.getLogger(Database.class.getName());
   private static final Object dbSetupLock = new Object();
-  private static boolean s_isDbSetup = false;
-  private static boolean s_areDBTablesCreated = false;
+  private static boolean isDbSetup = false;
+  private static boolean areDbTablesCreated = false;
 
   private static File getCurrentDataBaseDir() {
     final File dbRootDir = getDBRoot();
@@ -111,7 +111,7 @@ public class Database {
   private static void ensureDbTablesAreCreated(final Connection conn) {
     synchronized (dbSetupLock) {
       try {
-        if (s_areDBTablesCreated) {
+        if (areDbTablesCreated) {
           return;
         }
         final ResultSet rs = conn.getMetaData().getTables(null, null, null, null);
@@ -168,7 +168,7 @@ public class Database {
           s.execute("create table bad_words" + "(" + "word varchar(40) NOT NULL PRIMARY KEY " + ")");
           s.close();
         }
-        s_areDBTablesCreated = true;
+        areDbTablesCreated = true;
       } catch (final SQLException sqle) {
         // only close if an error occurs
         try {
@@ -187,14 +187,14 @@ public class Database {
    */
   private static void ensureDbIsSetup() {
     synchronized (dbSetupLock) {
-      if (s_isDbSetup) {
+      if (isDbSetup) {
         return;
       }
       // setup the derby location
       System.getProperties().setProperty("derby.system.home", getCurrentDataBaseDir().getAbsolutePath());
       // shut the database down on finish
       Runtime.getRuntime().addShutdownHook(new Thread(() -> shutDownDB()));
-      s_isDbSetup = true;
+      isDbSetup = true;
     }
     // we want to backup the database on occassion
     final Thread backupThread = new Thread(() -> {

--- a/src/main/java/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
@@ -39,7 +39,7 @@ import games.strategy.util.Util;
 public class TripleAWarClubForumPoster extends AbstractForumPoster {
   private static final long serialVersionUID = -4017550807078258152L;
   private static final String WAR_CLUB_FORUM_URL = "http://www.tripleawarclub.org/modules/newbb";
-  private static Pattern s_XOOPS_TOKEN_REQUEST =
+  private static final Pattern XOOPS_TOKEN_REQUEST_PATTERN =
       Pattern.compile(".*XOOPS_TOKEN_REQUEST[^>]*value=\"([^\"]*)\".*", Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
   /**
@@ -109,7 +109,7 @@ public class TripleAWarClubForumPoster extends AbstractForumPoster {
           throw new Exception("Could not load reply page: " + url + ". Site returned " + status);
         }
         final String body = Util.getStringFromInputStream(response.getEntity().getContent());
-        final Matcher m = s_XOOPS_TOKEN_REQUEST.matcher(body);
+        final Matcher m = XOOPS_TOKEN_REQUEST_PATTERN.matcher(body);
         if (!m.matches()) {
           throw new Exception("Unable to find 'XOOPS_TOKEN_REQUEST' form field on reply page");
         }

--- a/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
@@ -31,7 +31,7 @@ import games.strategy.ui.Util;
 public class PBEMDiceRoller implements IRandomSource {
   private final String m_gameUUID;
   private final IRemoteDiceServer m_remoteDiceServer;
-  private static Frame s_focusWindow;
+  private static Frame focusWindow;
 
   /**
    * If the game has multiple frames, allows the ui to
@@ -40,7 +40,7 @@ public class PBEMDiceRoller implements IRandomSource {
    * focused window (or a visble window if none are focused).
    */
   public static void setFocusWindow(final Frame w) {
-    s_focusWindow = w;
+    focusWindow = w;
   }
 
   public PBEMDiceRoller(final IRemoteDiceServer diceServer, final String gameUuid) {
@@ -79,8 +79,8 @@ public class PBEMDiceRoller implements IRandomSource {
   }
 
   private static Frame getFocusedFrame() {
-    if (s_focusWindow != null) {
-      return s_focusWindow;
+    if (focusWindow != null) {
+      return focusWindow;
     }
     final Frame[] frames = Frame.getFrames();
     Frame focusedFrame = null;

--- a/src/main/java/games/strategy/engine/random/PlainRandomSource.java
+++ b/src/main/java/games/strategy/engine/random/PlainRandomSource.java
@@ -22,7 +22,7 @@ public class PlainRandomSource implements IRandomSource {
   }
 
 
-  private static MersenneTwister s_random;
+  private static MersenneTwister random;
 
   @Override
   public synchronized int[] getRandom(final int max, final int count, final String annotation)
@@ -39,9 +39,9 @@ public class PlainRandomSource implements IRandomSource {
 
   @Override
   public synchronized int getRandom(final int max, final String annotation) throws IllegalArgumentException {
-    if (s_random == null) {
-      s_random = new MersenneTwister(getSeed());
+    if (random == null) {
+      random = new MersenneTwister(getSeed());
     }
-    return s_random.nextInt(max);
+    return random.nextInt(max);
   }
 }

--- a/src/main/java/games/strategy/engine/random/RemoteRandom.java
+++ b/src/main/java/games/strategy/engine/random/RemoteRandom.java
@@ -10,14 +10,14 @@ import games.strategy.engine.vault.Vault;
 import games.strategy.engine.vault.VaultID;
 
 public class RemoteRandom implements IRemoteRandom {
-  private static List<VerifiedRandomNumbers> s_verifiedRandomNumbers = new ArrayList<>();
+  private static final List<VerifiedRandomNumbers> verifiedRandomNumbers = new ArrayList<>();
 
   public static synchronized List<VerifiedRandomNumbers> getVerifiedRandomNumbers() {
-    return new ArrayList<>(s_verifiedRandomNumbers);
+    return new ArrayList<>(verifiedRandomNumbers);
   }
 
   private static synchronized void addVerifiedRandomNumber(final VerifiedRandomNumbers number) {
-    s_verifiedRandomNumbers.add(number);
+    verifiedRandomNumbers.add(number);
   }
 
   private final PlainRandomSource m_plainRandom = new PlainRandomSource();

--- a/src/main/java/games/strategy/engine/vault/VaultID.java
+++ b/src/main/java/games/strategy/engine/vault/VaultID.java
@@ -6,10 +6,10 @@ import games.strategy.net.INode;
 
 public class VaultID implements Serializable {
   private static final long serialVersionUID = 8863728184933393296L;
-  private static long s_currentID;
+  private static long currentId;
 
   private static synchronized long getNextID() {
-    return s_currentID++;
+    return currentId++;
   }
 
   private final INode m_generatedOn;

--- a/src/main/java/games/strategy/net/GUID.java
+++ b/src/main/java/games/strategy/net/GUID.java
@@ -20,17 +20,17 @@ public class GUID implements Externalizable {
   // the local identifier
   // this coupled with the unique vm prefix comprise
   // our unique id
-  private static AtomicInteger s_lastID = new AtomicInteger();
+  private static AtomicInteger lastId = new AtomicInteger();
   private int m_id;
   private VMID m_prefix;
 
   public GUID() {
-    m_id = s_lastID.getAndIncrement();
+    m_id = lastId.getAndIncrement();
     m_prefix = vm_prefix;
     // handle wrap around if needed
     if (m_id < 0) {
       vm_prefix = new VMID();
-      s_lastID = new AtomicInteger();
+      lastId = new AtomicInteger();
     }
   }
 

--- a/src/main/java/games/strategy/sound/SoundProperties.java
+++ b/src/main/java/games/strategy/sound/SoundProperties.java
@@ -20,7 +20,7 @@ class SoundProperties {
   static final String DEFAULT_ERA_FOLDER = "ww2";
   static final String GENERIC_FOLDER = "generic";
   static final String OBJECTIVES_PANEL_NAME = "Objectives.Panel.Name";
-  private static SoundProperties s_op = null;
+  private static SoundProperties instance = null;
   private static Instant timestamp = Instant.EPOCH;
   private final Properties m_properties = new Properties();
 
@@ -40,11 +40,11 @@ class SoundProperties {
 
   static SoundProperties getInstance(final ResourceLoader loader) {
     // cache properties for 1 second
-    if (s_op == null || timestamp.plusSeconds(1).isBefore(Instant.now())) {
-      s_op = new SoundProperties(loader);
+    if (instance == null || timestamp.plusSeconds(1).isBefore(Instant.now())) {
+      instance = new SoundProperties(loader);
       timestamp = Instant.now();
     }
-    return s_op;
+    return instance;
   }
 
   String getDefaultEraFolder() {

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogSettings.java
@@ -21,11 +21,11 @@ public class ProLogSettings implements Serializable {
   public int LimitLogHistoryTo = 5;
   public boolean EnableAILogging = true;
   public Level AILoggingDepth = Level.FINEST;
-  private static ProLogSettings s_lastSettings = null;
+  private static ProLogSettings lastSettings = null;
   private static final String PROGRAM_SETTINGS = "Program Settings";
 
   static ProLogSettings loadSettings() {
-    if (s_lastSettings == null) {
+    if (lastSettings == null) {
       ProLogSettings result = new ProLogSettings();
       try {
         final byte[] pool = Preferences.userNodeForPackage(ProAI.class).getByteArray(PROGRAM_SETTINGS, null);
@@ -38,15 +38,15 @@ public class ProLogSettings implements Serializable {
       if (result == null) {
         result = new ProLogSettings();
       }
-      s_lastSettings = result;
+      lastSettings = result;
       return result;
     } else {
-      return s_lastSettings;
+      return lastSettings;
     }
   }
 
   static void saveSettings(final ProLogSettings settings) {
-    s_lastSettings = settings;
+    lastSettings = settings;
     try (final ByteArrayOutputStream pool = new ByteArrayOutputStream(10000);
         ObjectOutputStream outputStream = new ObjectOutputStream(pool)) {
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogUI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/logging/ProLogUI.java
@@ -10,7 +10,7 @@ import games.strategy.triplea.ui.TripleAFrame;
  * Class to manage log window display.
  */
 public class ProLogUI {
-  private static ProLogWindow s_settingsWindow = null;
+  private static ProLogWindow settingsWindow = null;
   private static String currentName = "";
   private static int currentRound = 0;
 
@@ -18,38 +18,38 @@ public class ProLogUI {
     if (!SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("Wrong thread, should be running on AWT thread.");
     }
-    s_settingsWindow = new ProLogWindow(frame);
+    settingsWindow = new ProLogWindow(frame);
   }
 
   public static void clearCachedInstances() {
-    if (s_settingsWindow != null) {
-      s_settingsWindow.clear();
+    if (settingsWindow != null) {
+      settingsWindow.clear();
     }
-    s_settingsWindow = null;
+    settingsWindow = null;
   }
 
   public static void showSettingsWindow() {
-    if (s_settingsWindow == null) {
+    if (settingsWindow == null) {
       return;
     }
-    s_settingsWindow.setVisible(true);
+    settingsWindow.setVisible(true);
   }
 
   static void notifyAILogMessage(final Level level, final String message) {
-    if (s_settingsWindow == null) {
+    if (settingsWindow == null) {
       return;
     }
-    s_settingsWindow.addMessage(level, message);
+    settingsWindow.addMessage(level, message);
   }
 
   public static void notifyStartOfRound(final int round, final String name) {
-    if (s_settingsWindow == null) {
+    if (settingsWindow == null) {
       return;
     }
     if (round != currentRound || !name.equals(currentName)) {
       currentRound = round;
       currentName = name;
-      s_settingsWindow.notifyNewRound(round, name);
+      settingsWindow.notifyNewRound(round, name);
     }
   }
 }

--- a/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
+++ b/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
@@ -27,14 +27,14 @@ public class MyFormatter {
   /**
    * Some exceptions to the rules.
    */
-  private static Map<String, String> s_plural;
+  private static final Map<String, String> plural;
 
   static {
-    s_plural = new HashMap<>();
-    s_plural.put("armour", "armour");
-    s_plural.put("infantry", "infantry");
-    s_plural.put("artillery", "artilleries");
-    s_plural.put("factory", "factories");
+    plural = new HashMap<>();
+    plural.put("armour", "armour");
+    plural.put("infantry", "infantry");
+    plural.put("artillery", "artilleries");
+    plural.put("factory", "factories");
   }
 
   public static String unitsToTextNoOwner(final Collection<Unit> units) {
@@ -112,8 +112,8 @@ public class MyFormatter {
   }
 
   public static String pluralize(final String in) {
-    if (s_plural.containsKey(in)) {
-      return s_plural.get(in);
+    if (plural.containsKey(in)) {
+      return plural.get(in);
     }
     if (in.endsWith("man")) {
       return in.substring(0, in.lastIndexOf("man")) + "men";

--- a/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -31,13 +31,13 @@ public final class TileImageFactory {
   private final Object m_mutex = new Object();
   // one instance in the application
   private static final String SHOW_RELIEF_IMAGES_PREFERENCE = "ShowRelief2";
-  private static boolean s_showReliefImages = true;
+  private static boolean showReliefImages = true;
   private static final String SHOW_MAP_BLENDS_PREFERENCE = "ShowBlends";
-  private static boolean s_showMapBlends = false;
+  private static boolean showMapBlends = false;
   private static final String SHOW_MAP_BLEND_MODE = "BlendMode";
-  private static String s_showMapBlendMode = "normal";
+  private static String showMapBlendMode = "normal";
   private static final String SHOW_MAP_BLEND_ALPHA = "BlendAlpha";
-  private static float s_showMapBlendAlpha = 1.0f;
+  private static float showMapBlendAlpha = 1.0f;
   private final Composite composite = AlphaComposite.Src;
   private static GraphicsConfiguration configuration =
       GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
@@ -48,26 +48,26 @@ public final class TileImageFactory {
 
   static {
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);
-    s_showReliefImages = prefs.getBoolean(SHOW_RELIEF_IMAGES_PREFERENCE, true);
-    s_showMapBlends = prefs.getBoolean(SHOW_MAP_BLENDS_PREFERENCE, false);
-    s_showMapBlendMode = prefs.get(SHOW_MAP_BLEND_MODE, "normal");
-    s_showMapBlendAlpha = prefs.getFloat(SHOW_MAP_BLEND_ALPHA, 1.0f);
+    showReliefImages = prefs.getBoolean(SHOW_RELIEF_IMAGES_PREFERENCE, true);
+    showMapBlends = prefs.getBoolean(SHOW_MAP_BLENDS_PREFERENCE, false);
+    showMapBlendMode = prefs.get(SHOW_MAP_BLEND_MODE, "normal");
+    showMapBlendAlpha = prefs.getFloat(SHOW_MAP_BLEND_ALPHA, 1.0f);
   }
 
   public static boolean getShowReliefImages() {
-    return s_showReliefImages;
+    return showReliefImages;
   }
 
   public static boolean getShowMapBlends() {
-    return s_showMapBlends;
+    return showMapBlends;
   }
 
   private static String getShowMapBlendMode() {
-    return s_showMapBlendMode.toUpperCase();
+    return showMapBlendMode.toUpperCase();
   }
 
   private static float getShowMapBlendAlpha() {
-    return s_showMapBlendAlpha;
+    return showMapBlendAlpha;
   }
 
   public void setScale(final double newScale) {
@@ -81,9 +81,9 @@ public final class TileImageFactory {
   }
 
   public static void setShowReliefImages(final boolean showReliefImages) {
-    s_showReliefImages = showReliefImages;
+    TileImageFactory.showReliefImages = showReliefImages;
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);
-    prefs.putBoolean(SHOW_RELIEF_IMAGES_PREFERENCE, s_showReliefImages);
+    prefs.putBoolean(SHOW_RELIEF_IMAGES_PREFERENCE, TileImageFactory.showReliefImages);
     try {
       prefs.flush();
     } catch (final BackingStoreException ex) {
@@ -92,9 +92,9 @@ public final class TileImageFactory {
   }
 
   public static void setShowMapBlends(final boolean showMapBlends) {
-    s_showMapBlends = showMapBlends;
+    TileImageFactory.showMapBlends = showMapBlends;
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);
-    prefs.putBoolean(SHOW_MAP_BLENDS_PREFERENCE, s_showMapBlends);
+    prefs.putBoolean(SHOW_MAP_BLENDS_PREFERENCE, TileImageFactory.showMapBlends);
     try {
       prefs.flush();
     } catch (final BackingStoreException ex) {
@@ -103,9 +103,9 @@ public final class TileImageFactory {
   }
 
   public static void setShowMapBlendMode(final String showMapBlendMode) {
-    s_showMapBlendMode = showMapBlendMode;
+    TileImageFactory.showMapBlendMode = showMapBlendMode;
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);
-    prefs.put(SHOW_MAP_BLEND_MODE, s_showMapBlendMode);
+    prefs.put(SHOW_MAP_BLEND_MODE, TileImageFactory.showMapBlendMode);
     try {
       prefs.flush();
     } catch (final BackingStoreException ex) {
@@ -114,9 +114,9 @@ public final class TileImageFactory {
   }
 
   public static void setShowMapBlendAlpha(final float showMapBlendAlpha) {
-    s_showMapBlendAlpha = showMapBlendAlpha;
+    TileImageFactory.showMapBlendAlpha = showMapBlendAlpha;
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);
-    prefs.putFloat(SHOW_MAP_BLEND_ALPHA, s_showMapBlendAlpha);
+    prefs.putFloat(SHOW_MAP_BLEND_ALPHA, TileImageFactory.showMapBlendAlpha);
     try {
       prefs.flush();
     } catch (final BackingStoreException ex) {
@@ -181,7 +181,7 @@ public final class TileImageFactory {
       // This is null if there is no image
       final URL url = m_resourceLoader.getResource(fileName);
 
-      if ((!s_showMapBlends || !s_showReliefImages || !transparent) && url == null) {
+      if ((!showMapBlends || !showReliefImages || !transparent) && url == null) {
         return null;
       }
       loadImage(url, fileName, transparent, true, true);
@@ -225,7 +225,7 @@ public final class TileImageFactory {
 
   private Image loadImage(final URL imageLocation, final String fileName, final boolean transparent,
       final boolean cache, final boolean scale) {
-    if (s_showMapBlends && s_showReliefImages && transparent) {
+    if (showMapBlends && showReliefImages && transparent) {
       return loadBlendedImage(fileName, cache, scale);
     } else {
       return loadUnblendedImage(imageLocation, fileName, transparent, cache, scale);

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -33,12 +33,12 @@ import games.strategy.util.PointFileReaderWriter;
 public class AutoPlacementFinder {
   private static int PLACEWIDTH = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static int PLACEHEIGHT = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
-  private static MapData s_mapData;
+  private static MapData mapData;
   private static boolean placeDimensionsSet = false;
   private static double unit_zoom_percent = 1;
   private static int unit_width = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static int unit_height = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
   private static final String TRIPLEA_UNIT_ZOOM = "triplea.unit.zoom";
   private static final String TRIPLEA_UNIT_WIDTH = "triplea.unit.width";
@@ -78,15 +78,15 @@ public class AutoPlacementFinder {
     // create hash map of placements
     final Map<String, Collection<Point>> m_placements = new HashMap<>();
     // ask user where the map is
-    final String mapDir = s_mapFolderLocation == null ? getMapDirectory() : s_mapFolderLocation.getName();
+    final String mapDir = mapFolderLocation == null ? getMapDirectory() : mapFolderLocation.getName();
     if (mapDir == null) {
       System.out.println("You need to specify a map name for this to work");
       System.out.println("Shutting down");
       System.exit(0);
     }
     final File file = getMapPropertiesFile(mapDir);
-    if (file.exists() && s_mapFolderLocation == null) {
-      s_mapFolderLocation = file.getParentFile();
+    if (file.exists() && mapFolderLocation == null) {
+      mapFolderLocation = file.getParentFile();
     }
     if (!placeDimensionsSet) {
       try {
@@ -192,7 +192,7 @@ public class AutoPlacementFinder {
     }
     try {
       // makes TripleA read all the text data files for the map.
-      s_mapData = new MapData(mapDir);
+      mapData = new MapData(mapDir);
     } catch (final Exception ex) {
       JOptionPane.showMessageDialog(null, new JLabel(
           "Could not find map. Make sure it is in finalized location and contains centers.txt and polygons.txt"));
@@ -205,21 +205,21 @@ public class AutoPlacementFinder {
     textOptionPane.show();
     textOptionPane.appendNewLine("Place Dimensions in pixels, being used: " + PLACEWIDTH + "x" + PLACEHEIGHT + "\r\n");
     textOptionPane.appendNewLine("Calculating, this may take a while...\r\n");
-    final Iterator<String> terrIter = s_mapData.getTerritories().iterator();
+    final Iterator<String> terrIter = mapData.getTerritories().iterator();
     while (terrIter.hasNext()) {
       final String name = terrIter.next();
       List<Point> points;
-      if (s_mapData.hasContainedTerritory(name)) {
+      if (mapData.hasContainedTerritory(name)) {
         final Set<Polygon> containedPolygons = new HashSet<>();
-        for (final String containedName : s_mapData.getContainedTerritory(name)) {
-          containedPolygons.addAll(s_mapData.getPolygons(containedName));
+        for (final String containedName : mapData.getContainedTerritory(name)) {
+          containedPolygons.addAll(mapData.getPolygons(containedName));
         }
-        points = getPlacementsStartingAtTopLeft(s_mapData.getPolygons(name), s_mapData.getBoundingRect(name),
-            s_mapData.getCenter(name), containedPolygons);
+        points = getPlacementsStartingAtTopLeft(mapData.getPolygons(name), mapData.getBoundingRect(name),
+            mapData.getCenter(name), containedPolygons);
         m_placements.put(name, points);
       } else {
-        points = getPlacementsStartingAtMiddle(s_mapData.getPolygons(name), s_mapData.getBoundingRect(name),
-            s_mapData.getCenter(name));
+        points = getPlacementsStartingAtMiddle(mapData.getPolygons(name), mapData.getBoundingRect(name),
+            mapData.getCenter(name));
         m_placements.put(name, points);
       }
       textOptionPane.appendNewLine(name + ": " + points.size());
@@ -228,7 +228,7 @@ public class AutoPlacementFinder {
     textOptionPane.countDown();
     try {
       final String fileName =
-          new FileSave("Where To Save place.txt ?", "place.txt", s_mapFolderLocation).getPathString();
+          new FileSave("Where To Save place.txt ?", "place.txt", mapFolderLocation).getPathString();
       if (fileName == null) {
         textOptionPane.appendNewLine("You chose not to save, Shutting down");
         textOptionPane.dispose();
@@ -536,7 +536,7 @@ public class AutoPlacementFinder {
     if (folderString != null && folderString.length() > 0) {
       final File mapFolder = new File(folderString);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + folderString);
       }

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -50,7 +50,7 @@ public class CenterPicker extends JFrame {
   // hash map for polygon points
   private Map<String, List<Polygon>> polygons = new HashMap<>();
   private final JLabel locationLabel = new JLabel();
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
 
   /**
@@ -64,10 +64,10 @@ public class CenterPicker extends JFrame {
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
     System.out.println("Select the map");
-    final FileOpen mapSelection = new FileOpen("Select The Map", s_mapFolderLocation, ".gif", ".png");
+    final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
-    if (s_mapFolderLocation == null && mapSelection.getFile() != null) {
-      s_mapFolderLocation = mapSelection.getFile().getParentFile();
+    if (mapFolderLocation == null && mapSelection.getFile() != null) {
+      mapFolderLocation = mapSelection.getFile().getParentFile();
     }
     if (mapName != null) {
       System.out.println("Map : " + mapName);
@@ -107,8 +107,8 @@ public class CenterPicker extends JFrame {
     super("Center Picker");
     setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
     File file = null;
-    if (s_mapFolderLocation != null && s_mapFolderLocation.exists()) {
-      file = new File(s_mapFolderLocation, "polygons.txt");
+    if (mapFolderLocation != null && mapFolderLocation.exists()) {
+      file = new File(mapFolderLocation, "polygons.txt");
     }
     if (file == null || !file.exists()) {
       file = new File(new File(mapName).getParent() + File.separator + "polygons.txt");
@@ -125,7 +125,7 @@ public class CenterPicker extends JFrame {
       }
     } else {
       try {
-        final String polyPath = new FileOpen("Select A Polygon File", s_mapFolderLocation, ".txt").getPathString();
+        final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyPath != null) {
           polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
         }
@@ -232,7 +232,7 @@ public class CenterPicker extends JFrame {
   private void saveCenters() {
     try {
       final String fileName =
-          new FileSave("Where To Save centers.txt ?", "centers.txt", s_mapFolderLocation).getPathString();
+          new FileSave("Where To Save centers.txt ?", "centers.txt", mapFolderLocation).getPathString();
       if (fileName == null) {
         return;
       }
@@ -253,7 +253,7 @@ public class CenterPicker extends JFrame {
   private void loadCenters() {
     try {
       System.out.println("Load a center file");
-      final String centerName = new FileOpen("Load A Center File", s_mapFolderLocation, ".txt").getPathString();
+      final String centerName = new FileOpen("Load A Center File", mapFolderLocation, ".txt").getPathString();
       if (centerName == null) {
         return;
       }
@@ -334,7 +334,7 @@ public class CenterPicker extends JFrame {
       }
       final File mapFolder = new File(value);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + value);
       }
@@ -342,12 +342,12 @@ public class CenterPicker extends JFrame {
       System.out.println("Only argument allowed is the map directory.");
     }
     // might be set by -D
-    if (s_mapFolderLocation == null || s_mapFolderLocation.length() < 1) {
+    if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
       final String value = System.getProperty(TRIPLEA_MAP_FOLDER);
       if (value != null && value.length() > 0) {
         final File mapFolder = new File(value);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
+          mapFolderLocation = mapFolder;
         } else {
           System.out.println("Could not find directory: " + value);
         }

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -62,7 +62,7 @@ import games.strategy.util.PointFileReaderWriter;
  */
 public class PolygonGrabber extends JFrame {
   private static final long serialVersionUID = 6381498094805120687L;
-  private static boolean s_islandMode;
+  private static boolean islandMode;
   private final JCheckBoxMenuItem modeItem;
   // the current set of polyongs
   private List<Polygon> current;
@@ -74,7 +74,7 @@ public class PolygonGrabber extends JFrame {
   // holds the centers for the polygons
   private Map<String, Point> centers;
   private final JLabel location = new JLabel();
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
 
   /**
@@ -88,10 +88,10 @@ public class PolygonGrabber extends JFrame {
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
     System.out.println("Select the map");
-    final FileOpen mapSelection = new FileOpen("Select The Map", s_mapFolderLocation, ".gif", ".png");
+    final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
-    if (s_mapFolderLocation == null && mapSelection.getFile() != null) {
-      s_mapFolderLocation = mapSelection.getFile().getParentFile();
+    if (mapFolderLocation == null && mapSelection.getFile() != null) {
+      mapFolderLocation = mapSelection.getFile().getParentFile();
     }
     if (mapName != null) {
       System.out.println("Map : " + mapName);
@@ -133,8 +133,8 @@ public class PolygonGrabber extends JFrame {
     super("Polygon grabber");
     setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
     File file = null;
-    if (s_mapFolderLocation != null && s_mapFolderLocation.exists()) {
-      file = new File(s_mapFolderLocation, "centers.txt");
+    if (mapFolderLocation != null && mapFolderLocation.exists()) {
+      file = new File(mapFolderLocation, "centers.txt");
     }
     if (file == null || !file.exists()) {
       file = new File(new File(mapName).getParent() + File.separator + "centers.txt");
@@ -153,7 +153,7 @@ public class PolygonGrabber extends JFrame {
     } else {
       try {
         System.out.println("Select the Centers file");
-        final String centerPath = new FileOpen("Select A Center File", s_mapFolderLocation, ".txt").getPathString();
+        final String centerPath = new FileOpen("Select A Center File", mapFolderLocation, ".txt").getPathString();
         if (centerPath != null) {
           System.out.println("Centers : " + centerPath);
           centers = PointFileReaderWriter.readOneToOne(new FileInputStream(centerPath));
@@ -269,12 +269,12 @@ public class PolygonGrabber extends JFrame {
     final JMenuItem saveItem = new JMenuItem(saveAction);
     saveItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
     final JMenuItem exitItem = new JMenuItem(exitAction);
-    s_islandMode = false;
+    islandMode = false;
     modeItem = new JCheckBoxMenuItem("Island Mode", false);
     modeItem.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent event) {
-        s_islandMode = modeItem.getState();
+        islandMode = modeItem.getState();
         repaint();
       }
     });
@@ -338,7 +338,7 @@ public class PolygonGrabber extends JFrame {
         while (iter.hasNext()) {
           final Collection<Polygon> polygons = iter.next().getValue();
           final Iterator<Polygon> iter2 = polygons.iterator();
-          if (s_islandMode) {
+          if (islandMode) {
             while (iter2.hasNext()) {
               final Polygon item = iter2.next();
               g.drawPolygon(item.xpoints, item.ypoints, item.npoints);
@@ -370,7 +370,7 @@ public class PolygonGrabber extends JFrame {
    */
   private void savePolygons() {
     final String polyName =
-        new FileSave("Where To Save Polygons.txt ?", "polygons.txt", s_mapFolderLocation).getPathString();
+        new FileSave("Where To Save Polygons.txt ?", "polygons.txt", mapFolderLocation).getPathString();
     try {
       if (polyName == null) {
         return;
@@ -391,7 +391,7 @@ public class PolygonGrabber extends JFrame {
    */
   private void loadPolygons() {
     System.out.println("Load a polygon file");
-    final String polyName = new FileOpen("Load A Polygon File", s_mapFolderLocation, ".txt").getPathString();
+    final String polyName = new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getPathString();
     try {
       if (polyName == null) {
         return;
@@ -746,7 +746,7 @@ public class PolygonGrabber extends JFrame {
       }
       final File mapFolder = new File(value);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + value);
       }
@@ -754,12 +754,12 @@ public class PolygonGrabber extends JFrame {
       System.out.println("Only argument allowed is the map directory.");
     }
     // might be set by -D
-    if (s_mapFolderLocation == null || s_mapFolderLocation.length() < 1) {
+    if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
       final String value = System.getProperty(TRIPLEA_MAP_FOLDER);
       if (value != null && value.length() > 0) {
         final File mapFolder = new File(value);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
+          mapFolderLocation = mapFolder;
         } else {
           System.out.println("Could not find directory: " + value);
         }

--- a/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/src/main/java/tools/image/ReliefImageBreaker.java
@@ -40,7 +40,7 @@ public class ReliefImageBreaker {
   private static JFrame observer = new JFrame();
   private boolean seaZoneOnly;
   private MapData mapData;
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
 
   /**
@@ -54,10 +54,10 @@ public class ReliefImageBreaker {
             + "<br>for each territory and sea zone."
             + "<br><br>TripleA no longer uses these, and instead uses reliefTiles (use the TileImageBreaker for that)."
             + "</html>"));
-    final FileSave locationSelection = new FileSave("Where to save Relief Images?", null, s_mapFolderLocation);
+    final FileSave locationSelection = new FileSave("Where to save Relief Images?", null, mapFolderLocation);
     location = locationSelection.getPathString();
-    if (s_mapFolderLocation == null && locationSelection.getFile() != null) {
-      s_mapFolderLocation = locationSelection.getFile().getParentFile();
+    if (mapFolderLocation == null && locationSelection.getFile() != null) {
+      mapFolderLocation = locationSelection.getFile().getParentFile();
     }
     if (location == null) {
       System.out.println("You need to select a folder to save the tiles in for this to work");
@@ -160,7 +160,7 @@ public class ReliefImageBreaker {
    */
   private static Image loadImage() {
     System.out.println("Select the map");
-    final String mapName = new FileOpen("Select The Map", s_mapFolderLocation, ".gif", ".png").getPathString();
+    final String mapName = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png").getPathString();
     if (mapName != null) {
       final Image img = Toolkit.getDefaultToolkit().createImage(mapName);
       final MediaTracker tracker = new MediaTracker(new Panel());
@@ -246,7 +246,7 @@ public class ReliefImageBreaker {
       }
       final File mapFolder = new File(value);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + value);
       }
@@ -254,12 +254,12 @@ public class ReliefImageBreaker {
       System.out.println("Only argument allowed is the map directory.");
     }
     // might be set by -D
-    if (s_mapFolderLocation == null || s_mapFolderLocation.length() < 1) {
+    if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
       final String value = System.getProperty(TRIPLEA_MAP_FOLDER);
       if (value != null && value.length() > 0) {
         final File mapFolder = new File(value);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
+          mapFolderLocation = mapFolder;
         } else {
           System.out.println("Could not find directory: " + value);
         }

--- a/src/main/java/tools/image/TileImageBreaker.java
+++ b/src/main/java/tools/image/TileImageBreaker.java
@@ -32,7 +32,7 @@ public class TileImageBreaker {
   private static String location = null;
   private static JFrame observer = new JFrame();
   private boolean baseMap;
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
   private static final JTextAreaOptionPane textOptionPane = new JTextAreaOptionPane(null,
       "TileImageBreaker Log\r\n\r\n", "", "TileImageBreaker Log", null, 500, 300, true, 1, null);
@@ -55,10 +55,10 @@ public class TileImageBreaker {
             + "<br>For the base image (the one used to make centers.txt, etc), please save it to a folder called "
             + "baseTiles"
             + "<br>For the relief image, please save it to a folder called reliefTiles" + "</html>"));
-    final FileSave locationSelection = new FileSave("Where to save Tile Images?", null, s_mapFolderLocation);
+    final FileSave locationSelection = new FileSave("Where to save Tile Images?", null, mapFolderLocation);
     location = locationSelection.getPathString();
-    if (s_mapFolderLocation == null && locationSelection.getFile() != null) {
-      s_mapFolderLocation = locationSelection.getFile().getParentFile();
+    if (mapFolderLocation == null && locationSelection.getFile() != null) {
+      mapFolderLocation = locationSelection.getFile().getParentFile();
     }
     if (location == null) {
       System.out.println("You need to select a folder to save the tiles in for this to work");
@@ -123,7 +123,7 @@ public class TileImageBreaker {
    */
   private static Image loadImage() {
     System.out.println("Select the map");
-    final String mapName = new FileOpen("Select The Map", s_mapFolderLocation, ".gif", ".png").getPathString();
+    final String mapName = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png").getPathString();
     if (mapName != null) {
       final Image img = Toolkit.getDefaultToolkit().createImage(mapName);
       final MediaTracker tracker = new MediaTracker(new Panel());
@@ -159,7 +159,7 @@ public class TileImageBreaker {
       }
       final File mapFolder = new File(value);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + value);
       }
@@ -167,12 +167,12 @@ public class TileImageBreaker {
       System.out.println("Only argument allowed is the map directory.");
     }
     // might be set by -D
-    if (s_mapFolderLocation == null || s_mapFolderLocation.length() < 1) {
+    if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
       final String value = System.getProperty(TRIPLEA_MAP_FOLDER);
       if (value != null && value.length() > 0) {
         final File mapFolder = new File(value);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
+          mapFolderLocation = mapFolder;
         } else {
           System.out.println("Could not find directory: " + value);
         }

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -35,7 +35,7 @@ import games.strategy.util.PointFileReaderWriter;
 public class TileImageReconstructor {
   private static String baseTileLocation = null;
   private static String imageSaveLocation = null;
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
   private static final JTextAreaOptionPane textOptionPane = new JTextAreaOptionPane(null,
       "TileImageReconstructor Log\r\n\r\n", "", "TileImageReconstructor Log", null, 500, 300, true, 1, null);
@@ -52,10 +52,10 @@ public class TileImageReconstructor {
             + "<br>You must know the size of the map image before you begin, this is normally found in the "
             + "map.properties file. "
             + "</html>"));
-    final FileSave baseTileLocationSelection = new FileSave("Where are the Tile Images?", null, s_mapFolderLocation);
+    final FileSave baseTileLocationSelection = new FileSave("Where are the Tile Images?", null, mapFolderLocation);
     baseTileLocation = baseTileLocationSelection.getPathString();
-    if (s_mapFolderLocation == null && baseTileLocationSelection.getFile() != null) {
-      s_mapFolderLocation = baseTileLocationSelection.getFile().getParentFile();
+    if (mapFolderLocation == null && baseTileLocationSelection.getFile() != null) {
+      mapFolderLocation = baseTileLocationSelection.getFile().getParentFile();
     }
     if (baseTileLocation == null) {
       System.out.println("You need to select a folder where the basetiles are for this to work");
@@ -63,8 +63,8 @@ public class TileImageReconstructor {
       System.exit(0);
       return;
     }
-    final FileSave imageSaveLocationSelection = new FileSave("Save Map Image As?", null, s_mapFolderLocation,
-        JFileChooser.FILES_ONLY, new File(s_mapFolderLocation, "map.png"), new FileFilter() {
+    final FileSave imageSaveLocationSelection = new FileSave("Save Map Image As?", null, mapFolderLocation,
+        JFileChooser.FILES_ONLY, new File(mapFolderLocation, "map.png"), new FileFilter() {
           @Override
           public boolean accept(final File f) {
             if (f.isDirectory()) {
@@ -112,7 +112,7 @@ public class TileImageReconstructor {
         "Do Not Also Draw Polygons?", JOptionPane.YES_NO_OPTION) == JOptionPane.NO_OPTION) {
       try {
         System.out.println("Load a polygon file");
-        final String polyName = new FileOpen("Load A Polygon File", s_mapFolderLocation, ".txt").getPathString();
+        final String polyName = new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyName != null) {
           final FileInputStream in = new FileInputStream(polyName);
           m_polygons = PointFileReaderWriter.readOneToManyPolygons(in);
@@ -189,7 +189,7 @@ public class TileImageReconstructor {
       }
       final File mapFolder = new File(value);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + value);
       }
@@ -197,12 +197,12 @@ public class TileImageReconstructor {
       System.out.println("Only argument allowed is the map directory.");
     }
     // might be set by -D
-    if (s_mapFolderLocation == null || s_mapFolderLocation.length() < 1) {
+    if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
       final String value = System.getProperty(TRIPLEA_MAP_FOLDER);
       if (value != null && value.length() > 0) {
         final File mapFolder = new File(value);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
+          mapFolderLocation = mapFolder;
         } else {
           System.out.println("Could not find directory: " + value);
         }

--- a/src/main/java/tools/image/XmlUpdater.java
+++ b/src/main/java/tools/image/XmlUpdater.java
@@ -16,7 +16,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 public class XmlUpdater {
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
 
   /**
@@ -24,7 +24,7 @@ public class XmlUpdater {
    */
   public static void main(final String[] args) throws Exception {
     handleCommandLineArgs(args);
-    final File gameXmlFile = new FileOpen("Select xml file", s_mapFolderLocation, ".xml").getFile();
+    final File gameXmlFile = new FileOpen("Select xml file", mapFolderLocation, ".xml").getFile();
     if (gameXmlFile == null) {
       System.out.println("No file selected");
       return;
@@ -74,7 +74,7 @@ public class XmlUpdater {
       }
       final File mapFolder = new File(value);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + value);
       }
@@ -82,12 +82,12 @@ public class XmlUpdater {
       System.out.println("Only argument allowed is the map directory.");
     }
     // might be set by -D
-    if (s_mapFolderLocation == null || s_mapFolderLocation.length() < 1) {
+    if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
       final String value = System.getProperty(TRIPLEA_MAP_FOLDER);
       if (value != null && value.length() > 0) {
         final File mapFolder = new File(value);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
+          mapFolderLocation = mapFolder;
         } else {
           System.out.println("Could not find directory: " + value);
         }

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -40,7 +40,7 @@ import tools.image.FileSave;
  */
 // TODO: get this moved to its own package tree
 public class ConnectionFinder {
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
   private static final String LINE_THICKNESS = "triplea.map.lineThickness";
   private static final String SCALE_PIXELS = "triplea.map.scalePixels";
@@ -66,21 +66,21 @@ public class ConnectionFinder {
             + "</html>"));
     System.out.println("Select polygons.txt");
     File polyFile = null;
-    if (s_mapFolderLocation != null && s_mapFolderLocation.exists()) {
-      polyFile = new File(s_mapFolderLocation, "polygons.txt");
+    if (mapFolderLocation != null && mapFolderLocation.exists()) {
+      polyFile = new File(mapFolderLocation, "polygons.txt");
     }
     if (polyFile != null && polyFile.exists() && JOptionPane.showConfirmDialog(null,
         "A polygons.txt file was found in the map's folder, do you want to use it?", "File Suggestion", 1) == 0) {
       // yay
     } else {
-      polyFile = new FileOpen("Select The polygons.txt file", s_mapFolderLocation, ".txt").getFile();
+      polyFile = new FileOpen("Select The polygons.txt file", mapFolderLocation, ".txt").getFile();
     }
     if (polyFile == null || !polyFile.exists()) {
       System.out.println("No polygons.txt Selected. Shutting down.");
       System.exit(0);
     }
-    if (s_mapFolderLocation == null && polyFile != null) {
-      s_mapFolderLocation = polyFile.getParentFile();
+    if (mapFolderLocation == null && polyFile != null) {
+      mapFolderLocation = polyFile.getParentFile();
     }
     final Map<String, List<Area>> territoryAreas = new HashMap<>();
     Map<String, List<Polygon>> mapOfPolygons = null;
@@ -176,7 +176,7 @@ public class ConnectionFinder {
     }
     try {
       final String fileName = new FileSave("Where To Save connections.txt ? (cancel to print to console)",
-          "connections.txt", s_mapFolderLocation).getPathString();
+          "connections.txt", mapFolderLocation).getPathString();
       final StringBuffer connectionsString = convertToXml(connections);
       if (fileName == null) {
         System.out.println();
@@ -385,7 +385,7 @@ public class ConnectionFinder {
       if (arg.startsWith(TRIPLEA_MAP_FOLDER)) {
         final File mapFolder = new File(value);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
+          mapFolderLocation = mapFolder;
         } else {
           System.out.println("Could not find directory: " + value);
         }
@@ -404,12 +404,12 @@ public class ConnectionFinder {
       }
     }
     // might be set by -D
-    if (s_mapFolderLocation == null || s_mapFolderLocation.length() < 1) {
+    if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
       final String value = System.getProperty(TRIPLEA_MAP_FOLDER);
       if (value != null && value.length() > 0) {
         final File mapFolder = new File(value);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
+          mapFolderLocation = mapFolder;
         } else {
           System.out.println("Could not find directory: " + value);
         }

--- a/src/main/java/tools/map/making/ImageShrinker.java
+++ b/src/main/java/tools/map/making/ImageShrinker.java
@@ -21,7 +21,7 @@ import tools.image.FileOpen;
  * Takes an image and shrinks it. Used for making small images.
  */
 public class ImageShrinker {
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder"; // TODO: find other duplications of this value.
 
   public static void main(final String[] args) throws Exception {
@@ -33,12 +33,12 @@ public class ImageShrinker {
             + "<br>So we suggest you instead shrink the image with paint.net or photoshop or gimp, etc, then clean it "
             + "up before saving."
             + "</html>"));
-    final File mapFile = new FileOpen("Select The Large Image", s_mapFolderLocation, ".gif", ".png").getFile();
+    final File mapFile = new FileOpen("Select The Large Image", mapFolderLocation, ".gif", ".png").getFile();
     if (mapFile == null || !mapFile.exists()) {
       throw new IllegalStateException(mapFile + "File does not exist");
     }
-    if (s_mapFolderLocation == null) {
-      s_mapFolderLocation = mapFile.getParentFile();
+    if (mapFolderLocation == null) {
+      mapFolderLocation = mapFile.getParentFile();
     }
     final String input = JOptionPane.showInputDialog(null, "Select scale");
     final float scale = Float.parseFloat(input);
@@ -86,7 +86,7 @@ public class ImageShrinker {
       }
       final File mapFolder = new File(value);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + value);
       }
@@ -94,12 +94,12 @@ public class ImageShrinker {
       System.out.println("Only argument allowed is the map directory.");
     }
     // might be set by -D
-    if (s_mapFolderLocation == null || s_mapFolderLocation.length() < 1) {
+    if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
       final String value = System.getProperty(TRIPLEA_MAP_FOLDER);
       if (value != null && value.length() > 0) {
         final File mapFolder = new File(value);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
+          mapFolderLocation = mapFolder;
         } else {
           System.out.println("Could not find directory: " + value);
         }

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -52,12 +52,12 @@ public class MapCreator extends JFrame {
   private static final String TRIPLEA_UNIT_ZOOM = "triplea.unit.zoom";
   private static final String TRIPLEA_UNIT_WIDTH = "triplea.unit.width";
   private static final String TRIPLEA_UNIT_HEIGHT = "triplea.unit.height";
-  private static long s_memory = Runtime.getRuntime().maxMemory();
-  private static File s_mapFolderLocation = null;
-  private static double s_unit_zoom = 0.75;
-  private static int s_unit_width = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
-  private static int s_unit_height = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
-  private static boolean s_runUtilitiesAsSeperateProcesses = true;
+  private static long memoryInBytes = Runtime.getRuntime().maxMemory();
+  private static File mapFolderLocation = null;
+  private static double unitZoom = 0.75;
+  private static int unitWidth = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
+  private static int unitHeight = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
+  private static boolean runUtilitiesAsSeperateProcesses = true;
   final JPanel mainPanel;
   final JPanel sidePanel;
   final JButton part1;
@@ -199,12 +199,12 @@ public class MapCreator extends JFrame {
     panel1.add(new JLabel("Click button to select where your map folder is:"));
     final JButton mapFolderButton = new JButton("Select Map Folder");
     mapFolderButton.addActionListener(SwingAction.of("Select Map Folder", e -> {
-      final String path = new FileSave("Where is your map's folder?", null, s_mapFolderLocation).getPathString();
+      final String path = new FileSave("Where is your map's folder?", null, mapFolderLocation).getPathString();
       if (path != null) {
         final File mapFolder = new File(path);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
-          System.setProperty(TRIPLEA_MAP_FOLDER, s_mapFolderLocation.getPath());
+          mapFolderLocation = mapFolder;
+          System.setProperty(TRIPLEA_MAP_FOLDER, mapFolderLocation.getPath());
         }
       }
     }));
@@ -212,7 +212,7 @@ public class MapCreator extends JFrame {
     panel1.add(Box.createVerticalStrut(30));
     panel1.add(new JLabel("Set the unit scaling (unit image zoom): "));
     panel1.add(new JLabel("Choose one of: 1.25, 1, 0.875, 0.8333, 0.75, 0.6666, 0.5625, 0.5"));
-    final JTextField unitZoomText = new JTextField("" + s_unit_zoom);
+    final JTextField unitZoomText = new JTextField("" + unitZoom);
     unitZoomText.setMaximumSize(new Dimension(100, 20));
     unitZoomText.addFocusListener(new FocusListener() {
       @Override
@@ -221,18 +221,18 @@ public class MapCreator extends JFrame {
       @Override
       public void focusLost(final FocusEvent e) {
         try {
-          s_unit_zoom = Math.min(4.0, Math.max(0.1, Double.parseDouble(unitZoomText.getText())));
-          System.setProperty(TRIPLEA_UNIT_ZOOM, "" + s_unit_zoom);
+          unitZoom = Math.min(4.0, Math.max(0.1, Double.parseDouble(unitZoomText.getText())));
+          System.setProperty(TRIPLEA_UNIT_ZOOM, "" + unitZoom);
         } catch (final Exception ex) {
           // ignore malformed input
         }
-        unitZoomText.setText("" + s_unit_zoom);
+        unitZoomText.setText("" + unitZoom);
       }
     });
     panel1.add(unitZoomText);
     panel1.add(Box.createVerticalStrut(30));
     panel1.add(new JLabel("Set the width of the unit images: "));
-    final JTextField unitWidthText = new JTextField("" + s_unit_width);
+    final JTextField unitWidthText = new JTextField("" + unitWidth);
     unitWidthText.setMaximumSize(new Dimension(100, 20));
     unitWidthText.addFocusListener(new FocusListener() {
       @Override
@@ -241,18 +241,18 @@ public class MapCreator extends JFrame {
       @Override
       public void focusLost(final FocusEvent e) {
         try {
-          s_unit_width = Math.min(400, Math.max(1, Integer.parseInt(unitWidthText.getText())));
-          System.setProperty(TRIPLEA_UNIT_WIDTH, "" + s_unit_width);
+          unitWidth = Math.min(400, Math.max(1, Integer.parseInt(unitWidthText.getText())));
+          System.setProperty(TRIPLEA_UNIT_WIDTH, "" + unitWidth);
         } catch (final Exception ex) {
           // ignore malformed input
         }
-        unitWidthText.setText("" + s_unit_width);
+        unitWidthText.setText("" + unitWidth);
       }
     });
     panel1.add(unitWidthText);
     panel1.add(Box.createVerticalStrut(30));
     panel1.add(new JLabel("Set the height of the unit images: "));
-    final JTextField unitHeightText = new JTextField("" + s_unit_height);
+    final JTextField unitHeightText = new JTextField("" + unitHeight);
     unitHeightText.setMaximumSize(new Dimension(100, 20));
     unitHeightText.addFocusListener(new FocusListener() {
       @Override
@@ -261,12 +261,12 @@ public class MapCreator extends JFrame {
       @Override
       public void focusLost(final FocusEvent e) {
         try {
-          s_unit_height = Math.min(400, Math.max(1, Integer.parseInt(unitHeightText.getText())));
-          System.setProperty(TRIPLEA_UNIT_HEIGHT, "" + s_unit_height);
+          unitHeight = Math.min(400, Math.max(1, Integer.parseInt(unitHeightText.getText())));
+          System.setProperty(TRIPLEA_UNIT_HEIGHT, "" + unitHeight);
         } catch (final Exception ex) {
           // ignore malformed input
         }
-        unitHeightText.setText("" + s_unit_height);
+        unitHeightText.setText("" + unitHeight);
       }
     });
     panel1.add(unitHeightText);
@@ -275,7 +275,7 @@ public class MapCreator extends JFrame {
         .add(new JLabel("<html>Here you can set the 'max memory' that utilities like the Polygon Grabber will use.<br>"
             + "This is useful is you have a very large map, or ever get any Java Heap Space errors.</html>"));
     panel1.add(new JLabel("Set the amount of memory to use when running new processes (in megabytes [mb]):"));
-    final JTextField memoryText = new JTextField("" + (s_memory / (1024 * 1024)));
+    final JTextField memoryText = new JTextField("" + (memoryInBytes / (1024 * 1024)));
     memoryText.setMaximumSize(new Dimension(100, 20));
     memoryText.addFocusListener(new FocusListener() {
       @Override
@@ -284,18 +284,18 @@ public class MapCreator extends JFrame {
       @Override
       public void focusLost(final FocusEvent e) {
         try {
-          s_memory = (long) 1024 * 1024 * Math.min(4096, Math.max(256, Integer.parseInt(memoryText.getText())));
+          memoryInBytes = (long) 1024 * 1024 * Math.min(4096, Math.max(256, Integer.parseInt(memoryText.getText())));
         } catch (final Exception ex) {
           // ignore malformed input
         }
-        memoryText.setText("" + (s_memory / (1024 * 1024)));
+        memoryText.setText("" + (memoryInBytes / (1024 * 1024)));
       }
     });
     panel1.add(memoryText);
     final JCheckBox runTypeBox = new JCheckBox("Run All Utilities as Separate Processes");
-    runTypeBox.setSelected(s_runUtilitiesAsSeperateProcesses);
+    runTypeBox.setSelected(runUtilitiesAsSeperateProcesses);
     runTypeBox.addActionListener(SwingAction.of("Run All Utilities as Separate Processes",
-        e -> s_runUtilitiesAsSeperateProcesses = runTypeBox.isSelected()));
+        e -> runUtilitiesAsSeperateProcesses = runTypeBox.isSelected()));
     panel1.add(runTypeBox);
     panel1.add(Box.createVerticalStrut(30));
     panel1.validate();
@@ -309,7 +309,7 @@ public class MapCreator extends JFrame {
     panel2.add(Box.createVerticalStrut(30));
     final JButton mapPropertiesMakerButton = new JButton("Run the Map Properties Maker");
     mapPropertiesMakerButton.addActionListener(SwingAction.of("Run the Map Properties Maker", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(MapPropertiesMaker.class);
       } else {
         (new Thread() {
@@ -324,7 +324,7 @@ public class MapCreator extends JFrame {
     panel2.add(Box.createVerticalStrut(30));
     final JButton centerPickerButton = new JButton("Run the Center Picker");
     centerPickerButton.addActionListener(SwingAction.of("Run the Center Picker", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(CenterPicker.class);
       } else {
         (new Thread() {
@@ -339,7 +339,7 @@ public class MapCreator extends JFrame {
     panel2.add(Box.createVerticalStrut(30));
     final JButton polygonGrabberButton = new JButton("Run the Polygon Grabber");
     polygonGrabberButton.addActionListener(SwingAction.of("Run the Polygon Grabber", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(PolygonGrabber.class);
       } else {
         (new Thread() {
@@ -355,7 +355,7 @@ public class MapCreator extends JFrame {
     panel2.add(Box.createVerticalStrut(30));
     final JButton autoPlacerButton = new JButton("Run the Automatic Placement Finder");
     autoPlacerButton.addActionListener(SwingAction.of("Run the Automatic Placement Finder", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(AutoPlacementFinder.class);
       } else {
         (new Thread() {
@@ -371,7 +371,7 @@ public class MapCreator extends JFrame {
     panel2.add(Box.createVerticalStrut(30));
     final JButton placementPickerButton = new JButton("Run the Placement Picker");
     placementPickerButton.addActionListener(SwingAction.of("Run the Placement Picker", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(PlacementPicker.class);
       } else {
         (new Thread() {
@@ -386,7 +386,7 @@ public class MapCreator extends JFrame {
     panel2.add(Box.createVerticalStrut(30));
     final JButton tileBreakerButton = new JButton("Run the Tile Image Breaker");
     tileBreakerButton.addActionListener(SwingAction.of("Run the Tile Image Breaker", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(TileImageBreaker.class);
       } else {
         (new Thread() {
@@ -405,7 +405,7 @@ public class MapCreator extends JFrame {
     panel2.add(Box.createVerticalStrut(30));
     final JButton decorationPlacerButton = new JButton("Run the Decoration Placer");
     decorationPlacerButton.addActionListener(SwingAction.of("Run the Decoration Placer", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(DecorationPlacer.class);
       } else {
         (new Thread() {
@@ -434,7 +434,7 @@ public class MapCreator extends JFrame {
     panel3.add(Box.createVerticalStrut(30));
     final JButton connectionFinderButton = new JButton("Run the Connection Finder");
     connectionFinderButton.addActionListener(SwingAction.of("Run the Connection Finder", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(ConnectionFinder.class);
       } else {
         (new Thread() {
@@ -462,7 +462,7 @@ public class MapCreator extends JFrame {
     panel4.add(Box.createVerticalStrut(30));
     final JButton reliefBreakerButton = new JButton("Run the Relief Image Breaker");
     reliefBreakerButton.addActionListener(SwingAction.of("Run the Relief Image Breaker", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(ReliefImageBreaker.class);
       } else {
         (new Thread() {
@@ -481,7 +481,7 @@ public class MapCreator extends JFrame {
     panel4.add(Box.createVerticalStrut(30));
     final JButton imageShrinkerButton = new JButton("Run the Image Shrinker");
     imageShrinkerButton.addActionListener(SwingAction.of("Run the Image Shrinker", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(ImageShrinker.class);
       } else {
         (new Thread() {
@@ -500,7 +500,7 @@ public class MapCreator extends JFrame {
     panel4.add(Box.createVerticalStrut(30));
     final JButton tileImageReconstructorButton = new JButton("Run the Tile Image Reconstructor");
     tileImageReconstructorButton.addActionListener(SwingAction.of("Run the Tile Image Reconstructor", e -> {
-      if (s_runUtilitiesAsSeperateProcesses) {
+      if (runUtilitiesAsSeperateProcesses) {
         runUtility(TileImageReconstructor.class);
       } else {
         new Thread(() -> {
@@ -520,14 +520,14 @@ public class MapCreator extends JFrame {
 
   private static void runUtility(final Class<?> javaClass) {
     final List<String> commands = new ArrayList<>();
-    ProcessRunnerUtil.populateBasicJavaArgs(commands, s_memory);
-    if (s_mapFolderLocation != null && s_mapFolderLocation.exists()) {
+    ProcessRunnerUtil.populateBasicJavaArgs(commands, memoryInBytes);
+    if (mapFolderLocation != null && mapFolderLocation.exists()) {
       // no need for quotes, that will just screw up the process builder
-      commands.add("-D" + TRIPLEA_MAP_FOLDER + "=" + s_mapFolderLocation.getAbsolutePath());
+      commands.add("-D" + TRIPLEA_MAP_FOLDER + "=" + mapFolderLocation.getAbsolutePath());
     }
-    commands.add("-D" + TRIPLEA_UNIT_ZOOM + "=" + s_unit_zoom);
-    commands.add("-D" + TRIPLEA_UNIT_WIDTH + "=" + s_unit_width);
-    commands.add("-D" + TRIPLEA_UNIT_HEIGHT + "=" + s_unit_height);
+    commands.add("-D" + TRIPLEA_UNIT_ZOOM + "=" + unitZoom);
+    commands.add("-D" + TRIPLEA_UNIT_WIDTH + "=" + unitWidth);
+    commands.add("-D" + TRIPLEA_UNIT_HEIGHT + "=" + unitHeight);
     commands.add(javaClass.getName());
     ProcessRunnerUtil.exec(commands);
     // example: java -classpath triplea.jar -Dtriplea.map.folder="C:/Users" tools/image/CenterPicker

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -62,13 +62,13 @@ import tools.image.FileSave;
  */
 public class MapPropertiesMaker extends JFrame {
   private static final long serialVersionUID = 8182821091131994702L;
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
   private static final String TRIPLEA_UNIT_ZOOM = "triplea.unit.zoom";
   private static final String TRIPLEA_UNIT_WIDTH = "triplea.unit.width";
   private static final String TRIPLEA_UNIT_HEIGHT = "triplea.unit.height";
   private static final MapProperties mapProperties = new MapProperties();
-  private static JPanel s_playerColorChooser = new JPanel();
+  private static final JPanel playerColorChooser = new JPanel();
 
   public static String[] getProperties() {
     return new String[] {TRIPLEA_MAP_FOLDER, TRIPLEA_UNIT_ZOOM, TRIPLEA_UNIT_WIDTH, TRIPLEA_UNIT_HEIGHT};
@@ -79,18 +79,18 @@ public class MapPropertiesMaker extends JFrame {
     // JOptionPane.showMessageDialog(null, new JLabel("<html>" + "This is the MapPropertiesMaker, it will create a
     // map.properties file for
     // you. " + "</html>"));
-    if (s_mapFolderLocation == null) {
+    if (mapFolderLocation == null) {
       System.out.println("Select the map folder");
-      final String path = new FileSave("Where is your map's folder?", null, s_mapFolderLocation).getPathString();
+      final String path = new FileSave("Where is your map's folder?", null, mapFolderLocation).getPathString();
       if (path != null) {
         final File mapFolder = new File(path);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
-          System.setProperty(TRIPLEA_MAP_FOLDER, s_mapFolderLocation.getPath());
+          mapFolderLocation = mapFolder;
+          System.setProperty(TRIPLEA_MAP_FOLDER, mapFolderLocation.getPath());
         }
       }
     }
-    if (s_mapFolderLocation != null) {
+    if (mapFolderLocation != null) {
       final MapPropertiesMaker maker = new MapPropertiesMaker();
       maker.setSize(800, 800);
       maker.setLocationRelativeTo(null);
@@ -213,7 +213,7 @@ public class MapPropertiesMaker extends JFrame {
     panel.add(new JLabel("Create Players and Click on the Color to set their Color: "), new GridBagConstraints(0, row++,
         2, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(20, 50, 20, 50), 0, 0));
     createPlayerColorChooser();
-    panel.add(s_playerColorChooser, new GridBagConstraints(0, row++, 2, 1, 1, 1, GridBagConstraints.CENTER,
+    panel.add(playerColorChooser, new GridBagConstraints(0, row++, 2, 1, 1, 1, GridBagConstraints.CENTER,
         GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
     final JButton showMore = new JButton("Show All Options");
     showMore.addActionListener(SwingAction.of("Show All Options", e -> {
@@ -232,11 +232,11 @@ public class MapPropertiesMaker extends JFrame {
   }
 
   private void createPlayerColorChooser() {
-    s_playerColorChooser.removeAll();
-    s_playerColorChooser.setLayout(new GridBagLayout());
+    playerColorChooser.removeAll();
+    playerColorChooser.setLayout(new GridBagLayout());
     int row = 0;
     for (final Entry<String, Color> entry : mapProperties.getColorMap().entrySet()) {
-      s_playerColorChooser.add(new JLabel(entry.getKey()), new GridBagConstraints(0, row, 1, 1, 1, 1,
+      playerColorChooser.add(new JLabel(entry.getKey()), new GridBagConstraints(0, row, 1, 1, 1, 1,
           GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
       final JLabel label = new JLabel(entry.getKey()) {
         private static final long serialVersionUID = 5624227155029721033L;
@@ -272,7 +272,7 @@ public class MapPropertiesMaker extends JFrame {
         @Override
         public void mouseReleased(final MouseEvent e) {}
       });
-      s_playerColorChooser.add(label, new GridBagConstraints(1, row, 1, 1, 1, 1, GridBagConstraints.CENTER,
+      playerColorChooser.add(label, new GridBagConstraints(1, row, 1, 1, 1, 1, GridBagConstraints.CENTER,
           GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
       final JButton removePlayer = new JButton("Remove " + entry.getKey());
       removePlayer.addActionListener(new AbstractAction("Remove " + entry.getKey()) {
@@ -286,7 +286,7 @@ public class MapPropertiesMaker extends JFrame {
           MapPropertiesMaker.this.repaint();
         }
       });
-      s_playerColorChooser.add(removePlayer, new GridBagConstraints(2, row, 1, 1, 1, 1, GridBagConstraints.WEST,
+      playerColorChooser.add(removePlayer, new GridBagConstraints(2, row, 1, 1, 1, 1, GridBagConstraints.WEST,
           GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
       row++;
     }
@@ -302,9 +302,9 @@ public class MapPropertiesMaker extends JFrame {
       MapPropertiesMaker.this.repaint();
 
     }));
-    s_playerColorChooser.add(addPlayer, new GridBagConstraints(0, row, 1, 1, 1, 1, GridBagConstraints.EAST,
+    playerColorChooser.add(addPlayer, new GridBagConstraints(0, row, 1, 1, 1, 1, GridBagConstraints.EAST,
         GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
-    s_playerColorChooser.add(nameTextField, new GridBagConstraints(1, row++, 1, 1, 1, 1, GridBagConstraints.WEST,
+    playerColorChooser.add(nameTextField, new GridBagConstraints(1, row++, 1, 1, 1, 1, GridBagConstraints.WEST,
         GridBagConstraints.NONE, new Insets(10, 10, 10, 10), 0, 0));
   }
 
@@ -313,7 +313,7 @@ public class MapPropertiesMaker extends JFrame {
     try {
       System.out.println("Load a properties file");
       final String centerName =
-          new FileOpen("Load A Properties File", s_mapFolderLocation, ".properties").getPathString();
+          new FileOpen("Load A Properties File", mapFolderLocation, ".properties").getPathString();
       if (centerName == null) {
         return;
       }
@@ -337,7 +337,7 @@ public class MapPropertiesMaker extends JFrame {
   private static void saveProperties() {
     try {
       final String fileName =
-          new FileSave("Where To Save map.properties ?", "map.properties", s_mapFolderLocation).getPathString();
+          new FileSave("Where To Save map.properties ?", "map.properties", mapFolderLocation).getPathString();
       if (fileName == null) {
         return;
       }
@@ -414,7 +414,7 @@ public class MapPropertiesMaker extends JFrame {
     if (folderString != null && folderString.length() > 0) {
       final File mapFolder = new File(folderString);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + folderString);
       }

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -58,10 +58,10 @@ public class PlacementPicker extends JFrame {
   private final JCheckBoxMenuItem showAllModeItem;
   private final JCheckBoxMenuItem showOverflowModeItem;
   private final JCheckBoxMenuItem showIncompleteModeItem;
-  private static boolean s_showAllMode = false;
-  private static boolean s_showOverflowMode = false;
-  private static boolean s_showIncompleteMode = false;
-  private static int s_incompleteNum = 1;
+  private static boolean showAllMode = false;
+  private static boolean showOverflowMode = false;
+  private static boolean showIncompleteMode = false;
+  private static int incompleteNum = 1;
   private Point currentSquare;
   private Image image;
   private final JLabel locationLabel = new JLabel();
@@ -75,7 +75,7 @@ public class PlacementPicker extends JFrame {
   private static double unit_zoom_percent = 1;
   private static int unit_width = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static int unit_height = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
   private static final String TRIPLEA_UNIT_ZOOM = "triplea.unit.zoom";
   private static final String TRIPLEA_UNIT_WIDTH = "triplea.unit.width";
@@ -120,10 +120,10 @@ public class PlacementPicker extends JFrame {
             + "yet completed enough, "
             + "<br>placements for, turn on the mode options in the 'edit' menu. " + "</html>"));
     System.out.println("Select the map");
-    final FileOpen mapSelection = new FileOpen("Select The Map", s_mapFolderLocation, ".gif", ".png");
+    final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
-    if (s_mapFolderLocation == null && mapSelection.getFile() != null) {
-      s_mapFolderLocation = mapSelection.getFile().getParentFile();
+    if (mapFolderLocation == null && mapSelection.getFile() != null) {
+      mapFolderLocation = mapSelection.getFile().getParentFile();
     }
     if (mapName != null) {
       final PlacementPicker picker = new PlacementPicker(mapName);
@@ -150,8 +150,8 @@ public class PlacementPicker extends JFrame {
     if (!placeDimensionsSet) {
       try {
         File file = null;
-        if (s_mapFolderLocation != null && s_mapFolderLocation.exists()) {
-          file = new File(s_mapFolderLocation, "map.properties");
+        if (mapFolderLocation != null && mapFolderLocation.exists()) {
+          file = new File(mapFolderLocation, "map.properties");
         }
         if (file == null || !file.exists()) {
           file = new File(new File(mapName).getParent() + File.separator + "map.properties");
@@ -257,8 +257,8 @@ public class PlacementPicker extends JFrame {
       }
     }
     File file = null;
-    if (s_mapFolderLocation != null && s_mapFolderLocation.exists()) {
-      file = new File(s_mapFolderLocation, "polygons.txt");
+    if (mapFolderLocation != null && mapFolderLocation.exists()) {
+      file = new File(mapFolderLocation, "polygons.txt");
     }
     if (file == null || !file.exists()) {
       file = new File(new File(mapName).getParent() + File.separator + "polygons.txt");
@@ -275,7 +275,7 @@ public class PlacementPicker extends JFrame {
     } else {
       try {
         System.out.println("Select the Polygons file");
-        final String polyPath = new FileOpen("Select A Polygon File", s_mapFolderLocation, ".txt").getPathString();
+        final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyPath != null) {
           System.out.println("Polygons : " + polyPath);
           polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
@@ -342,15 +342,15 @@ public class PlacementPicker extends JFrame {
     fileMenu.add(saveItem);
     fileMenu.addSeparator();
     fileMenu.add(exitItem);
-    s_showAllMode = false;
-    s_showOverflowMode = false;
-    s_showIncompleteMode = false;
-    s_incompleteNum = 1;
+    showAllMode = false;
+    showOverflowMode = false;
+    showIncompleteMode = false;
+    incompleteNum = 1;
     showAllModeItem = new JCheckBoxMenuItem("Show All Placements Mode", false);
     showAllModeItem.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent event) {
-        s_showAllMode = showAllModeItem.getState();
+        showAllMode = showAllModeItem.getState();
         repaint();
       }
     });
@@ -358,7 +358,7 @@ public class PlacementPicker extends JFrame {
     showOverflowModeItem.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent event) {
-        s_showOverflowMode = showOverflowModeItem.getState();
+        showOverflowMode = showOverflowModeItem.getState();
         repaint();
       }
     });
@@ -370,12 +370,12 @@ public class PlacementPicker extends JFrame {
           final String num = JOptionPane.showInputDialog(null,
               "Enter the minimum number of placements each territory must have.\r\n(examples: 1, 4, etc.)");
           try {
-            s_incompleteNum = Math.max(1, Math.min(50, Integer.parseInt(num)));
+            incompleteNum = Math.max(1, Math.min(50, Integer.parseInt(num)));
           } catch (final Exception ex) {
-            s_incompleteNum = 1;
+            incompleteNum = 1;
           }
         }
-        s_showIncompleteMode = showIncompleteModeItem.getState();
+        showIncompleteMode = showIncompleteModeItem.getState();
         repaint();
       }
     });
@@ -416,7 +416,7 @@ public class PlacementPicker extends JFrame {
       public void paint(final Graphics g) {
         // super.paint(g);
         g.drawImage(image, 0, 0, this);
-        if (s_showAllMode) {
+        if (showAllMode) {
           g.setColor(Color.yellow);
           for (final Entry<String, List<Point>> entry : placements.entrySet()) {
             if (entry.getKey().equals(currentCountry) && currentPlacements != null
@@ -427,7 +427,7 @@ public class PlacementPicker extends JFrame {
             while (pointIter.hasNext()) {
               final Point item = pointIter.next();
               g.fillRect(item.x, item.y, PLACEWIDTH, PLACEHEIGHT);
-              if (s_showOverflowMode && !pointIter.hasNext()) {
+              if (showOverflowMode && !pointIter.hasNext()) {
                 g.setColor(Color.gray);
                 g.fillRect(item.x + PLACEWIDTH, item.y + PLACEHEIGHT / 2, PLACEWIDTH, 4);
                 g.setColor(Color.yellow);
@@ -435,14 +435,14 @@ public class PlacementPicker extends JFrame {
             }
           }
         }
-        if (s_showIncompleteMode) {
+        if (showIncompleteMode) {
           g.setColor(Color.green);
           final Set<String> territories = new HashSet<>(polygons.keySet());
           final Iterator<String> terrIter = territories.iterator();
           while (terrIter.hasNext()) {
             final String terr = terrIter.next();
             final List<Point> points = placements.get(terr);
-            if (points != null && points.size() >= s_incompleteNum) {
+            if (points != null && points.size() >= incompleteNum) {
               terrIter.remove();
             }
           }
@@ -467,7 +467,7 @@ public class PlacementPicker extends JFrame {
         while (pointIter.hasNext()) {
           final Point item = pointIter.next();
           g.fillRect(item.x, item.y, PLACEWIDTH, PLACEHEIGHT);
-          if (s_showOverflowMode && !pointIter.hasNext()) {
+          if (showOverflowMode && !pointIter.hasNext()) {
             g.setColor(Color.gray);
             g.fillRect(item.x + PLACEWIDTH, item.y + PLACEHEIGHT / 2, PLACEWIDTH, 4);
             g.setColor(Color.red);
@@ -484,7 +484,7 @@ public class PlacementPicker extends JFrame {
    */
   private void savePlacements() {
     final String fileName =
-        new FileSave("Where To Save place.txt ?", "place.txt", s_mapFolderLocation).getPathString();
+        new FileSave("Where To Save place.txt ?", "place.txt", mapFolderLocation).getPathString();
     try {
       if (fileName == null) {
         return;
@@ -505,7 +505,7 @@ public class PlacementPicker extends JFrame {
    */
   private void loadPlacements() {
     System.out.println("Load a placement file");
-    final String placeName = new FileOpen("Load A Placement File", s_mapFolderLocation, ".txt").getPathString();
+    final String placeName = new FileOpen("Load A Placement File", mapFolderLocation, ".txt").getPathString();
     try {
       if (placeName == null) {
         return;
@@ -655,7 +655,7 @@ public class PlacementPicker extends JFrame {
     if (folderString != null && folderString.length() > 0) {
       final File mapFolder = new File(folderString);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + folderString);
       }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle StaticVariableName rule, specifically removing the `s_` prefix from all `static` fields.

In some cases, I added the `final` modifier to the field, if possible, since I was already making a change on that line.  There were a few other instances where I tweaked a field modifier for the same reason.  I will highlight all field modifier changes in a forthcoming review.