### PR TITLE
Serialization proxy: Rename save game formats

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameDataFileUtils.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataFileUtils.java
@@ -20,14 +20,14 @@ public final class GameDataFileUtils {
   private GameDataFileUtils() {}
 
   private static SaveGameFormat getDefaultSaveGameFormat() {
-    return ClientSetting.TEST_USE_NEW_SAVE_GAME_FORMAT.booleanValue()
-        ? SaveGameFormat.NEW
-        : SaveGameFormat.CURRENT;
+    return ClientSetting.TEST_USE_PROXY_SERIALIZATION.booleanValue()
+        ? SaveGameFormat.PROXY_SERIALIZATION
+        : SaveGameFormat.SERIALIZATION;
   }
 
   @VisibleForTesting
   enum SaveGameFormat {
-    CURRENT, NEW;
+    SERIALIZATION, PROXY_SERIALIZATION;
   }
 
   /**
@@ -71,27 +71,27 @@ public final class GameDataFileUtils {
 
   private static Collection<String> getCandidateExtensions(final SaveGameFormat saveGameFormat) {
     switch (saveGameFormat) {
-      case CURRENT:
-        return getCurrentCandidateExtensions();
-      case NEW:
-        return getNewCandidateExtensions();
+      case SERIALIZATION:
+        return getSerializationCandidateExtensions();
+      case PROXY_SERIALIZATION:
+        return getProxySerializationCandidateExtensions();
       default:
         throw new AssertionError(String.format("unknown save game format (%s)", saveGameFormat));
     }
   }
 
-  private static Collection<String> getCurrentCandidateExtensions() {
+  private static Collection<String> getSerializationCandidateExtensions() {
     final String legacyExtension = ".svg";
 
     // Macs download a game data file as "tsvg.gz", so that extension must be used when evaluating candidate game data
     // files.
     final String macOsAlternativeExtension = "tsvg.gz";
 
-    return Arrays.asList(getExtension(SaveGameFormat.CURRENT), legacyExtension, macOsAlternativeExtension);
+    return Arrays.asList(getExtension(SaveGameFormat.SERIALIZATION), legacyExtension, macOsAlternativeExtension);
   }
 
-  private static Collection<String> getNewCandidateExtensions() {
-    return Arrays.asList(getExtension(SaveGameFormat.NEW));
+  private static Collection<String> getProxySerializationCandidateExtensions() {
+    return Arrays.asList(getExtension(SaveGameFormat.PROXY_SERIALIZATION));
   }
 
   /**
@@ -105,20 +105,20 @@ public final class GameDataFileUtils {
 
   private static String getExtension(final SaveGameFormat saveGameFormat) {
     switch (saveGameFormat) {
-      case CURRENT:
-        return getCurrentExtension();
-      case NEW:
-        return getNewExtension();
+      case SERIALIZATION:
+        return getSerializationExtension();
+      case PROXY_SERIALIZATION:
+        return getProxySerializationExtension();
       default:
         throw new AssertionError(String.format("unknown save game format (%s)", saveGameFormat));
     }
   }
 
-  private static String getCurrentExtension() {
+  private static String getSerializationExtension() {
     return ".tsvg";
   }
 
-  private static String getNewExtension() {
+  private static String getProxySerializationExtension() {
     return ".tsvgx";
   }
 

--- a/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -87,9 +87,9 @@ public final class GameDataManager {
   public static GameData loadGame(final InputStream is, final @Nullable String path) throws IOException {
     checkNotNull(is);
 
-    return ClientSetting.TEST_USE_NEW_SAVE_GAME_FORMAT.booleanValue()
-        ? loadGameInNewFormat(is)
-        : loadGameInCurrentFormat(is, path);
+    return ClientSetting.TEST_USE_PROXY_SERIALIZATION.booleanValue()
+        ? loadGameInProxySerializationFormat(is)
+        : loadGameInSerializationFormat(is, path);
   }
 
   private static String getPath(final File file) {
@@ -101,7 +101,7 @@ public final class GameDataManager {
   }
 
   @VisibleForTesting
-  static GameData loadGameInNewFormat(final InputStream is) throws IOException {
+  static GameData loadGameInProxySerializationFormat(final InputStream is) throws IOException {
     return fromMemento(loadMemento(new CloseShieldInputStream(is)));
   }
 
@@ -123,7 +123,9 @@ public final class GameDataManager {
     }
   }
 
-  private static GameData loadGameInCurrentFormat(final InputStream inputStream, final @Nullable String savegamePath)
+  private static GameData loadGameInSerializationFormat(
+      final InputStream inputStream,
+      final @Nullable String savegamePath)
       throws IOException {
     final ObjectInputStream input = new ObjectInputStream(new GZIPInputStream(inputStream));
     try {
@@ -305,18 +307,18 @@ public final class GameDataManager {
       final GameData gameData,
       final boolean includeDelegates)
       throws IOException {
-    if (ClientSetting.TEST_USE_NEW_SAVE_GAME_FORMAT.booleanValue()) {
-      saveGameInNewFormat(
+    if (ClientSetting.TEST_USE_PROXY_SERIALIZATION.booleanValue()) {
+      saveGameInProxySerializationFormat(
           os,
           gameData,
           Collections.singletonMap(GameDataMemento.ExportOptionName.EXCLUDE_DELEGATES, !includeDelegates));
     } else {
-      saveGameInCurrentFormat(os, gameData, includeDelegates);
+      saveGameInSerializationFormat(os, gameData, includeDelegates);
     }
   }
 
   @VisibleForTesting
-  static void saveGameInNewFormat(
+  static void saveGameInProxySerializationFormat(
       final OutputStream os,
       final GameData gameData,
       final Map<GameDataMemento.ExportOptionName, Object> optionsByName)
@@ -343,7 +345,7 @@ public final class GameDataManager {
     }
   }
 
-  private static void saveGameInCurrentFormat(
+  private static void saveGameInSerializationFormat(
       final OutputStream sink,
       final GameData data,
       final boolean saveDelegateInfo)

--- a/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -147,9 +147,6 @@ public enum ClientSetting implements GameSetting {
     }
   }
 
-  /**
-   * Returns true if a value has been set for the current property.
-   */
   @Override
   public boolean isSet() {
     return !value().trim().isEmpty();

--- a/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -88,7 +88,7 @@ public enum ClientSetting implements GameSetting {
 
   TEST_LOBBY_PORT,
 
-  TEST_USE_NEW_SAVE_GAME_FORMAT(false),
+  TEST_USE_PROXY_SERIALIZATION(false),
 
   TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY(true),
 

--- a/src/main/java/games/strategy/triplea/settings/ClientSettingUiBinding.java
+++ b/src/main/java/games/strategy/triplea/settings/ClientSettingUiBinding.java
@@ -133,11 +133,11 @@ enum ClientSettingUiBinding implements GameSettingUiBinding {
       SelectionComponentFactory.intValueRange(ClientSetting.TEST_LOBBY_PORT, 1, 99999),
       "Specifies the port for connecting to a test lobby."),
 
-  TEST_USE_NEW_SAVE_GAME_FORMAT_BINDING(
-      "Use New Save Game Format",
+  TEST_USE_PROXY_SERIALIZATION_BINDING(
+      "Use Proxy Serialization",
       SettingType.TESTING,
-      ClientSetting.TEST_USE_NEW_SAVE_GAME_FORMAT,
-      "Specifies whether or not to use the new save game format."),
+      ClientSetting.TEST_USE_PROXY_SERIALIZATION,
+      "Specifies whether or not to use proxies when serializing/deserializing games."),
 
   TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY_BINDING(
       "Show First Time Prompts",

--- a/src/test/java/games/strategy/engine/framework/GameDataFileUtilsTests.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataFileUtilsTests.java
@@ -14,9 +14,9 @@ import games.strategy.engine.framework.GameDataFileUtils.SaveGameFormat;
 public final class GameDataFileUtilsTests {
   @RunWith(Enclosed.class)
   public static final class AddExtensionTests {
-    public static final class WhenSaveGameFormatIsCurrentTest {
+    public static final class WhenSaveGameFormatIsSerializationTest {
       private static String addExtension(final String fileName) {
-        return GameDataFileUtils.addExtension(fileName, SaveGameFormat.CURRENT);
+        return GameDataFileUtils.addExtension(fileName, SaveGameFormat.SERIALIZATION);
       }
 
       @Test
@@ -30,9 +30,9 @@ public final class GameDataFileUtilsTests {
       }
     }
 
-    public static final class WhenSaveGameFormatIsNewTest {
+    public static final class WhenSaveGameFormatIsProxySerializationTest {
       private static String addExtension(final String fileName) {
-        return GameDataFileUtils.addExtension(fileName, SaveGameFormat.NEW);
+        return GameDataFileUtils.addExtension(fileName, SaveGameFormat.PROXY_SERIALIZATION);
       }
 
       @Test
@@ -50,10 +50,10 @@ public final class GameDataFileUtilsTests {
   @RunWith(Enclosed.class)
   public static final class AddExtensionIfAbsentTests {
     @RunWith(Enclosed.class)
-    public static final class WhenSaveGameFormatIsCurrentTests {
+    public static final class WhenSaveGameFormatIsSerializationTests {
       public static final class WhenFileSystemIsCaseSensitiveTest {
         private static String addExtensionIfAbsent(final String fileName) {
-          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.CURRENT, IOCase.SENSITIVE);
+          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.SERIALIZATION, IOCase.SENSITIVE);
         }
 
         @Test
@@ -74,7 +74,7 @@ public final class GameDataFileUtilsTests {
 
       public static final class WhenFileSystemIsCaseInsensitiveTest {
         private static String addExtensionIfAbsent(final String fileName) {
-          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.CURRENT, IOCase.INSENSITIVE);
+          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.SERIALIZATION, IOCase.INSENSITIVE);
         }
 
         @Test
@@ -95,10 +95,10 @@ public final class GameDataFileUtilsTests {
     }
 
     @RunWith(Enclosed.class)
-    public static final class WhenSaveGameFormatIsNewTests {
+    public static final class WhenSaveGameFormatIsProxySerializationTests {
       public static final class WhenFileSystemIsCaseSensitiveTest {
         private static String addExtensionIfAbsent(final String fileName) {
-          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.NEW, IOCase.SENSITIVE);
+          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.PROXY_SERIALIZATION, IOCase.SENSITIVE);
         }
 
         @Test
@@ -119,7 +119,10 @@ public final class GameDataFileUtilsTests {
 
       public static final class WhenFileSystemIsCaseInsensitiveTest {
         private static String addExtensionIfAbsent(final String fileName) {
-          return GameDataFileUtils.addExtensionIfAbsent(fileName, SaveGameFormat.NEW, IOCase.INSENSITIVE);
+          return GameDataFileUtils.addExtensionIfAbsent(
+              fileName,
+              SaveGameFormat.PROXY_SERIALIZATION,
+              IOCase.INSENSITIVE);
         }
 
         @Test
@@ -143,10 +146,10 @@ public final class GameDataFileUtilsTests {
   @RunWith(Enclosed.class)
   public static final class IsCandidateFileNameTests {
     @RunWith(Enclosed.class)
-    public static final class WhenSaveGameFormatIsCurrentTests {
+    public static final class WhenSaveGameFormatIsSerializationTests {
       public static final class WhenFileSystemIsCaseSensitiveTest {
         private static boolean isCandidateFileName(final String fileName) {
-          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.CURRENT, IOCase.SENSITIVE);
+          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.SERIALIZATION, IOCase.SENSITIVE);
         }
 
         @Test
@@ -187,7 +190,7 @@ public final class GameDataFileUtilsTests {
 
       public static final class WhenFileSystemIsCaseInsensitiveTest {
         private static boolean isCandidateFileName(final String fileName) {
-          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.CURRENT, IOCase.INSENSITIVE);
+          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.SERIALIZATION, IOCase.INSENSITIVE);
         }
 
         @Test
@@ -228,10 +231,10 @@ public final class GameDataFileUtilsTests {
     }
 
     @RunWith(Enclosed.class)
-    public static final class WhenSaveGameFormatIsNewTests {
+    public static final class WhenSaveGameFormatIsProxySerializationTests {
       public static final class WhenFileSystemIsCaseSensitiveTest {
         private static boolean isCandidateFileName(final String fileName) {
-          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.NEW, IOCase.SENSITIVE);
+          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.PROXY_SERIALIZATION, IOCase.SENSITIVE);
         }
 
         @Test
@@ -252,7 +255,10 @@ public final class GameDataFileUtilsTests {
 
       public static final class WhenFileSystemIsCaseInsensitiveTest {
         private static boolean isCandidateFileName(final String fileName) {
-          return GameDataFileUtils.isCandidateFileName(fileName, SaveGameFormat.NEW, IOCase.INSENSITIVE);
+          return GameDataFileUtils.isCandidateFileName(
+              fileName,
+              SaveGameFormat.PROXY_SERIALIZATION,
+              IOCase.INSENSITIVE);
         }
 
         @Test

--- a/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -32,49 +32,49 @@ public class GameDataManagerTest {
   }
 
   @Test
-  public void shouldBeAbleToRoundTripGameDataInNewFormat() throws Exception {
+  public void shouldBeAbleToRoundTripGameDataInProxySerializationFormat() throws Exception {
     final GameData expected = TestGameDataFactory.newValidGameData();
 
-    final byte[] bytes = saveGameInNewFormat(expected);
-    final GameData actual = loadGameInNewFormat(bytes);
+    final byte[] bytes = saveGameInProxySerializationFormat(expected);
+    final GameData actual = loadGameInProxySerializationFormat(bytes);
 
     assertThat(actual, is(equalToGameData(expected)));
   }
 
-  private static byte[] saveGameInNewFormat(final GameData gameData) throws Exception {
+  private static byte[] saveGameInProxySerializationFormat(final GameData gameData) throws Exception {
     try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-      GameDataManager.saveGameInNewFormat(baos, gameData, Collections.emptyMap());
+      GameDataManager.saveGameInProxySerializationFormat(baos, gameData, Collections.emptyMap());
       return baos.toByteArray();
     }
   }
 
-  private static GameData loadGameInNewFormat(final byte[] bytes) throws Exception {
+  private static GameData loadGameInProxySerializationFormat(final byte[] bytes) throws Exception {
     try (final ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
-      return GameDataManager.loadGameInNewFormat(bais);
+      return GameDataManager.loadGameInProxySerializationFormat(bais);
     }
   }
 
   @Test
-  public void loadGameInNewFormat_ShouldNotCloseInputStream() throws Exception {
-    try (final InputStream is = spy(newInputStreamWithGameInNewFormat())) {
-      GameDataManager.loadGameInNewFormat(is);
+  public void loadGameInProxySerializationFormat_ShouldNotCloseInputStream() throws Exception {
+    try (final InputStream is = spy(newInputStreamWithGameInProxySerializationFormat())) {
+      GameDataManager.loadGameInProxySerializationFormat(is);
 
       verify(is, never()).close();
     }
   }
 
-  private static InputStream newInputStreamWithGameInNewFormat() throws Exception {
+  private static InputStream newInputStreamWithGameInProxySerializationFormat() throws Exception {
     final GameData gameData = TestGameDataFactory.newValidGameData();
-    final byte[] bytes = saveGameInNewFormat(gameData);
+    final byte[] bytes = saveGameInProxySerializationFormat(gameData);
     return new ByteArrayInputStream(bytes);
   }
 
   @Test
-  public void saveGameInNewFormat_ShouldNotCloseOutputStream() throws Exception {
+  public void saveGameInProxySerializationFormat_ShouldNotCloseOutputStream() throws Exception {
     final OutputStream os = mock(OutputStream.class);
     final GameData gameData = TestGameDataFactory.newValidGameData();
 
-    GameDataManager.saveGameInNewFormat(os, gameData, Collections.emptyMap());
+    GameDataManager.saveGameInProxySerializationFormat(os, gameData, Collections.emptyMap());
 
     verify(os, never()).close();
   }


### PR DESCRIPTION
This PR renames the "current" and "new" save game formats, as suggested in [#2172](https://github.com/triplea-game/triplea/pull/2172#discussion_r130819584):

* "current" -> "serialization"
* "new" -> "proxy serialization"