### PR TITLE
Remove Substance Swing 'Look and Feel' library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,6 @@ sourceSets {
 dependencies {
     compile 'commons-io:commons-io:2.5'
     compile 'postgresql:postgresql:9.1-901-1.jdbc4'
-    compile 'com.github.insubstantial:substance:7.3'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
     compile 'com.google.guava:guava:19.0'
     compile 'com.googlecode.soundlibs:jlayer:1.0.1-2'

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -312,7 +312,7 @@ public class GameRunner {
       protected void dispatchEvent(final AWTEvent newEvent) {
         try {
           super.dispatchEvent(newEvent);
-          // This ensures, that all exceptions/errors inside any swing framework (like substance) are logged correctly
+          // This ensures, that all exceptions/errors inside any swing framework are logged correctly
         } catch (final Throwable t) {
           ClientLogger.logError(t);
           throw t;

--- a/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -1,39 +1,10 @@
 package games.strategy.engine.framework.lookandfeel;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.swing.UIManager;
-
-import org.pushingpixels.substance.api.skin.SubstanceAutumnLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceBusinessBlackSteelLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceBusinessBlueSteelLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceBusinessLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceCeruleanLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceChallengerDeepLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceCremeCoffeeLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceCremeLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceDustCoffeeLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceDustLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceEmeraldDuskLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceGeminiLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceGraphiteAquaLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceGraphiteGlassLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceGraphiteLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceMagellanLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceMarinerLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceMistAquaLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceMistSilverLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceModerateLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceNebulaBrickWallLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceNebulaLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceOfficeBlack2007LookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceOfficeBlue2007LookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceOfficeSilver2007LookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceRavenLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceSaharaLookAndFeel;
-import org.pushingpixels.substance.api.skin.SubstanceTwilightLookAndFeel;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.engine.framework.system.SystemProperties;
@@ -43,38 +14,15 @@ import games.strategy.ui.SwingAction;
 public class LookAndFeel {
 
   public static List<String> getLookAndFeelAvailableList() {
-    final List<String> substanceLooks = new ArrayList<>();
-    for (final UIManager.LookAndFeelInfo look : UIManager.getInstalledLookAndFeels()) {
-      substanceLooks.add(look.getClassName());
-    }
-    substanceLooks.addAll(Arrays.asList(SubstanceAutumnLookAndFeel.class.getName(),
-        SubstanceBusinessBlackSteelLookAndFeel.class.getName(), SubstanceBusinessBlueSteelLookAndFeel.class.getName(),
-        SubstanceBusinessLookAndFeel.class.getName(), SubstanceCeruleanLookAndFeel.class.getName(),
-        SubstanceChallengerDeepLookAndFeel.class.getName(), SubstanceCremeCoffeeLookAndFeel.class.getName(),
-        SubstanceCremeLookAndFeel.class.getName(), SubstanceDustCoffeeLookAndFeel.class.getName(),
-        SubstanceDustLookAndFeel.class.getName(), SubstanceEmeraldDuskLookAndFeel.class.getName(),
-        SubstanceGeminiLookAndFeel.class.getName(), SubstanceGraphiteAquaLookAndFeel.class.getName(),
-        SubstanceGraphiteGlassLookAndFeel.class.getName(), SubstanceGraphiteLookAndFeel.class.getName(),
-        SubstanceMagellanLookAndFeel.class.getName(), SubstanceMarinerLookAndFeel.class.getName(),
-        SubstanceMistAquaLookAndFeel.class.getName(), SubstanceMistSilverLookAndFeel.class.getName(),
-        SubstanceModerateLookAndFeel.class.getName(), SubstanceNebulaBrickWallLookAndFeel.class.getName(),
-        SubstanceNebulaLookAndFeel.class.getName(), SubstanceOfficeBlack2007LookAndFeel.class.getName(),
-        SubstanceOfficeBlue2007LookAndFeel.class.getName(), SubstanceOfficeSilver2007LookAndFeel.class.getName(),
-        SubstanceRavenLookAndFeel.class.getName(), SubstanceSaharaLookAndFeel.class.getName(),
-        SubstanceTwilightLookAndFeel.class.getName()));
-    return substanceLooks;
+    return Arrays.stream(UIManager.getInstalledLookAndFeels())
+        .map(UIManager.LookAndFeelInfo::getClassName)
+        .collect(Collectors.toList());
   }
 
   public static void setupLookAndFeel() {
     SwingAction.invokeAndWait(() -> {
       try {
         UIManager.setLookAndFeel(ClientSetting.LOOK_AND_FEEL_PREF.value());
-        // FYI if you are getting a null pointer exception in Substance, like this:
-        // org.pushingpixels.substance.internal.utils.SubstanceColorUtilities
-        // .getDefaultBackgroundColor(SubstanceColorUtilities.java:758)
-        // Then it is because you included the swingx substance library without including swingx.
-        // You can solve by including both swingx libraries or removing both,
-        // or by setting the look and feel twice in a row.
       } catch (final Throwable t) {
         if (!SystemProperties.isMac()) {
           try {


### PR DESCRIPTION
Proposed to the community here: https://forums.triplea-game.org/topic/270/drop-substance-ui-look-and-feel

Reasons for removal:
- not all of the Substance themes work. Some are 'poison pills' and crash your system. When checking I did not find a good way for the code to know about this before hand.
- Substance integrates at a deep layer in an old Java UI framework. There are actually a number of bugs in the framework itself that we hit every now and then.
- Substance is not supported anymore, there will not be any patches for it.
- The latest Java framework we hope to move to (JavaFX) over coming time does not need Substance, so Substance will be dropped pretty soon.
- One fewer Jar => smaller download and faster install

<!--

All PRs should follow the standards outlined at:
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_standards.md

More about those standards here: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_format.md

To learn more about the process of reviewing PRs, see: 
https://github.com/triplea-game/triplea/blob/master/docs/dev/code_reviews.md

-->
