### PR TITLE
Fix build break caused by #2233 [High Priority]

### DIFF
--- a/src/main/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxy.java
@@ -4,12 +4,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 
+import javax.annotation.concurrent.Immutable;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ProductionFrontier;
 import games.strategy.engine.data.ProductionRule;
 import games.strategy.persistence.serializable.Proxy;
 import games.strategy.persistence.serializable.ProxyFactory;
-import net.jcip.annotations.Immutable;
 
 /**
  * A serializable proxy for the {@link ProductionFrontier} class.

--- a/src/main/java/games/strategy/internal/persistence/serializable/ProductionRuleProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ProductionRuleProxy.java
@@ -2,6 +2,8 @@ package games.strategy.internal.persistence.serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import javax.annotation.concurrent.Immutable;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.NamedAttachable;
 import games.strategy.engine.data.ProductionRule;
@@ -9,7 +11,6 @@ import games.strategy.engine.data.Resource;
 import games.strategy.persistence.serializable.Proxy;
 import games.strategy.persistence.serializable.ProxyFactory;
 import games.strategy.util.IntegerMap;
-import net.jcip.annotations.Immutable;
 
 /**
  * A serializable proxy for the {@link ProductionRule} class.


### PR DESCRIPTION
`master` is currently broken because #2233 was not rebased against the changes in #2246.  This PR replaces the now-unavailable JCIP annotations with their JSR 305 equivalents.