### PR TITLE
Remove duplicate production dialog (#2184)

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -82,11 +82,14 @@ public class ProductionPanel extends JPanel {
    */
   public IntegerMap<ProductionRule> show(final PlayerID id, final JFrame parent, final GameData data, final boolean bid,
       final IntegerMap<ProductionRule> initialPurchase) {
-    dialog = JDialogBuilder.builder()
-        .parentFrame(parent)
+    final JDialogBuilder dialogBuilder = JDialogBuilder.builder()
         .contents(this)
-        .title("Produce")
-        .build();
+        .title("Produce");
+    if (parent != null) {
+      dialogBuilder.parentFrame(parent);
+    }
+    dialog = dialogBuilder.build();
+
     this.bid = bid;
     this.data = data;
     this.initRules(id, data, initialPurchase);

--- a/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -82,20 +82,11 @@ public class ProductionPanel extends JPanel {
    */
   public IntegerMap<ProductionRule> show(final PlayerID id, final JFrame parent, final GameData data, final boolean bid,
       final IntegerMap<ProductionRule> initialPurchase) {
-    if (parent != null) {
-      dialog = JDialogBuilder.builder()
-          .parentFrame(parent)
-          .contents(this)
-          .title("Produce")
-          .build();
-      dialog.pack();
-      dialog.setLocationRelativeTo(parent);
-      dialog.setVisible(true);
-      // making the dialog visible will block until it is closed
-      dialog.dispose();
-
-
-    }
+    dialog = JDialogBuilder.builder()
+        .parentFrame(parent)
+        .contents(this)
+        .title("Produce")
+        .build();
     this.bid = bid;
     this.data = data;
     this.initRules(id, data, initialPurchase);

--- a/src/main/java/swinglib/JDialogBuilder.java
+++ b/src/main/java/swinglib/JDialogBuilder.java
@@ -36,7 +36,6 @@ public final class JDialogBuilder {
   private String title;
   private JComponent contents;
 
-
   private JDialogBuilder() {}
 
   public static JDialogBuilder builder() {
@@ -50,7 +49,6 @@ public final class JDialogBuilder {
   public JDialog build() {
     checkNotNull(title);
     checkNotNull(contents);
-    checkNotNull(parentFrame);
 
     final JDialog dialog = new JDialog(parentFrame, title, true);
     dialog.getContentPane().add(contents);

--- a/src/test/java/swinglib/JDialogBuilderTest.java
+++ b/src/test/java/swinglib/JDialogBuilderTest.java
@@ -1,7 +1,10 @@
 package swinglib;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeFalse;
 
 import java.awt.GraphicsEnvironment;
@@ -21,7 +24,6 @@ public class JDialogBuilderTest {
     final JDialog dialog = JDialogBuilder.builder()
         .contents(new JPanel())
         .title("title")
-        .parentFrame(new JFrame())
         .build();
     assertThat(dialog.getTitle(), is("title"));
   }
@@ -30,33 +32,59 @@ public class JDialogBuilderTest {
     assumeFalse("requires headed graphics environment", GraphicsEnvironment.isHeadless());
   }
 
-  @Test(expected = NullPointerException.class)
-  public void contentsIsRequired() {
+  @Test
+  public void checkParentFrame() {
     assumeHeadedGraphicsEnvironment();
 
+    final JFrame parentFrame = new JFrame();
+
+    final JDialog dialog = JDialogBuilder.builder()
+        .contents(new JPanel())
+        .parentFrame(parentFrame)
+        .title("title")
+        .build();
+
+    assertThat(dialog.getParent(), is(sameInstance(parentFrame)));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void contentsIsRequired() {
     JDialogBuilder.builder()
         .title("title")
-        .parentFrame(new JFrame())
         .build();
+  }
+
+  @Test
+  public void parentFrameIsNotRequired() {
+    assumeHeadedGraphicsEnvironment();
+
+    final JDialog dialog = JDialogBuilder.builder()
+        .contents(new JPanel())
+        .title("title")
+        .build();
+
+    assertThat(dialog.getParent(), is(not(nullValue())));
   }
 
   @Test(expected = NullPointerException.class)
   public void titleIsRequired() {
-    assumeHeadedGraphicsEnvironment();
-
     JDialogBuilder.builder()
         .contents(new JPanel())
-        .parentFrame(new JFrame())
         .build();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void contentsCanNotBeNull() {
+    JDialogBuilder.builder().contents(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void parentFrameCanNotBeNull() {
+    JDialogBuilder.builder().parentFrame(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void titleCanNotBeEmpty() {
     JDialogBuilder.builder().title(" ");
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void parentCanNotBeNull() {
-    JDialogBuilder.builder().parentFrame(null);
   }
 }


### PR DESCRIPTION
This PR fixes the duplicate production dialog reported in #2184.

There is still a latent NPE in this code.  If `parent` is `null`, `JDialogBuilder#parentFrame()` will throw an NPE.

Viewing with whitespace changes ignored (`?w=1`) will reduce some noise.