### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 4)

### DIFF
--- a/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/src/main/java/games/strategy/engine/data/GameMap.java
@@ -345,7 +345,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @return the shortest route between two territories or null if no route exists.
    */
   public Route getRoute(final Territory t1, final Territory t2) {
-    return getRoute(t1, t2, Matches.TerritoryIsLandOrWater);
+    return getRoute(t1, t2, Matches.territoryIsLandOrWater());
   }
 
   /**
@@ -441,7 +441,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @return the distance between two territories or -1 if they are not connected.
    */
   public int getDistance(final Territory t1, final Territory t2) {
-    return getDistance(t1, t2, Matches.TerritoryIsLandOrWater);
+    return getDistance(t1, t2, Matches.territoryIsLandOrWater());
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/ai/AIUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/AIUtils.java
@@ -105,8 +105,8 @@ public class AIUtils {
       }
     }
     if (attacking) {
-      final int art = Match.countMatches(units, Matches.UnitIsArtillery);
-      final int artSupport = Match.countMatches(units, Matches.UnitIsArtillerySupportable);
+      final int art = Match.countMatches(units, Matches.unitIsArtillery());
+      final int artSupport = Match.countMatches(units, Matches.unitIsArtillerySupportable());
       strength += Math.min(art, artSupport);
     }
     return strength;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -117,7 +117,7 @@ final class ProTechAI {
           Matches.UnitIsSea,
           Matches.UnitCanMove);
       final Match<Unit> enemyTransportable = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
-          Matches.unitCanBeTransported(), Matches.UnitIsNotAA, Matches.UnitCanMove);
+          Matches.unitCanBeTransported(), Matches.unitIsNotAa(), Matches.UnitCanMove);
       final Match<Unit> transport = Match.allOf(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
       final List<Territory> enemyFighterTerritories = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0;
@@ -208,10 +208,10 @@ final class ProTechAI {
                 int inf = 2;
                 int other = 1;
                 for (final Unit checkUnit : thisTransUnits) {
-                  if (Matches.UnitIsInfantry.match(checkUnit)) {
+                  if (Matches.unitIsInfantry().match(checkUnit)) {
                     inf--;
                   }
-                  if (Matches.UnitIsNotInfantry.match(checkUnit)) {
+                  if (Matches.unitIsNotInfantry().match(checkUnit)) {
                     inf--;
                     other--;
                   }
@@ -228,12 +228,12 @@ final class ProTechAI {
               transUnits.removeAll(alreadyLoaded);
               final List<Unit> availTransUnits = sortTransportUnits(transUnits);
               for (final Unit transUnit : availTransUnits) {
-                if (availInf > 0 && Matches.UnitIsInfantry.match(transUnit)) {
+                if (availInf > 0 && Matches.unitIsInfantry().match(transUnit)) {
                   availInf--;
                   loadedUnits.add(transUnit);
                   alreadyLoaded.add(transUnit);
                 }
-                if (availInf > 0 && availOther > 0 && Matches.UnitIsNotInfantry.match(transUnit)) {
+                if (availInf > 0 && availOther > 0 && Matches.unitIsNotInfantry().match(transUnit)) {
                   availInf--;
                   availOther--;
                   loadedUnits.add(transUnit);
@@ -330,8 +330,8 @@ final class ProTechAI {
       }
     }
     if (attacking && !sea) {
-      final int art = Match.countMatches(units, Matches.UnitIsArtillery);
-      final int artSupport = Match.countMatches(units, Matches.UnitIsArtillerySupportable);
+      final int art = Match.countMatches(units, Matches.unitIsArtillery());
+      final int artSupport = Match.countMatches(units, Matches.unitIsArtillerySupportable());
       strength += Math.min(art, artSupport);
     }
     return strength;
@@ -608,9 +608,9 @@ final class ProTechAI {
     // old functionality retained, i.e. no route condition is imposed.
     // feel free to change, if you are confortable all calls to this function conform.
     final Match.CompositeBuilder<Territory> endCondBuilder = Match.newCompositeBuilder(
-        Matches.TerritoryIsImpassable.invert());
+        Matches.territoryIsImpassable().invert());
     if (!neutral || Properties.getNeutralsImpassable(data)) {
-      endCondBuilder.add(Matches.TerritoryIsNeutralButNotWater.invert());
+      endCondBuilder.add(Matches.territoryIsNeutralButNotWater().invert());
     }
     return findFontier(territory, endCondBuilder.all(), Match.always(), distance, data);
   }
@@ -685,9 +685,9 @@ final class ProTechAI {
     final List<Unit> armor = new ArrayList<>();
     final List<Unit> others = new ArrayList<>();
     for (final Unit x : transUnits) {
-      if (Matches.UnitIsArtillerySupportable.match(x)) {
+      if (Matches.unitIsArtillerySupportable().match(x)) {
         infantry.add(x);
-      } else if (Matches.UnitIsArtillery.match(x)) {
+      } else if (Matches.unitIsArtillery().match(x)) {
         artillery.add(x);
       } else if (Matches.UnitCanBlitz.match(x)) {
         armor.add(x);
@@ -738,6 +738,6 @@ final class ProTechAI {
    * Assumes that water is passable to air units always.
    */
   private static Match<Territory> territoryIsImpassableToAirUnits() {
-    return Match.allOf(Matches.TerritoryIsLand, Matches.TerritoryIsImpassable);
+    return Match.allOf(Matches.TerritoryIsLand, Matches.territoryIsImpassable());
   }
 }

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
@@ -76,7 +76,7 @@ public class ProPurchaseOptionMap {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         aaOptions.add(ppo);
         ProLogger.debug("AA: " + ppo);
-      } else if (Matches.UnitTypeIsLand.match(unitType)) {
+      } else if (Matches.unitTypeIsLand().match(unitType)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         landFodderOptions.add(ppo);
         if (ppo.getAttack() >= ppo.getDefense() || ppo.isAttackSupport() || ppo.getMovement() > 1) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProTerritoryManager.java
@@ -319,7 +319,7 @@ public class ProTerritoryManager {
             Matches.unitIsNotDisabled())),
         Matches.territoryHasUnitsThatMatch(airbasesCanScramble));
     if (fromIslandOnly) {
-      canScrambleBuilder.add(Matches.TerritoryIsIsland);
+      canScrambleBuilder.add(Matches.territoryIsIsland());
     }
 
     // Find potential territories to scramble from
@@ -344,7 +344,7 @@ public class ProTerritoryManager {
         // Find potential scramble units from territory
         final Collection<Unit> airbases = from.getUnits().getMatches(airbasesCanScramble);
         final int maxCanScramble = getMaxScrambleCount(airbases);
-        final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.TerritoryIsNotImpassable);
+        final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.territoryIsNotImpassable());
         List<Unit> canScrambleAir = from.getUnits()
             .getMatches(Match.allOf(Matches.unitIsEnemyOf(data, player), Matches.unitCanScramble(),
                 Matches.unitIsNotDisabled(), Matches.unitWasScrambled().invert(),

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -226,7 +226,7 @@ public class ProMatches {
 
   private static Match<Territory> territoryHasNonMobileInfraFactory() {
     final Match<Unit> nonMobileInfraFactoryMatch = Match.allOf(Matches.UnitCanProduceUnits,
-        Matches.UnitIsInfrastructure, Matches.unitHasMovementLeft.invert());
+        Matches.UnitIsInfrastructure, Matches.unitHasMovementLeft().invert());
     return Matches.territoryHasUnitsThatMatch(nonMobileInfraFactoryMatch);
   }
 
@@ -276,13 +276,13 @@ public class ProMatches {
   }
 
   public static Match<Territory> territoryIsEnemyNotNeutralLand(final PlayerID player, final GameData data) {
-    return Match.allOf(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
+    return Match.allOf(territoryIsEnemyLand(player, data), Matches.territoryIsNeutralButNotWater().invert());
   }
 
   public static Match<Territory> territoryIsOrAdjacentToEnemyNotNeutralLand(final PlayerID player,
       final GameData data) {
     final Match<Territory> isMatch =
-        Match.allOf(territoryIsEnemyLand(player, data), Matches.TerritoryIsNeutralButNotWater.invert());
+        Match.allOf(territoryIsEnemyLand(player, data), Matches.territoryIsNeutralButNotWater().invert());
     final Match<Territory> adjacentMatch = Match.allOf(territoryCanMoveLandUnits(player, data, false),
         Matches.territoryHasNeighborMatching(data, isMatch));
     return Match.anyOf(isMatch, adjacentMatch);
@@ -347,7 +347,7 @@ public class ProMatches {
   }
 
   private static Match<Unit> unitCanBeMovedAndIsOwned(final PlayerID player) {
-    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft);
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft());
   }
 
   public static Match<Unit> unitCanBeMovedAndIsOwnedAir(final PlayerID player, final boolean isCombatMove) {
@@ -409,7 +409,7 @@ public class ProMatches {
   public static Match<Unit> unitCantBeMovedAndIsAlliedDefender(final PlayerID player, final GameData data,
       final Territory t) {
     final Match<Unit> myUnitHasNoMovementMatch =
-        Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft.invert());
+        Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitHasMovementLeft().invert());
     final Match<Unit> alliedUnitMatch =
         Match.allOf(Matches.unitIsOwnedBy(player).invert(), Matches.isUnitAllied(player, data),
             Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(t.getUnits().getUnits(), null, player,
@@ -508,7 +508,7 @@ public class ProMatches {
         return false;
       }
       final Match<Unit> match = Match.allOf(unitIsOwnedTransportableUnit(player), Matches.unitHasNotMoved(),
-          Matches.unitHasMovementLeft, Matches.unitIsBeingTransported().invert());
+          Matches.unitHasMovementLeft(), Matches.unitIsBeingTransported().invert());
       return match.match(u);
     });
   }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProOddsCalculator.java
@@ -143,7 +143,7 @@ public class ProOddsCalculator {
     final List<Unit> mainCombatDefenders =
         Match.getMatches(defendingUnits, Matches.unitCanBeInBattle(false, !t.isWater(), 1, false, true, true));
     double tuvSwing = results.getAverageTUVswing(attacker, mainCombatAttackers, defender, mainCombatDefenders, data);
-    if (Matches.TerritoryIsNeutralButNotWater.match(t)) { // Set TUV swing for neutrals
+    if (Matches.territoryIsNeutralButNotWater().match(t)) { // Set TUV swing for neutrals
       final double attackingUnitValue = TuvUtils.getTuv(mainCombatAttackers, ProData.unitValueMap);
       final double remainingUnitValue =
           results.getAverageTUVofUnitsLeftOver(ProData.unitValueMap, ProData.unitValueMap).getFirst();

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -87,7 +87,7 @@ public class WeakAI extends AbstractAI {
     // find a land route to an enemy territory from our capitol
     final Route invasionRoute =
         Utils.findNearest(capitol, Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data),
-            Match.allOf(Matches.TerritoryIsLand, Matches.TerritoryIsNeutralButNotWater.invert()), data);
+            Match.allOf(Matches.TerritoryIsLand, Matches.territoryIsNeutralButNotWater().invert()), data);
     return invasionRoute == null;
   }
 
@@ -414,7 +414,7 @@ public class WeakAI extends AbstractAI {
           Match.allOf(Matches.unitCanTransport(), Matches.unitIsOwnedBy(player), Matches.unitHasNotMoved());
       final Match<Territory> enemyTerritory =
           Match.allOf(Matches.isTerritoryEnemy(player, data), Matches.TerritoryIsLand,
-              Matches.TerritoryIsNeutralButNotWater.invert(), Matches.TerritoryIsEmpty);
+              Matches.territoryIsNeutralButNotWater().invert(), Matches.territoryIsEmpty());
       final int trans = t.getUnits().countMatches(ownedTransports);
       if (trans > 0) {
         final Route newRoute = Utils.findNearest(t, enemyTerritory, routeCondition, data);
@@ -447,14 +447,14 @@ public class WeakAI extends AbstractAI {
       // these are the units we can move
       final Match<Unit> moveOfType = Match.allOf(
           Matches.unitIsOwnedBy(player),
-          Matches.UnitIsNotAA,
+          Matches.unitIsNotAa(),
           // we can never move factories
           Matches.UnitCanMove,
           Matches.UnitIsNotInfrastructure,
           Matches.UnitIsLand);
       final Match<Territory> moveThrough =
-          Match.allOf(Matches.TerritoryIsImpassable.invert(),
-              Matches.TerritoryIsNeutralButNotWater.invert(), Matches.TerritoryIsLand);
+          Match.allOf(Matches.territoryIsImpassable().invert(),
+              Matches.territoryIsNeutralButNotWater().invert(), Matches.TerritoryIsLand);
       final List<Unit> units = t.getUnits().getMatches(moveOfType);
       if (units.size() == 0) {
         continue;
@@ -487,7 +487,7 @@ public class WeakAI extends AbstractAI {
         }
       } else { // if we cant move to a capitol, move towards the enemy
         final Match<Territory> routeCondition =
-            Match.allOf(Matches.TerritoryIsLand, Matches.TerritoryIsImpassable.invert());
+            Match.allOf(Matches.TerritoryIsLand, Matches.territoryIsImpassable().invert());
         Route newRoute = Utils.findNearest(t, Matches.territoryHasEnemyLandUnits(player, data), routeCondition, data);
         // move to any enemy territory
         if (newRoute == null) {
@@ -515,10 +515,10 @@ public class WeakAI extends AbstractAI {
         Matches.isTerritoryAllied(player, data),
         Match.of(o -> !delegate.getBattleTracker().wasConquered(o)));
     final Match<Territory> routeCondition = Match.allOf(
-        Matches.territoryHasEnemyAaForCombatOnly(player, data).invert(), Matches.TerritoryIsImpassable.invert());
+        Matches.territoryHasEnemyAaForCombatOnly(player, data).invert(), Matches.territoryIsImpassable().invert());
     for (final Territory t : delegateRemote.getTerritoriesWhereAirCantLand()) {
       final Route noAaRoute = Utils.findNearest(t, canLand, routeCondition, data);
-      final Route aaRoute = Utils.findNearest(t, canLand, Matches.TerritoryIsImpassable.invert(), data);
+      final Route aaRoute = Utils.findNearest(t, canLand, Matches.territoryIsImpassable().invert(), data);
       final Collection<Unit> airToLand =
           t.getUnits().getMatches(Match.allOf(Matches.UnitIsAir, Matches.unitIsOwnedBy(player)));
       // dont bother to see if all the air units have enough movement points
@@ -612,7 +612,7 @@ public class WeakAI extends AbstractAI {
           Collections.sort(unitsSortedByCost, AIUtils.getCostComparator());
           for (final Unit unit : unitsSortedByCost) {
             final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsLand,
-                Matches.UnitIsNotInfrastructure, Matches.UnitCanMove, Matches.UnitIsNotAA,
+                Matches.UnitIsNotInfrastructure, Matches.UnitCanMove, Matches.unitIsNotAa(),
                 Matches.unitCanNotMoveDuringCombatMove().invert());
             if (!unitsAlreadyMoved.contains(unit) && match.match(unit)) {
               moveRoutes.add(data.getMap().getRoute(attackFrom, enemy));
@@ -643,7 +643,7 @@ public class WeakAI extends AbstractAI {
             Matches.unitIsOwnedBy(player),
             Matches.UnitIsStrategicBomber.invert(),
             Match.of(o -> !unitsAlreadyMoved.contains(o)),
-            Matches.UnitIsNotAA,
+            Matches.unitIsNotAa(),
             Matches.UnitCanMove,
             Matches.UnitIsNotInfrastructure,
             Matches.unitCanNotMoveDuringCombatMove().invert(),

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -266,7 +266,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final Territory t = territories.next();
       if (!m_battleTracker.hasPendingBattle(t, false)) {
         Collection<IBattle> battles = adjBombardment.get(t);
-        battles = Match.getMatches(battles, Matches.BattleIsAmphibious);
+        battles = Match.getMatches(battles, Matches.battleIsAmphibious());
         if (!battles.isEmpty()) {
           final Collection<Unit> bombardUnits = t.getUnits().getMatches(ownedAndCanBombard);
           final List<Unit> listedBombardUnits = new ArrayList<>();
@@ -658,7 +658,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             Matches.unitIsNotDisabled())),
         Matches.territoryHasUnitsThatMatch(airbasesCanScramble));
     if (fromIslandOnly) {
-      canScrambleBuilder.add(Matches.TerritoryIsIsland);
+      canScrambleBuilder.add(Matches.territoryIsIsland());
     }
     final Match<Territory> canScramble = canScrambleBuilder.all();
     final HashMap<Territory, HashSet<Territory>> scrambleTerrs = new HashMap<>();
@@ -731,7 +731,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         // find how many is the max this territory can scramble
         final Collection<Unit> airbases = from.getUnits().getMatches(airbasesCanScramble);
         final int maxCanScramble = getMaxScrambleCount(airbases);
-        final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.TerritoryIsNotImpassable);
+        final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.territoryIsNotImpassable());
         final Collection<Unit> canScrambleAir = from.getUnits()
             .getMatches(Match.allOf(Matches.unitIsEnemyOf(data, m_player), Matches.unitCanScramble(),
                 Matches.unitIsNotDisabled(), Matches.unitWasScrambled().invert(),

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -980,7 +980,7 @@ public class BattleTracker implements Serializable {
     if (dependent == null) {
       return Collections.emptyList();
     }
-    return Match.getMatches(dependent, Matches.BattleIsEmpty.invert());
+    return Match.getMatches(dependent, Matches.battleIsEmpty().invert());
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -128,8 +128,8 @@ public class DiceRoll implements Externalizable {
       }
     }
     final List<Unit> defendingAa = Match.getMatches(defendingAaForThisRoll,
-        (defending ? Matches.UnitAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero
-            : Matches.UnitOffensiveAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero));
+        (defending ? Matches.unitAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero()
+            : Matches.unitOffensiveAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero()));
     if (defendingAa.isEmpty()) {
       return new DiceRoll(new ArrayList<>(0), 0);
     }
@@ -187,8 +187,8 @@ public class DiceRoll implements Externalizable {
       final Collection<Unit> defendingAaForThisRoll, final Collection<Unit> validAttackingUnitsForThisRoll,
       final GameData data, final boolean fillInSortedDiceAndRecordHits) {
     final List<Unit> defendingAa = Match.getMatches(defendingAaForThisRoll,
-        (defending ? Matches.UnitAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero
-            : Matches.UnitOffensiveAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero));
+        (defending ? Matches.unitAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero()
+            : Matches.unitOffensiveAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero()));
     if (defendingAa.size() <= 0) {
       return Triple.of(0, 0, false);
     }
@@ -211,8 +211,8 @@ public class DiceRoll implements Externalizable {
     // any sense)
     // set up all 3 groups of aa guns
     final List<Unit> normalNonInfiniteAa = new ArrayList<>(defendingAa);
-    final List<Unit> infiniteAa = Match.getMatches(defendingAa, Matches.UnitMaxAAattacksIsInfinite);
-    final List<Unit> overstackAa = Match.getMatches(defendingAa, Matches.UnitMayOverStackAA);
+    final List<Unit> infiniteAa = Match.getMatches(defendingAa, Matches.unitMaxAaAttacksIsInfinite());
+    final List<Unit> overstackAa = Match.getMatches(defendingAa, Matches.unitMayOverStackAa());
     overstackAa.removeAll(infiniteAa);
     normalNonInfiniteAa.removeAll(infiniteAa);
     normalNonInfiniteAa.removeAll(overstackAa);

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -623,8 +623,8 @@ public final class Matches {
         Matches.unitIsAaThatCanHitTheseUnits(unitsMovingOrAttacking, typeOfAa, airborneTechTargetsAllowed),
         Matches.unitIsAaThatWillNotFireIfPresentEnemyUnits(unitsMovingOrAttacking).invert(),
         Matches.unitIsAaThatCanFireOnRound(battleRoundNumber),
-        (defending ? UnitAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero
-            : UnitOffensiveAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero));
+        (defending ? unitAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero()
+            : unitOffensiveAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero()));
   }
 
   private static Match<UnitType> unitTypeIsAaForCombatOnly() {
@@ -665,36 +665,47 @@ public final class Matches {
     return Match.of(obj -> unitTypeIsAaForAnything().match(obj.getType()));
   }
 
-  public static final Match<Unit> UnitIsNotAA = unitIsAaForAnything().invert();
+  public static Match<Unit> unitIsNotAa() {
+    return unitIsAaForAnything().invert();
+  }
 
-  public static final Match<UnitType> UnitTypeMaxAAattacksIsInfinite =
-      Match.of(obj -> UnitAttachment.get(obj).getMaxAAattacks() == -1);
+  private static Match<UnitType> unitTypeMaxAaAttacksIsInfinite() {
+    return Match.of(obj -> UnitAttachment.get(obj).getMaxAAattacks() == -1);
+  }
 
-  public static final Match<Unit> UnitMaxAAattacksIsInfinite =
-      Match.of(obj -> UnitTypeMaxAAattacksIsInfinite.match(obj.getType()));
+  static Match<Unit> unitMaxAaAttacksIsInfinite() {
+    return Match.of(obj -> unitTypeMaxAaAttacksIsInfinite().match(obj.getType()));
+  }
 
-  public static final Match<UnitType> UnitTypeMayOverStackAA =
-      Match.of(obj -> UnitAttachment.get(obj).getMayOverStackAA());
+  private static Match<UnitType> unitTypeMayOverStackAa() {
+    return Match.of(obj -> UnitAttachment.get(obj).getMayOverStackAA());
+  }
 
-  public static final Match<Unit> UnitMayOverStackAA = Match.of(obj -> UnitTypeMayOverStackAA.match(obj.getType()));
+  static Match<Unit> unitMayOverStackAa() {
+    return Match.of(obj -> unitTypeMayOverStackAa().match(obj.getType()));
+  }
 
-  public static final Match<Unit> UnitAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero = Match.of(obj -> {
-    final UnitAttachment ua = UnitAttachment.get(obj.getType());
-    return ua.getAttackAA(obj.getOwner()) > 0 && ua.getMaxAAattacks() != 0;
-  });
+  static Match<Unit> unitAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero() {
+    return Match.of(obj -> {
+      final UnitAttachment ua = UnitAttachment.get(obj.getType());
+      return ua.getAttackAA(obj.getOwner()) > 0 && ua.getMaxAAattacks() != 0;
+    });
+  }
 
-  public static final Match<Unit> UnitOffensiveAttackAAisGreaterThanZeroAndMaxAAattacksIsNotZero = Match.of(obj -> {
-    final UnitAttachment ua = UnitAttachment.get(obj.getType());
-    return ua.getOffensiveAttackAA(obj.getOwner()) > 0 && ua.getMaxAAattacks() != 0;
-  });
+  static Match<Unit> unitOffensiveAttackAaIsGreaterThanZeroAndMaxAaAttacksIsNotZero() {
+    return Match.of(obj -> {
+      final UnitAttachment ua = UnitAttachment.get(obj.getType());
+      return ua.getOffensiveAttackAA(obj.getOwner()) > 0 && ua.getMaxAAattacks() != 0;
+    });
+  }
 
-  public static final Match<Unit> UnitIsInfantry = Match.of(obj -> {
-    final UnitType type = obj.getUnitType();
-    final UnitAttachment ua = UnitAttachment.get(type);
-    return ua.getIsInfantry();
-  });
+  public static Match<Unit> unitIsInfantry() {
+    return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getIsInfantry());
+  }
 
-  public static final Match<Unit> UnitIsNotInfantry = UnitIsInfantry.invert();
+  public static Match<Unit> unitIsNotInfantry() {
+    return unitIsInfantry().invert();
+  }
 
   public static final Match<Unit> UnitIsAirTransportable = Match.of(obj -> {
     final TechAttachment ta = TechAttachment.get(obj.getOwner());
@@ -706,7 +717,9 @@ public final class Matches {
     return ua.getIsAirTransportable();
   });
 
-  public static final Match<Unit> UnitIsNotAirTransportable = UnitIsAirTransportable.invert();
+  static Match<Unit> unitIsNotAirTransportable() {
+    return UnitIsAirTransportable.invert();
+  }
 
   public static final Match<Unit> UnitIsAirTransport = Match.of(obj -> {
     final TechAttachment ta = TechAttachment.get(obj.getOwner());
@@ -718,39 +731,49 @@ public final class Matches {
     return ua.getIsAirTransport();
   });
 
-  public static final Match<Unit> UnitIsArtillery = Match.of(obj -> {
-    final UnitType type = obj.getUnitType();
-    final UnitAttachment ua = UnitAttachment.get(type);
-    return ua.getArtillery();
-  });
+  public static Match<Unit> unitIsArtillery() {
+    return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getArtillery());
+  }
 
-  public static final Match<Unit> UnitIsArtillerySupportable = Match.of(obj -> {
-    final UnitType type = obj.getUnitType();
-    final UnitAttachment ua = UnitAttachment.get(type);
-    return ua.getArtillerySupportable();
-  });
+  public static Match<Unit> unitIsArtillerySupportable() {
+    return Match.of(obj -> UnitAttachment.get(obj.getUnitType()).getArtillerySupportable());
+  }
 
   // TODO: CHECK whether this makes any sense
-  public static final Match<Territory> TerritoryIsLandOrWater = Match.of(Objects::nonNull);
+  public static Match<Territory> territoryIsLandOrWater() {
+    return Match.of(Objects::nonNull);
+  }
 
   public static final Match<Territory> TerritoryIsWater = Match.of(Territory::isWater);
 
-  public static final Match<Territory> TerritoryIsIsland = Match.of(t -> {
-    final Collection<Territory> neighbors = t.getData().getMap().getNeighbors(t);
-    return neighbors.size() == 1 && TerritoryIsWater.match(neighbors.iterator().next());
-  });
+  /**
+   * Returns a match indicating the specified territory is an island.
+   */
+  public static Match<Territory> territoryIsIsland() {
+    return Match.of(t -> {
+      final Collection<Territory> neighbors = t.getData().getMap().getNeighbors(t);
+      return neighbors.size() == 1 && TerritoryIsWater.match(neighbors.iterator().next());
+    });
+  }
 
-  public static final Match<Territory> TerritoryIsVictoryCity = Match.of(t -> {
-    final TerritoryAttachment ta = TerritoryAttachment.get(t);
-    if (ta == null) {
-      return false;
-    }
-    return ta.getVictoryCity() != 0;
-  });
+  /**
+   * Returns a match indicating the specified territory is a victory city.
+   */
+  public static Match<Territory> territoryIsVictoryCity() {
+    return Match.of(t -> {
+      final TerritoryAttachment ta = TerritoryAttachment.get(t);
+      if (ta == null) {
+        return false;
+      }
+      return ta.getVictoryCity() != 0;
+    });
+  }
 
   public static final Match<Territory> TerritoryIsLand = TerritoryIsWater.invert();
 
-  public static final Match<Territory> TerritoryIsEmpty = Match.of(t -> t.getUnits().size() == 0);
+  public static Match<Territory> territoryIsEmpty() {
+    return Match.of(t -> t.getUnits().size() == 0);
+  }
 
   /**
    * Tests for Land, Convoys Centers and Convoy Routes, and Contested Territories.
@@ -952,22 +975,34 @@ public final class Matches {
     });
   }
 
-  public static final Match<Territory> TerritoryIsNeutralButNotWater = Match.of(t -> {
-    if (t.isWater()) {
-      return false;
-    }
-    return t.getOwner().equals(PlayerID.NULL_PLAYERID);
-  });
+  /**
+   * Returns a match indicating the specified territory is neutral and not water.
+   */
+  public static Match<Territory> territoryIsNeutralButNotWater() {
+    return Match.of(t -> {
+      if (t.isWater()) {
+        return false;
+      }
+      return t.getOwner().equals(PlayerID.NULL_PLAYERID);
+    });
+  }
 
-  public static final Match<Territory> TerritoryIsImpassable = Match.of(t -> {
-    if (t.isWater()) {
-      return false;
-    }
-    final TerritoryAttachment ta = TerritoryAttachment.get(t);
-    return ta != null && ta.getIsImpassable();
-  });
+  /**
+   * Returns a match indicating the specified territory is impassable.
+   */
+  public static Match<Territory> territoryIsImpassable() {
+    return Match.of(t -> {
+      if (t.isWater()) {
+        return false;
+      }
+      final TerritoryAttachment ta = TerritoryAttachment.get(t);
+      return ta != null && ta.getIsImpassable();
+    });
+  }
 
-  public static final Match<Territory> TerritoryIsNotImpassable = TerritoryIsImpassable.invert();
+  public static Match<Territory> territoryIsNotImpassable() {
+    return territoryIsImpassable().invert();
+  }
 
   static Match<Territory> seaCanMoveOver(final PlayerID player, final GameData data) {
     return Match.of(t -> {
@@ -981,7 +1016,7 @@ public final class Matches {
   static Match<Territory> airCanFlyOver(final PlayerID player, final GameData data,
       final boolean areNeutralsPassableByAir) {
     return Match.of(t -> {
-      if (!areNeutralsPassableByAir && TerritoryIsNeutralButNotWater.match(t)) {
+      if (!areNeutralsPassableByAir && territoryIsNeutralButNotWater().match(t)) {
         return false;
       }
       if (!territoryIsPassableAndNotRestricted(player, data).match(t)) {
@@ -994,7 +1029,7 @@ public final class Matches {
 
   public static Match<Territory> territoryIsPassableAndNotRestricted(final PlayerID player, final GameData data) {
     return Match.of(t -> {
-      if (Matches.TerritoryIsImpassable.match(t)) {
+      if (Matches.territoryIsImpassable().match(t)) {
         return false;
       }
       if (!Properties.getMovementByTerritoryRestricted(data)) {
@@ -1046,11 +1081,11 @@ public final class Matches {
     final boolean areNeutralsPassableByAir =
         neutralsPassable && Properties.getNeutralFlyoverAllowed(data);
     return Match.of(t -> {
-      if (Matches.TerritoryIsImpassable.match(t)) {
+      if (Matches.territoryIsImpassable().match(t)) {
         return false;
       }
       if ((!neutralsPassable || (hasAirUnitsNotBeingTransported && !areNeutralsPassableByAir))
-          && TerritoryIsNeutralButNotWater.match(t)) {
+          && territoryIsNeutralButNotWater().match(t)) {
         return false;
       }
       if (Properties.getMovementByTerritoryRestricted(data)) {
@@ -1092,9 +1127,13 @@ public final class Matches {
     });
   }
 
-  public static final Match<IBattle> BattleIsEmpty = Match.of(IBattle::isEmpty);
+  static Match<IBattle> battleIsEmpty() {
+    return Match.of(IBattle::isEmpty);
+  }
 
-  public static final Match<IBattle> BattleIsAmphibious = Match.of(IBattle::isAmphibious);
+  static Match<IBattle> battleIsAmphibious() {
+    return Match.of(IBattle::isAmphibious);
+  }
 
   public static Match<Unit> unitHasEnoughMovementForRoutes(final List<Route> route) {
     return unitHasEnoughMovementForRoute(Route.create(route));
@@ -1156,7 +1195,9 @@ public final class Matches {
   /**
    * Match units that have at least 1 movement left.
    */
-  public static final Match<Unit> unitHasMovementLeft = Match.of(o -> TripleAUnit.get(o).getMovementLeft() >= 1);
+  public static Match<Unit> unitHasMovementLeft() {
+    return Match.of(o -> TripleAUnit.get(o).getMovementLeft() >= 1);
+  }
 
   public static final Match<Unit> UnitCanMove = Match.of(u -> unitTypeCanMove(u.getOwner()).match(u.getType()));
 
@@ -1528,7 +1569,9 @@ public final class Matches {
 
   public static final Match<Unit> UnitIsLand = Match.allOf(unitIsNotSea(), unitIsNotAir());
 
-  public static final Match<UnitType> UnitTypeIsLand = Match.allOf(unitTypeIsNotSea(), unitTypeIsNotAir());
+  public static Match<UnitType> unitTypeIsLand() {
+    return Match.allOf(unitTypeIsNotSea(), unitTypeIsNotAir());
+  }
 
   public static final Match<Unit> UnitIsNotLand = UnitIsLand.invert();
 
@@ -2223,13 +2266,13 @@ public final class Matches {
             canBeInBattle.add(Matches.unitTypeIsSea().invert());
           }
         } else { // is sea battle
-          canBeInBattle.add(Matches.UnitTypeIsLand.invert());
+          canBeInBattle.add(Matches.unitTypeIsLand().invert());
         }
       } else { // defense
         if (isLandBattle) {
           canBeInBattle.add(Matches.unitTypeIsSea().invert());
         } else { // is sea battle
-          canBeInBattle.add(Matches.UnitTypeIsLand.invert());
+          canBeInBattle.add(Matches.unitTypeIsLand().invert());
         }
       }
 

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -239,7 +239,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
     // right now, land units on transports have movement taken away when they their transport moves
     moveableUnitOwnedByMeBuilder.add(Match.anyOf(
-        Matches.unitHasMovementLeft,
+        Matches.unitHasMovementLeft(),
         Match.allOf(
             Matches.UnitIsLand,
             Matches.unitIsBeingTransported())));
@@ -326,7 +326,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
         Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
     final Match<Unit> ownedFightersMatch =
         Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsAir,
-            Matches.UnitCanLandOnCarrier, Matches.unitHasMovementLeft);
+            Matches.UnitCanLandOnCarrier, Matches.unitHasMovementLeft());
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> ownedFighters = t.getUnits().getMatches(ownedFightersMatch);
@@ -571,7 +571,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
   }
 
   static Collection<Territory> getEmptyNeutral(final Route route) {
-    final Match<Territory> emptyNeutral = Match.allOf(Matches.TerritoryIsEmpty, Matches.TerritoryIsNeutralButNotWater);
+    final Match<Territory> emptyNeutral = Match.allOf(
+        Matches.territoryIsEmpty(),
+        Matches.territoryIsNeutralButNotWater());
     final Collection<Territory> neutral = route.getMatches(emptyNeutral);
     return neutral;
   }

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -352,7 +352,7 @@ public class MoveValidator {
           if (Matches.UnitIsAirTransportable.match(unit)) {
             continue;
           }
-          if (Matches.UnitIsInfantry.match(unit)) {
+          if (Matches.unitIsInfantry().match(unit)) {
             continue;
           }
           final TripleAUnit taUnit = (TripleAUnit) unit;
@@ -366,7 +366,7 @@ public class MoveValidator {
     if (Match.anyMatch(units, Matches.UnitIsAir)) { // check aircraft
       if (route.hasSteps()
           && (!Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
-        if (Match.anyMatch(route.getMiddleSteps(), Matches.TerritoryIsNeutralButNotWater)) {
+        if (Match.anyMatch(route.getMiddleSteps(), Matches.territoryIsNeutralButNotWater())) {
           return result.setErrorReturnResult("Air units cannot fly over neutral territories");
         }
       }
@@ -403,14 +403,14 @@ public class MoveValidator {
     if (getEditMode(data)) {
       return result;
     }
-    if (route.anyMatch(Matches.TerritoryIsImpassable)) {
+    if (route.anyMatch(Matches.territoryIsImpassable())) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_IMPASSABLE);
     }
     if (!route.anyMatch(Matches.territoryIsPassableAndNotRestricted(player, data))) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_RESTRICTED);
     }
     final Match<Territory> neutralOrEnemy =
-        Match.anyOf(Matches.TerritoryIsNeutralButNotWater,
+        Match.anyOf(Matches.territoryIsNeutralButNotWater(),
             Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data));
     // final CompositeMatch<Unit> transportsCanNotControl = new
     // CompositeMatchAnd<Unit>(Matches.unitIsTransportAndNotDestroyer(),
@@ -454,7 +454,7 @@ public class MoveValidator {
       // if there are non-paratroopers present, then we cannot fly over stuff
       // if there are neutral territories in the middle, we cannot fly over (unless allowed to)
       // otherwise we can generally fly over anything in noncombat
-      if (route.anyMatch(Match.allOf(Matches.TerritoryIsNeutralButNotWater, Matches.TerritoryIsWater.invert()))
+      if (route.anyMatch(Match.allOf(Matches.territoryIsNeutralButNotWater(), Matches.TerritoryIsWater.invert()))
           && (!Properties.getNeutralFlyoverAllowed(data) || isNeutralsImpassable(data))) {
         return result.setErrorReturnResult("Air units cannot fly over neutral territories in non combat");
       }
@@ -601,7 +601,7 @@ public class MoveValidator {
         if (!hasEnoughMovementForRoute.match(unit)) {
           boolean unitOk = false;
           if ((Matches.UnitIsAirTransportable.match(unit) && Matches.unitHasNotMoved().match(unit))
-              && (mechanizedSupportAvailable > 0 && Matches.unitHasNotMoved().match(unit) && Matches.UnitIsInfantry
+              && (mechanizedSupportAvailable > 0 && Matches.unitHasNotMoved().match(unit) && Matches.unitIsInfantry()
                   .match(unit))) {
             // we have paratroopers and mechanized infantry, so we must check for both
             // simple: if it movement group contains an air-transport, then assume we are doing paratroopers. else,
@@ -631,7 +631,7 @@ public class MoveValidator {
               result.addDisallowedUnit("Not all units have enough movement", unit);
             }
           } else if (mechanizedSupportAvailable > 0 && Matches.unitHasNotMoved().match(unit)
-              && Matches.UnitIsInfantry.match(unit)) {
+              && Matches.unitIsInfantry().match(unit)) {
             mechanizedSupportAvailable--;
           } else if (Matches.unitIsOwnedBy(player).invert().match(unit) && Matches.alliedUnit(player, data).match(unit)
               && Matches.unitTypeCanLandOnCarrier().match(unit.getType())
@@ -714,14 +714,14 @@ public class MoveValidator {
       }
     }
     // don't allow move through impassable territories
-    if (!isEditMode && route.anyMatch(Matches.TerritoryIsImpassable)) {
+    if (!isEditMode && route.anyMatch(Matches.territoryIsImpassable())) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_IMPASSABLE);
     }
     if (canCrossNeutralTerritory(data, route, player, result).getError() != null) {
       return result;
     }
     if (isNeutralsImpassable(data) && !isNeutralsBlitzable(data)
-        && !route.getMatches(Matches.TerritoryIsNeutralButNotWater).isEmpty()) {
+        && !route.getMatches(Matches.territoryIsNeutralButNotWater()).isEmpty()) {
       return result.setErrorReturnResult(CANNOT_VIOLATE_NEUTRALITY);
     }
     return result;
@@ -1193,7 +1193,7 @@ public class MoveValidator {
     if (units.isEmpty() || !Match.allMatch(units, Match.anyOf(Matches.UnitIsAir, Matches.UnitIsLand))) {
       return true;
     }
-    for (final Unit unit : Match.getMatches(units, Matches.UnitIsNotAirTransportable)) {
+    for (final Unit unit : Match.getMatches(units, Matches.unitIsNotAirTransportable())) {
       if (Matches.UnitIsLand.match(unit)) {
         return true;
       }
@@ -1478,7 +1478,7 @@ public class MoveValidator {
     // Ignore the end territory in our tests. it must be in the route, so it shouldn't affect the route choice
     // final Match<Territory> territoryIsEnd = Matches.territoryIs(end);
     // No neutral countries on route predicate
-    final Match<Territory> noNeutral = Matches.TerritoryIsNeutralButNotWater.invert();
+    final Match<Territory> noNeutral = Matches.territoryIsNeutralButNotWater().invert();
     // No aa guns on route predicate
     final Match<Territory> noAa = Matches.territoryHasEnemyAaForAnything(player, data).invert();
     // no enemy units on the route predicate
@@ -1508,8 +1508,8 @@ public class MoveValidator {
       // at least try for a route without impassable territories, but allowing restricted territories, since there is a
       // chance politics may change in the future.
       defaultRoute = data.getMap().getRoute_IgnoreEnd(start, end,
-          (isNeutralsImpassable ? Match.allOf(noNeutral, Matches.TerritoryIsImpassable)
-              : Matches.TerritoryIsImpassable));
+          (isNeutralsImpassable ? Match.allOf(noNeutral, Matches.territoryIsImpassable())
+              : Matches.territoryIsImpassable()));
       // ok, so there really is nothing, so just return any route, without conditions
       if (defaultRoute == null) {
         return data.getMap().getRoute(start, end);

--- a/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -222,8 +222,8 @@ public class RandomStartDelegate extends BaseTripleADelegate {
   }
 
   public Match<Territory> getTerritoryPickableMatch() {
-    return Match.allOf(Matches.TerritoryIsLand, Matches.TerritoryIsNotImpassable,
-        Matches.isTerritoryOwnedBy(PlayerID.NULL_PLAYERID), Matches.TerritoryIsEmpty);
+    return Match.allOf(Matches.TerritoryIsLand, Matches.territoryIsNotImpassable(),
+        Matches.isTerritoryOwnedBy(PlayerID.NULL_PLAYERID), Matches.territoryIsEmpty());
   }
 
   private Match<PlayerID> getPlayerCanPickMatch() {

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -156,7 +156,7 @@ public class RocketsFireHelper {
     final Match.CompositeBuilder<Territory> allowedBuilder = Match.newCompositeBuilder(
         Matches.territoryAllowsRocketsCanFlyOver(player, data));
     if (!isRocketsCanFlyOverImpassables(data)) {
-      allowedBuilder.add(Matches.TerritoryIsNotImpassable);
+      allowedBuilder.add(Matches.territoryIsNotImpassable());
     }
     final Match<Unit> attackableUnits =
         Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsBeingTransported().invert());

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculatorPanel.java
@@ -1184,7 +1184,7 @@ class OddsCalculatorPanel extends JPanel {
           // no duplicates or infrastructure allowed. no sea if land, no land if sea.
           if (typesUsed.contains(category.getType()) || Matches.unitTypeIsInfrastructure().match(category.getType())
               || (land && Matches.unitTypeIsSea().match(category.getType()))
-              || (!land && Matches.UnitTypeIsLand.match(category.getType()))) {
+              || (!land && Matches.unitTypeIsLand().match(category.getType()))) {
             continue;
           }
           final String unitName =

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1446,7 +1446,7 @@ public class MovePanel extends AbstractMovePanel {
     }
     final Match.CompositeBuilder<Unit> moveableUnitOwnedByMeBuilder = Match.newCompositeBuilder(
         Matches.unitIsOwnedBy(getCurrentPlayer()),
-        Matches.unitHasMovementLeft);
+        Matches.unitHasMovementLeft());
     if (!nonCombat) {
       // if not non combat, cannot move aa units
       moveableUnitOwnedByMeBuilder.add(Matches.unitCanNotMoveDuringCombatMove().invert());
@@ -1495,7 +1495,7 @@ public class MovePanel extends AbstractMovePanel {
     }
     final Match.CompositeBuilder<Unit> moveableUnitOwnedByMeBuilder = Match.newCompositeBuilder(
         Matches.unitIsOwnedBy(getCurrentPlayer()),
-        Matches.unitHasMovementLeft);
+        Matches.unitHasMovementLeft());
     if (!nonCombat) {
       // if not non combat, cannot move aa units
       moveableUnitOwnedByMeBuilder.add(Matches.unitCanNotMoveDuringCombatMove().invert());

--- a/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -182,7 +182,7 @@ public class StatPanel extends AbstractStatPanel {
 
     public void setStatCollums() {
       stats = new IStat[] {new PuStat(), new ProductionStat(), new UnitsStat(), new TuvStat()};
-      if (Match.anyMatch(gameData.getMap().getTerritories(), Matches.TerritoryIsVictoryCity)) {
+      if (Match.anyMatch(gameData.getMap().getTerritories(), Matches.territoryIsVictoryCity())) {
         final List<IStat> stats = new ArrayList<>(Arrays.asList(StatPanel.this.stats));
         stats.add(new VictoryCityStat());
         StatPanel.this.stats = stats.toArray(new IStat[stats.size()]);

--- a/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -375,9 +375,9 @@ public class RevisedTest {
     // start a battle in se
     removeFrom(sz14, sz14.getUnits().getUnits());
     addTo(sz15, transport(gameData).create(1, british));
-    load(egypt.getUnits().getMatches(Matches.UnitIsInfantry), new Route(egypt, sz15));
+    load(egypt.getUnits().getMatches(Matches.unitIsInfantry()), new Route(egypt, sz15));
     move(sz15.getUnits().getUnits(), new Route(sz15, sz14));
-    move(sz14.getUnits().getMatches(Matches.UnitIsInfantry), new Route(sz14, se));
+    move(sz14.getUnits().getMatches(Matches.unitIsInfantry()), new Route(sz14, se));
     final Route route = new Route(uk, territory("7 Sea Zone", gameData), we, se);
     move(uk.getUnits().getMatches(Matches.UnitIsStrategicBomber), route);
     // the aa gun should have fired and hit
@@ -1304,7 +1304,7 @@ public class RevisedTest {
     move.start();
     // remove the russians units in caucasus so we can blitz
     final Territory cauc = territory("Caucasus", gameData);
-    removeFrom(cauc, cauc.getUnits().getMatches(Matches.UnitIsNotAA));
+    removeFrom(cauc, cauc.getUnits().getMatches(Matches.unitIsNotAa()));
     // blitz
     final Territory wr = territory("West Russia", gameData);
     move(wr.getUnits().getMatches(Matches.UnitCanBlitz), new Route(wr, cauc));

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -349,7 +349,7 @@ public class WW2V3Year41Test {
     final List<Unit> transports = sz9.getUnits().getMatches(Matches.UnitIsTransport);
     move(transports, sz9ToSz7);
     // load the transport
-    load(uk.getUnits().getMatches(Matches.UnitIsInfantry), new Route(uk, sz7));
+    load(uk.getUnits().getMatches(Matches.unitIsInfantry()), new Route(uk, sz7));
     moveDelegate(gameData).end();
     final ScriptedRandomSource randomSource = new ScriptedRandomSource(new int[] {0, 1});
     bridge.setRandomSource(randomSource);
@@ -781,7 +781,7 @@ public class WW2V3Year41Test {
     // move the transport where to the sub is
     assertValid(moveDelegate.move(sz8.getUnits().getUnits(), new Route(sz8, sz7)));
     // load the transport
-    load(uk.getUnits().getMatches(Matches.UnitIsInfantry), new Route(uk, sz7));
+    load(uk.getUnits().getMatches(Matches.unitIsInfantry()), new Route(uk, sz7));
     // move the transport out
     assertValid(
         moveDelegate.move(sz7.getUnits().getMatches(Matches.unitOwnedBy(british(gameData))), new Route(sz7, sz6)));
@@ -984,7 +984,7 @@ public class WW2V3Year41Test {
     final PlayerID british = GameDataTestUtil.british(gameData);
     addTo(eg, infantry(gameData).create(2, british));
     // load the transports
-    load(balkans.getUnits().getMatches(Matches.UnitIsInfantry), new Route(balkans, sz14));
+    load(balkans.getUnits().getMatches(Matches.unitIsInfantry()), new Route(balkans, sz14));
     // move the fleet
     move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
     // move troops from Libya
@@ -1035,7 +1035,7 @@ public class WW2V3Year41Test {
     addTo(sz14, transport(gameData).create(1, italians));
     addTo(sz14, destroyer(gameData).create(2, italians));
     // load the transports
-    load(balkans.getUnits().getMatches(Matches.UnitIsInfantry), new Route(balkans, sz14));
+    load(balkans.getUnits().getMatches(Matches.unitIsInfantry()), new Route(balkans, sz14));
     // move the fleet
     move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
     // unload the transports
@@ -1088,7 +1088,7 @@ public class WW2V3Year41Test {
     final Territory li = territory("Libya", gameData);
     final Territory balkans = territory("Balkans", gameData);
     // load the transports
-    load(balkans.getUnits().getMatches(Matches.UnitIsInfantry), new Route(balkans, sz14));
+    load(balkans.getUnits().getMatches(Matches.unitIsInfantry()), new Route(balkans, sz14));
     // move the fleet
     move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
     // move troops from Libya
@@ -1167,7 +1167,7 @@ public class WW2V3Year41Test {
     final List<Unit> toMove = new ArrayList<>();
     // 1 armour and 1 infantry
     toMove.addAll(france.getUnits().getMatches(Matches.UnitCanBlitz));
-    toMove.add(france.getUnits().getMatches(Matches.UnitIsInfantry).get(0));
+    toMove.add(france.getUnits().getMatches(Matches.unitIsInfantry()).get(0));
     move(toMove, r);
   }
 
@@ -1182,9 +1182,9 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // get rid of the infantry in france
-    removeFrom(france, france.getUnits().getMatches(Matches.UnitIsInfantry));
+    removeFrom(france, france.getUnits().getMatches(Matches.unitIsInfantry()));
     // move an infantry from germany to france
-    move(germany.getUnits().getMatches(Matches.UnitIsInfantry).subList(0, 1), new Route(germany, france));
+    move(germany.getUnits().getMatches(Matches.unitIsInfantry()).subList(0, 1), new Route(germany, france));
     // try to move all the units in france, the infantry should not be able to move
     final Route r = new Route(france, germany);
     final String error = moveDelegate(gameData).move(france.getUnits().getUnits(), r);

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -83,7 +83,7 @@ public class WW2V3Year42Test {
     // move the bomber to attack
     move(germany.getUnits().getMatches(Matches.UnitIsStrategicBomber), new Route(germany, sz5, karrelia));
     // move an infantry to invade
-    move(baltic.getUnits().getMatches(Matches.UnitIsInfantry), new Route(baltic, karrelia));
+    move(baltic.getUnits().getMatches(Matches.unitIsInfantry()), new Route(baltic, karrelia));
     final BattleTracker battleTracker = MoveDelegate.getBattleTracker(gameData);
     // we should have a pending land battle, and a pending bombing raid
     assertNotNull(battleTracker.getPendingBattle(karrelia, false, null));


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is one part in a series of related PRs in order to keep the review size reasonable.