### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 3)

### DIFF
--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -721,7 +721,7 @@ class ProCombatMoveAI {
         for (final Territory t : bomberMoveMap.get(unit)) {
           final boolean territoryCanBeBombed = t.getUnits().anyMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
           if (territoryCanBeBombed && canAirSafelyLandAfterAttack(unit, t)) {
-            final int noAaBombingDefense = t.getUnits().anyMatch(Matches.UnitIsAAforBombingThisUnitOnly) ? 0 : 1;
+            final int noAaBombingDefense = t.getUnits().anyMatch(Matches.unitIsAaForBombingThisUnitOnly()) ? 0 : 1;
             int maxDamage = 0;
             final TerritoryAttachment ta = TerritoryAttachment.get(t);
             if (ta != null) {
@@ -776,7 +776,7 @@ class ProCombatMoveAI {
             final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player, data);
             final boolean isOverwhelmingWin =
                 ProBattleUtils.checkForOverwhelmingWin(t, attackingUnits, defendingUnits);
-            final boolean hasAa = Match.anyMatch(defendingUnits, Matches.UnitIsAAforAnything);
+            final boolean hasAa = Match.anyMatch(defendingUnits, Matches.unitIsAaForAnything());
             if (!hasAa && !isOverwhelmingWin) {
               minWinPercentage = result.getWinPercentage();
               minWinTerritory = t;
@@ -1040,7 +1040,7 @@ class ProCombatMoveAI {
         }
         final List<Unit> defendingUnits = attackMap.get(t).getMaxEnemyDefenders(player, data);
         double estimate = ProBattleUtils.estimateStrengthDifference(t, attackMap.get(t).getUnits(), defendingUnits);
-        final boolean hasAa = Match.anyMatch(defendingUnits, Matches.UnitIsAAforAnything);
+        final boolean hasAa = Match.anyMatch(defendingUnits, Matches.unitIsAaForAnything());
         if (hasAa) {
           estimate -= 10;
         }
@@ -1130,7 +1130,7 @@ class ProCombatMoveAI {
                 Match.noneMatch(defendingUnits, ProMatches.unitIsEnemyAndNotInfa(player, data));
             final boolean isOverwhelmingWin =
                 ProBattleUtils.checkForOverwhelmingWin(t, patd.getUnits(), defendingUnits);
-            final boolean hasAa = Match.anyMatch(defendingUnits, Matches.UnitIsAAforAnything);
+            final boolean hasAa = Match.anyMatch(defendingUnits, Matches.unitIsAaForAnything());
             if (!hasNoDefenders && !isOverwhelmingWin && (!hasAa || result.getWinPercentage() < minWinPercentage)) {
               minWinPercentage = result.getWinPercentage();
               minWinTerritory = t;
@@ -1188,7 +1188,7 @@ class ProCombatMoveAI {
                 Match.noneMatch(defendingUnits, ProMatches.unitIsEnemyAndNotInfa(player, data));
             final boolean isOverwhelmingWin =
                 ProBattleUtils.checkForOverwhelmingWin(t, patd.getUnits(), defendingUnits);
-            final boolean hasAa = Match.anyMatch(defendingUnits, Matches.UnitIsAAforAnything);
+            final boolean hasAa = Match.anyMatch(defendingUnits, Matches.unitIsAaForAnything());
             if (!isAirUnit || (!hasNoDefenders && !isOverwhelmingWin
                 && (!hasAa || result.getWinPercentage() < minWinPercentage))) {
               minWinPercentage = result.getWinPercentage();

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -359,7 +359,7 @@ class ProNonCombatMoveAI {
       patd.setMaxEnemyUnits(new ArrayList<>(enemyAttackingUnits));
       patd.setMaxEnemyBombardUnits(enemyAttackOptions.getMax(t).getMaxBombardUnits());
       final List<Unit> minDefendingUnitsAndNotAa =
-          Match.getMatches(patd.getCantMoveUnits(), Matches.UnitIsAAforAnything.invert());
+          Match.getMatches(patd.getCantMoveUnits(), Matches.unitIsAaForAnything().invert());
       final ProBattleResult minResult = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits),
           minDefendingUnitsAndNotAa, enemyAttackOptions.getMax(t).getMaxBombardUnits());
       patd.setMinBattleResult(minResult);
@@ -375,7 +375,8 @@ class ProNonCombatMoveAI {
       final Set<Unit> defendingUnits = new HashSet<>(patd.getMaxUnits());
       defendingUnits.addAll(patd.getMaxAmphibUnits());
       defendingUnits.addAll(patd.getCantMoveUnits());
-      final List<Unit> defendingUnitsAndNotAa = Match.getMatches(defendingUnits, Matches.UnitIsAAforAnything.invert());
+      final List<Unit> defendingUnitsAndNotAa =
+          Match.getMatches(defendingUnits, Matches.unitIsAaForAnything().invert());
       final ProBattleResult result = calc.calculateBattleResults(t, new ArrayList<>(enemyAttackingUnits),
           defendingUnitsAndNotAa, enemyAttackOptions.getMax(t).getMaxBombardUnits());
       int isFactory = 0;
@@ -1927,7 +1928,7 @@ class ProNonCombatMoveAI {
       final Territory currentTerritory = unitTerritoryMap.get(u);
 
       // Only check AA units whose territory can't be held and don't have factories
-      if (Matches.UnitIsAAforAnything.match(u) && !moveMap.get(currentTerritory).isCanHold()
+      if (Matches.unitIsAaForAnything().match(u) && !moveMap.get(currentTerritory).isCanHold()
           && !ProMatches.territoryHasInfraFactoryAndIsLand().match(currentTerritory)) {
         Territory maxValueTerritory = null;
         double maxValue = 0;
@@ -1948,7 +1949,7 @@ class ProNonCombatMoveAI {
           // Find value and try to move to territory that doesn't already have AA
           final List<Unit> units = new ArrayList<>(moveMap.get(t).getCantMoveUnits());
           units.addAll(moveMap.get(t).getUnits());
-          final boolean hasAa = Match.anyMatch(units, Matches.UnitIsAAforAnything);
+          final boolean hasAa = Match.anyMatch(units, Matches.unitIsAaForAnything());
           double value = moveMap.get(t).getValue();
           if (hasAa) {
             value *= 0.01;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -714,7 +714,7 @@ class ProPurchaseAI {
       final boolean enemyCanBomb =
           Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsStrategicBomber);
       final boolean territoryCanBeBombed = t.getUnits().anyMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
-      final boolean hasAaBombingDefense = t.getUnits().anyMatch(Matches.UnitIsAAforBombingThisUnitOnly);
+      final boolean hasAaBombingDefense = t.getUnits().anyMatch(Matches.unitIsAaForBombingThisUnitOnly());
       ProLogger.debug(t + ", enemyCanBomb=" + enemyCanBomb + ", territoryCanBeBombed=" + territoryCanBeBombed
           + ", hasAABombingDefense=" + hasAaBombingDefense);
       if (!enemyCanBomb || !territoryCanBeBombed || hasAaBombingDefense) {
@@ -734,7 +734,7 @@ class ProPurchaseAI {
       ProPurchaseOption bestAaOption = null;
       int minCost = Integer.MAX_VALUE;
       for (final ProPurchaseOption ppo : purchaseOptionsForTerritory) {
-        final boolean isAaForBombing = Matches.UnitTypeIsAAforBombingThisUnitOnly.match(ppo.getUnitType());
+        final boolean isAaForBombing = Matches.unitTypeIsAaForBombingThisUnitOnly().match(ppo.getUnitType());
         if (isAaForBombing && ppo.getCost() < minCost
             && !Matches.UnitTypeConsumesUnitsOnCreation.match(ppo.getUnitType())) {
           bestAaOption = ppo;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -117,7 +117,7 @@ final class ProTechAI {
           Matches.UnitIsSea,
           Matches.UnitCanMove);
       final Match<Unit> enemyTransportable = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
-          Matches.UnitCanBeTransported, Matches.UnitIsNotAA, Matches.UnitCanMove);
+          Matches.unitCanBeTransported(), Matches.UnitIsNotAA, Matches.UnitCanMove);
       final Match<Unit> transport = Match.allOf(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
       final List<Territory> enemyFighterTerritories = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0;

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
@@ -67,12 +67,12 @@ public class ProPurchaseOptionMap {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         specialOptions.add(ppo);
         ProLogger.debug("Special: " + ppo);
-      } else if (Matches.UnitTypeCanProduceUnits.match(unitType)
+      } else if (Matches.unitTypeCanProduceUnits().match(unitType)
           && Matches.unitTypeIsInfrastructure().match(unitType)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         factoryOptions.add(ppo);
         ProLogger.debug("Factory: " + ppo);
-      } else if (Matches.UnitTypeIsAAforBombingThisUnitOnly.match(unitType)) {
+      } else if (Matches.unitTypeIsAaForBombingThisUnitOnly().match(unitType)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         aaOptions.add(ppo);
         ProLogger.debug("AA: " + ppo);
@@ -86,7 +86,7 @@ public class ProPurchaseOptionMap {
           landDefenseOptions.add(ppo);
         }
         ProLogger.debug("Land: " + ppo);
-      } else if (Matches.UnitTypeIsAir.match(unitType)) {
+      } else if (Matches.unitTypeIsAir().match(unitType)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         airOptions.add(ppo);
         ProLogger.debug("Air: " + ppo);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -352,7 +352,7 @@ public class ProMatches {
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedAir(final PlayerID player, final boolean isCombatMove) {
     return Match.of(u -> {
-      if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+      if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().match(u)) {
         return false;
       }
       final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsAir);
@@ -362,7 +362,7 @@ public class ProMatches {
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedLand(final PlayerID player, final boolean isCombatMove) {
     return Match.of(u -> {
-      if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+      if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().match(u)) {
         return false;
       }
       final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsLand,
@@ -373,7 +373,7 @@ public class ProMatches {
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedSea(final PlayerID player, final boolean isCombatMove) {
     return Match.of(u -> {
-      if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+      if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().match(u)) {
         return false;
       }
       final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsSea);
@@ -383,7 +383,7 @@ public class ProMatches {
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedTransport(final PlayerID player, final boolean isCombatMove) {
     return Match.of(u -> {
-      if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+      if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().match(u)) {
         return false;
       }
       final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.UnitIsTransport);
@@ -393,7 +393,7 @@ public class ProMatches {
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedBombard(final PlayerID player) {
     return Match.of(u -> {
-      if (Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+      if (Matches.unitCanNotMoveDuringCombatMove().match(u)) {
         return false;
       }
       final Match<Unit> match = Match.allOf(unitCanBeMovedAndIsOwned(player), Matches.unitCanBombard(player));
@@ -403,7 +403,7 @@ public class ProMatches {
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedNonCombatInfra(final PlayerID player) {
     return Match.allOf(unitCanBeMovedAndIsOwned(player),
-        Matches.UnitCanNotMoveDuringCombatMove, Matches.UnitIsInfrastructure);
+        Matches.unitCanNotMoveDuringCombatMove(), Matches.UnitIsInfrastructure);
   }
 
   public static Match<Unit> unitCantBeMovedAndIsAlliedDefender(final PlayerID player, final GameData data,
@@ -445,7 +445,7 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsEnemyAndNotAA(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsAAforAnything.invert());
+    return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsAaForAnything().invert());
   }
 
   public static Match<Unit> unitIsEnemyAndNotInfa(final PlayerID player, final GameData data) {
@@ -493,18 +493,18 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsOwnedTransportableUnit(final PlayerID player) {
-    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported, Matches.UnitCanMove);
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCanBeTransported(), Matches.UnitCanMove);
   }
 
   public static Match<Unit> unitIsOwnedCombatTransportableUnit(final PlayerID player) {
-    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitCanBeTransported,
-        Matches.UnitCanNotMoveDuringCombatMove.invert(), Matches.UnitCanMove);
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCanBeTransported(),
+        Matches.unitCanNotMoveDuringCombatMove().invert(), Matches.UnitCanMove);
   }
 
   public static Match<Unit> unitIsOwnedTransportableUnitAndCanBeLoaded(final PlayerID player,
       final boolean isCombatMove) {
     return Match.of(u -> {
-      if (isCombatMove && Matches.UnitCanNotMoveDuringCombatMove.match(u)) {
+      if (isCombatMove && Matches.unitCanNotMoveDuringCombatMove().match(u)) {
         return false;
       }
       final Match<Unit> match = Match.allOf(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved(),

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -411,7 +411,7 @@ public class WeakAI extends AbstractAI {
         continue;
       }
       final Match<Unit> ownedTransports =
-          Match.allOf(Matches.UnitCanTransport, Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved());
+          Match.allOf(Matches.unitCanTransport(), Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved());
       final Match<Territory> enemyTerritory =
           Match.allOf(Matches.isTerritoryEnemy(player, data), Matches.TerritoryIsLand,
               Matches.TerritoryIsNeutralButNotWater.invert(), Matches.TerritoryIsEmpty);
@@ -613,7 +613,7 @@ public class WeakAI extends AbstractAI {
           for (final Unit unit : unitsSortedByCost) {
             final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsLand,
                 Matches.UnitIsNotInfrastructure, Matches.UnitCanMove, Matches.UnitIsNotAA,
-                Matches.UnitCanNotMoveDuringCombatMove.invert());
+                Matches.unitCanNotMoveDuringCombatMove().invert());
             if (!unitsAlreadyMoved.contains(unit) && match.match(unit)) {
               moveRoutes.add(data.getMap().getRoute(attackFrom, enemy));
               // if unloading units, unload all of them,
@@ -646,7 +646,7 @@ public class WeakAI extends AbstractAI {
             Matches.UnitIsNotAA,
             Matches.UnitCanMove,
             Matches.UnitIsNotInfrastructure,
-            Matches.UnitCanNotMoveDuringCombatMove.invert(),
+            Matches.unitCanNotMoveDuringCombatMove().invert(),
             Matches.unitIsNotSea());
         final Set<Territory> dontMoveFrom = new HashSet<>();
         // find our strength that we can attack with
@@ -747,9 +747,9 @@ public class WeakAI extends AbstractAI {
             continue;
           }
           final UnitType results = (UnitType) resourceOrUnit;
-          if (Matches.unitTypeIsSea().match(results) || Matches.UnitTypeIsAir.match(results)
-              || Matches.unitTypeIsInfrastructure().match(results) || Matches.UnitTypeIsAAforAnything.match(results)
-              || Matches.UnitTypeHasMaxBuildRestrictions.match(results)
+          if (Matches.unitTypeIsSea().match(results) || Matches.unitTypeIsAir().match(results)
+              || Matches.unitTypeIsInfrastructure().match(results) || Matches.unitTypeIsAaForAnything().match(results)
+              || Matches.unitTypeHasMaxBuildRestrictions().match(results)
               || Matches.UnitTypeConsumesUnitsOnCreation.match(results)
               || Matches.unitTypeIsStatic(player).match(results)) {
             continue;
@@ -941,8 +941,10 @@ public class WeakAI extends AbstractAI {
           continue;
         }
         final UnitType results = (UnitType) resourceOrUnit;
-        if (Matches.UnitTypeIsAir.match(results) || Matches.unitTypeIsInfrastructure().match(results)
-            || Matches.UnitTypeIsAAforAnything.match(results) || Matches.UnitTypeHasMaxBuildRestrictions.match(results)
+        if (Matches.unitTypeIsAir().match(results)
+            || Matches.unitTypeIsInfrastructure().match(results)
+            || Matches.unitTypeIsAaForAnything().match(results)
+            || Matches.unitTypeHasMaxBuildRestrictions().match(results)
             || Matches.UnitTypeConsumesUnitsOnCreation.match(results)
             || Matches.unitTypeIsStatic(player).match(results)) {
           continue;

--- a/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -155,7 +155,7 @@ public class CanalAttachment extends DefaultAttachment {
   public HashSet<UnitType> getExcludedUnits() {
     if (m_excludedUnits == null) {
       return new HashSet<>(
-          Match.getMatches(getData().getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeIsAir));
+          Match.getMatches(getData().getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsAir()));
     }
     return m_excludedUnits;
   }

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1244,7 +1244,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allAir =
-              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeIsAir);
+              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsAir());
           for (final UnitType air : allAir) {
             taa.setMovementBonus("2:" + air.getName());
           }
@@ -1252,7 +1252,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allAa =
-              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeIsAAforAnything);
+              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsAaForAnything());
           for (final UnitType aa : allAa) {
             taa.setRadarBonus("1:" + aa.getName());
           }
@@ -1268,7 +1268,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allJets = Match.getMatches(data.getUnitTypeList().getAllUnitTypes(),
-              Match.allOf(Matches.UnitTypeIsAir, Matches.unitTypeIsStrategicBomber().invert()));
+              Match.allOf(Matches.unitTypeIsAir(), Matches.unitTypeIsStrategicBomber().invert()));
           final boolean ww2v3TechModel = Properties.getWW2V3TechModel(data);
           for (final UnitType jet : allJets) {
             if (ww2v3TechModel) {
@@ -1283,7 +1283,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allFactories =
-              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeCanProduceUnits);
+              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeCanProduceUnits());
           for (final UnitType factory : allFactories) {
             taa.setProductionBonus("2:" + factory.getName());
             taa.setMinimumTerritoryValueForProductionBonus("3");
@@ -1299,7 +1299,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allRockets =
-              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeIsRocket);
+              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsRocket());
           for (final UnitType rocket : allRockets) {
             taa.setRocketDiceNumber("1:" + rocket.getName());
           }

--- a/src/main/java/games/strategy/triplea/attachments/UnitTypeComparator.java
+++ b/src/main/java/games/strategy/triplea/attachments/UnitTypeComparator.java
@@ -24,10 +24,10 @@ public class UnitTypeComparator implements Comparator<UnitType> {
     if (ua2.getIsInfrastructure() && !ua1.getIsInfrastructure()) {
       return -1;
     }
-    if (Matches.UnitTypeIsAAforAnything.match(u1) && !Matches.UnitTypeIsAAforAnything.match(u2)) {
+    if (Matches.unitTypeIsAaForAnything().match(u1) && !Matches.unitTypeIsAaForAnything().match(u2)) {
       return 1;
     }
-    if (!Matches.UnitTypeIsAAforAnything.match(u1) && Matches.UnitTypeIsAAforAnything.match(u2)) {
+    if (!Matches.unitTypeIsAaForAnything().match(u1) && Matches.unitTypeIsAaForAnything().match(u2)) {
       return -1;
     }
     if (ua1.getIsAir() && !ua2.getIsAir()) {

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -87,7 +87,7 @@ class AAInMoveUtil implements Serializable {
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(movingPlayer, getData());
     final List<Unit> defendingAa = territory.getUnits().getMatches(Matches.unitIsAaThatCanFire(units,
-        airborneTechTargetsAllowed, movingPlayer, Matches.UnitIsAAforFlyOverOnly, 1, true, getData()));
+        airborneTechTargetsAllowed, movingPlayer, Matches.unitIsAaForFlyOverOnly(), 1, true, getData()));
     // comes ordered alphabetically already
     final List<String> aaTypes = UnitAttachment.getAllOfTypeAAs(defendingAa);
     // stacks are backwards
@@ -196,7 +196,7 @@ class AAInMoveUtil implements Serializable {
     // that will be a battle
     // and handled else where in this tangled mess
     final Match<Unit> hasAa = Matches.unitIsAaThatCanFire(units, airborneTechTargetsAllowed, movingPlayer,
-        Matches.UnitIsAAforFlyOverOnly, 1, true, data);
+        Matches.unitIsAaForFlyOverOnly(), 1, true, data);
     // AA guns in transports shouldn't be able to fire
     final List<Territory> territoriesWhereAaWillFire = new ArrayList<>();
     for (final Territory current : route.getMiddleSteps()) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -102,7 +102,7 @@ public class BattleCalculator {
     }
     final GameData data = bridge.getData();
     final boolean allowMultipleHitsPerUnit =
-        !defendingAa.isEmpty() && Match.allMatch(defendingAa, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
+        !defendingAa.isEmpty() && Match.allMatch(defendingAa, Matches.unitAaShotDamageableInsteadOfKillingInstantly());
     if (isChooseAA(data)) {
       final String text = "Select " + dice.getHits() + " casualties from aa fire in " + terr.getName();
       return selectCasualties(null, hitPlayer, planes, allFriendlyUnits, firingPlayer, allEnemyUnits, amphibious,
@@ -586,15 +586,15 @@ public class BattleCalculator {
     final Collection<Unit> killedNonAmphibUnits = new ArrayList<>();
     final Collection<UnitType> amphibTypes = new ArrayList<>();
     // Get a list of all selected killed units that are NOT amphibious
-    final Match<Unit> match = Match.allOf(Matches.UnitIsLand, Matches.UnitWasNotAmphibious);
+    final Match<Unit> match = Match.allOf(Matches.UnitIsLand, Matches.unitWasNotAmphibious());
     killedNonAmphibUnits.addAll(Match.getMatches(killed, match));
     // If all killed units are amphibious, just return them
     if (killedNonAmphibUnits.isEmpty()) {
       return killed;
     }
     // Get a list of all units that are amphibious and remove those that are killed
-    allAmphibUnits.addAll(Match.getMatches(targets, Matches.UnitWasAmphibious));
-    allAmphibUnits.removeAll(Match.getMatches(killed, Matches.UnitWasAmphibious));
+    allAmphibUnits.addAll(Match.getMatches(targets, Matches.unitWasAmphibious()));
+    allAmphibUnits.removeAll(Match.getMatches(killed, Matches.unitWasAmphibious()));
     final Iterator<Unit> allAmphibUnitsIter = allAmphibUnits.iterator();
     // Get a collection of the unit types of the amphib units
     while (allAmphibUnitsIter.hasNext()) {

--- a/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -92,7 +92,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
               Match.allOf(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
-          if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.UnitCanBeTransported)) {
+          if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.unitCanBeTransported())) {
             return "Can't add land units that can't be transported, to water";
           }
           seaTransports.addAll(territory.getUnits().getMatches(friendlySeaTransports));

--- a/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -78,7 +78,7 @@ class EditValidator {
               Match.allOf(Matches.UnitIsTransport, Matches.UnitIsSea, Matches.alliedUnit(player, data));
           final Collection<Unit> seaTransports = Match.getMatches(units, friendlySeaTransports);
           final Collection<Unit> landUnitsToAdd = Match.getMatches(units, Matches.UnitIsLand);
-          if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.UnitCanBeTransported)) {
+          if (landUnitsToAdd.isEmpty() || !Match.allMatch(landUnitsToAdd, Matches.unitCanBeTransported())) {
             return "Can't add land units that can't be transported, to water";
           }
           seaTransports.addAll(territory.getUnits().getMatches(friendlySeaTransports));
@@ -138,13 +138,13 @@ class EditValidator {
       return result;
     }
     // if transport selected, all transported units must be deleted too
-    for (final Unit unit : Match.getMatches(units, Matches.UnitCanTransport)) {
+    for (final Unit unit : Match.getMatches(units, Matches.unitCanTransport())) {
       if (!units.containsAll(TransportTracker.transporting(unit))) {
         return "Can't remove transport without removing transported units";
       }
     }
     // if transported units selected, transport must be deleted too
-    for (final Unit unit : Match.getMatches(units, Matches.UnitCanBeTransported)) {
+    for (final Unit unit : Match.getMatches(units, Matches.unitCanBeTransported())) {
       final Unit transport = TransportTracker.transportedBy(unit);
       if (transport != null && !units.contains(transport)) {
         return "Can't remove transported units without removing transport";

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -477,9 +477,13 @@ public final class Matches {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getIsKamikaze());
   }
 
-  public static final Match<UnitType> UnitTypeIsAir = Match.of(type -> UnitAttachment.get(type).getIsAir());
+  public static Match<UnitType> unitTypeIsAir() {
+    return Match.of(type -> UnitAttachment.get(type).getIsAir());
+  }
 
-  public static final Match<UnitType> UnitTypeIsNotAir = Match.of(type -> !UnitAttachment.get(type).getIsAir());
+  private static Match<UnitType> unitTypeIsNotAir() {
+    return Match.of(type -> !UnitAttachment.get(type).getIsAir());
+  }
 
   public static final Match<Unit> UnitCanLandOnCarrier =
       Match.of(unit -> UnitAttachment.get(unit.getType()).getCarrierCost() != -1);
@@ -496,54 +500,71 @@ public final class Matches {
         && data.getRelationshipTracker().isAllied(player, unit.getOwner()));
   }
 
-  public static final Match<Unit> UnitCanBeTransported =
-      Match.of(unit -> UnitAttachment.get(unit.getType()).getTransportCost() != -1);
+  public static Match<Unit> unitCanBeTransported() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getTransportCost() != -1);
+  }
 
-  public static final Match<Unit> UnitWasAmphibious = Match.of(obj -> ((TripleAUnit) obj).getWasAmphibious());
+  static Match<Unit> unitWasAmphibious() {
+    return Match.of(obj -> ((TripleAUnit) obj).getWasAmphibious());
+  }
 
-  public static final Match<Unit> UnitWasNotAmphibious = UnitWasAmphibious.invert();
+  static Match<Unit> unitWasNotAmphibious() {
+    return unitWasAmphibious().invert();
+  }
 
-  public static final Match<Unit> UnitWasInCombat = Match.of(obj -> ((TripleAUnit) obj).getWasInCombat());
+  static Match<Unit> unitWasInCombat() {
+    return Match.of(obj -> ((TripleAUnit) obj).getWasInCombat());
+  }
 
-  public static final Match<Unit> UnitWasUnloadedThisTurn =
-      Match.of(obj -> ((TripleAUnit) obj).getUnloadedTo() != null);
+  static Match<Unit> unitWasUnloadedThisTurn() {
+    return Match.of(obj -> ((TripleAUnit) obj).getUnloadedTo() != null);
+  }
 
-  public static final Match<Unit> UnitWasLoadedThisTurn = Match.of(obj -> ((TripleAUnit) obj).getWasLoadedThisTurn());
+  private static Match<Unit> unitWasLoadedThisTurn() {
+    return Match.of(obj -> ((TripleAUnit) obj).getWasLoadedThisTurn());
+  }
 
-  public static final Match<Unit> UnitWasNotLoadedThisTurn = UnitWasLoadedThisTurn.invert();
+  static Match<Unit> unitWasNotLoadedThisTurn() {
+    return unitWasLoadedThisTurn().invert();
+  }
 
-  public static final Match<Unit> UnitCanTransport =
-      Match.of(unit -> UnitAttachment.get(unit.getType()).getTransportCapacity() != -1);
+  public static Match<Unit> unitCanTransport() {
+    return Match.of(unit -> UnitAttachment.get(unit.getType()).getTransportCapacity() != -1);
+  }
 
-  public static final Match<UnitType> UnitTypeCanProduceUnits =
-      Match.of(obj -> UnitAttachment.get(obj).getCanProduceUnits());
+  public static Match<UnitType> unitTypeCanProduceUnits() {
+    return Match.of(obj -> UnitAttachment.get(obj).getCanProduceUnits());
+  }
 
-  public static final Match<Unit> UnitCanProduceUnits = Match.of(obj -> UnitTypeCanProduceUnits.match(obj.getType()));
+  public static final Match<Unit> UnitCanProduceUnits = Match.of(obj -> unitTypeCanProduceUnits().match(obj.getType()));
 
-  public static final Match<UnitType> UnitTypeHasMaxBuildRestrictions =
-      Match.of(type -> UnitAttachment.get(type).getMaxBuiltPerPlayer() >= 0);
+  public static Match<UnitType> unitTypeHasMaxBuildRestrictions() {
+    return Match.of(type -> UnitAttachment.get(type).getMaxBuiltPerPlayer() >= 0);
+  }
 
-  public static final Match<UnitType> UnitTypeIsRocket = Match.of(obj -> UnitAttachment.get(obj).getIsRocket());
+  public static Match<UnitType> unitTypeIsRocket() {
+    return Match.of(obj -> UnitAttachment.get(obj).getIsRocket());
+  }
 
-  public static final Match<Unit> UnitIsRocket = Match.of(obj -> UnitTypeIsRocket.match(obj.getType()));
+  static Match<Unit> unitIsRocket() {
+    return Match.of(obj -> unitTypeIsRocket().match(obj.getType()));
+  }
 
-  public static final Match<Unit> UnitHasMovementLimit = Match.of(obj -> {
-    final UnitType type = obj.getUnitType();
-    final UnitAttachment ua = UnitAttachment.get(type);
-    return ua.getMovementLimit() != null;
-  });
+  static Match<Unit> unitHasMovementLimit() {
+    return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getMovementLimit() != null);
+  }
 
-  public static final Match<Unit> UnitHasAttackingLimit = Match.of(obj -> {
-    final UnitType type = obj.getUnitType();
-    final UnitAttachment ua = UnitAttachment.get(type);
-    return ua.getAttackingLimit() != null;
-  });
+  static final Match<Unit> unitHasAttackingLimit() {
+    return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getAttackingLimit() != null);
+  }
 
-  public static final Match<UnitType> UnitTypeCanNotMoveDuringCombatMove =
-      Match.of(type -> UnitAttachment.get(type).getCanNotMoveDuringCombatMove());
+  private static Match<UnitType> unitTypeCanNotMoveDuringCombatMove() {
+    return Match.of(type -> UnitAttachment.get(type).getCanNotMoveDuringCombatMove());
+  }
 
-  public static final Match<Unit> UnitCanNotMoveDuringCombatMove =
-      Match.of(obj -> UnitTypeCanNotMoveDuringCombatMove.match(obj.getType()));
+  public static Match<Unit> unitCanNotMoveDuringCombatMove() {
+    return Match.of(obj -> unitTypeCanNotMoveDuringCombatMove().match(obj.getType()));
+  }
 
   private static Match<Unit> unitIsAaThatCanHitTheseUnits(final Collection<Unit> targets,
       final Match<Unit> typeOfAa, final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed) {
@@ -567,8 +588,9 @@ public final class Matches {
     return Match.of(obj -> UnitAttachment.get(obj.getType()).getTypeAA().matches(typeAa));
   }
 
-  public static final Match<Unit> UnitAAShotDamageableInsteadOfKillingInstantly =
-      Match.of(obj -> UnitAttachment.get(obj.getType()).getDamageableAA());
+  static Match<Unit> unitAaShotDamageableInsteadOfKillingInstantly() {
+    return Match.of(obj -> UnitAttachment.get(obj.getType()).getDamageableAA());
+  }
 
   private static Match<Unit> unitIsAaThatWillNotFireIfPresentEnemyUnits(final Collection<Unit> enemyUnitsPresent) {
     return Match.of(obj -> {
@@ -605,32 +627,45 @@ public final class Matches {
             : UnitOffensiveAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero));
   }
 
-  public static final Match<UnitType> UnitTypeIsAAforCombatOnly =
-      Match.of(obj -> UnitAttachment.get(obj).getIsAAforCombatOnly());
+  private static Match<UnitType> unitTypeIsAaForCombatOnly() {
+    return Match.of(obj -> UnitAttachment.get(obj).getIsAAforCombatOnly());
+  }
 
-  public static final Match<Unit> UnitIsAAforCombatOnly =
-      Match.of(obj -> UnitTypeIsAAforCombatOnly.match(obj.getType()));
+  static Match<Unit> unitIsAaForCombatOnly() {
+    return Match.of(obj -> unitTypeIsAaForCombatOnly().match(obj.getType()));
+  }
 
-  public static final Match<UnitType> UnitTypeIsAAforBombingThisUnitOnly =
-      Match.of(obj -> UnitAttachment.get(obj).getIsAAforBombingThisUnitOnly());
+  public static Match<UnitType> unitTypeIsAaForBombingThisUnitOnly() {
+    return Match.of(obj -> UnitAttachment.get(obj).getIsAAforBombingThisUnitOnly());
+  }
 
-  public static final Match<Unit> UnitIsAAforBombingThisUnitOnly =
-      Match.of(obj -> UnitTypeIsAAforBombingThisUnitOnly.match(obj.getType()));
+  public static Match<Unit> unitIsAaForBombingThisUnitOnly() {
+    return Match.of(obj -> unitTypeIsAaForBombingThisUnitOnly().match(obj.getType()));
+  }
 
-  public static final Match<UnitType> UnitTypeIsAAforFlyOverOnly =
-      Match.of(obj -> UnitAttachment.get(obj).getIsAAforFlyOverOnly());
+  private static Match<UnitType> unitTypeIsAaForFlyOverOnly() {
+    return Match.of(obj -> UnitAttachment.get(obj).getIsAAforFlyOverOnly());
+  }
 
-  public static final Match<Unit> UnitIsAAforFlyOverOnly =
-      Match.of(obj -> UnitTypeIsAAforFlyOverOnly.match(obj.getType()));
+  static Match<Unit> unitIsAaForFlyOverOnly() {
+    return Match.of(obj -> unitTypeIsAaForFlyOverOnly().match(obj.getType()));
+  }
 
-  public static final Match<UnitType> UnitTypeIsAAforAnything = Match.of(obj -> {
-    final UnitAttachment ua = UnitAttachment.get(obj);
-    return ua.getIsAAforBombingThisUnitOnly() || ua.getIsAAforCombatOnly() || ua.getIsAAforFlyOverOnly();
-  });
+  /**
+   * Returns a match indicating the specified unit type is anti-aircraft for any condition.
+   */
+  public static Match<UnitType> unitTypeIsAaForAnything() {
+    return Match.of(obj -> {
+      final UnitAttachment ua = UnitAttachment.get(obj);
+      return ua.getIsAAforBombingThisUnitOnly() || ua.getIsAAforCombatOnly() || ua.getIsAAforFlyOverOnly();
+    });
+  }
 
-  public static final Match<Unit> UnitIsAAforAnything = Match.of(obj -> UnitTypeIsAAforAnything.match(obj.getType()));
+  public static Match<Unit> unitIsAaForAnything() {
+    return Match.of(obj -> unitTypeIsAaForAnything().match(obj.getType()));
+  }
 
-  public static final Match<Unit> UnitIsNotAA = UnitIsAAforAnything.invert();
+  public static final Match<Unit> UnitIsNotAA = unitIsAaForAnything().invert();
 
   public static final Match<UnitType> UnitTypeMaxAAattacksIsInfinite =
       Match.of(obj -> UnitAttachment.get(obj).getMaxAAattacks() == -1);
@@ -1202,11 +1237,11 @@ public final class Matches {
   }
 
   private static Match<Unit> unitIsEnemyAaForAnything(final PlayerID player, final GameData data) {
-    return Match.allOf(UnitIsAAforAnything, enemyUnit(player, data));
+    return Match.allOf(unitIsAaForAnything(), enemyUnit(player, data));
   }
 
   private static Match<Unit> unitIsEnemyAaForCombat(final PlayerID player, final GameData data) {
-    return Match.allOf(UnitIsAAforCombatOnly, enemyUnit(player, data));
+    return Match.allOf(unitIsAaForCombatOnly(), enemyUnit(player, data));
   }
 
   static Match<Unit> unitIsInTerritory(final Territory territory) {
@@ -1493,7 +1528,7 @@ public final class Matches {
 
   public static final Match<Unit> UnitIsLand = Match.allOf(unitIsNotSea(), unitIsNotAir());
 
-  public static final Match<UnitType> UnitTypeIsLand = Match.allOf(unitTypeIsNotSea(), UnitTypeIsNotAir);
+  public static final Match<UnitType> UnitTypeIsLand = Match.allOf(unitTypeIsNotSea(), unitTypeIsNotAir());
 
   public static final Match<Unit> UnitIsNotLand = UnitIsLand.invert();
 
@@ -2173,14 +2208,14 @@ public final class Matches {
       supportOrNotInfrastructureOrAa.add(Matches.unitTypeIsInfrastructure().invert());
       supportOrNotInfrastructureOrAa.add(Matches.unitTypeIsSupporterOrHasCombatAbility(attack, player));
       if (!doNotIncludeAa) {
-        supportOrNotInfrastructureOrAa.add(Match.allOf(Matches.UnitTypeIsAAforCombatOnly,
+        supportOrNotInfrastructureOrAa.add(Match.allOf(Matches.unitTypeIsAaForCombatOnly(),
             Matches.unitTypeIsAaThatCanFireOnRound(battleRound)));
       }
       canBeInBattle.add(supportOrNotInfrastructureOrAa.any());
 
       if (attack) {
         if (!includeAttackersThatCanNotMove) {
-          canBeInBattle.add(Matches.UnitTypeCanNotMoveDuringCombatMove.invert());
+          canBeInBattle.add(Matches.unitTypeCanNotMoveDuringCombatMove().invert());
           canBeInBattle.add(Matches.unitTypeCanMove(player));
         }
         if (isLandBattle) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -246,7 +246,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
     // if not non combat, cannot move aa units
     if (GameStepPropertiesHelper.isCombatMove(getData())) {
-      moveableUnitOwnedByMeBuilder.add(Matches.UnitCanNotMoveDuringCombatMove.invert());
+      moveableUnitOwnedByMeBuilder.add(Matches.unitCanNotMoveDuringCombatMove().invert());
     }
     for (final Territory item : getData().getMap().getTerritories()) {
       if (item.getUnits().anyMatch(moveableUnitOwnedByMeBuilder.all())) {

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -368,7 +368,7 @@ public class MovePerformer implements Serializable {
     final boolean paratroopsLanding = Match.anyMatch(arrived, paratroopNAirTransports)
         && MoveValidator.allLandUnitsAreBeingParatroopered(arrived);
     final Map<Unit, Collection<Unit>> dependentAirTransportableUnits =
-        MoveValidator.getDependents(Match.getMatches(arrived, Matches.UnitCanTransport));
+        MoveValidator.getDependents(Match.getMatches(arrived, Matches.unitCanTransport()));
     // add newly created dependents
     if (m_newDependents != null) {
       for (final Entry<Unit, Collection<Unit>> entry : m_newDependents.entrySet()) {

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -300,9 +300,9 @@ public class MoveValidator {
       }
     }
     // Don't allow aa guns (and other disallowed units) to move in combat unless they are in a transport
-    if (Match.anyMatch(units, Matches.UnitCanNotMoveDuringCombatMove)
+    if (Match.anyMatch(units, Matches.unitCanNotMoveDuringCombatMove())
         && (!route.getStart().isWater() || !route.getEnd().isWater())) {
-      for (final Unit unit : Match.getMatches(units, Matches.UnitCanNotMoveDuringCombatMove)) {
+      for (final Unit unit : Match.getMatches(units, Matches.unitCanNotMoveDuringCombatMove())) {
         result.addDisallowedUnit("Cannot move AA guns in combat movement phase", unit);
       }
     }
@@ -380,7 +380,7 @@ public class MoveValidator {
       }
     }
     // See if they've already been in combat
-    if (Match.anyMatch(units, Matches.UnitWasInCombat) && Match.anyMatch(units, Matches.UnitWasUnloadedThisTurn)) {
+    if (Match.anyMatch(units, Matches.unitWasInCombat()) && Match.anyMatch(units, Matches.unitWasUnloadedThisTurn())) {
       final Collection<Territory> end = Collections.singleton(route.getEnd());
       if (!end.isEmpty()
           && Match.allMatch(end, Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data))
@@ -574,7 +574,7 @@ public class MoveValidator {
       // Initialize available Mechanized Inf support
       int mechanizedSupportAvailable = getMechanizedSupportAvail(units, player);
       final Map<Unit, Collection<Unit>> dependencies =
-          getDependents(Match.getMatches(units, Matches.UnitCanTransport));
+          getDependents(Match.getMatches(units, Matches.unitCanTransport()));
       // add those just added
       // TODO: do not EVER user something from the UI in a validation method. Only the local computer (ie: client) has a
       // copy of this UI
@@ -673,7 +673,7 @@ public class MoveValidator {
     // test for stack limits per unit
     if (route.getEnd() != null) {
       final Collection<Unit> unitsWithStackingLimits =
-          Match.getMatches(units, Match.anyOf(Matches.UnitHasMovementLimit, Matches.UnitHasAttackingLimit));
+          Match.getMatches(units, Match.anyOf(Matches.unitHasMovementLimit(), Matches.unitHasAttackingLimit()));
       for (final Territory t : route.getSteps()) {
         final Collection<Unit> unitsAllowedSoFar = new ArrayList<>();
         if (Matches.isTerritoryEnemyAndNotUnownedWater(player, data).match(t)
@@ -851,7 +851,7 @@ public class MoveValidator {
       final List<Unit> transports =
           Match.getMatches(units, Match.anyOf(Matches.UnitIsTransport, Matches.UnitIsAirTransport));
       final List<Unit> transportable =
-          Match.getMatches(units, Match.anyOf(Matches.UnitCanBeTransported, Matches.UnitIsAirTransportable));
+          Match.getMatches(units, Match.anyOf(Matches.unitCanBeTransported(), Matches.UnitIsAirTransportable));
       // Check if there are transports in the group to be checked
       if (alreadyLoaded.keySet().containsAll(transports)) {
         // Check each transportable unit -vs those already loaded.
@@ -955,7 +955,7 @@ public class MoveValidator {
     // If there are non-sea transports return
     final boolean seaOrNoTransportsPresent =
         transportsToLoad.isEmpty()
-            || Match.anyMatch(transportsToLoad, Match.allOf(Matches.UnitIsSea, Matches.UnitCanTransport));
+            || Match.anyMatch(transportsToLoad, Match.allOf(Matches.UnitIsSea, Matches.unitCanTransport()));
     if (!seaOrNoTransportsPresent) {
       return result;
     }
@@ -1040,7 +1040,7 @@ public class MoveValidator {
     final Collection<Unit> land = Match.getMatches(units, Matches.UnitIsLand);
     final Collection<Unit> landAndAir = Match.getMatches(units, Match.anyOf(Matches.UnitIsLand, Matches.UnitIsAir));
     // make sure we can be transported
-    final Match<Unit> cantBeTransported = Matches.UnitCanBeTransported.invert();
+    final Match<Unit> cantBeTransported = Matches.unitCanBeTransported().invert();
     for (final Unit unit : Match.getMatches(land, cantBeTransported)) {
       result.addDisallowedUnit("Not all units can be transported", unit);
     }
@@ -1099,7 +1099,7 @@ public class MoveValidator {
       final Map<Unit, Unit> unitsToTransports = TransportUtils.mapTransports(route, land, transportsToLoad);
       final Iterator<Unit> iter = land.iterator();
       // CompositeMatch<Unit> landUnitsAtSea = new CompositeMatchOr<Unit>(Matches.unitIsLandAndOwnedBy(player),
-      // Matches.UnitCanBeTransported);
+      // Matches.unitCanBeTransported());
       while (!isEditMode && iter.hasNext()) {
         final TripleAUnit unit = (TripleAUnit) iter.next();
         if (Matches.unitHasMoved().match(unit)) {

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -300,7 +300,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
     m_defendingAA = Match.getMatches(canFire, Matches.unitIsAaThatCanFire(m_attackingUnits, airborneTechTargetsAllowed,
-        m_attacker, Matches.UnitIsAAforCombatOnly, m_round, true, m_data));
+        m_attacker, Matches.unitIsAaForCombatOnly(), m_round, true, m_data));
     // comes ordered alphabetically
     m_defendingAAtypes = UnitAttachment.getAllOfTypeAAs(m_defendingAA);
     // stacks are backwards
@@ -313,7 +313,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     canFire.addAll(m_attackingWaitingToDie);
     // no airborne targets for offensive aa
     m_offensiveAA = Match.getMatches(canFire, Matches.unitIsAaThatCanFire(m_defendingUnits,
-        new HashMap<>(), m_defender, Matches.UnitIsAAforCombatOnly, m_round, false, m_data));
+        new HashMap<>(), m_defender, Matches.unitIsAaForCombatOnly(), m_round, false, m_data));
     // comes ordered alphabetically
     m_offensiveAAtypes = UnitAttachment.getAllOfTypeAAs(m_offensiveAA);
     // stacks are backwards
@@ -432,7 +432,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       // If any attacking transports are in the battle, set their status to later restrict load/unload
       if (current.equals(m_attacker)) {
         final CompositeChange change = new CompositeChange();
-        final Collection<Unit> transports = Match.getMatches(attackingUnits, Matches.UnitCanTransport);
+        final Collection<Unit> transports = Match.getMatches(attackingUnits, Matches.unitCanTransport());
         final Iterator<Unit> attackTranIter = transports.iterator();
         while (attackTranIter.hasNext()) {
           change.add(ChangeFactory.unitPropertyChange(attackTranIter.next(), true, TripleAUnit.WAS_IN_COMBAT));
@@ -1401,7 +1401,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     } else if (planes) {
       units = Match.getMatches(units, Matches.UnitIsAir);
     } else if (partialAmphib) {
-      units = Match.getMatches(units, Matches.UnitWasNotAmphibious);
+      units = Match.getMatches(units, Matches.unitWasNotAmphibious());
     }
     if (Match.anyMatch(units, Matches.UnitIsSea)) {
       availableTerritories = Match.getMatches(availableTerritories, Matches.TerritoryIsWater);
@@ -1481,7 +1481,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           }
         }
         // remove amphib units from those retreating
-        units = Match.getMatches(units, Matches.UnitWasNotAmphibious);
+        units = Match.getMatches(units, Matches.unitWasNotAmphibious());
         retreatUnitsAndPlanes(units, retreatTo, defender, bridge);
         final String messageShort = retreatingPlayer.getName() + " retreats non-amphibious units";
         getDisplay(bridge).notifyRetreat(messageShort, messageShort, step, retreatingPlayer);
@@ -1560,7 +1560,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   void reLoadTransports(final Collection<Unit> units, final CompositeChange change) {
-    final Collection<Unit> transports = Match.getMatches(units, Matches.UnitCanTransport);
+    final Collection<Unit> transports = Match.getMatches(units, Matches.unitCanTransport());
     // Put units back on their transports
     for (final Unit transport : transports) {
       final Collection<Unit> unloaded = TransportTracker.unloaded(transport);
@@ -2390,7 +2390,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return Collections.emptyList();
     }
     final Collection<Unit> dependents = new ArrayList<>();
-    if (Match.anyMatch(targets, Matches.UnitCanTransport)) {
+    if (Match.anyMatch(targets, Matches.unitCanTransport())) {
       // just worry about transports
       for (final Unit target : targets) {
         dependents.addAll(TransportTracker.transportingAndUnloaded(target));
@@ -2535,7 +2535,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       if (!dependents.isEmpty()) {
         for (final Unit unit : dependents) {
           // clear the loaded by ONLY for Combat unloads. NonCombat unloads are handled elsewhere.
-          if (Matches.UnitWasUnloadedThisTurn.match(unit)) {
+          if (Matches.unitWasUnloadedThisTurn().match(unit)) {
             change.add(ChangeFactory.unitPropertyChange(unit, null, TripleAUnit.TRANSPORTED_BY));
           }
         }

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -144,7 +144,7 @@ public class RocketsFireHelper {
   }
 
   Match<Unit> rocketMatch(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.UnitIsRocket, Matches.unitIsOwnedBy(player), Matches.unitIsNotDisabled(),
+    return Match.allOf(Matches.unitIsRocket(), Matches.unitIsOwnedBy(player), Matches.unitIsNotDisabled(),
         Matches.unitIsBeingTransported().invert(), Matches.UnitIsSubmerged.invert(), Matches.unitHasNotMoved());
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -95,13 +95,13 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     final Match<Unit> defenders = Match.allOf(Matches.enemyUnit(m_attacker, m_data),
         Match.anyOf(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(m_battleSite).invert(),
             Matches.unitIsAaThatCanFire(m_attackingUnits, airborneTechTargetsAllowed, m_attacker,
-                Matches.UnitIsAAforBombingThisUnitOnly, m_round, true, m_data)));
+                Matches.unitIsAaForBombingThisUnitOnly(), m_round, true, m_data)));
     if (m_targets.isEmpty()) {
       m_defendingUnits = Match.getMatches(m_battleSite.getUnits().getUnits(), defenders);
     } else {
       final List<Unit> targets =
           Match.getMatches(m_battleSite.getUnits().getUnits(), Matches.unitIsAaThatCanFire(m_attackingUnits,
-              airborneTechTargetsAllowed, m_attacker, Matches.UnitIsAAforBombingThisUnitOnly, m_round, true, m_data));
+              airborneTechTargetsAllowed, m_attacker, Matches.unitIsAaForBombingThisUnitOnly(), m_round, true, m_data));
       targets.addAll(m_targets.keySet());
       m_defendingUnits = targets;
     }
@@ -183,7 +183,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     final HashMap<String, HashSet<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAA(m_attacker, m_data);
     m_defendingAA = m_battleSite.getUnits().getMatches(Matches.unitIsAaThatCanFire(m_attackingUnits,
-        airborneTechTargetsAllowed, m_attacker, Matches.UnitIsAAforBombingThisUnitOnly, m_round, true, m_data));
+        airborneTechTargetsAllowed, m_attacker, Matches.unitIsAaForBombingThisUnitOnly(), m_round, true, m_data));
     m_AAtypes = UnitAttachment.getAllOfTypeAAs(m_defendingAA);
     // reverse since stacks are in reverse order
     Collections.reverse(m_AAtypes);
@@ -469,7 +469,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     getDisplay(bridge).notifyDice(dice, SELECT_PREFIX + currentTypeAa + CASUALTIES_SUFFIX);
     final boolean isEditMode = BaseEditDelegate.getEditMode(m_data);
     final boolean allowMultipleHitsPerUnit =
-        !defendingAa.isEmpty() && Match.allMatch(defendingAa, Matches.UnitAAShotDamageableInsteadOfKillingInstantly);
+        !defendingAa.isEmpty() && Match.allMatch(defendingAa, Matches.unitAaShotDamageableInsteadOfKillingInstantly());
     if (isEditMode) {
       final String text = currentTypeAa + AA_GUNS_FIRE_SUFFIX;
       final CasualtyDetails casualtySelection = BattleCalculator.selectCasualties(RAID, m_attacker,

--- a/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -211,10 +211,10 @@ public class UnitImageFactory {
         if (TechTracker.hasRocket(id) && UnitAttachment.get(type).getIsRocket()) {
           name = new StringBuilder("rockets");
         }
-        if (TechTracker.hasAARadar(id) && Matches.UnitTypeIsAAforAnything.match(type)) {
+        if (TechTracker.hasAARadar(id) && Matches.unitTypeIsAaForAnything().match(type)) {
           name.append("_r");
         }
-      } else if (UnitAttachment.get(type).getIsRocket() && Matches.UnitTypeIsAAforAnything.match(type)) {
+      } else if (UnitAttachment.get(type).getIsRocket() && Matches.unitTypeIsAaForAnything().match(type)) {
         if (TechTracker.hasRocket(id)) {
           name.append("_rockets");
         }
@@ -225,7 +225,7 @@ public class UnitImageFactory {
         if (TechTracker.hasRocket(id)) {
           name.append("_rockets");
         }
-      } else if (Matches.UnitTypeIsAAforAnything.match(type)) {
+      } else if (Matches.unitTypeIsAaForAnything().match(type)) {
         if (TechTracker.hasAARadar(id)) {
           name.append("_r");
         }

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -872,8 +872,8 @@ class OddsCalculatorPanel extends JPanel {
           if (u1.getIsSea() != u2.getIsSea()) {
             return u1.getIsSea() ? 1 : -1;
           }
-          if (Matches.UnitTypeIsAAforAnything.match(ut1) != Matches.UnitTypeIsAAforAnything.match(ut2)) {
-            return Matches.UnitTypeIsAAforAnything.match(ut1) ? 1 : -1;
+          if (Matches.unitTypeIsAaForAnything().match(ut1) != Matches.unitTypeIsAaForAnything().match(ut2)) {
+            return Matches.unitTypeIsAaForAnything().match(ut1) ? 1 : -1;
           }
           if (u1.getIsAir() != u2.getIsAir()) {
             return u1.getIsAir() ? 1 : -1;

--- a/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
@@ -65,7 +65,7 @@ class UnitInformation {
             + (currentAttachment.getCanProduceUnits() == false ? "-" : "true") + ","
             + (currentAttachment.getIsMarine() == 0 ? "-" : currentAttachment.getIsMarine()) + ","
             + (currentAttachment.getTransportCost() == -1 ? "-" : currentAttachment.getTransportCost()) + ","
-            + (Matches.UnitTypeIsAAforAnything.match(currentType) == false ? "-" : "true") + ","
+            + (Matches.unitTypeIsAaForAnything().match(currentType) == false ? "-" : "true") + ","
             + (currentAttachment.getIsAir() == false ? "-" : "true") + ","
             + (currentAttachment.getIsStrategicBomber() == false ? "-" : "true") + ","
             + (currentAttachment.getCarrierCost() == -1 ? "-" : currentAttachment.getCarrierCost()) + ","

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -339,7 +339,7 @@ public class MovePanel extends AbstractMovePanel {
       movableBuilder.add(Matches.UnitCanMove);
     }
     if (!nonCombat) {
-      movableBuilder.add(Matches.UnitCanNotMoveDuringCombatMove.invert());
+      movableBuilder.add(Matches.unitCanNotMoveDuringCombatMove().invert());
     }
     if (route != null) {
       final Match<Unit> enoughMovement = Match.of(u -> {
@@ -1077,7 +1077,7 @@ public class MovePanel extends AbstractMovePanel {
           Matches.unitIsOwnedBy(getCurrentPlayer()),
           Matches.UnitIsLand);
       if (nonCombat) {
-        unloadableBuilder.add(Matches.UnitCanNotMoveDuringCombatMove.invert());
+        unloadableBuilder.add(Matches.unitCanNotMoveDuringCombatMove().invert());
       }
       return unloadableBuilder.all();
     }
@@ -1449,7 +1449,7 @@ public class MovePanel extends AbstractMovePanel {
         Matches.unitHasMovementLeft);
     if (!nonCombat) {
       // if not non combat, cannot move aa units
-      moveableUnitOwnedByMeBuilder.add(Matches.UnitCanNotMoveDuringCombatMove.invert());
+      moveableUnitOwnedByMeBuilder.add(Matches.unitCanNotMoveDuringCombatMove().invert());
     }
     final int size = allTerritories.size();
     // new focused index is 1 greater
@@ -1498,7 +1498,7 @@ public class MovePanel extends AbstractMovePanel {
         Matches.unitHasMovementLeft);
     if (!nonCombat) {
       // if not non combat, cannot move aa units
-      moveableUnitOwnedByMeBuilder.add(Matches.UnitCanNotMoveDuringCombatMove.invert());
+      moveableUnitOwnedByMeBuilder.add(Matches.unitCanNotMoveDuringCombatMove().invert());
     }
     final Map<Territory, List<Unit>> highlight = new HashMap<>();
     for (final Territory t : allTerritories) {

--- a/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -108,8 +108,8 @@ public class TransportUtils {
   public static Map<Unit, Unit> mapTransportsAlreadyLoaded(final Collection<Unit> units,
       final Collection<Unit> transports) {
 
-    final Collection<Unit> canBeTransported = Match.getMatches(units, Matches.UnitCanBeTransported);
-    final Collection<Unit> canTransport = Match.getMatches(transports, Matches.UnitCanTransport);
+    final Collection<Unit> canBeTransported = Match.getMatches(units, Matches.unitCanBeTransported());
+    final Collection<Unit> canTransport = Match.getMatches(transports, Matches.unitCanTransport());
 
     final Map<Unit, Unit> mapping = new HashMap<>();
     for (final Unit currentTransported : canBeTransported) {
@@ -193,7 +193,7 @@ public class TransportUtils {
       final int movementLeft2 = TripleAUnit.get(o2).getMovementLeft();
       return Integer.compare(movementLeft2, movementLeft1);
     };
-    final List<Unit> canTransport = Match.getMatches(transports, Matches.UnitCanTransport);
+    final List<Unit> canTransport = Match.getMatches(transports, Matches.unitCanTransport());
     Collections.sort(canTransport, transportCapacityComparator);
     return canTransport;
   }
@@ -204,7 +204,7 @@ public class TransportUtils {
       final int cost2 = UnitAttachment.get((o2).getUnitType()).getTransportCost();
       return Integer.compare(cost2, cost1);
     };
-    final List<Unit> canBeTransported = Match.getMatches(units, Matches.UnitCanBeTransported);
+    final List<Unit> canBeTransported = Match.getMatches(units, Matches.unitCanBeTransported());
     Collections.sort(canBeTransported, transportCostComparator);
     return canBeTransported;
   }
@@ -239,8 +239,8 @@ public class TransportUtils {
 
   private static Map<Unit, List<Unit>> findTransportsThatUnitsCouldUnloadFrom(final Collection<Unit> units,
       final Collection<Unit> transports) {
-    final List<Unit> canBeTransported = Match.getMatches(units, Matches.UnitCanBeTransported);
-    final List<Unit> canTransport = Match.getMatches(transports, Matches.UnitCanTransport);
+    final List<Unit> canBeTransported = Match.getMatches(units, Matches.unitCanBeTransported());
+    final List<Unit> canTransport = Match.getMatches(transports, Matches.unitCanTransport());
     final Map<Unit, List<Unit>> result = new LinkedHashMap<>();
     for (final Unit unit : canBeTransported) {
       final List<Unit> transportOptions = new ArrayList<>();

--- a/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -52,7 +52,8 @@ public class BattleCalculatorTest {
     setSelectAaCasualties(data, false);
     final DiceRoll roll = new DiceRoll(new int[] {0}, 1, 1, false);
     final Collection<Unit> planes = bomber(data).create(5, british(data));
-    final Collection<Unit> defendingAa = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAa =
+        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
     final Collection<Unit> casualties = BattleCalculator.getAACasualties(false, planes, planes, defendingAa,
@@ -68,7 +69,8 @@ public class BattleCalculatorTest {
     setSelectAaCasualties(data, false);
     final DiceRoll roll = new DiceRoll(new int[] {0}, 1, 1, false);
     final List<Unit> planes = bomber(data).create(5, british(data));
-    final Collection<Unit> defendingAa = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAa =
+        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
     TripleAUnit.get(planes.get(0)).setAlreadyMoved(1);
@@ -85,7 +87,8 @@ public class BattleCalculatorTest {
     // 6 bombers and 6 fighters
     final Collection<Unit> planes = bomber(data).create(6, british(data));
     planes.addAll(fighter(data).create(6, british(data)));
-    final Collection<Unit> defendingAa = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAa =
+        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
     // don't allow rolling, 6 of each is deterministic
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
@@ -111,7 +114,8 @@ public class BattleCalculatorTest {
     // 5 bombers and 5 fighters
     final Collection<Unit> planes = bomber(data).create(5, british(data));
     planes.addAll(fighter(data).create(5, british(data)));
-    final Collection<Unit> defendingAa = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAa =
+        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
     // should roll once, a hit
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, 1, 1, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);
@@ -141,7 +145,8 @@ public class BattleCalculatorTest {
     // 6 bombers and 6 fighters
     final Collection<Unit> planes = bomber(data).create(6, british(data));
     planes.addAll(fighter(data).create(6, british(data)));
-    final Collection<Unit> defendingAa = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAa =
+        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
     when(dummyPlayer.selectCasualties(any(), any(), anyInt(), any(), any(), any(), any(), any(), any(), anyBoolean(),
         any(),
         any(), any(), any(), anyBoolean())).thenAnswer(new Answer<CasualtyDetails>() {
@@ -181,7 +186,8 @@ public class BattleCalculatorTest {
     // 7 bombers and 7 fighters
     final Collection<Unit> planes = bomber(data).create(7, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
-    final Collection<Unit> defendingAa = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAa =
+        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
     when(dummyPlayer.selectCasualties(any(), any(), anyInt(), any(), any(), any(), any(), any(), any(), anyBoolean(),
         any(), any(), any(), any(), anyBoolean())).thenAnswer(new Answer<CasualtyDetails>() {
           @Override
@@ -220,7 +226,8 @@ public class BattleCalculatorTest {
     // 2 extra units, roll once
     final Collection<Unit> planes = bomber(data).create(7, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
-    final Collection<Unit> defendingAa = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAa =
+        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
     // one roll, a hit
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0});
     bridge.setRandomSource(randomSource);
@@ -252,7 +259,8 @@ public class BattleCalculatorTest {
     // 2 extra units, roll once
     final Collection<Unit> planes = bomber(data).create(7, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
-    final Collection<Unit> defendingAa = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAa =
+        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
     // one roll, a miss
     final ScriptedRandomSource randomSource =
         new ScriptedRandomSource(new int[] {2, 0, 0, 0, ScriptedRandomSource.ERROR});
@@ -283,7 +291,8 @@ public class BattleCalculatorTest {
     // 6 bombers, 7 fighters
     final Collection<Unit> planes = bomber(data).create(6, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
-    final Collection<Unit> defendingAa = territory("Germany", data).getUnits().getMatches(Matches.UnitIsAAforAnything);
+    final Collection<Unit> defendingAa =
+        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
     // 1 roll for the extra fighter
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, ScriptedRandomSource.ERROR});
     bridge.setRandomSource(randomSource);

--- a/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -554,7 +554,7 @@ public class MoveDelegateTest extends DelegateTest {
     route3.setStart(japanSeaZone);
     route3.add(sfeSeaZone);
     final Collection<Unit> remainingTrns = Match.getMatches(japanSeaZone.getUnits().getUnits(),
-        Match.allOf(Matches.unitHasNotMoved(), Matches.UnitWasNotLoadedThisTurn));
+        Match.allOf(Matches.unitHasNotMoved(), Matches.unitWasNotLoadedThisTurn()));
     results = delegate.move(remainingTrns, route3);
     assertNull(results);
   }

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -140,7 +140,7 @@ public class WW2V3Year41Test {
     final Collection<Unit> planes = bomber(gameData).create(3, british(gameData));
     planes.addAll(fighter(gameData).create(3, british(gameData)));
     final Collection<Unit> defendingAa =
-        territory("Germany", gameData).getUnits().getMatches(Matches.UnitIsAAforAnything);
+        territory("Germany", gameData).getUnits().getMatches(Matches.unitIsAaForAnything());
     // don't allow rolling, 6 of each is deterministic
     bridge.setRandomSource(new ScriptedRandomSource(new int[] {ScriptedRandomSource.ERROR}));
     final DiceRoll roll =
@@ -169,7 +169,7 @@ public class WW2V3Year41Test {
     final Collection<Unit> planes = bomber(gameData).create(4, british(gameData));
     planes.addAll(fighter(gameData).create(4, british(gameData)));
     final Collection<Unit> defendingAa =
-        territory("Germany", gameData).getUnits().getMatches(Matches.UnitIsAAforAnything);
+        territory("Germany", gameData).getUnits().getMatches(Matches.unitIsAaForAnything());
     // 1 roll, a hit
     // then a dice to select the casualty
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, 1});
@@ -202,7 +202,7 @@ public class WW2V3Year41Test {
     final Collection<Unit> planes = bomber(gameData).create(4, british(gameData));
     planes.addAll(fighter(gameData).create(4, british(gameData)));
     final Collection<Unit> defendingAa =
-        territory("Germany", gameData).getUnits().getMatches(Matches.UnitIsAAforAnything);
+        territory("Germany", gameData).getUnits().getMatches(Matches.unitIsAaForAnything());
     // 1 roll, a miss
     // then a dice to select the casualty
     final ScriptedRandomSource randomSource =
@@ -465,7 +465,7 @@ public class WW2V3Year41Test {
      * Move one
      */
     String errorResults =
-        moveDelegate.move(poland.getUnits().getMatches(Matches.UnitIsAAforAnything), new Route(poland, germany));
+        moveDelegate.move(poland.getUnits().getMatches(Matches.unitIsAaForAnything()), new Route(poland, germany));
     assertValid(errorResults);
     assertEquals(germany.getUnits().getUnitCount(), preCount + 1);
     /*
@@ -480,11 +480,11 @@ public class WW2V3Year41Test {
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
     // load the trn
-    errorResults = moveDelegate.move(finland.getUnits().getMatches(Matches.UnitIsAAforAnything),
+    errorResults = moveDelegate.move(finland.getUnits().getMatches(Matches.unitIsAaForAnything()),
         new Route(finland, sz5), sz5.getUnits().getMatches(Matches.UnitIsTransport));
     assertValid(errorResults);
     // unload the trn
-    errorResults = moveDelegate.move(sz5.getUnits().getMatches(Matches.UnitIsAAforAnything), new Route(sz5, germany));
+    errorResults = moveDelegate.move(sz5.getUnits().getMatches(Matches.unitIsAaForAnything()), new Route(sz5, germany));
     assertValid(errorResults);
     assertEquals(germany.getUnits().getUnitCount(), preCount + 2);
     /*


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is one part in a series of related PRs in order to keep the review size reasonable.