### PR TITLE
Remove superfluous Travis Postgres service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ addons:
       - python3
       - python3-yaml
 install: ./.travis/setup_lobby_database
-services:
-- postgresql
 script: JAVA_OPTS=-Xmx1G ./gradlew check jacocoTestReport
 after_success: 
 - ./.travis/update_checkstyle_thresholds


### PR DESCRIPTION
Per the [Travis docs](https://docs.travis-ci.com/user/database-setup/#Starting-Services), a service need only be installed in the `services` section or the `addons` section.  This PR removes Postgres from the `services` section, as the definition in the `addons` is more specific.