### PR TITLE
Checkstyle: Remove s_ prefix from variable names

### DIFF
--- a/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -23,7 +23,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
    * the message before
    * closing the socket).
    */
-  private static final Logger s_logger = Logger.getLogger(ServerQuarantineConversation.class.getName());
+  private static final Logger logger = Logger.getLogger(ServerQuarantineConversation.class.getName());
 
   private enum STEP {
     READ_NAME, READ_MAC, CHALLENGE, ACK_ERROR
@@ -61,22 +61,22 @@ public class ServerQuarantineConversation extends QuarantineConversation {
         case READ_NAME:
           // read name, send challent
           m_remoteName = (String) o;
-          if (s_logger.isLoggable(Level.FINER)) {
-            s_logger.log(Level.FINER, "read name:" + m_remoteName);
+          if (logger.isLoggable(Level.FINER)) {
+            logger.log(Level.FINER, "read name:" + m_remoteName);
           }
           m_step = STEP.READ_MAC;
           return ACTION.NONE;
         case READ_MAC:
           // read name, send challent
           m_remoteMac = (String) o;
-          if (s_logger.isLoggable(Level.FINER)) {
-            s_logger.log(Level.FINER, "read mac:" + m_remoteMac);
+          if (logger.isLoggable(Level.FINER)) {
+            logger.log(Level.FINER, "read mac:" + m_remoteMac);
           }
           if (m_validator != null) {
             challenge = m_validator.getChallengeProperties(m_remoteName, m_channel.socket().getRemoteSocketAddress());
           }
-          if (s_logger.isLoggable(Level.FINER)) {
-            s_logger.log(Level.FINER, "writing challenge:" + challenge);
+          if (logger.isLoggable(Level.FINER)) {
+            logger.log(Level.FINER, "writing challenge:" + challenge);
           }
           send((Serializable) challenge);
           m_step = STEP.CHALLENGE;
@@ -84,14 +84,14 @@ public class ServerQuarantineConversation extends QuarantineConversation {
         case CHALLENGE:
           @SuppressWarnings("unchecked")
           final Map<String, String> response = (Map<String, String>) o;
-          if (s_logger.isLoggable(Level.FINER)) {
-            s_logger.log(Level.FINER, "read challenge response:" + response);
+          if (logger.isLoggable(Level.FINER)) {
+            logger.log(Level.FINER, "read challenge response:" + response);
           }
           if (m_validator != null) {
             final String error = m_validator.verifyConnection(challenge, response, m_remoteName, m_remoteMac,
                 m_channel.socket().getRemoteSocketAddress());
-            if (s_logger.isLoggable(Level.FINER)) {
-              s_logger.log(Level.FINER, "error:" + error);
+            if (logger.isLoggable(Level.FINER)) {
+              logger.log(Level.FINER, "error:" + error);
             }
             send(error);
             if (error != null) {
@@ -103,8 +103,8 @@ public class ServerQuarantineConversation extends QuarantineConversation {
           }
           // get a unique name
           m_remoteName = m_serverMessenger.getUniqueName(m_remoteName);
-          if (s_logger.isLoggable(Level.FINER)) {
-            s_logger.log(Level.FINER, "Sending name:" + m_remoteName);
+          if (logger.isLoggable(Level.FINER)) {
+            logger.log(Level.FINER, "Sending name:" + m_remoteName);
           }
           // send the node its name and our name
           send(new String[] {m_remoteName, m_serverMessenger.getLocalNode().getName()});
@@ -122,7 +122,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
           throw new IllegalStateException("Invalid state");
       }
     } catch (final Throwable t) {
-      s_logger.log(Level.SEVERE, "Error with connection", t);
+      logger.log(Level.SEVERE, "Error with connection", t);
       return ACTION.TERMINATE;
     }
   }

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -59,7 +59,7 @@ public class BattleCalculator {
   }
 
   // There is a problem with this variable, that it isn't
-  // private static IntegerMap<UnitType> s_costsForTuvForAllPlayersMergedAndAveraged;
+  // private static IntegerMap<UnitType> costsForTuvForAllPlayersMergedAndAveraged;
   // being cleared out when we switch maps.
   // we want to sort in a determined way so that those looking at the dice results
   // can tell what dice is for who
@@ -999,7 +999,7 @@ public class BattleCalculator {
       costs.put(ut, averagedCost);
     }
     // There is a problem with this variable, that it isn't being cleared out when we
-    // s_costsForTuvForAllPlayersMergedAndAveraged = costs;
+    // costsForTuvForAllPlayersMergedAndAveraged = costs;
     // switch maps.
     return costs;
   }

--- a/src/main/java/games/strategy/triplea/printgenerator/PUChart.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PUChart.java
@@ -62,7 +62,7 @@ class PUChart {
       for (int j = i + 1; j < numPlayers; j++) {
         // i = firstPlayerMoney ; j = secondPlayerMoney
         if (moneyArray[i].equals(moneyArray[j])) {
-          // s_avoidMap.put(s_playerArray[i], s_playerArray[j]);
+          // avoidMap.put(playerArray[i], playerArray[j]);
           avoidMap.put(i, j);
         }
       }

--- a/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -579,7 +579,7 @@ public class ObjectivePanel extends AbstractStatPanel {
     private static final String PROPERTY_FILE = "objectives.properties";
     static final String GROUP_PROPERTY = "TABLEGROUP";
     static final String OBJECTIVES_PANEL_NAME = "Objectives.Panel.Name";
-    private static ObjectiveProperties s_op = null;
+    private static ObjectiveProperties instance = null;
     private static Instant timestamp = Instant.EPOCH;
     private final Properties properties = new Properties();
 
@@ -600,11 +600,11 @@ public class ObjectivePanel extends AbstractStatPanel {
 
     public static ObjectiveProperties getInstance() {
       // cache properties for 1 second
-      if (s_op == null || timestamp.plusSeconds(1).isBefore(Instant.now())) {
-        s_op = new ObjectiveProperties();
+      if (instance == null || timestamp.plusSeconds(1).isBefore(Instant.now())) {
+        instance = new ObjectiveProperties();
         timestamp = Instant.now();
       }
-      return s_op;
+      return instance;
     }
 
     public String getProperty(final String objectiveKey) {

--- a/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -99,16 +99,16 @@ public final class ScreenshotExporter {
       if (titleColor == null) {
         titleColor = Color.BLACK;
       }
-      final String s_title_x = iuiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_X);
-      final String s_title_y = iuiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_Y);
-      final String s_title_size = iuiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_FONT_SIZE);
+      final String encodedTitleX = iuiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_X);
+      final String encodedTitleY = iuiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_Y);
+      final String encodedTitleSize = iuiContext.getMapData().getProperty(MapData.PROPERTY_SCREENSHOT_TITLE_FONT_SIZE);
       int titleX;
       int titleY;
       int titleSize;
       try {
-        titleX = (int) (Integer.parseInt(s_title_x) * scale);
-        titleY = (int) (Integer.parseInt(s_title_y) * scale);
-        titleSize = Integer.parseInt(s_title_size);
+        titleX = (int) (Integer.parseInt(encodedTitleX) * scale);
+        titleY = (int) (Integer.parseInt(encodedTitleY) * scale);
+        titleSize = Integer.parseInt(encodedTitleSize);
       } catch (final NumberFormatException nfe) {
         // choose safe defaults
         titleX = (int) (15 * scale);

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -103,28 +103,28 @@ public class DecorationPlacer extends JFrame {
   // hash map for polygon points
   private Map<String, List<Polygon>> polygons = new HashMap<>();
   private final JLabel locationLabel = new JLabel();
-  private static File s_mapFolderLocation = null;
+  private static File mapFolderLocation = null;
   private static final String TRIPLEA_MAP_FOLDER = "triplea.map.folder";
-  private static File s_currentImageFolderLocation = null;
-  private static File s_currentImagePointsTextFile = null;
+  private static File currentImageFolderLocation = null;
+  private static File currentImagePointsTextFile = null;
   private Point currentMousePoint = new Point(0, 0);
   private Triple<String, Image, Point> currentSelectedImage = null;
   private Map<String, Tuple<Image, List<Point>>> currentImagePoints = new HashMap<>();
-  private static boolean s_highlightAll = false;
-  private static boolean s_createNewImageOnRightClick = false;
-  private static Image s_staticImageForPlacing = null;
-  private static boolean s_showFromTopLeft = true;
-  private static ImagePointType s_imagePointType = ImagePointType.decorations;
-  private static boolean s_cheapMutex = false;
-  private static boolean s_showPointNames = false;
+  private static boolean highlightAll = false;
+  private static boolean createNewImageOnRightClick = false;
+  private static Image staticImageForPlacing = null;
+  private static boolean showFromTopLeft = true;
+  private static ImagePointType imagePointType = ImagePointType.decorations;
+  private static boolean cheapMutex = false;
+  private static boolean showPointNames = false;
 
   public static void main(final String[] args) {
     handleCommandLineArgs(args);
     System.out.println("Select the map");
-    final FileOpen mapSelection = new FileOpen("Select The Map", s_mapFolderLocation, ".gif", ".png");
+    final FileOpen mapSelection = new FileOpen("Select The Map", mapFolderLocation, ".gif", ".png");
     final String mapName = mapSelection.getPathString();
-    if (s_mapFolderLocation == null && mapSelection.getFile() != null) {
-      s_mapFolderLocation = mapSelection.getFile().getParentFile();
+    if (mapFolderLocation == null && mapSelection.getFile() != null) {
+      mapFolderLocation = mapSelection.getFile().getParentFile();
     }
     if (mapName != null) {
       System.out.println("Map : " + mapName);
@@ -183,10 +183,10 @@ public class DecorationPlacer extends JFrame {
     super("Decoration Placer");
     setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
     setLocationRelativeTo(null);
-    s_highlightAll = false;
+    highlightAll = false;
     File fileCenters = null;
-    if (s_mapFolderLocation != null && s_mapFolderLocation.exists()) {
-      fileCenters = new File(s_mapFolderLocation, "centers.txt");
+    if (mapFolderLocation != null && mapFolderLocation.exists()) {
+      fileCenters = new File(mapFolderLocation, "centers.txt");
     }
     if (fileCenters == null || !fileCenters.exists()) {
       fileCenters = new File(new File(mapName).getParent() + File.separator + "centers.txt");
@@ -206,7 +206,7 @@ public class DecorationPlacer extends JFrame {
     } else {
       try {
         System.out.println("Select the Centers file");
-        final String centerPath = new FileOpen("Select A Center File", s_mapFolderLocation, ".txt").getPathString();
+        final String centerPath = new FileOpen("Select A Center File", mapFolderLocation, ".txt").getPathString();
         if (centerPath != null) {
           System.out.println("Centers : " + centerPath);
           centers = PointFileReaderWriter.readOneToOne(new FileInputStream(centerPath));
@@ -222,8 +222,8 @@ public class DecorationPlacer extends JFrame {
       }
     }
     File filePoly = null;
-    if (s_mapFolderLocation != null && s_mapFolderLocation.exists()) {
-      filePoly = new File(s_mapFolderLocation, "polygons.txt");
+    if (mapFolderLocation != null && mapFolderLocation.exists()) {
+      filePoly = new File(mapFolderLocation, "polygons.txt");
     }
     if (filePoly == null || !filePoly.exists()) {
       filePoly = new File(new File(mapName).getParent() + File.separator + "polygons.txt");
@@ -243,7 +243,7 @@ public class DecorationPlacer extends JFrame {
     } else {
       try {
         System.out.println("Select the Polygons file");
-        final String polyPath = new FileOpen("Select A Polygon File", s_mapFolderLocation, ".txt").getPathString();
+        final String polyPath = new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getPathString();
         if (polyPath != null) {
           System.out.println("Polygons : " + polyPath);
           polygons = PointFileReaderWriter.readOneToManyPolygons(new FileInputStream(polyPath));
@@ -328,7 +328,7 @@ public class DecorationPlacer extends JFrame {
     highlightAllModeItem.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent event) {
-        s_highlightAll = highlightAllModeItem.getState();
+        highlightAll = highlightAllModeItem.getState();
         DecorationPlacer.this.repaint();
       }
     });
@@ -336,7 +336,7 @@ public class DecorationPlacer extends JFrame {
     showNamesModeItem.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(final ActionEvent event) {
-        s_showPointNames = showNamesModeItem.getState();
+        showPointNames = showNamesModeItem.getState();
         DecorationPlacer.this.repaint();
       }
     });
@@ -387,7 +387,7 @@ public class DecorationPlacer extends JFrame {
   }
 
   private void paintToG(final Graphics g) {
-    if (s_cheapMutex) {
+    if (cheapMutex) {
       return;
     }
     g.drawImage(image, 0, 0, this);
@@ -395,34 +395,34 @@ public class DecorationPlacer extends JFrame {
     for (final Entry<String, Tuple<Image, List<Point>>> entry : currentImagePoints.entrySet()) {
       for (final Point p : entry.getValue().getSecond()) {
         g.drawImage(entry.getValue().getFirst(), p.x,
-            p.y - (s_showFromTopLeft ? 0 : entry.getValue().getFirst().getHeight(null)), null);
+            p.y - (showFromTopLeft ? 0 : entry.getValue().getFirst().getHeight(null)), null);
         if (currentSelectedImage != null && currentSelectedImage.getThird().equals(p)) {
           g.setColor(Color.green);
-          g.drawRect(p.x, p.y - (s_showFromTopLeft ? 0 : entry.getValue().getFirst().getHeight(null)),
+          g.drawRect(p.x, p.y - (showFromTopLeft ? 0 : entry.getValue().getFirst().getHeight(null)),
               entry.getValue().getFirst().getWidth(null), entry.getValue().getFirst().getHeight(null));
           g.setColor(Color.red);
-        } else if (s_highlightAll) {
-          g.drawRect(p.x, p.y - (s_showFromTopLeft ? 0 : entry.getValue().getFirst().getHeight(null)),
+        } else if (highlightAll) {
+          g.drawRect(p.x, p.y - (showFromTopLeft ? 0 : entry.getValue().getFirst().getHeight(null)),
               entry.getValue().getFirst().getWidth(null), entry.getValue().getFirst().getHeight(null));
         }
-        if (s_showPointNames) {
+        if (showPointNames) {
           g.drawString(entry.getKey(), p.x,
-              p.y - (s_showFromTopLeft ? 0 : entry.getValue().getFirst().getHeight(null)));
+              p.y - (showFromTopLeft ? 0 : entry.getValue().getFirst().getHeight(null)));
         }
       }
     }
     if (currentSelectedImage != null) {
       g.setColor(Color.green);
       g.drawImage(currentSelectedImage.getSecond(), currentMousePoint.x,
-          currentMousePoint.y - (s_showFromTopLeft ? 0 : currentSelectedImage.getSecond().getHeight(null)), null);
-      if (s_highlightAll) {
+          currentMousePoint.y - (showFromTopLeft ? 0 : currentSelectedImage.getSecond().getHeight(null)), null);
+      if (highlightAll) {
         g.drawRect(currentMousePoint.x,
-            currentMousePoint.y - (s_showFromTopLeft ? 0 : currentSelectedImage.getSecond().getHeight(null)),
+            currentMousePoint.y - (showFromTopLeft ? 0 : currentSelectedImage.getSecond().getHeight(null)),
             currentSelectedImage.getSecond().getWidth(null), currentSelectedImage.getSecond().getHeight(null));
       }
-      if (s_showPointNames) {
+      if (showPointNames) {
         g.drawString(currentSelectedImage.getFirst(), currentMousePoint.x,
-            currentMousePoint.y - (s_showFromTopLeft ? 0 : currentSelectedImage.getSecond().getHeight(null)));
+            currentMousePoint.y - (showFromTopLeft ? 0 : currentSelectedImage.getSecond().getHeight(null)));
       }
     }
   }
@@ -431,14 +431,14 @@ public class DecorationPlacer extends JFrame {
     final BufferedImage bufferedImage =
         new BufferedImage(image.getWidth(null), image.getHeight(null), BufferedImage.TYPE_INT_ARGB);
     final Graphics g = bufferedImage.getGraphics();
-    final boolean saveHighlight = s_highlightAll;
-    final boolean saveNames = s_showPointNames;
-    s_highlightAll = false;
-    s_showPointNames = false;
+    final boolean saveHighlight = highlightAll;
+    final boolean saveNames = showPointNames;
+    highlightAll = false;
+    showPointNames = false;
     paintToG(g);
     g.dispose();
-    s_highlightAll = saveHighlight;
-    s_showPointNames = saveNames;
+    highlightAll = saveHighlight;
+    showPointNames = saveNames;
     image = bufferedImage;
   }
 
@@ -458,7 +458,7 @@ public class DecorationPlacer extends JFrame {
     }
     try {
       final String fileName = new FileSave("Where To Save Image Points Text File?", JFileChooser.FILES_ONLY,
-          s_currentImagePointsTextFile, s_mapFolderLocation).getPathString();
+          currentImagePointsTextFile, mapFolderLocation).getPathString();
       if (fileName == null) {
         return;
       }
@@ -484,7 +484,7 @@ public class DecorationPlacer extends JFrame {
     for (final ImagePointType type : ImagePointType.getTypes()) {
       final JRadioButton button = new JRadioButton(type.toString() + "      :      " + type.getDescription());
       button.setActionCommand(type.toString());
-      if (s_imagePointType == type) {
+      if (imagePointType == type) {
         button.setSelected(true);
       } else {
         button.setSelected(false);
@@ -498,7 +498,7 @@ public class DecorationPlacer extends JFrame {
     final String choice = selected.getActionCommand();
     for (final ImagePointType type : ImagePointType.getTypes()) {
       if (type.toString().equals(choice)) {
-        s_imagePointType = type;
+        imagePointType = type;
         System.out.println("Selected Type: " + choice);
         break;
       }
@@ -506,9 +506,9 @@ public class DecorationPlacer extends JFrame {
   }
 
   private void topLeftOrBottomLeft() {
-    final Object[] showFromTopLeft = {"Point is Top Left", "Point is Bottom Left"};
+    final Object[] options = {"Point is Top Left", "Point is Bottom Left"};
     System.out.println("Select Show images from top left or bottom left point?");
-    s_showFromTopLeft = JOptionPane.showOptionDialog(this,
+    showFromTopLeft = JOptionPane.showOptionDialog(this,
         "Are the images shown from the top left, or from the bottom left point? \r\n"
             + "All images are shown from the top left, except for 'name_place.txt', 'pu_place.txt', and "
             + "'comments.txt'. \r\n"
@@ -517,12 +517,12 @@ public class DecorationPlacer extends JFrame {
             + "[meaning bottom left]. \r\n"
             + "Do NOT change this from whatever the default has choosen, unless you know exactly what you are doing!",
         "Show images from top left or bottom left point?", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE,
-        null, showFromTopLeft,
-        showFromTopLeft[(s_imagePointType.isCanUseBottomLeftPoint() ? 1 : 0)]) != JOptionPane.NO_OPTION;
+        null, options,
+        options[(imagePointType.isCanUseBottomLeftPoint() ? 1 : 0)]) != JOptionPane.NO_OPTION;
   }
 
   private void loadImagesAndPoints() {
-    s_cheapMutex = true;
+    cheapMutex = true;
     currentImagePoints = new HashMap<>();
     currentSelectedImage = null;
     selectImagePointType();
@@ -537,12 +537,12 @@ public class DecorationPlacer extends JFrame {
             + "capitols.txt [flags], etc, basically all others) ?",
         "Folder full of images OR Text file full of points?", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE,
         null, miscOrNamesOptions,
-        miscOrNamesOptions[(s_imagePointType.isUseFolder() ? 0 : 1)]) != JOptionPane.NO_OPTION) {
+        miscOrNamesOptions[(imagePointType.isUseFolder() ? 0 : 1)]) != JOptionPane.NO_OPTION) {
       // points are 'territory name' as opposed to exactly an image file name, like 'territory name.png' (everything but
       // decorations is a
       // territory name, while decorations are image file names)
       loadImageFolder();
-      if (s_currentImageFolderLocation == null) {
+      if (currentImageFolderLocation == null) {
         return;
       }
       loadImagePointTextFile();
@@ -558,9 +558,9 @@ public class DecorationPlacer extends JFrame {
               + "(name_place.txt) ?",
           "Points end in .png OR they do not?", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null,
           pointsAreNamesOptions,
-          pointsAreNamesOptions[(s_imagePointType.isEndInPng() ? 0 : 1)]) == JOptionPane.NO_OPTION);
-      s_createNewImageOnRightClick = false;
-      s_staticImageForPlacing = null;
+          pointsAreNamesOptions[(imagePointType.isEndInPng() ? 0 : 1)]) == JOptionPane.NO_OPTION);
+      createNewImageOnRightClick = false;
+      staticImageForPlacing = null;
     } else {
       loadImagePointTextFile();
       topLeftOrBottomLeft();
@@ -575,35 +575,35 @@ public class DecorationPlacer extends JFrame {
               + "(If you choose the later option, you must Right Click on a territory to create an image for that "
               + "territory.)",
           "Fill in all territories OR let you select them?", JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE,
-          null, fillAllOptions, fillAllOptions[(s_imagePointType.isFillAll() ? 0 : 1)]) != JOptionPane.NO_OPTION);
+          null, fillAllOptions, fillAllOptions[(imagePointType.isFillAll() ? 0 : 1)]) != JOptionPane.NO_OPTION);
     }
-    s_cheapMutex = false;
+    cheapMutex = false;
     System.out.println("");
     repaint();
-    JOptionPane.showMessageDialog(this, new JLabel(s_imagePointType.getInstructions()));
+    JOptionPane.showMessageDialog(this, new JLabel(imagePointType.getInstructions()));
   }
 
   private static void loadImageFolder() {
     System.out.println("Load an image folder (eg: 'misc' or 'territoryNames', etc)");
-    File folder = new File(s_mapFolderLocation, s_imagePointType.getFolderName());
+    File folder = new File(mapFolderLocation, imagePointType.getFolderName());
     if (!folder.exists()) {
-      folder = s_mapFolderLocation;
+      folder = mapFolderLocation;
     }
     final FileSave imageFolder = new FileSave("Load an Image Folder", null, folder);
     if (imageFolder.getPathString() == null || imageFolder.getFile() == null
         || !imageFolder.getFile().exists()) {
-      s_currentImageFolderLocation = null;
+      currentImageFolderLocation = null;
     } else {
-      s_currentImageFolderLocation = imageFolder.getFile();
+      currentImageFolderLocation = imageFolder.getFile();
     }
   }
 
   private void loadImagePointTextFile() {
     try {
       System.out.println("Load the points text file (eg: decorations.txt or pu_place.txt, etc)");
-      final FileOpen centerName = new FileOpen("Load an Image Points Text File", s_mapFolderLocation,
-          new File(s_mapFolderLocation, s_imagePointType.getFileName()), ".txt");
-      s_currentImagePointsTextFile = centerName.getFile();
+      final FileOpen centerName = new FileOpen("Load an Image Points Text File", mapFolderLocation,
+          new File(mapFolderLocation, imagePointType.getFileName()), ".txt");
+      currentImagePointsTextFile = centerName.getFile();
       if (centerName.getFile() != null && centerName.getFile().exists() && centerName.getPathString() != null) {
         final FileInputStream in = new FileInputStream(centerName.getPathString());
         currentPoints = PointFileReaderWriter.readOneToMany(in);
@@ -616,28 +616,28 @@ public class DecorationPlacer extends JFrame {
   }
 
   private void fillCurrentImagePointsBasedOnTextFile(final boolean fillInAllTerritories) {
-    s_staticImageForPlacing = null;
-    File image = new File(s_mapFolderLocation + File.separator + s_imagePointType.getFolderName(),
-        s_imagePointType.getImageName());
+    staticImageForPlacing = null;
+    File image = new File(mapFolderLocation + File.separator + imagePointType.getFolderName(),
+        imagePointType.getImageName());
     if (!image.exists()) {
       image = new File(ClientFileSystemHelper.getRootFolder() + File.separator + ResourceLoader.RESOURCE_FOLDER
-          + File.separator + s_imagePointType.getFolderName(), s_imagePointType.getImageName());
+          + File.separator + imagePointType.getFolderName(), imagePointType.getImageName());
     }
     if (!image.exists()) {
       image = null;
     }
-    while (s_staticImageForPlacing == null) {
+    while (staticImageForPlacing == null) {
       final FileOpen imageSelection = new FileOpen("Select Example Image To Use",
-          (image == null ? s_mapFolderLocation : new File(image.getParent())), image, ".gif", ".png");
+          (image == null ? mapFolderLocation : new File(image.getParent())), image, ".gif", ".png");
       if (imageSelection.getFile() == null || !imageSelection.getFile().exists()) {
         continue;
       }
-      s_staticImageForPlacing = createImage(imageSelection.getPathString());
+      staticImageForPlacing = createImage(imageSelection.getPathString());
     }
-    final int width = s_staticImageForPlacing.getWidth(null);
-    final int height = s_staticImageForPlacing.getHeight(null);
-    final int addY = (s_imagePointType == ImagePointType.comments ? ((-ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS))
-        : (s_imagePointType == ImagePointType.pu_place ? (ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS) : 0));
+    final int width = staticImageForPlacing.getWidth(null);
+    final int height = staticImageForPlacing.getHeight(null);
+    final int addY = (imagePointType == ImagePointType.comments ? ((-ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS))
+        : (imagePointType == ImagePointType.pu_place ? (ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS) : 0));
     if (fillInAllTerritories) {
       for (final Entry<String, Point> entry : centers.entrySet()) {
         List<Point> points = currentPoints.get(entry.getKey());
@@ -645,28 +645,28 @@ public class DecorationPlacer extends JFrame {
           System.out.println("Did NOT find point for: " + entry.getKey());
           points = new ArrayList<>();
           final Point p = new Point(entry.getValue().x - (width / 2),
-              entry.getValue().y + addY + ((s_showFromTopLeft ? -1 : 1) * (height / 2)));
+              entry.getValue().y + addY + ((showFromTopLeft ? -1 : 1) * (height / 2)));
           points.add(p);
         } else {
           System.out.println("Found point for: " + entry.getKey());
         }
-        currentImagePoints.put(entry.getKey(), Tuple.of(s_staticImageForPlacing, points));
+        currentImagePoints.put(entry.getKey(), Tuple.of(staticImageForPlacing, points));
       }
     } else {
       for (final Entry<String, List<Point>> entry : currentPoints.entrySet()) {
         currentImagePoints.put(entry.getKey(),
-            Tuple.of(s_staticImageForPlacing, entry.getValue()));
+            Tuple.of(staticImageForPlacing, entry.getValue()));
       }
     }
     // !fillInAllTerritories;
-    s_createNewImageOnRightClick = true;
+    createNewImageOnRightClick = true;
   }
 
   private void fillCurrentImagePointsBasedOnImageFolder(final boolean pointsAreExactlyTerritoryNames) {
-    final int addY = (s_imagePointType == ImagePointType.comments ? ((-ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS))
-        : (s_imagePointType == ImagePointType.pu_place ? (ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS) : 0));
+    final int addY = (imagePointType == ImagePointType.comments ? ((-ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS))
+        : (imagePointType == ImagePointType.pu_place ? (ImagePointType.SPACE_BETWEEN_NAMES_AND_PUS) : 0));
     final List<String> allTerritories = new ArrayList<>(centers.keySet());
-    for (final File file : s_currentImageFolderLocation.listFiles()) {
+    for (final File file : currentImageFolderLocation.listFiles()) {
       if (!file.getPath().endsWith(".png") && !file.getPath().endsWith(".gif")) {
         continue;
       }
@@ -684,7 +684,7 @@ public class DecorationPlacer extends JFrame {
           points.add(new Point(50, 50));
         } else {
           p = new Point(p.x - (image.getWidth(null) / 2),
-              p.y + addY + ((s_showFromTopLeft ? -1 : 1) * (image.getHeight(null) / 2)));
+              p.y + addY + ((showFromTopLeft ? -1 : 1) * (image.getHeight(null) / 2)));
           points.add(p);
           allTerritories.remove(possibleTerritoryName);
           System.out.println("Found point for: " + possibleTerritoryName);
@@ -695,7 +695,7 @@ public class DecorationPlacer extends JFrame {
       currentImagePoints.put((pointsAreExactlyTerritoryNames ? possibleTerritoryName : imageName),
           Tuple.of(image, points));
     }
-    if (!allTerritories.isEmpty() && s_imagePointType == ImagePointType.name_place) {
+    if (!allTerritories.isEmpty() && imagePointType == ImagePointType.name_place) {
       JOptionPane.showMessageDialog(this, new JLabel("Territory images not found in folder: " + allTerritories));
       System.out.println(allTerritories);
     }
@@ -710,7 +710,7 @@ public class DecorationPlacer extends JFrame {
    *        .lang.boolean rightMouse true if the right mouse button was hit
    */
   private void mouseEvent(final boolean ctrlDown, final boolean rightMouse) {
-    if (s_cheapMutex) {
+    if (cheapMutex) {
       return;
     }
     if (!rightMouse && !ctrlDown && currentSelectedImage == null) {
@@ -733,16 +733,16 @@ public class DecorationPlacer extends JFrame {
       currentImagePoints.put(currentSelectedImage.getFirst(),
           Tuple.of(currentSelectedImage.getSecond(), points));
       currentSelectedImage = null;
-    } else if (rightMouse && !ctrlDown && s_createNewImageOnRightClick && s_staticImageForPlacing != null
+    } else if (rightMouse && !ctrlDown && createNewImageOnRightClick && staticImageForPlacing != null
         && currentSelectedImage == null) {
       // create a new point here in this territory
       final Optional<String> territoryName = Util.findTerritoryName(currentMousePoint, polygons);
       if (territoryName.isPresent()) {
         final List<Point> points = new ArrayList<>();
         points.add(new Point(currentMousePoint));
-        currentImagePoints.put(territoryName.get(), Tuple.of(s_staticImageForPlacing, points));
+        currentImagePoints.put(territoryName.get(), Tuple.of(staticImageForPlacing, points));
       }
-    } else if (rightMouse && !ctrlDown && s_imagePointType.isCanHaveMultiplePoints()) {
+    } else if (rightMouse && !ctrlDown && imagePointType.isCanHaveMultiplePoints()) {
       // if none selected find the image we are clicking on, and duplicate it (not replace/move it)
       if (currentSelectedImage == null) {
         Point testPoint = null;
@@ -802,7 +802,7 @@ public class DecorationPlacer extends JFrame {
       }
       final File mapFolder = new File(value);
       if (mapFolder.exists()) {
-        s_mapFolderLocation = mapFolder;
+        mapFolderLocation = mapFolder;
       } else {
         System.out.println("Could not find directory: " + value);
       }
@@ -810,12 +810,12 @@ public class DecorationPlacer extends JFrame {
       System.out.println("Only argument allowed is the map directory.");
     }
     // might be set by -D
-    if (s_mapFolderLocation == null || s_mapFolderLocation.length() < 1) {
+    if (mapFolderLocation == null || mapFolderLocation.length() < 1) {
       final String value = System.getProperty(TRIPLEA_MAP_FOLDER);
       if (value != null && value.length() > 0) {
         final File mapFolder = new File(value);
         if (mapFolder.exists()) {
-          s_mapFolderLocation = mapFolder;
+          mapFolderLocation = mapFolder;
         } else {
           System.out.println("Could not find directory: " + value);
         }


### PR DESCRIPTION
This PR fixes violations of the following Checkstyle rules by removing the `s_` prefix from variable names:

* ConstantName
* LocalFinalVariableName
* StaticVariableName

I thought I got all of these in a previous PR, but apparently my IDE's Checkstyle plugin violation list was out-of-date or something.