### PR TITLE
Serialization proxy: Add game loader to game data memento

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameData.java
+++ b/src/main/java/games/strategy/engine/data/GameData.java
@@ -515,6 +515,8 @@ public class GameData implements Serializable {
     sb.append(gameName);
     sb.append(", gameVersion=");
     sb.append(gameVersion);
+    sb.append(", loader=");
+    sb.append(loader);
     // TODO: include remaining significant fields
     sb.append("]");
     return sb.toString();

--- a/src/main/java/games/strategy/engine/data/GameDataMemento.java
+++ b/src/main/java/games/strategy/engine/data/GameDataMemento.java
@@ -9,6 +9,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
+import games.strategy.engine.framework.IGameLoader;
 import games.strategy.util.Version;
 import games.strategy.util.memento.MementoExporter;
 import games.strategy.util.memento.MementoImportException;
@@ -37,6 +38,7 @@ public final class GameDataMemento {
   @VisibleForTesting
   interface PropertyNames {
     String DICE_SIDES = "diceSides";
+    String LOADER = "loader";
     String NAME = "name";
     String VERSION = "version";
   }
@@ -100,6 +102,7 @@ public final class GameDataMemento {
     @Override
     public void exportProperties(final GameData gameData, final Map<String, Object> propertiesByName) {
       propertiesByName.put(PropertyNames.DICE_SIDES, gameData.getDiceSides());
+      propertiesByName.put(PropertyNames.LOADER, gameData.getGameLoader());
       propertiesByName.put(PropertyNames.NAME, gameData.getGameName());
       propertiesByName.put(PropertyNames.VERSION, gameData.getGameVersion());
       // TODO: handle remaining properties
@@ -120,6 +123,7 @@ public final class GameDataMemento {
     public GameData importProperties(final Map<String, Object> propertiesByName) throws MementoImportException {
       final GameData gameData = new GameData();
       gameData.setDiceSides(getRequiredProperty(propertiesByName, PropertyNames.DICE_SIDES, Integer.class));
+      gameData.setGameLoader(getRequiredProperty(propertiesByName, PropertyNames.LOADER, IGameLoader.class));
       gameData.setGameName(getRequiredProperty(propertiesByName, PropertyNames.NAME, String.class));
       gameData.setGameVersion(getRequiredProperty(propertiesByName, PropertyNames.VERSION, Version.class));
       // TODO: handle remaining properties

--- a/src/main/java/games/strategy/internal/persistence/serializable/TripleAProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/TripleAProxy.java
@@ -1,0 +1,29 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.triplea.TripleA;
+import net.jcip.annotations.Immutable;
+
+/**
+ * A serializable proxy for the {@link TripleA} class.
+ */
+@Immutable
+public final class TripleAProxy implements Proxy {
+  private static final long serialVersionUID = 263867233328100619L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(TripleA.class, TripleAProxy::new);
+
+  public TripleAProxy(final TripleA triplea) {
+    checkNotNull(triplea);
+
+    // do nothing; no persistent state
+  }
+
+  @Override
+  public Object readResolve() {
+    return new TripleA();
+  }
+}

--- a/src/main/java/games/strategy/triplea/TripleA.java
+++ b/src/main/java/games/strategy/triplea/TripleA.java
@@ -183,4 +183,9 @@ public class TripleA implements IGameLoader {
       }
     };
   }
+
+  @Override
+  public String toString() {
+    return "TripleA[]";
+  }
 }

--- a/src/test/java/games/strategy/engine/data/Matchers.java
+++ b/src/test/java/games/strategy/engine/data/Matchers.java
@@ -45,9 +45,14 @@ public final class Matchers {
     @Override
     protected boolean matchesSafely(final GameData actual) {
       return (expected.getDiceSides() == actual.getDiceSides())
+          && areBothNullOrBothNotNull(expected.getGameLoader(), actual.getGameLoader())
           && Objects.equals(expected.getGameName(), actual.getGameName())
           && Objects.equals(expected.getGameVersion(), actual.getGameVersion());
       // TODO: include remaining fields
+    }
+
+    private static boolean areBothNullOrBothNotNull(final Object expected, final Object actual) {
+      return (expected == null) == (actual == null);
     }
   }
 }

--- a/src/test/java/games/strategy/engine/data/TestGameDataFactory.java
+++ b/src/test/java/games/strategy/engine/data/TestGameDataFactory.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.data;
 
+import games.strategy.triplea.TripleA;
 import games.strategy.util.Version;
 
 /**
@@ -16,6 +17,7 @@ public final class TestGameDataFactory {
   public static GameData newValidGameData() {
     final GameData gameData = new GameData();
     gameData.setDiceSides(42);
+    gameData.setGameLoader(new TripleA());
     gameData.setGameName("name");
     gameData.setGameVersion(new Version(1, 2, 3, 4));
     // TODO: initialize other attributes

--- a/src/test/java/games/strategy/internal/persistence/serializable/TripleAProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/TripleAProxyAsProxyTest.java
@@ -1,0 +1,35 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.triplea.TripleA;
+
+public final class TripleAProxyAsProxyTest extends AbstractProxyTestCase<TripleA> {
+  public TripleAProxyAsProxyTest() {
+    super(TripleA.class);
+  }
+
+  @Override
+  protected void assertPrincipalEquals(final TripleA expected, final TripleA actual) {
+    checkNotNull(expected);
+    checkNotNull(actual);
+
+    assertTrue("no persistent state; all non-null instances are considered equal", true);
+  }
+
+  @Override
+  protected Collection<TripleA> createPrincipals() {
+    return Arrays.asList(new TripleA());
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getProxyFactories() {
+    return Arrays.asList(TripleAProxy.FACTORY);
+  }
+}


### PR DESCRIPTION
This PR adds the game loader property to the `GameData` memento.  The only instance of `IGameLoader` that needs a proxy is `TripleA` as `TestGameLoader` should never be persisted to a save game.