### PR TITLE
Checkstyle: Replace leading uppercase letter from local variables

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -50,23 +50,23 @@ final class ProTechAI {
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final int pusRemaining = player.getResources().getQuantity(pus);
     final Resource techtokens = data.getResourceList().getResource(Constants.TECH_TOKENS);
-    final int TechTokens = player.getResources().getQuantity(techtokens);
+    final int techTokensQuantity = player.getResources().getQuantity(techtokens);
     int tokensToBuy = 0;
-    if (!capDanger && TechTokens < 3 && pusRemaining > Math.random() * 160) {
+    if (!capDanger && techTokensQuantity < 3 && pusRemaining > Math.random() * 160) {
       tokensToBuy = 1;
     }
-    if (TechTokens > 0 || tokensToBuy > 0) {
+    if (techTokensQuantity > 0 || tokensToBuy > 0) {
       final List<TechnologyFrontier> cats = TechAdvance.getPlayerTechCategories(data, player);
       // retaining 65% chance of choosing land advances using basic ww2v3 model.
       if (data.getTechnologyFrontier().isEmpty()) {
         if (Math.random() > 0.35) {
-          techDelegate.rollTech(TechTokens + tokensToBuy, cats.get(1), tokensToBuy, null);
+          techDelegate.rollTech(techTokensQuantity + tokensToBuy, cats.get(1), tokensToBuy, null);
         } else {
-          techDelegate.rollTech(TechTokens + tokensToBuy, cats.get(0), tokensToBuy, null);
+          techDelegate.rollTech(techTokensQuantity + tokensToBuy, cats.get(0), tokensToBuy, null);
         }
       } else {
         final int rand = (int) (Math.random() * cats.size());
-        techDelegate.rollTech(TechTokens + tokensToBuy, cats.get(rand), tokensToBuy, null);
+        techDelegate.rollTech(techTokensQuantity + tokensToBuy, cats.get(rand), tokensToBuy, null);
       }
     }
   }

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -89,10 +89,10 @@ class AAInMoveUtil implements Serializable {
     final List<Unit> defendingAa = territory.getUnits().getMatches(Matches.unitIsAaThatCanFire(units,
         airborneTechTargetsAllowed, movingPlayer, Matches.UnitIsAAforFlyOverOnly, 1, true, getData()));
     // comes ordered alphabetically already
-    final List<String> AAtypes = UnitAttachment.getAllOfTypeAAs(defendingAa);
+    final List<String> aaTypes = UnitAttachment.getAllOfTypeAAs(defendingAa);
     // stacks are backwards
-    Collections.reverse(AAtypes);
-    for (final String currentTypeAa : AAtypes) {
+    Collections.reverse(aaTypes);
+    for (final String currentTypeAa : aaTypes) {
       final Collection<Unit> currentPossibleAa = Match.getMatches(defendingAa, Matches.unitIsAaOfTypeAa(currentTypeAa));
       final Set<UnitType> targetUnitTypesForThisTypeAa =
           UnitAttachment.get(currentPossibleAa.iterator().next().getType()).getTargetsAA(getData());

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -290,9 +290,9 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
   }
 
   private static void changeUnitOwnership(final IDelegateBridge bridge) {
-    final PlayerID Player = bridge.getPlayerID();
-    final PlayerAttachment pa = PlayerAttachment.get(Player);
-    final Collection<PlayerID> PossibleNewOwners = pa.getGiveUnitControl();
+    final PlayerID player = bridge.getPlayerID();
+    final PlayerAttachment pa = PlayerAttachment.get(player);
+    final Collection<PlayerID> possibleNewOwners = pa.getGiveUnitControl();
     final Collection<Territory> territories = bridge.getData().getMap().getTerritories();
     final CompositeChange change = new CompositeChange();
     final Collection<Tuple<Territory, Collection<Unit>>> changeList =
@@ -303,10 +303,10 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       if (ta != null && ta.getChangeUnitOwners() != null && !ta.getChangeUnitOwners().isEmpty()) {
         final Collection<PlayerID> terrNewOwners = ta.getChangeUnitOwners();
         for (final PlayerID terrNewOwner : terrNewOwners) {
-          if (PossibleNewOwners.contains(terrNewOwner)) {
+          if (possibleNewOwners.contains(terrNewOwner)) {
             // PlayerOwnerChange
             final Collection<Unit> units =
-                currTerritory.getUnits().getMatches(Match.allOf(Matches.unitOwnedBy(Player),
+                currTerritory.getUnits().getMatches(Match.allOf(Matches.unitOwnedBy(player),
                     Matches.unitCanBeGivenByTerritoryTo(terrNewOwner)));
             if (!units.isEmpty()) {
               change.add(ChangeFactory.changeOwner(units, terrNewOwner, currTerritory));

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -269,10 +269,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         battles = Match.getMatches(battles, Matches.BattleIsAmphibious);
         if (!battles.isEmpty()) {
           final Collection<Unit> bombardUnits = t.getUnits().getMatches(ownedAndCanBombard);
-          final List<Unit> ListedBombardUnits = new ArrayList<>();
-          ListedBombardUnits.addAll(bombardUnits);
-          sortUnitsToBombard(ListedBombardUnits, attacker);
-          final Iterator<Unit> bombarding = ListedBombardUnits.iterator();
+          final List<Unit> listedBombardUnits = new ArrayList<>();
+          listedBombardUnits.addAll(bombardUnits);
+          sortUnitsToBombard(listedBombardUnits, attacker);
+          final Iterator<Unit> bombarding = listedBombardUnits.iterator();
           if (!bombardUnits.isEmpty()) {
             // ask if they want to bombard
             if (!remotePlayer.selectShoreBombard(t)) {

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -169,8 +169,8 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     if (null != (result = checkEditMode())) {
       return result;
     }
-    final Resource PUs = getData().getResourceList().getResource(Constants.PUS);
-    final int oldTotal = player.getResources().getQuantity(PUs);
+    final Resource pus = getData().getResourceList().getResource(Constants.PUS);
+    final int oldTotal = player.getResources().getQuantity(pus);
     if (oldTotal == newTotal) {
       return "New PUs total is unchanged";
     }
@@ -178,7 +178,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
       return "New PUs total is invalid";
     }
     logEvent("Changing PUs for " + player.getName() + " from " + oldTotal + " to " + newTotal, null);
-    m_bridge.addChange(ChangeFactory.changeResourcesChange(player, PUs, (newTotal - oldTotal)));
+    m_bridge.addChange(ChangeFactory.changeResourcesChange(player, pus, (newTotal - oldTotal)));
     return null;
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -183,7 +183,7 @@ public class RocketsFireHelper {
     final GameData data = bridge.getData();
     final PlayerID attacked = attackedTerritory.getOwner();
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
-    final boolean DamageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
+    final boolean damageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
     // unit damage vs territory damage
     final Collection<Unit> enemyUnits = attackedTerritory.getUnits().getMatches(
         Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert()));
@@ -204,7 +204,7 @@ public class RocketsFireHelper {
       return;
     }
     final String transcript;
-    if (DamageFromBombingDoneToUnits) {
+    if (damageFromBombingDoneToUnits) {
       // TODO: rockets needs to be completely redone to allow for multiple rockets to fire at different targets, etc
       // etc.
       final HashSet<UnitType> legalTargetsForTheseRockets = new HashSet<>();
@@ -355,7 +355,7 @@ public class RocketsFireHelper {
       }
     }
     int territoryProduction = TerritoryAttachment.getProduction(attackedTerritory);
-    if (DamageFromBombingDoneToUnits && !targets.isEmpty()) {
+    if (damageFromBombingDoneToUnits && !targets.isEmpty()) {
       // we are doing damage to 'target', not to the territory
       final Unit target = targets.iterator().next();
       // UnitAttachment ua = UnitAttachment.get(target.getType());
@@ -384,7 +384,7 @@ public class RocketsFireHelper {
     }
     // Record the PUs lost
     DelegateFinder.moveDelegate(data).pusLost(attackedTerritory, cost);
-    if (DamageFromBombingDoneToUnits && !targets.isEmpty()) {
+    if (damageFromBombingDoneToUnits && !targets.isEmpty()) {
       getRemote(bridge).reportMessage(
           "Rocket attack in " + attackedTerritory.getName() + " does " + cost + " damage to "
               + targets.iterator().next(),

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -213,16 +213,16 @@ class EditPanel extends ActionPanel {
         }
         final int oldTotal = player.getResources().getQuantity(pus);
         int newTotal = oldTotal;
-        final JTextField PUsField = new JTextField(String.valueOf(oldTotal), 4);
-        PUsField.setMaximumSize(PUsField.getPreferredSize());
-        final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), new JScrollPane(PUsField),
+        final JTextField pusField = new JTextField(String.valueOf(oldTotal), 4);
+        pusField.setMaximumSize(pusField.getPreferredSize());
+        final int option = JOptionPane.showOptionDialog(getTopLevelAncestor(), new JScrollPane(pusField),
             "Select new number of PUs", JOptionPane.OK_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, null, null);
         if (option != JOptionPane.OK_OPTION) {
           cancelEditAction.actionPerformed(null);
           return;
         }
         try {
-          newTotal = Integer.parseInt(PUsField.getText());
+          newTotal = Integer.parseInt(pusField.getText());
         } catch (final Exception e) {
           // ignore malformed input
         }

--- a/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -498,9 +498,9 @@ public class HistoryLog extends JFrame {
     }
     logWriter.println("Production/PUs Summary :\n");
     for (final PlayerID player : players) {
-      final int PUs = player.getResources().getQuantity(pus);
+      final int pusQuantity = player.getResources().getQuantity(pus);
       final int production = getProduction(player, data);
-      logWriter.println("    " + player.getName() + " : " + production + " / " + PUs);
+      logWriter.println("    " + player.getName() + " : " + production + " / " + pusQuantity);
     }
     logWriter.println();
     logWriter.println();

--- a/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -186,9 +186,9 @@ class GameMenu {
   }
 
   private void addRollDice(final JMenu parentMenu) {
-    final JMenuItem RollDiceBox = new JMenuItem("Roll Dice");
-    RollDiceBox.setMnemonic(KeyEvent.VK_R);
-    RollDiceBox.addActionListener(e -> {
+    final JMenuItem rollDiceBox = new JMenuItem("Roll Dice");
+    rollDiceBox.setMnemonic(KeyEvent.VK_R);
+    rollDiceBox.addActionListener(e -> {
       final IntTextField numberOfText = new IntTextField(0, 100);
       final IntTextField diceSidesText = new IntTextField(1, 200);
       numberOfText.setText(String.valueOf(0));
@@ -229,7 +229,7 @@ class GameMenu {
         // ignore malformed input
       }
     });
-    parentMenu.add(RollDiceBox);
+    parentMenu.add(rollDiceBox);
   }
 
   private void addBattleCalculatorMenu(final JMenu menuGame) {

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -267,12 +267,12 @@ public class ConnectionFinder {
    * @return a double that represents the area of the given point array of a polygon
    */
   private static double calcSignedPolygonArea(final Point2D[] pointArray) {
-    final int N = pointArray.length;
+    final int length = pointArray.length;
     int i;
     int j;
     double area = 0;
-    for (i = 0; i < N; i++) {
-      j = (i + 1) % N;
+    for (i = 0; i < length; i++) {
+      j = (i + 1) % length;
       area += pointArray[i].getX() * pointArray[j].getY();
       area -= pointArray[i].getY() * pointArray[j].getX();
     }
@@ -288,7 +288,7 @@ public class ConnectionFinder {
    * @return a Point2D object that represents the center of mass of the given point array
    */
   private static Point2D calcCenterOfMass(final Point2D[] pointArray) {
-    final int N = pointArray.length;
+    final int length = pointArray.length;
     double cx = 0;
     double cy = 0;
     double area = calcSignedPolygonArea(pointArray);
@@ -296,8 +296,8 @@ public class ConnectionFinder {
     int i;
     int j;
     double factor = 0;
-    for (i = 0; i < N; i++) {
-      j = (i + 1) % N;
+    for (i = 0; i < length; i++) {
+      j = (i + 1) % length;
       factor = (pointArray[i].getX() * pointArray[j].getY() - pointArray[j].getX() * pointArray[i].getY());
       cx += (pointArray[i].getX() + pointArray[j].getX()) * factor;
       cy += (pointArray[i].getY() + pointArray[j].getY()) * factor;


### PR DESCRIPTION
This PR fixes violations of the Checkstyle LocalFinalVariableName rule by replacing any leading uppercase letter in local variables with the corresponding lowercase letter.  In a few cases, the local variable had to be renamed further to avoid a collision with an existing variable or to avoid violating another Checkstyle rule.