### PR TITLE
Serialization proxy: Move feature toggle to client settings

### DIFF
--- a/src/main/java/games/strategy/engine/config/client/GameEnginePropertyReader.java
+++ b/src/main/java/games/strategy/engine/config/client/GameEnginePropertyReader.java
@@ -43,9 +43,6 @@ public class GameEnginePropertyReader {
   interface PropertyKeys {
     String ENGINE_VERSION = "engine_version";
     String JAVAFX_UI = "javafx_ui";
-    String LOBBY_BACKUP_HOST_ADDRESS = "lobby_backup_url";
-    String LOBBY_PROP_FILE_URL = "lobby_properties_file_url";
-    String MAP_LISTING_SOURCE_FILE = "map_list_file";
     String NEW_SAVE_GAME_FORMAT = "new_save_game_format";
   }
 }

--- a/src/main/java/games/strategy/engine/config/client/GameEnginePropertyReader.java
+++ b/src/main/java/games/strategy/engine/config/client/GameEnginePropertyReader.java
@@ -30,19 +30,13 @@ public class GameEnginePropertyReader {
     return new Version(propertyFileReader.readProperty(PropertyKeys.ENGINE_VERSION));
   }
 
-
   public boolean useJavaFxUi() {
     return propertyFileReader.readProperty(PropertyKeys.JAVAFX_UI).equalsIgnoreCase(String.valueOf(true));
-  }
-
-  public boolean useNewSaveGameFormat() {
-    return propertyFileReader.readProperty(PropertyKeys.NEW_SAVE_GAME_FORMAT).equalsIgnoreCase(String.valueOf(true));
   }
 
   @VisibleForTesting
   interface PropertyKeys {
     String ENGINE_VERSION = "engine_version";
     String JAVAFX_UI = "javafx_ui";
-    String NEW_SAVE_GAME_FORMAT = "new_save_game_format";
   }
 }

--- a/src/main/java/games/strategy/engine/framework/GameDataFileUtils.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataFileUtils.java
@@ -9,7 +9,7 @@ import org.apache.commons.io.IOCase;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import games.strategy.engine.ClientContext;
+import games.strategy.triplea.settings.ClientSetting;
 
 /**
  * A collection of utilities for working with game data files.
@@ -17,12 +17,13 @@ import games.strategy.engine.ClientContext;
 public final class GameDataFileUtils {
   private static final IOCase DEFAULT_IO_CASE = IOCase.SYSTEM;
 
-  private static final SaveGameFormat DEFAULT_SAVE_GAME_FORMAT =
-      ClientContext.gameEnginePropertyReader().useNewSaveGameFormat()
-          ? SaveGameFormat.NEW
-          : SaveGameFormat.CURRENT;
-
   private GameDataFileUtils() {}
+
+  private static SaveGameFormat getDefaultSaveGameFormat() {
+    return ClientSetting.TEST_USE_NEW_SAVE_GAME_FORMAT.booleanValue()
+        ? SaveGameFormat.NEW
+        : SaveGameFormat.CURRENT;
+  }
 
   @VisibleForTesting
   enum SaveGameFormat {
@@ -39,7 +40,7 @@ public final class GameDataFileUtils {
   public static String addExtension(final String fileName) {
     checkNotNull(fileName);
 
-    return addExtension(fileName, DEFAULT_SAVE_GAME_FORMAT);
+    return addExtension(fileName, getDefaultSaveGameFormat());
   }
 
   @VisibleForTesting
@@ -58,7 +59,7 @@ public final class GameDataFileUtils {
   public static String addExtensionIfAbsent(final String fileName) {
     checkNotNull(fileName);
 
-    return addExtensionIfAbsent(fileName, DEFAULT_SAVE_GAME_FORMAT, DEFAULT_IO_CASE);
+    return addExtensionIfAbsent(fileName, getDefaultSaveGameFormat(), DEFAULT_IO_CASE);
   }
 
   @VisibleForTesting
@@ -99,7 +100,7 @@ public final class GameDataFileUtils {
    * @return The game data file extension including the leading period.
    */
   public static String getExtension() {
-    return getExtension(DEFAULT_SAVE_GAME_FORMAT);
+    return getExtension(getDefaultSaveGameFormat());
   }
 
   private static String getExtension(final SaveGameFormat saveGameFormat) {
@@ -131,7 +132,7 @@ public final class GameDataFileUtils {
   public static boolean isCandidateFileName(final String fileName) {
     checkNotNull(fileName);
 
-    return isCandidateFileName(fileName, DEFAULT_SAVE_GAME_FORMAT, DEFAULT_IO_CASE);
+    return isCandidateFileName(fileName, getDefaultSaveGameFormat(), DEFAULT_IO_CASE);
   }
 
   @VisibleForTesting

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -36,6 +36,7 @@ import games.strategy.engine.delegate.IDelegate;
 import games.strategy.engine.framework.headlessGameServer.HeadlessGameServer;
 import games.strategy.persistence.serializable.ProxyableObjectOutputStream;
 import games.strategy.triplea.UrlConstants;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.util.ThreadUtil;
 import games.strategy.util.Version;
 import games.strategy.util.memento.Memento;
@@ -86,7 +87,7 @@ public final class GameDataManager {
   public static GameData loadGame(final InputStream is, final @Nullable String path) throws IOException {
     checkNotNull(is);
 
-    return ClientContext.gameEnginePropertyReader().useNewSaveGameFormat()
+    return ClientSetting.TEST_USE_NEW_SAVE_GAME_FORMAT.booleanValue()
         ? loadGameInNewFormat(is)
         : loadGameInCurrentFormat(is, path);
   }
@@ -304,7 +305,7 @@ public final class GameDataManager {
       final GameData gameData,
       final boolean includeDelegates)
       throws IOException {
-    if (ClientContext.gameEnginePropertyReader().useNewSaveGameFormat()) {
+    if (ClientSetting.TEST_USE_NEW_SAVE_GAME_FORMAT.booleanValue()) {
       saveGameInNewFormat(
           os,
           gameData,

--- a/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -88,6 +88,8 @@ public enum ClientSetting implements GameSetting {
 
   TEST_LOBBY_PORT,
 
+  TEST_USE_NEW_SAVE_GAME_FORMAT(false),
+
   TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY(true),
 
   TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE,

--- a/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -20,11 +20,11 @@ import games.strategy.engine.ClientFileSystemHelper;
  * Note: After saving values, `ClientSetting.flush()` needs to be called to persist those values.
  * </p>
  *
- *
  * <p>
  * Typical usage:
- * </p><code><pre>
+ * </p>
  *
+ * <code><pre>
  * // loading a value
  * String value = ClientSetting.AI_PAUSE_DURATION.value();
  *
@@ -35,40 +35,75 @@ import games.strategy.engine.ClientFileSystemHelper;
  */
 public enum ClientSetting implements GameSetting {
   AI_PAUSE_DURATION(400),
+
   ARROW_KEY_SCROLL_SPEED(70),
+
   BATTLE_CALC_SIMULATION_COUNT_DICE(2000),
+
   BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK(5000),
+
   CONFIRM_DEFENSIVE_ROLLS(false),
+
   CONFIRM_ENEMY_CASUALTIES(false),
+
   DEFAULT_GAME_NAME_PREF("Big World : 1942"),
+
   DEFAULT_GAME_URI_PREF,
+
   FASTER_ARROW_KEY_SCROLL_MULTIPLIER(2),
+
   SPACE_BAR_CONFIRMS_CASUALTIES(true),
+
   LOBBY_LAST_USED_HOST,
+
   LOBBY_LAST_USED_PORT,
+
   LOOK_AND_FEEL_PREF(UIManager.getSystemLookAndFeelClassName()),
+
   MAP_EDGE_SCROLL_SPEED(30),
+
   MAP_EDGE_SCROLL_ZONE_SIZE(30),
+
   MAP_FOLDER_OVERRIDE,
+
   MAP_LIST_OVERRIDE,
+
   PROXY_CHOICE,
+
   PROXY_HOST,
+
   PROXY_PORT,
+
   SAVE_GAMES_FOLDER_PATH(new File(ClientFileSystemHelper.getUserRootFolder(), "savedGames")),
+
   SERVER_OBSERVER_JOIN_WAIT_TIME(180),
+
   SERVER_START_GAME_SYNC_WAIT_TIME(180),
+
   SHOW_BATTLES_WHEN_OBSERVING(true),
+
   SHOW_BETA_FEATURES(false),
+
   TEST_LOBBY_HOST,
+
   TEST_LOBBY_PORT,
+
   TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY(true),
+
   TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE,
+
   TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES,
+
   TRIPLEA_PROMPT_TO_DOWNLOAD_TUTORIAL_MAP,
+
   TRIPLEA_SERVER_OBSERVER_JOIN_WAIT_TIME,
+
   TRIPLEA_SERVER_START_GAME_SYNC_WAIT_TIME,
+
   USER_MAPS_FOLDER_PATH(new File(ClientFileSystemHelper.getUserRootFolder(), "downloadedMaps")),
+
   WHEEL_SCROLL_AMOUNT(60),
+
   PLAYER_NAME(System.getProperty("user.name"));
 
   public final String defaultValue;

--- a/src/main/java/games/strategy/triplea/settings/ClientSettingUiBinding.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSettingUiBinding.java
@@ -133,6 +133,12 @@ enum ClientSettingUiBinding implements GameSettingUiBinding {
       SelectionComponentFactory.intValueRange(ClientSetting.TEST_LOBBY_PORT, 1, 99999),
       "Specifies the port for connecting to a test lobby."),
 
+  TEST_USE_NEW_SAVE_GAME_FORMAT_BINDING(
+      "Use New Save Game Format",
+      SettingType.TESTING,
+      ClientSetting.TEST_USE_NEW_SAVE_GAME_FORMAT,
+      "Specifies whether or not to use the new save game format."),
+
   TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY_BINDING(
       "Show First Time Prompts",
       SettingType.GAME,

--- a/src/main/java/games/strategy/triplea/settings/ClientSettingUiBinding.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSettingUiBinding.java
@@ -30,37 +30,44 @@ enum ClientSettingUiBinding implements GameSettingUiBinding {
       SettingType.AI,
       SelectionComponentFactory.intValueRange(ClientSetting.AI_PAUSE_DURATION, 0, 3000),
       "Time between AI moves"),
+
   ARROW_KEY_SCROLL_SPEED_BINDING(
       "Arrow Key Scroll Speed",
       SettingType.MAP_SCROLLING,
       SelectionComponentFactory.intValueRange(ClientSetting.ARROW_KEY_SCROLL_SPEED, 0, 500),
       "How fast the map is scrolled when using the arrow keys"),
+
   BATTLE_CALC_SIMULATION_COUNT_DICE_BINDING(
       "Simulation Count (Dice)",
       SettingType.BATTLE_SIMULATOR,
       SelectionComponentFactory.intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_DICE, 10, 100000),
       "Default battle simulation count in dice games"),
+
   BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK_BINDING(
       "Simulation Count (LL)",
       SettingType.BATTLE_SIMULATOR,
       SelectionComponentFactory.intValueRange(ClientSetting.BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK, 10, 100000),
       "Default battle simulation count in low luck games"),
+
   CONFIRM_DEFENSIVE_ROLLS_BINDING(
       "Confirm defensive rolls",
       SettingType.COMBAT,
       ClientSetting.CONFIRM_DEFENSIVE_ROLLS,
       "Whether battle should proceed until you confirm the dice you roll while on defense"),
+
   CONFIRM_ENEMY_CASUALTIES_BINDING(
       "Confirm enemy casualties",
       SettingType.COMBAT,
       ClientSetting.CONFIRM_ENEMY_CASUALTIES,
       "Whether battles should proceed only once every player has confirmed the casualties selected"),
+
   SPACE_BAR_CONFIRMS_CASUALTIES_BINDING(
       "Space bar confirms Casualties",
       SettingType.COMBAT,
       ClientSetting.SPACE_BAR_CONFIRMS_CASUALTIES,
       "When set to true casualty confirmation can be accepted by pressing space bar.\n"
-      + "When set to false, the confirm casualty button has to always be clicked."),
+          + "When set to false, the confirm casualty button has to always be clicked."),
+
   LOOK_AND_FEEL_PREF_BINDING(
       "Look and Feel",
       SettingType.LOOK_AND_FEEL,
@@ -68,31 +75,37 @@ enum ClientSettingUiBinding implements GameSettingUiBinding {
           ClientSetting.LOOK_AND_FEEL_PREF,
           LookAndFeel.getLookAndFeelAvailableList()),
       "Adjust the UI theme for the game, requires a restart to take effect"),
+
   MAP_EDGE_SCROLL_SPEED_BINDING(
       "Map Scroll Speed",
       SettingType.MAP_SCROLLING,
       SelectionComponentFactory.intValueRange(ClientSetting.MAP_EDGE_SCROLL_SPEED, 0, 300),
       "How fast the map scrolls when the mouse is moved close to the map edge"),
+
   MAP_EDGE_SCROLL_ZONE_SIZE_BINDING(
       "Scroll Zone Size",
       SettingType.MAP_SCROLLING,
       SelectionComponentFactory.intValueRange(ClientSetting.MAP_EDGE_SCROLL_ZONE_SIZE, 0, 300),
       "How close to the edge of the map the mouse needs to be for the map to start scrolling"),
+
   SERVER_START_GAME_SYNC_WAIT_TIME_BINDING(
       "Start game timeout",
       SettingType.NETWORK_TIMEOUTS,
       SelectionComponentFactory.intValueRange(ClientSetting.SERVER_START_GAME_SYNC_WAIT_TIME, 120, 1500),
       "Max seconds to wait for all clients to sync data on game start"),
+
   SERVER_OBSERVER_JOIN_WAIT_TIME_BINDING(
       "Observer join timeout",
       SettingType.NETWORK_TIMEOUTS,
       SelectionComponentFactory.intValueRange(ClientSetting.SERVER_OBSERVER_JOIN_WAIT_TIME, 60, 1500),
       "Max seconds for host to wait for clients and Observers"),
+
   SHOW_BATTLES_WHEN_OBSERVING_BINDING(
       "Show battles as observer",
       SettingType.GAME,
       ClientSetting.SHOW_BATTLES_WHEN_OBSERVING,
       "Whether to show a battle if you are only observing."),
+
   SHOW_BETA_FEATURES_BINDING(
       "Show Beta Features",
       SettingType.TESTING,
@@ -100,48 +113,56 @@ enum ClientSettingUiBinding implements GameSettingUiBinding {
       "Toggles whether to show 'beta' features. These are game features that are still "
           + "under development and potentially may not be working yet.\n"
           + "Restart to fully activate"),
+
   MAP_LIST_OVERRIDE_BINDING(
       "Map List Override",
       SettingType.TESTING,
       SelectionComponentFactory.filePath(ClientSetting.MAP_LIST_OVERRIDE),
       "Overrides the map listing file specified in 'game_engine.properties'. You can for example download a copy of the"
           + "listing file, update it, and put the path to that file here."),
+
   TEST_LOBBY_HOST_BINDING(
       "Lobby Host Override",
       SettingType.TESTING,
       SelectionComponentFactory.textField(ClientSetting.TEST_LOBBY_HOST),
       "Overrides the IP address or hostname used to connect to the lobby. Useful for connecting to a test lobby."),
+
   TEST_LOBBY_PORT_BINDING(
       "Lobby Port Override",
       SettingType.TESTING,
       SelectionComponentFactory.intValueRange(ClientSetting.TEST_LOBBY_PORT, 1, 99999),
       "Specifies the port for connecting to a test lobby."),
+
   TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY_BINDING(
       "Show First Time Prompts",
       SettingType.GAME,
       ClientSetting.TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY,
       "Setting to true will trigger for any first time prompts to be shown"),
+
   SAVE_GAMES_FOLDER_PATH_BINDING(
       "Saved Games Folder",
       SettingType.FOLDER_LOCATIONS,
       SelectionComponentFactory.folderPath(ClientSetting.SAVE_GAMES_FOLDER_PATH),
       "The folder where saved game files will be stored by default"),
+
   USER_MAPS_FOLDER_PATH_BINDING(
       "Maps Folder",
       SettingType.FOLDER_LOCATIONS,
       SelectionComponentFactory.folderPath(ClientSetting.USER_MAPS_FOLDER_PATH),
       "The folder where game engine will download and find map files."),
+
   WHEEL_SCROLL_AMOUNT_BINDING(
       "Mouse Wheel Scroll Speed",
       SettingType.MAP_SCROLLING,
       SelectionComponentFactory.intValueRange(ClientSetting.WHEEL_SCROLL_AMOUNT, 10, 300),
       "How fast the map will scroll when using the mouse wheel"),
+
   PROXY_CHOICE(
       "Network Proxy",
       SettingType.NETWORK_PROXY,
       SelectionComponentFactory.proxySettings(),
       "Configure TripleA's Network and Proxy Settings\n"
-      + "This only effects Play-By-Forum games, dice servers, and map downloads.");
+          + "This only effects Play-By-Forum games, dice servers, and map downloads.");
 
 
   final SettingType type;

--- a/src/test/java/games/strategy/engine/config/client/GameEnginePropertyReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/client/GameEnginePropertyReaderTest.java
@@ -2,12 +2,10 @@ package games.strategy.engine.config.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -30,29 +28,5 @@ public class GameEnginePropertyReaderTest {
         .thenReturn("1.0.1.3");
 
     assertThat(testObj.getEngineVersion(), is(new Version(1, 0, 1, 3)));
-  }
-
-  @Test
-  public void useNewSaveGameFormat_ShouldReturnTrueWhenPropertyValueIsCaseSensitiveTrue() {
-    when(mockPropertyFileReader.readProperty(GameEnginePropertyReader.PropertyKeys.NEW_SAVE_GAME_FORMAT))
-        .thenReturn("true");
-
-    assertThat(testObj.useNewSaveGameFormat(), is(true));
-  }
-
-  @Test
-  public void useNewSaveGameFormat_ShouldReturnTrueWhenPropertyValueIsCaseInsensitiveTrue() {
-    when(mockPropertyFileReader.readProperty(GameEnginePropertyReader.PropertyKeys.NEW_SAVE_GAME_FORMAT))
-        .thenReturn("True");
-
-    assertThat(testObj.useNewSaveGameFormat(), is(true));
-  }
-
-  @Test
-  public void useNewSaveGameFormat_ShouldReturnFalseWhenPropertyValueIsAbsent() {
-    when(mockPropertyFileReader.readProperty(GameEnginePropertyReader.PropertyKeys.NEW_SAVE_GAME_FORMAT))
-        .thenReturn("");
-
-    assertThat(testObj.useNewSaveGameFormat(), is(false));
   }
 }


### PR DESCRIPTION
This PR moves the serialization proxy feature toggle from the game engine properties file to the new client settings infrastructure.  The feature toggle is placed under the Test category with a default value of `false` (disabled).

There were also a few housekeeping changes in this PR:

* Unused keys were removed from `GameEnginePropertyReader$PropertyKeys`.  These keys correspond to settings previously moved to the client settings infrastructure.
* Newlines were added between each value in the `ClientSetting` and `ClientSettingUiBinding` enums.  This was done to prevent the Eclipse formatter from wrapping all values as a single line.  (Alternatively, a Javadoc could be added for each value, but that seemed unnecessary as most settings are self-explanatory.)