### PR TITLE
Checkstyle: Remove underscores from variables

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/src/main/java/games/strategy/engine/data/GameParser.java
@@ -552,18 +552,18 @@ public class GameParser {
       throw new GameParseException(mapName,
           "diagonal-connections attribute must be either \"explicit\" or \"implicit\"");
     }
-    final int x_size = Integer.valueOf(xs);
-    final int y_size;
+    final int sizeX = Integer.valueOf(xs);
+    final int sizeY;
     if (ys != null) {
-      y_size = Integer.valueOf(ys);
+      sizeY = Integer.valueOf(ys);
     } else {
-      y_size = 0;
+      sizeY = 0;
     }
-    map.setGridDimensions(x_size, y_size);
+    map.setGridDimensions(sizeX, sizeY);
     if (gridType.equals("square")) {
       // Add territories
-      for (int y = 0; y < y_size; y++) {
-        for (int x = 0; x < x_size; x++) {
+      for (int y = 0; y < sizeY; y++) {
+        for (int x = 0; x < sizeX; x++) {
           final boolean isWater;
           isWater = water.contains(x + "-" + y);
           final Territory newTerritory = new Territory(name + "_" + x + "_" + y, isWater, data, x, y);
@@ -578,32 +578,32 @@ public class GameParser {
       }
       // Add any implicit horizontal connections
       if (horizontalConnectionsImplict) {
-        for (int y = 0; y < y_size; y++) {
-          for (int x = 0; x < x_size - 1; x++) {
+        for (int y = 0; y < sizeY; y++) {
+          for (int x = 0; x < sizeX - 1; x++) {
             map.addConnection(map.getTerritoryFromCoordinates(x, y), map.getTerritoryFromCoordinates(x + 1, y));
           }
         }
       }
       // Add any implicit vertical connections
       if (verticalConnectionsImplict) {
-        for (int x = 0; x < x_size; x++) {
-          for (int y = 0; y < y_size - 1; y++) {
+        for (int x = 0; x < sizeX; x++) {
+          for (int y = 0; y < sizeY - 1; y++) {
             map.addConnection(map.getTerritoryFromCoordinates(x, y), map.getTerritoryFromCoordinates(x, y + 1));
           }
         }
       }
       // Add any implicit acute diagonal connections
       if (diagonalConnectionsImplict) {
-        for (int y = 0; y < y_size - 1; y++) {
-          for (int x = 0; x < x_size - 1; x++) {
+        for (int y = 0; y < sizeY - 1; y++) {
+          for (int x = 0; x < sizeX - 1; x++) {
             map.addConnection(map.getTerritoryFromCoordinates(x, y), map.getTerritoryFromCoordinates(x + 1, y + 1));
           }
         }
       }
       // Add any implicit obtuse diagonal connections
       if (diagonalConnectionsImplict) {
-        for (int y = 0; y < y_size - 1; y++) {
-          for (int x = 1; x < x_size; x++) {
+        for (int y = 0; y < sizeY - 1; y++) {
+          for (int x = 1; x < sizeX; x++) {
             map.addConnection(map.getTerritoryFromCoordinates(x, y), map.getTerritoryFromCoordinates(x - 1, y + 1));
           }
         }
@@ -611,8 +611,8 @@ public class GameParser {
       // This type is a triangular grid of points and lines, used for in several rail games
     } else if (gridType.equals("points-and-lines")) {
       // Add territories
-      for (int y = 0; y < y_size; y++) {
-        for (int x = 0; x < x_size; x++) {
+      for (int y = 0; y < sizeY; y++) {
+        for (int x = 0; x < sizeX; x++) {
           final boolean isWater = false;
           if (!water.contains(x + "-" + y)) {
             final Territory newTerritory = new Territory(name + "_" + x + "_" + y, isWater, data, x, y);
@@ -628,8 +628,8 @@ public class GameParser {
       }
       // Add any implicit horizontal connections
       if (horizontalConnectionsImplict) {
-        for (int y = 0; y < y_size; y++) {
-          for (int x = 0; x < x_size - 1; x++) {
+        for (int y = 0; y < sizeY; y++) {
+          for (int x = 0; x < sizeX - 1; x++) {
             final Territory from = map.getTerritoryFromCoordinates(x, y);
             final Territory to = map.getTerritoryFromCoordinates(x + 1, y);
             if (from != null && to != null) {
@@ -640,8 +640,8 @@ public class GameParser {
       }
       // Add any implicit acute diagonal connections
       if (diagonalConnectionsImplict) {
-        for (int y = 1; y < y_size; y++) {
-          for (int x = 0; x < x_size - 1; x++) {
+        for (int y = 1; y < sizeY; y++) {
+          for (int x = 0; x < sizeX - 1; x++) {
             if (y % 4 == 0 || (y + 1) % 4 == 0) {
               final Territory from = map.getTerritoryFromCoordinates(x, y);
               final Territory to = map.getTerritoryFromCoordinates(x, y - 1);
@@ -660,8 +660,8 @@ public class GameParser {
       }
       // Add any implicit obtuse diagonal connections
       if (diagonalConnectionsImplict) {
-        for (int y = 1; y < y_size; y++) {
-          for (int x = 0; x < x_size - 1; x++) {
+        for (int y = 1; y < sizeY; y++) {
+          for (int x = 0; x < sizeX - 1; x++) {
             if (y % 4 == 0 || (y + 1) % 4 == 0) {
               final Territory from = map.getTerritoryFromCoordinates(x, y);
               final Territory to = map.getTerritoryFromCoordinates(x - 1, y - 1);

--- a/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -640,18 +640,18 @@ public class GameDataExporter {
     xmlfile.append("    </map>\n");
   }
 
-  private class Connection {
-    private final Territory _t1;
-    private final Territory _t2;
+  private static final class Connection {
+    private final Territory territory1;
+    private final Territory territory2;
 
     private Connection(final Territory t1, final Territory t2) {
-      _t1 = t1;
-      _t2 = t2;
+      territory1 = t1;
+      territory2 = t2;
     }
 
     @Override
     public int hashCode() {
-      return _t1.hashCode() + _t2.hashCode();
+      return territory1.hashCode() + territory2.hashCode();
     }
 
     @Override
@@ -660,7 +660,7 @@ public class GameDataExporter {
         return false;
       }
       final Connection con = (Connection) o;
-      return (_t1 == con._t1 && _t2 == con._t2);
+      return (territory1 == con.territory1 && territory2 == con.territory2);
     }
   }
 

--- a/src/main/java/games/strategy/net/IPFinder.java
+++ b/src/main/java/games/strategy/net/IPFinder.java
@@ -83,23 +83,23 @@ public class IPFinder {
 
   private static boolean isPrivateNetworkAddress(final InetAddress address) {
     // stupid java signed byte type
-    final byte _192 = (byte) 0xC0;
-    final byte _172 = (byte) 0xAC;
-    final byte _168 = (byte) 0xA8;
-    final byte _169 = (byte) 0xA9;
-    final byte _252 = (byte) 0xFC;
-    final byte _254 = (byte) 0xFE;
+    final byte octet192 = (byte) 0xC0;
+    final byte octet172 = (byte) 0xAC;
+    final byte octet168 = (byte) 0xA8;
+    final byte octet169 = (byte) 0xA9;
+    final byte octet252 = (byte) 0xFC;
+    final byte octet254 = (byte) 0xFE;
     final byte[] bytes = address.getAddress();
     // ip 4
     if (bytes.length == 4) {
       // http://en.wikipedia.org/wiki/Private_network
-      if ((bytes[0] == 10) || (bytes[0] == _172 && bytes[1] >= 16 && bytes[1] <= 31)
-          || (bytes[0] == _192 && bytes[1] == _168) || (bytes[0] == _169 && bytes[1] == _254)) {
+      if ((bytes[0] == 10) || (bytes[0] == octet172 && bytes[1] >= 16 && bytes[1] <= 31)
+          || (bytes[0] == octet192 && bytes[1] == octet168) || (bytes[0] == octet169 && bytes[1] == octet254)) {
         return true;
       }
     } else { // ip 6
       // http://en.wikipedia.org/wiki/IPv6#Addressing
-      if ((bytes[0] == _252 && bytes[1] == 0) || bytes[0] == _254) {
+      if ((bytes[0] == octet252 && bytes[1] == 0) || bytes[0] == octet254) {
         return true;
       }
     }

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -307,11 +307,11 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     final Change place = ChangeFactory.addUnits(at, placeableUnits);
     change.add(remove);
     change.add(place);
-    final UndoablePlacement current_placement = new UndoablePlacement(change, producer, at, placeableUnits);
-    m_placements.add(current_placement);
+    final UndoablePlacement currentPlacement = new UndoablePlacement(change, producer, at, placeableUnits);
+    m_placements.add(currentPlacement);
     updateUndoablePlacementIndexes();
     final String transcriptText = MyFormatter.unitsToTextNoOwner(placeableUnits) + " placed in " + at.getName();
-    m_bridge.getHistoryWriter().startEvent(transcriptText, current_placement.getDescriptionObject());
+    m_bridge.getHistoryWriter().startEvent(transcriptText, currentPlacement.getDescriptionObject());
     if (movedAirTranscriptTextForHistory != null) {
       m_bridge.getHistoryWriter().addChildToEvent(movedAirTranscriptTextForHistory);
     }

--- a/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BaseEditDelegate.java
@@ -98,10 +98,10 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
   protected void logEvent(final String message, final Object renderingObject) {
     // find last event node
     boolean foundChild = false;
-    final GameData game_data = getData();
-    game_data.acquireReadLock();
+    final GameData gameData = getData();
+    gameData.acquireReadLock();
     try {
-      HistoryNode curNode = game_data.getHistory().getLastNode();
+      HistoryNode curNode = gameData.getHistory().getLastNode();
       while (!(curNode instanceof Step) && !(curNode instanceof Event)) {
         if (curNode instanceof EventChild) {
           foundChild = true;
@@ -110,7 +110,7 @@ public abstract class BaseEditDelegate extends BasePersistentDelegate {
         curNode = (HistoryNode) curNode.getPreviousNode();
       }
     } finally {
-      game_data.releaseReadLock();
+      gameData.releaseReadLock();
     }
     if (foundChild) {
       m_bridge.getHistoryWriter().addChildToEvent(message, renderingObject);

--- a/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -762,9 +762,9 @@ public class MapPanel extends ImageScrollerLargeView {
     movementLeftForCurrentUnits =
         movementLeft.getFirst() + (movementLeft.getSecond() > movementLeft.getFirst() ? "+" : "");
     final Set<UnitCategory> categories = UnitSeperator.categorize(units);
-    final int icon_width = uiContext.getUnitImageFactory().getUnitImageWidth();
+    final int iconWidth = uiContext.getUnitImageFactory().getUnitImageWidth();
     final int xSpace = 5;
-    final BufferedImage img = Util.createImage(categories.size() * (xSpace + icon_width),
+    final BufferedImage img = Util.createImage(categories.size() * (xSpace + iconWidth),
         uiContext.getUnitImageFactory().getUnitImageHeight(), true);
     final Graphics2D g = img.createGraphics();
     g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.6f));
@@ -776,7 +776,7 @@ public class MapPanel extends ImageScrollerLargeView {
     try {
       int i = 0;
       for (final UnitCategory category : categories) {
-        final Point place = new Point(i * (icon_width + xSpace), 0);
+        final Point place = new Point(i * (iconWidth + xSpace), 0);
         final UnitsDrawer drawer = new UnitsDrawer(category.getUnits().size(), category.getType().getName(),
             category.getOwner().getName(), place, category.getDamaged(), category.getBombingDamage(),
             category.getDisabled(), false, "", uiContext);

--- a/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -236,8 +236,8 @@ public class ProductionPanel extends JPanel {
 
     protected JPanel getPanelComponent() {
       final JPanel panel = new JPanel();
-      final ScrollableTextField i_text = new ScrollableTextField(0, Integer.MAX_VALUE);
-      i_text.setValue(quantity);
+      final ScrollableTextField textField = new ScrollableTextField(0, Integer.MAX_VALUE);
+      textField.setValue(quantity);
       panel.setLayout(new GridBagLayout());
       final JLabel info = new JLabel("  ");
       final JLabel name = new JLabel("  ");
@@ -298,10 +298,10 @@ public class ProductionPanel extends JPanel {
           new Insets(5, space, space, space), 0, 0));
       panel.add(info, new GridBagConstraints(0, 2, 1, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.NONE,
           new Insets(5, space, space, space), 0, 0));
-      panel.add(i_text, new GridBagConstraints(0, 3, 1, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.NONE,
+      panel.add(textField, new GridBagConstraints(0, 3, 1, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.NONE,
           new Insets(10, space, space, space), 0, 0));
-      i_text.addChangeListener(listener);
-      textFields.add(i_text);
+      textField.addChangeListener(listener);
+      textFields.add(textField);
       panel.setBorder(new EtchedBorder());
       return panel;
     }

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -422,10 +422,10 @@ public class MapPropertiesMaker extends JFrame {
     final String zoomString = System.getProperty(TRIPLEA_UNIT_ZOOM);
     if (zoomString != null && zoomString.length() > 0) {
       try {
-        final double unit_zoom_percent = Double.parseDouble(zoomString);
+        final double unitZoomPercent = Double.parseDouble(zoomString);
         // mapProperties.setUNITS_SCALE(unit_zoom_percent);
         mapProperties.setUnitsScale(zoomString);
-        System.out.println("Unit Zoom Percent to use: " + unit_zoom_percent);
+        System.out.println("Unit Zoom Percent to use: " + unitZoomPercent);
       } catch (final Exception ex) {
         System.err.println("Not a decimal percentage: " + zoomString);
       }
@@ -433,10 +433,10 @@ public class MapPropertiesMaker extends JFrame {
     final String widthString = System.getProperty(TRIPLEA_UNIT_WIDTH);
     if (widthString != null && widthString.length() > 0) {
       try {
-        final int unit_width = Integer.parseInt(widthString);
-        mapProperties.setUnitsWidth(unit_width);
-        mapProperties.setUnitsCounterOffsetWidth(unit_width / 4);
-        System.out.println("Unit Width to use: " + unit_width);
+        final int unitWidth = Integer.parseInt(widthString);
+        mapProperties.setUnitsWidth(unitWidth);
+        mapProperties.setUnitsCounterOffsetWidth(unitWidth / 4);
+        System.out.println("Unit Width to use: " + unitWidth);
       } catch (final Exception ex) {
         System.err.println("Not an integer: " + widthString);
       }
@@ -444,10 +444,10 @@ public class MapPropertiesMaker extends JFrame {
     final String heightString = System.getProperty(TRIPLEA_UNIT_HEIGHT);
     if (heightString != null && heightString.length() > 0) {
       try {
-        final int unit_height = Integer.parseInt(heightString);
-        mapProperties.setUnitsHeight(unit_height);
-        mapProperties.setUnitsCounterOffsetHeight(unit_height);
-        System.out.println("Unit Height to use: " + unit_height);
+        final int unitHeight = Integer.parseInt(heightString);
+        mapProperties.setUnitsHeight(unitHeight);
+        mapProperties.setUnitsCounterOffsetHeight(unitHeight);
+        System.out.println("Unit Height to use: " + unitHeight);
       } catch (final Exception ex) {
         System.err.println("Not an integer: " + heightString);
       }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle LocalFinalVariableName and MemberName rules by removing underscores from variable names.  (Note that this does **not** include members with an `m_` prefix.)

#### Testing

I verified the changes to the `GameDataExporter$Connection` class did not cause any regressions by exporting a game XML file both before and after the change, and then comparing the two.  No differences were reported.