### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 1)

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -462,7 +462,7 @@ class ProNonCombatMoveAI {
       double unitOwnerMultiplier = 1;
       if (Match.noneMatch(moveMap.get(t).getCantMoveUnits(), Matches.unitIsOwnedBy(player))) {
         if (t.isWater()
-            && Match.noneMatch(moveMap.get(t).getCantMoveUnits(), Matches.UnitIsTransportButNotCombatTransport)) {
+            && Match.noneMatch(moveMap.get(t).getCantMoveUnits(), Matches.unitIsTransportButNotCombatTransport())) {
           unitOwnerMultiplier = 0;
         } else {
           unitOwnerMultiplier = 0.5;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -761,7 +761,7 @@ class ProPurchaseAI {
       final List<ProPlaceTerritory> prioritizedLandTerritories, final ProPurchaseOptionMap purchaseOptions,
       final Map<Territory, Double> territoryValueMap) {
 
-    final List<Unit> unplacedUnits = player.getUnits().getMatches(Matches.UnitIsNotSea);
+    final List<Unit> unplacedUnits = player.getUnits().getMatches(Matches.unitIsNotSea());
     if (resourceTracker.isEmpty() && unplacedUnits.isEmpty()) {
       return;
     }
@@ -1068,7 +1068,7 @@ class ProPurchaseAI {
       units.addAll(ProPurchaseUtils.getPlaceUnits(t, purchaseTerritories));
       final List<Unit> myUnits = Match.getMatches(units, Matches.unitIsOwnedBy(player));
       final int numMyTransports = Match.countMatches(myUnits, Matches.UnitIsTransport);
-      final int numSeaDefenders = Match.countMatches(units, Matches.UnitIsNotTransport);
+      final int numSeaDefenders = Match.countMatches(units, Matches.unitIsNotTransport());
 
       // Determine needed defense strength
       int needDefenders = 0;
@@ -1779,7 +1779,7 @@ class ProPurchaseAI {
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories, final ProPurchaseOptionMap purchaseOptions) {
 
     ProLogger.info("Populate production rule map");
-    final List<Unit> unplacedUnits = player.getUnits().getMatches(Matches.UnitIsNotSea);
+    final List<Unit> unplacedUnits = player.getUnits().getMatches(Matches.unitIsNotSea());
     final IntegerMap<ProductionRule> purchaseMap = new IntegerMap<>();
     for (final ProPurchaseOption ppo : purchaseOptions.getAllOptions()) {
       int numUnits = 0;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -253,7 +253,7 @@ final class ProTechAI {
       if (onWater) {
         final Iterator<Unit> enemyWaterUnitsIter = enemyWaterUnits.iterator();
         while (enemyWaterUnitsIter.hasNext() && !nonTransportsInAttack) {
-          if (Matches.UnitIsNotTransport.match(enemyWaterUnitsIter.next())) {
+          if (Matches.unitIsNotTransport().match(enemyWaterUnitsIter.next())) {
             nonTransportsInAttack = true;
           }
         }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
@@ -89,7 +89,7 @@ public class ProPurchaseOptionMap {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         airOptions.add(ppo);
         ProLogger.debug("Air: " + ppo);
-      } else if (Matches.UnitTypeIsSea.match(unitType)) {
+      } else if (Matches.unitTypeIsSea().match(unitType)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         if (!ppo.isSub()) {
           seaDefenseOptions.add(ppo);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProBattleUtils.java
@@ -82,7 +82,7 @@ public class ProBattleUtils {
     List<Unit> unitsThatCanFight =
         Match.getMatches(myUnits, Matches.unitCanBeInBattle(attacking, !t.isWater(), 1, false, true, true));
     if (Properties.getTransportCasualtiesRestricted(data)) {
-      unitsThatCanFight = Match.getMatches(unitsThatCanFight, Matches.UnitIsTransportButNotCombatTransport.invert());
+      unitsThatCanFight = Match.getMatches(unitsThatCanFight, Matches.unitIsTransportButNotCombatTransport().invert());
     }
     final int myHitPoints = BattleCalculator.getTotalHitpointsLeft(unitsThatCanFight);
     final double myPower = estimatePower(t, myUnits, enemyUnits, attacking);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -507,7 +507,7 @@ public class ProMatches {
       if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
         return false;
       }
-      final Match<Unit> match = Match.allOf(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved,
+      final Match<Unit> match = Match.allOf(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved(),
           Matches.unitHasMovementLeft, Matches.unitIsBeingTransported().invert());
       return match.match(u);
     });

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -272,7 +272,7 @@ public class WeakAI extends AbstractAI {
     firstSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(0);
     lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     final Match<Unit> ownedAndNotMoved =
-        Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved, Transporting);
+        Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved(), Transporting);
     final List<Unit> unitsToMove = new ArrayList<>();
     final List<Unit> transports = firstSeaZoneOnAmphib.getUnits().getMatches(ownedAndNotMoved);
     if (transports.size() <= maxTrans) {
@@ -303,7 +303,7 @@ public class WeakAI extends AbstractAI {
       firstSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(1);
       lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     }
-    final Match<Unit> ownedAndNotMoved = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved);
+    final Match<Unit> ownedAndNotMoved = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved());
     for (final Territory t : data.getMap()) {
       // move sea units to the capitol, unless they are loaded transports
       if (t.isWater()) {
@@ -411,7 +411,7 @@ public class WeakAI extends AbstractAI {
         continue;
       }
       final Match<Unit> ownedTransports =
-          Match.allOf(Matches.UnitCanTransport, Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved);
+          Match.allOf(Matches.UnitCanTransport, Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved());
       final Match<Territory> enemyTerritory =
           Match.allOf(Matches.isTerritoryEnemy(player, data), Matches.TerritoryIsLand,
               Matches.TerritoryIsNeutralButNotWater.invert(), Matches.TerritoryIsEmpty);
@@ -647,7 +647,7 @@ public class WeakAI extends AbstractAI {
             Matches.UnitCanMove,
             Matches.UnitIsNotInfrastructure,
             Matches.UnitCanNotMoveDuringCombatMove.invert(),
-            Matches.UnitIsNotSea);
+            Matches.unitIsNotSea());
         final Set<Territory> dontMoveFrom = new HashSet<>();
         // find our strength that we can attack with
         int ourStrength = 0;
@@ -747,7 +747,7 @@ public class WeakAI extends AbstractAI {
             continue;
           }
           final UnitType results = (UnitType) resourceOrUnit;
-          if (Matches.UnitTypeIsSea.match(results) || Matches.UnitTypeIsAir.match(results)
+          if (Matches.unitTypeIsSea().match(results) || Matches.UnitTypeIsAir.match(results)
               || Matches.UnitTypeIsInfrastructure.match(results) || Matches.UnitTypeIsAAforAnything.match(results)
               || Matches.UnitTypeHasMaxBuildRestrictions.match(results)
               || Matches.UnitTypeConsumesUnitsOnCreation.match(results)
@@ -949,7 +949,7 @@ public class WeakAI extends AbstractAI {
         }
         final int transportCapacity = UnitAttachment.get(results).getTransportCapacity();
         // buy transports if we can be amphibious
-        if (Matches.UnitTypeIsSea.match(results)) {
+        if (Matches.unitTypeIsSea().match(results)) {
           if (!isAmphib || transportCapacity <= 0) {
             continue;
           }

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -1010,7 +1010,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       } else if (exclType.equals("enemy_surface")) { // any enemy units (not trn/sub) in the territory
         allUnits.retainAll(
             Match.getMatches(allUnits, Match.allOf(Matches.enemyUnitOfAnyOfThesePlayers(players, data),
-                Matches.UnitIsNotSub, Matches.UnitIsNotTransportButCouldBeCombatTransport)));
+                Matches.unitIsNotSub(), Matches.unitIsNotTransportButCouldBeCombatTransport())));
       } else {
         return false;
       }

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1268,7 +1268,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allJets = Match.getMatches(data.getUnitTypeList().getAllUnitTypes(),
-              Match.allOf(Matches.UnitTypeIsAir, Matches.UnitTypeIsStrategicBomber.invert()));
+              Match.allOf(Matches.UnitTypeIsAir, Matches.unitTypeIsStrategicBomber().invert()));
           final boolean ww2v3TechModel = Properties.getWW2V3TechModel(data);
           for (final UnitType jet : allJets) {
             if (ww2v3TechModel) {
@@ -1309,7 +1309,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allDestroyers =
-              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeIsDestroyer);
+              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsDestroyer());
           for (final UnitType destroyer : allDestroyers) {
             taa.setUnitAbilitiesGained(destroyer.getName() + ":" + ABILITY_CAN_BOMBARD);
           }
@@ -1317,7 +1317,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allBombers =
-              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeIsStrategicBomber);
+              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsStrategicBomber());
           final int heavyBomberDiceRollsTotal = Properties.getHeavyBomberDiceRolls(data);
           final boolean heavyBombersLhtr = Properties.getLHTR_Heavy_Bombers(data);
           for (final UnitType bomber : allBombers) {

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -788,7 +788,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         }
       }
       // make sure all units are land
-      if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsNotSea)) {
+      if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsNotSea())) {
         return "Cant place sea units on land";
       }
     }
@@ -981,7 +981,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         final int requiredNumber = requiredUnitsMap.getInt(ut);
         final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.allOf(
             Matches.unitIsOwnedBy(unit.getOwner()), Matches.unitIsOfType(ut),
-            Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.UnitHasNotTakenAnyDamage, Matches.UnitIsNotDisabled);
+            Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.unitHasNotTakenAnyDamage(), Matches.UnitIsNotDisabled);
         final Collection<Unit> unitsBeingRemoved =
             Match.getNMatches(unitsAtStartOfTurnInTo, requiredNumber, unitIsOwnedByAndOfTypeAndNotDamaged);
         unitsAtStartOfTurnInTo.removeAll(unitsBeingRemoved);

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -167,7 +167,7 @@ public class AirBattle extends AbstractBattle {
           final Match.CompositeBuilder<Unit> attackerSuicideBuilder = Match.newCompositeBuilder(
               Matches.UnitIsSuicide);
           if (m_isBombingRun) {
-            attackerSuicideBuilder.add(Matches.UnitIsNotStrategicBomber);
+            attackerSuicideBuilder.add(Matches.unitIsNotStrategicBomber());
           }
           if (Match.anyMatch(m_attackingUnits, attackerSuicideBuilder.all())) {
             final List<Unit> suicideUnits = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -421,7 +421,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final GameData data = bridge.getData();
     final boolean ignoreTransports = isIgnoreTransportInMovement(data);
     final boolean ignoreSubs = isIgnoreSubInMovement(data);
-    final Match<Unit> seaTransports = Match.allOf(Matches.UnitIsTransportButNotCombatTransport, Matches.UnitIsSea);
+    final Match<Unit> seaTransports = Match.allOf(Matches.unitIsTransportButNotCombatTransport(), Matches.UnitIsSea);
     final Match<Unit> seaTranportsOrSubs = Match.anyOf(seaTransports, Matches.UnitIsSub);
     // we want to match all sea zones with our units and enemy units
     final Match<Territory> anyTerritoryWithOwnAndEnemy = Match.allOf(
@@ -1210,7 +1210,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       return;
     }
     final Match<Unit> canBeAttackedDefault = Match.allOf(Matches.unitIsOwnedBy(m_player),
-        Matches.UnitIsSea, Matches.UnitIsNotTransportButCouldBeCombatTransport, Matches.UnitIsNotSub);
+        Matches.UnitIsSea, Matches.unitIsNotTransportButCouldBeCombatTransport(), Matches.unitIsNotSub());
     final boolean onlyWhereThereAreBattlesOrAmphibious =
         Properties.getKamikazeSuicideAttacksOnlyWhereBattlesAre(data);
     final Collection<Territory> pendingBattles = m_battleTracker.getPendingBattleSites(false);

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -501,8 +501,8 @@ public class BattleTracker implements Serializable {
           - Match.countMatches(arrivedUnits, Matches.UnitIsSubmerged);
       // If transports are restricted from controlling sea zones, subtract them
       final Match<Unit> transportsCanNotControl = Match.allOf(
-          Matches.UnitIsTransportAndNotDestroyer,
-          Matches.UnitIsTransportButNotCombatTransport);
+          Matches.unitIsTransportAndNotDestroyer(),
+          Matches.unitIsTransportButNotCombatTransport());
       if (!Properties.getTransportControlSeaZone(data)) {
         totalMatches -= Match.countMatches(arrivedUnits, transportsCanNotControl);
       }

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -226,7 +226,7 @@ class EditValidator {
     if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsOwnedBy(player))) {
       return "Not all units have the same owner";
     }
-    if (units.isEmpty() || !Match.allMatch(units, Matches.UnitHasMoreThanOneHitPointTotal)) {
+    if (units.isEmpty() || !Match.allMatch(units, Matches.unitHasMoreThanOneHitPointTotal())) {
       return "Not all units have more than one total hitpoints";
     }
     for (final Unit u : units) {

--- a/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -103,9 +103,9 @@ public class Fire implements IExecutable {
     if (countTransports > 0 && isTransportCasualtiesRestricted(bridge.getData())) {
       final CasualtyDetails message;
       final Collection<Unit> nonTransports = Match.getMatches(m_attackableUnits,
-          Match.anyOf(Matches.UnitIsNotTransportButCouldBeCombatTransport, Matches.UnitIsNotSea));
+          Match.anyOf(Matches.unitIsNotTransportButCouldBeCombatTransport(), Matches.unitIsNotSea()));
       final Collection<Unit> transportsOnly = Match.getMatches(m_attackableUnits,
-          Match.allOf(Matches.UnitIsTransportButNotCombatTransport, Matches.UnitIsSea));
+          Match.allOf(Matches.unitIsTransportButNotCombatTransport(), Matches.UnitIsSea));
       final int numPossibleHits = AbstractBattle.getMaxHits(nonTransports);
       // more hits than combat units
       if (hitCount > numPossibleHits) {
@@ -122,12 +122,12 @@ public class Fire implements IExecutable {
         while (playerIter.hasNext()) {
           final PlayerID player = playerIter.next();
           final Match<Unit> match = Match.allOf(
-              Matches.UnitIsTransportButNotCombatTransport,
+              Matches.unitIsTransportButNotCombatTransport(),
               Matches.unitIsOwnedBy(player));
           final Collection<Unit> playerTransports = Match.getMatches(transportsOnly, match);
           final int transportsToRemove = Math.max(0, playerTransports.size() - extraHits);
           transportsOnly.removeAll(
-              Match.getNMatches(playerTransports, transportsToRemove, Matches.UnitIsTransportButNotCombatTransport));
+              Match.getNMatches(playerTransports, transportsToRemove, Matches.unitIsTransportButNotCombatTransport()));
         }
         m_killed = nonTransports;
         m_damaged = Collections.emptyList();

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -74,84 +74,124 @@ import games.strategy.util.Util;
  * </p>
  */
 public class Matches {
-  public static final Match<UnitType> UnitTypeHasMoreThanOneHitPointTotal =
-      Match.of(ut -> UnitAttachment.get(ut).getHitPoints() > 1);
+  public static Match<UnitType> unitTypeHasMoreThanOneHitPointTotal() {
+    return Match.of(ut -> UnitAttachment.get(ut).getHitPoints() > 1);
+  }
 
-  public static final Match<Unit> UnitHasMoreThanOneHitPointTotal =
-      Match.of(unit -> UnitTypeHasMoreThanOneHitPointTotal.match(unit.getType()));
+  public static Match<Unit> unitHasMoreThanOneHitPointTotal() {
+    return Match.of(unit -> unitTypeHasMoreThanOneHitPointTotal().match(unit.getType()));
+  }
 
-  public static final Match<Unit> UnitHasTakenSomeDamage = Match.of(unit -> unit.getHits() > 0);
+  public static Match<Unit> unitHasTakenSomeDamage() {
+    return Match.of(unit -> unit.getHits() > 0);
+  }
 
-  public static final Match<Unit> UnitHasNotTakenAnyDamage = UnitHasTakenSomeDamage.invert();
+  public static Match<Unit> unitHasNotTakenAnyDamage() {
+    return unitHasTakenSomeDamage().invert();
+  }
 
   public static final Match<Unit> UnitIsSea = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSea());
 
   public static final Match<Unit> UnitIsSub = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSub());
 
-  public static final Match<Unit> UnitIsNotSub = UnitIsSub.invert();
+  public static Match<Unit> unitIsNotSub() {
+    return UnitIsSub.invert();
+  }
 
-  public static final Match<Unit> UnitIsCombatTransport = Match.of(unit -> {
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-    return (ua.getIsCombatTransport() && ua.getIsSea());
-  });
-
-  public static final Match<Unit> UnitIsNotCombatTransport = UnitIsCombatTransport.invert();
-
-  public static final Match<Unit> UnitIsTransportButNotCombatTransport = Match.of(unit -> {
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-    return (ua.getTransportCapacity() != -1 && ua.getIsSea() && !ua.getIsCombatTransport());
-  });
-
-  public static final Match<Unit> UnitIsNotTransportButCouldBeCombatTransport = Match.of(unit -> {
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-    if (ua.getTransportCapacity() == -1) {
-      return true;
-    } else {
+  private static Match<Unit> unitIsCombatTransport() {
+    return Match.of(unit -> {
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return ua.getIsCombatTransport() && ua.getIsSea();
-    }
-  });
+    });
+  }
+
+  static Match<Unit> unitIsNotCombatTransport() {
+    return unitIsCombatTransport().invert();
+  }
+
+  /**
+   * Returns a match indicating the specified unit is a transport but not a combat transport.
+   */
+  public static Match<Unit> unitIsTransportButNotCombatTransport() {
+    return Match.of(unit -> {
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      return ua.getTransportCapacity() != -1 && ua.getIsSea() && !ua.getIsCombatTransport();
+    });
+  }
+
+  /**
+   * Returns a match indicating the specified unit is not a transport but may be a combat transport.
+   */
+  public static Match<Unit> unitIsNotTransportButCouldBeCombatTransport() {
+    return Match.of(unit -> {
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      if (ua.getTransportCapacity() == -1) {
+        return true;
+      }
+      return ua.getIsCombatTransport() && ua.getIsSea();
+    });
+  }
 
   public static final Match<Unit> UnitIsDestroyer =
       Match.of(unit -> UnitAttachment.get(unit.getType()).getIsDestroyer());
 
-  public static final Match<UnitType> UnitTypeIsDestroyer = Match.of(type -> UnitAttachment.get(type).getIsDestroyer());
+  public static Match<UnitType> unitTypeIsDestroyer() {
+    return Match.of(type -> UnitAttachment.get(type).getIsDestroyer());
+  }
 
   public static final Match<Unit> UnitIsTransport = Match.of(unit -> {
     final UnitAttachment ua = UnitAttachment.get(unit.getType());
     return (ua.getTransportCapacity() != -1 && ua.getIsSea());
   });
 
-  public static final Match<Unit> UnitIsNotTransport = UnitIsTransport.invert();
+  public static Match<Unit> unitIsNotTransport() {
+    return UnitIsTransport.invert();
+  }
 
-  public static final Match<Unit> UnitIsTransportAndNotDestroyer = Match.of(unit -> {
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-    return (!Matches.UnitIsDestroyer.match(unit) && ua.getTransportCapacity() != -1 && ua.getIsSea());
-  });
+  static Match<Unit> unitIsTransportAndNotDestroyer() {
+    return Match.of(unit -> {
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      return !Matches.UnitIsDestroyer.match(unit) && ua.getTransportCapacity() != -1 && ua.getIsSea();
+    });
+  }
 
-  public static final Match<UnitType> UnitTypeIsStrategicBomber = Match.of(obj -> {
-    final UnitAttachment ua = UnitAttachment.get(obj);
-    if (ua == null) {
-      return false;
-    }
-    return ua.getIsStrategicBomber();
-  });
+  /**
+   * Returns a match indicating the specified unit type is a strategic bomber.
+   */
+  public static Match<UnitType> unitTypeIsStrategicBomber() {
+    return Match.of(obj -> {
+      final UnitAttachment ua = UnitAttachment.get(obj);
+      if (ua == null) {
+        return false;
+      }
+      return ua.getIsStrategicBomber();
+    });
+  }
 
   public static final Match<Unit> UnitIsStrategicBomber =
-      Match.of(obj -> UnitTypeIsStrategicBomber.match(obj.getType()));
+      Match.of(obj -> unitTypeIsStrategicBomber().match(obj.getType()));
 
-  public static final Match<Unit> UnitIsNotStrategicBomber = UnitIsStrategicBomber.invert();
+  static Match<Unit> unitIsNotStrategicBomber() {
+    return UnitIsStrategicBomber.invert();
+  }
 
-  public static final Match<UnitType> UnitTypeCanLandOnCarrier = Match.of(obj -> {
-    final UnitAttachment ua = UnitAttachment.get(obj);
-    if (ua == null) {
-      return false;
-    }
-    return ua.getCarrierCost() != -1;
-  });
+  static final Match<UnitType> unitTypeCanLandOnCarrier() {
+    return Match.of(obj -> {
+      final UnitAttachment ua = UnitAttachment.get(obj);
+      if (ua == null) {
+        return false;
+      }
+      return ua.getCarrierCost() != -1;
+    });
+  }
 
-  public static final Match<Unit> unitHasMoved = Match.of(unit -> TripleAUnit.get(unit).getAlreadyMoved() > 0);
+  static Match<Unit> unitHasMoved() {
+    return Match.of(unit -> TripleAUnit.get(unit).getAlreadyMoved() > 0);
+  }
 
-  public static final Match<Unit> unitHasNotMoved = unitHasMoved.invert();
+  public static Match<Unit> unitHasNotMoved() {
+    return unitHasMoved().invert();
+  }
 
   static Match<Unit> unitCanAttack(final PlayerID id) {
     return Match.of(unit -> {
@@ -175,16 +215,27 @@ public class Matches {
     return Match.of(unit -> data.getRelationshipTracker().isAtWar(unit.getOwner(), player));
   }
 
-  public static final Match<Unit> UnitIsNotSea = Match.of(unit -> !UnitAttachment.get(unit.getType()).getIsSea());
+  public static Match<Unit> unitIsNotSea() {
+    return Match.of(unit -> !UnitAttachment.get(unit.getType()).getIsSea());
+  }
 
-  public static final Match<UnitType> UnitTypeIsSea = Match.of(type -> UnitAttachment.get(type).getIsSea());
+  public static Match<UnitType> unitTypeIsSea() {
+    return Match.of(type -> UnitAttachment.get(type).getIsSea());
+  }
 
-  public static final Match<UnitType> UnitTypeIsNotSea = Match.of(type -> !UnitAttachment.get(type).getIsSea());
+  public static Match<UnitType> unitTypeIsNotSea() {
+    return Match.of(type -> !UnitAttachment.get(type).getIsSea());
+  }
 
-  public static final Match<UnitType> UnitTypeIsSeaOrAir = Match.of(type -> {
-    final UnitAttachment ua = UnitAttachment.get(type);
-    return ua.getIsSea() || ua.getIsAir();
-  });
+  /**
+   * Returns a match indicating the specified unit type is for sea or air units.
+   */
+  public static Match<UnitType> unitTypeIsSeaOrAir() {
+    return Match.of(type -> {
+      final UnitAttachment ua = UnitAttachment.get(type);
+      return ua.getIsSea() || ua.getIsAir();
+    });
+  }
 
   public static final Match<Unit> UnitIsAir = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsAir());
 
@@ -1407,9 +1458,9 @@ public class Matches {
     });
   }
 
-  public static final Match<Unit> UnitIsLand = Match.allOf(UnitIsNotSea, UnitIsNotAir);
+  public static final Match<Unit> UnitIsLand = Match.allOf(unitIsNotSea(), UnitIsNotAir);
 
-  public static final Match<UnitType> UnitTypeIsLand = Match.allOf(UnitTypeIsNotSea, UnitTypeIsNotAir);
+  public static final Match<UnitType> UnitTypeIsLand = Match.allOf(unitTypeIsNotSea(), UnitTypeIsNotAir);
 
   public static final Match<Unit> UnitIsNotLand = UnitIsLand.invert();
 
@@ -1446,7 +1497,7 @@ public class Matches {
   public static Match<Territory> territoryIsBlockedSea(final PlayerID player, final GameData data) {
     final Match<Unit> sub = Match.allOf(Matches.UnitIsSub.invert());
     final Match<Unit> transport =
-        Match.allOf(Matches.UnitIsTransportButNotCombatTransport.invert(), Matches.UnitIsLand.invert());
+        Match.allOf(Matches.unitIsTransportButNotCombatTransport().invert(), Matches.UnitIsLand.invert());
     final Match.CompositeBuilder<Unit> unitCondBuilder = Match.newCompositeBuilder(
         Matches.UnitIsInfrastructure.invert(),
         Matches.alliedUnit(player, data).invert());
@@ -1498,7 +1549,9 @@ public class Matches {
   public static Match<Unit> unitCanBeRepairedByFacilitiesInItsTerritory(final Territory territory,
       final PlayerID player, final GameData data) {
     return Match.of(damagedUnit -> {
-      final Match<Unit> damaged = Match.allOf(Matches.UnitHasMoreThanOneHitPointTotal, Matches.UnitHasTakenSomeDamage);
+      final Match<Unit> damaged = Match.allOf(
+          Matches.unitHasMoreThanOneHitPointTotal(),
+          Matches.unitHasTakenSomeDamage());
       if (!damaged.match(damagedUnit)) {
         return false;
       }
@@ -1629,7 +1682,7 @@ public class Matches {
       for (final UnitType ut : requiredUnits) {
         final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.allOf(
             Matches.unitIsOwnedBy(unitWhichRequiresUnits.getOwner()), Matches.unitIsOfType(ut),
-            Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.UnitHasNotTakenAnyDamage, Matches.UnitIsNotDisabled);
+            Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.unitHasNotTakenAnyDamage(), Matches.UnitIsNotDisabled);
         final int requiredNumber = requiredUnitsMap.getInt(ut);
         final int numberInTerritory =
             Match.countMatches(unitsInTerritoryAtStartOfTurn, unitIsOwnedByAndOfTypeAndNotDamaged);
@@ -2096,14 +2149,14 @@ public class Matches {
         }
         if (isLandBattle) {
           if (doNotIncludeBombardingSeaUnits) {
-            canBeInBattle.add(Matches.UnitTypeIsSea.invert());
+            canBeInBattle.add(Matches.unitTypeIsSea().invert());
           }
         } else { // is sea battle
           canBeInBattle.add(Matches.UnitTypeIsLand.invert());
         }
       } else { // defense
         if (isLandBattle) {
-          canBeInBattle.add(Matches.UnitTypeIsSea.invert());
+          canBeInBattle.add(Matches.unitTypeIsSea().invert());
         } else { // is sea battle
           canBeInBattle.add(Matches.UnitTypeIsLand.invert());
         }

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -402,7 +402,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final boolean repairOnlyOwn =
         Properties.getBattleshipsRepairAtBeginningOfRound(bridge.getData());
     final Match<Unit> damagedUnits =
-        Match.allOf(Matches.UnitHasMoreThanOneHitPointTotal, Matches.UnitHasTakenSomeDamage);
+        Match.allOf(Matches.unitHasMoreThanOneHitPointTotal(), Matches.unitHasTakenSomeDamage());
     final Match<Unit> damagedUnitsOwned = Match.allOf(damagedUnits, Matches.unitIsOwnedBy(player));
     final Map<Territory, Set<Unit>> damagedMap = new HashMap<>();
     final Iterator<Territory> iterTerritories = data.getMap().getTerritories().iterator();

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -227,9 +227,9 @@ public class MovePerformer implements Serializable {
           // Ignore Trn on Trn forces.
           if (isIgnoreTransportInMovement(bridge.getData())) {
             final boolean allOwnedTransports =
-                !arrived.isEmpty() && Match.allMatch(arrived, Matches.UnitIsTransportButNotCombatTransport);
+                !arrived.isEmpty() && Match.allMatch(arrived, Matches.unitIsTransportButNotCombatTransport());
             final boolean allEnemyTransports =
-                !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, Matches.UnitIsTransportButNotCombatTransport);
+                !enemyUnits.isEmpty() && Match.allMatch(enemyUnits, Matches.unitIsTransportButNotCombatTransport());
             // If everybody is a transport, don't create a battle
             if (allOwnedTransports && allEnemyTransports) {
               ignoreBattle = true;

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -413,8 +413,8 @@ public class MoveValidator {
         Match.anyOf(Matches.TerritoryIsNeutralButNotWater,
             Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data));
     // final CompositeMatch<Unit> transportsCanNotControl = new
-    // CompositeMatchAnd<Unit>(Matches.UnitIsTransportAndNotDestroyer,
-    // Matches.UnitIsTransportButNotCombatTransport);
+    // CompositeMatchAnd<Unit>(Matches.unitIsTransportAndNotDestroyer(),
+    // Matches.unitIsTransportButNotCombatTransport());
     final boolean navalMayNotNonComIntoControlled =
         isWW2V2(data) || Properties.getNavalUnitsMayNotNonCombatMoveIntoControlledSeaZones(data);
     // TODO need to account for subs AND transports that are ignored, not just OR
@@ -600,8 +600,8 @@ public class MoveValidator {
       for (final Unit unit : moveTest) {
         if (!hasEnoughMovementForRoute.match(unit)) {
           boolean unitOk = false;
-          if ((Matches.UnitIsAirTransportable.match(unit) && Matches.unitHasNotMoved.match(unit))
-              && (mechanizedSupportAvailable > 0 && Matches.unitHasNotMoved.match(unit) && Matches.UnitIsInfantry
+          if ((Matches.UnitIsAirTransportable.match(unit) && Matches.unitHasNotMoved().match(unit))
+              && (mechanizedSupportAvailable > 0 && Matches.unitHasNotMoved().match(unit) && Matches.UnitIsInfantry
                   .match(unit))) {
             // we have paratroopers and mechanized infantry, so we must check for both
             // simple: if it movement group contains an air-transport, then assume we are doing paratroopers. else,
@@ -620,7 +620,7 @@ public class MoveValidator {
             } else {
               mechanizedSupportAvailable--;
             }
-          } else if (Matches.UnitIsAirTransportable.match(unit) && Matches.unitHasNotMoved.match(unit)) {
+          } else if (Matches.UnitIsAirTransportable.match(unit) && Matches.unitHasNotMoved().match(unit)) {
             for (final Unit airTransport : dependencies.keySet()) {
               if (dependencies.get(airTransport) == null || dependencies.get(airTransport).contains(unit)) {
                 unitOk = true;
@@ -630,11 +630,11 @@ public class MoveValidator {
             if (!unitOk) {
               result.addDisallowedUnit("Not all units have enough movement", unit);
             }
-          } else if (mechanizedSupportAvailable > 0 && Matches.unitHasNotMoved.match(unit)
+          } else if (mechanizedSupportAvailable > 0 && Matches.unitHasNotMoved().match(unit)
               && Matches.UnitIsInfantry.match(unit)) {
             mechanizedSupportAvailable--;
           } else if (Matches.unitIsOwnedBy(player).invert().match(unit) && Matches.alliedUnit(player, data).match(unit)
-              && Matches.UnitTypeCanLandOnCarrier.match(unit.getType())
+              && Matches.unitTypeCanLandOnCarrier().match(unit.getType())
               && Match.anyMatch(moveTest, Matches.unitIsAlliedCarrier(unit.getOwner(), data))) {
             // this is so that if the unit is owned by any ally and it is cargo, then it will not count.
             // (shouldn't it be a dependant in this case??)
@@ -772,10 +772,10 @@ public class MoveValidator {
     final Match<Unit> subOnly =
         Match.anyOf(Matches.UnitIsInfrastructure, Matches.UnitIsSub, Matches.enemyUnit(player, data).invert());
     final Match<Unit> transportOnly =
-        Match.anyOf(Matches.UnitIsInfrastructure, Matches.UnitIsTransportButNotCombatTransport,
+        Match.anyOf(Matches.UnitIsInfrastructure, Matches.unitIsTransportButNotCombatTransport(),
             Matches.UnitIsLand, Matches.enemyUnit(player, data).invert());
     final Match<Unit> transportOrSubOnly =
-        Match.anyOf(Matches.UnitIsInfrastructure, Matches.UnitIsTransportButNotCombatTransport,
+        Match.anyOf(Matches.UnitIsInfrastructure, Matches.unitIsTransportButNotCombatTransport(),
             Matches.UnitIsLand, Matches.UnitIsSub, Matches.enemyUnit(player, data).invert());
     final boolean getIgnoreTransportInMovement = isIgnoreTransportInMovement(data);
     final boolean getIgnoreSubInMovement = isIgnoreSubInMovement(data);
@@ -982,7 +982,7 @@ public class MoveValidator {
       final Match<Unit> enemySubmarineMatch = Match.allOf(Matches.unitIsEnemyOf(data, player), Matches.UnitIsSub);
       final Match<Unit> ownedSeaNonTransportMatch =
           Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsSea,
-              Matches.UnitIsNotTransportButCouldBeCombatTransport);
+              Matches.unitIsNotTransportButCouldBeCombatTransport());
       for (final Unit transport : transports) {
         if (!isNonCombat && route.numberOfStepsIncludingStart() == 2) {
           if (Matches.territoryHasEnemyUnits(player, data).match(routeEnd)
@@ -1102,7 +1102,7 @@ public class MoveValidator {
       // Matches.UnitCanBeTransported);
       while (!isEditMode && iter.hasNext()) {
         final TripleAUnit unit = (TripleAUnit) iter.next();
-        if (Matches.unitHasMoved.match(unit)) {
+        if (Matches.unitHasMoved().match(unit)) {
           result.addDisallowedUnit("Units cannot move before loading onto transports", unit);
         }
         final Unit transport = unitsToTransports.get(unit);
@@ -1234,17 +1234,17 @@ public class MoveValidator {
       final Map<Unit, Unit> airTransportsAndParatroops =
           TransportUtils.mapTransportsToLoad(paratroopsRequiringTransport, airTransports);
       for (final Unit paratroop : airTransportsAndParatroops.keySet()) {
-        if (Matches.unitHasMoved.match(paratroop)) {
+        if (Matches.unitHasMoved().match(paratroop)) {
           result.addDisallowedUnit("Cannot paratroop units that have already moved", paratroop);
         }
         final Unit transport = airTransportsAndParatroops.get(paratroop);
-        if (Matches.unitHasMoved.match(transport)) {
+        if (Matches.unitHasMoved().match(transport)) {
           result.addDisallowedUnit("Cannot move then transport paratroops", transport);
         }
       }
       final Territory routeEnd = route.getEnd();
       for (final Unit paratroop : paratroopsRequiringTransport) {
-        if (Matches.unitHasMoved.match(paratroop)) {
+        if (Matches.unitHasMoved().match(paratroop)) {
           result.addDisallowedUnit("Cannot paratroop units that have already moved", paratroop);
         }
         if (Matches.isTerritoryFriendly(player, data).match(routeEnd)
@@ -1451,7 +1451,7 @@ public class MoveValidator {
       if (available >= cost) {
         // this is to test if they started in the same sea zone or not, and its not a very good way of testing it.
         if ((taCarrier.getAlreadyMoved() == taPlane.getAlreadyMoved())
-            || (Matches.unitHasNotMoved.match(plane) && Matches.unitHasNotMoved.match(carrier))
+            || (Matches.unitHasNotMoved().match(plane) && Matches.unitHasNotMoved().match(carrier))
             || (Matches.unitIsOwnedBy(playerWhoIsDoingTheMovement).invert().match(plane) && Matches.alliedUnit(
                 playerWhoIsDoingTheMovement, data).match(plane))) {
           available -= cost;

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -599,7 +599,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         steps.add(AIR_ATTACK_NON_SUBS);
       }
     }
-    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsNotSub)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.unitIsNotSub())) {
       steps.add(m_attacker.getName() + FIRE);
       steps.add(m_defender.getName() + SELECT_CASUALTIES);
     }
@@ -627,7 +627,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         steps.add(AIR_DEFEND_NON_SUBS);
       }
     }
-    if (Match.anyMatch(m_defendingUnits, Matches.UnitIsNotSub)) {
+    if (Match.anyMatch(m_defendingUnits, Matches.unitIsNotSub())) {
       steps.add(m_defender.getName() + FIRE);
       steps.add(m_attacker.getName() + SELECT_CASUALTIES);
     }
@@ -848,7 +848,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
             // Get all allied transports in the territory
             final Match<Unit> matchAllied = Match.allOf(
                 Matches.UnitIsTransport,
-                Matches.UnitIsNotCombatTransport,
+                Matches.unitIsNotCombatTransport(),
                 Matches.isUnitAllied(m_attacker, m_data));
             final List<Unit> alliedTransports = Match.getMatches(m_battleSite.getUnits().getUnits(), matchAllied);
             // If no transports, just end the battle
@@ -1219,10 +1219,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         Matches.unitIsBeingTransported().invert(),
         Matches.UnitIsSubmerged.invert());
     if (Properties.getIgnoreSubInMovement(m_data)) {
-      enemyUnitsThatPreventRetreatBuilder.add(Matches.UnitIsNotSub);
+      enemyUnitsThatPreventRetreatBuilder.add(Matches.unitIsNotSub());
     }
     if (Properties.getIgnoreTransportInMovement(m_data)) {
-      enemyUnitsThatPreventRetreatBuilder.add(Matches.UnitIsNotTransportButCouldBeCombatTransport);
+      enemyUnitsThatPreventRetreatBuilder.add(Matches.unitIsNotTransportButCouldBeCombatTransport());
     }
     Collection<Territory> possible = Match.getMatches(m_attackingFrom,
         Matches.territoryHasUnitsThatMatch(enemyUnitsThatPreventRetreatBuilder.all()).invert());
@@ -1271,7 +1271,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return false;
     }
     return !m_defendingUnits.isEmpty()
-        && Match.allMatch(m_defendingUnits, Matches.UnitIsTransportButNotCombatTransport);
+        && Match.allMatch(m_defendingUnits, Matches.unitIsTransportButNotCombatTransport());
   }
 
   private boolean canAttackerRetreatSubs() {
@@ -1735,7 +1735,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // Get all allied transports in the territory
     final Match<Unit> matchAllied = Match.allOf(
         Matches.UnitIsTransport,
-        Matches.UnitIsNotCombatTransport,
+        Matches.unitIsNotCombatTransport(),
         Matches.isUnitAllied(player, m_data),
         Matches.UnitIsSea);
     final List<Unit> alliedTransports = Match.getMatches(m_battleSite.getUnits().getUnits(), matchAllied);
@@ -1839,7 +1839,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     Collection<Unit> units = new ArrayList<>(m_defendingUnits.size() + m_defendingWaitingToDie.size());
     units.addAll(m_defendingUnits);
     units.addAll(m_defendingWaitingToDie);
-    units = Match.getMatches(units, Matches.UnitIsNotSub);
+    units = Match.getMatches(units, Matches.unitIsNotSub());
     // if restricted, remove aircraft from attackers
     if (isAirAttackSubRestricted() && !canAirAttackSubs(m_attackingUnits, units)) {
       units.removeAll(Match.getMatches(units, Matches.UnitIsAir));
@@ -1868,7 +1868,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     if (!canAirAttackSubs(m_defendingUnits, units)) {
       units = Match.getMatches(units, Matches.UnitIsAir);
-      final Collection<Unit> enemyUnitsNotSubs = Match.getMatches(m_defendingUnits, Matches.UnitIsNotSub);
+      final Collection<Unit> enemyUnitsNotSubs = Match.getMatches(m_defendingUnits, Matches.unitIsNotSub());
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>();
       allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingUnits);
       allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingWaitingToDie);
@@ -1892,7 +1892,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
     if (!canAirAttackSubs(m_attackingUnits, units)) {
       units = Match.getMatches(units, Matches.UnitIsAir);
-      final Collection<Unit> enemyUnitsNotSubs = Match.getMatches(m_attackingUnits, Matches.UnitIsNotSub);
+      final Collection<Unit> enemyUnitsNotSubs = Match.getMatches(m_attackingUnits, Matches.unitIsNotSub());
       if (enemyUnitsNotSubs.isEmpty()) {
         return;
       }
@@ -1910,8 +1910,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (m_defendingUnits.size() == 0) {
       return;
     }
-    Collection<Unit> units = Match.getMatches(m_attackingUnits, Matches.UnitIsNotSub);
-    units.addAll(Match.getMatches(m_attackingWaitingToDie, Matches.UnitIsNotSub));
+    Collection<Unit> units = Match.getMatches(m_attackingUnits, Matches.unitIsNotSub());
+    units.addAll(Match.getMatches(m_attackingWaitingToDie, Matches.unitIsNotSub()));
     // See if allied air can participate in combat
     if (!isAlliedAirIndependent()) {
       units = Match.getMatches(units, Matches.unitIsOwnedBy(m_attacker));
@@ -1985,7 +1985,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       } else {
         m_attackingWaitingToDie.addAll(Match.getMatches(killed, Matches.UnitIsSub));
       }
-      remove(Match.getMatches(killed, Matches.UnitIsNotSub), bridge, m_battleSite, defender);
+      remove(Match.getMatches(killed, Matches.unitIsNotSub()), bridge, m_battleSite, defender);
     } else if (returnFire == ReturnFire.NONE) {
       remove(killed, bridge, m_battleSite, defender);
     }

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -145,7 +145,7 @@ public class RocketsFireHelper {
 
   Match<Unit> rocketMatch(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.UnitIsRocket, Matches.unitIsOwnedBy(player), Matches.UnitIsNotDisabled,
-        Matches.unitIsBeingTransported().invert(), Matches.UnitIsSubmerged.invert(), Matches.unitHasNotMoved);
+        Matches.unitIsBeingTransported().invert(), Matches.UnitIsSubmerged.invert(), Matches.unitHasNotMoved());
   }
 
   private static Set<Territory> getTargetsWithinRange(final Territory territory, final GameData data,

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -229,7 +229,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
         result.addDisallowedUnit("Can Only Launch Airborne Forces", u);
       } else if (Matches.UnitIsDisabled.match(u)) {
         result.addDisallowedUnit("Must Not Be Disabled", u);
-      } else if (!Matches.unitHasNotMoved.match(u)) {
+      } else if (!Matches.unitHasNotMoved().match(u)) {
         result.addDisallowedUnit("Must Not Have Previously Moved Airborne Forces", u);
       } else if (Matches.UnitIsAirborne.match(u)) {
         result.addDisallowedUnit("Cannot Move Units Already Airborne", u);
@@ -292,7 +292,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
 
   private static Match<Unit> getAirborneMatch(final Set<UnitType> types, final Collection<PlayerID> unitOwners) {
     return Match.allOf(Matches.unitIsOwnedByOfAnyOfThesePlayers(unitOwners),
-        Matches.unitIsOfTypes(types), Matches.UnitIsNotDisabled, Matches.unitHasNotMoved,
+        Matches.unitIsOfTypes(types), Matches.UnitIsNotDisabled, Matches.unitHasNotMoved(),
         Matches.UnitIsAirborne.invert());
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
+++ b/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
@@ -33,7 +33,7 @@ public class UnitBattleComparator implements Comparator<Unit> {
     if (Properties.getBattleshipsRepairAtEndOfRound(data)
         || Properties.getBattleshipsRepairAtBeginningOfRound(data)) {
       for (final UnitType ut : data.getUnitTypeList()) {
-        if (Matches.UnitTypeHasMoreThanOneHitPointTotal.match(ut)) {
+        if (Matches.unitTypeHasMoreThanOneHitPointTotal().match(ut)) {
           m_multiHitpointCanRepair.add(ut);
         }
       }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -888,12 +888,12 @@ class OddsCalculatorPanel extends JPanel {
       final Match<UnitType> predicate;
       if (land) {
         if (defender) {
-          predicate = Matches.UnitTypeIsNotSea;
+          predicate = Matches.unitTypeIsNotSea();
         } else {
-          predicate = Match.anyOf(Matches.UnitTypeIsNotSea, Matches.unitTypeCanBombard(id));
+          predicate = Match.anyOf(Matches.unitTypeIsNotSea(), Matches.unitTypeCanBombard(id));
         }
       } else {
-        predicate = Matches.UnitTypeIsSeaOrAir;
+        predicate = Matches.unitTypeIsSeaOrAir();
       }
       final IntegerMap<UnitType> costs;
       try {
@@ -1182,7 +1182,7 @@ class OddsCalculatorPanel extends JPanel {
         for (final UnitCategory category : categories) {
           // no duplicates or infrastructure allowed. no sea if land, no land if sea.
           if (typesUsed.contains(category.getType()) || Matches.UnitTypeIsInfrastructure.match(category.getType())
-              || (land && Matches.UnitTypeIsSea.match(category.getType()))
+              || (land && Matches.unitTypeIsSea().match(category.getType()))
               || (!land && Matches.UnitTypeIsLand.match(category.getType()))) {
             continue;
           }

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -358,7 +358,7 @@ class EditPanel extends ActionPanel {
       public void actionPerformed(final ActionEvent event) {
         currentAction = this;
         setWidgetActivation();
-        final List<Unit> units = Match.getMatches(selectedUnits, Matches.UnitHasMoreThanOneHitPointTotal);
+        final List<Unit> units = Match.getMatches(selectedUnits, Matches.unitHasMoreThanOneHitPointTotal());
         if (units == null || units.isEmpty() || !selectedTerritory.getUnits().getUnits().containsAll(units)) {
           cancelEditAction.actionPerformed(null);
           return;
@@ -526,7 +526,7 @@ class EditPanel extends ActionPanel {
     data.acquireReadLock();
     try {
       final Set<UnitType> allUnitTypes = data.getUnitTypeList().getAllUnitTypes();
-      if (Match.anyMatch(allUnitTypes, Matches.UnitTypeHasMoreThanOneHitPointTotal)) {
+      if (Match.anyMatch(allUnitTypes, Matches.unitTypeHasMoreThanOneHitPointTotal())) {
         add(new JButton(changeUnitHitDamageAction));
       }
       if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -362,7 +362,7 @@ public class MovePanel extends AbstractMovePanel {
         movableBuilder.add(Matches.UnitIsNotLand);
       }
       if (!water) {
-        movableBuilder.add(Matches.UnitIsNotSea);
+        movableBuilder.add(Matches.unitIsNotSea());
       }
     }
     if (units != null && !units.isEmpty()) {
@@ -843,14 +843,14 @@ public class MovePanel extends AbstractMovePanel {
         // Load Bombers with paratroops
         if ((!nonCombat || isParatroopersCanMoveDuringNonCombat(getData()))
             && TechAttachment.isAirTransportable(getCurrentPlayer())
-            && Match.anyMatch(selectedUnits, Match.allOf(Matches.UnitIsAirTransport, Matches.unitHasNotMoved))) {
+            && Match.anyMatch(selectedUnits, Match.allOf(Matches.UnitIsAirTransport, Matches.unitHasNotMoved()))) {
           final PlayerID player = getCurrentPlayer();
           // TODO Transporting allied units
           // Get the potential units to load
           final Match.CompositeBuilder<Unit> unitsToLoadMatchBuilder = Match.newCompositeBuilder(
               Matches.UnitIsAirTransportable,
               Matches.unitIsOwnedBy(player),
-              Matches.unitHasNotMoved);
+              Matches.unitHasNotMoved());
           final Collection<Unit> unitsToLoad =
               Match.getMatches(route.getStart().getUnits().getUnits(), unitsToLoadMatchBuilder.all());
           unitsToLoad.removeAll(selectedUnits);
@@ -861,7 +861,7 @@ public class MovePanel extends AbstractMovePanel {
           final Match.CompositeBuilder<Unit> candidateAirTransportsMatchBuilder = Match.newCompositeBuilder(
               Matches.UnitIsAirTransport,
               Matches.unitIsOwnedBy(player),
-              Matches.unitHasNotMoved,
+              Matches.unitHasNotMoved(),
               Matches.transportIsNotTransporting());
           final Collection<Unit> candidateAirTransports =
               Match.getMatches(t.getUnits().getMatches(unitsToMoveMatch), candidateAirTransportsMatchBuilder.all());

--- a/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -140,7 +140,7 @@ public class PlacePanel extends AbstractMovePanel {
           units = Match.getMatches(units, unitIsSeaOrCanLandOnCarrier);
         }
       } else {
-        units = Match.getMatches(units, Matches.UnitIsNotSea);
+        units = Match.getMatches(units, Matches.unitIsNotSea());
       }
       if (units.isEmpty()) {
         return Collections.emptyList();

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -217,9 +217,9 @@ public class UnitsDrawer implements IDrawable {
         Matches.unitIsOfType(type),
         Matches.unitIsOwnedBy(data.getPlayerList().getPlayerID(playerName)));
     if (damaged > 0) {
-      selectedUnitsBuilder.add(Matches.UnitHasTakenSomeDamage);
+      selectedUnitsBuilder.add(Matches.unitHasTakenSomeDamage());
     } else {
-      selectedUnitsBuilder.add(Matches.UnitHasNotTakenAnyDamage);
+      selectedUnitsBuilder.add(Matches.unitHasNotTakenAnyDamage());
     }
     if (bombingUnitDamage > 0) {
       selectedUnitsBuilder.add(Matches.UnitHasTakenSomeBombingUnitDamage);

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -554,7 +554,7 @@ public class MoveDelegateTest extends DelegateTest {
     route3.setStart(japanSeaZone);
     route3.add(sfeSeaZone);
     final Collection<Unit> remainingTrns = Match.getMatches(japanSeaZone.getUnits().getUnits(),
-        Match.allOf(Matches.unitHasNotMoved, Matches.UnitWasNotLoadedThisTurn));
+        Match.allOf(Matches.unitHasNotMoved(), Matches.UnitWasNotLoadedThisTurn));
     results = delegate.move(remainingTrns, route3);
     assertNull(results);
   }

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -799,13 +799,13 @@ public class WW2V3Year41Test {
     final Territory sz12 = territory("12 Sea Zone", gameData);
     final Route r = new Route(sz14, sz13, sz12);
     // move the battleship
-    move(sz14.getUnits().getMatches(Matches.UnitHasMoreThanOneHitPointTotal), r);
+    move(sz14.getUnits().getMatches(Matches.unitHasMoreThanOneHitPointTotal()), r);
     // move everything
-    move(sz14.getUnits().getMatches(Matches.UnitIsNotTransport), r);
+    move(sz14.getUnits().getMatches(Matches.unitIsNotTransport()), r);
     // undo it
     move.undoMove(1);
     // move again
-    move(sz14.getUnits().getMatches(Matches.UnitIsNotTransport), r);
+    move(sz14.getUnits().getMatches(Matches.unitIsNotTransport()), r);
     final MustFightBattle mfb =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz12, false, null);
     // only 3 attacking units


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is one part in a series of related PRs in order to keep the review size reasonable.