### PR TITLE
Move TestGameLoader to test source set

### DIFF
--- a/src/test/java/games/strategy/engine/xml/TestGameLoader.java
+++ b/src/test/java/games/strategy/engine/xml/TestGameLoader.java
@@ -17,25 +17,14 @@ import games.strategy.engine.message.IRemote;
 public final class TestGameLoader implements IGameLoader {
   private static final long serialVersionUID = -8019996788216172034L;
 
-  /**
-   * Return an array of player types that can play on the server.
-   * This array must not contain any entries that could play on the client.
-   */
   @Override
   public String[] getServerPlayerTypes() {
     return null;
   }
 
-  /**
-   * The game is about to start.
-   */
   @Override
   public void startGame(final IGame game, final Set<IGamePlayer> players, final boolean headless) {}
 
-  /**
-   * Create the players. Given a map of playerName -> type,
-   * where type is one of the Strings returned by a get*PlayerType() method.
-   */
   @Override
   public Set<IGamePlayer> createPlayers(final Map<String, String> players) {
     return null;

--- a/src/test/java/games/strategy/engine/xml/TestGameLoader.java
+++ b/src/test/java/games/strategy/engine/xml/TestGameLoader.java
@@ -27,14 +27,6 @@ public final class TestGameLoader implements IGameLoader {
   }
 
   /**
-   * Return an array of player types that can play on the client.
-   * This array must not contain any entries that could play on the server.
-   */
-  public String[] getClientPlayerTypes() {
-    return null;
-  }
-
-  /**
    * The game is about to start.
    */
   @Override

--- a/src/test/java/games/strategy/engine/xml/TestGameLoader.java
+++ b/src/test/java/games/strategy/engine/xml/TestGameLoader.java
@@ -11,7 +11,10 @@ import games.strategy.engine.gamePlayer.IGamePlayer;
 import games.strategy.engine.message.IChannelSubscribor;
 import games.strategy.engine.message.IRemote;
 
-public class TestGameLoader implements IGameLoader {
+/**
+ * Fake implementation of {@link IGameLoader} that does nothing.
+ */
+public final class TestGameLoader implements IGameLoader {
   private static final long serialVersionUID = -8019996788216172034L;
 
   /**


### PR DESCRIPTION
The `g.s.engine.xml.TestGameLoader` class is used exclusively by test code and should not be distributed with the production code.  This PR moves it from the main source set to the test source set (and cleans it up a bit in the process).

Within this repo, this class is only used by tests that load the `GameExample.xml` and `Test.xml` maps.  I searched the repos under the `triplea-maps` organization and found no references to this game loader.