### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 2)

### DIFF
--- a/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -387,7 +387,9 @@ public class TripleAPlayer extends AbstractHumanPlayer<TripleAFrame> implements 
         && !id.getRepairFrontier().getRules().isEmpty()) {
       final GameData data = getGameData();
       if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
-        final Match<Unit> myDamaged = Match.allOf(Matches.unitIsOwnedBy(id), Matches.UnitHasTakenSomeBombingUnitDamage);
+        final Match<Unit> myDamaged = Match.allOf(
+            Matches.unitIsOwnedBy(id),
+            Matches.unitHasTakenSomeBombingUnitDamage());
         final Collection<Unit> damagedUnits = new ArrayList<>();
         for (final Territory t : data.getMap().getTerritories()) {
           damagedUnits.addAll(Match.getMatches(t.getUnits().getUnits(), myDamaged));

--- a/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -341,7 +341,7 @@ public class TripleAUnit extends Unit {
    * Will return 0 if the unit cannot be damaged, or is at max damage.
    */
   public int getHowMuchMoreDamageCanThisUnitTake(final Unit u, final Territory t) {
-    if (!Matches.UnitCanBeDamaged.match(u)) {
+    if (!Matches.unitCanBeDamaged().match(u)) {
       return 0;
     }
     final TripleAUnit taUnit = (TripleAUnit) u;
@@ -357,7 +357,7 @@ public class TripleAUnit extends Unit {
    * Will return -1 if the unit is of the type that cannot be damaged
    */
   public int getHowMuchDamageCanThisUnitTakeTotal(final Unit u, final Territory t) {
-    if (!Matches.UnitCanBeDamaged.match(u)) {
+    if (!Matches.unitCanBeDamaged().match(u)) {
       return -1;
     }
     final UnitAttachment ua = UnitAttachment.get(u.getType());

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -407,7 +407,7 @@ class ProCombatMoveAI {
 
       // Determine whether its worth trying to hold territory
       double totalValue = 0.0;
-      final List<Unit> nonAirAttackers = Match.getMatches(patd.getMaxUnits(), Matches.UnitIsNotAir);
+      final List<Unit> nonAirAttackers = Match.getMatches(patd.getMaxUnits(), Matches.unitIsNotAir());
       for (final Unit u : nonAirAttackers) {
         totalValue += territoryValueMap.get(ProData.unitTerritoryMap.get(u));
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -906,7 +906,7 @@ class ProNonCombatMoveAI {
         if (!t.isWater() && !t.equals(ProData.myCapital)
             && !ProMatches.territoryHasInfraFactoryAndIsLand().match(t)) {
           double totalValue = 0.0;
-          final List<Unit> nonAirDefenders = Match.getMatches(moveMap.get(t).getTempUnits(), Matches.UnitIsNotAir);
+          final List<Unit> nonAirDefenders = Match.getMatches(moveMap.get(t).getTempUnits(), Matches.unitIsNotAir());
           for (final Unit u : nonAirDefenders) {
             totalValue += territoryValueMap.get(unitTerritoryMap.get(u));
           }
@@ -1733,7 +1733,7 @@ class ProNonCombatMoveAI {
     // Move air units to safe territory with most attack options
     for (final Iterator<Unit> it = unitMoveMap.keySet().iterator(); it.hasNext();) {
       final Unit u = it.next();
-      if (Matches.UnitIsNotAir.match(u)) {
+      if (Matches.unitIsNotAir().match(u)) {
         continue;
       }
       double maxAirValue = 0;
@@ -1814,7 +1814,7 @@ class ProNonCombatMoveAI {
     // Move air units to safest territory
     for (final Iterator<Unit> it = unitMoveMap.keySet().iterator(); it.hasNext();) {
       final Unit u = it.next();
-      if (Matches.UnitIsNotAir.match(u)) {
+      if (Matches.unitIsNotAir().match(u)) {
         continue;
       }
       double minStrengthDifference = Double.POSITIVE_INFINITY;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -88,7 +88,7 @@ class ProPurchaseAI {
         }
         final Unit possibleFactoryNeedingRepair = TripleAUnit.getBiggestProducer(
             Match.getMatches(fixTerr.getUnits().getUnits(), ourFactories), fixTerr, player, data, false);
-        if (Matches.UnitHasTakenSomeBombingUnitDamage.match(possibleFactoryNeedingRepair)) {
+        if (Matches.unitHasTakenSomeBombingUnitDamage().match(possibleFactoryNeedingRepair)) {
           unitsThatCanProduceNeedingRepair.put(possibleFactoryNeedingRepair, fixTerr);
         }
       }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
@@ -67,7 +67,8 @@ public class ProPurchaseOptionMap {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         specialOptions.add(ppo);
         ProLogger.debug("Special: " + ppo);
-      } else if (Matches.UnitTypeCanProduceUnits.match(unitType) && Matches.UnitTypeIsInfrastructure.match(unitType)) {
+      } else if (Matches.UnitTypeCanProduceUnits.match(unitType)
+          && Matches.unitTypeIsInfrastructure().match(unitType)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         factoryOptions.add(ppo);
         ProLogger.debug("Factory: " + ppo);

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -308,15 +308,15 @@ public class ProTerritoryManager {
       }
     }
     final Match<Unit> airbasesCanScramble = Match.allOf(Matches.unitIsEnemyOf(data, player),
-        Matches.UnitIsAirBase, Matches.UnitIsNotDisabled, Matches.unitIsBeingTransported().invert());
+        Matches.unitIsAirBase(), Matches.unitIsNotDisabled(), Matches.unitIsBeingTransported().invert());
     final Match.CompositeBuilder<Territory> canScrambleBuilder = Match.newCompositeBuilder(
         Match.anyOf(
             Matches.TerritoryIsWater,
             Matches.isTerritoryEnemy(player, data)),
         Matches.territoryHasUnitsThatMatch(Match.allOf(
-            Matches.UnitCanScramble,
+            Matches.unitCanScramble(),
             Matches.unitIsEnemyOf(data, player),
-            Matches.UnitIsNotDisabled)),
+            Matches.unitIsNotDisabled())),
         Matches.territoryHasUnitsThatMatch(airbasesCanScramble));
     if (fromIslandOnly) {
       canScrambleBuilder.add(Matches.TerritoryIsIsland);
@@ -346,8 +346,8 @@ public class ProTerritoryManager {
         final int maxCanScramble = getMaxScrambleCount(airbases);
         final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.TerritoryIsNotImpassable);
         List<Unit> canScrambleAir = from.getUnits()
-            .getMatches(Match.allOf(Matches.unitIsEnemyOf(data, player), Matches.UnitCanScramble,
-                Matches.UnitIsNotDisabled, Matches.UnitWasScrambled.invert(),
+            .getMatches(Match.allOf(Matches.unitIsEnemyOf(data, player), Matches.unitCanScramble(),
+                Matches.unitIsNotDisabled(), Matches.unitWasScrambled().invert(),
                 Matches.unitCanScrambleOnRouteDistance(toBattleRoute)));
 
         // Add max scramble units
@@ -370,7 +370,7 @@ public class ProTerritoryManager {
 
   private static int getMaxScrambleCount(final Collection<Unit> airbases) {
     if (airbases.isEmpty()
-        || !Match.allMatch(airbases, Match.allOf(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
+        || !Match.allMatch(airbases, Match.allOf(Matches.unitIsAirBase(), Matches.unitIsNotDisabled()))) {
       throw new IllegalStateException("All units must be viable airbases");
     }
 

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -748,7 +748,7 @@ public class WeakAI extends AbstractAI {
           }
           final UnitType results = (UnitType) resourceOrUnit;
           if (Matches.unitTypeIsSea().match(results) || Matches.UnitTypeIsAir.match(results)
-              || Matches.UnitTypeIsInfrastructure.match(results) || Matches.UnitTypeIsAAforAnything.match(results)
+              || Matches.unitTypeIsInfrastructure().match(results) || Matches.UnitTypeIsAAforAnything.match(results)
               || Matches.UnitTypeHasMaxBuildRestrictions.match(results)
               || Matches.UnitTypeConsumesUnitsOnCreation.match(results)
               || Matches.unitTypeIsStatic(player).match(results)) {
@@ -817,7 +817,7 @@ public class WeakAI extends AbstractAI {
         }
         final Unit possibleFactoryNeedingRepair = TripleAUnit.getBiggestProducer(
             Match.getMatches(fixTerr.getUnits().getUnits(), ourFactories), fixTerr, player, data, false);
-        if (Matches.UnitHasTakenSomeBombingUnitDamage.match(possibleFactoryNeedingRepair)) {
+        if (Matches.unitHasTakenSomeBombingUnitDamage().match(possibleFactoryNeedingRepair)) {
           unitsThatCanProduceNeedingRepair.put(possibleFactoryNeedingRepair, fixTerr);
         }
         final TripleAUnit taUnit = (TripleAUnit) possibleFactoryNeedingRepair;
@@ -941,7 +941,7 @@ public class WeakAI extends AbstractAI {
           continue;
         }
         final UnitType results = (UnitType) resourceOrUnit;
-        if (Matches.UnitTypeIsAir.match(results) || Matches.UnitTypeIsInfrastructure.match(results)
+        if (Matches.UnitTypeIsAir.match(results) || Matches.unitTypeIsInfrastructure().match(results)
             || Matches.UnitTypeIsAAforAnything.match(results) || Matches.UnitTypeHasMaxBuildRestrictions.match(results)
             || Matches.UnitTypeConsumesUnitsOnCreation.match(results)
             || Matches.unitTypeIsStatic(player).match(results)) {

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -980,8 +980,11 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       for (final UnitType ut : requiredUnits) {
         final int requiredNumber = requiredUnitsMap.getInt(ut);
         final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.allOf(
-            Matches.unitIsOwnedBy(unit.getOwner()), Matches.unitIsOfType(ut),
-            Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.unitHasNotTakenAnyDamage(), Matches.UnitIsNotDisabled);
+            Matches.unitIsOwnedBy(unit.getOwner()),
+            Matches.unitIsOfType(ut),
+            Matches.unitHasNotTakenAnyBombingUnitDamage(),
+            Matches.unitHasNotTakenAnyDamage(),
+            Matches.unitIsNotDisabled());
         final Collection<Unit> unitsBeingRemoved =
             Match.getNMatches(unitsAtStartOfTurnInTo, requiredNumber, unitIsOwnedByAndOfTypeAndNotDamaged);
         unitsAtStartOfTurnInTo.removeAll(unitsBeingRemoved);

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -166,19 +166,19 @@ public class AirBattle extends AbstractBattle {
           m_defendingWaitingToDie.clear();
           // kill any suicide attackers (veqryn)
           final Match.CompositeBuilder<Unit> attackerSuicideBuilder = Match.newCompositeBuilder(
-              Matches.UnitIsSuicide);
+              Matches.unitIsSuicide());
           if (m_isBombingRun) {
             attackerSuicideBuilder.add(Matches.unitIsNotStrategicBomber());
           }
           if (Match.anyMatch(m_attackingUnits, attackerSuicideBuilder.all())) {
-            final List<Unit> suicideUnits = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);
+            final List<Unit> suicideUnits = Match.getMatches(m_attackingUnits, Matches.unitIsSuicide());
             m_attackingUnits.removeAll(suicideUnits);
             remove(suicideUnits, bridge, m_battleSite);
             tuvLostAttacker = TuvUtils.getTUV(suicideUnits, m_attacker, attackerCosts, m_data);
             m_attackerLostTUV += tuvLostAttacker;
           }
-          if (Match.anyMatch(m_defendingUnits, Matches.UnitIsSuicide)) {
-            final List<Unit> suicideUnits = Match.getMatches(m_defendingUnits, Matches.UnitIsSuicide);
+          if (Match.anyMatch(m_defendingUnits, Matches.unitIsSuicide())) {
+            final List<Unit> suicideUnits = Match.getMatches(m_defendingUnits, Matches.unitIsSuicide());
             m_defendingUnits.removeAll(suicideUnits);
             remove(suicideUnits, bridge, m_battleSite);
             tuvLostDefender = TuvUtils.getTUV(suicideUnits, m_defender, defenderCosts, m_data);
@@ -647,9 +647,9 @@ public class AirBattle extends AbstractBattle {
     final Match.CompositeBuilder<Unit> matchBuilder = Match.newCompositeBuilder(
         Matches.unitCanAirBattle,
         Matches.unitIsEnemyOf(data, attacker),
-        Matches.UnitWasInAirBattle.invert());
+        Matches.unitWasInAirBattle().invert());
     if (!Properties.getCanScrambleIntoAirBattles(data)) {
-      matchBuilder.add(Matches.UnitWasScrambled.invert());
+      matchBuilder.add(Matches.unitWasScrambled().invert());
     }
     return matchBuilder.all();
   }
@@ -658,9 +658,9 @@ public class AirBattle extends AbstractBattle {
     final Match.CompositeBuilder<Unit> matchBuilder = Match.newCompositeBuilder(
         Matches.unitCanIntercept,
         Matches.unitIsEnemyOf(data, attacker),
-        Matches.UnitWasInAirBattle.invert());
+        Matches.unitWasInAirBattle().invert());
     if (!Properties.getCanScrambleIntoAirBattles(data)) {
-      matchBuilder.add(Matches.UnitWasScrambled.invert());
+      matchBuilder.add(Matches.unitWasScrambled().invert());
     }
     return matchBuilder.all();
   }

--- a/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -519,7 +519,7 @@ public class AirMovementValidator {
   private static List<Unit> getAirUnitsToValidate(final Collection<Unit> units, final Route route,
       final PlayerID player) {
     final Match<Unit> ownedAirMatch =
-        Match.allOf(Matches.UnitIsAir, Matches.unitOwnedBy(player), Matches.UnitIsKamikaze.invert());
+        Match.allOf(Matches.UnitIsAir, Matches.unitOwnedBy(player), Matches.unitIsKamikaze().invert());
     final List<Unit> ownedAir = new ArrayList<>();
     ownedAir.addAll(Match.getMatches(route.getEnd().getUnits().getUnits(), ownedAirMatch));
     ownedAir.addAll(Match.getMatches(units, ownedAirMatch));

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -603,7 +603,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       }
       for (final PlayerID p : enemyPlayers) {
         final Match<Unit> canPreventCapture = Match.allOf(Matches.unitIsEnemyOf(data, p),
-            Matches.UnitIsNotAir, Matches.UnitIsNotInfrastructure);
+            Matches.unitIsNotAir(), Matches.UnitIsNotInfrastructure);
         enemyUnitsOfAbandonedToUnits.addAll(territory.getUnits().getMatches(canPreventCapture));
       }
       // only look at bombing battles, because otherwise the normal attack will determine the ownership of the territory
@@ -647,15 +647,15 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       }
     }
     final Match<Unit> airbasesCanScramble = Match.allOf(Matches.unitIsEnemyOf(data, m_player),
-        Matches.UnitIsAirBase, Matches.UnitIsNotDisabled, Matches.unitIsBeingTransported().invert());
+        Matches.unitIsAirBase(), Matches.unitIsNotDisabled(), Matches.unitIsBeingTransported().invert());
     final Match.CompositeBuilder<Territory> canScrambleBuilder = Match.newCompositeBuilder(
         Match.anyOf(
             Matches.TerritoryIsWater,
             Matches.isTerritoryEnemy(m_player, data)),
         Matches.territoryHasUnitsThatMatch(Match.allOf(
-            Matches.UnitCanScramble,
+            Matches.unitCanScramble(),
             Matches.unitIsEnemyOf(data, m_player),
-            Matches.UnitIsNotDisabled)),
+            Matches.unitIsNotDisabled())),
         Matches.territoryHasUnitsThatMatch(airbasesCanScramble));
     if (fromIslandOnly) {
       canScrambleBuilder.add(Matches.TerritoryIsIsland);
@@ -733,8 +733,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         final int maxCanScramble = getMaxScrambleCount(airbases);
         final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.TerritoryIsNotImpassable);
         final Collection<Unit> canScrambleAir = from.getUnits()
-            .getMatches(Match.allOf(Matches.unitIsEnemyOf(data, m_player), Matches.UnitCanScramble,
-                Matches.UnitIsNotDisabled, Matches.UnitWasScrambled.invert(),
+            .getMatches(Match.allOf(Matches.unitIsEnemyOf(data, m_player), Matches.unitCanScramble(),
+                Matches.unitIsNotDisabled(), Matches.unitWasScrambled().invert(),
                 Matches.unitCanScrambleOnRouteDistance(toBattleRoute)));
         if (maxCanScramble > 0 && !canScrambleAir.isEmpty()) {
           scramblers.put(from, Tuple.of(airbases, canScrambleAir));
@@ -951,7 +951,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
   public static int getMaxScrambleCount(final Collection<Unit> airbases) {
     if (airbases.isEmpty()
-        || !Match.allMatch(airbases, Match.allOf(Matches.UnitIsAirBase, Matches.UnitIsNotDisabled))) {
+        || !Match.allMatch(airbases, Match.allOf(Matches.unitIsAirBase(), Matches.unitIsNotDisabled()))) {
       throw new IllegalStateException("All units must be viable airbases");
     }
     // find how many is the max this territory can scramble
@@ -975,7 +975,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final boolean mustReturnToBase = Properties.getScrambled_Units_Return_To_Base(data);
     for (final Territory t : data.getMap().getTerritories()) {
       int carrierCostOfCurrentTerr = 0;
-      final Collection<Unit> wasScrambled = t.getUnits().getMatches(Matches.UnitWasScrambled);
+      final Collection<Unit> wasScrambled = t.getUnits().getMatches(Matches.unitWasScrambled());
       for (final Unit u : wasScrambled) {
         final CompositeChange change = new CompositeChange();
         final Territory originatedFrom = TripleAUnit.get(u).getOriginatedFrom();
@@ -1024,7 +1024,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     }
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
-      final Collection<Unit> airbases = t.getUnits().getMatches(Matches.UnitIsAirBase);
+      final Collection<Unit> airbases = t.getUnits().getMatches(Matches.unitIsAirBase());
       for (final Unit u : airbases) {
         final UnitAttachment ua = UnitAttachment.get(u.getType());
         final int currentMax = ((TripleAUnit) u).getMaxScrambleCount();
@@ -1047,7 +1047,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     }
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
-      for (final Unit u : t.getUnits().getMatches(Matches.UnitWasInAirBattle)) {
+      for (final Unit u : t.getUnits().getMatches(Matches.unitWasInAirBattle())) {
         change.add(ChangeFactory.unitPropertyChange(u, false, TripleAUnit.WAS_IN_AIR_BATTLE));
       }
     }
@@ -1062,7 +1062,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final Map<Territory, Collection<Unit>> defendingAirThatCanNotLand = m_battleTracker.getDefendingAirThatCanNotLand();
     final boolean isWW2v2orIsSurvivingAirMoveToLand = Properties.getWW2V2(data)
         || Properties.getSurvivingAirMoveToLand(data);
-    final Match<Unit> alliedDefendingAir = Match.allOf(Matches.UnitIsAir, Matches.UnitWasScrambled.invert());
+    final Match<Unit> alliedDefendingAir = Match.allOf(Matches.UnitIsAir, Matches.unitWasScrambled().invert());
     for (final Entry<Territory, Collection<Unit>> entry : defendingAirThatCanNotLand.entrySet()) {
       final Territory battleSite = entry.getKey();
       final Collection<Unit> defendingAir = entry.getValue();

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -386,14 +386,14 @@ public class BattleTracker implements Serializable {
     final GameData data = bridge.getData();
     final Collection<Unit> canConquer = Match.getMatches(units,
         Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(units, route, id, data, false).invert());
-    if (Match.noneMatch(canConquer, Matches.UnitIsNotAir)) {
+    if (Match.noneMatch(canConquer, Matches.unitIsNotAir())) {
       return;
     }
     final Collection<Unit> presentFromStartTilEnd = new ArrayList<>(canConquer);
     if (unitsNotUnloadedTilEndOfRoute != null) {
       presentFromStartTilEnd.removeAll(unitsNotUnloadedTilEndOfRoute);
     }
-    final boolean canConquerMiddleSteps = Match.anyMatch(presentFromStartTilEnd, Matches.UnitIsNotAir);
+    final boolean canConquerMiddleSteps = Match.anyMatch(presentFromStartTilEnd, Matches.unitIsNotAir());
     final boolean scramblingEnabled = Properties.getScramble_Rules_In_Effect(data);
     final Match<Territory> conquerable = Match.allOf(
         Matches.territoryIsEmptyOfCombatUnits(data, id),
@@ -687,7 +687,7 @@ public class BattleTracker implements Serializable {
     // Remove any bombing raids against captured territory
     // TODO: see if necessary
     if (Match.anyMatch(territory.getUnits().getUnits(),
-        Match.allOf(Matches.unitIsEnemyOf(data, id), Matches.UnitCanBeDamaged))) {
+        Match.allOf(Matches.unitIsEnemyOf(data, id), Matches.unitCanBeDamaged()))) {
       final IBattle bombingBattle = getPendingBattle(territory, true, null);
       if (bombingBattle != null) {
         final BattleResults results = new BattleResults(bombingBattle, WhoWon.DRAW, data);
@@ -772,7 +772,7 @@ public class BattleTracker implements Serializable {
     }
     // destroy any disabled units owned by the enemy that are NOT infrastructure or factories
     final Match<Unit> enemyToBeDestroyed = Match.allOf(Matches.enemyUnit(id, data),
-        Matches.UnitIsDisabled, Matches.UnitIsInfrastructure.invert());
+        Matches.unitIsDisabled(), Matches.UnitIsInfrastructure.invert());
     final Collection<Unit> destroyed = territory.getUnits().getMatches(enemyToBeDestroyed);
     if (!destroyed.isEmpty()) {
       final Change destroyUnits = ChangeFactory.removeUnits(territory, destroyed);

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -260,7 +260,7 @@ class EditValidator {
     if (units.isEmpty() || !Match.allMatch(units, Matches.unitIsOwnedBy(player))) {
       return "Not all units have the same owner";
     }
-    if (units.isEmpty() || !Match.allMatch(units, Matches.UnitCanBeDamaged)) {
+    if (units.isEmpty() || !Match.allMatch(units, Matches.unitCanBeDamaged())) {
       return "Not all units can take bombing damage";
     }
     for (final Unit u : units) {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -73,7 +73,9 @@ import games.strategy.util.Util;
  * The benefits should be obvious to any right minded person.
  * </p>
  */
-public class Matches {
+public final class Matches {
+  private Matches() {}
+
   public static Match<UnitType> unitTypeHasMoreThanOneHitPointTotal() {
     return Match.of(ut -> UnitAttachment.get(ut).getHitPoints() > 1);
   }
@@ -239,7 +241,9 @@ public class Matches {
 
   public static final Match<Unit> UnitIsAir = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsAir());
 
-  public static final Match<Unit> UnitIsNotAir = Match.of(unit -> !UnitAttachment.get(unit.getType()).getIsAir());
+  public static Match<Unit> unitIsNotAir() {
+    return Match.of(unit -> !UnitAttachment.get(unit.getType()).getIsAir());
+  }
 
   public static Match<UnitType> unitTypeCanBombard(final PlayerID id) {
     return Match.of(type -> UnitAttachment.get(type).getCanBombard(id));
@@ -313,11 +317,17 @@ public class Matches {
     });
   }
 
-  public static final Match<Unit> UnitIsAirBase = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsAirBase());
+  public static Match<Unit> unitIsAirBase() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsAirBase());
+  }
 
-  public static final Match<UnitType> UnitTypeCanBeDamaged = Match.of(ut -> UnitAttachment.get(ut).getCanBeDamaged());
+  public static Match<UnitType> unitTypeCanBeDamaged() {
+    return Match.of(ut -> UnitAttachment.get(ut).getCanBeDamaged());
+  }
 
-  public static final Match<Unit> UnitCanBeDamaged = Match.of(unit -> UnitTypeCanBeDamaged.match(unit.getType()));
+  public static Match<Unit> unitCanBeDamaged() {
+    return Match.of(unit -> unitTypeCanBeDamaged().match(unit.getType()));
+  }
 
   static Match<Unit> unitIsAtMaxDamageOrNotCanBeDamaged(final Territory t) {
     return Match.of(unit -> {
@@ -342,48 +352,61 @@ public class Matches {
     });
   }
 
-  public static final Match<Unit> UnitHasTakenSomeBombingUnitDamage =
-      Match.of(unit -> ((TripleAUnit) unit).getUnitDamage() > 0);
+  public static Match<Unit> unitHasTakenSomeBombingUnitDamage() {
+    return Match.of(unit -> ((TripleAUnit) unit).getUnitDamage() > 0);
+  }
 
-  public static final Match<Unit> UnitHasNotTakenAnyBombingUnitDamage = UnitHasTakenSomeBombingUnitDamage.invert();
+  public static Match<Unit> unitHasNotTakenAnyBombingUnitDamage() {
+    return unitHasTakenSomeBombingUnitDamage().invert();
+  }
 
-  public static final Match<Unit> UnitIsDisabled = Match.of(unit -> {
-    if (!UnitCanBeDamaged.match(unit)) {
-      return false;
-    }
-    if (!Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(unit.getData())) {
-      return false;
-    }
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-    final TripleAUnit taUnit = (TripleAUnit) unit;
-    if (ua.getMaxOperationalDamage() < 0) {
-      // factories may or may not have max operational damage set, so we must still determine here
-      // assume that if maxOperationalDamage < 0, then the max damage must be based on the territory value (if the
-      // damage >= production of
-      // territory, then we are disabled)
-      // TerritoryAttachment ta = TerritoryAttachment.get(t);
-      // return taUnit.getUnitDamage() >= ta.getProduction();
-      return false;
-    }
-    // only greater than. if == then we can still operate
-    return taUnit.getUnitDamage() > ua.getMaxOperationalDamage();
-  });
+  /**
+   * Returns a match indicating the specified unit is disabled.
+   */
+  public static Match<Unit> unitIsDisabled() {
+    return Match.of(unit -> {
+      if (!unitCanBeDamaged().match(unit)) {
+        return false;
+      }
+      if (!Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(unit.getData())) {
+        return false;
+      }
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      final TripleAUnit taUnit = (TripleAUnit) unit;
+      if (ua.getMaxOperationalDamage() < 0) {
+        // factories may or may not have max operational damage set, so we must still determine here
+        // assume that if maxOperationalDamage < 0, then the max damage must be based on the territory value (if the
+        // damage >= production of
+        // territory, then we are disabled)
+        // TerritoryAttachment ta = TerritoryAttachment.get(t);
+        // return taUnit.getUnitDamage() >= ta.getProduction();
+        return false;
+      }
+      // only greater than. if == then we can still operate
+      return taUnit.getUnitDamage() > ua.getMaxOperationalDamage();
+    });
+  }
 
-  public static final Match<Unit> UnitIsNotDisabled = UnitIsDisabled.invert();
+  public static Match<Unit> unitIsNotDisabled() {
+    return unitIsDisabled().invert();
+  }
 
-  public static final Match<Unit> UnitCanDieFromReachingMaxDamage = Match.of(unit -> {
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-    if (!ua.getCanBeDamaged()) {
-      return false;
-    }
-    return ua.getCanDieFromReachingMaxDamage();
-  });
+  static Match<Unit> unitCanDieFromReachingMaxDamage() {
+    return Match.of(unit -> {
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      if (!ua.getCanBeDamaged()) {
+        return false;
+      }
+      return ua.getCanDieFromReachingMaxDamage();
+    });
+  }
 
-  public static final Match<UnitType> UnitTypeIsInfrastructure =
-      Match.of(ut -> UnitAttachment.get(ut).getIsInfrastructure());
+  public static Match<UnitType> unitTypeIsInfrastructure() {
+    return Match.of(ut -> UnitAttachment.get(ut).getIsInfrastructure());
+  }
 
   public static final Match<Unit> UnitIsInfrastructure =
-      Match.of(unit -> UnitTypeIsInfrastructure.match(unit.getType()));
+      Match.of(unit -> unitTypeIsInfrastructure().match(unit.getType()));
 
   public static final Match<Unit> UnitIsNotInfrastructure = UnitIsInfrastructure.invert();
 
@@ -417,12 +440,17 @@ public class Matches {
     return Match.of(usa -> usa.getPlayers().contains(player));
   }
 
-  public static final Match<Unit> UnitCanScramble =
-      Match.of(unit -> UnitAttachment.get(unit.getType()).getCanScramble());
+  public static Match<Unit> unitCanScramble() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getCanScramble());
+  }
 
-  public static final Match<Unit> UnitWasScrambled = Match.of(obj -> ((TripleAUnit) obj).getWasScrambled());
+  public static Match<Unit> unitWasScrambled() {
+    return Match.of(obj -> ((TripleAUnit) obj).getWasScrambled());
+  }
 
-  public static final Match<Unit> UnitWasInAirBattle = Match.of(obj -> ((TripleAUnit) obj).getWasInAirBattle());
+  static Match<Unit> unitWasInAirBattle() {
+    return Match.of(obj -> ((TripleAUnit) obj).getWasInAirBattle());
+  }
 
   public static Match<Unit> unitCanBombard(final PlayerID id) {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getCanBombard(id));
@@ -431,8 +459,9 @@ public class Matches {
   public static final Match<Unit> UnitCanBlitz =
       Match.of(unit -> UnitAttachment.get(unit.getType()).getCanBlitz(unit.getOwner()));
 
-  public static final Match<Unit> UnitIsLandTransport =
-      Match.of(unit -> UnitAttachment.get(unit.getType()).getIsLandTransport());
+  static Match<Unit> unitIsLandTransport() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsLandTransport());
+  }
 
   static Match<Unit> unitIsNotInfrastructureAndNotCapturedOnEntering(final PlayerID player,
       final Territory terr, final GameData data) {
@@ -440,9 +469,13 @@ public class Matches {
         && !unitCanBeCapturedOnEnteringToInThisTerritory(player, terr, data).match(unit));
   }
 
-  public static final Match<Unit> UnitIsSuicide = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSuicide());
+  static Match<Unit> unitIsSuicide() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsSuicide());
+  }
 
-  public static final Match<Unit> UnitIsKamikaze = Match.of(unit -> UnitAttachment.get(unit.getType()).getIsKamikaze());
+  static Match<Unit> unitIsKamikaze() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsKamikaze());
+  }
 
   public static final Match<UnitType> UnitTypeIsAir = Match.of(type -> UnitAttachment.get(type).getIsAir());
 
@@ -1372,7 +1405,7 @@ public class Matches {
       }
       final Set<PlayerID> enemies = new HashSet<>();
       for (final Unit u : t.getUnits()
-          .getMatches(Match.allOf(enemyUnit(player, data), UnitIsNotAir, UnitIsNotInfrastructure))) {
+          .getMatches(Match.allOf(enemyUnit(player, data), unitIsNotAir(), UnitIsNotInfrastructure))) {
         enemies.add(u.getOwner());
       }
       return (Matches.isAtWarWithAnyOfThesePlayers(enemies, data)).match(t.getOwner());
@@ -1458,7 +1491,7 @@ public class Matches {
     });
   }
 
-  public static final Match<Unit> UnitIsLand = Match.allOf(unitIsNotSea(), UnitIsNotAir);
+  public static final Match<Unit> UnitIsLand = Match.allOf(unitIsNotSea(), unitIsNotAir());
 
   public static final Match<UnitType> UnitTypeIsLand = Match.allOf(unitTypeIsNotSea(), UnitTypeIsNotAir);
 
@@ -1513,7 +1546,7 @@ public class Matches {
   }
 
   public static final Match<Unit> UnitCanRepairOthers = Match.of(unit -> {
-    if (UnitIsDisabled.match(unit)) {
+    if (unitIsDisabled().match(unit)) {
       return false;
     }
     if (Matches.unitIsBeingTransported().match(unit)) {
@@ -1593,7 +1626,7 @@ public class Matches {
 
   static Match<Unit> unitCanGiveBonusMovementToThisUnit(final Unit unitWhichWillGetBonus) {
     return Match.of(unitCanGiveBonusMovement -> {
-      if (UnitIsDisabled.match(unitCanGiveBonusMovement)) {
+      if (unitIsDisabled().match(unitCanGiveBonusMovement)) {
         return false;
       }
       final UnitType type = unitCanGiveBonusMovement.getUnitType();
@@ -1681,8 +1714,11 @@ public class Matches {
       boolean canBuild = true;
       for (final UnitType ut : requiredUnits) {
         final Match<Unit> unitIsOwnedByAndOfTypeAndNotDamaged = Match.allOf(
-            Matches.unitIsOwnedBy(unitWhichRequiresUnits.getOwner()), Matches.unitIsOfType(ut),
-            Matches.UnitHasNotTakenAnyBombingUnitDamage, Matches.unitHasNotTakenAnyDamage(), Matches.UnitIsNotDisabled);
+            Matches.unitIsOwnedBy(unitWhichRequiresUnits.getOwner()),
+            Matches.unitIsOfType(ut),
+            Matches.unitHasNotTakenAnyBombingUnitDamage(),
+            Matches.unitHasNotTakenAnyDamage(),
+            Matches.unitIsNotDisabled());
         final int requiredNumber = requiredUnitsMap.getInt(ut);
         final int numberInTerritory =
             Match.countMatches(unitsInTerritoryAtStartOfTurn, unitIsOwnedByAndOfTypeAndNotDamaged);
@@ -1712,7 +1748,7 @@ public class Matches {
         return true;
       }
       final Match<Unit> unitIsOwnedByAndNotDisabled = Match.allOf(
-          Matches.unitIsOwnedBy(unitWhichRequiresUnits.getOwner()), Matches.UnitIsNotDisabled);
+          Matches.unitIsOwnedBy(unitWhichRequiresUnits.getOwner()), Matches.unitIsNotDisabled());
       unitsInTerritoryAtStartOfTurn
           .retainAll(Match.getMatches(unitsInTerritoryAtStartOfTurn, unitIsOwnedByAndNotDisabled));
       boolean canBuild = false;
@@ -1766,7 +1802,7 @@ public class Matches {
       Match.allOf(UnitCanProduceUnits, UnitIsInfrastructure);
 
   public static final Match<Unit> UnitCanProduceUnitsAndCanBeDamaged =
-      Match.allOf(UnitCanProduceUnits, UnitCanBeDamaged);
+      Match.allOf(UnitCanProduceUnits, unitCanBeDamaged());
 
   /**
    * See if a unit can invade. Units with canInvadeFrom not set, or set to "all", can invade from any other unit.
@@ -2134,7 +2170,7 @@ public class Matches {
       final Match.CompositeBuilder<UnitType> canBeInBattle = Match.newCompositeBuilder();
 
       final Match.CompositeBuilder<UnitType> supportOrNotInfrastructureOrAa = Match.newCompositeBuilder();
-      supportOrNotInfrastructureOrAa.add(Matches.UnitTypeIsInfrastructure.invert());
+      supportOrNotInfrastructureOrAa.add(Matches.unitTypeIsInfrastructure().invert());
       supportOrNotInfrastructureOrAa.add(Matches.unitTypeIsSupporterOrHasCombatAbility(attack, player));
       if (!doNotIncludeAa) {
         supportOrNotInfrastructureOrAa.add(Match.allOf(Matches.UnitTypeIsAAforCombatOnly,
@@ -2171,7 +2207,4 @@ public class Matches {
   public static <T> Match<T> isNotInList(final List<T> list) {
     return Match.of(not(list::contains));
   }
-
-  /** Creates new Matches. */
-  private Matches() {}
 }

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -529,11 +529,11 @@ public class MoveDelegate extends AbstractMoveDelegate {
     Collection<Unit> kamikazeUnits = new ArrayList<>();
 
     // confirm kamikaze moves, and remove them from unresolved units
-    if (getKamikazeAir || Match.anyMatch(units, Matches.UnitIsKamikaze)) {
+    if (getKamikazeAir || Match.anyMatch(units, Matches.unitIsKamikaze())) {
       kamikazeUnits = result.getUnresolvedUnits(MoveValidator.NOT_ALL_AIR_UNITS_CAN_LAND);
       if (kamikazeUnits.size() > 0 && getRemotePlayer().confirmMoveKamikaze()) {
         for (final Unit unit : kamikazeUnits) {
-          if (getKamikazeAir || Matches.UnitIsKamikaze.match(unit)) {
+          if (getKamikazeAir || Matches.unitIsKamikaze().match(unit)) {
             result.removeUnresolvedUnit(MoveValidator.NOT_ALL_AIR_UNITS_CAN_LAND, unit);
             isKamikaze = true;
           }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -103,7 +103,7 @@ public class MoveValidator {
     // dont let the user move out of a battle zone
     // the exception is air units and unloading units into a battle zone
     if (AbstractMoveDelegate.getBattleTracker(data).hasPendingBattle(route.getStart(), false)
-        && Match.anyMatch(units, Matches.UnitIsNotAir)) {
+        && Match.anyMatch(units, Matches.unitIsNotAir())) {
       // if the units did not move into the territory, then they can move out
       // this will happen if there is a submerged sub in the area, and
       // a different unit moved into the sea zone setting up a battle
@@ -283,7 +283,7 @@ public class MoveValidator {
           && (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsAir))) {
         return result.setErrorReturnResult("Cannot blitz out of a battle further into enemy territory");
       }
-      for (final Unit u : Match.getMatches(units, Match.allOf(Matches.UnitCanBlitz.invert(), Matches.UnitIsNotAir))) {
+      for (final Unit u : Match.getMatches(units, Match.allOf(Matches.UnitCanBlitz.invert(), Matches.unitIsNotAir()))) {
         result.addDisallowedUnit("Not all units can blitz out of empty enemy territory", u);
       }
     }
@@ -730,7 +730,7 @@ public class MoveValidator {
   private static int getMechanizedSupportAvail(final Collection<Unit> units, final PlayerID player) {
     int mechanizedSupportAvailable = 0;
     if (TechAttachment.isMechanizedInfantry(player)) {
-      final Match<Unit> transportLand = Match.allOf(Matches.UnitIsLandTransport, Matches.unitIsOwnedBy(player));
+      final Match<Unit> transportLand = Match.allOf(Matches.unitIsLandTransport(), Matches.unitIsOwnedBy(player));
       mechanizedSupportAvailable = Match.countMatches(units, transportLand);
     }
     return mechanizedSupportAvailable;

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -263,7 +263,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     addDependentUnits(dependencies);
     // mark units with no movement
     // for all but air
-    Collection<Unit> nonAir = Match.getMatches(attackingUnits, Matches.UnitIsNotAir);
+    Collection<Unit> nonAir = Match.getMatches(attackingUnits, Matches.unitIsNotAir());
     // we dont want to change the movement of transported land units if this is a sea battle
     // so restrict non air to remove land units
     if (m_battleSite.isWater()) {
@@ -505,11 +505,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         steps.add(NAVAL_BOMBARDMENT);
         steps.add(SELECT_NAVAL_BOMBARDMENT_CASUALTIES);
       }
-      if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSuicide)) {
+      if (Match.anyMatch(m_attackingUnits, Matches.unitIsSuicide())) {
         steps.add(SUICIDE_ATTACK);
         steps.add(m_defender.getName() + SELECT_CASUALTIES_SUICIDE);
       }
-      if (Match.anyMatch(m_defendingUnits, Matches.UnitIsSuicide) && !isDefendingSuicideAndMunitionUnitsDoNotFire()) {
+      if (Match.anyMatch(m_defendingUnits, Matches.unitIsSuicide()) && !isDefendingSuicideAndMunitionUnitsDoNotFire()) {
         steps.add(SUICIDE_DEFEND);
         steps.add(m_attacker.getName() + SELECT_CASUALTIES_SUICIDE);
       }
@@ -1614,7 +1614,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final IDelegateBridge bridge) {
     retreating.addAll(getDependentUnits(retreating));
     // our own air units dont retreat with land units
-    final Match<Unit> notMyAir = Match.anyOf(Matches.UnitIsNotAir, Matches.unitIsOwnedBy(m_attacker).invert());
+    final Match<Unit> notMyAir = Match.anyOf(Matches.unitIsNotAir(), Matches.unitIsOwnedBy(m_attacker).invert());
     retreating = Match.getMatches(retreating, notMyAir);
     final String transcriptText;
     // in WW2V1, defending subs can retreat so show owner
@@ -1663,7 +1663,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // retreating.addAll(getDependentUnits(retreating));
     retreating.addAll(getDependentUnits(units));
     // our own air units dont retreat with land units
-    final Match<Unit> notMyAir = Match.anyOf(Matches.UnitIsNotAir, Matches.unitIsOwnedBy(m_attacker).invert());
+    final Match<Unit> notMyAir = Match.anyOf(Matches.unitIsNotAir(), Matches.unitIsOwnedBy(m_attacker).invert());
     final Collection<Unit> nonAirRetreating = Match.getMatches(retreating, notMyAir);
     final String transcriptText = MyFormatter.unitsToTextNoOwner(nonAirRetreating) + " retreated to " + to.getName();
     bridge.getHistoryWriter().addChildToEvent(transcriptText, new ArrayList<>(nonAirRetreating));
@@ -1711,13 +1711,13 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    */
   private void checkSuicideUnits(final IDelegateBridge bridge) {
     if (isDefendingSuicideAndMunitionUnitsDoNotFire()) {
-      final List<Unit> deadUnits = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);
+      final List<Unit> deadUnits = Match.getMatches(m_attackingUnits, Matches.unitIsSuicide());
       getDisplay(bridge).deadUnitNotification(m_battleID, m_attacker, deadUnits, m_dependentUnits);
       remove(deadUnits, bridge, m_battleSite, false);
     } else {
       final List<Unit> deadUnits = new ArrayList<>();
-      deadUnits.addAll(Match.getMatches(m_defendingUnits, Matches.UnitIsSuicide));
-      deadUnits.addAll(Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide));
+      deadUnits.addAll(Match.getMatches(m_defendingUnits, Matches.unitIsSuicide()));
+      deadUnits.addAll(Match.getMatches(m_attackingUnits, Matches.unitIsSuicide()));
       getDisplay(bridge).deadUnitNotification(m_battleID, m_attacker, deadUnits, m_dependentUnits);
       getDisplay(bridge).deadUnitNotification(m_battleID, m_defender, deadUnits, m_dependentUnits);
       remove(deadUnits, bridge, m_battleSite, null);
@@ -1936,7 +1936,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (firing.isEmpty()) {
       return;
     }
-    final Collection<Unit> attacked = Match.getMatches(m_defendingUnits, Matches.UnitIsNotAir);
+    final Collection<Unit> attacked = Match.getMatches(m_defendingUnits, Matches.unitIsNotAir());
     // if there are destroyers in the attacked units, we can return fire.
     final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>();
     allEnemyUnitsAliveOrWaitingToDie.addAll(m_defendingUnits);
@@ -1956,7 +1956,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (firing.isEmpty()) {
       return;
     }
-    final Collection<Unit> attacked = Match.getMatches(m_attackingUnits, Matches.UnitIsNotAir);
+    final Collection<Unit> attacked = Match.getMatches(m_attackingUnits, Matches.unitIsNotAir());
     if (attacked.isEmpty()) {
       return;
     }
@@ -2031,8 +2031,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // TODO: add a global toggle for returning fire (Veqryn)
     final Match<Unit> attackableUnits = Match.allOf(
         Matches.unitIsNotInfrastructureAndNotCapturedOnEntering(m_attacker, m_battleSite, m_data),
-        Matches.UnitIsSuicide.invert(), Matches.unitIsBeingTransported().invert());
-    final Collection<Unit> suicideAttackers = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);
+        Matches.unitIsSuicide().invert(), Matches.unitIsBeingTransported().invert());
+    final Collection<Unit> suicideAttackers = Match.getMatches(m_attackingUnits, Matches.unitIsSuicide());
     final Collection<Unit> attackedDefenders = Match.getMatches(m_defendingUnits, attackableUnits);
     // comparatively simple rules for isSuicide units. if AirAttackSubRestricted and you have no destroyers, you can't
     // attack subs with
@@ -2062,8 +2062,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // TODO: add a global toggle for returning fire (Veqryn)
     final Match<Unit> attackableUnits = Match.allOf(Matches.UnitIsNotInfrastructure,
-        Matches.UnitIsSuicide.invert(), Matches.unitIsBeingTransported().invert());
-    final Collection<Unit> suicideDefenders = Match.getMatches(m_defendingUnits, Matches.UnitIsSuicide);
+        Matches.unitIsSuicide().invert(), Matches.unitIsBeingTransported().invert());
+    final Collection<Unit> suicideDefenders = Match.getMatches(m_defendingUnits, Matches.unitIsSuicide());
     final Collection<Unit> attackedAttackers = Match.getMatches(m_attackingUnits, attackableUnits);
     // comparatively simple rules for isSuicide units. if AirAttackSubRestricted and you have no destroyers, you can't
     // attack subs with
@@ -2316,7 +2316,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
             (removeForNextRound ? m_round + 1 : m_round), true, doNotIncludeAa, doNotIncludeSeaBombardmentUnits)
             .invert()));
     // remove any disabled units from combat
-    unitList.removeAll(Match.getMatches(unitList, Matches.UnitIsDisabled));
+    unitList.removeAll(Match.getMatches(unitList, Matches.unitIsDisabled()));
     // remove capturableOnEntering units (veqryn)
     unitList.removeAll(Match.getMatches(unitList,
         Matches.unitCanBeCapturedOnEnteringToInThisTerritory(m_attacker, m_battleSite, m_data)));
@@ -2324,7 +2324,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     unitList.removeAll(Match.getMatches(unitList, Match.allOf(Matches.unitIsBeingTransported(),
         Matches.UnitIsAir, Matches.UnitCanLandOnCarrier)));
     // remove any units that were in air combat (veqryn)
-    unitList.removeAll(Match.getMatches(unitList, Matches.UnitWasInAirBattle));
+    unitList.removeAll(Match.getMatches(unitList, Matches.unitWasInAirBattle()));
     return unitList;
   }
 
@@ -2518,7 +2518,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return;
     }
     // do we need to change ownership
-    if (Match.anyMatch(m_attackingUnits, Matches.UnitIsNotAir)) {
+    if (Match.anyMatch(m_attackingUnits, Matches.unitIsNotAir())) {
       if (Matches.isTerritoryEnemyAndNotUnownedWater(m_attacker, m_data).match(m_battleSite)) {
         m_battleTracker.addToConquered(m_battleSite);
       }
@@ -2585,7 +2585,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // TODO: why do we keep checking throughout this entire class if the units in m_defendingUnits are allied with
     // defender, and if the
     // units in m_attackingUnits are allied with the attacker? Does it really matter?
-    final Match<Unit> alliedDefendingAir = Match.allOf(Matches.UnitIsAir, Matches.UnitWasScrambled.invert());
+    final Match<Unit> alliedDefendingAir = Match.allOf(Matches.UnitIsAir, Matches.unitWasScrambled().invert());
     final Collection<Unit> defendingAir = Match.getMatches(m_defendingUnits, alliedDefendingAir);
     // no planes, exit
     if (defendingAir.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -144,7 +144,7 @@ public class RocketsFireHelper {
   }
 
   Match<Unit> rocketMatch(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.UnitIsRocket, Matches.unitIsOwnedBy(player), Matches.UnitIsNotDisabled,
+    return Match.allOf(Matches.UnitIsRocket, Matches.unitIsOwnedBy(player), Matches.unitIsNotDisabled(),
         Matches.unitIsBeingTransported().invert(), Matches.UnitIsSubmerged.invert(), Matches.unitHasNotMoved());
   }
 
@@ -419,8 +419,8 @@ public class RocketsFireHelper {
       }
     }
     // kill any units that can die if they have reached max damage (veqryn)
-    if (Match.anyMatch(targets, Matches.UnitCanDieFromReachingMaxDamage)) {
-      final List<Unit> unitsCanDie = Match.getMatches(targets, Matches.UnitCanDieFromReachingMaxDamage);
+    if (Match.anyMatch(targets, Matches.unitCanDieFromReachingMaxDamage())) {
+      final List<Unit> unitsCanDie = Match.getMatches(targets, Matches.unitCanDieFromReachingMaxDamage());
       unitsCanDie
           .retainAll(Match.getMatches(unitsCanDie, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory)));
       if (!unitsCanDie.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -227,7 +227,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
         result.addDisallowedUnit("Must Own All Airborne Forces", u);
       } else if (!Matches.unitIsOfTypes(airborneTypes).match(u)) {
         result.addDisallowedUnit("Can Only Launch Airborne Forces", u);
-      } else if (Matches.UnitIsDisabled.match(u)) {
+      } else if (Matches.unitIsDisabled().match(u)) {
         result.addDisallowedUnit("Must Not Be Disabled", u);
       } else if (!Matches.unitHasNotMoved().match(u)) {
         result.addDisallowedUnit("Must Not Have Previously Moved Airborne Forces", u);
@@ -292,7 +292,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
 
   private static Match<Unit> getAirborneMatch(final Set<UnitType> types, final Collection<PlayerID> unitOwners) {
     return Match.allOf(Matches.unitIsOwnedByOfAnyOfThesePlayers(unitOwners),
-        Matches.unitIsOfTypes(types), Matches.UnitIsNotDisabled, Matches.unitHasNotMoved(),
+        Matches.unitIsOfTypes(types), Matches.unitIsNotDisabled(), Matches.unitHasNotMoved(),
         Matches.UnitIsAirborne.invert());
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -241,8 +241,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           }
         }
         // kill any suicide attackers (veqryn)
-        if (Match.anyMatch(m_attackingUnits, Matches.UnitIsSuicide)) {
-          final List<Unit> suicideUnits = Match.getMatches(m_attackingUnits, Matches.UnitIsSuicide);
+        if (Match.anyMatch(m_attackingUnits, Matches.unitIsSuicide())) {
+          final List<Unit> suicideUnits = Match.getMatches(m_attackingUnits, Matches.unitIsSuicide());
           m_attackingUnits.removeAll(suicideUnits);
           final Change removeSuicide = ChangeFactory.removeUnits(m_battleSite, suicideUnits);
           final String transcriptText = MyFormatter.unitsToText(suicideUnits) + " lost in " + m_battleSite.getName();
@@ -253,8 +253,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           bridge.addChange(removeSuicide);
         }
         // kill any units that can die if they have reached max damage (veqryn)
-        if (Match.anyMatch(m_targets.keySet(), Matches.UnitCanDieFromReachingMaxDamage)) {
-          final List<Unit> unitsCanDie = Match.getMatches(m_targets.keySet(), Matches.UnitCanDieFromReachingMaxDamage);
+        if (Match.anyMatch(m_targets.keySet(), Matches.unitCanDieFromReachingMaxDamage())) {
+          final List<Unit> unitsCanDie =
+              Match.getMatches(m_targets.keySet(), Matches.unitCanDieFromReachingMaxDamage());
           unitsCanDie
               .retainAll(Match.getMatches(unitsCanDie, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite)));
           if (!unitsCanDie.isEmpty()) {

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -1015,7 +1015,7 @@ class OddsCalculatorPanel extends JPanel {
             u.setHits(category.getDamaged());
           }
         }
-        if (category.getDisabled() && Matches.UnitTypeCanBeDamaged.match(category.getType())) {
+        if (category.getDisabled() && Matches.unitTypeCanBeDamaged().match(category.getType())) {
           // add 1 because it is the max operational damage and we want to disable it
           final int unitDamage = Math.max(0, 1 + UnitAttachment.get(category.getType()).getMaxOperationalDamage());
           for (final Unit u : units) {
@@ -1182,7 +1182,7 @@ class OddsCalculatorPanel extends JPanel {
         final Set<UnitType> typesUsed = new HashSet<>();
         for (final UnitCategory category : categories) {
           // no duplicates or infrastructure allowed. no sea if land, no land if sea.
-          if (typesUsed.contains(category.getType()) || Matches.UnitTypeIsInfrastructure.match(category.getType())
+          if (typesUsed.contains(category.getType()) || Matches.unitTypeIsInfrastructure().match(category.getType())
               || (land && Matches.unitTypeIsSea().match(category.getType()))
               || (!land && Matches.UnitTypeIsLand.match(category.getType()))) {
             continue;

--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -405,7 +405,7 @@ class EditPanel extends ActionPanel {
       public void actionPerformed(final ActionEvent event) {
         currentAction = this;
         setWidgetActivation();
-        final List<Unit> units = Match.getMatches(selectedUnits, Matches.UnitCanBeDamaged);
+        final List<Unit> units = Match.getMatches(selectedUnits, Matches.unitCanBeDamaged());
         if (units == null || units.isEmpty() || !selectedTerritory.getUnits().getUnits().containsAll(units)) {
           cancelEditAction.actionPerformed(null);
           return;
@@ -530,7 +530,7 @@ class EditPanel extends ActionPanel {
         add(new JButton(changeUnitHitDamageAction));
       }
       if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
-          && Match.anyMatch(allUnitTypes, Matches.UnitTypeCanBeDamaged)) {
+          && Match.anyMatch(allUnitTypes, Matches.unitTypeCanBeDamaged())) {
         add(new JButton(changeUnitBombingDamageAction));
       }
     } finally {

--- a/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -126,7 +126,7 @@ public class ProductionRepairPanel extends JPanel {
       this.allowedPlayersToRepair = allowedPlayersToRepair;
       final Match<Unit> myDamagedUnits =
           Match.allOf(Matches.unitIsOwnedByOfAnyOfThesePlayers(this.allowedPlayersToRepair),
-              Matches.UnitHasTakenSomeBombingUnitDamage);
+              Matches.unitHasTakenSomeBombingUnitDamage());
       final Collection<Territory> terrsWithPotentiallyDamagedUnits =
           Match.getMatches(data.getMap().getTerritories(), Matches.territoryHasUnitsThatMatch(myDamagedUnits));
       for (final RepairRule repairRule : player.getRepairFrontier()) {
@@ -244,7 +244,7 @@ public class ProductionRepairPanel extends JPanel {
       repairResults = rule.getResults().getInt(type);
       final TripleAUnit taUnit = (TripleAUnit) repairUnit;
       final Optional<ImageIcon> icon = uiContext.getUnitImageFactory().getIcon(type, id, data,
-          Matches.UnitHasTakenSomeBombingUnitDamage.match(repairUnit), Matches.UnitIsDisabled.match(repairUnit));
+          Matches.unitHasTakenSomeBombingUnitDamage().match(repairUnit), Matches.unitIsDisabled().match(repairUnit));
       final String text = "<html> x " + ResourceCollection.toStringForHTML(cost, data) + "</html>";
 
       final JLabel label =

--- a/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -75,8 +75,8 @@ public class SimpleUnitPanel extends JPanel {
         if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
           // check to see if the repair rule matches the damaged unit
           if (unit.getType().equals((repairRule.getResults().keySet().iterator().next()))) {
-            addUnits(player, data, quantity, unit.getType(), Matches.UnitHasTakenSomeBombingUnitDamage.match(unit),
-                Matches.UnitIsDisabled.match(unit));
+            addUnits(player, data, quantity, unit.getType(), Matches.unitHasTakenSomeBombingUnitDamage().match(unit),
+                Matches.unitIsDisabled().match(unit));
           }
         }
       }

--- a/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -173,7 +173,7 @@ public class UnitsDrawer implements IDrawable {
     }
     displayHitDamage(bounds, graphics);
     // Display Factory Damage
-    if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data) && Matches.UnitTypeCanBeDamaged.match(type)) {
+    if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data) && Matches.unitTypeCanBeDamaged().match(type)) {
       displayFactoryDamage(bounds, graphics);
     }
   }
@@ -222,9 +222,9 @@ public class UnitsDrawer implements IDrawable {
       selectedUnitsBuilder.add(Matches.unitHasNotTakenAnyDamage());
     }
     if (bombingUnitDamage > 0) {
-      selectedUnitsBuilder.add(Matches.UnitHasTakenSomeBombingUnitDamage);
+      selectedUnitsBuilder.add(Matches.unitHasTakenSomeBombingUnitDamage());
     } else {
-      selectedUnitsBuilder.add(Matches.UnitHasNotTakenAnyBombingUnitDamage);
+      selectedUnitsBuilder.add(Matches.unitHasNotTakenAnyBombingUnitDamage());
     }
     final List<Unit> rVal = t.getUnits().getMatches(selectedUnitsBuilder.all());
     return Tuple.of(t, rVal);

--- a/src/main/java/games/strategy/triplea/util/UnitSeperator.java
+++ b/src/main/java/games/strategy/triplea/util/UnitSeperator.java
@@ -76,7 +76,7 @@ public class UnitSeperator {
       if (dependent != null) {
         currentDependents = dependent.get(current);
       }
-      final boolean disabled = Matches.UnitIsDisabled.match(current);
+      final boolean disabled = Matches.unitIsDisabled().match(current);
       final UnitCategory entry = new UnitCategory(current, currentDependents, unitMovement, current.getHits(),
           TripleAUnit.get(current).getUnitDamage(), disabled, unitTransportCost);
       // we test to see if we have the key using equals, then since

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1472,7 +1472,7 @@ public class WW2V3Year41Test {
   @Test
   public void testRepair() {
     final Territory germany = territory("Germany", gameData);
-    final Unit factory = germany.getUnits().getMatches(Matches.UnitCanBeDamaged).get(0);
+    final Unit factory = germany.getUnits().getMatches(Matches.unitCanBeDamaged()).get(0);
     final PurchaseDelegate del = purchaseDelegate(gameData);
     del.setDelegateBridgeAndPlayer(getDelegateBridge(germans(gameData)));
     del.start();
@@ -1488,7 +1488,7 @@ public class WW2V3Year41Test {
     IntegerMap<RepairRule> repairs = new IntegerMap<>();
     repairs.put(repair, 1);
     String error = del.purchaseRepair(Collections.singletonMap(
-        Match.getMatches(germany.getUnits().getUnits(), Matches.UnitCanBeDamaged).iterator().next(), repairs));
+        Match.getMatches(germany.getUnits().getUnits(), Matches.unitCanBeDamaged()).iterator().next(), repairs));
     assertValid(error);
     assertEquals(((TripleAUnit) factory).getUnitDamage(), 0);
     // Find cost
@@ -1510,7 +1510,7 @@ public class WW2V3Year41Test {
     repairs = new IntegerMap<>();
     repairs.put(repair, 2);
     error = del.purchaseRepair(Collections.singletonMap(
-        Match.getMatches(germany.getUnits().getUnits(), Matches.UnitCanBeDamaged).iterator().next(), repairs));
+        Match.getMatches(germany.getUnits().getUnits(), Matches.unitCanBeDamaged()).iterator().next(), repairs));
     assertValid(error);
     assertEquals(((TripleAUnit) factory).getUnitDamage(), 0);
     // Find cost
@@ -1521,7 +1521,7 @@ public class WW2V3Year41Test {
   @Test
   public void testRepairMoreThanDamaged() {
     final Territory germany = territory("Germany", gameData);
-    final Unit factory = germany.getUnits().getMatches(Matches.UnitCanBeDamaged).get(0);
+    final Unit factory = germany.getUnits().getMatches(Matches.unitCanBeDamaged()).get(0);
     final PurchaseDelegate del = purchaseDelegate(gameData);
     del.setDelegateBridgeAndPlayer(getDelegateBridge(germans(gameData)));
     del.start();
@@ -1535,7 +1535,7 @@ public class WW2V3Year41Test {
     // we have 1 damaged marker, but trying to repair 2
     repairs.put(repair, 2);
     final String error = del.purchaseRepair(Collections.singletonMap(
-        Match.getMatches(germany.getUnits().getUnits(), Matches.UnitCanBeDamaged).iterator().next(), repairs));
+        Match.getMatches(germany.getUnits().getUnits(), Matches.unitCanBeDamaged()).iterator().next(), repairs));
     // it is no longer an error, we just math max 0 it
     assertValid(error);
     assertEquals(((TripleAUnit) factory).getUnitDamage(), 0);

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -79,7 +79,7 @@ public class WW2V3Year42Test {
     when(dummyPlayer.shouldBomberBomb(any())).thenReturn(true);
     bridge.setRemote(dummyPlayer);
     // remove the russian units
-    removeFrom(karrelia, karrelia.getUnits().getMatches(Matches.UnitCanBeDamaged.invert()));
+    removeFrom(karrelia, karrelia.getUnits().getMatches(Matches.unitCanBeDamaged().invert()));
     // move the bomber to attack
     move(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber), new Route(germany, sz5, karrelia));
     // move an infantry to invade


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is one part in a series of related PRs in order to keep the review size reasonable.