### PR TITLE
Run Map Creator UI startup code on EDT (#2213)

### DIFF
--- a/src/main/java/games/strategy/ui/SwingAction.java
+++ b/src/main/java/games/strategy/ui/SwingAction.java
@@ -1,5 +1,7 @@
 package games.strategy.ui;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.awt.event.ActionEvent;
 import java.lang.reflect.InvocationTargetException;
 import java.util.function.Consumer;
@@ -8,7 +10,6 @@ import javax.swing.AbstractAction;
 import javax.swing.SwingUtilities;
 
 import games.strategy.debug.ClientLogger;
-
 
 /**
  * Builder class for using Lambda expressions to create 'AbstractAction'
@@ -60,17 +61,28 @@ public class SwingAction {
     };
   }
 
+  /**
+   * Synchronously executes the specified action on the Swing event dispatch thread.
+   *
+   * <p>
+   * This method may safely be called from any thread, including the Swing event dispatch thread.
+   * </p>
+   *
+   * @param action The action to execute.
+   */
   public static void invokeAndWait(final Runnable action) {
+    checkNotNull(action);
+
     try {
       if (SwingUtilities.isEventDispatchThread()) {
         action.run();
       } else {
-        SwingUtilities.invokeAndWait(() -> action.run());
+        SwingUtilities.invokeAndWait(action);
       }
     } catch (final InvocationTargetException e) {
       ClientLogger.logError(e);
     } catch (final InterruptedException e) {
-      ClientLogger.logQuietly(e);
+      Thread.currentThread().interrupt();
     }
   }
 }

--- a/src/main/java/tools/map/making/MapCreator.java
+++ b/src/main/java/tools/map/making/MapCreator.java
@@ -75,10 +75,13 @@ public class MapCreator extends JFrame {
 
   public static void main(final String[] args) {
     LookAndFeel.setupLookAndFeel();
-    final MapCreator creator = new MapCreator();
-    creator.setSize(800, 600);
-    creator.setLocationRelativeTo(null);
-    creator.setVisible(true);
+
+    SwingAction.invokeAndWait(() -> {
+      final MapCreator creator = new MapCreator();
+      creator.setSize(800, 600);
+      creator.setLocationRelativeTo(null);
+      creator.setVisible(true);
+    });
   }
 
   private MapCreator() {


### PR DESCRIPTION
This PR fixes the UI threading violation exceptions reported in #2213 when starting the Map Creator using the Substance L&F.

#### Functional changes

I forced the UI startup code in `MapCreator#main()` to run on the EDT.

#### Refactoring changes

I did some minor cleanup of the `SwingAction#invokeAndWait()` method while I was here.  The changes should be self-explanatory.

#### Testing

I verified starting the Map Creator using both the Substance and Nimbus L&Fs produces no errors in the console.