### PR TITLE
Replace JCIP annotations with equivalent JSR 305 annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,6 @@ dependencies {
     compile 'com.sun.mail:mailapi:1.5.5'
     compile 'com.sun.mail:smtp:1.5.5'
     compile 'commons-io:commons-io:2.5'
-    compile 'net.jcip:jcip-annotations:1.0'
     compile 'org.apache.httpcomponents:httpclient:4.5.3'
     compile 'org.apache.httpcomponents:httpmime:4.5.3'
     compile 'org.apache.commons:commons-math3:3.6.1'

--- a/src/main/java/games/strategy/internal/persistence/serializable/GameDataProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/GameDataProxy.java
@@ -4,6 +4,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.InvalidObjectException;
 
+import javax.annotation.concurrent.Immutable;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameDataMemento;
 import games.strategy.persistence.serializable.Proxy;
@@ -11,7 +13,6 @@ import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.util.memento.Memento;
 import games.strategy.util.memento.MementoExportException;
 import games.strategy.util.memento.MementoImportException;
-import net.jcip.annotations.Immutable;
 
 /**
  * A serializable proxy for the {@link GameData} class.

--- a/src/main/java/games/strategy/internal/persistence/serializable/IntegerMapProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/IntegerMapProxy.java
@@ -4,10 +4,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 
+import javax.annotation.concurrent.Immutable;
+
 import games.strategy.persistence.serializable.Proxy;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.util.IntegerMap;
-import net.jcip.annotations.Immutable;
 
 /**
  * A serializable proxy for the {@link IntegerMap} class.

--- a/src/main/java/games/strategy/internal/persistence/serializable/PropertyBagMementoProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/PropertyBagMementoProxy.java
@@ -4,10 +4,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 
+import javax.annotation.concurrent.Immutable;
+
 import games.strategy.persistence.serializable.Proxy;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.util.memento.PropertyBagMemento;
-import net.jcip.annotations.Immutable;
 
 /**
  * A serializable proxy for the {@link PropertyBagMemento} class.

--- a/src/main/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxy.java
@@ -2,13 +2,14 @@ package games.strategy.internal.persistence.serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import javax.annotation.concurrent.Immutable;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.ResourceCollection;
 import games.strategy.persistence.serializable.Proxy;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.util.IntegerMap;
-import net.jcip.annotations.Immutable;
 
 /**
  * A serializable proxy for the {@link ResourceCollection} class.

--- a/src/main/java/games/strategy/internal/persistence/serializable/ResourceProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ResourceProxy.java
@@ -4,12 +4,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 
+import javax.annotation.concurrent.Immutable;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.IAttachment;
 import games.strategy.engine.data.Resource;
 import games.strategy.persistence.serializable.Proxy;
 import games.strategy.persistence.serializable.ProxyFactory;
-import net.jcip.annotations.Immutable;
 
 /**
  * A serializable proxy for the {@link Resource} class.

--- a/src/main/java/games/strategy/internal/persistence/serializable/TripleAProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/TripleAProxy.java
@@ -2,10 +2,11 @@ package games.strategy.internal.persistence.serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import javax.annotation.concurrent.Immutable;
+
 import games.strategy.persistence.serializable.Proxy;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.triplea.TripleA;
-import net.jcip.annotations.Immutable;
 
 /**
  * A serializable proxy for the {@link TripleA} class.

--- a/src/main/java/games/strategy/internal/persistence/serializable/VersionProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/VersionProxy.java
@@ -2,10 +2,11 @@ package games.strategy.internal.persistence.serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import javax.annotation.concurrent.Immutable;
+
 import games.strategy.persistence.serializable.Proxy;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.util.Version;
-import net.jcip.annotations.Immutable;
 
 /**
  * A serializable proxy for the {@link Version} class.

--- a/src/main/java/games/strategy/persistence/serializable/DefaultProxyFactory.java
+++ b/src/main/java/games/strategy/persistence/serializable/DefaultProxyFactory.java
@@ -2,7 +2,7 @@ package games.strategy.persistence.serializable;
 
 import java.util.function.Function;
 
-import net.jcip.annotations.Immutable;
+import javax.annotation.concurrent.Immutable;
 
 @Immutable
 final class DefaultProxyFactory<T> implements ProxyFactory {

--- a/src/main/java/games/strategy/persistence/serializable/DefaultProxyRegistry.java
+++ b/src/main/java/games/strategy/persistence/serializable/DefaultProxyRegistry.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import net.jcip.annotations.Immutable;
+import javax.annotation.concurrent.Immutable;
 
 @Immutable
 final class DefaultProxyRegistry implements ProxyRegistry {

--- a/src/main/java/games/strategy/util/memento/PropertyBagMemento.java
+++ b/src/main/java/games/strategy/util/memento/PropertyBagMemento.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import net.jcip.annotations.Immutable;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * Implementation of {@link Memento} that represents the originator state as a collection of name-value pairs.

--- a/src/test/java/games/strategy/persistence/serializable/FakeNonSerializableClass.java
+++ b/src/test/java/games/strategy/persistence/serializable/FakeNonSerializableClass.java
@@ -3,8 +3,7 @@ package games.strategy.persistence.serializable;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
-
-import net.jcip.annotations.Immutable;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * A fake non-serializable class used for testing the object serialization streams.

--- a/src/test/java/games/strategy/persistence/serializable/FakeNonSerializableClassProxy.java
+++ b/src/test/java/games/strategy/persistence/serializable/FakeNonSerializableClassProxy.java
@@ -2,7 +2,7 @@ package games.strategy.persistence.serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import net.jcip.annotations.Immutable;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * A serializable proxy for the {@code FakeNonSerializableClass} class.


### PR DESCRIPTION
I didn't realize that the FindBugs JSR 305 module (`com.google.code.findbugs:jsr305`) included equivalents for the JCIP (Java Concurrency in Practice) annotations.  Since we're using the JSR 305 module for its nullity annotations, it makes sense to use its concurrency annotations, as well, so that we can reduce the number of build dependencies.

The only difference between the annotations is that the JSR 305 annotations have a `CLASS` retention policy, while the JCIP annotations have a `RUNTIME` retention policy.  Since we only use these annotations for documentation, the `CLASS` retention policy is sufficient.