### PR TITLE
Display UnitChooser title only when set explicitly (#2215)

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -31,7 +31,7 @@ import games.strategy.ui.ScrollableTextFieldListener;
 import games.strategy.util.IntegerMap;
 import games.strategy.util.Match;
 
-public class UnitChooser extends JPanel {
+final class UnitChooser extends JPanel {
   private static final long serialVersionUID = -4667032237550267682L;
   private final List<ChooserEntry> entries = new ArrayList<>();
   private final Map<Unit, Collection<Unit>> dependents;
@@ -45,13 +45,12 @@ public class UnitChooser extends JPanel {
   private final IUIContext uiContext;
   private final Match<Collection<Unit>> match;
 
-  /** Creates new UnitChooser. */
-  public UnitChooser(final Collection<Unit> units, final Map<Unit, Collection<Unit>> dependent, final GameData data,
+  UnitChooser(final Collection<Unit> units, final Map<Unit, Collection<Unit>> dependent, final GameData data,
       final boolean allowTwoHit, final IUIContext uiContext) {
     this(units, Collections.emptyList(), dependent, data, allowTwoHit, uiContext);
   }
 
-  public UnitChooser(final Collection<Unit> units, final Collection<Unit> defaultSelections,
+  UnitChooser(final Collection<Unit> units, final Collection<Unit> defaultSelections,
       final Map<Unit, Collection<Unit>> dependent, final GameData data, final boolean allowTwoHit,
       final IUIContext uiContext) {
     this(units, defaultSelections, dependent, false, false, data, allowTwoHit, uiContext);
@@ -98,7 +97,7 @@ public class UnitChooser extends JPanel {
   /**
    * Set the maximum number of units that we can choose.
    */
-  public void setMax(final int max) {
+  void setMax(final int max) {
     total = max;
     textFieldListener.changedValue(null);
     autoSelectButton.setVisible(false);
@@ -111,7 +110,7 @@ public class UnitChooser extends JPanel {
     autoSelectButton.setText("Max");
   }
 
-  public void setTitle(final String title) {
+  void setTitle(final String title) {
     this.title.setText(title);
   }
 
@@ -228,7 +227,7 @@ public class UnitChooser extends JPanel {
     }
   }
 
-  public Collection<Unit> getSelected() {
+  Collection<Unit> getSelected() {
     return getSelected(true);
   }
 
@@ -236,7 +235,7 @@ public class UnitChooser extends JPanel {
    * get the units selected.
    * If units are two hit enabled, returns those with two hits (ie: those killed).
    */
-  public List<Unit> getSelected(final boolean selectDependents) {
+  List<Unit> getSelected(final boolean selectDependents) {
     final List<Unit> selectedUnits = new ArrayList<>();
     for (final ChooserEntry entry : entries) {
       addToCollection(selectedUnits, entry, entry.getFinalHit(), selectDependents);
@@ -247,7 +246,7 @@ public class UnitChooser extends JPanel {
   /**
    * Only applicable if this dialog was constructed using multiple hit points.
    */
-  public List<Unit> getSelectedDamagedMultipleHitPointUnits() {
+  List<Unit> getSelectedDamagedMultipleHitPointUnits() {
     final List<Unit> selectedUnits = new ArrayList<>();
     for (ChooserEntry chooserEntry : entries) {
       if (chooserEntry.hasMultipleHitPoints()) {

--- a/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -112,6 +112,7 @@ final class UnitChooser extends JPanel {
 
   void setTitle(final String title) {
     this.title.setText(title);
+    this.title.setVisible(true);
   }
 
   private void updateLeft() {
@@ -196,10 +197,11 @@ final class UnitChooser extends JPanel {
 
   private void layoutEntries() {
     this.setLayout(new GridBagLayout());
-    title = new JTextArea("Choose units");
+    title = new JTextArea();
     title.setBackground(this.getBackground());
     title.setEditable(false);
     title.setWrapStyleWord(true);
+    title.setVisible(false);
     final Insets nullInsets = new Insets(0, 0, 0, 0);
     final Dimension buttonSize = new Dimension(80, 20);
     selectNoneButton = new JButton("None");


### PR DESCRIPTION
This PR removes the "Choose units" title from the `UnitChooser` dialog reported in #2215.

The core of the change is in e88fe41.  That commit should be viewed in isolation to avoid any distractions from the refactoring.

#### Functional changes

* The default "Choose units" title is no longer displayed in the `UnitChooser` dialog.  For example, when placing units:

![unit-chooser-without-title](https://user-images.githubusercontent.com/4826349/29377928-557007e6-828b-11e7-9e41-1c5c2036425c.png)

* The title will only be displayed if set explicitly via `UnitChooser#setTitle()`.  For example, when selecting AA casualties:

![unit-chooser-with-title](https://user-images.githubusercontent.com/4826349/29377949-5e61c0a6-828b-11e7-84bc-af431f502792.png)

#### Refactoring changes

* `UnitChooser` is only used by clients in the same package, so I reduced its visibility from public to package-private.

#### Testing

I tested the following code paths:

Scenario | Title
:-- | :--
Place units | Not visible
Load transports | Visible
Select AA casualties | Visible

The remaining code paths, while not tested, should display the title, as they all call `setTitle()`.