### PR TITLE
Serialization proxy: Add proxy for ProductionFrontier

### DIFF
--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework;
 
 import games.strategy.internal.persistence.serializable.GameDataProxy;
 import games.strategy.internal.persistence.serializable.IntegerMapProxy;
+import games.strategy.internal.persistence.serializable.ProductionFrontierProxy;
 import games.strategy.internal.persistence.serializable.ProductionRuleProxy;
 import games.strategy.internal.persistence.serializable.PropertyBagMementoProxy;
 import games.strategy.internal.persistence.serializable.ResourceCollectionProxy;
@@ -22,6 +23,7 @@ final class ProxyRegistries {
     return ProxyRegistry.newInstance(
         GameDataProxy.FACTORY,
         IntegerMapProxy.FACTORY,
+        ProductionFrontierProxy.FACTORY,
         ProductionRuleProxy.FACTORY,
         PropertyBagMementoProxy.FACTORY,
         ResourceProxy.FACTORY,

--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework;
 
 import games.strategy.internal.persistence.serializable.GameDataProxy;
 import games.strategy.internal.persistence.serializable.IntegerMapProxy;
+import games.strategy.internal.persistence.serializable.ProductionRuleProxy;
 import games.strategy.internal.persistence.serializable.PropertyBagMementoProxy;
 import games.strategy.internal.persistence.serializable.ResourceCollectionProxy;
 import games.strategy.internal.persistence.serializable.ResourceProxy;
@@ -21,6 +22,7 @@ final class ProxyRegistries {
     return ProxyRegistry.newInstance(
         GameDataProxy.FACTORY,
         IntegerMapProxy.FACTORY,
+        ProductionRuleProxy.FACTORY,
         PropertyBagMementoProxy.FACTORY,
         ResourceProxy.FACTORY,
         ResourceCollectionProxy.FACTORY,

--- a/src/main/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxy.java
@@ -1,0 +1,42 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.List;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.ProductionFrontier;
+import games.strategy.engine.data.ProductionRule;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+import net.jcip.annotations.Immutable;
+
+/**
+ * A serializable proxy for the {@link ProductionFrontier} class.
+ */
+@Immutable
+public final class ProductionFrontierProxy implements Proxy {
+  private static final long serialVersionUID = 4785506781105056191L;
+
+  public static final ProxyFactory FACTORY =
+      ProxyFactory.newInstance(ProductionFrontier.class, ProductionFrontierProxy::new);
+
+  private final GameData gameData;
+  private final String name;
+  private final List<ProductionRule> rules;
+
+  public ProductionFrontierProxy(final ProductionFrontier productionFrontier) {
+    checkNotNull(productionFrontier);
+
+    gameData = productionFrontier.getData();
+    name = productionFrontier.getName();
+    rules = productionFrontier.getRules();
+  }
+
+  @Override
+  public Object readResolve() {
+    final ProductionFrontier productionFrontier = new ProductionFrontier(name, gameData);
+    rules.forEach(productionFrontier::addRule);
+    return productionFrontier;
+  }
+}

--- a/src/main/java/games/strategy/internal/persistence/serializable/ProductionRuleProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ProductionRuleProxy.java
@@ -1,0 +1,41 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.NamedAttachable;
+import games.strategy.engine.data.ProductionRule;
+import games.strategy.engine.data.Resource;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.util.IntegerMap;
+import net.jcip.annotations.Immutable;
+
+/**
+ * A serializable proxy for the {@link ProductionRule} class.
+ */
+@Immutable
+public final class ProductionRuleProxy implements Proxy {
+  private static final long serialVersionUID = 3541658838672456487L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(ProductionRule.class, ProductionRuleProxy::new);
+
+  private final IntegerMap<Resource> costs;
+  private final GameData gameData;
+  private final String name;
+  private final IntegerMap<NamedAttachable> results;
+
+  public ProductionRuleProxy(final ProductionRule productionRule) {
+    checkNotNull(productionRule);
+
+    costs = productionRule.getCosts();
+    gameData = productionRule.getData();
+    name = productionRule.getName();
+    results = productionRule.getResults();
+  }
+
+  @Override
+  public Object readResolve() {
+    return new ProductionRule(name, gameData, results, costs);
+  }
+}

--- a/src/test/java/games/strategy/engine/data/GameDataMementoTest.java
+++ b/src/test/java/games/strategy/engine/data/GameDataMementoTest.java
@@ -3,7 +3,7 @@ package games.strategy.engine.data;
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
-import static games.strategy.engine.data.Matchers.equalToGameData;
+import static games.strategy.engine.data.Matchers.equalTo;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -29,7 +29,7 @@ public final class GameDataMementoTest {
     final Memento memento = mementoExporter.exportMemento(expected);
     final GameData actual = mementoImporter.importMemento(memento);
 
-    assertThat(actual, is(equalToGameData(expected)));
+    assertThat(actual, is(equalTo(expected)));
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/data/Matchers.java
+++ b/src/test/java/games/strategy/engine/data/Matchers.java
@@ -1,39 +1,198 @@
 package games.strategy.engine.data;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
-import java.util.Objects;
+import javax.annotation.Nullable;
 
+import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
+
+import com.google.common.reflect.TypeToken;
+
+import games.strategy.util.IntegerMap;
 
 /**
  * A collection of matchers for types in the {@link games.strategy.engine.data} package.
  */
 public final class Matchers {
+  private static final Map<Class<?>, EqualityComparator<Object>> EQUALITY_COMPARATORS_BY_TYPE =
+      createEqualityComparatorsByType();
+
   private Matchers() {}
 
+  @FunctionalInterface
+  private interface EqualityComparator<T> {
+    boolean equals(T o1, T o2);
+  }
+
+  private static Map<Class<?>, EqualityComparator<Object>> createEqualityComparatorsByType() {
+    final Map<Class<?>, EqualityComparator<Object>> equalityComparatorsByType = new HashMap<>();
+    addTypeSafeEqualityComparator(equalityComparatorsByType, Collection.class, Matchers::collectionEquals);
+    addTypeSafeEqualityComparator(equalityComparatorsByType, GameData.class, Matchers::gameDataEquals);
+    addTypeSafeEqualityComparator(equalityComparatorsByType, IntegerMap.class, Matchers::integerMapEquals);
+    addTypeSafeEqualityComparator(equalityComparatorsByType, Map.class, Matchers::mapEquals);
+    addTypeSafeEqualityComparator(equalityComparatorsByType, ProductionFrontier.class,
+        Matchers::productionFrontierEquals);
+    addTypeSafeEqualityComparator(equalityComparatorsByType, ProductionRule.class, Matchers::productionRuleEquals);
+    addTypeSafeEqualityComparator(equalityComparatorsByType, Resource.class, Matchers::resourceEquals);
+    addTypeSafeEqualityComparator(equalityComparatorsByType, ResourceCollection.class,
+        Matchers::resourceCollectionEquals);
+    return Collections.unmodifiableMap(equalityComparatorsByType);
+  }
+
+  private static <T> void addTypeSafeEqualityComparator(
+      final Map<Class<?>, EqualityComparator<Object>> equalityComparatorsByType,
+      final Class<T> type,
+      final EqualityComparator<T> equalityComparator) {
+    final EqualityComparator<Object> typeSafeEqualityComparator = (o1, o2) -> {
+      try {
+        return equalityComparator.equals(type.cast(o1), type.cast(o2));
+      } catch (final ClassCastException e) {
+        return false;
+      }
+    };
+    equalityComparatorsByType.put(type, typeSafeEqualityComparator);
+  }
+
+  private static boolean collectionEquals(final Collection<?> o1, final Collection<?> o2) {
+    if (o1.size() != o2.size()) {
+      return false;
+    }
+
+    final Iterator<?> o1Iterator = o1.iterator();
+    final Iterator<?> o2Iterator = o2.iterator();
+    while (o1Iterator.hasNext()) {
+      if (!equals(o1Iterator.next(), o2Iterator.next())) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private static boolean gameDataEquals(final GameData o1, final GameData o2) {
+    return (o1.getDiceSides() == o2.getDiceSides())
+        && areBothNullOrBothNotNull(o1.getGameLoader(), o2.getGameLoader())
+        && equals(o1.getGameName(), o2.getGameName())
+        && equals(o1.getGameVersion(), o2.getGameVersion());
+  }
+
+  private static boolean areBothNullOrBothNotNull(final Object o1, final Object o2) {
+    return (o1 == null) == (o2 == null);
+  }
+
+  private static boolean integerMapEquals(final IntegerMap<?> o1, final IntegerMap<?> o2) {
+    return mapEquals(o1.toMap(), o2.toMap());
+  }
+
+  private static boolean mapEquals(final Map<?, ?> o1, final Map<?, ?> o2) {
+    if (o1.size() != o2.size()) {
+      return false;
+    }
+
+    for (final Map.Entry<?, ?> entry1 : o1.entrySet()) {
+      // NB: We can't simply lookup key1 in o2 because that will use Object#equals() instead of the EqualityComparator
+      boolean key1Found = false;
+      for (final Map.Entry<?, ?> entry2 : o2.entrySet()) {
+        if (equals(entry1.getKey(), entry2.getKey())) {
+          key1Found = true;
+          if (!equals(entry1.getValue(), entry2.getValue())) {
+            return false;
+          }
+          break;
+        }
+      }
+
+      if (!key1Found) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private static boolean productionFrontierEquals(final ProductionFrontier o1, final ProductionFrontier o2) {
+    return equals(o1.getData(), o2.getData())
+        && equals(o1.getName(), o2.getName())
+        && equals(o1.getRules(), o2.getRules());
+  }
+
+  private static boolean productionRuleEquals(final ProductionRule o1, final ProductionRule o2) {
+    return equals(o1.getData(), o2.getData())
+        && equals(o1.getName(), o2.getName())
+        && equals(o1.getCosts(), o2.getCosts())
+        && equals(o1.getResults(), o2.getResults());
+  }
+
+  private static boolean resourceEquals(final Resource o1, final Resource o2) {
+    return equals(o1.getAttachments(), o2.getAttachments())
+        && equals(o1.getData(), o2.getData())
+        && equals(o1.getName(), o2.getName());
+  }
+
+  private static boolean resourceCollectionEquals(final ResourceCollection o1, final ResourceCollection o2) {
+    return equals(o1.getData(), o2.getData())
+        && equals(o1.getResourcesCopy(), o2.getResourcesCopy());
+  }
+
+  private static boolean equals(final Object o1, final Object o2) {
+    if (o1 == o2) {
+      return true;
+    } else if (o1 == null) {
+      return o2 == null;
+    } else if (o2 == null) {
+      return false; // o1 cannot be null here
+    }
+
+    return getEqualityComparatorFor(o1.getClass()).equals(o1, o2);
+  }
+
+  private static EqualityComparator<Object> getEqualityComparatorFor(final Class<?> type) {
+    // first try concrete type
+    EqualityComparator<Object> equalityComparator = EQUALITY_COMPARATORS_BY_TYPE.get(type);
+    if (equalityComparator != null) {
+      return equalityComparator;
+    }
+
+    // then try any declared or inherited interface
+    for (final TypeToken<?> typeToken : TypeToken.of(type).getTypes().interfaces()) {
+      equalityComparator = EQUALITY_COMPARATORS_BY_TYPE.get(typeToken.getRawType());
+      if (equalityComparator != null) {
+        return equalityComparator;
+      }
+    }
+
+    // otherwise delegate to Object#equals
+    return (o1, o2) -> o1.equals(o2);
+  }
+
   /**
-   * Creates a matcher that matches when the examined {@link GameData} is logically equal to the specified
-   * {@link GameData}.
+   * Creates a matcher that matches when the examined object is logically equal to the specified object.
    *
-   * @param expected The expected {@link GameData} value.
+   * <p>
+   * The returned matcher uses the registered {@link EqualityComparator}s to determine if the objects are equal. If a
+   * comparator is not available for a particular type, a default comparator based on {@link Object#equals(Object)} will
+   * be used instead. Developers can extend the {@link Matchers#EQUALITY_COMPARATORS_BY_TYPE} map with their own custom
+   * comparators, as needed.
+   * </p>
+   *
+   * @param expected The expected value.
    *
    * @return A new matcher.
    */
-  public static Matcher<GameData> equalToGameData(final GameData expected) {
-    checkNotNull(expected);
-
-    return new IsGameDataEqual(expected);
+  public static <T> Matcher<T> equalTo(final @Nullable T expected) {
+    return new IsEqual<>(expected);
   }
 
-  private static final class IsGameDataEqual extends TypeSafeMatcher<GameData> {
-    private final GameData expected;
+  private static final class IsEqual<T> extends BaseMatcher<T> {
+    private final Object expected;
 
-    IsGameDataEqual(final GameData expected) {
-      assert expected != null;
-
+    IsEqual(final @Nullable Object expected) {
       this.expected = expected;
     }
 
@@ -43,123 +202,8 @@ public final class Matchers {
     }
 
     @Override
-    protected boolean matchesSafely(final GameData actual) {
-      return (expected.getDiceSides() == actual.getDiceSides())
-          && areBothNullOrBothNotNull(expected.getGameLoader(), actual.getGameLoader())
-          && Objects.equals(expected.getGameName(), actual.getGameName())
-          && Objects.equals(expected.getGameVersion(), actual.getGameVersion());
-      // TODO: include remaining fields
-    }
-
-    private static boolean areBothNullOrBothNotNull(final Object expected, final Object actual) {
-      return (expected == null) == (actual == null);
-    }
-  }
-
-  /**
-   * Creates a matcher that matches when the examined {@link ProductionRule} is logically equal to the specified
-   * {@link ProductionRule}.
-   *
-   * @param expected The expected {@link ProductionRule} value.
-   *
-   * @return A new matcher.
-   */
-  public static Matcher<ProductionRule> equalToProductionRule(final ProductionRule expected) {
-    checkNotNull(expected);
-
-    return new IsProductionRuleEqual(expected);
-  }
-
-  private static final class IsProductionRuleEqual extends TypeSafeMatcher<ProductionRule> {
-    private final ProductionRule expected;
-
-    IsProductionRuleEqual(final ProductionRule expected) {
-      assert expected != null;
-
-      this.expected = expected;
-    }
-
-    @Override
-    public void describeTo(final Description description) {
-      description.appendValue(expected);
-    }
-
-    @Override
-    protected boolean matchesSafely(final ProductionRule actual) {
-      return equalToGameData(expected.getData()).matches(actual.getData())
-          && Objects.equals(expected.getName(), actual.getName())
-          && Objects.equals(expected.getCosts(), actual.getCosts())
-          && Objects.equals(expected.getResults(), actual.getResults());
-    }
-  }
-
-  /**
-   * Creates a matcher that matches when the examined {@link Resource} is logically equal to the specified
-   * {@link Resource}.
-   *
-   * @param expected The expected {@link Resource} value.
-   *
-   * @return A new matcher.
-   */
-  public static Matcher<Resource> equalToResource(final Resource expected) {
-    checkNotNull(expected);
-
-    return new IsResourceEqual(expected);
-  }
-
-  private static final class IsResourceEqual extends TypeSafeMatcher<Resource> {
-    private final Resource expected;
-
-    IsResourceEqual(final Resource expected) {
-      assert expected != null;
-
-      this.expected = expected;
-    }
-
-    @Override
-    public void describeTo(final Description description) {
-      description.appendValue(expected);
-    }
-
-    @Override
-    protected boolean matchesSafely(final Resource actual) {
-      return Objects.equals(expected.getAttachments(), actual.getAttachments())
-          && equalToGameData(expected.getData()).matches(actual.getData())
-          && Objects.equals(expected.getName(), actual.getName());
-    }
-  }
-
-  /**
-   * Creates a matcher that matches when the examined {@link ResourceCollection} is logically equal to the specified
-   * {@link ResourceCollection}.
-   *
-   * @param expected The expected {@link ResourceCollection} value.
-   *
-   * @return A new matcher.
-   */
-  public static Matcher<ResourceCollection> equalToResourceCollection(final ResourceCollection expected) {
-    checkNotNull(expected);
-
-    return new IsResourceCollectionEqual(expected);
-  }
-
-  private static final class IsResourceCollectionEqual extends TypeSafeMatcher<ResourceCollection> {
-    private final ResourceCollection expected;
-
-    IsResourceCollectionEqual(final ResourceCollection expected) {
-      assert expected != null;
-
-      this.expected = expected;
-    }
-
-    @Override
-    public void describeTo(final Description description) {
-      description.appendValue(expected);
-    }
-
-    @Override
-    protected boolean matchesSafely(final ResourceCollection actual) {
-      return Objects.equals(expected.getResourcesCopy(), actual.getResourcesCopy());
+    public boolean matches(final Object actual) {
+      return Matchers.equals(expected, actual);
     }
   }
 }

--- a/src/test/java/games/strategy/engine/data/Matchers.java
+++ b/src/test/java/games/strategy/engine/data/Matchers.java
@@ -57,6 +57,43 @@ public final class Matchers {
   }
 
   /**
+   * Creates a matcher that matches when the examined {@link ProductionRule} is logically equal to the specified
+   * {@link ProductionRule}.
+   *
+   * @param expected The expected {@link ProductionRule} value.
+   *
+   * @return A new matcher.
+   */
+  public static Matcher<ProductionRule> equalToProductionRule(final ProductionRule expected) {
+    checkNotNull(expected);
+
+    return new IsProductionRuleEqual(expected);
+  }
+
+  private static final class IsProductionRuleEqual extends TypeSafeMatcher<ProductionRule> {
+    private final ProductionRule expected;
+
+    IsProductionRuleEqual(final ProductionRule expected) {
+      assert expected != null;
+
+      this.expected = expected;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+      description.appendValue(expected);
+    }
+
+    @Override
+    protected boolean matchesSafely(final ProductionRule actual) {
+      return equalToGameData(expected.getData()).matches(actual.getData())
+          && Objects.equals(expected.getName(), actual.getName())
+          && Objects.equals(expected.getCosts(), actual.getCosts())
+          && Objects.equals(expected.getResults(), actual.getResults());
+    }
+  }
+
+  /**
    * Creates a matcher that matches when the examined {@link Resource} is logically equal to the specified
    * {@link Resource}.
    *

--- a/src/test/java/games/strategy/engine/data/TestGameDataComponentFactory.java
+++ b/src/test/java/games/strategy/engine/data/TestGameDataComponentFactory.java
@@ -1,10 +1,35 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import games.strategy.util.IntegerMap;
+
 /**
  * A factory for creating game data component instances for use in tests.
  */
 public final class TestGameDataComponentFactory {
   private TestGameDataComponentFactory() {}
+
+  /**
+   * Creates a new {@link ProductionRule} instance.
+   *
+   * @param gameData The game data associated with the production rule.
+   * @param name The production rule name.
+   *
+   * @return A new {@link ProductionRule} instance.
+   */
+  public static ProductionRule newProductionRule(final GameData gameData, final String name) {
+    checkNotNull(gameData);
+    checkNotNull(name);
+
+    final IntegerMap<NamedAttachable> resources = new IntegerMap<>();
+    resources.add(newResource(gameData, "resource1"), 11);
+    resources.add(newResource(gameData, "resource2"), 22);
+    final IntegerMap<Resource> costs = new IntegerMap<>();
+    costs.add(newResource(gameData, "resource3"), 33);
+    costs.add(newResource(gameData, "resource4"), 44);
+    return new ProductionRule(name, gameData, resources, costs);
+  }
 
   /**
    * Creates a new {@link Resource} instance.
@@ -15,6 +40,9 @@ public final class TestGameDataComponentFactory {
    * @return A new {@link Resource} instance.
    */
   public static Resource newResource(final GameData gameData, final String name) {
+    checkNotNull(gameData);
+    checkNotNull(name);
+
     final Resource resource = new Resource(name, gameData);
     resource.addAttachment("key1", new FakeAttachment("attachment1"));
     resource.addAttachment("key2", new FakeAttachment("attachment2"));

--- a/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.framework;
 
-import static games.strategy.engine.data.Matchers.equalToGameData;
+import static games.strategy.engine.data.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -38,7 +38,7 @@ public class GameDataManagerTest {
     final byte[] bytes = saveGameInProxySerializationFormat(expected);
     final GameData actual = loadGameInProxySerializationFormat(bytes);
 
-    assertThat(actual, is(equalToGameData(expected)));
+    assertThat(actual, is(equalTo(expected)));
   }
 
   private static byte[] saveGameInProxySerializationFormat(final GameData gameData) throws Exception {

--- a/src/test/java/games/strategy/internal/persistence/serializable/GameDataProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/GameDataProxyAsProxyTest.java
@@ -1,7 +1,6 @@
 package games.strategy.internal.persistence.serializable;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static games.strategy.engine.data.Matchers.equalToGameData;
+import static games.strategy.engine.data.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -20,10 +19,7 @@ public final class GameDataProxyAsProxyTest extends AbstractProxyTestCase<GameDa
 
   @Override
   protected void assertPrincipalEquals(final GameData expected, final GameData actual) {
-    checkNotNull(expected);
-    checkNotNull(actual);
-
-    assertThat(actual, is(equalToGameData(expected)));
+    assertThat(actual, is(equalTo(expected)));
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxyAsProxyTest.java
@@ -1,0 +1,49 @@
+package games.strategy.internal.persistence.serializable;
+
+import static games.strategy.engine.data.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.ProductionFrontier;
+import games.strategy.engine.data.TestGameDataComponentFactory;
+import games.strategy.engine.data.TestGameDataFactory;
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+public final class ProductionFrontierProxyAsProxyTest extends AbstractProxyTestCase<ProductionFrontier> {
+  public ProductionFrontierProxyAsProxyTest() {
+    super(ProductionFrontier.class);
+  }
+
+  @Override
+  protected void assertPrincipalEquals(final ProductionFrontier expected, final ProductionFrontier actual) {
+    assertThat(actual, is(equalTo(expected)));
+  }
+
+  @Override
+  protected Collection<ProductionFrontier> createPrincipals() {
+    return Arrays.asList(newProductionFrontier());
+  }
+
+  private static ProductionFrontier newProductionFrontier() {
+    final GameData gameData = TestGameDataFactory.newValidGameData();
+    final ProductionFrontier productionFrontier = new ProductionFrontier("productionFrontier", gameData);
+    productionFrontier.addRule(TestGameDataComponentFactory.newProductionRule(gameData, "productionRule1"));
+    productionFrontier.addRule(TestGameDataComponentFactory.newProductionRule(gameData, "productionRule2"));
+    return productionFrontier;
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getProxyFactories() {
+    return TestProxyFactoryCollectionBuilder.forGameData()
+        .add(IntegerMapProxy.FACTORY)
+        .add(ProductionFrontierProxy.FACTORY)
+        .add(ProductionRuleProxy.FACTORY)
+        .add(ResourceProxy.FACTORY)
+        .build();
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/ProductionRuleProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ProductionRuleProxyAsProxyTest.java
@@ -1,0 +1,58 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static games.strategy.engine.data.Matchers.equalToProductionRule;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.NamedAttachable;
+import games.strategy.engine.data.ProductionRule;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.TestGameDataComponentFactory;
+import games.strategy.engine.data.TestGameDataFactory;
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.util.IntegerMap;
+
+public final class ProductionRuleProxyAsProxyTest extends AbstractProxyTestCase<ProductionRule> {
+  public ProductionRuleProxyAsProxyTest() {
+    super(ProductionRule.class);
+  }
+
+  @Override
+  protected void assertPrincipalEquals(final ProductionRule expected, final ProductionRule actual) {
+    checkNotNull(expected);
+    checkNotNull(actual);
+
+    assertThat(actual, is(equalToProductionRule(expected)));
+  }
+
+  @Override
+  protected Collection<ProductionRule> createPrincipals() {
+    return Arrays.asList(newProductionRule());
+  }
+
+  private static ProductionRule newProductionRule() {
+    final GameData gameData = TestGameDataFactory.newValidGameData();
+    final IntegerMap<NamedAttachable> resources = new IntegerMap<>();
+    resources.add(TestGameDataComponentFactory.newResource(gameData, "resource1"), 11);
+    resources.add(TestGameDataComponentFactory.newResource(gameData, "resource2"), 22);
+    final IntegerMap<Resource> costs = new IntegerMap<>();
+    costs.add(TestGameDataComponentFactory.newResource(gameData, "resource3"), 33);
+    costs.add(TestGameDataComponentFactory.newResource(gameData, "resource4"), 44);
+    return new ProductionRule("productionRule", gameData, resources, costs);
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getProxyFactories() {
+    return TestProxyFactoryCollectionBuilder.forGameData()
+        .add(IntegerMapProxy.FACTORY)
+        .add(ProductionRuleProxy.FACTORY)
+        .add(ResourceProxy.FACTORY)
+        .build();
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/ProductionRuleProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ProductionRuleProxyAsProxyTest.java
@@ -1,22 +1,17 @@
 package games.strategy.internal.persistence.serializable;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static games.strategy.engine.data.Matchers.equalToProductionRule;
+import static games.strategy.engine.data.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.NamedAttachable;
 import games.strategy.engine.data.ProductionRule;
-import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.TestGameDataComponentFactory;
 import games.strategy.engine.data.TestGameDataFactory;
 import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
-import games.strategy.util.IntegerMap;
 
 public final class ProductionRuleProxyAsProxyTest extends AbstractProxyTestCase<ProductionRule> {
   public ProductionRuleProxyAsProxyTest() {
@@ -25,26 +20,14 @@ public final class ProductionRuleProxyAsProxyTest extends AbstractProxyTestCase<
 
   @Override
   protected void assertPrincipalEquals(final ProductionRule expected, final ProductionRule actual) {
-    checkNotNull(expected);
-    checkNotNull(actual);
-
-    assertThat(actual, is(equalToProductionRule(expected)));
+    assertThat(actual, is(equalTo(expected)));
   }
 
   @Override
   protected Collection<ProductionRule> createPrincipals() {
-    return Arrays.asList(newProductionRule());
-  }
-
-  private static ProductionRule newProductionRule() {
-    final GameData gameData = TestGameDataFactory.newValidGameData();
-    final IntegerMap<NamedAttachable> resources = new IntegerMap<>();
-    resources.add(TestGameDataComponentFactory.newResource(gameData, "resource1"), 11);
-    resources.add(TestGameDataComponentFactory.newResource(gameData, "resource2"), 22);
-    final IntegerMap<Resource> costs = new IntegerMap<>();
-    costs.add(TestGameDataComponentFactory.newResource(gameData, "resource3"), 33);
-    costs.add(TestGameDataComponentFactory.newResource(gameData, "resource4"), 44);
-    return new ProductionRule("productionRule", gameData, resources, costs);
+    return Arrays.asList(TestGameDataComponentFactory.newProductionRule(
+        TestGameDataFactory.newValidGameData(),
+        "productionRule"));
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxyAsProxyTest.java
@@ -1,7 +1,6 @@
 package games.strategy.internal.persistence.serializable;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static games.strategy.engine.data.Matchers.equalToResourceCollection;
+import static games.strategy.engine.data.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -22,10 +21,7 @@ public final class ResourceCollectionProxyAsProxyTest extends AbstractProxyTestC
 
   @Override
   protected void assertPrincipalEquals(final ResourceCollection expected, final ResourceCollection actual) {
-    checkNotNull(expected);
-    checkNotNull(actual);
-
-    assertThat(actual, is(equalToResourceCollection(expected)));
+    assertThat(actual, is(equalTo(expected)));
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/ResourceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ResourceProxyAsProxyTest.java
@@ -1,7 +1,6 @@
 package games.strategy.internal.persistence.serializable;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static games.strategy.engine.data.Matchers.equalToResource;
+import static games.strategy.engine.data.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -21,10 +20,7 @@ public final class ResourceProxyAsProxyTest extends AbstractProxyTestCase<Resour
 
   @Override
   protected void assertPrincipalEquals(final Resource expected, final Resource actual) {
-    checkNotNull(expected);
-    checkNotNull(actual);
-
-    assertThat(actual, is(equalToResource(expected)));
+    assertThat(actual, is(equalTo(expected)));
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/TripleAProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/TripleAProxyAsProxyTest.java
@@ -1,6 +1,5 @@
 package games.strategy.internal.persistence.serializable;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -17,9 +16,6 @@ public final class TripleAProxyAsProxyTest extends AbstractProxyTestCase<TripleA
 
   @Override
   protected void assertPrincipalEquals(final TripleA expected, final TripleA actual) {
-    checkNotNull(expected);
-    checkNotNull(actual);
-
     assertTrue("no persistent state; all non-null instances are considered equal", true);
   }
 

--- a/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
+++ b/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
@@ -46,9 +46,6 @@ public abstract class AbstractProxyTestCase<T> {
    * @throws AssertionError If the two principals are not equal.
    */
   protected void assertPrincipalEquals(final T expected, final T actual) {
-    checkNotNull(expected);
-    checkNotNull(actual);
-
     assertThat(actual, is(expected));
   }
 


### PR DESCRIPTION
This PR adds a serialization proxy for `ProductionFrontier` and its dependency `ProductionRule`.

Note that this PR contains some significant changes in the `Matchers` class.  I discovered that `DefaultNamed`, which is an ancestor of a number of `GameDataComponent` types, implements `equals()`, but only in terms of the `m_name` field.  Thus, other fields (especially in subclasses) may differ between two instances, but as long as the instances have the same name, they are considered equal.  This caused some false positives when testing if a deserialized object was equal to the original object that was serialized.

`Matchers` already contained custom equality comparators for several types, but they were mostly shallow (e.g. they didn't properly handle collections of types that required custom equality comparators, and thus ended up delegating to `equals()`).  I ended up modifying the matchers in this class to perform a deep equality check while always using the custom equality comparators.

I think there are a few smells left in `Matchers`, and I plan on addressing them immediately after this PR is merged.  Specifically, I don't like that this class is becoming a kitchen sink for every custom equality comparator.  I have some ideas for how to better structure things, and I welcome any additional suggestions.  If it's not clear from the code, this is all test code and doesn't affect production in any way.