### PR TITLE
Restore hidden cursor after move completion (#2185)

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -49,13 +49,12 @@ public abstract class AbstractMovePanel extends ActionPanel {
   };
 
   private final Action doneMoveAction = new WeakAction("Done", doneMove);
-
-  private boolean cancelMoveEnabled = false;
+  private final Action cancelMoveAction = SwingComponents.newAbstractAction("Cancel", this::cancelMove);
 
   AbstractMovePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map);
     this.frame = frame;
-    cancelMoveEnabled = false;
+    cancelMoveAction.setEnabled(false);
     undoableMoves = Collections.emptyList();
   }
 
@@ -103,7 +102,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
   }
 
   final void enableCancelButton() {
-    cancelMoveEnabled = true;
+    cancelMoveAction.setEnabled(true);
   }
 
   protected final GameData getGameData() {
@@ -121,13 +120,13 @@ public abstract class AbstractMovePanel extends ActionPanel {
   }
 
   final void cancelMove() {
-    if (cancelMoveEnabled) {
+    if (cancelMoveAction.isEnabled()) {
       cancelMoveAction();
       if (frame != null) {
         frame.clearStatusMessage();
       }
       this.setEnabled(false);
-      cancelMoveEnabled = false;
+      cancelMoveAction.setEnabled(false);
     }
   }
 
@@ -220,7 +219,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
       listening = false;
       cleanUpSpecific();
       bridge = null;
-      cancelMoveEnabled = false;
+      cancelMoveAction.setEnabled(false);
       removeAll();
       refresh.run();
     });
@@ -244,7 +243,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
       this.actionLabel.setText(id.getName() + actionLabel);
       add(leftBox(this.actionLabel));
       if (setCancelButton()) {
-        add(leftBox(new JButton(SwingComponents.newAbstractAction("Cancel", this::cancelMove))));
+        add(leftBox(new JButton(cancelMoveAction)));
       }
       add(leftBox(new JButton(doneMoveAction)));
       addAdditionalButtons();

--- a/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -244,7 +244,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
       this.actionLabel.setText(id.getName() + actionLabel);
       add(leftBox(this.actionLabel));
       if (setCancelButton()) {
-        add(leftBox(new JButton(SwingComponents.newAbstractAction(this::cancelMove))));
+        add(leftBox(new JButton(SwingComponents.newAbstractAction("Cancel", this::cancelMove))));
       }
       add(leftBox(new JButton(doneMoveAction)));
       addAdditionalButtons();

--- a/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -49,7 +49,15 @@ public abstract class AbstractMovePanel extends ActionPanel {
   };
 
   private final Action doneMoveAction = new WeakAction("Done", doneMove);
-  private final Action cancelMoveAction = SwingComponents.newAbstractAction("Cancel", this::cancelMove);
+
+  private final Action cancelMoveAction = new AbstractAction("Cancel") {
+    private static final long serialVersionUID = -257745862234175428L;
+
+    @Override
+    public void actionPerformed(final ActionEvent e) {
+      cancelMove();
+    }
+  };
 
   AbstractMovePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map);

--- a/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -54,7 +54,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
   AbstractMovePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map);
     this.frame = frame;
-    cancelMoveAction.setEnabled(false);
+    disableCancelButton();
     undoableMoves = Collections.emptyList();
   }
 
@@ -105,6 +105,10 @@ public abstract class AbstractMovePanel extends ActionPanel {
     cancelMoveAction.setEnabled(true);
   }
 
+  private void disableCancelButton() {
+    cancelMoveAction.setEnabled(false);
+  }
+
   protected final GameData getGameData() {
     return bridge.getGameData();
   }
@@ -120,14 +124,12 @@ public abstract class AbstractMovePanel extends ActionPanel {
   }
 
   final void cancelMove() {
-    if (cancelMoveAction.isEnabled()) {
-      cancelMoveAction();
-      if (frame != null) {
-        frame.clearStatusMessage();
-      }
-      this.setEnabled(false);
-      cancelMoveAction.setEnabled(false);
+    cancelMoveAction();
+    if (frame != null) {
+      frame.clearStatusMessage();
     }
+    this.setEnabled(false);
+    disableCancelButton();
   }
 
   final String undoMove(final int moveIndex) {
@@ -219,7 +221,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
       listening = false;
       cleanUpSpecific();
       bridge = null;
-      cancelMoveAction.setEnabled(false);
+      disableCancelButton();
       removeAll();
       refresh.run();
     });

--- a/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -26,6 +26,7 @@ import games.strategy.triplea.delegate.UndoableMove;
 import games.strategy.triplea.delegate.dataObjects.MoveDescription;
 import games.strategy.triplea.delegate.remote.IAbstractMoveDelegate;
 import games.strategy.ui.SwingComponents;
+import swinglib.JButtonBuilder;
 
 public abstract class AbstractMovePanel extends ActionPanel {
   private static final long serialVersionUID = -4153574987414031433L;
@@ -50,14 +51,10 @@ public abstract class AbstractMovePanel extends ActionPanel {
 
   private final Action doneMoveAction = new WeakAction("Done", doneMove);
 
-  private final Action cancelMoveAction = new AbstractAction("Cancel") {
-    private static final long serialVersionUID = -257745862234175428L;
-
-    @Override
-    public void actionPerformed(final ActionEvent e) {
-      cancelMove();
-    }
-  };
+  private final JButton cancelMoveButton = JButtonBuilder.builder()
+      .title("Cancel")
+      .actionListener(this::cancelMove)
+      .build();
 
   AbstractMovePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map);
@@ -110,11 +107,11 @@ public abstract class AbstractMovePanel extends ActionPanel {
   }
 
   final void enableCancelButton() {
-    cancelMoveAction.setEnabled(true);
+    cancelMoveButton.setEnabled(true);
   }
 
   private void disableCancelButton() {
-    cancelMoveAction.setEnabled(false);
+    cancelMoveButton.setEnabled(false);
   }
 
   protected final GameData getGameData() {
@@ -253,7 +250,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
       this.actionLabel.setText(id.getName() + actionLabel);
       add(leftBox(this.actionLabel));
       if (setCancelButton()) {
-        add(leftBox(new JButton(cancelMoveAction)));
+        add(leftBox(cancelMoveButton));
       }
       add(leftBox(new JButton(doneMoveAction)));
       addAdditionalButtons();

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1346,6 +1346,7 @@ public class MovePanel extends AbstractMovePanel {
     selectedUnits.clear();
     updateRouteAndMouseShadowUnits(null);
     forced = null;
+    getMap().showMouseCursor();
   }
 
   @Override

--- a/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/src/main/java/games/strategy/ui/SwingComponents.java
@@ -63,28 +63,6 @@ public class SwingComponents {
   private static final Collection<String> visiblePrompts = new HashSet<>();
 
   /**
-   * Convenience method to create {@code AbstractAction} instances using lambdas.
-   * Example usage:
-   * <code><pre>
-   *   AbstractAction action = SwingComponents.newAbstractAction("Something", () -> {
-   *    if (value) {
-   *      doSomething();
-   *    }
-   *   });
-   * </pre></code>
-   */
-  public static AbstractAction newAbstractAction(final String name, final Runnable action) {
-    return new AbstractAction(name) {
-      private static final long serialVersionUID = -280371946771796597L;
-
-      @Override
-      public void actionPerformed(final ActionEvent e) {
-        action.run();
-      }
-    };
-  }
-
-  /**
    * Enum for swing codes that represent key events. In this case holding control or the
    * meta keys.
    */

--- a/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/src/main/java/games/strategy/ui/SwingComponents.java
@@ -66,15 +66,15 @@ public class SwingComponents {
    * Convenience method to create {@code AbstractAction} instances using lambdas.
    * Example usage:
    * <code><pre>
-   *   AbstractAction action = SwingComponents.newAbstractionAction(() -> {
+   *   AbstractAction action = SwingComponents.newAbstractAction("Something", () -> {
    *    if (value) {
    *      doSomething();
    *    }
    *   });
    * </pre></code>
    */
-  public static AbstractAction newAbstractAction(final Runnable action) {
-    return new AbstractAction() {
+  public static AbstractAction newAbstractAction(final String name, final Runnable action) {
+    return new AbstractAction(name) {
       private static final long serialVersionUID = -280371946771796597L;
 
       @Override


### PR DESCRIPTION
This PR addresses the cursor remaining hidden after move completion, as reported in #2185.  It also fixes the following related issues I observed during my investigation:

* The cancel button on the move panel has an empty label.
* The cancel button on the move panel was always enabled; it should be disabled when no move is in progress.

It appears that all of these issues are related to the changes made to `AbstractMovePanel` in 7c6df19.  Specifically:

* The new `cancelMoveEnabled` field had no effect on the enablement state of the cancel button in the UI.
* The `cancelMove()` method was changed to only execute its body if `cancelMoveEnabled` was `true`.  This was the root cause of the hidden cursor not being restored after completing a move because by the time `cancelMove()` was executed (via the call in `setActive()`), the `cancelMoveEnabled` flag had been reset to `false` due to the execution of `cancelMove()` being deferred via `SwingUtilities#invokeLater()`.

I fixed these issues by partially reverting some changes from 7c6df19:

* `cancelMoveEnabled` was removed and the original `cancelMoveAction` field was restored.
* Code to set the `cancelMoveEnabled` flag was replaced with the original code to enable/disable `cancelMoveAction`.
* `cancelMove()` was restored to always execute its body regardless of the enablement state of `cancelMoveAction`.  That is, when this method is called programatically, it will always be executed; execution will only be conditional when invoked via clicking the cancel button.

Please advise if any improvements can be made to address the spirit of the changes from 7c6df19.

NB: I think it's appropriate to squash the commits in this PR before merging.  They all essentially fix different symptoms of the same root cause.