### PR TITLE
Checkstyle: Remove m_ and s_ prefixes from local variable names

### DIFF
--- a/src/main/java/games/strategy/debug/GenericConsole.java
+++ b/src/main/java/games/strategy/debug/GenericConsole.java
@@ -30,22 +30,22 @@ public abstract class GenericConsole extends JFrame {
     m_text.setWrapStyleWord(true);
     final JScrollPane scroll = new JScrollPane(m_text);
     getContentPane().add(scroll, BorderLayout.CENTER);
-    final JToolBar m_actions = new JToolBar(SwingConstants.HORIZONTAL);
-    getContentPane().add(m_actions, BorderLayout.SOUTH);
-    m_actions.setFloatable(false);
-    m_actions.add(m_threadDiagnoseAction);
-    final AbstractAction m_memoryAction = SwingAction.of("Memory", e -> append(DebugUtils.getMemory()));
-    m_actions.add(m_memoryAction);
-    final AbstractAction m_propertiesAction = SwingAction.of("Properties", e -> append(DebugUtils.getProperties()));
-    m_actions.add(m_propertiesAction);
-    final Action m_copyAction = SwingAction.of("Copy to clipboard", e -> {
+    final JToolBar actions = new JToolBar(SwingConstants.HORIZONTAL);
+    getContentPane().add(actions, BorderLayout.SOUTH);
+    actions.setFloatable(false);
+    actions.add(m_threadDiagnoseAction);
+    final AbstractAction memoryAction = SwingAction.of("Memory", e -> append(DebugUtils.getMemory()));
+    actions.add(memoryAction);
+    final AbstractAction propertiesAction = SwingAction.of("Properties", e -> append(DebugUtils.getProperties()));
+    actions.add(propertiesAction);
+    final Action copyAction = SwingAction.of("Copy to clipboard", e -> {
       final String text = m_text.getText();
       final StringSelection select = new StringSelection(text);
       Toolkit.getDefaultToolkit().getSystemClipboard().setContents(select, select);
     });
-    m_actions.add(m_copyAction);
-    final AbstractAction m_clearAction = SwingAction.of("Clear", e -> clear());
-    m_actions.add(m_clearAction);
+    actions.add(copyAction);
+    final AbstractAction clearAction = SwingAction.of("Clear", e -> clear());
+    actions.add(clearAction);
     SwingUtilities.invokeLater(() -> pack());
   }
 

--- a/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -531,9 +531,9 @@ public class GameDataExporter {
     xmlfile.append("        <sequence>\n");
     for (final GameStep step : data.getSequence()) {
       try {
-        final Field mDelegateField = GameStep.class.getDeclaredField("m_delegate"); // TODO: unchecked reflection
-        mDelegateField.setAccessible(true);
-        final String delegate = (String) mDelegateField.get(step);
+        final Field delegateField = GameStep.class.getDeclaredField("m_delegate"); // TODO: unchecked reflection
+        delegateField.setAccessible(true);
+        final String delegate = (String) delegateField.get(step);
         xmlfile.append("            <step name=\"").append(step.getName()).append("\" delegate=\"").append(delegate)
             .append("\"");
       } catch (final NullPointerException | NoSuchFieldException | IllegalArgumentException

--- a/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -110,7 +110,7 @@ public class ClientGame extends AbstractGame {
       }
     };
     m_channelMessenger.registerChannelSubscriber(m_gameModifiedChannel, IGame.GAME_MODIFICATION_CHANNEL);
-    final IGameStepAdvancer m_gameStepAdvancer = (stepName, player) -> {
+    final IGameStepAdvancer gameStepAdvancer = (stepName, player) -> {
       if (m_isGameOver) {
         return;
       }
@@ -152,7 +152,7 @@ public class ClientGame extends AbstractGame {
       }
       gp.start(stepName);
     };
-    m_remoteMessenger.registerRemote(m_gameStepAdvancer, getRemoteStepAdvancerName(m_channelMessenger.getLocalNode()));
+    m_remoteMessenger.registerRemote(gameStepAdvancer, getRemoteStepAdvancerName(m_channelMessenger.getLocalNode()));
     for (final PlayerID player : m_gamePlayers.keySet()) {
       final IRemoteRandom remoteRandom = new RemoteRandom(this);
       m_remoteMessenger.registerRemote(remoteRandom, ServerGame.getRemoteRandomName(player));

--- a/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -149,7 +149,7 @@ public class ServerGame extends AbstractGame {
     m_channelMessenger.registerChannelSubscriber(m_gameModifiedChannel, IGame.GAME_MODIFICATION_CHANNEL);
     setupDelegateMessaging(data);
     m_randomStats = new RandomStats(m_remoteMessenger);
-    final IServerRemote m_serverRemote = () -> {
+    final IServerRemote serverRemote = () -> {
       final ByteArrayOutputStream sink = new ByteArrayOutputStream(5000);
       try {
         saveGame(sink);
@@ -159,7 +159,7 @@ public class ServerGame extends AbstractGame {
       }
       return sink.toByteArray();
     };
-    m_remoteMessenger.registerRemote(m_serverRemote, SERVER_REMOTE);
+    m_remoteMessenger.registerRemote(serverRemote, SERVER_REMOTE);
   }
 
   public void addObserver(final IObserverWaitingToJoin blockingObserver,

--- a/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -52,7 +52,7 @@ class PlayerSelectorRow {
     name = new JLabel(playerName + ":");
 
     enabledCheckBox = new JCheckBox();
-    final ActionListener m_disablePlayerActionListener = new ActionListener() {
+    final ActionListener disablePlayerActionListener = new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent e) {
         if (enabledCheckBox.isSelected()) {
@@ -67,7 +67,7 @@ class PlayerSelectorRow {
         setWidgetActivation();
       }
     };
-    enabledCheckBox.addActionListener(m_disablePlayerActionListener);
+    enabledCheckBox.addActionListener(disablePlayerActionListener);
     enabledCheckBox.setSelected(playersEnablementListing.get(playerName));
     enabledCheckBox.setEnabled(disableable.contains(playerName));
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -317,13 +317,13 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     playerRows = new ArrayList<>();
     final Map<String, String> players = model.getPlayersToNodeListing();
     final Map<String, Boolean> playersEnabled = model.getPlayersEnabledListing();
-    final Map<String, Collection<String>> m_playerNamesAndAlliancesInTurnOrder =
+    final Map<String, Collection<String>> playerNamesAndAlliancesInTurnOrder =
         model.getPlayerNamesAndAlliancesInTurnOrderLinkedHashMap();
     final Map<String, String> reloadSelections = PlayerID.currentPlayers(gameSelectorModel.getGameData());
-    final Set<String> playerNames = m_playerNamesAndAlliancesInTurnOrder.keySet();
+    final Set<String> playerNames = playerNamesAndAlliancesInTurnOrder.keySet();
     for (final String name : playerNames) {
       final PlayerRow newPlayerRow =
-          new PlayerRow(name, reloadSelections, m_playerNamesAndAlliancesInTurnOrder.get(name),
+          new PlayerRow(name, reloadSelections, playerNamesAndAlliancesInTurnOrder.get(name),
               gameSelectorModel.getGameData().getGameLoader().getServerPlayerTypes());
       playerRows.add(newPlayerRow);
       newPlayerRow.update(players, playersEnabled);

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
@@ -51,8 +51,8 @@ public class DiceServerEditor extends EditorPanel {
       row++;
     }
     if (remoteDiceServer.supportsGameId()) {
-      final JLabel m_gameIdLabel = new JLabel("Game ID:");
-      add(m_gameIdLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
+      final JLabel gameIdLabel = new JLabel("Game ID:");
+      add(gameIdLabel, new GridBagConstraints(0, row, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,
           new Insets(0, 0, bottomSpace, labelSpace), 0, 0));
       add(gameId, new GridBagConstraints(1, row, 2, 1, 1.0, 0, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
           new Insets(0, 0, bottomSpace, 0), 0, 0));

--- a/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -37,8 +37,6 @@ class LobbyGameTableModel extends AbstractTableModel {
     gameList = new ArrayList<>();
 
     m_messenger = messenger;
-    final IChannelMessenger m_channelMessenger = channelMessenger;
-    final IRemoteMessenger m_remoteMessenger = remoteMessenger;
     lobbyGameBroadcaster = new ILobbyGameBroadcaster() {
       @Override
       public void gameUpdated(final GUID gameId, final GameDescription description) {
@@ -52,10 +50,10 @@ class LobbyGameTableModel extends AbstractTableModel {
         removeGame(gameId);
       }
     };
-    m_channelMessenger.registerChannelSubscriber(lobbyGameBroadcaster, ILobbyGameBroadcaster.GAME_BROADCASTER_CHANNEL);
+    channelMessenger.registerChannelSubscriber(lobbyGameBroadcaster, ILobbyGameBroadcaster.GAME_BROADCASTER_CHANNEL);
 
     final Map<GUID, GameDescription> games =
-        ((ILobbyGameController) m_remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE)).listGames();
+        ((ILobbyGameController) remoteMessenger.getRemote(ILobbyGameController.GAME_CONTROLLER_REMOTE)).listGames();
     for (final GUID id : games.keySet()) {
       updateGame(id, games.get(id));
     }

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
@@ -27,8 +27,7 @@ class LobbyGameController implements ILobbyGameController {
 
   LobbyGameController(final ILobbyGameBroadcaster broadcaster, final IMessenger messenger) {
     m_broadcaster = broadcaster;
-    final IMessenger m_messenger = messenger;
-    ((IServerMessenger) m_messenger).addConnectionChangeListener(new IConnectionChangeListener() {
+    ((IServerMessenger) messenger).addConnectionChangeListener(new IConnectionChangeListener() {
       @Override
       public void connectionRemoved(final INode to) {
         connectionLost(to);

--- a/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
+++ b/src/main/java/games/strategy/engine/message/RemoteMethodCall.java
@@ -147,8 +147,8 @@ public class RemoteMethodCall implements Externalizable {
       out.writeByte(Byte.MAX_VALUE);
     } else {
       out.writeByte(m_args.length);
-      for (final Object m_arg : m_args) {
-        out.writeObject(m_arg);
+      for (final Object arg : m_args) {
+        out.writeObject(arg);
       }
     }
   }

--- a/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -60,11 +60,11 @@ public class UnifiedMessenger {
    */
   public UnifiedMessenger(final IMessenger messenger) {
     m_messenger = messenger;
-    final IMessageListener m_messageListener = (msg, from) -> UnifiedMessenger.this.messageReceived(msg, from);
-    m_messenger.addMessageListener(m_messageListener);
-    final IMessengerErrorListener m_messengerErrorListener =
+    final IMessageListener messageListener = (msg, from) -> UnifiedMessenger.this.messageReceived(msg, from);
+    m_messenger.addMessageListener(messageListener);
+    final IMessengerErrorListener messengerErrorListener =
         (messenger1, reason) -> UnifiedMessenger.this.messengerInvalid();
-    m_messenger.addErrorListener(m_messengerErrorListener);
+    m_messenger.addErrorListener(messengerErrorListener);
     if (m_messenger.isServer()) {
       m_hub = new UnifiedMessengerHub(m_messenger, this);
     }

--- a/src/main/java/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
+++ b/src/main/java/games/strategy/engine/pbem/TripleAWarClubForumPoster.java
@@ -97,8 +97,8 @@ public class TripleAWarClubForumPoster extends AbstractForumPoster {
         HttpClientBuilder.create().setRedirectStrategy(new LaxRedirectStrategy()).build()) {
       HttpContext httpContext = login(client);
       // load the reply page
-      final String s_forumId = "20";
-      final String url = WAR_CLUB_FORUM_URL + "/reply.php?forum=" + s_forumId + "&topic_id="
+      final String forumId = "20";
+      final String url = WAR_CLUB_FORUM_URL + "/reply.php?forum=" + forumId + "&topic_id="
           + URLEncoder.encode(m_topicId, StandardCharsets.UTF_8.name());
       String xoopsTokenRequest;
       HttpGet httpGet = new HttpGet(url);
@@ -119,7 +119,7 @@ public class TripleAWarClubForumPoster extends AbstractForumPoster {
       MultipartEntityBuilder builder = MultipartEntityBuilder.create()
           .addTextBody("subject", subject)
           .addTextBody("message", summary)
-          .addTextBody("forum", s_forumId)
+          .addTextBody("forum", forumId)
           .addTextBody("topic_id", m_topicId)
           .addTextBody("XOOPS_TOKEN_REQUEST", xoopsTokenRequest)
           .addTextBody("xoops_upload_file[]", "userfile")
@@ -147,7 +147,7 @@ public class TripleAWarClubForumPoster extends AbstractForumPoster {
           throw new Exception("Posting summary failed, the server didn't respond with thank you message");
         }
         m_turnSummaryRef =
-            "www.tripleawarclub.org/modules/newbb/viewtopic.php?topic_id=" + m_topicId + "&forum=" + s_forumId;
+            "www.tripleawarclub.org/modules/newbb/viewtopic.php?topic_id=" + m_topicId + "&forum=" + forumId;
       }
       // now logout, this is just to be nice, so we don't care if this fails
       try {

--- a/src/main/java/games/strategy/engine/random/RandomStatsDetails.java
+++ b/src/main/java/games/strategy/engine/random/RandomStatsDetails.java
@@ -38,53 +38,53 @@ public class RandomStatsDetails implements Serializable {
   }
 
   private static DiceStatistic getDiceStatistic(final IntegerMap<Integer> stats, final int diceSides) {
-    final double m_average;
-    final int m_total;
-    final double m_median;
-    final double m_stdDeviation;
-    final double m_variance;
+    final double average;
+    final int total;
+    final double median;
+    final double stdDeviation;
+    final double variance;
     if (stats.totalValues() != 0) {
       int sumTotal = 0;
-      int total = 0;
+      int localTotal = 0;
       // TODO: does this need to be updated to take data.getDiceSides() ?
       for (int i = 1; i <= diceSides; i++) {
         sumTotal += i * stats.getInt(Integer.valueOf(i));
-        total += stats.getInt(Integer.valueOf(i));
+        localTotal += stats.getInt(Integer.valueOf(i));
       }
-      m_total = total;
-      m_average = (sumTotal) / ((double) stats.totalValues());
+      total = localTotal;
+      average = (sumTotal) / ((double) stats.totalValues());
       /**
        * calculate median
        */
-      if (total % 2 != 0) {
-        m_median = calcMedian((total / 2) + 1, diceSides, stats);
+      if (localTotal % 2 != 0) {
+        median = calcMedian((localTotal / 2) + 1, diceSides, stats);
       } else {
         double tmp1 = 0;
         double tmp2 = 0;
-        tmp1 = calcMedian((total / 2), diceSides, stats);
-        tmp2 = calcMedian((total / 2) + 1, diceSides, stats);
-        m_median = (tmp1 + tmp2) / 2;
+        tmp1 = calcMedian((localTotal / 2), diceSides, stats);
+        tmp2 = calcMedian((localTotal / 2) + 1, diceSides, stats);
+        median = (tmp1 + tmp2) / 2;
       }
       // calculate variance
-      double variance = 0;
+      double sumOfSquaredMeanDeviations = 0;
       // TODO: does this need to be updated to take data.getDiceSides() ?
       for (int i = 1; i <= diceSides; i++) {
-        variance += (stats.getInt(Integer.valueOf(i)) - (total / diceSides))
-            * (stats.getInt(Integer.valueOf(i)) - (total / diceSides));
+        sumOfSquaredMeanDeviations += (stats.getInt(Integer.valueOf(i)) - (localTotal / diceSides))
+            * (stats.getInt(Integer.valueOf(i)) - (localTotal / diceSides));
       }
-      m_variance = variance / (total - 1);
+      variance = sumOfSquaredMeanDeviations / (localTotal - 1);
       /**
        * calculate standard deviation
        */
-      m_stdDeviation = Math.sqrt(m_variance);
+      stdDeviation = Math.sqrt(variance);
     } else {
-      m_average = 0;
-      m_total = 0;
-      m_median = 0;
-      m_stdDeviation = 0;
-      m_variance = 0;
+      average = 0;
+      total = 0;
+      median = 0;
+      stdDeviation = 0;
+      variance = 0;
     }
-    return new DiceStatistic(m_average, m_total, m_median, m_stdDeviation, m_variance);
+    return new DiceStatistic(average, total, median, stdDeviation, variance);
   }
 
   public Map<PlayerID, IntegerMap<Integer>> getData() {

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -615,8 +615,8 @@ public class BattleTracker implements Serializable {
         // remove all the tokens of the captured player
         final Resource tokens = data.getResourceList().getResource(Constants.TECH_TOKENS);
         if (tokens != null) {
-          final int m_currTokens = whoseCapital.getResources().getQuantity(Constants.TECH_TOKENS);
-          final Change removeTokens = ChangeFactory.changeResourcesChange(whoseCapital, tokens, -m_currTokens);
+          final int currTokens = whoseCapital.getResources().getQuantity(Constants.TECH_TOKENS);
+          final Change removeTokens = ChangeFactory.changeResourcesChange(whoseCapital, tokens, -currTokens);
           bridge.addChange(removeTokens);
           if (changeTracker != null) {
             changeTracker.addChange(removeTokens);

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -2585,12 +2585,12 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // defender, and if the
     // units in m_attackingUnits are allied with the attacker? Does it really matter?
     final Match<Unit> alliedDefendingAir = Match.allOf(Matches.UnitIsAir, Matches.UnitWasScrambled.invert());
-    final Collection<Unit> m_defendingAir = Match.getMatches(m_defendingUnits, alliedDefendingAir);
+    final Collection<Unit> defendingAir = Match.getMatches(m_defendingUnits, alliedDefendingAir);
     // no planes, exit
-    if (m_defendingAir.isEmpty()) {
+    if (defendingAir.isEmpty()) {
       return;
     }
-    int carrierCost = AirMovementValidator.carrierCost(m_defendingAir);
+    int carrierCost = AirMovementValidator.carrierCost(defendingAir);
     final int carrierCapacity = AirMovementValidator.carrierCapacity(m_defendingUnits, m_battleSite);
     // add dependant air to carrier cost
     carrierCost +=
@@ -2605,18 +2605,18 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // add dependant air to carrier cost
     carrierCost +=
         AirMovementValidator.carrierCost(Match.getMatches(getDependentUnits(m_defendingUnits), alliedDefendingAir));
-    for (final Unit currentUnit : new ArrayList<>(m_defendingAir)) {
+    for (final Unit currentUnit : new ArrayList<>(defendingAir)) {
       if (!Matches.UnitCanLandOnCarrier.match(currentUnit)) {
-        m_defendingAir.remove(currentUnit);
+        defendingAir.remove(currentUnit);
         continue;
       }
       carrierCost += UnitAttachment.get(currentUnit.getType()).getCarrierCost();
       if (carrierCapacity >= carrierCost) {
-        m_defendingAir.remove(currentUnit);
+        defendingAir.remove(currentUnit);
       }
     }
     // Moved this choosing to after all battles, as we legally should be able to land in a territory if we win there.
-    m_battleTracker.addToDefendingAirThatCanNotLand(m_defendingAir, m_battleSite);
+    m_battleTracker.addToDefendingAirThatCanNotLand(defendingAir, m_battleSite);
   }
 
   static CompositeChange clearTransportedByForAlliedAirOnCarrier(final Collection<Unit> attackingUnits,

--- a/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
@@ -164,21 +164,21 @@ public class IndividualUnitPanel extends JPanel {
     this.setLayout(new GridBagLayout());
     final Insets nullInsets = new Insets(0, 0, 0, 0);
     final Dimension buttonSize = new Dimension(80, 20);
-    final JButton m_selectNoneButton = new JButton("None");
-    m_selectNoneButton.setPreferredSize(buttonSize);
-    final JButton m_autoSelectButton = new JButton("Max");
-    m_autoSelectButton.setPreferredSize(buttonSize);
+    final JButton selectNoneButton = new JButton("None");
+    selectNoneButton.setPreferredSize(buttonSize);
+    final JButton autoSelectButton = new JButton("Max");
+    autoSelectButton.setPreferredSize(buttonSize);
     add(title, new GridBagConstraints(0, 0, 7, 1, 0, 0.5, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
         nullInsets, 0, 0));
-    m_selectNoneButton.addActionListener(e -> selectNone());
-    m_autoSelectButton.addActionListener(e -> autoSelect());
+    selectNoneButton.addActionListener(e -> selectNone());
+    autoSelectButton.addActionListener(e -> autoSelect());
     int rowIndex = 1;
     for (final SingleUnitPanel entry : entries) {
       entry.createComponents(this, rowIndex);
       rowIndex++;
     }
     if (showSelectAll) {
-      add(m_autoSelectButton, new GridBagConstraints(0, rowIndex, 7, 1, 0, 0.5, GridBagConstraints.EAST,
+      add(autoSelectButton, new GridBagConstraints(0, rowIndex, 7, 1, 0, 0.5, GridBagConstraints.EAST,
           GridBagConstraints.NONE, nullInsets, 0, 0));
       rowIndex++;
     }
@@ -239,8 +239,6 @@ public class IndividualUnitPanel extends JPanel {
         final ScrollableTextFieldListener textFieldListener, final int max, final int min, final int currentValue,
         final boolean showMaxAndMin) {
       this.unit = unit;
-      final GameData m_data = data;
-      final IUIContext m_context = context;
       countTextFieldListener = textFieldListener;
       textField = new ScrollableTextField(0, 512);
       if (max >= 0) {
@@ -255,7 +253,7 @@ public class IndividualUnitPanel extends JPanel {
       setLayout(new GridBagLayout());
 
       final boolean isDamaged = taUnit.getUnitDamage() > 0 || taUnit.getHits() > 0;
-      final JLabel label = m_context.createUnitImageJLabel(this.unit.getType(), this.unit.getOwner(), m_data,
+      final JLabel label = context.createUnitImageJLabel(this.unit.getType(), this.unit.getOwner(), data,
           isDamaged ? IUIContext.UnitDamage.DAMAGED : IUIContext.UnitDamage.NOT_DAMAGED,
           taUnit.getDisabled() ? IUIContext.UnitEnable.DISABLED : IUIContext.UnitEnable.ENABLED);
 

--- a/src/main/java/games/strategy/triplea/ui/IndividualUnitPanelGrouped.java
+++ b/src/main/java/games/strategy/triplea/ui/IndividualUnitPanelGrouped.java
@@ -109,14 +109,14 @@ public class IndividualUnitPanelGrouped extends JPanel {
     this.setLayout(new GridBagLayout());
     final Insets nullInsets = new Insets(0, 0, 0, 0);
     final Dimension buttonSize = new Dimension(80, 20);
-    final JButton m_selectNoneButton = new JButton("None");
-    m_selectNoneButton.setPreferredSize(buttonSize);
-    final JButton m_autoSelectButton = new JButton("Max");
-    m_autoSelectButton.setPreferredSize(buttonSize);
+    final JButton selectNoneButton = new JButton("None");
+    selectNoneButton.setPreferredSize(buttonSize);
+    final JButton autoSelectButton = new JButton("Max");
+    autoSelectButton.setPreferredSize(buttonSize);
     add(title, new GridBagConstraints(0, 0, 7, 1, 0, 0.5, GridBagConstraints.EAST, GridBagConstraints.HORIZONTAL,
         nullInsets, 0, 0));
-    m_selectNoneButton.addActionListener(e -> selectNone());
-    m_autoSelectButton.addActionListener(e -> autoSelect());
+    selectNoneButton.addActionListener(e -> selectNone());
+    autoSelectButton.addActionListener(e -> autoSelect());
     final JPanel entries = new JPanel();
     entries.setLayout(new FlowLayout());
     entries.setBorder(BorderFactory.createEmptyBorder());
@@ -155,7 +155,7 @@ public class IndividualUnitPanelGrouped extends JPanel {
         nullInsets, 0, 0));
     rowIndex++;
     if (showSelectAll) {
-      add(m_autoSelectButton, new GridBagConstraints(0, 2, 7, 1, 0, 0.5, GridBagConstraints.CENTER,
+      add(autoSelectButton, new GridBagConstraints(0, 2, 7, 1, 0, 0.5, GridBagConstraints.CENTER,
           GridBagConstraints.NONE, nullInsets, 0, 0));
       rowIndex++;
     }

--- a/src/main/java/games/strategy/triplea/ui/MoveForumPosterPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MoveForumPosterPanel.java
@@ -14,8 +14,8 @@ public class MoveForumPosterPanel extends AbstractForumPosterPanel {
 
   MoveForumPosterPanel(final GameData data, final MapPanel map) {
     super(data, map);
-    final AbstractAction m_doneAction = SwingAction.of("Done", e -> release());
-    forumPosterComponent = new ForumPosterComponent(getData(), m_doneAction, getTitle());
+    final AbstractAction doneAction = SwingAction.of("Done", e -> release());
+    forumPosterComponent = new ForumPosterComponent(getData(), doneAction, getTitle());
 
   }
 

--- a/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -76,19 +76,19 @@ public class TabbedProductionPanel extends ProductionPanel {
   private void calculateRowsAndColumns(final ProductionTabsProperties properties, final int largestList) {
     if (properties == null || properties.getRows() == 0 || properties.getColumns() == 0
         || properties.getRows() * properties.getColumns() < largestList) {
-      final int m_maxColumns;
+      final int maxColumns;
       if (largestList <= 36) {
-        m_maxColumns = Math.max(8,
+        maxColumns = Math.max(8,
             Math.min(12, new BigDecimal(largestList).divide(new BigDecimal(3), RoundingMode.UP).intValue()));
       } else if (largestList <= 64) {
-        m_maxColumns = Math.max(8,
+        maxColumns = Math.max(8,
             Math.min(16, new BigDecimal(largestList).divide(new BigDecimal(4), RoundingMode.UP).intValue()));
       } else {
-        m_maxColumns = Math.max(8,
+        maxColumns = Math.max(8,
             Math.min(16, new BigDecimal(largestList).divide(new BigDecimal(5), RoundingMode.UP).intValue()));
       }
       rows =
-          Math.max(2, new BigDecimal(largestList).divide(new BigDecimal(m_maxColumns), RoundingMode.UP).intValue());
+          Math.max(2, new BigDecimal(largestList).divide(new BigDecimal(maxColumns), RoundingMode.UP).intValue());
       columns =
           Math.max(3, new BigDecimal(largestList).divide(new BigDecimal(rows), RoundingMode.UP).intValue());
     } else {

--- a/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -284,9 +284,9 @@ public class TechPanel extends ActionPanel {
       final JLabel title = new JLabel("Select the number of tech rolls:");
       title.setBorder(new EmptyBorder(5, 5, 5, 5));
       textField = new ScrollableTextField(0, pus / TechTracker.getTechCost(player));
-      final ScrollableTextFieldListener m_listener =
+      final ScrollableTextFieldListener listener =
           stf -> setLabel(this.pus - (TechTracker.getTechCost(this.player) * textField.getValue()));
-      textField.addChangeListener(m_listener);
+      textField.addChangeListener(listener);
       final JLabel costLabel = new JLabel("x" + TechTracker.getTechCost(this.player));
       setLabel(pus);
       final int space = 0;
@@ -338,11 +338,11 @@ public class TechPanel extends ActionPanel {
       title.setBorder(new EmptyBorder(5, 5, 5, 5));
       final int techCost = TechTracker.getTechCost(this.player);
       textField = new ScrollableTextField(0, totalPus / techCost);
-      final ScrollableTextFieldListener m_listener = stf -> {
+      final ScrollableTextFieldListener listener = stf -> {
         setLabel(TechTracker.getTechCost(this.player) * textField.getValue());
         setWidgetActivation();
       };
-      textField.addChangeListener(m_listener);
+      textField.addChangeListener(listener);
       final JLabel costLabel = new JLabel("x" + techCost + " cost per token");
       setLabel(0);
       setTokens(currTokens);

--- a/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/TechResultsDisplay.java
@@ -21,7 +21,6 @@ public class TechResultsDisplay extends JPanel {
   private static final long serialVersionUID = -8303376983862918107L;
 
   TechResultsDisplay(final TechResults msg, final IUIContext uiContext, final GameData data) {
-    final IUIContext m_uiContext = uiContext;
     setLayout(new GridBagLayout());
     add(new JLabel("You got " + msg.getHits() + " hit" + (msg.getHits() != 1 ? "s" : "") + "."), new GridBagConstraints(
         0, 0, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 5, 0), 0, 0));
@@ -42,9 +41,9 @@ public class TechResultsDisplay extends JPanel {
       JLabel die;
       if (remainder > 0) {
         die = new JLabel(
-            m_uiContext.getDiceImageFactory().getDieIcon(roll, roll <= remainder ? Die.DieType.HIT : Die.DieType.MISS));
+            uiContext.getDiceImageFactory().getDieIcon(roll, roll <= remainder ? Die.DieType.HIT : Die.DieType.MISS));
       } else {
-        die = new JLabel(m_uiContext.getDiceImageFactory().getDieIcon(roll,
+        die = new JLabel(uiContext.getDiceImageFactory().getDieIcon(roll,
             roll == data.getDiceSides() ? Die.DieType.HIT : Die.DieType.MISS));
       }
       dice.add(die);

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -229,7 +229,7 @@ public class TripleAFrame extends MainGameFrame {
     editModeButtonModel = new JToggleButton.ToggleButtonModel();
     editModeButtonModel.setEnabled(false);
     showCommentLogButtonModel = new JToggleButton.ToggleButtonModel();
-    final AbstractAction m_showCommentLogAction = new AbstractAction() {
+    final AbstractAction showCommentLogAction = new AbstractAction() {
       private static final long serialVersionUID = 3964381772343872268L;
 
       @Override
@@ -269,7 +269,7 @@ public class TripleAFrame extends MainGameFrame {
         }
       }
     };
-    showCommentLogButtonModel.addActionListener(m_showCommentLogAction);
+    showCommentLogButtonModel.addActionListener(showCommentLogAction);
     showCommentLogButtonModel.setSelected(false);
     menu = new TripleAMenuBar(this);
     this.setJMenuBar(menu);

--- a/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -172,7 +172,7 @@ class ViewMenu {
   }
 
   private void addUnitSizeMenu(final JMenu parentMenu) {
-    final NumberFormat s_decimalFormat = new DecimalFormat("00.##");
+    final NumberFormat decimalFormat = new DecimalFormat("00.##");
     // This is the action listener used
     class UnitSizeAction extends AbstractAction {
       private static final long serialVersionUID = -6280511505686687867L;
@@ -180,7 +180,7 @@ class ViewMenu {
 
       public UnitSizeAction(final double scaleFactor) {
         this.scaleFactor = scaleFactor;
-        putValue(Action.NAME, s_decimalFormat.format(scaleFactor * 100) + "%");
+        putValue(Action.NAME, decimalFormat.format(scaleFactor * 100) + "%");
       }
 
       @Override

--- a/src/main/java/games/strategy/ui/ScrollableTextField.java
+++ b/src/main/java/games/strategy/ui/ScrollableTextField.java
@@ -44,7 +44,7 @@ public class ScrollableTextField extends JPanel {
       inset = new Insets(2, 0, 2, 0);
     }
     upButton = new JButton(up);
-    final Action m_incrementAction = new AbstractAction("inc") {
+    final Action incrementAction = new AbstractAction("inc") {
       private static final long serialVersionUID = 2125871167112459475L;
 
       @Override
@@ -55,11 +55,11 @@ public class ScrollableTextField extends JPanel {
         }
       }
     };
-    upButton.addActionListener(m_incrementAction);
+    upButton.addActionListener(incrementAction);
     upButton.setMargin(inset);
     downButton = new JButton(down);
     downButton.setMargin(inset);
-    final Action m_decrementAction = new AbstractAction("dec") {
+    final Action decrementAction = new AbstractAction("dec") {
       private static final long serialVersionUID = 787758939168986726L;
 
       @Override
@@ -70,10 +70,10 @@ public class ScrollableTextField extends JPanel {
         }
       }
     };
-    downButton.addActionListener(m_decrementAction);
+    downButton.addActionListener(decrementAction);
     maxButton = new JButton(max);
     maxButton.setMargin(inset);
-    final Action m_maxAction = new AbstractAction("max") {
+    final Action maxAction = new AbstractAction("max") {
       private static final long serialVersionUID = -3899827439573519512L;
 
       @Override
@@ -84,10 +84,10 @@ public class ScrollableTextField extends JPanel {
         }
       }
     };
-    maxButton.addActionListener(m_maxAction);
+    maxButton.addActionListener(maxAction);
     minButton = new JButton(min);
     minButton.setMargin(inset);
-    final Action m_minAction = new AbstractAction("min") {
+    final Action minAction = new AbstractAction("min") {
       private static final long serialVersionUID = 5785321239855254848L;
 
       @Override
@@ -98,7 +98,7 @@ public class ScrollableTextField extends JPanel {
         }
       }
     };
-    minButton.addActionListener(m_minAction);
+    minButton.addActionListener(minAction);
     final JPanel upDown = new JPanel();
     upDown.setLayout(new BoxLayout(upDown, BoxLayout.Y_AXIS));
     upDown.add(upButton);
@@ -109,8 +109,8 @@ public class ScrollableTextField extends JPanel {
     maxMin.add(minButton);
     add(upDown);
     add(maxMin);
-    final IntTextFieldChangeListener m_textListener = field -> notifyListeners();
-    text.addChangeListener(m_textListener);
+    final IntTextFieldChangeListener textListener = field -> notifyListeners();
+    text.addChangeListener(textListener);
     setWidgetActivation();
   }
 

--- a/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/src/main/java/games/strategy/ui/SwingComponents.java
@@ -326,11 +326,11 @@ public class SwingComponents {
   }
 
   public static JEditorPane newHtmlJEditorPane() {
-    final JEditorPane m_descriptionPane = new JEditorPane();
-    m_descriptionPane.setEditable(false);
-    m_descriptionPane.setContentType("text/html");
-    m_descriptionPane.setBackground(new JLabel().getBackground());
-    return m_descriptionPane;
+    final JEditorPane descriptionPane = new JEditorPane();
+    descriptionPane.setEditable(false);
+    descriptionPane.setContentType("text/html");
+    descriptionPane.setBackground(new JLabel().getBackground());
+    return descriptionPane;
   }
 
   public static void newOpenUrlConfirmationDialog(final UrlConstants url) {

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -76,7 +76,7 @@ public class AutoPlacementFinder {
    */
   static void calculate() {
     // create hash map of placements
-    final Map<String, Collection<Point>> m_placements = new HashMap<>();
+    final Map<String, Collection<Point>> placements = new HashMap<>();
     // ask user where the map is
     final String mapDir = mapFolderLocation == null ? getMapDirectory() : mapFolderLocation.getName();
     if (mapDir == null) {
@@ -216,11 +216,11 @@ public class AutoPlacementFinder {
         }
         points = getPlacementsStartingAtTopLeft(mapData.getPolygons(name), mapData.getBoundingRect(name),
             mapData.getCenter(name), containedPolygons);
-        m_placements.put(name, points);
+        placements.put(name, points);
       } else {
         points = getPlacementsStartingAtMiddle(mapData.getPolygons(name), mapData.getBoundingRect(name),
             mapData.getCenter(name));
-        m_placements.put(name, points);
+        placements.put(name, points);
       }
       textOptionPane.appendNewLine(name + ": " + points.size());
     } // while
@@ -234,7 +234,7 @@ public class AutoPlacementFinder {
         textOptionPane.dispose();
         System.exit(0);
       }
-      PointFileReaderWriter.writeOneToMany(new FileOutputStream(fileName), m_placements);
+      PointFileReaderWriter.writeOneToMany(new FileOutputStream(fileName), placements);
       textOptionPane.appendNewLine("Data written to :" + new File(fileName).getCanonicalPath());
     } catch (final Exception ex) {
       ex.printStackTrace();

--- a/src/main/java/tools/image/JTextAreaOptionPane.java
+++ b/src/main/java/tools/image/JTextAreaOptionPane.java
@@ -41,8 +41,8 @@ class JTextAreaOptionPane {
     layout.setVgap(30);
     windowFrame.setLayout(layout);
     windowFrame.setTitle(title);
-    final JLabel m_label = new JLabel();
-    m_label.setText(labelText);
+    final JLabel label = new JLabel();
+    label.setText(labelText);
     okButton.setText("OK");
     okButton.setEnabled(false);
     editor.setEditable(false);
@@ -53,7 +53,7 @@ class JTextAreaOptionPane {
     }
     editor.setCaretPosition(0);
     windowFrame.setPreferredSize(new Dimension(editorSizeX, editorSizeY));
-    windowFrame.getContentPane().add(m_label, BorderLayout.NORTH);
+    windowFrame.getContentPane().add(label, BorderLayout.NORTH);
     windowFrame.getContentPane().add(new JScrollPane(editor), BorderLayout.CENTER);
     windowFrame.getContentPane().add(okButton, BorderLayout.SOUTH);
     okButton.addActionListener(e -> {

--- a/src/main/java/tools/image/ReliefImageBreaker.java
+++ b/src/main/java/tools/image/ReliefImageBreaker.java
@@ -189,9 +189,9 @@ public class ReliefImageBreaker {
       item.translate(-bounds.x, -bounds.y);
       alphaChannelImage.getGraphics().fillPolygon(item);
     }
-    final GraphicsConfiguration m_localGraphicSystem =
+    final GraphicsConfiguration localGraphicSystem =
         GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
-    final BufferedImage relief = m_localGraphicSystem.createCompatibleImage(width, height,
+    final BufferedImage relief = localGraphicSystem.createCompatibleImage(width, height,
         seaZoneOnly ? Transparency.BITMASK : Transparency.TRANSLUCENT);
     relief.getGraphics().drawImage(map, 0, 0, width, height, bounds.x, bounds.y, bounds.x + width, bounds.y + height,
         observer);

--- a/src/main/java/tools/image/TileImageBreaker.java
+++ b/src/main/java/tools/image/TileImageBreaker.java
@@ -93,9 +93,9 @@ public class TileImageBreaker {
       for (int y = 0; (y) * TileManager.TILE_SIZE < map.getHeight(null); y++) {
         final Rectangle bounds = new Rectangle(x * TileManager.TILE_SIZE, y * TileManager.TILE_SIZE,
             TileManager.TILE_SIZE, TileManager.TILE_SIZE);
-        final GraphicsConfiguration m_localGraphicSystem =
+        final GraphicsConfiguration localGraphicSystem =
             GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
-        final BufferedImage relief = m_localGraphicSystem.createCompatibleImage(TileManager.TILE_SIZE,
+        final BufferedImage relief = localGraphicSystem.createCompatibleImage(TileManager.TILE_SIZE,
             TileManager.TILE_SIZE, baseMap ? Transparency.BITMASK : Transparency.TRANSLUCENT);
         relief.getGraphics().drawImage(map, 0, 0, TileManager.TILE_SIZE, TileManager.TILE_SIZE, bounds.x, bounds.y,
             bounds.x + TileManager.TILE_SIZE, bounds.y + TileManager.TILE_SIZE, observer);


### PR DESCRIPTION
This PR fixes violations of the Checkstyle LocalFinalVariableName rule, specifically by removing any `m_` and `s_` prefixes.