### PR TITLE
Wrap text in setting descriptions

### DIFF
--- a/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -21,8 +21,8 @@ import swinglib.GridBagHelper;
 import swinglib.JButtonBuilder;
 import swinglib.JLabelBuilder;
 import swinglib.JPanelBuilder;
+import swinglib.JScrollPaneBuilder;
 import swinglib.JTextAreaBuilder;
-
 
 /**
  * UI window with controls to update game settings and preferences, {@see ClientSetting}.
@@ -108,16 +108,13 @@ enum SettingsWindow {
 
       grid.add(setting.buildSelectionComponent());
 
-      grid.add(JPanelBuilder.builder()
-          .add(
-              JTextAreaBuilder.builder()
-                  .text(setting.description)
-                  .rows(2)
-                  .columns(40)
-                  .maximumSize(60, 50)
-                  .readOnly()
-                  .borderWidth(1)
-                  .build())
+      grid.add(JScrollPaneBuilder.builder()
+          .view(JTextAreaBuilder.builder()
+              .text(setting.description)
+              .rows(2)
+              .columns(40)
+              .readOnly()
+              .build())
           .build());
     });
     return SwingComponents.newJScrollPane(contents);

--- a/src/main/java/swinglib/JScrollPaneBuilder.java
+++ b/src/main/java/swinglib/JScrollPaneBuilder.java
@@ -1,0 +1,60 @@
+package swinglib;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.awt.Component;
+
+import javax.swing.JScrollPane;
+
+/**
+ * A builder for incrementally creating instances of {@link JScrollPane}.
+ *
+ * <p>
+ * Example usage:
+ * </p>
+ *
+ * <pre>
+ * <code>
+ * JScrollPaneBuilder scrollPane = JScrollPaneBuilder.builder()
+ *     .view(view)
+ *     .build();
+ * </code>
+ * </pre>
+ */
+public final class JScrollPaneBuilder {
+  private Component view;
+
+  private JScrollPaneBuilder() {}
+
+  public static JScrollPaneBuilder builder() {
+    return new JScrollPaneBuilder();
+  }
+
+  /**
+   * Sets the component to display in the scroll pane's viewport.
+   *
+   * @param view The component to display in the scroll pane's viewport.
+   *
+   * @throws NullPointerException If {@code view} is {@code null}.
+   */
+  public JScrollPaneBuilder view(final Component view) {
+    checkNotNull(view, "view must not be null");
+
+    this.view = view;
+    return this;
+  }
+
+  /**
+   * Creates a new scroll pane using the builder's current state.
+   *
+   * @return A new scroll pane.
+   *
+   * @throws IllegalStateException If {@code view} is unspecified.
+   */
+  public JScrollPane build() {
+    checkState(view != null, "view must be specified");
+
+    return new JScrollPane(view);
+  }
+}

--- a/src/main/java/swinglib/JTextAreaBuilder.java
+++ b/src/main/java/swinglib/JTextAreaBuilder.java
@@ -1,9 +1,5 @@
 package swinglib;
 
-import java.awt.Color;
-import java.awt.Dimension;
-
-import javax.swing.BorderFactory;
 import javax.swing.JTextArea;
 
 import com.google.common.base.Preconditions;
@@ -16,9 +12,7 @@ import com.google.common.base.Strings;
  *     .text(setting.description)
  *     .rows(2)
  *     .columns(40)
- *     .maximumSize(120, 50)
  *     .readOnly()
- *     .borderWidth(1)
  *     .build();
  * </pre></code>
  */
@@ -27,13 +21,9 @@ public final class JTextAreaBuilder {
   private String text;
   private int rows = 3;
   private int columns = 15;
-  private int borderWidth;
   private boolean readOnly = false;
-  private Dimension maxSize;
 
-  private JTextAreaBuilder() {
-
-  }
+  private JTextAreaBuilder() {}
 
   public static JTextAreaBuilder builder() {
     return new JTextAreaBuilder();
@@ -42,25 +32,19 @@ public final class JTextAreaBuilder {
   /**
    * Constructs a Swing JTextArea using current builder values.
    * Values that must be set: text, rows, columns
-   * By default the JTextArea will have line wrapping turned on.
+   * The JTextArea will have line wrapping turned on.
    */
   public JTextArea build() {
     Preconditions.checkArgument(rows > 0);
     Preconditions.checkArgument(columns > 0);
     final JTextArea textArea = new JTextArea(Strings.nullToEmpty(text), rows, columns);
+    textArea.setLineWrap(true);
     textArea.setWrapStyleWord(true);
-
-    if (borderWidth > 0) {
-      textArea.setBorder(BorderFactory.createLineBorder(Color.black, borderWidth));
-    }
 
     if (readOnly) {
       textArea.setEditable(false);
     }
 
-    if (maxSize != null) {
-      textArea.setMaximumSize(maxSize);
-    }
     return textArea;
   }
 
@@ -69,22 +53,26 @@ public final class JTextAreaBuilder {
     return this;
   }
 
-  /* TODO: test me */
-  public JTextAreaBuilder borderWidth(final int width) {
-    this.borderWidth = width;
-    return this;
-  }
-
-  public JTextAreaBuilder maximumSize(final int width, final int height) {
-    maxSize = new Dimension(width, height);
-    return this;
-  }
-
+  /**
+   * Sets the number of text area rows.
+   *
+   * @param value The number of text area rows.
+   *
+   * @throws IllegalArgumentException If {@code value} is not positive.
+   */
   public JTextAreaBuilder rows(final int value) {
+    Preconditions.checkArgument(value > 0);
     this.rows = value;
     return this;
   }
 
+  /**
+   * Sets the number of text area columns.
+   *
+   * @param value The number of text area columns.
+   *
+   * @throws IllegalArgumentException If {@code value} is not positive.
+   */
   public JTextAreaBuilder columns(final int value) {
     Preconditions.checkArgument(value > 0);
     this.columns = value;

--- a/src/test/java/swinglib/JScrollPaneBuilderTest.java
+++ b/src/test/java/swinglib/JScrollPaneBuilderTest.java
@@ -1,0 +1,51 @@
+package swinglib;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import java.awt.Component;
+
+import javax.swing.JLabel;
+import javax.swing.JScrollPane;
+
+import org.junit.Test;
+
+public final class JScrollPaneBuilderTest {
+  private final JScrollPaneBuilder builder = JScrollPaneBuilder.builder();
+
+  @Test
+  public void view_ShouldThrowExceptionWhenViewIsNull() {
+    catchException(() -> builder.view(null));
+
+    assertThat(caughtException(), allOf(
+        is(instanceOf(NullPointerException.class)),
+        hasMessageThat(containsString("view"))));
+  }
+
+  @Test
+  public void build_ShouldThrowExceptionWhenViewUnspecified() {
+    catchException(() -> builder.build());
+
+    assertThat(caughtException(), allOf(
+        is(instanceOf(IllegalStateException.class)),
+        hasMessageThat(containsString("view"))));
+  }
+
+  @Test
+  public void build_ShouldSetView() {
+    final Component view = new JLabel();
+
+    final JScrollPane scrollPane = builder
+        .view(view)
+        .build();
+
+    assertThat(scrollPane.getViewport().getView(), is(sameInstance(view)));
+  }
+}

--- a/src/test/java/swinglib/JTextAreaBuilderTest.java
+++ b/src/test/java/swinglib/JTextAreaBuilderTest.java
@@ -18,7 +18,6 @@ public class JTextAreaBuilderTest {
     assertThat(area.isEditable(), is(true));
   }
 
-
   @Test
   public void text() {
     final JTextArea area = JTextAreaBuilder.builder()
@@ -39,11 +38,8 @@ public class JTextAreaBuilderTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void rowsNonZero() {
-    JTextAreaBuilder.builder()
-        .rows(0)
-        .build();
+    JTextAreaBuilder.builder().rows(0);
   }
-
 
   @Test
   public void columns() {
@@ -60,24 +56,10 @@ public class JTextAreaBuilderTest {
   }
 
   @Test
-  public void maximumSize() {
-    final int maxWidth = 1000;
-    final int maxHeight = 33;
-
-    final JTextArea area = JTextAreaBuilder.builder()
-        .maximumSize(maxWidth, maxHeight)
-        .build();
-    assertThat(area.getMaximumSize().width, is(maxWidth));
-    assertThat(area.getMaximumSize().height, is(maxHeight));
-  }
-
-  @Test
   public void readOnly() {
     final JTextArea area = JTextAreaBuilder.builder()
         .readOnly()
         .build();
     assertThat(area.isEditable(), is(false));
   }
-
-
 }


### PR DESCRIPTION
This PR modifies the settings window so that all description text is word-wrapped.

I also modified the UI to use the default border for the scroll pane wrapping the description text area so that it changes with the L&F.  If it is always set to black, it does not match the borders of the other controls in the window.  And if we continue to support a dark-themed L&F in the future, the black border may not be visible.

Using the Metal L&F:

##### Before
![settings-window-before](https://user-images.githubusercontent.com/4826349/29200067-3fd41a04-7e20-11e7-9fd2-ec908ceaf6b2.png)

##### After
![settings-window-after](https://user-images.githubusercontent.com/4826349/29200070-4521876c-7e20-11e7-8f2a-2c6b67dd63d9.png)