### PR TITLE
Checkstyle: Fix static variable name violations

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/src/main/java/games/strategy/engine/data/GameMap.java
@@ -77,7 +77,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     Collections.sort(m_territories, TERRITORY_GRID_ORDERING);
   }
 
-  private static Comparator<Territory> TERRITORY_GRID_ORDERING = (t1, t2) -> {
+  private static final Comparator<Territory> TERRITORY_GRID_ORDERING = (t1, t2) -> {
     if ((t1 == null && t2 == null) || t1 == t2) {
       return 0;
     }

--- a/src/main/java/games/strategy/engine/lobby/client/ui/TableSorter.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/TableSorter.java
@@ -72,7 +72,7 @@ class TableSorter extends AbstractTableModel {
   private TableModel tableModel;
   static final int DESCENDING = -1;
   private static final int NOT_SORTED = 0;
-  private static Directive EMPTY_DIRECTIVE = new Directive(-1, NOT_SORTED);
+  private static final Directive EMPTY_DIRECTIVE = new Directive(-1, NOT_SORTED);
   // TODO needs to be rewritten in order to remove the warning
   @SuppressWarnings("unchecked")
   private static final Comparator<Object> COMPARABLE_COMAPRATOR =

--- a/src/main/java/games/strategy/net/GUID.java
+++ b/src/main/java/games/strategy/net/GUID.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class GUID implements Externalizable {
   private static final long serialVersionUID = 8426441559602874190L;
   // this prefix is unique across vms
-  private static VMID vm_prefix = new VMID();
+  private static VMID vmPrefix = new VMID();
   // the local identifier
   // this coupled with the unique vm prefix comprise
   // our unique id
@@ -26,10 +26,10 @@ public class GUID implements Externalizable {
 
   public GUID() {
     m_id = lastId.getAndIncrement();
-    m_prefix = vm_prefix;
+    m_prefix = vmPrefix;
     // handle wrap around if needed
     if (m_id < 0) {
-      vm_prefix = new VMID();
+      vmPrefix = new VMID();
       lastId = new AtomicInteger();
     }
   }

--- a/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -31,7 +31,7 @@ import games.strategy.util.UrlStreams;
  */
 public class ResourceLoader implements Closeable {
   private final URLClassLoader m_loader;
-  public static String RESOURCE_FOLDER = "assets";
+  public static final String RESOURCE_FOLDER = "assets";
 
   private final ResourceLocationTracker resourceLocationTracker;
 

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProTerritoryValueUtils.java
@@ -23,8 +23,8 @@ import games.strategy.util.Match;
  */
 public class ProTerritoryValueUtils {
 
-  private static int MIN_FACTORY_CHECK_DISTANCE = 9;
-  private static int MAX_FACTORY_CHECK_DISTANCE = 30;
+  private static final int MIN_FACTORY_CHECK_DISTANCE = 9;
+  private static final int MAX_FACTORY_CHECK_DISTANCE = 30;
 
   public static double findTerritoryAttackValue(final PlayerID player, final Territory t) {
     final GameData data = ProData.getData();

--- a/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
@@ -11,8 +11,8 @@ import games.strategy.engine.history.Step;
 import games.strategy.triplea.Constants;
 
 public abstract class BaseEditDelegate extends BasePersistentDelegate {
-  public static String EDITMODE_ON = "Turning on Edit Mode";
-  public static String EDITMODE_OFF = "Turning off Edit Mode";
+  private static final String EDITMODE_ON = "Turning on Edit Mode";
+  private static final String EDITMODE_OFF = "Turning off Edit Mode";
 
   /**
    * Called before the delegate will run, AND before "start" is called.

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -45,7 +45,7 @@ import games.strategy.util.Match;
 @AutoSave(afterStepEnd = true)
 public class MoveDelegate extends AbstractMoveDelegate {
 
-  public static String CLEANING_UP_DURING_MOVEMENT_PHASE = "Cleaning up during movement phase";
+  public static final String CLEANING_UP_DURING_MOVEMENT_PHASE = "Cleaning up during movement phase";
 
   // needToInitialize means we only do certain things once, so that if a game is saved then
   // loaded, they aren't done again

--- a/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -35,11 +35,11 @@ public class MapImage {
   }
 
   private BufferedImage m_smallMapImage;
-  private static Font PROPERTY_MAP_FONT = null;
-  private static Color PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR = null;
-  private static Color PROPERTY_UNIT_COUNT_COLOR = null;
-  private static Color PROPERTY_UNIT_FACTORY_DAMAGE_COLOR = null;
-  private static Color PROPERTY_UNIT_HIT_DAMAGE_COLOR = null;
+  private static Font propertyMapFont = null;
+  private static Color propertyTerritoryNameAndPuAndCommentColor = null;
+  private static Color propertyUnitCountColor = null;
+  private static Color propertyUnitFactoryDamageColor = null;
+  private static Color propertyUnitHitDamageColor = null;
   private static final String PROPERTY_MAP_FONT_SIZE_STRING = "PROPERTY_MAP_FONT_SIZE";
   private static final String PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR_STRING =
       "PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR";
@@ -48,106 +48,106 @@ public class MapImage {
   private static final String PROPERTY_UNIT_HIT_DAMAGE_COLOR_STRING = "PROPERTY_UNIT_HIT_DAMAGE_COLOR";
 
   public static Font getPropertyMapFont() {
-    if (PROPERTY_MAP_FONT == null) {
+    if (propertyMapFont == null) {
       final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
-      PROPERTY_MAP_FONT = new Font("Ariel", Font.BOLD, pref.getInt(PROPERTY_MAP_FONT_SIZE_STRING, 12));
+      propertyMapFont = new Font("Ariel", Font.BOLD, pref.getInt(PROPERTY_MAP_FONT_SIZE_STRING, 12));
     }
-    return PROPERTY_MAP_FONT;
+    return propertyMapFont;
   }
 
   public static Color getPropertyTerritoryNameAndPUAndCommentcolor() {
-    if (PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR == null) {
+    if (propertyTerritoryNameAndPuAndCommentColor == null) {
       final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
-      PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR =
+      propertyTerritoryNameAndPuAndCommentColor =
           new Color(pref.getInt(PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR_STRING, Color.black.getRGB()));
     }
-    return PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR;
+    return propertyTerritoryNameAndPuAndCommentColor;
   }
 
   public static Color getPropertyUnitCountColor() {
-    if (PROPERTY_UNIT_COUNT_COLOR == null) {
+    if (propertyUnitCountColor == null) {
       final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
-      PROPERTY_UNIT_COUNT_COLOR = new Color(pref.getInt(PROPERTY_UNIT_COUNT_COLOR_STRING, Color.white.getRGB()));
+      propertyUnitCountColor = new Color(pref.getInt(PROPERTY_UNIT_COUNT_COLOR_STRING, Color.white.getRGB()));
     }
-    return PROPERTY_UNIT_COUNT_COLOR;
+    return propertyUnitCountColor;
   }
 
   public static Color getPropertyUnitFactoryDamageColor() {
-    if (PROPERTY_UNIT_FACTORY_DAMAGE_COLOR == null) {
+    if (propertyUnitFactoryDamageColor == null) {
       final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
-      PROPERTY_UNIT_FACTORY_DAMAGE_COLOR =
+      propertyUnitFactoryDamageColor =
           new Color(pref.getInt(PROPERTY_UNIT_FACTORY_DAMAGE_COLOR_STRING, Color.black.getRGB()));
     }
-    return PROPERTY_UNIT_FACTORY_DAMAGE_COLOR;
+    return propertyUnitFactoryDamageColor;
   }
 
   public static Color getPropertyUnitHitDamageColor() {
-    if (PROPERTY_UNIT_HIT_DAMAGE_COLOR == null) {
+    if (propertyUnitHitDamageColor == null) {
       final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
-      PROPERTY_UNIT_HIT_DAMAGE_COLOR =
+      propertyUnitHitDamageColor =
           new Color(pref.getInt(PROPERTY_UNIT_HIT_DAMAGE_COLOR_STRING, Color.black.getRGB()));
     }
-    return PROPERTY_UNIT_HIT_DAMAGE_COLOR;
+    return propertyUnitHitDamageColor;
   }
 
   public static void setPropertyMapFont(final Font font) {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.putInt(PROPERTY_MAP_FONT_SIZE_STRING, font.getSize());
-    PROPERTY_MAP_FONT = font;
+    propertyMapFont = font;
   }
 
   public static void setPropertyTerritoryNameAndPUAndCommentcolor(final Color color) {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.putInt(PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR_STRING, color.getRGB());
-    PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR = color;
+    propertyTerritoryNameAndPuAndCommentColor = color;
   }
 
   public static void setPropertyUnitCountColor(final Color color) {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.putInt(PROPERTY_UNIT_COUNT_COLOR_STRING, color.getRGB());
-    PROPERTY_UNIT_COUNT_COLOR = color;
+    propertyUnitCountColor = color;
   }
 
   public static void setPropertyUnitFactoryDamageColor(final Color color) {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.putInt(PROPERTY_UNIT_FACTORY_DAMAGE_COLOR_STRING, color.getRGB());
-    PROPERTY_UNIT_FACTORY_DAMAGE_COLOR = color;
+    propertyUnitFactoryDamageColor = color;
   }
 
   public static void setPropertyUnitHitDamageColor(final Color color) {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.putInt(PROPERTY_UNIT_HIT_DAMAGE_COLOR_STRING, color.getRGB());
-    PROPERTY_UNIT_HIT_DAMAGE_COLOR = color;
+    propertyUnitHitDamageColor = color;
   }
 
   public static void resetPropertyMapFont() {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.remove(PROPERTY_MAP_FONT_SIZE_STRING);
-    PROPERTY_MAP_FONT = new Font("Ariel", Font.BOLD, 12);
+    propertyMapFont = new Font("Ariel", Font.BOLD, 12);
   }
 
   public static void resetPropertyTerritoryNameAndPUAndCommentcolor() {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.remove(PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR_STRING);
-    PROPERTY_TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR = Color.black;
+    propertyTerritoryNameAndPuAndCommentColor = Color.black;
   }
 
   public static void resetPropertyUnitCountColor() {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.remove(PROPERTY_UNIT_COUNT_COLOR_STRING);
-    PROPERTY_UNIT_COUNT_COLOR = Color.white;
+    propertyUnitCountColor = Color.white;
   }
 
   public static void resetPropertyUnitFactoryDamageColor() {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.remove(PROPERTY_UNIT_FACTORY_DAMAGE_COLOR_STRING);
-    PROPERTY_UNIT_FACTORY_DAMAGE_COLOR = Color.black;
+    propertyUnitFactoryDamageColor = Color.black;
   }
 
   public static void resetPropertyUnitHitDamageColor() {
     final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
     pref.remove(PROPERTY_UNIT_HIT_DAMAGE_COLOR_STRING);
-    PROPERTY_UNIT_HIT_DAMAGE_COLOR = Color.black;
+    propertyUnitHitDamageColor = Color.black;
   }
 
   /** Creates a new instance of MapImage. */

--- a/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -29,14 +29,14 @@ public class UnitImageFactory {
    * Width of all icons.
    * You probably want getUnitImageWidth(), which takes scale factor into account.
    */
-  private static int UNIT_ICON_WIDTH = DEFAULT_UNIT_ICON_SIZE;
+  private static int unitIconWidth = DEFAULT_UNIT_ICON_SIZE;
   /**
    * Height of all icons.
    * You probably want getUnitImageHeight(), which takes scale factor into account.
    **/
-  private static int UNIT_ICON_HEIGHT = DEFAULT_UNIT_ICON_SIZE;
-  private static int UNIT_COUNTER_OFFSET_WIDTH = DEFAULT_UNIT_ICON_SIZE / 4;
-  private static int UNIT_COUNTER_OFFSET_HEIGHT = UNIT_ICON_HEIGHT;
+  private static int unitIconHeight = DEFAULT_UNIT_ICON_SIZE;
+  private static int unitCounterOffsetWidth = DEFAULT_UNIT_ICON_SIZE / 4;
+  private static int unitCounterOffsetHeight = unitIconHeight;
   private static final String FILE_NAME_BASE = "units/";
   // maps Point -> image
   private final Map<String, Image> m_images = new HashMap<>();
@@ -51,10 +51,10 @@ public class UnitImageFactory {
 
   public void setResourceLoader(final ResourceLoader loader, final double scaleFactor, final int initialUnitWidth,
       final int initialUnitHeight, final int initialUnitCounterOffsetWidth, final int initialUnitCounterOffsetHeight) {
-    UNIT_ICON_WIDTH = initialUnitWidth;
-    UNIT_ICON_HEIGHT = initialUnitHeight;
-    UNIT_COUNTER_OFFSET_WIDTH = initialUnitCounterOffsetWidth;
-    UNIT_COUNTER_OFFSET_HEIGHT = initialUnitCounterOffsetHeight;
+    unitIconWidth = initialUnitWidth;
+    unitIconHeight = initialUnitHeight;
+    unitCounterOffsetWidth = initialUnitCounterOffsetWidth;
+    unitCounterOffsetHeight = initialUnitCounterOffsetHeight;
     m_scaleFactor = scaleFactor;
     m_resourceLoader = loader;
     clearImageCache();
@@ -81,22 +81,22 @@ public class UnitImageFactory {
    * Return the width of scaled units.
    */
   public int getUnitImageWidth() {
-    return (int) (m_scaleFactor * UNIT_ICON_WIDTH);
+    return (int) (m_scaleFactor * unitIconWidth);
   }
 
   /**
    * Return the height of scaled units.
    */
   public int getUnitImageHeight() {
-    return (int) (m_scaleFactor * UNIT_ICON_HEIGHT);
+    return (int) (m_scaleFactor * unitIconHeight);
   }
 
   public int getUnitCounterOffsetWidth() {
-    return (int) (m_scaleFactor * UNIT_COUNTER_OFFSET_WIDTH);
+    return (int) (m_scaleFactor * unitCounterOffsetWidth);
   }
 
   public int getUnitCounterOffsetHeight() {
-    return (int) (m_scaleFactor * UNIT_COUNTER_OFFSET_HEIGHT);
+    return (int) (m_scaleFactor * unitCounterOffsetHeight);
   }
 
   // Clear the image and icon cache

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -31,13 +31,13 @@ import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.util.PointFileReaderWriter;
 
 public class AutoPlacementFinder {
-  private static int PLACEWIDTH = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
-  private static int PLACEHEIGHT = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
+  private static int placeWidth = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
+  private static int placeHeight = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static MapData mapData;
   private static boolean placeDimensionsSet = false;
-  private static double unit_zoom_percent = 1;
-  private static int unit_width = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
-  private static int unit_height = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
+  private static double unitZoomPercent = 1;
+  private static int unitWidth = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
+  private static int unitHeight = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
   private static final String TRIPLEA_UNIT_ZOOM = "triplea.unit.zoom";
@@ -91,9 +91,9 @@ public class AutoPlacementFinder {
     if (!placeDimensionsSet) {
       try {
         if (file.exists()) {
-          double scale = unit_zoom_percent;
-          int width = unit_width;
-          int height = unit_height;
+          double scale = unitZoomPercent;
+          int width = unitWidth;
+          int height = unitHeight;
           boolean found = false;
           final String scaleProperty = MapData.PROPERTY_UNITS_SCALE + "=";
           final String widthProperty = MapData.PROPERTY_UNITS_WIDTH + "=";
@@ -144,9 +144,9 @@ public class AutoPlacementFinder {
                 "File Suggestion", 1);
 
             if (result == 0) {
-              unit_zoom_percent = scale;
-              PLACEWIDTH = (int) (unit_zoom_percent * width);
-              PLACEHEIGHT = (int) (unit_zoom_percent * height);
+              unitZoomPercent = scale;
+              placeWidth = (int) (unitZoomPercent * width);
+              placeHeight = (int) (unitZoomPercent * height);
               placeDimensionsSet = true;
             }
           }
@@ -156,14 +156,14 @@ public class AutoPlacementFinder {
       }
     }
     if (!placeDimensionsSet || JOptionPane.showConfirmDialog(new JPanel(),
-        "Placement Box Size already set (" + PLACEWIDTH + "x" + PLACEHEIGHT + "), "
+        "Placement Box Size already set (" + placeWidth + "x" + placeHeight + "), "
             + "do you wish to continue with this?\r\n"
             + "Select Yes to continue, Select No to override and change the size.",
         "Placement Box Size", JOptionPane.YES_NO_OPTION) == 1) {
       try {
         final String result = getUnitsScale();
         try {
-          unit_zoom_percent = Double.parseDouble(result.toLowerCase());
+          unitZoomPercent = Double.parseDouble(result.toLowerCase());
         } catch (final NumberFormatException ex) {
           // ignore malformed input
         }
@@ -171,7 +171,7 @@ public class AutoPlacementFinder {
             "Enter the unit's image width in pixels (unscaled / without zoom).\r\n(e.g. 48)");
         if (width != null) {
           try {
-            PLACEWIDTH = (int) (unit_zoom_percent * Integer.parseInt(width));
+            placeWidth = (int) (unitZoomPercent * Integer.parseInt(width));
           } catch (final NumberFormatException ex) {
             // ignore malformed input
           }
@@ -180,7 +180,7 @@ public class AutoPlacementFinder {
             "Enter the unit's image height in pixels (unscaled / without zoom).\r\n(e.g. 48)");
         if (height != null) {
           try {
-            PLACEHEIGHT = (int) (unit_zoom_percent * Integer.parseInt(height));
+            placeHeight = (int) (unitZoomPercent * Integer.parseInt(height));
           } catch (final NumberFormatException ex) {
             // ignore malformed input
           }
@@ -203,7 +203,7 @@ public class AutoPlacementFinder {
       System.exit(0);
     }
     textOptionPane.show();
-    textOptionPane.appendNewLine("Place Dimensions in pixels, being used: " + PLACEWIDTH + "x" + PLACEHEIGHT + "\r\n");
+    textOptionPane.appendNewLine("Place Dimensions in pixels, being used: " + placeWidth + "x" + placeHeight + "\r\n");
     textOptionPane.appendNewLine("Calculating, this may take a while...\r\n");
     final Iterator<String> terrIter = mapData.getTerritories().iterator();
     while (terrIter.hasNext()) {
@@ -302,9 +302,9 @@ public class AutoPlacementFinder {
       final Point center) {
     final List<Rectangle2D> placementRects = new ArrayList<>();
     final List<Point> placementPoints = new ArrayList<>();
-    final Rectangle2D place = new Rectangle2D.Double(center.x, center.y, PLACEHEIGHT, PLACEWIDTH);
-    int x = center.x - (PLACEHEIGHT / 2);
-    int y = center.y - (PLACEWIDTH / 2);
+    final Rectangle2D place = new Rectangle2D.Double(center.x, center.y, placeHeight, placeWidth);
+    int x = center.x - (placeHeight / 2);
+    int y = center.y - (placeWidth / 2);
     int step = 1;
     for (int i = 0; i < 2 * Math.max(bounding.width, bounding.height); i++) {
       for (int j = 0; j < Math.abs(step); j++) {
@@ -336,8 +336,8 @@ public class AutoPlacementFinder {
       }
     }
     if (placementPoints.isEmpty()) {
-      final int defaultx = center.x - (PLACEHEIGHT / 2);
-      final int defaulty = center.y - (PLACEWIDTH / 2);
+      final int defaultx = center.x - (placeHeight / 2);
+      final int defaulty = center.y - (placeWidth / 2);
       placementPoints.add(new Point(defaultx, defaulty));
     }
     return placementPoints;
@@ -361,7 +361,7 @@ public class AutoPlacementFinder {
       final Point center, final Collection<Polygon> containedCountryPolygons) {
     final List<Rectangle2D> placementRects = new ArrayList<>();
     final List<Point> placementPoints = new ArrayList<>();
-    final Rectangle2D place = new Rectangle2D.Double(center.x, center.y, PLACEHEIGHT, PLACEWIDTH);
+    final Rectangle2D place = new Rectangle2D.Double(center.x, center.y, placeHeight, placeWidth);
     for (int x = bounding.x + 1; x < bounding.width + bounding.x; x++) {
       for (int y = bounding.y + 1; y < bounding.height + bounding.y; y++) {
         isPlacement(countryPolygons, containedCountryPolygons, placementRects, placementPoints, place, x, y);
@@ -371,8 +371,8 @@ public class AutoPlacementFinder {
       }
     }
     if (placementPoints.isEmpty()) {
-      final int defaultx = center.x - (PLACEHEIGHT / 2);
-      final int defaulty = center.y - (PLACEWIDTH / 2);
+      final int defaultx = center.x - (placeHeight / 2);
+      final int defaulty = center.y - (placeWidth / 2);
       placementPoints.add(new Point(defaultx, defaulty));
     }
     return placementPoints;
@@ -402,7 +402,7 @@ public class AutoPlacementFinder {
   private static void isPlacement(final Collection<Polygon> countryPolygons,
       final Collection<Polygon> containedCountryPolygons, final List<Rectangle2D> placementRects,
       final List<Point> placementPoints, final Rectangle2D place, final int x, final int y) {
-    place.setFrame(x, y, PLACEWIDTH, PLACEHEIGHT);
+    place.setFrame(x, y, placeWidth, placeHeight);
     if (containedIn(place, countryPolygons) && !intersectsOneOf(place, placementRects)
         // make sure it is not in or intersects the contained country
         && (!containedIn(place, containedCountryPolygons) && !intersectsOneOf(place, containedCountryPolygons))) {
@@ -544,8 +544,8 @@ public class AutoPlacementFinder {
     final String zoomString = System.getProperty(TRIPLEA_UNIT_ZOOM);
     if (zoomString != null && zoomString.length() > 0) {
       try {
-        unit_zoom_percent = Double.parseDouble(zoomString);
-        System.out.println("Unit Zoom Percent to use: " + unit_zoom_percent);
+        unitZoomPercent = Double.parseDouble(zoomString);
+        System.out.println("Unit Zoom Percent to use: " + unitZoomPercent);
         placeDimensionsSet = true;
       } catch (final Exception ex) {
         System.err.println("Not a decimal percentage: " + zoomString);
@@ -554,8 +554,8 @@ public class AutoPlacementFinder {
     final String widthString = System.getProperty(TRIPLEA_UNIT_WIDTH);
     if (widthString != null && widthString.length() > 0) {
       try {
-        unit_width = Integer.parseInt(widthString);
-        System.out.println("Unit Width to use: " + unit_width);
+        unitWidth = Integer.parseInt(widthString);
+        System.out.println("Unit Width to use: " + unitWidth);
         placeDimensionsSet = true;
       } catch (final Exception ex) {
         System.err.println("Not an integer: " + widthString);
@@ -564,17 +564,17 @@ public class AutoPlacementFinder {
     final String heightString = System.getProperty(TRIPLEA_UNIT_HEIGHT);
     if (heightString != null && heightString.length() > 0) {
       try {
-        unit_height = Integer.parseInt(heightString);
-        System.out.println("Unit Height to use: " + unit_height);
+        unitHeight = Integer.parseInt(heightString);
+        System.out.println("Unit Height to use: " + unitHeight);
         placeDimensionsSet = true;
       } catch (final Exception ex) {
         System.err.println("Not an integer: " + heightString);
       }
     }
     if (placeDimensionsSet) {
-      PLACEWIDTH = (int) (unit_zoom_percent * unit_width);
-      PLACEHEIGHT = (int) (unit_zoom_percent * unit_height);
-      System.out.println("Place Dimensions to use: " + PLACEWIDTH + "x" + PLACEHEIGHT);
+      placeWidth = (int) (unitZoomPercent * unitWidth);
+      placeHeight = (int) (unitZoomPercent * unitHeight);
+      System.out.println("Place Dimensions to use: " + placeWidth + "x" + placeHeight);
     }
   }
 }

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -41,7 +41,7 @@ public class TileImageReconstructor {
       "TileImageReconstructor Log\r\n\r\n", "", "TileImageReconstructor Log", null, 500, 300, true, 1, null);
   private static int sizeX = -1;
   private static int sizeY = -1;
-  private static Map<String, List<Polygon>> m_polygons = new HashMap<>();
+  private static Map<String, List<Polygon>> polygons = new HashMap<>();
 
   public static void main(final String[] args) throws Exception {
     handleCommandLineArgs(args);
@@ -115,7 +115,7 @@ public class TileImageReconstructor {
         final String polyName = new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyName != null) {
           final FileInputStream in = new FileInputStream(polyName);
-          m_polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+          polygons = PointFileReaderWriter.readOneToManyPolygons(in);
         }
       } catch (final Exception ex) {
         ClientLogger.logQuietly(ex);
@@ -147,10 +147,10 @@ public class TileImageReconstructor {
         textOptionPane.appendNewLine("Drew " + tileName);
       }
     }
-    if (m_polygons != null && !m_polygons.isEmpty()) {
+    if (polygons != null && !polygons.isEmpty()) {
       graphics.setColor(Color.black);
       textOptionPane.appendNewLine("Drawing Polygons");
-      for (final Entry<String, List<Polygon>> entry : m_polygons.entrySet()) {
+      for (final Entry<String, List<Polygon>> entry : polygons.entrySet()) {
         for (final Polygon poly : entry.getValue()) {
           graphics.drawPolygon(poly.xpoints, poly.ypoints, poly.npoints);
         }

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -69,12 +69,12 @@ public class PlacementPicker extends JFrame {
   private Map<String, List<Point>> placements;
   private List<Point> currentPlacements;
   private String currentCountry;
-  private static int PLACEWIDTH = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
-  private static int PLACEHEIGHT = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
+  private static int placeWidth = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
+  private static int placeHeight = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static boolean placeDimensionsSet = false;
-  private static double unit_zoom_percent = 1;
-  private static int unit_width = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
-  private static int unit_height = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
+  private static double unitZoomPercent = 1;
+  private static int unitWidth = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
+  private static int unitHeight = UnitImageFactory.DEFAULT_UNIT_ICON_SIZE;
   private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
   private static final String TRIPLEA_UNIT_ZOOM = "triplea.unit.zoom";
@@ -157,9 +157,9 @@ public class PlacementPicker extends JFrame {
           file = new File(new File(mapName).getParent() + File.separator + "map.properties");
         }
         if (file.exists()) {
-          double scale = unit_zoom_percent;
-          int width = unit_width;
-          int height = unit_height;
+          double scale = unitZoomPercent;
+          int width = unitWidth;
+          int height = unitHeight;
           boolean found = false;
           final String scaleProperty = MapData.PROPERTY_UNITS_SCALE + "=";
           final String widthProperty = MapData.PROPERTY_UNITS_WIDTH + "=";
@@ -210,9 +210,9 @@ public class PlacementPicker extends JFrame {
                 "File Suggestion", 1);
 
             if (result == 0) {
-              unit_zoom_percent = scale;
-              PLACEWIDTH = (int) (unit_zoom_percent * width);
-              PLACEHEIGHT = (int) (unit_zoom_percent * height);
+              unitZoomPercent = scale;
+              placeWidth = (int) (unitZoomPercent * width);
+              placeHeight = (int) (unitZoomPercent * height);
               placeDimensionsSet = true;
             }
           }
@@ -222,14 +222,14 @@ public class PlacementPicker extends JFrame {
       }
     }
     if (!placeDimensionsSet || JOptionPane.showConfirmDialog(new JPanel(),
-        "Placement Box Size already set (" + PLACEWIDTH + "x" + PLACEHEIGHT + "), "
+        "Placement Box Size already set (" + placeWidth + "x" + placeHeight + "), "
             + "do you wish to continue with this?\r\n"
             + "Select Yes to continue, Select No to override and change the size.",
         "Placement Box Size", JOptionPane.YES_NO_OPTION) == 1) {
       try {
         final String result = getUnitsScale();
         try {
-          unit_zoom_percent = Double.parseDouble(result.toLowerCase());
+          unitZoomPercent = Double.parseDouble(result.toLowerCase());
         } catch (final NumberFormatException ex) {
           // ignore malformed input
         }
@@ -237,7 +237,7 @@ public class PlacementPicker extends JFrame {
             "Enter the unit's image width in pixels (unscaled / without zoom).\r\n(e.g. 48)");
         if (width != null) {
           try {
-            PLACEWIDTH = (int) (unit_zoom_percent * Integer.parseInt(width));
+            placeWidth = (int) (unitZoomPercent * Integer.parseInt(width));
           } catch (final NumberFormatException ex) {
             // ignore malformed input
           }
@@ -246,7 +246,7 @@ public class PlacementPicker extends JFrame {
             "Enter the unit's image height in pixels (unscaled / without zoom).\r\n(e.g. 48)");
         if (height != null) {
           try {
-            PLACEHEIGHT = (int) (unit_zoom_percent * Integer.parseInt(height));
+            placeHeight = (int) (unitZoomPercent * Integer.parseInt(height));
           } catch (final NumberFormatException ex) {
             // ignore malformed input
           }
@@ -426,10 +426,10 @@ public class PlacementPicker extends JFrame {
             final Iterator<Point> pointIter = entry.getValue().iterator();
             while (pointIter.hasNext()) {
               final Point item = pointIter.next();
-              g.fillRect(item.x, item.y, PLACEWIDTH, PLACEHEIGHT);
+              g.fillRect(item.x, item.y, placeWidth, placeHeight);
               if (showOverflowMode && !pointIter.hasNext()) {
                 g.setColor(Color.gray);
-                g.fillRect(item.x + PLACEWIDTH, item.y + PLACEHEIGHT / 2, PLACEWIDTH, 4);
+                g.fillRect(item.x + placeWidth, item.y + placeHeight / 2, placeWidth, 4);
                 g.setColor(Color.yellow);
               }
             }
@@ -458,7 +458,7 @@ public class PlacementPicker extends JFrame {
         }
         g.setColor(Color.red);
         if (currentSquare != null) {
-          g.drawRect(currentSquare.x, currentSquare.y, PLACEWIDTH, PLACEHEIGHT);
+          g.drawRect(currentSquare.x, currentSquare.y, placeWidth, placeHeight);
         }
         if (currentPlacements == null) {
           return;
@@ -466,10 +466,10 @@ public class PlacementPicker extends JFrame {
         final Iterator<Point> pointIter = currentPlacements.iterator();
         while (pointIter.hasNext()) {
           final Point item = pointIter.next();
-          g.fillRect(item.x, item.y, PLACEWIDTH, PLACEHEIGHT);
+          g.fillRect(item.x, item.y, placeWidth, placeHeight);
           if (showOverflowMode && !pointIter.hasNext()) {
             g.setColor(Color.gray);
-            g.fillRect(item.x + PLACEWIDTH, item.y + PLACEHEIGHT / 2, PLACEWIDTH, 4);
+            g.fillRect(item.x + placeWidth, item.y + placeHeight / 2, placeWidth, 4);
             g.setColor(Color.red);
           }
         }
@@ -663,8 +663,8 @@ public class PlacementPicker extends JFrame {
     final String zoomString = System.getProperty(TRIPLEA_UNIT_ZOOM);
     if (zoomString != null && zoomString.length() > 0) {
       try {
-        unit_zoom_percent = Double.parseDouble(zoomString);
-        System.out.println("Unit Zoom Percent to use: " + unit_zoom_percent);
+        unitZoomPercent = Double.parseDouble(zoomString);
+        System.out.println("Unit Zoom Percent to use: " + unitZoomPercent);
         placeDimensionsSet = true;
       } catch (final Exception ex) {
         System.err.println("Not a decimal percentage: " + zoomString);
@@ -673,8 +673,8 @@ public class PlacementPicker extends JFrame {
     final String widthString = System.getProperty(TRIPLEA_UNIT_WIDTH);
     if (widthString != null && widthString.length() > 0) {
       try {
-        unit_width = Integer.parseInt(widthString);
-        System.out.println("Unit Width to use: " + unit_width);
+        unitWidth = Integer.parseInt(widthString);
+        System.out.println("Unit Width to use: " + unitWidth);
         placeDimensionsSet = true;
       } catch (final Exception ex) {
         System.err.println("Not an integer: " + widthString);
@@ -683,17 +683,17 @@ public class PlacementPicker extends JFrame {
     final String heightString = System.getProperty(TRIPLEA_UNIT_HEIGHT);
     if (heightString != null && heightString.length() > 0) {
       try {
-        unit_height = Integer.parseInt(heightString);
-        System.out.println("Unit Height to use: " + unit_height);
+        unitHeight = Integer.parseInt(heightString);
+        System.out.println("Unit Height to use: " + unitHeight);
         placeDimensionsSet = true;
       } catch (final Exception ex) {
         System.err.println("Not an integer: " + heightString);
       }
     }
     if (placeDimensionsSet) {
-      PLACEWIDTH = (int) (unit_zoom_percent * unit_width);
-      PLACEHEIGHT = (int) (unit_zoom_percent * unit_height);
-      System.out.println("Place Dimensions to use: " + PLACEWIDTH + "x" + PLACEHEIGHT);
+      placeWidth = (int) (unitZoomPercent * unitWidth);
+      placeHeight = (int) (unitZoomPercent * unitHeight);
+      System.out.println("Place Dimensions to use: " + placeWidth + "x" + placeHeight);
     }
   }
 }


### PR DESCRIPTION
This PR fixes the remaining violations of the Checkstyle StaticVariableName rule.

In some cases where an UPPER_SNAKE_CASE name was used, it was apparent that the field was actually a constant, so I simply marked the field `final` instead of renaming it.  I'm not going to bother highlighting these in a review, as I think they will be obvious.

There were some unrelated accessibility changes that I will call out in a review.