### PR TITLE
Remove redundant null checks identified by static analysis

### DIFF
--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -516,7 +516,7 @@ public class BattleTracker implements Serializable {
       }
     }
     // If it was a Convoy Route- check ownership of the associated neighboring territory and set message
-    if (ta != null && ta.getConvoyRoute()) {
+    if (ta.getConvoyRoute()) {
       // we could be part of a convoy route for another territory
       final Collection<Territory> attachedConvoyTo =
           TerritoryAttachment.getWhatTerritoriesThisIsUsedInConvoysFor(territory, data);
@@ -567,7 +567,7 @@ public class BattleTracker implements Serializable {
     // if its a capital we take the money
     // NOTE: this is not checking to see if it is an enemy.
     // instead it is relying on the fact that the capital should be owned by the person it is attached to
-    if (ta != null && isTerritoryOwnerAnEnemy && ta.getCapital() != null) {
+    if (isTerritoryOwnerAnEnemy && ta.getCapital() != null) {
       // if the capital is owned by the capitols player take the money
       final PlayerID whoseCapital = data.getPlayerList().getPlayerID(ta.getCapital());
       final PlayerAttachment pa = PlayerAttachment.get(id);
@@ -649,8 +649,7 @@ public class BattleTracker implements Serializable {
     }
     // if we have specially set this territory to have whenCapturedByGoesTo,
     // then we set that here (except we don't set it if we are liberating allied owned territory)
-    if (ta != null && isTerritoryOwnerAnEnemy && newOwner.equals(id)
-        && Matches.territoryHasWhenCapturedByGoesTo().match(territory)) {
+    if (isTerritoryOwnerAnEnemy && newOwner.equals(id) && Matches.territoryHasWhenCapturedByGoesTo().match(territory)) {
       for (final String value : ta.getWhenCapturedByGoesTo()) {
         final String[] s = value.split(":");
         final PlayerID capturingPlayer = data.getPlayerList().getPlayerID(s[0]);
@@ -664,7 +663,7 @@ public class BattleTracker implements Serializable {
         }
       }
     }
-    if (isTerritoryOwnerAnEnemy && ta != null) {
+    if (isTerritoryOwnerAnEnemy) {
       final Change takeOver = ChangeFactory.changeOwner(territory, newOwner);
       bridge.getHistoryWriter().addChildToEvent(takeOver.toString());
       bridge.addChange(takeOver);
@@ -676,7 +675,7 @@ public class BattleTracker implements Serializable {
       if (territory.isWater()) {
         // should probably see if there is something actually happening for water
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_SEA, id);
-      } else if (ta != null && ta.getCapital() != null) {
+      } else if (ta.getCapital() != null) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_CAPITAL, id);
       } else if (m_blitzed.contains(territory) && Match.anyMatch(arrivedUnits, Matches.UnitCanBlitz)) {
         bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_TERRITORY_CAPTURE_BLITZ, id);
@@ -702,7 +701,7 @@ public class BattleTracker implements Serializable {
     captureOrDestroyUnits(territory, id, newOwner, bridge, changeTracker);
     // is this territory our capitol or a capitol of our ally
     // Also check to make sure playerAttachment even HAS a capital to fix abend
-    if (isTerritoryOwnerAnEnemy && terrOrigOwner != null && ta != null && ta.getCapital() != null
+    if (isTerritoryOwnerAnEnemy && terrOrigOwner != null && ta.getCapital() != null
         && TerritoryAttachment.getAllCapitals(terrOrigOwner, data).contains(territory)
         && relationshipTracker.isAllied(terrOrigOwner, id)) {
       // if it is give it back to the original owner

--- a/src/main/java/games/strategy/triplea/oddscalculator/ta/OddsCalculatorDialog.java
+++ b/src/main/java/games/strategy/triplea/oddscalculator/ta/OddsCalculatorDialog.java
@@ -30,7 +30,7 @@ public class OddsCalculatorDialog extends JDialog {
     dialog.addWindowListener(new WindowAdapter() {
       @Override
       public void windowClosed(final WindowEvent e) {
-        if (taFrame != null && taFrame.getUiContext() != null && !taFrame.getUiContext().isShutDown()) {
+        if (taFrame.getUiContext() != null && !taFrame.getUiContext().isShutDown()) {
           taFrame.getUiContext().removeShutdownWindow(dialog);
         }
       }

--- a/src/main/java/games/strategy/triplea/oddscalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddscalculator/ta/OddsCalculatorPanel.java
@@ -424,7 +424,7 @@ class OddsCalculatorPanel extends JPanel {
     // swing event thread
     dialog.setVisible(true);
     // results.get() could be null if we cancelled to quickly or something weird like that.
-    if (results == null || results.get() == null) {
+    if (results.get() == null) {
       setResultsToBlank();
     } else {
       attackerWin.setText(formatPercentage(results.get().getAttackerWinPercent()));

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -257,7 +257,7 @@ class EditPanel extends ActionPanel {
         } finally {
           getData().releaseReadLock();
         }
-        if (techs == null || techs.isEmpty()) {
+        if (techs.isEmpty()) {
           cancelEditAction.actionPerformed(null);
           return;
         }
@@ -320,7 +320,7 @@ class EditPanel extends ActionPanel {
         } finally {
           getData().releaseReadLock();
         }
-        if (techs == null || techs.isEmpty()) {
+        if (techs.isEmpty()) {
           cancelEditAction.actionPerformed(null);
           return;
         }

--- a/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -211,7 +211,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
         return;
       }
       if (currentAction == selectTerritoryAction) {
-        if (territory == null || !territoryChoices.contains(territory)) {
+        if (!territoryChoices.contains(territory)) {
           EventThreadJOptionPane.showMessageDialog(parent,
               "Must Pick An Unowned Territory (will have a white highlight)", "Must Pick An Unowned Territory",
               JOptionPane.WARNING_MESSAGE, new CountDownLatchHandler(true));

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -586,11 +586,11 @@ public class DecorationPlacer extends JFrame {
   private static void loadImageFolder() {
     System.out.println("Load an image folder (eg: 'misc' or 'territoryNames', etc)");
     File folder = new File(s_mapFolderLocation, s_imagePointType.getFolderName());
-    if (folder == null || !folder.exists()) {
+    if (!folder.exists()) {
       folder = s_mapFolderLocation;
     }
     final FileSave imageFolder = new FileSave("Load an Image Folder", null, folder);
-    if (imageFolder == null || imageFolder.getPathString() == null || imageFolder.getFile() == null
+    if (imageFolder.getPathString() == null || imageFolder.getFile() == null
         || !imageFolder.getFile().exists()) {
       s_currentImageFolderLocation = null;
     } else {
@@ -604,8 +604,7 @@ public class DecorationPlacer extends JFrame {
       final FileOpen centerName = new FileOpen("Load an Image Points Text File", s_mapFolderLocation,
           new File(s_mapFolderLocation, s_imagePointType.getFileName()), ".txt");
       s_currentImagePointsTextFile = centerName.getFile();
-      if (centerName != null && centerName.getFile() != null && centerName.getFile().exists()
-          && centerName.getPathString() != null) {
+      if (centerName.getFile() != null && centerName.getFile().exists() && centerName.getPathString() != null) {
         final FileInputStream in = new FileInputStream(centerName.getPathString());
         currentPoints = PointFileReaderWriter.readOneToMany(in);
       } else {
@@ -620,17 +619,17 @@ public class DecorationPlacer extends JFrame {
     s_staticImageForPlacing = null;
     File image = new File(s_mapFolderLocation + File.separator + s_imagePointType.getFolderName(),
         s_imagePointType.getImageName());
-    if (image == null || !image.exists()) {
+    if (!image.exists()) {
       image = new File(ClientFileSystemHelper.getRootFolder() + File.separator + ResourceLoader.RESOURCE_FOLDER
           + File.separator + s_imagePointType.getFolderName(), s_imagePointType.getImageName());
     }
-    if (image == null || !image.exists()) {
+    if (!image.exists()) {
       image = null;
     }
     while (s_staticImageForPlacing == null) {
       final FileOpen imageSelection = new FileOpen("Select Example Image To Use",
           (image == null ? s_mapFolderLocation : new File(image.getParent())), image, ".gif", ".png");
-      if (imageSelection == null || imageSelection.getFile() == null || !imageSelection.getFile().exists()) {
+      if (imageSelection.getFile() == null || !imageSelection.getFile().exists()) {
         continue;
       }
       s_staticImageForPlacing = createImage(imageSelection.getPathString());

--- a/src/main/java/tools/image/TileImageReconstructor.java
+++ b/src/main/java/tools/image/TileImageReconstructor.java
@@ -134,7 +134,7 @@ public class TileImageReconstructor {
       for (int y = 0; (y) * TileManager.TILE_SIZE < sizeY; y++) {
         final String tileName = x + "_" + y + ".png";
         final File tileFile = new File(baseTileLocation, tileName);
-        if (tileFile == null || !tileFile.exists()) {
+        if (!tileFile.exists()) {
           continue;
         }
         final Image tile = Toolkit.getDefaultToolkit().createImage(tileFile.getPath());


### PR DESCRIPTION
This PR removes some redundant `null` checks identified by static analysis.  These checks mostly fall into two classes:

* Variable is `final` and a previous check against `null` short-circuited the remaining code, so that any further checks are unnecessary.
* Variable was assigned as a result of the `new` operator, which can never return `null`.