### PR TITLE
Checkstyle: Rename local variable prefix "PUs" to "pus"

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -39,12 +39,12 @@ public class AIUtils {
    * </p>
    */
   static int getCost(final UnitType unitType, final PlayerID player, final GameData data) {
-    final Resource PUs = data.getResourceList().getResource(Constants.PUS);
+    final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final ProductionRule rule = getProductionRule(unitType, player);
     if (rule == null) {
       return Integer.MAX_VALUE;
     } else {
-      return rule.getCosts().getInt(PUs);
+      return rule.getCosts().getInt(pus);
     }
   }
 

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -455,8 +455,8 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
       purchase(true, bidAmount, purchaseDelegate, getGameData(), id);
     } else if (name.endsWith("Purchase")) {
       final IPurchaseDelegate purchaseDelegate = (IPurchaseDelegate) getPlayerBridge().getRemoteDelegate();
-      final Resource PUs = getGameData().getResourceList().getResource(Constants.PUS);
-      final int leftToSpend = id.getResources().getQuantity(PUs);
+      final Resource pus = getGameData().getResourceList().getResource(Constants.PUS);
+      final int leftToSpend = id.getResources().getQuantity(pus);
       purchase(false, leftToSpend, purchaseDelegate, getGameData(), id);
     } else if (name.endsWith("Tech")) {
       final ITechDelegate techDelegate = (ITechDelegate) getPlayerBridge().getRemoteDelegate();

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -48,11 +48,11 @@ final class ProTechAI {
     }
     final boolean capDanger = myStrength < (eStrength * 1.25F + 3.0F);
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
-    final int PUs = player.getResources().getQuantity(pus);
+    final int pusRemaining = player.getResources().getQuantity(pus);
     final Resource techtokens = data.getResourceList().getResource(Constants.TECH_TOKENS);
     final int TechTokens = player.getResources().getQuantity(techtokens);
     int tokensToBuy = 0;
-    if (!capDanger && TechTokens < 3 && PUs > Math.random() * 160) {
+    if (!capDanger && TechTokens < 3 && pusRemaining > Math.random() * 160) {
       tokensToBuy = 1;
     }
     if (TechTokens > 0 || tokensToBuy > 0) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOption.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOption.java
@@ -62,8 +62,8 @@ public class ProPurchaseOption {
     this.unitType = unitType;
     this.player = player;
     final UnitAttachment unitAttachment = UnitAttachment.get(unitType);
-    final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-    cost = productionRule.getCosts().getInt(PUs);
+    final Resource pus = data.getResourceList().getResource(Constants.PUS);
+    cost = productionRule.getCosts().getInt(pus);
     costs = productionRule.getCosts();
     movement = unitAttachment.getMovement(player);
     quantity = productionRule.getResults().totalValues();

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProResourceTracker.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProResourceTracker.java
@@ -58,8 +58,8 @@ public class ProResourceTracker {
   }
 
   public int getTempPUs(final GameData data) {
-    final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-    return tempPurchases.getInt(PUs);
+    final Resource pus = data.getResourceList().getResource(Constants.PUS);
+    return tempPurchases.getInt(pus);
   }
 
   @Override

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProPurchaseUtils.java
@@ -156,14 +156,14 @@ public class ProPurchaseUtils {
     final GameData data = ProData.getData();
 
     // Determine most cost efficient defender that can be produced in this territory
-    final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-    final int PUsRemaining = player.getResources().getQuantity(PUs);
+    final Resource pus = data.getResourceList().getResource(Constants.PUS);
+    final int pusRemaining = player.getResources().getQuantity(pus);
     final List<ProPurchaseOption> purchaseOptionsForTerritory =
         findPurchaseOptionsForTerritory(player, landPurchaseOptions, t, false);
     ProPurchaseOption bestDefenseOption = null;
     double maxDefenseEfficiency = 0;
     for (final ProPurchaseOption ppo : purchaseOptionsForTerritory) {
-      if (ppo.getDefenseEfficiency() > maxDefenseEfficiency && ppo.getCost() <= PUsRemaining) {
+      if (ppo.getDefenseEfficiency() > maxDefenseEfficiency && ppo.getCost() <= pusRemaining) {
         bestDefenseOption = ppo;
         maxDefenseEfficiency = ppo.getDefenseEfficiency();
       }
@@ -178,7 +178,7 @@ public class ProPurchaseUtils {
       while (true) {
 
         // If out of PUs or production then break
-        if (bestDefenseOption.getCost() > (PUsRemaining - pusSpent)
+        if (bestDefenseOption.getCost() > (pusRemaining - pusSpent)
             || remainingUnitProduction < bestDefenseOption.getQuantity()) {
           break;
         }
@@ -311,7 +311,7 @@ public class ProPurchaseUtils {
    * How many PU's does it cost the given player to produce the given unit including any dependents.
    */
   public static double getCost(final Unit unit) {
-    final Resource PUs = unit.getData().getResourceList().getResource(Constants.PUS);
+    final Resource pus = unit.getData().getResourceList().getResource(Constants.PUS);
     final Collection<Unit> units = TransportTracker.transportingAndUnloaded(unit);
     units.add(unit);
     double cost = 0.0;
@@ -320,7 +320,7 @@ public class ProPurchaseUtils {
       if (rule == null) {
         cost += ProData.unitValueMap.getInt(u.getType());
       } else {
-        cost += ((double) rule.getCosts().getInt(PUs)) / rule.getResults().totalValues();
+        cost += ((double) rule.getCosts().getInt(pus)) / rule.getResults().totalValues();
       }
     }
     return cost;

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -733,7 +733,7 @@ public class WeakAI extends AbstractAI {
       final GameData data, final PlayerID player) {
     if (purchaseForBid) {
       // bid will only buy land units, due to weak ai placement for bid not being able to handle sea units
-      final Resource PUs = data.getResourceList().getResource(Constants.PUS);
+      final Resource pus = data.getResourceList().getResource(Constants.PUS);
       int leftToSpend = pusToSpend;
       final List<ProductionRule> rules = player.getProductionFrontier().getRules();
       final IntegerMap<ProductionRule> purchase = new IntegerMap<>();
@@ -754,7 +754,7 @@ public class WeakAI extends AbstractAI {
               || Matches.unitTypeIsStatic(player).match(results)) {
             continue;
           }
-          final int cost = rule.getCosts().getInt(PUs);
+          final int cost = rule.getCosts().getInt(pus);
           if (cost < 1) {
             continue;
           }
@@ -785,8 +785,8 @@ public class WeakAI extends AbstractAI {
     if (isAmphib && amphibRoute != null) {
       defUnitsAtAmpibRoute = amphibRoute.getEnd().getUnits().getUnitCount();
     }
-    final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-    final int totalPu = player.getResources().getQuantity(PUs);
+    final Resource pus = data.getResourceList().getResource(Constants.PUS);
+    final int totalPu = player.getResources().getQuantity(pus);
     int leftToSpend = totalPu;
     final Territory capitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
     final List<ProductionRule> rules = player.getProductionFrontier().getRules();
@@ -954,7 +954,7 @@ public class WeakAI extends AbstractAI {
             continue;
           }
         }
-        final int cost = rule.getCosts().getInt(PUs);
+        final int cost = rule.getCosts().getInt(pus);
         if (cost < 1) {
           continue;
         }

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -63,8 +63,8 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
   public void start() {
     // figure out our current PUs before we do anything else, including super methods
     final GameData data = m_bridge.getData();
-    final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-    final int leftOverPUs = m_bridge.getPlayerID().getResources().getQuantity(PUs);
+    final Resource pus = data.getResourceList().getResource(Constants.PUS);
+    final int leftOverPUs = m_bridge.getPlayerID().getResources().getQuantity(pus);
     final IntegerMap<Resource> leftOverResources = m_bridge.getPlayerID().getResources().getResourcesCopy();
     super.start();
     if (!m_needToInitialize) {
@@ -84,7 +84,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       final int blockadeLoss = getBlockadeProductionLoss(m_player, data, m_bridge, endTurnReport);
       toAdd -= blockadeLoss;
       toAdd *= Properties.getPU_Multiplier(data);
-      int total = m_player.getResources().getQuantity(PUs) + toAdd;
+      int total = m_player.getResources().getQuantity(pus) + toAdd;
       final String transcriptText;
       if (blockadeLoss == 0) {
         transcriptText = m_player.getName() + " collect " + toAdd + MyFormatter.pluralize(" PU", toAdd) + "; end with "
@@ -110,7 +110,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
         toAdd -= total;
         total = 0;
       }
-      final Change change = ChangeFactory.changeResourcesChange(m_player, PUs, toAdd);
+      final Change change = ChangeFactory.changeResourcesChange(m_player, pus, toAdd);
       m_bridge.addChange(change);
       if (data.getProperties().get(Constants.PACIFIC_THEATER, false) && pa != null) {
         final Change changeVp = (ChangeFactory.attachmentPropertyChange(pa,
@@ -127,7 +127,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
 
       // now we do upkeep costs, including upkeep cost as a percentage of our entire income for this turn (including
       // NOs)
-      final int currentPUs = m_player.getResources().getQuantity(PUs);
+      final int currentPUs = m_player.getResources().getQuantity(pus);
       final float gainedPus = Math.max(0, currentPUs - leftOverPUs);
       int relationshipUpkeepCostFlat = 0;
       int relationshipUpkeepCostPercentage = 0;
@@ -158,7 +158,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
             + MyFormatter.pluralize(" PU", newTotal);
         m_bridge.getHistoryWriter().startEvent(transcriptText2);
         endTurnReport.append("<br />").append(transcriptText2).append("<br />");
-        final Change upkeep = ChangeFactory.changeResourcesChange(m_player, PUs, relationshipUpkeepTotalCost);
+        final Change upkeep = ChangeFactory.changeResourcesChange(m_player, pus, relationshipUpkeepTotalCost);
         m_bridge.addChange(upkeep);
       }
     }
@@ -276,14 +276,14 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     for (int i = 0; i < dice.size(); i++) {
       totalWarBonds += dice.getDie(i).getValue() + 1;
     }
-    final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-    final int currentPUs = giveWarBondsTo.getResources().getQuantity(PUs);
+    final Resource pus = data.getResourceList().getResource(Constants.PUS);
+    final int currentPUs = giveWarBondsTo.getResources().getQuantity(pus);
     final String transcriptText =
         player.getName() + " rolls " + totalWarBonds + MyFormatter.pluralize(" PU", totalWarBonds)
             + " from War Bonds, giving the total to " + giveWarBondsTo.getName() + ", who ends with "
             + (currentPUs + totalWarBonds) + MyFormatter.pluralize(" PU", (currentPUs + totalWarBonds)) + " total";
     delegateBridge.getHistoryWriter().startEvent(transcriptText);
-    final Change change = ChangeFactory.changeResourcesChange(giveWarBondsTo, PUs, totalWarBonds);
+    final Change change = ChangeFactory.changeResourcesChange(giveWarBondsTo, pus, totalWarBonds);
     delegateBridge.addChange(change);
     getRemotePlayer(player).reportMessage(annotation + MyFormatter.asDice(dice), annotation + MyFormatter.asDice(dice));
     return transcriptText + "<br />";

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -544,10 +544,10 @@ public class BattleTracker implements Serializable {
     // if neutral, we may charge money to enter
     if (territory.getOwner().isNull() && !territory.isWater()
         && Properties.getNeutralCharge(data) >= 0) {
-      final Resource PUs = data.getResourceList().getResource(Constants.PUS);
+      final Resource pus = data.getResourceList().getResource(Constants.PUS);
       final int puChargeIdeal = -Properties.getNeutralCharge(data);
-      final int puChargeReal = Math.min(0, Math.max(puChargeIdeal, -id.getResources().getQuantity(PUs)));
-      final Change neutralFee = ChangeFactory.changeResourcesChange(id, PUs, puChargeReal);
+      final int puChargeReal = Math.min(0, Math.max(puChargeIdeal, -id.getResources().getQuantity(pus)));
+      final Change neutralFee = ChangeFactory.changeResourcesChange(id, pus, puChargeReal);
       bridge.addChange(neutralFee);
       if (changeTracker != null) {
         changeTracker.addChange(neutralFee);
@@ -580,8 +580,8 @@ public class BattleTracker implements Serializable {
         bridge.getHistoryWriter()
             .addChildToEvent(id.getName() + " captures one of " + whoseCapital.getName() + " capitals");
       } else if (whoseCapital.equals(territory.getOwner())) {
-        final Resource PUs = data.getResourceList().getResource(Constants.PUS);
-        final int capturedPuCount = whoseCapital.getResources().getQuantity(PUs);
+        final Resource pus = data.getResourceList().getResource(Constants.PUS);
+        final int capturedPuCount = whoseCapital.getResources().getQuantity(pus);
         if (pa != null) {
           if (isPacificTheater(data)) {
             final Change changeVp =
@@ -592,7 +592,7 @@ public class BattleTracker implements Serializable {
             }
           }
         }
-        final Change remove = ChangeFactory.changeResourcesChange(whoseCapital, PUs, -capturedPuCount);
+        final Change remove = ChangeFactory.changeResourcesChange(whoseCapital, pus, -capturedPuCount);
         bridge.addChange(remove);
         if (paWhoseCapital != null && paWhoseCapital.getDestroysPUs()) {
           bridge.getHistoryWriter().addChildToEvent(id.getName() + " destroys " + capturedPuCount
@@ -606,7 +606,7 @@ public class BattleTracker implements Serializable {
           if (changeTracker != null) {
             changeTracker.addChange(remove);
           }
-          final Change add = ChangeFactory.changeResourcesChange(id, PUs, capturedPuCount);
+          final Change add = ChangeFactory.changeResourcesChange(id, pus, capturedPuCount);
           bridge.addChange(add);
           if (changeTracker != null) {
             changeTracker.addChange(add);

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -925,8 +925,8 @@ public class MoveValidator {
       final PlayerID player, final MoveValidationResult result) {
     // neutrals we will overfly in the first place
     final Collection<Territory> neutrals = MoveDelegate.getEmptyNeutral(route);
-    final int PUs = (player == null || player.isNull()) ? 0 : player.getResources().getQuantity(Constants.PUS);
-    if (PUs < getNeutralCharge(data, neutrals.size())) {
+    final int pus = (player == null || player.isNull()) ? 0 : player.getResources().getQuantity(Constants.PUS);
+    if (pus < getNeutralCharge(data, neutrals.size())) {
       return result.setErrorReturnResult(TOO_POOR_TO_VIOLATE_NEUTRALITY);
     }
     return result;

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -265,7 +265,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
    *        the politicalactionattachment this the money is charged for.
    */
   private void chargeForAction(final PoliticalActionAttachment paa) {
-    final Resource PUs = getData().getResourceList().getResource(Constants.PUS);
+    final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     final int cost = paa.getCostPU();
     if (cost > 0) {
       // don't notify user of spending money anymore
@@ -273,7 +273,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       final String transcriptText = m_bridge.getPlayerID().getName() + " spend " + cost + " PU on Political Action: "
           + MyFormatter.attachmentNameToText(paa.getName());
       m_bridge.getHistoryWriter().startEvent(transcriptText);
-      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), PUs, -cost);
+      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), pus, -cost);
       m_bridge.addChange(charge);
     } else {
       final String transcriptText = m_bridge.getPlayerID().getName() + " takes Political Action: "
@@ -289,9 +289,9 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
    * @return false if the player can't afford the action
    */
   private boolean checkEnoughMoney(final PoliticalActionAttachment paa) {
-    final Resource PUs = getData().getResourceList().getResource(Constants.PUS);
+    final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     final int cost = paa.getCostPU();
-    final int has = m_bridge.getPlayerID().getResources().getQuantity(PUs);
+    final int has = m_bridge.getPlayerID().getResources().getQuantity(pus);
     return has >= cost;
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -182,7 +182,7 @@ public class RocketsFireHelper {
       final Territory attackFrom) {
     final GameData data = bridge.getData();
     final PlayerID attacked = attackedTerritory.getOwner();
-    final Resource PUs = data.getResourceList().getResource(Constants.PUS);
+    final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final boolean DamageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
     // unit damage vs territory damage
     final Collection<Unit> enemyUnits = attackedTerritory.getUnits().getMatches(
@@ -397,14 +397,14 @@ public class RocketsFireHelper {
       getRemote(bridge).reportMessage("Rocket attack in " + attackedTerritory.getName() + " costs:" + cost,
           "Rocket attack in " + attackedTerritory.getName() + " costs:" + cost);
       // Trying to remove more PUs than the victim has is A Bad Thing[tm]
-      final int availForRemoval = attacked.getResources().getQuantity(PUs);
+      final int availForRemoval = attacked.getResources().getQuantity(pus);
       if (cost > availForRemoval) {
         cost = availForRemoval;
       }
       final String transcriptText =
           attacked.getName() + " lost " + cost + " PUs to rocket attack by " + player.getName();
       bridge.getHistoryWriter().startEvent(transcriptText);
-      final Change rocketCharge = ChangeFactory.changeResourcesChange(attacked, PUs, -cost);
+      final Change rocketCharge = ChangeFactory.changeResourcesChange(attacked, pus, -cost);
       bridge.addChange(rocketCharge);
     }
     bridge.getHistoryWriter().addChildToEvent(transcript, rockets == null ? null : new ArrayList<>(rockets));

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -812,10 +812,10 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BOMBING_STRATEGIC, m_attacker);
         }
         // get resources
-        final Resource PUs = m_data.getResourceList().getResource(Constants.PUS);
-        final int have = m_defender.getResources().getQuantity(PUs);
+        final Resource pus = m_data.getResourceList().getResource(Constants.PUS);
+        final int have = m_defender.getResources().getQuantity(pus);
         final int toRemove = Math.min(cost, have);
-        final Change change = ChangeFactory.changeResourcesChange(m_defender, PUs, -toRemove);
+        final Change change = ChangeFactory.changeResourcesChange(m_defender, pus, -toRemove);
         bridge.addChange(change);
         bridge.getHistoryWriter().addChildToEvent("Bombing raid in " + m_battleSite.getName() + " rolls: "
             + MyFormatter.asDice(m_dice) + " and costs: " + cost + " " + MyFormatter.pluralize("PU", cost) + ".");

--- a/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -294,15 +294,15 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   }
 
   boolean checkEnoughMoney(final int rolls, final IntegerMap<PlayerID> whoPaysHowMuch) {
-    final Resource PUs = getData().getResourceList().getResource(Constants.PUS);
+    final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     final int cost = rolls * getTechCost();
     if (whoPaysHowMuch == null || whoPaysHowMuch.isEmpty()) {
-      final int has = m_bridge.getPlayerID().getResources().getQuantity(PUs);
+      final int has = m_bridge.getPlayerID().getResources().getQuantity(pus);
       return has >= cost;
     } else {
       int runningTotal = 0;
       for (final Entry<PlayerID, Integer> entry : whoPaysHowMuch.entrySet()) {
-        final int has = entry.getKey().getResources().getQuantity(PUs);
+        final int has = entry.getKey().getResources().getQuantity(pus);
         final int paying = entry.getValue();
         if (paying > has) {
           return false;
@@ -314,12 +314,12 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   }
 
   private void chargeForTechRolls(final int rolls, final IntegerMap<PlayerID> whoPaysHowMuch) {
-    final Resource PUs = getData().getResourceList().getResource(Constants.PUS);
+    final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     int cost = rolls * getTechCost();
     if (whoPaysHowMuch == null || whoPaysHowMuch.isEmpty()) {
       final String transcriptText = m_bridge.getPlayerID().getName() + " spend " + cost + " on tech rolls";
       m_bridge.getHistoryWriter().startEvent(transcriptText);
-      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), PUs, -cost);
+      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), pus, -cost);
       m_bridge.addChange(charge);
     } else {
       for (final Entry<PlayerID, Integer> entry : whoPaysHowMuch.entrySet()) {
@@ -331,7 +331,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
         cost -= pays;
         final String transcriptText = p.getName() + " spend " + pays + " on tech rolls";
         m_bridge.getHistoryWriter().startEvent(transcriptText);
-        final Change charge = ChangeFactory.changeResourcesChange(p, PUs, -pays);
+        final Change charge = ChangeFactory.changeResourcesChange(p, pus, -pays);
         m_bridge.addChange(charge);
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/UserActionDelegate.java
@@ -117,9 +117,9 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
    * @return false if the player can't afford the action
    */
   private boolean checkEnoughMoney(final UserActionAttachment uaa) {
-    final Resource PUs = getData().getResourceList().getResource(Constants.PUS);
+    final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     final int cost = uaa.getCostPU();
-    final int has = m_bridge.getPlayerID().getResources().getQuantity(PUs);
+    final int has = m_bridge.getPlayerID().getResources().getQuantity(pus);
     return has >= cost;
   }
 
@@ -130,7 +130,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
    *        the UserActionAttachment this the money is charged for.
    */
   private void chargeForAction(final UserActionAttachment uaa) {
-    final Resource PUs = getData().getResourceList().getResource(Constants.PUS);
+    final Resource pus = getData().getResourceList().getResource(Constants.PUS);
     final int cost = uaa.getCostPU();
     if (cost > 0) {
       // don't notify user of spending money anymore
@@ -138,7 +138,7 @@ public class UserActionDelegate extends BaseTripleADelegate implements IUserActi
       final String transcriptText = m_bridge.getPlayerID().getName() + " spend " + cost + " PU on User Action: "
           + MyFormatter.attachmentNameToText(uaa.getName());
       m_bridge.getHistoryWriter().startEvent(transcriptText);
-      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), PUs, -cost);
+      final Change charge = ChangeFactory.changeResourcesChange(m_bridge.getPlayerID(), pus, -cost);
       m_bridge.addChange(charge);
     } else {
       final String transcriptText =

--- a/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -121,9 +121,9 @@ public class TechPanel extends ActionPanel {
       }
       advance = list.getSelectedValue();
     }
-    final int PUs = getCurrentPlayer().getResources().getQuantity(Constants.PUS);
+    final int pus = getCurrentPlayer().getResources().getQuantity(Constants.PUS);
     final String message = "Roll Tech";
-    final TechRollPanel techRollPanel = new TechRollPanel(PUs, getCurrentPlayer());
+    final TechRollPanel techRollPanel = new TechRollPanel(pus, getCurrentPlayer());
     final int choice = JOptionPane.showConfirmDialog(getTopLevelAncestor(), techRollPanel, message,
         JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null);
     if (choice != JOptionPane.OK_OPTION) {
@@ -183,7 +183,7 @@ public class TechPanel extends ActionPanel {
         JOptionPane.PLAIN_MESSAGE);
     final TechnologyFrontier category = list.getSelectedValue();
 
-    final int PUs = currentPlayer.getResources().getQuantity(Constants.PUS);
+    final int pus = currentPlayer.getResources().getQuantity(Constants.PUS);
     final String message = "Purchase Tech Tokens";
     // see if anyone will help us to pay
     Collection<PlayerID> helpPay;
@@ -193,7 +193,7 @@ public class TechPanel extends ActionPanel {
     } else {
       helpPay = null;
     }
-    final TechTokenPanel techTokenPanel = new TechTokenPanel(PUs, currTokens, currentPlayer, helpPay);
+    final TechTokenPanel techTokenPanel = new TechTokenPanel(pus, currTokens, currentPlayer, helpPay);
     final int choice = JOptionPane.showConfirmDialog(getTopLevelAncestor(), techTokenPanel, message,
         JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null);
     if (choice != JOptionPane.OK_OPTION) {


### PR DESCRIPTION
This PR fixes violations of the Checkstyle LocalFinalVariableName rule by renaming the local variable prefix `PUs` to `pus`.