### PR TITLE
Resize WaitWindow to accommodate all text

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ui/background/WaitWindow.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/WaitWindow.java
@@ -16,12 +16,14 @@ public class WaitWindow extends JWindow {
   private boolean m_finished = false;
 
   public WaitWindow() {
-    setSize(200, 80);
-    final WaitPanel mainPanel = new WaitPanel("Loading game, please wait.");
+    final WaitPanel mainPanel = new WaitPanel("Loading game, please wait...");
     setLocationRelativeTo(null);
     mainPanel.setBorder(new LineBorder(Color.BLACK));
     setLayout(new BorderLayout());
     add(mainPanel, BorderLayout.CENTER);
+
+    pack();
+    setSize(getSize().width, 80);
   }
 
   public void showWait() {

--- a/src/main/java/games/strategy/engine/framework/ui/background/WaitWindow.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/WaitWindow.java
@@ -13,10 +13,11 @@ import javax.swing.border.LineBorder;
  * A window that is displayed while loading a game to provide visual feedback to the user during this potentially
  * long-running operation.
  */
-public class WaitWindow extends JWindow {
+public final class WaitWindow extends JWindow {
   private static final long serialVersionUID = -8134956690669346954L;
-  private final Object m_mutex = new Object();
-  private Timer m_timer = new Timer();
+
+  private final Object mutex = new Object();
+  private Timer timer = new Timer();
 
   public WaitWindow() {
     final WaitPanel mainPanel = new WaitPanel("Loading game, please wait...");
@@ -40,9 +41,9 @@ public class WaitWindow extends JWindow {
       }
     };
 
-    synchronized (m_mutex) {
-      if (m_timer != null) {
-        m_timer.schedule(task, 15, 15);
+    synchronized (mutex) {
+      if (timer != null) {
+        timer.schedule(task, 15, 15);
       }
     }
   }
@@ -51,10 +52,10 @@ public class WaitWindow extends JWindow {
    * Hides the wait window.
    */
   public void doneWait() {
-    synchronized (m_mutex) {
-      if (m_timer != null) {
-        m_timer.cancel();
-        m_timer = null;
+    synchronized (mutex) {
+      if (timer != null) {
+        timer.cancel();
+        timer = null;
       }
     }
     SwingUtilities.invokeLater(() -> {

--- a/src/main/java/games/strategy/engine/framework/ui/background/WaitWindow.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/WaitWindow.java
@@ -2,8 +2,6 @@ package games.strategy.engine.framework.ui.background;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.util.Timer;
-import java.util.TimerTask;
 
 import javax.swing.JWindow;
 import javax.swing.SwingUtilities;
@@ -16,12 +14,11 @@ import javax.swing.border.LineBorder;
 public final class WaitWindow extends JWindow {
   private static final long serialVersionUID = -8134956690669346954L;
 
-  private final Object mutex = new Object();
-  private Timer timer = new Timer();
-
   public WaitWindow() {
-    final WaitPanel mainPanel = new WaitPanel("Loading game, please wait...");
+    setAlwaysOnTop(true);
     setLocationRelativeTo(null);
+
+    final WaitPanel mainPanel = new WaitPanel("Loading game, please wait...");
     mainPanel.setBorder(new LineBorder(Color.BLACK));
     setLayout(new BorderLayout());
     add(mainPanel, BorderLayout.CENTER);
@@ -34,30 +31,15 @@ public final class WaitWindow extends JWindow {
    * Shows the wait window.
    */
   public void showWait() {
-    final TimerTask task = new TimerTask() {
-      @Override
-      public void run() {
-        SwingUtilities.invokeLater(() -> toFront());
-      }
-    };
-
-    synchronized (mutex) {
-      if (timer != null) {
-        timer.schedule(task, 15, 15);
-      }
-    }
+    SwingUtilities.invokeLater(() -> {
+      setVisible(true);
+    });
   }
 
   /**
    * Hides the wait window.
    */
   public void doneWait() {
-    synchronized (mutex) {
-      if (timer != null) {
-        timer.cancel();
-        timer = null;
-      }
-    }
     SwingUtilities.invokeLater(() -> {
       setVisible(false);
       removeAll();

--- a/src/main/java/games/strategy/engine/framework/ui/background/WaitWindow.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/WaitWindow.java
@@ -9,6 +9,10 @@ import javax.swing.JWindow;
 import javax.swing.SwingUtilities;
 import javax.swing.border.LineBorder;
 
+/**
+ * A window that is displayed while loading a game to provide visual feedback to the user during this potentially
+ * long-running operation.
+ */
 public class WaitWindow extends JWindow {
   private static final long serialVersionUID = -8134956690669346954L;
   private final Object m_mutex = new Object();
@@ -26,6 +30,9 @@ public class WaitWindow extends JWindow {
     setSize(getSize().width, 80);
   }
 
+  /**
+   * Shows the wait window.
+   */
   public void showWait() {
     final TimerTask task = new TimerTask() {
       @Override
@@ -41,6 +48,9 @@ public class WaitWindow extends JWindow {
     }
   }
 
+  /**
+   * Hides the wait window.
+   */
   public void doneWait() {
     synchronized (m_mutex) {
       if (m_timer != null) {

--- a/src/main/java/games/strategy/engine/framework/ui/background/WaitWindow.java
+++ b/src/main/java/games/strategy/engine/framework/ui/background/WaitWindow.java
@@ -17,7 +17,6 @@ public class WaitWindow extends JWindow {
   private static final long serialVersionUID = -8134956690669346954L;
   private final Object m_mutex = new Object();
   private Timer m_timer = new Timer();
-  private boolean m_finished = false;
 
   public WaitWindow() {
     final WaitPanel mainPanel = new WaitPanel("Loading game, please wait...");
@@ -63,10 +62,5 @@ public class WaitWindow extends JWindow {
       removeAll();
       dispose();
     });
-    m_finished = true;
-  }
-
-  public boolean isFinished() {
-    return m_finished;
   }
 }


### PR DESCRIPTION
While playing around with different L&Fs, I observed that, in some cases, the text displayed by `WaitWindow` when loading a game is truncated.  This PR resizes `WaitWindow` to ensure all text is displayed regardless of L&F.

For example, using the Metal L&F:

##### Before
![wait-window-before](https://user-images.githubusercontent.com/4826349/29139973-d7aac964-7d16-11e7-915c-32441386ccb4.png)

##### After
![wait-window-after](https://user-images.githubusercontent.com/4826349/29139984-dec603e4-7d16-11e7-8141-60a99bda68de.png)

#### Functional changes
`WaitWindow` was modified to no longer use a fixed width.  The width is set to whatever is required to display the complete status text.  (Note that this window still uses a fixed height and the default Swing minimum width.)

#### Refactoring changes
I took this opportunity to do a bit of refactoring in `WaitWindow`:

* Remove unused members.
* Add missing Javadocs.
* Fix violations of the Checkstyle MemberName rule.

#### Testing
I verified the complete progress text is displayed using several different L&Fs.