### PR TITLE
Add '@InternalDoNotExport' to satisfy ValidateAttachmentsTest checks.

### DIFF
--- a/src/test/java/games/strategy/engine/data/FakeAttachment.java
+++ b/src/test/java/games/strategy/engine/data/FakeAttachment.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
+import games.strategy.engine.data.annotations.InternalDoNotExport;
+
 /**
  * Fake implementation of {@link IAttachment} useful for testing.
  */
@@ -51,11 +53,13 @@ public final class FakeAttachment implements IAttachment {
   }
 
   @Override
+  @InternalDoNotExport
   public void setAttachedTo(final Attachable attachable) {
     throw new UnsupportedOperationException();
   }
 
   @Override
+  @InternalDoNotExport
   public void setName(final String name) {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
Without, 'ValidateAttachmentsTest#testAllAttachments' fails with:

```
Could not find attachment 'this is surely not a valid identifier'. This is can be a map configuration problem, and would need to be fixed in the map XML. Or, the map XML is using a feature from a newer game engine version, and you will need to install the latest TripleA for it to be enabled. Meanwhile, the functionality provided by this attachment will not available.
Could not find delegate 'this is surely not a valid identifier'. This is can be a map configuration problem, and would need to be fixed in the map XML. Or, the map XML is using a feature from a newer game engine version, and you will need to install the latest TripleA for it to be enabled. Meanwhile, the functionality provided by this delegate will not available.

java.lang.AssertionError: One or more attachments are invalid:
WARNING: Class games.strategy.engine.data.FakeAttachment setter setName: begins with 'set' so must have either InternalDoNotExport or GameProperty annotation
```


---------------------------

After latest rebase found that this tweak was required for tests to pass.
