### PR TITLE
Checkstyle: Fix method name violation in JPanelBuilderTest

### DIFF
--- a/src/test/java/swinglib/JPanelBuilderTest.java
+++ b/src/test/java/swinglib/JPanelBuilderTest.java
@@ -44,7 +44,7 @@ public class JPanelBuilderTest {
   }
 
   @Test
-  public void xAlignmentCenter() {
+  public void horizontalAlignmentCenter() {
     final JPanel panel = JPanelBuilder.builder()
         .horizontalAlignmentCenter()
         .build();


### PR DESCRIPTION
This PR fixes a violation of the Checkstyle MethodName rule in the `JPanelBuilderTest` class.  I simply renamed the test method to match the name of the method under test.