### PR TITLE
Fix exceptions thrown when leaving game during battle (#2225)

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -496,7 +496,7 @@ public class BattleDisplay extends JPanel {
     if (SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("This method should not be run in the event dispatch thread");
     }
-    final AtomicReference<CasualtyDetails> casualtyDetails = new AtomicReference<>();
+    final AtomicReference<CasualtyDetails> casualtyDetails = new AtomicReference<>(new CasualtyDetails());
     final CountDownLatch continueLatch = new CountDownLatch(1);
     SwingUtilities.invokeLater(() -> {
       final boolean isEditMode = (dice == null);

--- a/src/main/java/games/strategy/util/CountDownLatchHandler.java
+++ b/src/main/java/games/strategy/util/CountDownLatchHandler.java
@@ -25,22 +25,6 @@ public class CountDownLatchHandler {
   }
 
   /**
-   * If "releaseLatchOnInterrupt" was set to true (defaults to false) on construction of this handler, then interruptAll
-   * will release and
-   * remove all current latches.
-   * Otherwise does nothing.
-   */
-  public void interruptAll() {
-    if (releaseLatchOnInterrupt) {
-      synchronized (this) {
-        for (final CountDownLatch latch : latchesToCloseOnShutdown) {
-          removeShutdownLatch(latch);
-        }
-      }
-    }
-  }
-
-  /**
    * If "releaseLatchOnInterrupt" was set to true (defaults to false) on construction of this handler, then
    * interruptLatch will release and
    * remove the latch.
@@ -49,17 +33,6 @@ public class CountDownLatchHandler {
   public void interruptLatch(final CountDownLatch latch) {
     if (releaseLatchOnInterrupt) {
       removeShutdownLatch(latch);
-    }
-  }
-
-  /**
-   * Indicates this handler has been shut down.
-   *
-   * @return {@code true} if this handler has been shutdown; otherwise {@code false}.
-   */
-  public boolean isShutDown() {
-    synchronized (this) {
-      return isShutDown;
     }
   }
 

--- a/src/main/java/games/strategy/util/CountDownLatchHandler.java
+++ b/src/main/java/games/strategy/util/CountDownLatchHandler.java
@@ -83,17 +83,8 @@ public class CountDownLatchHandler {
    * Releases the latch and removes it from the latches being handled by this handler.
    */
   public void removeShutdownLatch(final CountDownLatch latch) {
-    removeShutdownLatch(latch, false);
-  }
-
-  /**
-   * Removes the latch from the latches being handled by this handler, and will not release it if doNotRelease is true.
-   */
-  public void removeShutdownLatch(final CountDownLatch latch, final boolean doNotRelease) {
     synchronized (this) {
-      if (!doNotRelease) {
-        releaseLatch(latch);
-      }
+      releaseLatch(latch);
       latchesToCloseOnShutdown.remove(latch);
     }
   }


### PR DESCRIPTION
This PR fixes the NPE reported in the original description of #2225, as well as some `ConcurrentModificationException`s that were raised while testing the same scenario on Linux (for some reason, the CMEs do not occur on Windows).

The root cause of the NPE was that `BattleDisplay#getCasualties()` can return `null` when the game is shut down while waiting for the user to select casualties.

The root cause of the CMEs was that `CountDownLatchHandler#shutDown()` would iterate and modify the `latchesToCloseOnShutdown` list outside of a critical section, thus allowing multiple threads to execute this code concurrently.

It may be easier to review this PR with whitespace changes ignored (`?w=1`).

#### Functional changes
* The NPE was fixed by modifying `BattleDisplay#getCasualties()` to never return `null`.  If it is interrupted before the user can select casualties, it now returns an empty `CasualtyDetails`.
* The CMEs were fixed by modifying `CountDownLatchHandler#shutDown()` to execute the iteration and modification of `latchesToCloseOnShutdown` while the instance lock is held.

#### Refactoring changes
* Cleaned up `CountDownLatchHandler` to ensure it is truly thread safe:
    * Ensure `latchesToCloseOnShutdown` is only manipulated while the instance lock is held.
    * Ensure `isShutDown` is only manipulated while the instance lock is held.  Marking this field as `volatile` is no longer necessary if it is only accessed in a synchronized block.
    * Added annotations to document the threading requirements of this class to hopefully avoid a future dev from accidentally manipulating one of the fields requiring synchronization without first acquiring the appropriate lock.
* Removed unused `CountDownLatchHandler` methods.

#### Testing

I tested using the save game attached to #2225 and verified that the NPE no longer occurs on both Linux and Windows x64.  I also verified the CMEs no longer occur on Linux.