### PR TITLE
Temporary workaround for intermittent Travis build failures (#2244)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,14 @@ addons:
 install: ./.travis/setup_lobby_database
 services:
 - postgresql
-script: ./gradlew check jacocoTestReport
+script: JAVA_OPTS=-Xmx1G ./gradlew check jacocoTestReport
 after_success: 
 - ./.travis/update_checkstyle_thresholds
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
 before_deploy:
 - ./.travis/install_install4j
 - ENGINE_VERSION="$(grep engine_version game_engine.properties | sed 's/.*= *//g').$TRAVIS_BUILD_NUMBER"
-- ./gradlew -PengineVersion="$ENGINE_VERSION" release
+- JAVA_OPTS=-Xmx1G ./gradlew -PengineVersion="$ENGINE_VERSION" release
 - ./.travis/push_tag $ENGINE_VERSION
 - ./.travis/push_maps
 deploy:


### PR DESCRIPTION
This PR is a temporary workaround for the root cause of the intermittent Travis build failures described in #2244.  It prevents out-of-memory conditions by limiting the maximum heap size of the Gradle wrapper process to 1 GiB.  Depending on how travis-ci/travis-ci#8272 is resolved, this workaround may or may not become permanent.