### PR TITLE
Fix SetupPanel rendering (#2220)

### DIFF
--- a/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -159,6 +159,6 @@ abstract class SetupPanel extends JPanel implements ISetupPanel {
     setAllTypes.setAction(setAllTypesAction);
 
     panel.validate();
-    panel.invalidate();
+    panel.repaint();
   }
 }

--- a/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -45,23 +45,14 @@ abstract class SetupPanel extends JPanel implements ISetupPanel {
     }
   }
 
-  /**
-   * Subclasses that have chat override this.
-   */
   @Override
   public IChatPanel getChatPanel() {
     return null;
   }
 
-  /**
-   * Cleanup should occur here that occurs when we cancel.
-   */
   @Override
   public abstract void cancel();
 
-  /**
-   * Indicates we can start the game.
-   */
   @Override
   public abstract boolean canGameStart();
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -22,7 +22,7 @@ import games.strategy.engine.data.PlayerID;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.ui.SwingAction;
 
-public abstract class SetupPanel extends JPanel implements ISetupPanel {
+abstract class SetupPanel extends JPanel implements ISetupPanel {
   private static final long serialVersionUID = 4001323470187210773L;
   private static final String SET_ALL_DEFAULT_LABEL = "Default";
 
@@ -170,5 +170,4 @@ public abstract class SetupPanel extends JPanel implements ISetupPanel {
     panel.validate();
     panel.invalidate();
   }
-
 }


### PR DESCRIPTION
This PR fixes the `SetupPanel` rendering issue that occurs after returning to the staging screen from a game, as reported in #2220.

I originally thought this was some kind of race condition because I couldn't reproduce it on my Fedora VM but could reproduce it on my physical Windows machine.  I suspected a `SwingUtilities#invokeLater()` call was being interleaved somehow, and, in fact, found a perfect suspect in `LocalSetupPanel#update()` that triggers the `SetupPanel#layoutPlayerComponents()` method, which is responsible for creating the screen that is exhibiting the rendering issue.

However, after further investigation, it was determined that there is no race condition.  The problem actually has a relatively simple root cause that has probably been in the code for a while, but we only see it now due to the addition of the Resource Modifiers controls, which have two display states (expanded and collapsed).  What was missing in `layoutPlayerComponents()` is a call to `repaint()` after the container has been validated.  None of the UI code in `layoutPlayerComponents()` causes a [system-triggered repaint](http://www.oracle.com/technetwork/java/painting-140037.html#triggers) of the entire container, thus an application-triggered repaint is required.  See [this SO question](https://stackoverflow.com/questions/1097366/java-swing-revalidate-vs-repaint) for more information.

Now that I know what the root cause is, I have a theory as to why I didn't observe this issue on my Fedora VM.  Fedora 25+ uses the Wayland graphics stack, which triggers all sorts of slick animations during window transitions.  For example, when leaving the game and returning to the staging screen, the staging screen does not just appear immediately, but rather is animated from a zero size to its actual size in about half a second.  I believe this animation somehow triggers a resize event in Swing, which is one of the system repaint triggers listed above.  From my testing, no equivalent animation occurs on Windows 8.  Although not tested, I suspect there are no equivalent animations in the version of Ubuntu used to generate the original image in #2220 (or at least none that post a resize event to the Swing event queue).

The core of this change is in d0672d7.  Please view that in isolation to avoid noise from the refactoring.

#### Functional changes

* Force a repaint in `SetupPanel#layoutPlayerComponents()` after the container is validated to ensure the new graphical state of the panel is painted.  Specifically, to ensure a repaint of the regions outside the child components.  (The child components are correctly painted because they are first made visible in this method [system repaint trigger #1 in the above link].)

#### Refactoring changes

* `SetupPanel` is only used by clients in its own package, so I reduced its visibility from public to package-private.
* I removed some superfluous Javadocs from method overrides.  The superclass methods are already correctly Javadoced.

#### Testing

I tested on both Linux (Fedora) and Windows 8 x64.  In both cases, the staging screen (after first expanding the Resource Modifiers controls) was drawn correctly (i.e. with the Resource Modifiers controls collapsed) and without any graphical artifacts after returning from a game.  **However, I would appreciate if someone could verify this fix independently, preferably on Windows 7, Windows 10, or Ubuntu.**