### PR TITLE
Simplify IntegerMap and LinkedIntegerMap equals() implementations

### DIFF
--- a/src/main/java/games/strategy/util/IntegerMap.java
+++ b/src/main/java/games/strategy/util/IntegerMap.java
@@ -14,7 +14,7 @@ import java.util.Set;
  *
  * @param <T> The type of the map key.
  */
-public class IntegerMap<T> implements Cloneable, Serializable {
+public final class IntegerMap<T> implements Cloneable, Serializable {
   private static final long serialVersionUID = 6856531659284300930L;
   private final HashMap<T, Integer> mapValues;
 
@@ -381,26 +381,14 @@ public class IntegerMap<T> implements Cloneable, Serializable {
    * then a and b are not equal.
    */
   @Override
-  @SuppressWarnings("unchecked")
   public boolean equals(final Object o) {
     if (this == o) {
       return true;
-    }
-    if (o == null || !(o instanceof IntegerMap)) {
+    } else if (!(o instanceof IntegerMap)) {
       return false;
     }
-    final IntegerMap<T> map = (IntegerMap<T>) o;
-    if (!map.keySet().equals(this.keySet())) {
-      return false;
-    }
-    if (!map.mapValues.equals(this.mapValues)) {
-      return false;
-    }
-    for (final T key : map.keySet()) {
-      if (!(this.getInt(key) == map.getInt(key))) {
-        return false;
-      }
-    }
-    return true;
+
+    final IntegerMap<?> other = (IntegerMap<?>) o;
+    return mapValues.equals(other.mapValues);
   }
 }

--- a/src/main/java/games/strategy/util/LinkedIntegerMap.java
+++ b/src/main/java/games/strategy/util/LinkedIntegerMap.java
@@ -15,7 +15,7 @@ import java.util.Set;
  *
  * @param <T> The type of the map key.
  */
-public class LinkedIntegerMap<T> implements Cloneable, Serializable {
+public final class LinkedIntegerMap<T> implements Cloneable, Serializable {
   private static final long serialVersionUID = 6856531659284300930L;
   private final LinkedHashMap<T, Integer> m_values;
 
@@ -390,26 +390,14 @@ public class LinkedIntegerMap<T> implements Cloneable, Serializable {
    * then a and b are not equal.
    */
   @Override
-  @SuppressWarnings("unchecked")
   public boolean equals(final Object o) {
     if (this == o) {
       return true;
-    }
-    if (o == null || !(o instanceof LinkedIntegerMap)) {
+    } else if (!(o instanceof LinkedIntegerMap)) {
       return false;
     }
-    final LinkedIntegerMap<T> map = (LinkedIntegerMap<T>) o;
-    if (!map.keySet().equals(this.keySet())) {
-      return false;
-    }
-    if (!map.m_values.equals(this.m_values)) {
-      return false;
-    }
-    for (final T key : map.keySet()) {
-      if (!(this.getInt(key) == map.getInt(key))) {
-        return false;
-      }
-    }
-    return true;
+
+    final LinkedIntegerMap<?> other = (LinkedIntegerMap<?>) o;
+    return m_values.equals(other.m_values);
   }
 }

--- a/src/test/java/games/strategy/util/IntegerMapTest.java
+++ b/src/test/java/games/strategy/util/IntegerMapTest.java
@@ -1,14 +1,34 @@
 package games.strategy.util;
 
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 
 public class IntegerMapTest {
   private final Object v1 = new Object();
   private final Object v2 = new Object();
   private final Object v3 = new Object();
+
+  @Test
+  public void shouldBeEquatableAndHashable() {
+    EqualsVerifier.forClass(IntegerMap.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+
+    // We need to explicitly test this case because EqualsVerifier's internal prefab values for HashMap use the
+    // same value for all key/value pairs
+    assertThat(
+        "should not be equal when keys are equal but values are not equal",
+        new IntegerMap<>(v1, 1),
+        is(not(new IntegerMap<>(v1, 2))));
+  }
 
   @Test
   public void testAdd() {

--- a/src/test/java/games/strategy/util/LinkedIntegerMapTest.java
+++ b/src/test/java/games/strategy/util/LinkedIntegerMapTest.java
@@ -1,0 +1,28 @@
+package games.strategy.util;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
+public final class LinkedIntegerMapTest {
+  private final Object key = new Object();
+
+  @Test
+  public void shouldBeEquatableAndHashable() {
+    EqualsVerifier.forClass(LinkedIntegerMap.class)
+        .suppress(Warning.NULL_FIELDS)
+        .verify();
+
+    // We need to explicitly test this case because EqualsVerifier's internal prefab values for LinkedHashMap use the
+    // same value for all key/value pairs
+    assertThat(
+        "should not be equal when keys are equal but values are not equal",
+        new LinkedIntegerMap<>(key, 1),
+        is(not(new LinkedIntegerMap<>(key, 2))));
+  }
+}


### PR DESCRIPTION
While working #2194, I noticed that the implementation of `IntegerMap#equals()` is basically doing the equality check twice.  The implementation consisted of the following steps:

1. Check if map keys are equal
1. Check if map entries (i.e. keys and values) are equal
1. Check if maps have equal values for each key

This PR simplifies the `equals()` implementation in both `IntegerMap` and `LinkedIntegerMap` (which had an identical implementation) by only performing step (2), which is sufficient.

#### Testing

I first added unit tests to verify the existing implementations worked as expected.  Then I refactored to what's presented in this PR while keeping the tests green.