### PR TITLE
Skip headed tests in a headless environment (#2173)

### DIFF
--- a/src/test/java/swinglib/JDialogBuilderTest.java
+++ b/src/test/java/swinglib/JDialogBuilderTest.java
@@ -2,8 +2,9 @@ package swinglib;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assume.assumeFalse;
 
-import java.awt.HeadlessException;
+import java.awt.GraphicsEnvironment;
 
 import javax.swing.JDialog;
 import javax.swing.JFrame;
@@ -15,42 +16,38 @@ public class JDialogBuilderTest {
 
   @Test
   public void checkTitle() {
-    try {
-      final JDialog dialog = JDialogBuilder.builder()
-          .contents(new JPanel())
-          .title("title")
-          .parentFrame(new JFrame())
-          .build();
-      assertThat(dialog.getTitle(), is("title"));
-    } catch (final HeadlessException e) {
-      // this is okay, we'll see this in travis
-    }
+    assumeHeadedGraphicsEnvironment();
+
+    final JDialog dialog = JDialogBuilder.builder()
+        .contents(new JPanel())
+        .title("title")
+        .parentFrame(new JFrame())
+        .build();
+    assertThat(dialog.getTitle(), is("title"));
+  }
+
+  private static void assumeHeadedGraphicsEnvironment() {
+    assumeFalse("requires headed graphics environment", GraphicsEnvironment.isHeadless());
   }
 
   @Test(expected = NullPointerException.class)
   public void contentsIsRequired() {
-    try {
-      JDialogBuilder.builder()
-          .title("title")
-          .parentFrame(new JFrame())
-          .build();
-    } catch (final HeadlessException e) {
-      // this is okay, we'll see this in travis
-      throw new NullPointerException("fake the exception to pass the test");
-    }
+    assumeHeadedGraphicsEnvironment();
+
+    JDialogBuilder.builder()
+        .title("title")
+        .parentFrame(new JFrame())
+        .build();
   }
 
   @Test(expected = NullPointerException.class)
   public void titleIsRequired() {
-    try {
-      JDialogBuilder.builder()
-          .contents(new JPanel())
-          .parentFrame(new JFrame())
-          .build();
-    } catch (final HeadlessException e) {
-      // this is okay, we'll see this in travis
-      throw new NullPointerException("fake the exception to pass the test");
-    }
+    assumeHeadedGraphicsEnvironment();
+
+    JDialogBuilder.builder()
+        .contents(new JPanel())
+        .parentFrame(new JFrame())
+        .build();
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Per the discussion in #2173.  Please view with whitespace changes ignored (`?w=1`) to reduce noise.