### PR TITLE
Serialization proxy: Add proxy for ResourceCollection

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework;
 
 import games.strategy.internal.persistence.serializable.GameDataProxy;
 import games.strategy.internal.persistence.serializable.PropertyBagMementoProxy;
+import games.strategy.internal.persistence.serializable.ResourceCollectionProxy;
 import games.strategy.internal.persistence.serializable.ResourceProxy;
 import games.strategy.internal.persistence.serializable.TripleAProxy;
 import games.strategy.internal.persistence.serializable.VersionProxy;
@@ -20,6 +21,7 @@ final class ProxyRegistries {
         GameDataProxy.FACTORY,
         PropertyBagMementoProxy.FACTORY,
         ResourceProxy.FACTORY,
+        ResourceCollectionProxy.FACTORY,
         TripleAProxy.FACTORY,
         VersionProxy.FACTORY);
   }

--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -1,6 +1,9 @@
 package games.strategy.engine.framework;
 
+import games.strategy.internal.persistence.serializable.GameDataProxy;
 import games.strategy.internal.persistence.serializable.PropertyBagMementoProxy;
+import games.strategy.internal.persistence.serializable.ResourceProxy;
+import games.strategy.internal.persistence.serializable.TripleAProxy;
 import games.strategy.internal.persistence.serializable.VersionProxy;
 import games.strategy.persistence.serializable.ProxyRegistry;
 
@@ -14,7 +17,10 @@ final class ProxyRegistries {
 
   private static ProxyRegistry newGameDataMementoProxyRegistry() {
     return ProxyRegistry.newInstance(
+        GameDataProxy.FACTORY,
         PropertyBagMementoProxy.FACTORY,
+        ResourceProxy.FACTORY,
+        TripleAProxy.FACTORY,
         VersionProxy.FACTORY);
   }
 }

--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.framework;
 
 import games.strategy.internal.persistence.serializable.GameDataProxy;
+import games.strategy.internal.persistence.serializable.IntegerMapProxy;
 import games.strategy.internal.persistence.serializable.PropertyBagMementoProxy;
 import games.strategy.internal.persistence.serializable.ResourceCollectionProxy;
 import games.strategy.internal.persistence.serializable.ResourceProxy;
@@ -19,6 +20,7 @@ final class ProxyRegistries {
   private static ProxyRegistry newGameDataMementoProxyRegistry() {
     return ProxyRegistry.newInstance(
         GameDataProxy.FACTORY,
+        IntegerMapProxy.FACTORY,
         PropertyBagMementoProxy.FACTORY,
         ResourceProxy.FACTORY,
         ResourceCollectionProxy.FACTORY,

--- a/src/main/java/games/strategy/internal/persistence/serializable/GameDataProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/GameDataProxy.java
@@ -1,0 +1,45 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.InvalidObjectException;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameDataMemento;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.util.memento.Memento;
+import games.strategy.util.memento.MementoExportException;
+import games.strategy.util.memento.MementoImportException;
+import net.jcip.annotations.Immutable;
+
+/**
+ * A serializable proxy for the {@link GameData} class.
+ */
+@Immutable
+public final class GameDataProxy implements Proxy {
+  private static final long serialVersionUID = 8249846682421871173L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(GameData.class, GameDataProxy::new);
+
+  private final Memento memento;
+
+  public GameDataProxy(final GameData gameData) {
+    checkNotNull(gameData);
+
+    try {
+      memento = GameDataMemento.newExporter().exportMemento(gameData);
+    } catch (final MementoExportException e) {
+      throw new IllegalArgumentException("failed to create proxy from GameData", e);
+    }
+  }
+
+  @Override
+  public Object readResolve() throws InvalidObjectException {
+    try {
+      return GameDataMemento.newImporter().importMemento(memento);
+    } catch (final MementoImportException e) {
+      throw (InvalidObjectException) new InvalidObjectException("failed to create GameData from proxy").initCause(e);
+    }
+  }
+}

--- a/src/main/java/games/strategy/internal/persistence/serializable/IntegerMapProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/IntegerMapProxy.java
@@ -1,0 +1,33 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.util.IntegerMap;
+import net.jcip.annotations.Immutable;
+
+/**
+ * A serializable proxy for the {@link IntegerMap} class.
+ */
+@Immutable
+public final class IntegerMapProxy implements Proxy {
+  private static final long serialVersionUID = 1277651902932560180L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(IntegerMap.class, IntegerMapProxy::new);
+
+  private final Map<?, Integer> map;
+
+  public IntegerMapProxy(final IntegerMap<?> integerMap) {
+    checkNotNull(integerMap);
+
+    map = integerMap.toMap();
+  }
+
+  @Override
+  public Object readResolve() {
+    return new IntegerMap<>(map);
+  }
+}

--- a/src/main/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxy.java
@@ -1,0 +1,39 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.ResourceCollection;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.util.IntegerMap;
+import net.jcip.annotations.Immutable;
+
+/**
+ * A serializable proxy for the {@link ResourceCollection} class.
+ */
+@Immutable
+public final class ResourceCollectionProxy implements Proxy {
+  private static final long serialVersionUID = -513052202453337139L;
+
+  public static final ProxyFactory FACTORY =
+      ProxyFactory.newInstance(ResourceCollection.class, ResourceCollectionProxy::new);
+
+  private final GameData gameData;
+  private final Map<Resource, Integer> quantitiesByResource;
+
+  public ResourceCollectionProxy(final ResourceCollection resourceCollection) {
+    checkNotNull(resourceCollection);
+
+    gameData = resourceCollection.getData();
+    quantitiesByResource = resourceCollection.getResourcesCopy().toMap();
+  }
+
+  @Override
+  public Object readResolve() {
+    return new ResourceCollection(gameData, new IntegerMap<>(quantitiesByResource));
+  }
+}

--- a/src/main/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxy.java
@@ -2,8 +2,6 @@ package games.strategy.internal.persistence.serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.Map;
-
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.ResourceCollection;
@@ -23,17 +21,17 @@ public final class ResourceCollectionProxy implements Proxy {
       ProxyFactory.newInstance(ResourceCollection.class, ResourceCollectionProxy::new);
 
   private final GameData gameData;
-  private final Map<Resource, Integer> quantitiesByResource;
+  private final IntegerMap<Resource> resources;
 
   public ResourceCollectionProxy(final ResourceCollection resourceCollection) {
     checkNotNull(resourceCollection);
 
     gameData = resourceCollection.getData();
-    quantitiesByResource = resourceCollection.getResourcesCopy().toMap();
+    resources = resourceCollection.getResourcesCopy();
   }
 
   @Override
   public Object readResolve() {
-    return new ResourceCollection(gameData, new IntegerMap<>(quantitiesByResource));
+    return new ResourceCollection(gameData, resources);
   }
 }

--- a/src/main/java/games/strategy/internal/persistence/serializable/ResourceProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ResourceProxy.java
@@ -2,7 +2,6 @@ package games.strategy.internal.persistence.serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import games.strategy.engine.data.GameData;
@@ -28,7 +27,7 @@ public final class ResourceProxy implements Proxy {
   public ResourceProxy(final Resource resource) {
     checkNotNull(resource);
 
-    attachments = new HashMap<>(resource.getAttachments());
+    attachments = resource.getAttachments();
     gameData = resource.getData();
     name = resource.getName();
   }

--- a/src/main/java/games/strategy/internal/persistence/serializable/ResourceProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ResourceProxy.java
@@ -1,0 +1,42 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.IAttachment;
+import games.strategy.engine.data.Resource;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+import net.jcip.annotations.Immutable;
+
+/**
+ * A serializable proxy for the {@link Resource} class.
+ */
+@Immutable
+public final class ResourceProxy implements Proxy {
+  private static final long serialVersionUID = -314508780057279336L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(Resource.class, ResourceProxy::new);
+
+  private final Map<String, IAttachment> attachments;
+  private final GameData gameData;
+  private final String name;
+
+  public ResourceProxy(final Resource resource) {
+    checkNotNull(resource);
+
+    attachments = new HashMap<>(resource.getAttachments());
+    gameData = resource.getData();
+    name = resource.getName();
+  }
+
+  @Override
+  public Object readResolve() {
+    final Resource resource = new Resource(name, gameData);
+    attachments.forEach(resource::addAttachment);
+    return resource;
+  }
+}

--- a/src/main/java/games/strategy/util/IntegerMap.java
+++ b/src/main/java/games/strategy/util/IntegerMap.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map.Entry;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -61,6 +61,14 @@ public final class IntegerMap<T> implements Cloneable, Serializable {
     for (final IntegerMap<T> integerMap : integerMaps) {
       this.add(integerMap);
     }
+  }
+
+  public IntegerMap(final Map<T, Integer> map) {
+    mapValues = new HashMap<>(map);
+  }
+
+  public Map<T, Integer> toMap() {
+    return new HashMap<>(mapValues);
   }
 
   public int size() {
@@ -221,7 +229,7 @@ public final class IntegerMap<T> implements Cloneable, Serializable {
     }
     int maxValue = Integer.MIN_VALUE;
     T maxKey = null;
-    for (final Entry<T, Integer> entry : mapValues.entrySet()) {
+    for (final Map.Entry<T, Integer> entry : mapValues.entrySet()) {
       if (entry.getValue() > maxValue) {
         maxValue = entry.getValue();
         maxKey = entry.getKey();
@@ -239,7 +247,7 @@ public final class IntegerMap<T> implements Cloneable, Serializable {
     }
     int minValue = Integer.MAX_VALUE;
     T minKey = null;
-    for (final Entry<T, Integer> entry : mapValues.entrySet()) {
+    for (final Map.Entry<T, Integer> entry : mapValues.entrySet()) {
       if (entry.getValue() < minValue) {
         minValue = entry.getValue();
         minKey = entry.getKey();
@@ -351,7 +359,7 @@ public final class IntegerMap<T> implements Cloneable, Serializable {
     return mapValues.isEmpty();
   }
 
-  public Set<Entry<T, Integer>> entrySet() {
+  public Set<Map.Entry<T, Integer>> entrySet() {
     return mapValues.entrySet();
   }
 

--- a/src/test/java/games/strategy/engine/data/FakeAttachment.java
+++ b/src/test/java/games/strategy/engine/data/FakeAttachment.java
@@ -1,0 +1,67 @@
+package games.strategy.engine.data;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Fake implementation of {@link IAttachment} useful for testing.
+ */
+public final class FakeAttachment implements IAttachment {
+  private static final long serialVersionUID = 3686559484645729844L;
+
+  private final String name;
+
+  public FakeAttachment(final String name) {
+    this.name = name;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == this) {
+      return true;
+    } else if (!(obj instanceof FakeAttachment)) {
+      return false;
+    }
+
+    final FakeAttachment other = (FakeAttachment) obj;
+    return Objects.equals(name, other.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .toString();
+  }
+
+  @Override
+  public Attachable getAttachedTo() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public void setAttachedTo(final Attachable attachable) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setName(final String name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void validate(final GameData data) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/test/java/games/strategy/engine/data/FakeAttachmentTest.java
+++ b/src/test/java/games/strategy/engine/data/FakeAttachmentTest.java
@@ -1,0 +1,12 @@
+package games.strategy.engine.data;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public final class FakeAttachmentTest {
+  @Test
+  public void shouldBeEquatableAndHashable() {
+    EqualsVerifier.forClass(FakeAttachment.class).verify();
+  }
+}

--- a/src/test/java/games/strategy/engine/data/Matchers.java
+++ b/src/test/java/games/strategy/engine/data/Matchers.java
@@ -55,4 +55,40 @@ public final class Matchers {
       return (expected == null) == (actual == null);
     }
   }
+
+  /**
+   * Creates a matcher that matches when the examined {@link Resource} is logically equal to the specified
+   * {@link Resource}.
+   *
+   * @param expected The expected {@link Resource} value.
+   *
+   * @return A new matcher.
+   */
+  public static Matcher<Resource> equalToResource(final Resource expected) {
+    checkNotNull(expected);
+
+    return new IsResourceEqual(expected);
+  }
+
+  private static final class IsResourceEqual extends TypeSafeMatcher<Resource> {
+    private final Resource expected;
+
+    IsResourceEqual(final Resource expected) {
+      assert expected != null;
+
+      this.expected = expected;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+      description.appendValue(expected);
+    }
+
+    @Override
+    protected boolean matchesSafely(final Resource actual) {
+      return Objects.equals(expected.getAttachments(), actual.getAttachments())
+          && equalToGameData(expected.getData()).matches(actual.getData())
+          && Objects.equals(expected.getName(), actual.getName());
+    }
+  }
 }

--- a/src/test/java/games/strategy/engine/data/Matchers.java
+++ b/src/test/java/games/strategy/engine/data/Matchers.java
@@ -91,4 +91,38 @@ public final class Matchers {
           && Objects.equals(expected.getName(), actual.getName());
     }
   }
+
+  /**
+   * Creates a matcher that matches when the examined {@link ResourceCollection} is logically equal to the specified
+   * {@link ResourceCollection}.
+   *
+   * @param expected The expected {@link ResourceCollection} value.
+   *
+   * @return A new matcher.
+   */
+  public static Matcher<ResourceCollection> equalToResourceCollection(final ResourceCollection expected) {
+    checkNotNull(expected);
+
+    return new IsResourceCollectionEqual(expected);
+  }
+
+  private static final class IsResourceCollectionEqual extends TypeSafeMatcher<ResourceCollection> {
+    private final ResourceCollection expected;
+
+    IsResourceCollectionEqual(final ResourceCollection expected) {
+      assert expected != null;
+
+      this.expected = expected;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+      description.appendValue(expected);
+    }
+
+    @Override
+    protected boolean matchesSafely(final ResourceCollection actual) {
+      return Objects.equals(expected.getResourcesCopy(), actual.getResourcesCopy());
+    }
+  }
 }

--- a/src/test/java/games/strategy/engine/data/TestGameDataComponentFactory.java
+++ b/src/test/java/games/strategy/engine/data/TestGameDataComponentFactory.java
@@ -1,0 +1,23 @@
+package games.strategy.engine.data;
+
+/**
+ * A factory for creating game data component instances for use in tests.
+ */
+public final class TestGameDataComponentFactory {
+  private TestGameDataComponentFactory() {}
+
+  /**
+   * Creates a new {@link Resource} instance.
+   *
+   * @param gameData The game data associated with the resource.
+   * @param name The resource name.
+   *
+   * @return A new {@link Resource} instance.
+   */
+  public static Resource newResource(final GameData gameData, final String name) {
+    final Resource resource = new Resource(name, gameData);
+    resource.addAttachment("key1", new FakeAttachment("attachment1"));
+    resource.addAttachment("key2", new FakeAttachment("attachment2"));
+    return resource;
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/GameDataProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/GameDataProxyAsProxyTest.java
@@ -1,0 +1,42 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static games.strategy.engine.data.Matchers.equalToGameData;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.TestGameDataFactory;
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+public final class GameDataProxyAsProxyTest extends AbstractProxyTestCase<GameData> {
+  public GameDataProxyAsProxyTest() {
+    super(GameData.class);
+  }
+
+  @Override
+  protected void assertPrincipalEquals(final GameData expected, final GameData actual) {
+    checkNotNull(expected);
+    checkNotNull(actual);
+
+    assertThat(actual, is(equalToGameData(expected)));
+  }
+
+  @Override
+  protected Collection<GameData> createPrincipals() {
+    return Arrays.asList(TestGameDataFactory.newValidGameData());
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getProxyFactories() {
+    return Arrays.asList(
+        GameDataProxy.FACTORY,
+        PropertyBagMementoProxy.FACTORY,
+        TripleAProxy.FACTORY,
+        VersionProxy.FACTORY);
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/GameDataProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/GameDataProxyAsProxyTest.java
@@ -33,10 +33,6 @@ public final class GameDataProxyAsProxyTest extends AbstractProxyTestCase<GameDa
 
   @Override
   protected Collection<ProxyFactory> getProxyFactories() {
-    return Arrays.asList(
-        GameDataProxy.FACTORY,
-        PropertyBagMementoProxy.FACTORY,
-        TripleAProxy.FACTORY,
-        VersionProxy.FACTORY);
+    return TestProxyFactoryCollectionBuilder.forGameData().build();
   }
 }

--- a/src/test/java/games/strategy/internal/persistence/serializable/IntegerMapProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/IntegerMapProxyAsProxyTest.java
@@ -1,0 +1,29 @@
+package games.strategy.internal.persistence.serializable;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.util.IntegerMap;
+
+public final class IntegerMapProxyAsProxyTest extends AbstractProxyTestCase<IntegerMap<?>> {
+  @SuppressWarnings("unchecked")
+  public IntegerMapProxyAsProxyTest() {
+    super((Class<IntegerMap<?>>) (Class<?>) IntegerMap.class);
+  }
+
+  @Override
+  protected Collection<IntegerMap<?>> createPrincipals() {
+    final IntegerMap<String> integerMap = new IntegerMap<>();
+    integerMap.add("a", 1);
+    integerMap.add("b", 2);
+    integerMap.add("c", 3);
+    return Arrays.asList(integerMap);
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getProxyFactories() {
+    return Arrays.asList(IntegerMapProxy.FACTORY);
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxyAsProxyTest.java
@@ -1,0 +1,51 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static games.strategy.engine.data.Matchers.equalToResourceCollection;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.ResourceCollection;
+import games.strategy.engine.data.TestGameDataComponentFactory;
+import games.strategy.engine.data.TestGameDataFactory;
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+public final class ResourceCollectionProxyAsProxyTest extends AbstractProxyTestCase<ResourceCollection> {
+  public ResourceCollectionProxyAsProxyTest() {
+    super(ResourceCollection.class);
+  }
+
+  @Override
+  protected void assertPrincipalEquals(final ResourceCollection expected, final ResourceCollection actual) {
+    checkNotNull(expected);
+    checkNotNull(actual);
+
+    assertThat(actual, is(equalToResourceCollection(expected)));
+  }
+
+  @Override
+  protected Collection<ResourceCollection> createPrincipals() {
+    return Arrays.asList(newResourceCollection());
+  }
+
+  private static ResourceCollection newResourceCollection() {
+    final GameData gameData = TestGameDataFactory.newValidGameData();
+    final ResourceCollection resourceCollection = new ResourceCollection(gameData);
+    resourceCollection.addResource(TestGameDataComponentFactory.newResource(gameData, "resource1"), 11);
+    resourceCollection.addResource(TestGameDataComponentFactory.newResource(gameData, "resource2"), 22);
+    return resourceCollection;
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getProxyFactories() {
+    return TestProxyFactoryCollectionBuilder.forGameData()
+        .add(ResourceProxy.FACTORY)
+        .add(ResourceCollectionProxy.FACTORY)
+        .build();
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxyAsProxyTest.java
@@ -44,6 +44,7 @@ public final class ResourceCollectionProxyAsProxyTest extends AbstractProxyTestC
   @Override
   protected Collection<ProxyFactory> getProxyFactories() {
     return TestProxyFactoryCollectionBuilder.forGameData()
+        .add(IntegerMapProxy.FACTORY)
         .add(ResourceProxy.FACTORY)
         .add(ResourceCollectionProxy.FACTORY)
         .build();

--- a/src/test/java/games/strategy/internal/persistence/serializable/ResourceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ResourceProxyAsProxyTest.java
@@ -1,0 +1,48 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static games.strategy.engine.data.Matchers.equalToResource;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.engine.data.FakeAttachment;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.TestGameDataFactory;
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+public final class ResourceProxyAsProxyTest extends AbstractProxyTestCase<Resource> {
+  public ResourceProxyAsProxyTest() {
+    super(Resource.class);
+  }
+
+  @Override
+  protected void assertPrincipalEquals(final Resource expected, final Resource actual) {
+    checkNotNull(expected);
+    checkNotNull(actual);
+
+    assertThat(actual, is(equalToResource(expected)));
+  }
+
+  @Override
+  protected Collection<Resource> createPrincipals() {
+    return Arrays.asList(newResource());
+  }
+
+  private static Resource newResource() {
+    final Resource resource = new Resource("some resource", TestGameDataFactory.newValidGameData());
+    resource.addAttachment("key1", new FakeAttachment("attachment1"));
+    resource.addAttachment("key2", new FakeAttachment("attachment2"));
+    return resource;
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getProxyFactories() {
+    return TestProxyFactoryCollectionBuilder.forGameData()
+        .add(ResourceProxy.FACTORY)
+        .build();
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/ResourceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ResourceProxyAsProxyTest.java
@@ -8,8 +8,8 @@ import static org.junit.Assert.assertThat;
 import java.util.Arrays;
 import java.util.Collection;
 
-import games.strategy.engine.data.FakeAttachment;
 import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.TestGameDataComponentFactory;
 import games.strategy.engine.data.TestGameDataFactory;
 import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
@@ -29,14 +29,7 @@ public final class ResourceProxyAsProxyTest extends AbstractProxyTestCase<Resour
 
   @Override
   protected Collection<Resource> createPrincipals() {
-    return Arrays.asList(newResource());
-  }
-
-  private static Resource newResource() {
-    final Resource resource = new Resource("some resource", TestGameDataFactory.newValidGameData());
-    resource.addAttachment("key1", new FakeAttachment("attachment1"));
-    resource.addAttachment("key2", new FakeAttachment("attachment2"));
-    return resource;
+    return Arrays.asList(TestGameDataComponentFactory.newResource(TestGameDataFactory.newValidGameData(), "resource"));
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/TestProxyFactoryCollectionBuilder.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/TestProxyFactoryCollectionBuilder.java
@@ -1,0 +1,39 @@
+package games.strategy.internal.persistence.serializable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import games.strategy.persistence.serializable.ProxyFactory;
+
+/**
+ * Provides support for incrementally building proxy factory collections typically required by subclasses of
+ * {@code AbstractProxyTestCase}.
+ */
+final class TestProxyFactoryCollectionBuilder {
+  private final Collection<ProxyFactory> proxyFactories = new ArrayList<>();
+
+  private TestProxyFactoryCollectionBuilder() {}
+
+  /**
+   * Creates a new proxy factory collection builder that is pre-populated with all proxy factories required to serialize
+   * instances of {@code GameData}.
+   *
+   * @return A new proxy factory collection builder.
+   */
+  static TestProxyFactoryCollectionBuilder forGameData() {
+    return new TestProxyFactoryCollectionBuilder()
+        .add(GameDataProxy.FACTORY)
+        .add(PropertyBagMementoProxy.FACTORY)
+        .add(TripleAProxy.FACTORY)
+        .add(VersionProxy.FACTORY);
+  }
+
+  TestProxyFactoryCollectionBuilder add(final ProxyFactory proxyFactory) {
+    proxyFactories.add(proxyFactory);
+    return this;
+  }
+
+  Collection<ProxyFactory> build() {
+    return new ArrayList<>(proxyFactories);
+  }
+}

--- a/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
+++ b/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
@@ -1,6 +1,7 @@
 package games.strategy.persistence.serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -80,7 +81,9 @@ public abstract class AbstractProxyTestCase<T> {
 
   @Test
   public void shouldBeAbleToRoundTripPrincipal() throws Exception {
-    for (final T expected : createPrincipals()) {
+    final Collection<T> principals = createPrincipals();
+    assertThat(principals, is(not(empty())));
+    for (final T expected : principals) {
       assertThat(expected, is(not(nullValue())));
       final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/src/test/java/games/strategy/persistence/serializable/ProxyableObjectInputOutputStreamIntegrationTest.java
+++ b/src/test/java/games/strategy/persistence/serializable/ProxyableObjectInputOutputStreamIntegrationTest.java
@@ -5,6 +5,7 @@ import static com.googlecode.catchexception.CatchException.caughtException;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -25,15 +26,29 @@ public final class ProxyableObjectInputOutputStreamIntegrationTest {
   private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
   private Object readObject() throws Exception {
-    try (final InputStream is = new ByteArrayInputStream(baos.toByteArray());
-        final ObjectInputStream ois = new ObjectInputStream(is)) {
-      return ois.readObject();
-    }
+    return readObjects(1)[0];
   }
 
-  private void writeObject(final Object obj, final ProxyRegistry proxyRegistry) throws Exception {
+  private Object[] readObjects(final int count) throws Exception {
+    final Object[] objs = new Object[count];
+    try (final InputStream is = new ByteArrayInputStream(baos.toByteArray());
+        final ObjectInputStream ois = new ObjectInputStream(is)) {
+      for (int i = 0; i < count; ++i) {
+        objs[i] = ois.readObject();
+      }
+    }
+    return objs;
+  }
+
+  private void writeObject(final ProxyRegistry proxyRegistry, final Object obj) throws Exception {
+    writeObjects(proxyRegistry, obj);
+  }
+
+  private void writeObjects(final ProxyRegistry proxyRegistry, final Object... objs) throws Exception {
     try (final ObjectOutputStream oos = new ProxyableObjectOutputStream(baos, proxyRegistry)) {
-      oos.writeObject(obj);
+      for (final Object obj : objs) {
+        oos.writeObject(obj);
+      }
     }
   }
 
@@ -41,7 +56,7 @@ public final class ProxyableObjectInputOutputStreamIntegrationTest {
   public void shouldBeAbleToRoundTripNull() throws Exception {
     final ProxyRegistry proxyRegistry = ProxyRegistry.newInstance();
 
-    writeObject(null, proxyRegistry);
+    writeObject(proxyRegistry, null);
     final Object deserializedObj = readObject();
 
     assertThat(deserializedObj, is(nullValue()));
@@ -52,10 +67,24 @@ public final class ProxyableObjectInputOutputStreamIntegrationTest {
     final ProxyRegistry proxyRegistry = ProxyRegistry.newInstance();
     final Date obj = new Date();
 
-    writeObject(obj, proxyRegistry);
+    writeObject(proxyRegistry, obj);
     final Date deserializedObj = (Date) readObject();
 
     assertThat(deserializedObj, is(obj));
+  }
+
+  @Test
+  public void shouldPreserveReferencesToPreviouslySerializedSerializableObject() throws Exception {
+    final ProxyRegistry proxyRegistry = ProxyRegistry.newInstance();
+    final Date obj = new Date();
+
+    writeObjects(proxyRegistry, obj, obj);
+    final Object[] deserializedObjs = readObjects(2);
+    final Date deserializedObj1 = (Date) deserializedObjs[0];
+    final Date deserializedObj2 = (Date) deserializedObjs[1];
+
+    assertThat(deserializedObj1, is(obj));
+    assertThat(deserializedObj2, is(sameInstance(deserializedObj1)));
   }
 
   @Test
@@ -63,17 +92,31 @@ public final class ProxyableObjectInputOutputStreamIntegrationTest {
     final ProxyRegistry proxyRegistry = ProxyRegistry.newInstance(FakeNonSerializableClassProxy.FACTORY);
     final FakeNonSerializableClass obj = new FakeNonSerializableClass(2112, "42");
 
-    writeObject(obj, proxyRegistry);
+    writeObject(proxyRegistry, obj);
     final FakeNonSerializableClass deserializedObj = (FakeNonSerializableClass) readObject();
 
     assertThat(deserializedObj, is(obj));
   }
 
   @Test
+  public void shouldPreserveReferencesToPreviouslySerializedNonSerializableObject() throws Exception {
+    final ProxyRegistry proxyRegistry = ProxyRegistry.newInstance(FakeNonSerializableClassProxy.FACTORY);
+    final FakeNonSerializableClass obj = new FakeNonSerializableClass(2112, "42");
+
+    writeObjects(proxyRegistry, obj, obj);
+    final Object[] deserializedObjs = readObjects(2);
+    final FakeNonSerializableClass deserializedObj1 = (FakeNonSerializableClass) deserializedObjs[0];
+    final FakeNonSerializableClass deserializedObj2 = (FakeNonSerializableClass) deserializedObjs[1];
+
+    assertThat(deserializedObj1, is(obj));
+    assertThat(deserializedObj2, is(sameInstance(deserializedObj1)));
+  }
+
+  @Test
   public void shouldThrowExceptionWhenWritingNonSerializableObjectWithNoRegisteredProxyFactory() throws Exception {
     final ProxyRegistry proxyRegistry = ProxyRegistry.newInstance();
 
-    catchException(() -> writeObject(new FakeNonSerializableClass(2112, "42"), proxyRegistry));
+    catchException(() -> writeObject(proxyRegistry, new FakeNonSerializableClass(2112, "42")));
 
     assertThat(caughtException(), is(instanceOf(NotSerializableException.class)));
   }

--- a/src/test/java/games/strategy/util/IntegerMapTest.java
+++ b/src/test/java/games/strategy/util/IntegerMapTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 
@@ -15,6 +17,28 @@ public class IntegerMapTest {
   private final Object v1 = new Object();
   private final Object v2 = new Object();
   private final Object v3 = new Object();
+
+  @Test
+  public void shouldBeConstructableFromJavaMap() {
+    final IntegerMap<Object> expected = new IntegerMap<>();
+    expected.add(v1, 1);
+    expected.add(v2, 2);
+    expected.add(v3, 3);
+
+    final IntegerMap<Object> actual = new IntegerMap<>(ImmutableMap.of(v1, 1, v2, 2, v3, 3));
+
+    assertThat(actual, is(expected));
+  }
+
+  @Test
+  public void toMap_ShouldReturnEquivalentJavaMap() {
+    final IntegerMap<Object> map = new IntegerMap<>();
+    map.add(v1, 1);
+    map.add(v2, 2);
+    map.add(v3, 3);
+
+    assertThat(map.toMap(), is(ImmutableMap.of(v1, 1, v2, 2, v3, 3)));
+  }
 
   @Test
   public void shouldBeEquatableAndHashable() {


### PR DESCRIPTION
This PR adds a serialization proxy for `ResourceCollection` and its dependencies:

* `GameData`
* `IntegerMap`
* `Resource`

Up to this point, it was not necessary to add a proxy for `GameData` because I've been using `GameDataMemento` at the top-level for the reasons I discussed in the original design review.  However, `Resource` and `ResourceCollection` are the first instances of `GameDataComponent` I've proxied, and `GameDataComponent` maintains a back reference to the `GameData` instance that owns the component.  Because the `GameData` reference needs to be serialized, a proxy is now required.  However, there is no duplication of functionality between the `GameData` proxy and `GameDataMemento` because the `GameData` proxy simply delegates the actual serialization/deserialization to `GameDataMemento`.