### PR TITLE
Checkstyle: Remove m_ prefix from local variable names

### DIFF
--- a/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
+++ b/src/main/java/games/strategy/engine/gamePlayer/DefaultPlayerBridge.java
@@ -30,7 +30,7 @@ public class DefaultPlayerBridge implements IPlayerBridge {
   /** Creates new DefaultPlayerBridge. */
   public DefaultPlayerBridge(final IGame game) {
     m_game = game;
-    final GameStepListener m_gameStepListener = (stepName, delegateName, player, round, displayName) -> {
+    final GameStepListener gameStepListener = (stepName, delegateName, player, round, displayName) -> {
       if (stepName == null) {
         throw new IllegalArgumentException("Null step");
       }
@@ -40,7 +40,7 @@ public class DefaultPlayerBridge implements IPlayerBridge {
       m_currentStep = stepName;
       m_currentDelegate = delegateName;
     };
-    m_game.addGameStepListener(m_gameStepListener);
+    m_game.addGameStepListener(gameStepListener);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
@@ -23,12 +23,11 @@ class CountryChart {
   private final Map<Territory, List<Map<UnitType, Integer>>> infoMap = new HashMap<>();
 
   protected void saveToFile(final PlayerID player, final PrintGenerationData printData) {
-    final GameData m_data = printData.getData();
-    final PrintGenerationData m_printData = printData;
-    final Collection<Territory> m_terrCollection =
-        Match.getMatches(m_data.getMap().getTerritories(), Matches.territoryHasUnitsOwnedBy(player));
-    Iterator<Territory> terrIterator = m_terrCollection.iterator();
-    Iterator<UnitType> availableUnits = m_data.getUnitTypeList().iterator();
+    final GameData gameData = printData.getData();
+    final Collection<Territory> terrCollection =
+        Match.getMatches(gameData.getMap().getTerritories(), Matches.territoryHasUnitsOwnedBy(player));
+    Iterator<Territory> terrIterator = terrCollection.iterator();
+    Iterator<UnitType> availableUnits = gameData.getUnitTypeList().iterator();
     while (terrIterator.hasNext()) {
       final Territory currentTerritory = terrIterator.next();
       final UnitCollection unitsHere = currentTerritory.getUnits();
@@ -41,14 +40,14 @@ class CountryChart {
         unitPairs.add(innerMap);
       }
       infoMap.put(currentTerritory, unitPairs);
-      availableUnits = m_data.getUnitTypeList().iterator();
+      availableUnits = gameData.getUnitTypeList().iterator();
     }
     FileWriter countryFileWriter = null;
-    final File outFile = new File(m_printData.getOutDir(), player.getName() + ".csv");
+    final File outFile = new File(printData.getOutDir(), player.getName() + ".csv");
     try {
       countryFileWriter = new FileWriter(outFile, true);
       // Print Title
-      final int numUnits = m_data.getUnitTypeList().size();
+      final int numUnits = gameData.getUnitTypeList().size();
       for (int i = 0; i < numUnits / 2 - 1 + numUnits % 2; i++) {
         countryFileWriter.write(",");
       }
@@ -58,7 +57,7 @@ class CountryChart {
       }
       countryFileWriter.write("\r\n");
       // Print Unit Types
-      final Iterator<UnitType> unitIterator = m_data.getUnitTypeList().iterator();
+      final Iterator<UnitType> unitIterator = gameData.getUnitTypeList().iterator();
       countryFileWriter.write(",");
       while (unitIterator.hasNext()) {
         final UnitType currentType = unitIterator.next();
@@ -67,7 +66,7 @@ class CountryChart {
       countryFileWriter.write("\r\n");
       // Print Territories and Info
       terrIterator =
-          Match.getMatches(m_data.getMap().getTerritories(), Matches.territoryHasUnitsOwnedBy(player)).iterator();
+          Match.getMatches(gameData.getMap().getTerritories(), Matches.territoryHasUnitsOwnedBy(player)).iterator();
       while (terrIterator.hasNext()) {
         final Territory currentTerritory = terrIterator.next();
         countryFileWriter.write(currentTerritory.getName());

--- a/src/main/java/games/strategy/triplea/printgenerator/InitialSetup.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/InitialSetup.java
@@ -23,28 +23,27 @@ public class InitialSetup {
    * @param boolean useOriginalState
    */
   protected void run(final PrintGenerationData printData, final boolean useOriginalState) {
-    final GameData m_data = printData.getData();
-    final PrintGenerationData m_printData = printData;
+    final GameData gameData = printData.getData();
     if (useOriginalState) {
-      final HistoryNode root = (HistoryNode) m_data.getHistory().getRoot();
-      m_data.getHistory().gotoNode(root);
+      final HistoryNode root = (HistoryNode) gameData.getHistory().getRoot();
+      gameData.getHistory().gotoNode(root);
     }
-    final Iterator<UnitType> m_unitTypeIterator = m_data.getUnitTypeList().iterator();
-    while (m_unitTypeIterator.hasNext()) {
-      final UnitType currentType = m_unitTypeIterator.next();
+    final Iterator<UnitType> unitTypeIterator = gameData.getUnitTypeList().iterator();
+    while (unitTypeIterator.hasNext()) {
+      final UnitType currentType = unitTypeIterator.next();
       final UnitAttachment currentTypeUnitAttachment = UnitAttachment.get(currentType);
       unitInfoMap.put(currentType, currentTypeUnitAttachment);
     }
-    new UnitInformation().saveToFile(m_printData, unitInfoMap);
-    final Iterator<PlayerID> m_playerIterator = m_data.getPlayerList().iterator();
-    while (m_playerIterator.hasNext()) {
-      final PlayerID currentPlayer = m_playerIterator.next();
-      new CountryChart().saveToFile(currentPlayer, m_printData);
+    new UnitInformation().saveToFile(printData, unitInfoMap);
+    final Iterator<PlayerID> playerIterator = gameData.getPlayerList().iterator();
+    while (playerIterator.hasNext()) {
+      final PlayerID currentPlayer = playerIterator.next();
+      new CountryChart().saveToFile(currentPlayer, printData);
     }
-    new PUInfo().saveToFile(m_printData);
+    new PUInfo().saveToFile(printData);
     try {
-      new PlayerOrder().saveToFile(m_printData);
-      new PUChart(m_printData).saveToFile();
+      new PlayerOrder().saveToFile(printData);
+      new PUChart(printData).saveToFile();
     } catch (final IOException e) {
       ClientLogger.logQuietly(e);
     }

--- a/src/main/java/games/strategy/triplea/printgenerator/PUChart.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PUChart.java
@@ -34,10 +34,10 @@ class PUChart {
   private final File outDir;
 
   PUChart(final PrintGenerationData printData) {
-    final GameData m_data = printData.getData();
-    playerIterator = m_data.getPlayerList().iterator();
+    final GameData gameData = printData.getData();
+    playerIterator = gameData.getPlayerList().iterator();
     moneyMap = new IntegerMap<>();
-    numPlayers = m_data.getPlayerList().size();
+    numPlayers = gameData.getPlayerList().size();
     playerArray = new PlayerID[numPlayers];
     moneyArray = new Integer[numPlayers];
     avoidMap = new HashMap<>();

--- a/src/main/java/games/strategy/triplea/printgenerator/PUInfo.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PUInfo.java
@@ -16,12 +16,11 @@ public class PUInfo {
   private final Map<PlayerID, Map<Resource, Integer>> infoMap = new HashMap<>();
 
   protected void saveToFile(final PrintGenerationData printData) {
-    final GameData m_data = printData.getData();
-    final PrintGenerationData m_printData = printData;
-    Iterator<PlayerID> playerIterator = m_data.getPlayerList().iterator();
+    final GameData gameData = printData.getData();
+    Iterator<PlayerID> playerIterator = gameData.getPlayerList().iterator();
     while (playerIterator.hasNext()) {
       final PlayerID currentPlayer = playerIterator.next();
-      final Iterator<Resource> resourceIterator = m_data.getResourceList().getResources().iterator();
+      final Iterator<Resource> resourceIterator = gameData.getResourceList().getResources().iterator();
       final Map<Resource, Integer> resourceMap = new HashMap<>();
       while (resourceIterator.hasNext()) {
         final Resource currentResource = resourceIterator.next();
@@ -32,10 +31,10 @@ public class PUInfo {
     }
     FileWriter resourceWriter = null;
     try {
-      final File outFile = new File(m_printData.getOutDir(), "General Information.csv");
+      final File outFile = new File(printData.getOutDir(), "General Information.csv");
       resourceWriter = new FileWriter(outFile, true);
       // Print Title
-      final int numResources = m_data.getResourceList().size();
+      final int numResources = gameData.getResourceList().size();
       for (int i = 0; i < numResources / 2 - 1 + numResources % 2; i++) {
         resourceWriter.write(",");
       }
@@ -45,7 +44,7 @@ public class PUInfo {
       }
       resourceWriter.write("\r\n");
       // Print Resources
-      final Iterator<Resource> resourceIterator = m_data.getResourceList().getResources().iterator();
+      final Iterator<Resource> resourceIterator = gameData.getResourceList().getResources().iterator();
       resourceWriter.write(",");
       while (resourceIterator.hasNext()) {
         final Resource currentResource = resourceIterator.next();
@@ -53,7 +52,7 @@ public class PUInfo {
       }
       resourceWriter.write("\r\n");
       // Print Player's and Resource Amount's
-      playerIterator = m_data.getPlayerList().iterator();
+      playerIterator = gameData.getPlayerList().iterator();
       while (playerIterator.hasNext()) {
         final PlayerID currentPlayer = playerIterator.next();
         resourceWriter.write(currentPlayer.getName());

--- a/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
@@ -26,11 +26,10 @@ public class PlayerOrder {
   }
 
   protected void saveToFile(final PrintGenerationData printData) throws IOException {
-    final GameData m_data = printData.getData();
-    final PrintGenerationData m_printData = printData;
-    final Iterator<GameStep> m_gameStepIterator = m_data.getSequence().iterator();
-    while (m_gameStepIterator.hasNext()) {
-      final GameStep currentStep = m_gameStepIterator.next();
+    final GameData gameData = printData.getData();
+    final Iterator<GameStep> gameStepIterator = gameData.getSequence().iterator();
+    while (gameStepIterator.hasNext()) {
+      final GameStep currentStep = gameStepIterator.next();
       if (currentStep.getDelegate() != null && currentStep.getDelegate().getClass() != null) {
         final String delegateClassName = currentStep.getDelegate().getClass().getName();
         if (delegateClassName.equals(InitializationDelegate.class.getName())
@@ -49,8 +48,8 @@ public class PlayerOrder {
       }
     }
     FileWriter turnWriter = null;
-    m_printData.getOutDir().mkdir();
-    final File outFile = new File(m_printData.getOutDir(), "General Information.csv");
+    printData.getOutDir().mkdir();
+    final File outFile = new File(printData.getOutDir(), "General Information.csv");
     turnWriter = new FileWriter(outFile, true);
     turnWriter.write("Turn Order\r\n");
     final Set<PlayerID> noDuplicates = removeDups(playerSet);

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -92,7 +92,7 @@ class EditPanel extends ActionPanel {
   EditPanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map);
     this.frame = frame;
-    final JLabel m_actionLabel = new JLabel();
+    final JLabel actionLabel = new JLabel();
     performMoveAction = new AbstractAction("Perform Move or Other Actions") {
       private static final long serialVersionUID = 2205085537962024476L;
 
@@ -504,10 +504,10 @@ class EditPanel extends ActionPanel {
         cancelEditAction.actionPerformed(null);
       }
     };
-    m_actionLabel.setText("Edit Mode Actions");
+    actionLabel.setText("Edit Mode Actions");
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     setBorder(new EmptyBorder(5, 5, 0, 0));
-    add(m_actionLabel);
+    add(actionLabel);
     final JButton performMove = new JButton(performMoveAction);
     performMove.setToolTipText("<html>When in Edit Mode, you can perform special actions according to whatever phase "
         + "you are in, by switching back to the 'Action' tab.<br /> "

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -87,21 +87,21 @@ public class StatPanel extends AbstractStatPanel {
     if (!hasTech) {
       return;
     }
-    final JTable m_techTable = new JTable(techModel);
-    m_techTable.getTableHeader().setReorderingAllowed(false);
-    m_techTable.getColumnModel().getColumn(0).setPreferredWidth(500);
+    final JTable techTable = new JTable(techModel);
+    techTable.getTableHeader().setReorderingAllowed(false);
+    techTable.getColumnModel().getColumn(0).setPreferredWidth(500);
     // setupIconHeaders(m_techTable);
     // show icons for players:
     final TableCellRenderer componentRenderer = new JComponentTableCellRenderer();
-    for (int i = 1; i < m_techTable.getColumnCount(); i++) {
-      final TableColumn column = m_techTable.getColumnModel().getColumn(i);
+    for (int i = 1; i < techTable.getColumnCount(); i++) {
+      final TableColumn column = techTable.getColumnModel().getColumn(i);
       column.setHeaderRenderer(componentRenderer);
-      final String player = m_techTable.getColumnName(i);
+      final String player = techTable.getColumnName(i);
       final JLabel value = new JLabel("", getIcon(player), SwingConstants.CENTER);
       value.setToolTipText(player);
       column.setHeaderValue(value);
     }
-    scroll = new JScrollPane(m_techTable);
+    scroll = new JScrollPane(techTable);
     add(scroll);
   }
 

--- a/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/display/TripleADisplay.java
@@ -25,10 +25,7 @@ public class TripleADisplay implements ITripleADisplay {
   }
 
   @Override
-  public void initialize(final IDisplayBridge bridge) {
-    final IDisplayBridge m_displayBridge = bridge;
-    m_displayBridge.toString();
-  }
+  public void initialize(final IDisplayBridge bridge) {}
 
   // TODO: unit_dependents and battleTitle are both likely not used, they have been removed
   // from BattlePane().showBattle( .. ) already


### PR DESCRIPTION
This PR fixes violations of the Checkstyle LocalFinalVariableName rule by removing the `m_` prefix from such variables.

I thought I got all of these in a previous PR, but apparently my IDE's Checkstyle plugin violation list was out-of-date or something.