### PR TITLE
Checkstyle: Remove single lowercase prefix on local variable names

### DIFF
--- a/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -111,8 +111,8 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
     final List<INode> onlinePlayers = chat.getOnlinePlayers();
     int maxNameLength = 0;
     final FontMetrics fontMetrics = this.getFontMetrics(UIManager.getFont("TextField.font"));
-    for (final INode iNode : onlinePlayers) {
-      maxNameLength = Math.max(maxNameLength, fontMetrics.stringWidth(iNode.getName()));
+    for (final INode onlinePlayer : onlinePlayers) {
+      maxNameLength = Math.max(maxNameLength, fontMetrics.stringWidth(onlinePlayer.getName()));
     }
     int iconCounter = 0;
     if (setCellRenderer instanceof PlayerChatRenderer) {

--- a/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
@@ -117,11 +117,11 @@ public class ChangeFactory {
   }
 
   public static Change removeResourceCollection(final PlayerID id, final ResourceCollection resourceCollection) {
-    final CompositeChange cChange = new CompositeChange();
+    final CompositeChange compositeChange = new CompositeChange();
     for (final Resource r : resourceCollection.getResourcesCopy().keySet()) {
-      cChange.add(new ChangeResourceChange(id, r, -resourceCollection.getQuantity(r)));
+      compositeChange.add(new ChangeResourceChange(id, r, -resourceCollection.getQuantity(r)));
     }
-    return cChange;
+    return compositeChange;
   }
 
   public static Change setProperty(final String property, final Object value, final GameData data) {

--- a/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
+++ b/src/main/java/games/strategy/engine/framework/headlessGameServer/HeadlessGameServer.java
@@ -195,18 +195,18 @@ public class HeadlessGameServer {
     final String localPassword = System.getProperty(GameRunner.LOBBY_GAME_SUPPORT_PASSWORD, "");
     final String encryptedPassword = MD5Crypt.crypt(localPassword, salt);
     if (encryptedPassword.equals(hashedPassword)) {
-      final ServerGame iGame = m_iGame;
-      if (iGame != null) {
+      final ServerGame serverGame = m_iGame;
+      if (serverGame != null) {
         (new Thread(() -> {
           System.out.println("Remote Stop Game Initiated.");
           try {
-            iGame.saveGame(new File(
+            serverGame.saveGame(new File(
                 ClientSetting.SAVE_GAMES_FOLDER_PATH.value(),
                 SaveGameFileChooser.getAutoSaveFileName()));
           } catch (final Exception e) {
             ClientLogger.logQuietly(e);
           }
-          iGame.stopGame();
+          serverGame.stopGame();
         })).start();
       }
       return null;

--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -192,9 +192,9 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     if (getPlayerBridge().isGameOver()) {
       return;
     }
-    final IPoliticsDelegate iPoliticsDelegate;
+    final IPoliticsDelegate politicsDelegate;
     try {
-      iPoliticsDelegate = (IPoliticsDelegate) getPlayerBridge().getRemoteDelegate();
+      politicsDelegate = (IPoliticsDelegate) getPlayerBridge().getRemoteDelegate();
     } catch (final ClassCastException e) {
       final String errorContext = "PlayerBridge step name: " + getPlayerBridge().getStepName() + ", Remote class name: "
           + getPlayerBridge().getRemoteDelegate().getClass();
@@ -203,9 +203,9 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     }
 
     final PoliticalActionAttachment actionChoice =
-        ui.getPoliticalActionChoice(getPlayerID(), firstRun, iPoliticsDelegate);
+        ui.getPoliticalActionChoice(getPlayerID(), firstRun, politicsDelegate);
     if (actionChoice != null) {
-      iPoliticsDelegate.attemptAction(actionChoice);
+      politicsDelegate.attemptAction(actionChoice);
       politics(false);
     }
   }
@@ -214,9 +214,9 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
     if (getPlayerBridge().isGameOver()) {
       return;
     }
-    final IUserActionDelegate iUserActionDelegate;
+    final IUserActionDelegate userActionDelegate;
     try {
-      iUserActionDelegate = (IUserActionDelegate) getPlayerBridge().getRemoteDelegate();
+      userActionDelegate = (IUserActionDelegate) getPlayerBridge().getRemoteDelegate();
     } catch (final ClassCastException e) {
       final String errorContext = "PlayerBridge step name: " + getPlayerBridge().getStepName() + ", Remote class name: "
           + getPlayerBridge().getRemoteDelegate().getClass();
@@ -225,9 +225,9 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
       ClientLogger.logQuietly(e);
       throw new IllegalStateException(errorContext, e);
     }
-    final UserActionAttachment actionChoice = ui.getUserActionChoice(getPlayerID(), firstRun, iUserActionDelegate);
+    final UserActionAttachment actionChoice = ui.getUserActionChoice(getPlayerID(), firstRun, userActionDelegate);
     if (actionChoice != null) {
-      iUserActionDelegate.attemptAction(actionChoice);
+      userActionDelegate.attemptAction(actionChoice);
       userActions(false);
     }
   }

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -276,16 +276,16 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
         if (attackTokens.size() <= 0) {
           continue;
         }
-        final IntegerMap<Resource> rMap = new IntegerMap<>();
+        final IntegerMap<Resource> resourceMap = new IntegerMap<>();
         final Resource r = attackTokens.keySet().iterator().next();
         final int num = Math.min(attackTokens.getInt(r),
             (UnitAttachment.get(u.getType()).getHitPoints() * (Math.random() < .3 ? 1 : (Math.random() < .5 ? 2 : 3))));
-        rMap.put(r, num);
+        resourceMap.put(r, num);
         HashMap<Unit, IntegerMap<Resource>> attMap = rVal.get(t);
         if (attMap == null) {
           attMap = new HashMap<>();
         }
-        attMap.put(u, rMap);
+        attMap.put(u, resourceMap);
         rVal.put(t, attMap);
         attackTokens.add(r, -num);
         if (attackTokens.getInt(r) <= 0) {
@@ -587,7 +587,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
   }
 
   protected void politicalActions() {
-    final IPoliticsDelegate iPoliticsDelegate = (IPoliticsDelegate) getPlayerBridge().getRemoteDelegate();
+    final IPoliticsDelegate remotePoliticsDelegate = (IPoliticsDelegate) getPlayerBridge().getRemoteDelegate();
     final GameData data = getGameData();
     final PlayerID id = getPlayerID();
     final float numPlayers = data.getPlayerList().getPlayers().size();
@@ -622,7 +622,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
           if (i > maxWarActionsPerTurn) {
             break;
           }
-          iPoliticsDelegate.attemptAction(action);
+          remotePoliticsDelegate.attemptAction(action);
         }
       }
     } else {
@@ -649,7 +649,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
           if (i > maxOtherActionsPerTurn) {
             break;
           }
-          iPoliticsDelegate.attemptAction(action);
+          remotePoliticsDelegate.attemptAction(action);
         }
       }
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -156,9 +156,9 @@ public class ProOddsCalculator {
     }
 
     // Create battle result object
-    final List<Territory> tList = new ArrayList<>();
-    tList.add(t);
-    if (!tList.isEmpty() && Match.allMatch(tList, Matches.TerritoryIsLand)) {
+    final List<Territory> territoryList = new ArrayList<>();
+    territoryList.add(t);
+    if (!territoryList.isEmpty() && Match.allMatch(territoryList, Matches.TerritoryIsLand)) {
       return new ProBattleResult(winPercentage, tuvSwing,
           Match.anyMatch(averageAttackersRemaining, Matches.UnitIsLand), averageAttackersRemaining,
           averageDefendersRemaining, results.getAverageBattleRoundsFought());

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -143,8 +143,8 @@ public class ProUtils {
 
   public static List<Territory> getLiveEnemyCapitals(final GameData data, final PlayerID player) {
     final List<Territory> enemyCapitals = new ArrayList<>();
-    final List<PlayerID> ePlayers = getEnemyPlayers(player);
-    for (final PlayerID otherPlayer : ePlayers) {
+    final List<PlayerID> enemyPlayers = getEnemyPlayers(player);
+    for (final PlayerID otherPlayer : enemyPlayers) {
       enemyCapitals.addAll(TerritoryAttachment.getAllCurrentlyOwnedCapitals(otherPlayer, data));
     }
     enemyCapitals.retainAll(Match.getMatches(enemyCapitals, Matches.territoryIsNotImpassableToLandUnits(player, data)));

--- a/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/Utils.java
@@ -87,11 +87,11 @@ class Utils {
   // returns all territories that are water territories (veqryn)
   static List<Territory> onlyWaterTerr(final List<Territory> allTerr) {
     final List<Territory> water = new ArrayList<>(allTerr);
-    final Iterator<Territory> wFIter = water.iterator();
-    while (wFIter.hasNext()) {
-      final Territory waterFact = wFIter.next();
+    final Iterator<Territory> waterFactIter = water.iterator();
+    while (waterFactIter.hasNext()) {
+      final Territory waterFact = waterFactIter.next();
       if (!Matches.TerritoryIsWater.match(waterFact)) {
-        wFIter.remove();
+        waterFactIter.remove();
       }
     }
     return water;
@@ -105,8 +105,8 @@ class Utils {
     // Return territories containing a certain unit or set of Units
     final Match<Unit> limitShips = Match.allOf(unitCondition);
     final List<Territory> shipTerr = new ArrayList<>();
-    final Collection<Territory> tNeighbors = data.getMap().getTerritories();
-    for (final Territory t2 : tNeighbors) {
+    final Collection<Territory> neighbors = data.getMap().getTerritories();
+    for (final Territory t2 : neighbors) {
       if (t2.getUnits().anyMatch(limitShips)) {
         shipTerr.add(t2);
       }

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2163,18 +2163,18 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
           rule = rule.replaceFirst("-", "");
           add = false;
         }
-        final ProductionRule pRule = data.getProductionRuleList().getProductionRule(rule);
+        final ProductionRule productionRule = data.getProductionRuleList().getProductionRule(rule);
         if (add) {
-          if (!front.getRules().contains(pRule)) {
-            change.add(ChangeFactory.addProductionRule(pRule, front));
-            bridge.getHistoryWriter().startEvent(MyFormatter.attachmentNameToText(t.getName()) + ": " + pRule.getName()
-                + " added to " + front.getName());
+          if (!front.getRules().contains(productionRule)) {
+            change.add(ChangeFactory.addProductionRule(productionRule, front));
+            bridge.getHistoryWriter().startEvent(MyFormatter.attachmentNameToText(t.getName()) + ": "
+                + productionRule.getName() + " added to " + front.getName());
           }
         } else {
-          if (front.getRules().contains(pRule)) {
-            change.add(ChangeFactory.removeProductionRule(pRule, front));
-            bridge.getHistoryWriter().startEvent(MyFormatter.attachmentNameToText(t.getName()) + ": " + pRule.getName()
-                + " removed from " + front.getName());
+          if (front.getRules().contains(productionRule)) {
+            change.add(ChangeFactory.removeProductionRule(productionRule, front));
+            bridge.getHistoryWriter().startEvent(MyFormatter.attachmentNameToText(t.getName()) + ": "
+                + productionRule.getName() + " removed from " + front.getName());
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -254,9 +254,9 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
     // take first one
     PlayerID giveWarBondsTo = null;
     for (final PlayerID p : shareWith) {
-      final int pCount = TechAbilityAttachment.getWarBondDiceNumber(p, data);
-      final int pSides = TechAbilityAttachment.getWarBondDiceSides(p, data);
-      if (pSides <= 0 && pCount <= 0) {
+      final int diceCount = TechAbilityAttachment.getWarBondDiceNumber(p, data);
+      final int diceSides = TechAbilityAttachment.getWarBondDiceSides(p, data);
+      if (diceSides <= 0 && diceCount <= 0) {
         // if both are zero, then it must mean we did not share our war bonds tech with them, even though we are sharing
         // all tech (because
         // they cannot have this tech)

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -763,12 +763,12 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       for (final HashMap<Territory, Tuple<Collection<Unit>, Collection<Unit>>> scramblers : scramblersByTerritoryPlayer
           .get(terrPlayer)) {
         // verify that we didn't already scramble any of these units
-        final Iterator<Territory> tIter = scramblers.keySet().iterator();
-        while (tIter.hasNext()) {
-          final Territory t = tIter.next();
+        final Iterator<Territory> territoryIter = scramblers.keySet().iterator();
+        while (territoryIter.hasNext()) {
+          final Territory t = territoryIter.next();
           scramblers.get(t).getSecond().retainAll(t.getUnits().getUnits());
           if (scramblers.get(t).getSecond().isEmpty()) {
-            tIter.remove();
+            territoryIter.remove();
           }
         }
         if (scramblers.isEmpty()) {
@@ -1332,8 +1332,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         if (possibleUnits == null || !possibleUnits.containsAll(territoryEntry.getValue().keySet())) {
           throw new IllegalStateException("Player has chosen illegal units during Kamikaze Suicide Attacks");
         }
-        for (final IntegerMap<Resource> rMap : territoryEntry.getValue().values()) {
-          attackTokens.subtract(rMap);
+        for (final IntegerMap<Resource> resourceMap : territoryEntry.getValue().values()) {
+          attackTokens.subtract(resourceMap);
         }
       }
       if (!attackTokens.isPositive()) {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -697,9 +697,9 @@ public class Matches {
    */
   public static Match<Territory> territoryHasRouteToEnemyCapital(final GameData data, final PlayerID player) {
     return Match.of(t -> {
-      for (final PlayerID ePlayer : data.getPlayerList().getPlayers()) {
+      for (final PlayerID otherPlayer : data.getPlayerList().getPlayers()) {
         final List<Territory> capitalsListOwned =
-            new ArrayList<>(TerritoryAttachment.getAllCurrentlyOwnedCapitals(ePlayer, data));
+            new ArrayList<>(TerritoryAttachment.getAllCurrentlyOwnedCapitals(otherPlayer, data));
         for (final Territory current : capitalsListOwned) {
           if (!data.getRelationshipTracker().isAtWar(player, current.getOwner())) {
             continue;
@@ -721,9 +721,9 @@ public class Matches {
    */
   public static Match<Territory> territoryHasLandRouteToEnemyCapital(final GameData data, final PlayerID player) {
     return Match.of(t -> {
-      for (final PlayerID ePlayer : data.getPlayerList().getPlayers()) {
+      for (final PlayerID otherPlayer : data.getPlayerList().getPlayers()) {
         final List<Territory> capitalsListOwned =
-            new ArrayList<>(TerritoryAttachment.getAllCurrentlyOwnedCapitals(ePlayer, data));
+            new ArrayList<>(TerritoryAttachment.getAllCurrentlyOwnedCapitals(otherPlayer, data));
         for (final Territory current : capitalsListOwned) {
           if (!data.getRelationshipTracker().isAtWar(player, current.getOwner())) {
             continue;
@@ -1755,11 +1755,11 @@ public class Matches {
       if (!Matches.TerritoryIsLand.match(t)) {
         return true;
       }
-      final PlayerID tOwner = t.getOwner();
-      if (tOwner == null) {
+      final PlayerID territoryOwner = t.getOwner();
+      if (territoryOwner == null) {
         return true;
       }
-      return data.getRelationshipTracker().canMoveLandUnitsOverOwnedLand(tOwner, ownerOfUnitsMoving);
+      return data.getRelationshipTracker().canMoveLandUnitsOverOwnedLand(territoryOwner, ownerOfUnitsMoving);
     });
   }
 
@@ -1775,11 +1775,11 @@ public class Matches {
       if (!Matches.TerritoryIsLand.match(t)) {
         return true;
       }
-      final PlayerID tOwner = t.getOwner();
-      if (tOwner == null) {
+      final PlayerID territoryOwner = t.getOwner();
+      if (territoryOwner == null) {
         return true;
       }
-      return data.getRelationshipTracker().canMoveAirUnitsOverOwnedLand(tOwner, ownerOfUnitsMoving);
+      return data.getRelationshipTracker().canMoveAirUnitsOverOwnedLand(territoryOwner, ownerOfUnitsMoving);
     });
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -355,8 +355,8 @@ public class MoveValidator {
           if (Matches.UnitIsInfantry.match(unit)) {
             continue;
           }
-          final TripleAUnit tAUnit = (TripleAUnit) unit;
-          if (wasStartFoughtOver || tAUnit.getWasInCombat() || route.anyMatch(notEndOrFriendlyTerrs)
+          final TripleAUnit taUnit = (TripleAUnit) unit;
+          if (wasStartFoughtOver || taUnit.getWasInCombat() || route.anyMatch(notEndOrFriendlyTerrs)
               || route.anyMatch(notEndWasFought)) {
             result.addDisallowedUnit(NOT_ALL_UNITS_CAN_BLITZ, unit);
           }
@@ -1442,15 +1442,15 @@ public class MoveValidator {
     final Collection<Unit> canCarry = new ArrayList<>();
     int available = ua.getCarrierCapacity();
     final Iterator<Unit> iter = selectFrom.iterator();
-    final TripleAUnit tACarrier = (TripleAUnit) carrier;
+    final TripleAUnit taCarrier = (TripleAUnit) carrier;
     while (iter.hasNext()) {
       final Unit plane = iter.next();
-      final TripleAUnit tAPlane = (TripleAUnit) plane;
+      final TripleAUnit taPlane = (TripleAUnit) plane;
       final UnitAttachment planeAttachment = UnitAttachment.get(plane.getUnitType());
       final int cost = planeAttachment.getCarrierCost();
       if (available >= cost) {
         // this is to test if they started in the same sea zone or not, and its not a very good way of testing it.
-        if ((tACarrier.getAlreadyMoved() == tAPlane.getAlreadyMoved())
+        if ((taCarrier.getAlreadyMoved() == taPlane.getAlreadyMoved())
             || (Matches.unitHasNotMoved.match(plane) && Matches.unitHasNotMoved.match(carrier))
             || (Matches.unitIsOwnedBy(playerWhoIsDoingTheMovement).invert().match(plane) && Matches.alliedUnit(
                 playerWhoIsDoingTheMovement, data).match(plane))) {

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -436,8 +436,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       if (!(p1.equals(player) || p2.equals(player))) {
         continue;
       }
-      final PlayerID pOther = (p1.equals(player) ? p2 : p1);
-      if (!p1AlliedWith.contains(pOther)) {
+      final PlayerID otherPlayer = (p1.equals(player) ? p2 : p1);
+      if (!p1AlliedWith.contains(otherPlayer)) {
         continue;
       }
       final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
@@ -478,21 +478,21 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       if (!(p1.equals(player) || p2.equals(player))) {
         continue;
       }
-      final PlayerID pOther = (p1.equals(player) ? p2 : p1);
+      final PlayerID otherPlayer = (p1.equals(player) ? p2 : p1);
       final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
       final RelationshipType newType = data.getRelationshipTypeList().getRelationshipType(relationshipChange[2]);
       if (Matches.RelationshipTypeIsAtWar.match(currentType)
           && Matches.RelationshipTypeIsAtWar.invert().match(newType)) {
-        final Collection<PlayerID> pOtherAlliedWith =
-            Match.getMatches(players, Matches.isAlliedAndAlliancesCanChainTogether(pOther, data));
-        if (!pOtherAlliedWith.contains(pOther)) {
-          pOtherAlliedWith.add(pOther);
+        final Collection<PlayerID> otherPlayersAlliedWith =
+            Match.getMatches(players, Matches.isAlliedAndAlliancesCanChainTogether(otherPlayer, data));
+        if (!otherPlayersAlliedWith.contains(otherPlayer)) {
+          otherPlayersAlliedWith.add(otherPlayer);
         }
         if (!p1AlliedWith.contains(player)) {
           p1AlliedWith.add(player);
         }
         for (final PlayerID p3 : p1AlliedWith) {
-          for (final PlayerID p4 : pOtherAlliedWith) {
+          for (final PlayerID p4 : otherPlayersAlliedWith) {
             final RelationshipType currentOther = data.getRelationshipTracker().getRelationshipType(p3, p4);
             if (!currentOther.equals(newType) && Matches.RelationshipTypeIsAtWar.match(currentOther)) {
               change.add(ChangeFactory.relationshipChange(p3, p4, currentOther, newType));

--- a/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -40,17 +40,17 @@ public class DiceImageFactory {
   }
 
   private void generateDice(final int pipSize, final Color color, final Map<Integer, Image> images) {
-    final ImageFactory iFactory = new ImageFactory();
-    iFactory.setResourceLoader(m_resourceLoader);
+    final ImageFactory imageFactory = new ImageFactory();
+    imageFactory.setResourceLoader(m_resourceLoader);
     for (int i = 1; i <= m_diceSides; i++) {
       Image img = null;
       if (m_resourceLoader != null) {
         if (color == Color.black) {
-          img = iFactory.getImage("dice/" + i + ".png", false);
+          img = imageFactory.getImage("dice/" + i + ".png", false);
         } else if (color == Color.red) {
-          img = iFactory.getImage("dice/" + i + "_hit.png", false);
+          img = imageFactory.getImage("dice/" + i + "_hit.png", false);
         } else if (color == IGNORED) {
-          img = iFactory.getImage("dice/" + i + "_ignored.png", false);
+          img = imageFactory.getImage("dice/" + i + "_ignored.png", false);
         }
       }
       if (img != null) {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -648,46 +648,46 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
         final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
         final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
         final boolean allowMultipleHitsPerUnit) {
-      final List<Unit> rDamaged = new ArrayList<>(defaultCasualties.getDamaged());
-      final List<Unit> rKilled = new ArrayList<>(defaultCasualties.getKilled());
+      final List<Unit> damagedUnits = new ArrayList<>(defaultCasualties.getDamaged());
+      final List<Unit> killedUnits = new ArrayList<>(defaultCasualties.getKilled());
       if (keepAtLeastOneLand) {
         final List<Unit> notKilled = new ArrayList<>(selectFrom);
-        notKilled.removeAll(rKilled);
+        notKilled.removeAll(killedUnits);
         // no land units left, but we have a non land unit to kill and land unit was killed
         if (!Match.anyMatch(notKilled, Matches.UnitIsLand) && Match.anyMatch(notKilled, Matches.UnitIsNotLand)
-            && Match.anyMatch(rKilled, Matches.UnitIsLand)) {
+            && Match.anyMatch(killedUnits, Matches.UnitIsLand)) {
           final List<Unit> notKilledAndNotLand = Match.getMatches(notKilled, Matches.UnitIsNotLand);
           // sort according to cost
           Collections.sort(notKilledAndNotLand, AIUtils.getCostComparator());
           // remove the last killed unit, this should be the strongest
-          rKilled.remove(rKilled.size() - 1);
+          killedUnits.remove(killedUnits.size() - 1);
           // add the cheapest unit
-          rKilled.add(notKilledAndNotLand.get(0));
+          killedUnits.add(notKilledAndNotLand.get(0));
         }
       }
-      if (orderOfLosses != null && !orderOfLosses.isEmpty() && !rKilled.isEmpty()) {
+      if (orderOfLosses != null && !orderOfLosses.isEmpty() && !killedUnits.isEmpty()) {
         final List<Unit> orderOfLosses = new ArrayList<>(this.orderOfLosses);
         orderOfLosses.retainAll(selectFrom);
         if (!orderOfLosses.isEmpty()) {
-          int killedSize = rKilled.size();
-          rKilled.clear();
+          int killedSize = killedUnits.size();
+          killedUnits.clear();
           while (killedSize > 0 && !orderOfLosses.isEmpty()) {
-            rKilled.add(orderOfLosses.get(0));
+            killedUnits.add(orderOfLosses.get(0));
             orderOfLosses.remove(0);
             killedSize--;
           }
           if (killedSize > 0) {
             final List<Unit> defaultKilled = new ArrayList<>(defaultCasualties.getKilled());
-            defaultKilled.removeAll(rKilled);
+            defaultKilled.removeAll(killedUnits);
             while (killedSize > 0) {
-              rKilled.add(defaultKilled.get(0));
+              killedUnits.add(defaultKilled.get(0));
               defaultKilled.remove(0);
               killedSize--;
             }
           }
         }
       }
-      final CasualtyDetails casualtyDetails = new CasualtyDetails(rKilled, rDamaged, false);
+      final CasualtyDetails casualtyDetails = new CasualtyDetails(killedUnits, damagedUnits, false);
       return casualtyDetails;
     }
 

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -1016,9 +1016,9 @@ class OddsCalculatorPanel extends JPanel {
         }
         if (category.getDisabled() && Matches.UnitTypeCanBeDamaged.match(category.getType())) {
           // add 1 because it is the max operational damage and we want to disable it
-          final int uDamage = Math.max(0, 1 + UnitAttachment.get(category.getType()).getMaxOperationalDamage());
+          final int unitDamage = Math.max(0, 1 + UnitAttachment.get(category.getType()).getMaxOperationalDamage());
           for (final Unit u : units) {
-            ((TripleAUnit) u).setUnitDamage(uDamage);
+            ((TripleAUnit) u).setUnitDamage(unitDamage);
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
@@ -74,10 +74,10 @@ class CountryChart {
         final Iterator<Map<UnitType, Integer>> mapIterator = currentList.iterator();
         while (mapIterator.hasNext()) {
           final Map<UnitType, Integer> currentMap = mapIterator.next();
-          final Iterator<UnitType> uIter = currentMap.keySet().iterator();
-          while (uIter.hasNext()) {
-            final UnitType uHere = uIter.next();
-            final int here = currentMap.get(uHere);
+          final Iterator<UnitType> unitTypeIter = currentMap.keySet().iterator();
+          while (unitTypeIter.hasNext()) {
+            final UnitType unitTypeHere = unitTypeIter.next();
+            final int here = currentMap.get(unitTypeHere);
             countryFileWriter.write("," + here);
           }
         }

--- a/src/main/java/games/strategy/triplea/printgenerator/PUChart.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PUChart.java
@@ -81,16 +81,16 @@ class PUChart {
   protected void saveToFile() throws IOException {
     initializeMap();
     initializeAvoidMap();
-    final int yDimension = 6;
-    final int xDimension = 7;
-    final int numChartsNeeded = (int) Math.ceil(((double) moneyMap.totalValues()) / (xDimension * yDimension));
+    final int rows = 6;
+    final int cols = 7;
+    final int numChartsNeeded = (int) Math.ceil(((double) moneyMap.totalValues()) / (cols * rows));
     for (int i = 0; i < numChartsNeeded; i++) {
       g2d.setColor(Color.black);
       // Draw Country Names
       for (int z = 0; z < playerArray.length; z++) {
         final int valMod42 = moneyArray[z] % 42;
-        final int valModXDim = valMod42 % xDimension;
-        final int valFloorXDim = valMod42 / xDimension;
+        final int valModXDim = valMod42 % cols;
+        final int valFloorXDim = valMod42 / cols;
         if (avoidMap.containsKey(z) && moneyArray[z] / 42 == i) {
           final FontMetrics metrics = g2d.getFontMetrics();
           final int width = metrics.stringWidth(playerArray[z].getName()) / 2;
@@ -106,16 +106,16 @@ class PUChart {
         }
       }
       // Draw Ellipses and Numbers
-      for (int j = 0; j < yDimension; j++) {
-        for (int k = 0; k < xDimension; k++) {
-          final int numberincircle = xDimension * yDimension * i + xDimension * j + k;
+      for (int j = 0; j < rows; j++) {
+        for (int k = 0; k < cols; k++) {
+          final int numberincircle = cols * rows * i + cols * j + k;
           final String string = "" + numberincircle;
           drawEllipseAndString(k, j, string);
         }
       }
       // Write to file
-      final int firstnum = xDimension * yDimension * i;
-      final int secondnum = xDimension * yDimension * (i + 1) - 1;
+      final int firstnum = cols * rows * i;
+      final int secondnum = cols * rows * (i + 1) - 1;
       final File outputfile = new File(outDir, "PUchart" + firstnum + "-" + secondnum + ".png");
       ImageIO.write(puImage, "png", outputfile);
       final Color transparent = new Color(0, 0, 0, 0);

--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -209,11 +209,11 @@ public class BattleDisplay extends JPanel {
    *        player kills belongs to
    */
   private Collection<Unit> updateKilledUnits(final Collection<Unit> killedUnits, final PlayerID playerId) {
-    final JPanel lCausalityPanel;
+    final JPanel casualtyPanel;
     if (playerId.equals(defender)) {
-      lCausalityPanel = casualtiesInstantPanelDefender;
+      casualtyPanel = casualtiesInstantPanelDefender;
     } else {
-      lCausalityPanel = casualtiesInstantPanelAttacker;
+      casualtyPanel = casualtiesInstantPanelAttacker;
     }
     Map<Unit, Collection<Unit>> dependentsMap;
     gameData.acquireReadLock();
@@ -239,7 +239,7 @@ public class BattleDisplay extends JPanel {
         // TODO this size is of the transport collection size, not the transportED collection size.
         panel.add(new JLabel("x " + category.getUnits().size()));
       }
-      lCausalityPanel.add(panel);
+      casualtyPanel.add(panel);
     }
     return dependentUnitsReturned;
   }
@@ -615,18 +615,18 @@ public class BattleDisplay extends JPanel {
     casualtiesInstantPanelDefender.setLayout(new FlowLayout(FlowLayout.LEFT, 2, 2));
     casualtiesInstantPanelDefender.setBorder(new EtchedBorder(EtchedBorder.LOWERED));
     casualtiesInstantPanelDefender.add(labelNoneDefender);
-    final JPanel lInstantCasualtiesPanel = new JPanel();
-    lInstantCasualtiesPanel.setBorder(new EtchedBorder(EtchedBorder.LOWERED));
-    lInstantCasualtiesPanel.setLayout(new GridBagLayout());
-    final JLabel lCausalities = new JLabel("Casualties", SwingConstants.CENTER);
-    lCausalities.setFont(getPlayerComponent(attacker).getFont().deriveFont(Font.BOLD, 14));
-    lInstantCasualtiesPanel.add(lCausalities, new GridBagConstraints(0, 0, 2, 1, 1.0d, 1.0d, GridBagConstraints.CENTER,
-        GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
-    lInstantCasualtiesPanel.add(casualtiesInstantPanelAttacker, new GridBagConstraints(0, 2, 1, 1, 1.0d, 1.0d,
+    final JPanel instantCasualtiesPanel = new JPanel();
+    instantCasualtiesPanel.setBorder(new EtchedBorder(EtchedBorder.LOWERED));
+    instantCasualtiesPanel.setLayout(new GridBagLayout());
+    final JLabel casualtiesLabel = new JLabel("Casualties", SwingConstants.CENTER);
+    casualtiesLabel.setFont(getPlayerComponent(attacker).getFont().deriveFont(Font.BOLD, 14));
+    instantCasualtiesPanel.add(casualtiesLabel, new GridBagConstraints(0, 0, 2, 1, 1.0d, 1.0d,
         GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
-    lInstantCasualtiesPanel.add(casualtiesInstantPanelDefender, new GridBagConstraints(1, 2, 1, 1, 1.0d, 1.0d,
+    instantCasualtiesPanel.add(casualtiesInstantPanelAttacker, new GridBagConstraints(0, 2, 1, 1, 1.0d, 1.0d,
         GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
-    diceAndSteps.add(lInstantCasualtiesPanel, BorderLayout.SOUTH);
+    instantCasualtiesPanel.add(casualtiesInstantPanelDefender, new GridBagConstraints(1, 2, 1, 1, 1.0d, 1.0d,
+        GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
+    diceAndSteps.add(instantCasualtiesPanel, BorderLayout.SOUTH);
     setLayout(new BorderLayout());
     add(north, BorderLayout.NORTH);
     add(diceAndSteps, BorderLayout.CENTER);

--- a/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -763,8 +763,8 @@ public class MapPanel extends ImageScrollerLargeView {
         movementLeft.getFirst() + (movementLeft.getSecond() > movementLeft.getFirst() ? "+" : "");
     final Set<UnitCategory> categories = UnitSeperator.categorize(units);
     final int iconWidth = uiContext.getUnitImageFactory().getUnitImageWidth();
-    final int xSpace = 5;
-    final BufferedImage img = Util.createImage(categories.size() * (xSpace + iconWidth),
+    final int horizontalSpace = 5;
+    final BufferedImage img = Util.createImage(categories.size() * (horizontalSpace + iconWidth),
         uiContext.getUnitImageFactory().getUnitImageHeight(), true);
     final Graphics2D g = img.createGraphics();
     g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.6f));
@@ -776,7 +776,7 @@ public class MapPanel extends ImageScrollerLargeView {
     try {
       int i = 0;
       for (final UnitCategory category : categories) {
-        final Point place = new Point(i * (iconWidth + xSpace), 0);
+        final Point place = new Point(i * (iconWidth + horizontalSpace), 0);
         final UnitsDrawer drawer = new UnitsDrawer(category.getUnits().size(), category.getType().getName(),
             category.getOwner().getName(), place, category.getDamaged(), category.getBombingDamage(),
             category.getDisabled(), false, "", uiContext);

--- a/src/main/java/games/strategy/triplea/ui/MapRouteDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/MapRouteDrawer.java
@@ -66,28 +66,28 @@ public class MapRouteDrawer {
     graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
     final int numTerritories = route.getAllTerritories().size();
-    final int xOffset = mapPanel.getXOffset();
-    final int yOffset = mapPanel.getYOffset();
+    final int offsetX = mapPanel.getXOffset();
+    final int offsetY = mapPanel.getYOffset();
     final Point[] points = routeCalculator.getTranslatedRoute(getRoutePoints(routeDescription));
     final boolean tooFewTerritories = numTerritories <= 1;
     final boolean tooFewPoints = points.length <= 2;
     final double scale = mapPanel.getScale();
     if (tooFewTerritories || tooFewPoints) {
       if (routeDescription.getEnd() != null) { // AI has no End Point
-        drawDirectPath(graphics, new Point(routeDescription.getStart()), new Point(routeDescription.getEnd()), xOffset,
-            yOffset, scale);
+        drawDirectPath(graphics, new Point(routeDescription.getStart()), new Point(routeDescription.getEnd()), offsetX,
+            offsetY, scale);
       } else {
-        drawDirectPath(graphics, points[0], points[points.length - 1], xOffset, yOffset, scale);
+        drawDirectPath(graphics, points[0], points[points.length - 1], offsetX, offsetY, scale);
       }
       if (tooFewPoints && !tooFewTerritories) {
-        drawMoveLength(graphics, points, xOffset, yOffset, scale, numTerritories, maxMovement);
+        drawMoveLength(graphics, points, offsetX, offsetY, scale, numTerritories, maxMovement);
       }
     } else {
-      drawCurvedPath(graphics, points, xOffset, yOffset, scale);
-      drawMoveLength(graphics, points, xOffset, yOffset, scale, numTerritories, maxMovement);
+      drawCurvedPath(graphics, points, offsetX, offsetY, scale);
+      drawMoveLength(graphics, points, offsetX, offsetY, scale, numTerritories, maxMovement);
     }
-    drawJoints(graphics, points, xOffset, yOffset, scale);
-    drawCustomCursor(graphics, routeDescription, xOffset, yOffset, scale);
+    drawJoints(graphics, points, offsetX, offsetY, scale);
+    drawCustomCursor(graphics, routeDescription, offsetX, offsetY, scale);
   }
 
   /**
@@ -280,8 +280,8 @@ public class MapRouteDrawer {
     createMovementLeftImage(movementImage, String.valueOf(numTerritories - 1), unitMovementLeft);
 
     final int textXOffset = -movementImage.getWidth() / 2;
-    final double yDir = cursorPos.getY() - points[numTerritories - 2].getY();
-    final int textYOffset = yDir > 0 ? movementImage.getHeight() : movementImage.getHeight() * -2;
+    final double deltaY = cursorPos.getY() - points[numTerritories - 2].getY();
+    final int textYOffset = deltaY > 0 ? movementImage.getHeight() : movementImage.getHeight() * -2;
     for (Point[] cursorPositions : routeCalculator.getAllPoints(cursorPos)) {
       graphics.drawImage(movementImage,
           (int) ((cursorPositions[0].getX() + textXOffset - offsetX) * scale),

--- a/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -77,14 +77,14 @@ public class PoliticalStateOverview extends JPanel {
     // draw cells
     int x = 1;
     int y = 2;
-    for (final PlayerID pVertical : data.getPlayerList()) {
-      for (final PlayerID pHorizontal : data.getPlayerList()) {
-        if (pHorizontal.equals(pVertical)) {
+    for (final PlayerID verticalPlayer : data.getPlayerList()) {
+      for (final PlayerID horizontalPlayer : data.getPlayerList()) {
+        if (horizontalPlayer.equals(verticalPlayer)) {
           this.add(new JLabel(PoliticalStateOverview.LABEL_SELF), new GridBagConstraints(x++, y, 1, 1, 1.0, 1.0,
               GridBagConstraints.CENTER, GridBagConstraints.NONE, insets, 0, 0));
         } else {
-          this.add(getRelationshipLabel(pVertical, pHorizontal), new GridBagConstraints(x++, y, 1, 1, 1.0, 1.0,
-              GridBagConstraints.CENTER, GridBagConstraints.BOTH, insets, 0, 0));
+          this.add(getRelationshipLabel(verticalPlayer, horizontalPlayer), new GridBagConstraints(x++, y, 1, 1, 1.0,
+              1.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, insets, 0, 0));
         }
       }
       y = y + 2;

--- a/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
@@ -71,8 +71,8 @@ public class ProductionTabsProperties {
       return ruleLists;
     }
     ruleLists = new ArrayList<>();
-    final int iTabs = getNumberOfTabs();
-    for (int i = 1; i <= iTabs; i++) {
+    final int numberOfTabs = getNumberOfTabs();
+    for (int i = 1; i <= numberOfTabs; i++) {
       final String tabName = properties.getProperty(TAB_NAME + "." + i);
       final List<String> tabValues = Arrays.asList(properties.getProperty(TAB_UNITS + "." + i).split(":"));
       final List<Rule> ruleList = new ArrayList<>();

--- a/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -89,11 +89,11 @@ public final class ScreenshotExporter {
     try {
       // workaround to get the whole map
       // (otherwise the map is cut if current window is not on top of map)
-      final int xOffset = mapPanel.getXOffset();
-      final int yOffset = mapPanel.getYOffset();
+      final int offsetX = mapPanel.getXOffset();
+      final int offsetY = mapPanel.getYOffset();
       mapPanel.setTopLeft(0, 0);
       mapPanel.drawMapImage(mapGraphics);
-      mapPanel.setTopLeft(xOffset, yOffset);
+      mapPanel.setTopLeft(offsetX, offsetY);
       // overlay title
       Color titleColor = iuiContext.getMapData().getColorProperty(MapData.PROPERTY_SCREENSHOT_TITLE_COLOR);
       if (titleColor == null) {

--- a/src/main/java/games/strategy/util/PointFileReaderWriter.java
+++ b/src/main/java/games/strategy/util/PointFileReaderWriter.java
@@ -280,14 +280,14 @@ public class PointFileReaderWriter {
   }
 
   private static void createPolygonFromPoints(final Collection<Polygon> polygons, final ArrayList<Point> points) {
-    final int[] xPoints = new int[points.size()];
-    final int[] yPoints = new int[points.size()];
+    final int[] pointsX = new int[points.size()];
+    final int[] pointsY = new int[points.size()];
     for (int i = 0; i < points.size(); i++) {
       final Point p = points.get(i);
-      xPoints[i] = p.x;
-      yPoints[i] = p.y;
+      pointsX[i] = p.x;
+      pointsY[i] = p.y;
     }
-    polygons.add(new Polygon(xPoints, yPoints, xPoints.length));
+    polygons.add(new Polygon(pointsX, pointsY, pointsX.length));
   }
 
   private static void readMultiple(final String line, final HashMap<String, List<Point>> mapping) throws IOException {
@@ -298,13 +298,13 @@ public class PointFileReaderWriter {
     }
     final List<Point> points = new ArrayList<>();
     while (tokens.hasMoreTokens()) {
-      final String xString = tokens.nextToken(",(), ");
+      final String stringX = tokens.nextToken(",(), ");
       if (!tokens.hasMoreTokens()) {
         continue;
       }
-      final String yString = tokens.nextToken(",() ");
-      final int x = Integer.parseInt(xString);
-      final int y = Integer.parseInt(yString);
+      final String stringY = tokens.nextToken(",() ");
+      final int x = Integer.parseInt(stringX);
+      final int y = Integer.parseInt(stringY);
       points.add(new Point(x, y));
     }
     mapping.put(name, points);


### PR DESCRIPTION
This PR fixes violations of the Checkstyle LocalFinalVariableName rule by renaming local variables that have a single lowercase prefix (excluding the `rVal` local variables).

Please feel free to suggest any improvements to the new names that I chose.