### PR TITLE
Remove Serializable from SelectionComponent

### DIFF
--- a/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.settings;
 
-import java.io.Serializable;
 import java.util.Map;
 
 import javax.swing.JComponent;
@@ -9,9 +8,7 @@ import javax.swing.JComponent;
  * A SelectionComponent represents a UI component that a user can use to update the value of a ClientSetting.
  * Instances of this class are created in: {@code SelectionComponentFactory}
  */
-abstract class SelectionComponent implements Serializable {
-  private static final long serialVersionUID = -2224094425526210088L;
-
+abstract class SelectionComponent {
   abstract JComponent getJComponent();
 
   abstract boolean isValid();
@@ -38,4 +35,3 @@ abstract class SelectionComponent implements Serializable {
 
   abstract void reset();
 }
-

--- a/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -33,7 +33,6 @@ import swinglib.JPanelBuilder;
 class SelectionComponentFactory {
   static Supplier<SelectionComponent> proxySettings() {
     return () -> new SelectionComponent() {
-      private static final long serialVersionUID = -8485825527073729683L;
       final Preferences pref = Preferences.userNodeForPackage(GameRunner.class);
       final HttpProxy.ProxyChoice proxyChoice =
           HttpProxy.ProxyChoice.valueOf(pref.get(HttpProxy.PROXY_CHOICE, HttpProxy.ProxyChoice.NONE.toString()));
@@ -166,7 +165,6 @@ class SelectionComponentFactory {
    */
   static Supplier<SelectionComponent> intValueRange(final ClientSetting clientSetting, final int lo, final int hi) {
     return () -> new SelectionComponent() {
-      private static final long serialVersionUID = 8195633990481917808L;
       String value = clientSetting.value();
       final JTextField component = new JTextField(value, String.valueOf(hi).length());
 
@@ -242,7 +240,6 @@ class SelectionComponentFactory {
    */
   static SelectionComponent booleanRadioButtons(final ClientSetting clientSetting) {
     return new AlwaysValidInputSelectionComponent() {
-      private static final long serialVersionUID = 6104513062312556269L;
       final boolean initialSelection = clientSetting.booleanValue();
       final JRadioButton yesButton = new JRadioButton("True");
       final JRadioButton noButton = new JRadioButton("False");
@@ -293,7 +290,6 @@ class SelectionComponentFactory {
       final ClientSetting clientSetting,
       final SwingComponents.FolderSelectionMode folderSelectionMode) {
     return () -> new AlwaysValidInputSelectionComponent() {
-      private static final long serialVersionUID = -1775099967925891332L;
       final int expectedLength = 20;
       final JTextField field = new JTextField(clientSetting.value(), expectedLength);
       final JButton button = JButtonBuilder.builder()
@@ -348,7 +344,6 @@ class SelectionComponentFactory {
       final ClientSetting clientSetting,
       final List<String> availableOptions) {
     return () -> new AlwaysValidInputSelectionComponent() {
-      private static final long serialVersionUID = -8969206423938554118L;
       final JComboBox<String> comboBox = new JComboBox<>(availableOptions.toArray(new String[availableOptions.size()]));
 
       @Override
@@ -381,7 +376,6 @@ class SelectionComponentFactory {
 
   static Supplier<SelectionComponent> textField(final ClientSetting clientSetting) {
     return () -> new AlwaysValidInputSelectionComponent() {
-      private static final long serialVersionUID = 7549165488576728952L;
       final JTextField textField = new JTextField(clientSetting.value(), 20);
 
       @Override
@@ -410,10 +404,7 @@ class SelectionComponentFactory {
     };
   }
 
-
   private abstract static class AlwaysValidInputSelectionComponent extends SelectionComponent {
-    private static final long serialVersionUID = 6848335387637901069L;
-
     @Override
     void indicateError() {
       // no-op, component only allows valid selections
@@ -434,5 +425,4 @@ class SelectionComponentFactory {
       return "";
     }
   }
-
 }


### PR DESCRIPTION
This PR removes the `Serializable` interface from the `SelectionComponent` class per the discussion in Gitter.

After making this change, it seemed as if `SelectionComponent` should be an interface rather than an abstract class since it provides no implementation.  However, I'm not sure of @DanVanAtta's future plans for this type, so I didn't bother to change it.  Please advise if it should be converted to an interface, and I'll do it as part of this PR.

#### Testing

I modified and saved my client settings a few times to ensure there was no hidden serialization happening anywhere.  No problems were observed.