### PR TITLE
Serialization proxy: Refactor custom equality test framework

### DIFF
--- a/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
+++ b/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
@@ -1,0 +1,45 @@
+package games.strategy.engine.data;
+
+import games.strategy.test.EqualityComparator;
+
+/**
+ * A collection of equality comparators for engine data types.
+ */
+public final class EngineDataEqualityComparators {
+  private EngineDataEqualityComparators() {}
+
+  public static final EqualityComparator GAME_DATA = EqualityComparator.newInstance(
+      GameData.class,
+      (context, o1, o2) -> (o1.getDiceSides() == o2.getDiceSides())
+          && areBothNullOrBothNotNull(o1.getGameLoader(), o2.getGameLoader())
+          && context.equals(o1.getGameName(), o2.getGameName())
+          && context.equals(o1.getGameVersion(), o2.getGameVersion()));
+
+  private static boolean areBothNullOrBothNotNull(final Object o1, final Object o2) {
+    return (o1 == null) == (o2 == null);
+  }
+
+  public static final EqualityComparator PRODUCTION_FRONTIER = EqualityComparator.newInstance(
+      ProductionFrontier.class,
+      (context, o1, o2) -> context.equals(o1.getData(), o2.getData())
+          && context.equals(o1.getName(), o2.getName())
+          && context.equals(o1.getRules(), o2.getRules()));
+
+  public static final EqualityComparator PRODUCTION_RULE = EqualityComparator.newInstance(
+      ProductionRule.class,
+      (context, o1, o2) -> context.equals(o1.getData(), o2.getData())
+          && context.equals(o1.getName(), o2.getName())
+          && context.equals(o1.getCosts(), o2.getCosts())
+          && context.equals(o1.getResults(), o2.getResults()));
+
+  public static final EqualityComparator RESOURCE = EqualityComparator.newInstance(
+      Resource.class,
+      (context, o1, o2) -> context.equals(o1.getAttachments(), o2.getAttachments())
+          && context.equals(o1.getData(), o2.getData())
+          && context.equals(o1.getName(), o2.getName()));
+
+  public static final EqualityComparator RESOURCE_COLLECTION = EqualityComparator.newInstance(
+      ResourceCollection.class,
+      (context, o1, o2) -> context.equals(o1.getData(), o2.getData())
+          && context.equals(o1.getResourcesCopy(), o2.getResourcesCopy()));
+}

--- a/src/test/java/games/strategy/engine/data/GameDataMementoTest.java
+++ b/src/test/java/games/strategy/engine/data/GameDataMementoTest.java
@@ -3,7 +3,7 @@ package games.strategy.engine.data;
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionHamcrestMatchers.hasMessageThat;
-import static games.strategy.engine.data.Matchers.equalTo;
+import static games.strategy.engine.data.Matchers.equalToGameData;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
@@ -29,7 +29,7 @@ public final class GameDataMementoTest {
     final Memento memento = mementoExporter.exportMemento(expected);
     final GameData actual = mementoImporter.importMemento(memento);
 
-    assertThat(actual, is(equalTo(expected)));
+    assertThat(actual, is(equalToGameData(expected)));
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/data/Matchers.java
+++ b/src/test/java/games/strategy/engine/data/Matchers.java
@@ -1,209 +1,28 @@
 package games.strategy.engine.data;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
 import javax.annotation.Nullable;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
-import com.google.common.reflect.TypeToken;
-
-import games.strategy.util.IntegerMap;
+import games.strategy.test.EqualityComparatorRegistry;
 
 /**
  * A collection of matchers for types in the {@link games.strategy.engine.data} package.
  */
 public final class Matchers {
-  private static final Map<Class<?>, EqualityComparator<Object>> EQUALITY_COMPARATORS_BY_TYPE =
-      createEqualityComparatorsByType();
-
   private Matchers() {}
 
-  @FunctionalInterface
-  private interface EqualityComparator<T> {
-    boolean equals(T o1, T o2);
-  }
-
-  private static Map<Class<?>, EqualityComparator<Object>> createEqualityComparatorsByType() {
-    final Map<Class<?>, EqualityComparator<Object>> equalityComparatorsByType = new HashMap<>();
-    addTypeSafeEqualityComparator(equalityComparatorsByType, Collection.class, Matchers::collectionEquals);
-    addTypeSafeEqualityComparator(equalityComparatorsByType, GameData.class, Matchers::gameDataEquals);
-    addTypeSafeEqualityComparator(equalityComparatorsByType, IntegerMap.class, Matchers::integerMapEquals);
-    addTypeSafeEqualityComparator(equalityComparatorsByType, Map.class, Matchers::mapEquals);
-    addTypeSafeEqualityComparator(equalityComparatorsByType, ProductionFrontier.class,
-        Matchers::productionFrontierEquals);
-    addTypeSafeEqualityComparator(equalityComparatorsByType, ProductionRule.class, Matchers::productionRuleEquals);
-    addTypeSafeEqualityComparator(equalityComparatorsByType, Resource.class, Matchers::resourceEquals);
-    addTypeSafeEqualityComparator(equalityComparatorsByType, ResourceCollection.class,
-        Matchers::resourceCollectionEquals);
-    return Collections.unmodifiableMap(equalityComparatorsByType);
-  }
-
-  private static <T> void addTypeSafeEqualityComparator(
-      final Map<Class<?>, EqualityComparator<Object>> equalityComparatorsByType,
-      final Class<T> type,
-      final EqualityComparator<T> equalityComparator) {
-    final EqualityComparator<Object> typeSafeEqualityComparator = (o1, o2) -> {
-      try {
-        return equalityComparator.equals(type.cast(o1), type.cast(o2));
-      } catch (final ClassCastException e) {
-        return false;
-      }
-    };
-    equalityComparatorsByType.put(type, typeSafeEqualityComparator);
-  }
-
-  private static boolean collectionEquals(final Collection<?> o1, final Collection<?> o2) {
-    if (o1.size() != o2.size()) {
-      return false;
-    }
-
-    final Iterator<?> o1Iterator = o1.iterator();
-    final Iterator<?> o2Iterator = o2.iterator();
-    while (o1Iterator.hasNext()) {
-      if (!equals(o1Iterator.next(), o2Iterator.next())) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  private static boolean gameDataEquals(final GameData o1, final GameData o2) {
-    return (o1.getDiceSides() == o2.getDiceSides())
-        && areBothNullOrBothNotNull(o1.getGameLoader(), o2.getGameLoader())
-        && equals(o1.getGameName(), o2.getGameName())
-        && equals(o1.getGameVersion(), o2.getGameVersion());
-  }
-
-  private static boolean areBothNullOrBothNotNull(final Object o1, final Object o2) {
-    return (o1 == null) == (o2 == null);
-  }
-
-  private static boolean integerMapEquals(final IntegerMap<?> o1, final IntegerMap<?> o2) {
-    return mapEquals(o1.toMap(), o2.toMap());
-  }
-
-  private static boolean mapEquals(final Map<?, ?> o1, final Map<?, ?> o2) {
-    if (o1.size() != o2.size()) {
-      return false;
-    }
-
-    for (final Map.Entry<?, ?> entry1 : o1.entrySet()) {
-      // NB: We can't simply lookup key1 in o2 because that will use Object#equals() instead of the EqualityComparator
-      boolean key1Found = false;
-      for (final Map.Entry<?, ?> entry2 : o2.entrySet()) {
-        if (equals(entry1.getKey(), entry2.getKey())) {
-          key1Found = true;
-          if (!equals(entry1.getValue(), entry2.getValue())) {
-            return false;
-          }
-          break;
-        }
-      }
-
-      if (!key1Found) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
-  private static boolean productionFrontierEquals(final ProductionFrontier o1, final ProductionFrontier o2) {
-    return equals(o1.getData(), o2.getData())
-        && equals(o1.getName(), o2.getName())
-        && equals(o1.getRules(), o2.getRules());
-  }
-
-  private static boolean productionRuleEquals(final ProductionRule o1, final ProductionRule o2) {
-    return equals(o1.getData(), o2.getData())
-        && equals(o1.getName(), o2.getName())
-        && equals(o1.getCosts(), o2.getCosts())
-        && equals(o1.getResults(), o2.getResults());
-  }
-
-  private static boolean resourceEquals(final Resource o1, final Resource o2) {
-    return equals(o1.getAttachments(), o2.getAttachments())
-        && equals(o1.getData(), o2.getData())
-        && equals(o1.getName(), o2.getName());
-  }
-
-  private static boolean resourceCollectionEquals(final ResourceCollection o1, final ResourceCollection o2) {
-    return equals(o1.getData(), o2.getData())
-        && equals(o1.getResourcesCopy(), o2.getResourcesCopy());
-  }
-
-  private static boolean equals(final Object o1, final Object o2) {
-    if (o1 == o2) {
-      return true;
-    } else if (o1 == null) {
-      return o2 == null;
-    } else if (o2 == null) {
-      return false; // o1 cannot be null here
-    }
-
-    return getEqualityComparatorFor(o1.getClass()).equals(o1, o2);
-  }
-
-  private static EqualityComparator<Object> getEqualityComparatorFor(final Class<?> type) {
-    // first try concrete type
-    EqualityComparator<Object> equalityComparator = EQUALITY_COMPARATORS_BY_TYPE.get(type);
-    if (equalityComparator != null) {
-      return equalityComparator;
-    }
-
-    // then try any declared or inherited interface
-    for (final TypeToken<?> typeToken : TypeToken.of(type).getTypes().interfaces()) {
-      equalityComparator = EQUALITY_COMPARATORS_BY_TYPE.get(typeToken.getRawType());
-      if (equalityComparator != null) {
-        return equalityComparator;
-      }
-    }
-
-    // otherwise delegate to Object#equals
-    return (o1, o2) -> o1.equals(o2);
-  }
-
   /**
-   * Creates a matcher that matches when the examined object is logically equal to the specified object.
+   * Creates a matcher that matches when the examined {@link GameData} is logically equal to the specified
+   * {@link GameData}.
    *
-   * <p>
-   * The returned matcher uses the registered {@link EqualityComparator}s to determine if the objects are equal. If a
-   * comparator is not available for a particular type, a default comparator based on {@link Object#equals(Object)} will
-   * be used instead. Developers can extend the {@link Matchers#EQUALITY_COMPARATORS_BY_TYPE} map with their own custom
-   * comparators, as needed.
-   * </p>
-   *
-   * @param expected The expected value.
+   * @param expected The expected {@link GameData} value.
    *
    * @return A new matcher.
    */
-  public static <T> Matcher<T> equalTo(final @Nullable T expected) {
-    return new IsEqual<>(expected);
-  }
-
-  private static final class IsEqual<T> extends BaseMatcher<T> {
-    private final Object expected;
-
-    IsEqual(final @Nullable Object expected) {
-      this.expected = expected;
-    }
-
-    @Override
-    public void describeTo(final Description description) {
-      description.appendValue(expected);
-    }
-
-    @Override
-    public boolean matches(final Object actual) {
-      return Matchers.equals(expected, actual);
-    }
+  public static Matcher<GameData> equalToGameData(final @Nullable GameData expected) {
+    final EqualityComparatorRegistry equalityComparatorRegistry =
+        EqualityComparatorRegistry.newInstance(TestEqualityComparatorCollectionBuilder.forGameData().build());
+    return games.strategy.test.Matchers.equalTo(expected).withEqualityComparatorRegistry(equalityComparatorRegistry);
   }
 }

--- a/src/test/java/games/strategy/engine/data/TestEqualityComparatorCollectionBuilder.java
+++ b/src/test/java/games/strategy/engine/data/TestEqualityComparatorCollectionBuilder.java
@@ -1,0 +1,49 @@
+package games.strategy.engine.data;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import games.strategy.test.EqualityComparator;
+import games.strategy.util.CoreEqualityComparators;
+
+/**
+ * Provides support for incrementally building equality comparator collections typically required by test fixtures.
+ */
+public final class TestEqualityComparatorCollectionBuilder {
+  private final Collection<EqualityComparator> equalityComparators = new ArrayList<>();
+
+  private TestEqualityComparatorCollectionBuilder() {}
+
+  /**
+   * Creates a new equality comparator collection builder that is pre-populated with all equality comparators required
+   * to compare instances of {@code GameData} for equality.
+   *
+   * @return A new equality comparator collection builder.
+   */
+  public static TestEqualityComparatorCollectionBuilder forGameData() {
+    return new TestEqualityComparatorCollectionBuilder()
+        .add(CoreEqualityComparators.COLLECTION)
+        .add(CoreEqualityComparators.MAP)
+        .add(EngineDataEqualityComparators.GAME_DATA);
+  }
+
+  /**
+   * Adds the specified equality comparator to the collection under construction.
+   *
+   * @param equalityComparator The equality comparator to add.
+   *
+   * @return A reference to this builder.
+   */
+  public TestEqualityComparatorCollectionBuilder add(final EqualityComparator equalityComparator) {
+    checkNotNull(equalityComparator);
+
+    equalityComparators.add(equalityComparator);
+    return this;
+  }
+
+  public Collection<EqualityComparator> build() {
+    return new ArrayList<>(equalityComparators);
+  }
+}

--- a/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.framework;
 
-import static games.strategy.engine.data.Matchers.equalTo;
+import static games.strategy.engine.data.Matchers.equalToGameData;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -38,7 +38,7 @@ public class GameDataManagerTest {
     final byte[] bytes = saveGameInProxySerializationFormat(expected);
     final GameData actual = loadGameInProxySerializationFormat(bytes);
 
-    assertThat(actual, is(equalTo(expected)));
+    assertThat(actual, is(equalToGameData(expected)));
   }
 
   private static byte[] saveGameInProxySerializationFormat(final GameData gameData) throws Exception {

--- a/src/test/java/games/strategy/internal/persistence/serializable/GameDataProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/GameDataProxyAsProxyTest.java
@@ -1,16 +1,14 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.util.Arrays;
 import java.util.Collection;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
 import games.strategy.engine.data.TestGameDataFactory;
 import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
 
 public final class GameDataProxyAsProxyTest extends AbstractProxyTestCase<GameData> {
   public GameDataProxyAsProxyTest() {
@@ -18,13 +16,13 @@ public final class GameDataProxyAsProxyTest extends AbstractProxyTestCase<GameDa
   }
 
   @Override
-  protected void assertPrincipalEquals(final GameData expected, final GameData actual) {
-    assertThat(actual, is(equalTo(expected)));
+  protected Collection<GameData> createPrincipals() {
+    return Arrays.asList(TestGameDataFactory.newValidGameData());
   }
 
   @Override
-  protected Collection<GameData> createPrincipals() {
-    return Arrays.asList(TestGameDataFactory.newValidGameData());
+  protected Collection<EqualityComparator> getEqualityComparators() {
+    return TestEqualityComparatorCollectionBuilder.forGameData().build();
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxyAsProxyTest.java
@@ -1,27 +1,22 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.util.Arrays;
 import java.util.Collection;
 
+import games.strategy.engine.data.EngineDataEqualityComparators;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ProductionFrontier;
+import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
 import games.strategy.engine.data.TestGameDataComponentFactory;
 import games.strategy.engine.data.TestGameDataFactory;
 import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
+import games.strategy.util.CoreEqualityComparators;
 
 public final class ProductionFrontierProxyAsProxyTest extends AbstractProxyTestCase<ProductionFrontier> {
   public ProductionFrontierProxyAsProxyTest() {
     super(ProductionFrontier.class);
-  }
-
-  @Override
-  protected void assertPrincipalEquals(final ProductionFrontier expected, final ProductionFrontier actual) {
-    assertThat(actual, is(equalTo(expected)));
   }
 
   @Override
@@ -35,6 +30,16 @@ public final class ProductionFrontierProxyAsProxyTest extends AbstractProxyTestC
     productionFrontier.addRule(TestGameDataComponentFactory.newProductionRule(gameData, "productionRule1"));
     productionFrontier.addRule(TestGameDataComponentFactory.newProductionRule(gameData, "productionRule2"));
     return productionFrontier;
+  }
+
+  @Override
+  protected Collection<EqualityComparator> getEqualityComparators() {
+    return TestEqualityComparatorCollectionBuilder.forGameData()
+        .add(CoreEqualityComparators.INTEGER_MAP)
+        .add(EngineDataEqualityComparators.PRODUCTION_FRONTIER)
+        .add(EngineDataEqualityComparators.PRODUCTION_RULE)
+        .add(EngineDataEqualityComparators.RESOURCE)
+        .build();
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/ProductionRuleProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ProductionRuleProxyAsProxyTest.java
@@ -1,17 +1,17 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.util.Arrays;
 import java.util.Collection;
 
+import games.strategy.engine.data.EngineDataEqualityComparators;
 import games.strategy.engine.data.ProductionRule;
+import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
 import games.strategy.engine.data.TestGameDataComponentFactory;
 import games.strategy.engine.data.TestGameDataFactory;
 import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
+import games.strategy.util.CoreEqualityComparators;
 
 public final class ProductionRuleProxyAsProxyTest extends AbstractProxyTestCase<ProductionRule> {
   public ProductionRuleProxyAsProxyTest() {
@@ -19,15 +19,19 @@ public final class ProductionRuleProxyAsProxyTest extends AbstractProxyTestCase<
   }
 
   @Override
-  protected void assertPrincipalEquals(final ProductionRule expected, final ProductionRule actual) {
-    assertThat(actual, is(equalTo(expected)));
-  }
-
-  @Override
   protected Collection<ProductionRule> createPrincipals() {
     return Arrays.asList(TestGameDataComponentFactory.newProductionRule(
         TestGameDataFactory.newValidGameData(),
         "productionRule"));
+  }
+
+  @Override
+  protected Collection<EqualityComparator> getEqualityComparators() {
+    return TestEqualityComparatorCollectionBuilder.forGameData()
+        .add(CoreEqualityComparators.INTEGER_MAP)
+        .add(EngineDataEqualityComparators.PRODUCTION_RULE)
+        .add(EngineDataEqualityComparators.RESOURCE)
+        .build();
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ResourceCollectionProxyAsProxyTest.java
@@ -1,27 +1,22 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.util.Arrays;
 import java.util.Collection;
 
+import games.strategy.engine.data.EngineDataEqualityComparators;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.ResourceCollection;
+import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
 import games.strategy.engine.data.TestGameDataComponentFactory;
 import games.strategy.engine.data.TestGameDataFactory;
 import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
+import games.strategy.util.CoreEqualityComparators;
 
 public final class ResourceCollectionProxyAsProxyTest extends AbstractProxyTestCase<ResourceCollection> {
   public ResourceCollectionProxyAsProxyTest() {
     super(ResourceCollection.class);
-  }
-
-  @Override
-  protected void assertPrincipalEquals(final ResourceCollection expected, final ResourceCollection actual) {
-    assertThat(actual, is(equalTo(expected)));
   }
 
   @Override
@@ -35,6 +30,15 @@ public final class ResourceCollectionProxyAsProxyTest extends AbstractProxyTestC
     resourceCollection.addResource(TestGameDataComponentFactory.newResource(gameData, "resource1"), 11);
     resourceCollection.addResource(TestGameDataComponentFactory.newResource(gameData, "resource2"), 22);
     return resourceCollection;
+  }
+
+  @Override
+  protected Collection<EqualityComparator> getEqualityComparators() {
+    return TestEqualityComparatorCollectionBuilder.forGameData()
+        .add(CoreEqualityComparators.INTEGER_MAP)
+        .add(EngineDataEqualityComparators.RESOURCE)
+        .add(EngineDataEqualityComparators.RESOURCE_COLLECTION)
+        .build();
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/ResourceProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ResourceProxyAsProxyTest.java
@@ -1,17 +1,16 @@
 package games.strategy.internal.persistence.serializable;
 
-import static games.strategy.engine.data.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.util.Arrays;
 import java.util.Collection;
 
+import games.strategy.engine.data.EngineDataEqualityComparators;
 import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
 import games.strategy.engine.data.TestGameDataComponentFactory;
 import games.strategy.engine.data.TestGameDataFactory;
 import games.strategy.persistence.serializable.AbstractProxyTestCase;
 import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
 
 public final class ResourceProxyAsProxyTest extends AbstractProxyTestCase<Resource> {
   public ResourceProxyAsProxyTest() {
@@ -19,13 +18,15 @@ public final class ResourceProxyAsProxyTest extends AbstractProxyTestCase<Resour
   }
 
   @Override
-  protected void assertPrincipalEquals(final Resource expected, final Resource actual) {
-    assertThat(actual, is(equalTo(expected)));
+  protected Collection<Resource> createPrincipals() {
+    return Arrays.asList(TestGameDataComponentFactory.newResource(TestGameDataFactory.newValidGameData(), "resource"));
   }
 
   @Override
-  protected Collection<Resource> createPrincipals() {
-    return Arrays.asList(TestGameDataComponentFactory.newResource(TestGameDataFactory.newValidGameData(), "resource"));
+  protected Collection<EqualityComparator> getEqualityComparators() {
+    return TestEqualityComparatorCollectionBuilder.forGameData()
+        .add(EngineDataEqualityComparators.RESOURCE)
+        .build();
   }
 
   @Override

--- a/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
+++ b/src/test/java/games/strategy/persistence/serializable/AbstractProxyTestCase.java
@@ -1,6 +1,7 @@
 package games.strategy.persistence.serializable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static games.strategy.test.Matchers.equalTo;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -13,9 +14,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.Test;
+
+import games.strategy.test.EqualityComparator;
+import games.strategy.test.EqualityComparatorRegistry;
 
 /**
  * A fixture for testing the basic aspects of proxy classes.
@@ -23,6 +28,9 @@ import org.junit.Test;
  * @param <T> The type of the principal to be proxied.
  */
 public abstract class AbstractProxyTestCase<T> {
+  private final EqualityComparatorRegistry equalityComparatorRegistry =
+      EqualityComparatorRegistry.newInstance(getEqualityComparators());
+
   private final Class<T> principalType;
 
   private final ProxyRegistry proxyRegistry = ProxyRegistry.newInstance(getProxyFactories());
@@ -37,7 +45,9 @@ public abstract class AbstractProxyTestCase<T> {
    * Asserts that the specified principals are equal.
    *
    * <p>
-   * This implementation compares the two objects using the {@code equals} method.
+   * This implementation compares the two objects using the {@link games.strategy.test.Matchers#equalTo(Object)} matcher
+   * with an equality comparator registry composed of the items from {@link #getEqualityComparators()}. Subclasses may
+   * override and are not required to call the superclass implementation.
    * </p>
    *
    * @param expected The expected principal.
@@ -46,7 +56,7 @@ public abstract class AbstractProxyTestCase<T> {
    * @throws AssertionError If the two principals are not equal.
    */
   protected void assertPrincipalEquals(final T expected, final T actual) {
-    assertThat(actual, is(expected));
+    assertThat(actual, equalTo(expected).withEqualityComparatorRegistry(equalityComparatorRegistry));
   }
 
   /**
@@ -55,6 +65,21 @@ public abstract class AbstractProxyTestCase<T> {
    * @return The collection of principals to be tested.
    */
   protected abstract Collection<T> createPrincipals();
+
+  /**
+   * Gets the collection of equality comparators required to compare two instances of the principal type for equality.
+   *
+   * <p>
+   * This implementation returns an empty collection. Subclasses may override and are not required to call the
+   * superclass implementation.
+   * </p>
+   *
+   * @return The collection of equality comparators required to compare two instances of the principal type for
+   *         equality.
+   */
+  protected Collection<EqualityComparator> getEqualityComparators() {
+    return Arrays.asList();
+  }
 
   /**
    * Gets the collection of proxy factories required for the principal to be persisted.

--- a/src/test/java/games/strategy/test/EqualityComparator.java
+++ b/src/test/java/games/strategy/test/EqualityComparator.java
@@ -1,0 +1,121 @@
+package games.strategy.test;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A comparison function that determines if two objects are equal.
+ *
+ * <p>
+ * For some types, the {@link Object#equals(Object)} method cannot be overridden, or it has been implemented incorrectly
+ * and the implementation cannot be changed in order to preserve legacy behavior. In those cases, an equality comparator
+ * can be defined for the type with the correct definition of what it means for two instances of that type to be equal.
+ * </p>
+ *
+ * @see EqualityComparatorRegistry
+ * @see TestUtil#equals(EqualityComparatorRegistry, Object, Object)
+ */
+@Immutable
+public final class EqualityComparator {
+  private final Predicate<Object> predicate;
+  private final Class<?> type;
+
+  private EqualityComparator(final Class<?> type, final Predicate<Object> predicate) {
+    this.predicate = predicate;
+    this.type = type;
+  }
+
+  /**
+   * Indicates the specified objects are equal according to the definition of this comparator.
+   *
+   * @param context The comparator evaluation context.
+   * @param o1 The first object to compare.
+   * @param o2 The second object to compare.
+   *
+   * @return {@code true} if the specified objects are equal; otherwise {@code false}.
+   */
+  public boolean equals(final Context context, final Object o1, final Object o2) {
+    checkNotNull(context);
+    checkNotNull(o1);
+    checkNotNull(o2);
+
+    return predicate.test(context, o1, o2);
+  }
+
+  /**
+   * Gets the type of object to compare by this comparator.
+   *
+   * @return The type of object to compare by this comparator.
+   */
+  public Class<?> getType() {
+    return type;
+  }
+
+  /**
+   * Creates a new equality comparator.
+   *
+   * @param type The type of object to compare.
+   * @param predicate The predicate that tests two objects of the specified type for equality.
+   *
+   * @return A new new equality comparator.
+   */
+  public static <T> EqualityComparator newInstance(final Class<T> type, final Predicate<T> predicate) {
+    checkNotNull(type);
+    checkNotNull(predicate);
+
+    final Predicate<Object> typeSafePredicate = (context, o1, o2) -> {
+      try {
+        return predicate.test(context, type.cast(o1), type.cast(o2));
+      } catch (final ClassCastException e) {
+        return false;
+      }
+    };
+    return new EqualityComparator(type, typeSafePredicate);
+  }
+
+  /**
+   * The evaluation context of an equality check.
+   */
+  public interface Context {
+    /**
+     * Indicates the specified objects are equal.
+     *
+     * <p>
+     * {@link Predicate} implementors that need to perform further equality checks (e.g. when performing a deep equality
+     * check), should delegate those checks to this method. For example, if a type has a child object that must be
+     * included in the equality check, instead of using the expression
+     * {@code this.childObject.equals(other.childObject)} or
+     * {@code Objects.equals(this.childObject, other.childObject)}, one should instead use the expression
+     * {@code context.equals(this.childObject, other.childObject)} to ensure any registered {@code EqualityComparator}
+     * for the child object type is used.
+     * </p>
+     *
+     * @param o1 The first object to compare.
+     * @param o2 The second object to compare.
+     *
+     * @return {@code true} if the specified objects are equal; otherwise {@code false}.
+     */
+    boolean equals(@Nullable Object o1, @Nullable Object o2);
+  }
+
+  /**
+   * Tests if two objects are equal in the context of an equality check based on {@code EqualityComparator}s.
+   *
+   * @param <T> The type of object to compare.
+   */
+  @FunctionalInterface
+  public interface Predicate<T> {
+    /**
+     * Indicates the specified objects are equal.
+     *
+     * @param context The comparator evaluation context.
+     * @param o1 The first object to compare.
+     * @param o2 The second object to compare.
+     *
+     * @return {@code true} if the specified objects are equal; otherwise {@code false}.
+     */
+    boolean test(Context context, T o1, T o2);
+  }
+}

--- a/src/test/java/games/strategy/test/EqualityComparatorRegistry.java
+++ b/src/test/java/games/strategy/test/EqualityComparatorRegistry.java
@@ -1,0 +1,74 @@
+package games.strategy.test;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.annotation.concurrent.Immutable;
+
+import com.google.common.reflect.TypeToken;
+
+/**
+ * A service for obtaining an {@link EqualityComparator} for a specific type that can be used to compare two instances
+ * of that type for equality independent of {@link Object#equals(Object)}.
+ */
+@Immutable
+public final class EqualityComparatorRegistry {
+  private static final EqualityComparator DEFAULT_EQUALITY_COMPARATOR =
+      EqualityComparator.newInstance(Object.class, (context, o1, o2) -> o1.equals(o2));
+
+  private final Map<Class<?>, EqualityComparator> equalityComparatorsByType;
+
+  private EqualityComparatorRegistry(final Map<Class<?>, EqualityComparator> equalityComparatorsByType) {
+    this.equalityComparatorsByType = Collections.unmodifiableMap(equalityComparatorsByType);
+  }
+
+  /**
+   * Gets an equality comparator for the specified type.
+   *
+   * <p>
+   * The registry attempts to look up an equality comparator for the specified type in the following order:
+   * </p>
+   *
+   * <ol>
+   * <li>If an equality comparator for the exact type has been registered, use it.</li>
+   * <li>If an equality comparator for any interface implemented by the type has been registered, use it.</li>
+   * <li>Otherwise, use the default equality comparator that delegates to {@link Object#equals(Object)}.
+   * </ol>
+   *
+   * @param type The type for which an equality comparator is desired.
+   *
+   * @return An equality comparator for the specified type.
+   */
+  public EqualityComparator getEqualityComparatorFor(final Class<?> type) {
+    checkNotNull(type);
+
+    EqualityComparator equalityComparator = equalityComparatorsByType.get(type);
+    if (equalityComparator != null) {
+      return equalityComparator;
+    }
+
+    for (final TypeToken<?> typeToken : TypeToken.of(type).getTypes().interfaces()) {
+      equalityComparator = equalityComparatorsByType.get(typeToken.getRawType());
+      if (equalityComparator != null) {
+        return equalityComparator;
+      }
+    }
+
+    return DEFAULT_EQUALITY_COMPARATOR;
+  }
+
+  public static EqualityComparatorRegistry newInstance(final EqualityComparator... equalityComparators) {
+    return newInstance(Arrays.asList(equalityComparators));
+  }
+
+  public static EqualityComparatorRegistry newInstance(final Collection<EqualityComparator> equalityComparators) {
+    return new EqualityComparatorRegistry(
+        equalityComparators.stream().collect(Collectors.toMap(EqualityComparator::getType, Function.identity())));
+  }
+}

--- a/src/test/java/games/strategy/test/EqualityComparatorRegistryTest.java
+++ b/src/test/java/games/strategy/test/EqualityComparatorRegistryTest.java
@@ -1,0 +1,42 @@
+package games.strategy.test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Test;
+
+public final class EqualityComparatorRegistryTest {
+  @Test
+  public void getEqualityComparatorFor_ShouldReturnRegisteredComparatorWhenClassTypeRegistered() {
+    final EqualityComparatorRegistry equalityComparatorRegistry = EqualityComparatorRegistry.newInstance(
+        EqualityComparator.newInstance(ArrayList.class, (context, o1, o2) -> true));
+
+    final EqualityComparator actual = equalityComparatorRegistry.getEqualityComparatorFor(ArrayList.class);
+
+    assertThat(actual.getType(), is(ArrayList.class));
+  }
+
+  @Test
+  public void getEqualityComparatorFor_ShouldReturnRegisteredComparatorWhenInterfaceTypeRegistered() {
+    final EqualityComparatorRegistry equalityComparatorRegistry = EqualityComparatorRegistry.newInstance(
+        EqualityComparator.newInstance(Collection.class, (context, o1, o2) -> true));
+
+    final EqualityComparator actual = equalityComparatorRegistry.getEqualityComparatorFor(ArrayList.class);
+
+    assertThat(actual.getType(), is(Collection.class));
+  }
+
+  @Test
+  public void getEqualityComparatorFor_ShouldReturnDefaultComparatorWhenNoTypesRegistered() {
+    final EqualityComparatorRegistry equalityComparatorRegistry = EqualityComparatorRegistry.newInstance();
+
+    final EqualityComparator actual = equalityComparatorRegistry.getEqualityComparatorFor(ArrayList.class);
+
+    assertThat(actual, is(not(nullValue())));
+  }
+}

--- a/src/test/java/games/strategy/test/EqualsPredicate.java
+++ b/src/test/java/games/strategy/test/EqualsPredicate.java
@@ -1,0 +1,72 @@
+package games.strategy.test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+final class EqualsPredicate {
+  private final EqualityComparatorRegistry equalityComparatorRegistry;
+
+  EqualsPredicate(final EqualityComparatorRegistry equalityComparatorRegistry) {
+    this.equalityComparatorRegistry = equalityComparatorRegistry;
+  }
+
+  boolean test(final @Nullable Object o1, final @Nullable Object o2) {
+    return new Context().equals(o1, o2);
+  }
+
+  private final class Context implements EqualityComparator.Context {
+    private final Set<ActiveComparison> activeComparisons = new HashSet<>();
+
+    @Override
+    public boolean equals(final @Nullable Object o1, final @Nullable Object o2) {
+      if (o1 == o2) {
+        return true;
+      } else if (o1 == null) {
+        return o2 == null;
+      } else if (o2 == null) {
+        return false; // o1 cannot be null here
+      }
+
+      final ActiveComparison activeComparison = new ActiveComparison(o1, o2);
+      if (activeComparisons.contains(activeComparison)) {
+        return true; // short-circuit active comparisons; they will eventually be resolved
+      }
+
+      activeComparisons.add(activeComparison);
+      final boolean result = equalityComparatorRegistry.getEqualityComparatorFor(o1.getClass()).equals(this, o1, o2);
+      activeComparisons.remove(activeComparison);
+      return result;
+    }
+  }
+
+  private static final class ActiveComparison {
+    private final Object o1;
+    private final Object o2;
+
+    ActiveComparison(final Object o1, final Object o2) {
+      this.o1 = o1;
+      this.o2 = o2;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      if (obj == this) {
+        return true;
+      } else if (!(obj instanceof ActiveComparison)) {
+        return false;
+      }
+
+      final ActiveComparison other = (ActiveComparison) obj;
+      return (o1 == other.o1) && (o2 == other.o2);
+    }
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(o1) * 31 + System.identityHashCode(o2);
+    }
+  }
+}

--- a/src/test/java/games/strategy/test/EqualsPredicateTests.java
+++ b/src/test/java/games/strategy/test/EqualsPredicateTests.java
@@ -1,0 +1,189 @@
+package games.strategy.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+@RunWith(Enclosed.class)
+public final class EqualsPredicateTests {
+  private static EqualsPredicate newEqualsPredicate(final EqualityComparator... equalityComparators) {
+    return new EqualsPredicate(EqualityComparatorRegistry.newInstance(equalityComparators));
+  }
+
+  public static final class NullAndReferenceEqualityTest {
+    private final EqualsPredicate equalsPredicate = newEqualsPredicate();
+
+    @Test
+    public void shouldReturnTrueWhenO1IsNullAndO2IsNull() {
+      assertTrue(equalsPredicate.test(null, null));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenO1IsNullAndO2IsNotNull() {
+      assertFalse(equalsPredicate.test(null, new Object()));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenO1IsNotNullAndO2IsNull() {
+      assertFalse(equalsPredicate.test(new Object(), null));
+    }
+
+    @Test
+    public void shouldReturnTrueWhenObjectsAreSame() {
+      final Object o = new Object();
+
+      assertTrue(equalsPredicate.test(o, o));
+    }
+  }
+
+  public static final class EquatableObjectWithoutCustomComparatorTest {
+    private final EqualsPredicate equalsPredicate = newEqualsPredicate();
+
+    @Test
+    public void shouldReturnTrueWhenObjectsAreEqual() {
+      assertTrue(equalsPredicate.test(new Integer(42), new Integer(42)));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenObjectsAreNotEqual() {
+      assertFalse(equalsPredicate.test(new Integer(42), new Integer(-42)));
+    }
+  }
+
+  public static final class EquatableObjectWithCustomComparatorTest {
+    @Test
+    public void shouldReturnTrueWhenObjectsAreEqual() {
+      final EqualsPredicate equalsPredicate = newEqualsPredicate(
+          EqualityComparator.newInstance(Integer.class, (context, o1, o2) -> true));
+
+      assertTrue(equalsPredicate.test(new Integer(42), new Integer(-42)));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenObjectsAreNotEqual() {
+      final EqualsPredicate equalsPredicate = newEqualsPredicate(
+          EqualityComparator.newInstance(Integer.class, (context, o1, o2) -> false));
+
+      assertFalse(equalsPredicate.test(new Integer(42), new Integer(42)));
+    }
+  }
+
+  public static final class NonEquatableObjectTest {
+    private final EqualsPredicate equalsPredicate = newEqualsPredicate(
+        EqualityComparator.newInstance(FakeClass.class, (context, o1, o2) -> o1.value == o2.value));
+
+    @Test
+    public void shouldReturnTrueWhenObjectsAreEqual() {
+      assertTrue(equalsPredicate.test(new FakeClass(42), new FakeClass(42)));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenObjectsAreNotEqual() {
+      assertFalse(equalsPredicate.test(new FakeClass(42), new FakeClass(-42)));
+    }
+  }
+
+  public static final class NonEquatableNestedObjectTest {
+    private final EqualsPredicate equalsPredicate = newEqualsPredicate(
+        EqualityComparator.newInstance(FakeClass.class, (context, o1, o2) -> o1.value == o2.value),
+        EqualityComparator.newInstance(FakeNestedClass.class, (context, o1, o2) -> context.equals(o1.value, o2.value)));
+
+    @Test
+    public void shouldReturnTrueWhenObjectsAreEqual() {
+      assertTrue(equalsPredicate.test(
+          new FakeNestedClass(new FakeClass(42)),
+          new FakeNestedClass(new FakeClass(42))));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenObjectsAreNotEqual() {
+      assertFalse(equalsPredicate.test(
+          new FakeNestedClass(new FakeClass(42)),
+          new FakeNestedClass(new FakeClass(-42))));
+    }
+
+    private static final class FakeNestedClass {
+      final FakeClass value;
+
+      FakeNestedClass(final FakeClass value) {
+        this.value = value;
+      }
+    }
+  }
+
+  public static final class NonEquatableCircularReferenceTest {
+    final EqualsPredicate equalsPredicate = newEqualsPredicate(
+        EqualityComparator.newInstance(
+            FakeOwnerClass.class,
+            (context, o1, o2) -> context.equals(o1.ownee, o2.ownee) && (o1.value == o2.value)),
+        EqualityComparator.newInstance(
+            FakeOwneeClass.class,
+            (context, o1, o2) -> context.equals(o1.owner, o2.owner) && (o1.value == o2.value)));
+
+    @Test
+    public void shouldReturnTrueWhenObjectsAreEqual() {
+      final FakeOwnerClass owner1 = new FakeOwnerClass(11);
+      final FakeOwneeClass ownee1 = new FakeOwneeClass(owner1, 22);
+      owner1.ownee = ownee1;
+      final FakeOwnerClass owner2 = new FakeOwnerClass(11);
+      final FakeOwneeClass ownee2 = new FakeOwneeClass(owner2, 22);
+      owner2.ownee = ownee2;
+
+      assertTrue(equalsPredicate.test(owner1, owner2));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenOwneeObjectsAreNotEqual() {
+      final FakeOwnerClass owner1 = new FakeOwnerClass(11);
+      final FakeOwneeClass ownee1 = new FakeOwneeClass(owner1, 22);
+      owner1.ownee = ownee1;
+      final FakeOwnerClass owner2 = new FakeOwnerClass(11);
+      final FakeOwneeClass ownee2 = new FakeOwneeClass(owner2, -22);
+      owner2.ownee = ownee2;
+
+      assertFalse(equalsPredicate.test(owner1, owner2));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenOwnerObjectsAreNotEqual() {
+      final FakeOwnerClass owner1 = new FakeOwnerClass(11);
+      final FakeOwneeClass ownee1 = new FakeOwneeClass(owner1, 22);
+      owner1.ownee = ownee1;
+      final FakeOwnerClass owner2 = new FakeOwnerClass(-11);
+      final FakeOwneeClass ownee2 = new FakeOwneeClass(owner2, 22);
+      owner2.ownee = ownee2;
+
+      assertFalse(equalsPredicate.test(owner1, owner2));
+    }
+
+    private static final class FakeOwnerClass {
+      FakeOwneeClass ownee;
+      final int value;
+
+      FakeOwnerClass(final int value) {
+        this.value = value;
+      }
+    }
+
+    private static final class FakeOwneeClass {
+      final FakeOwnerClass owner;
+      final int value;
+
+      FakeOwneeClass(final FakeOwnerClass owner, final int value) {
+        this.owner = owner;
+        this.value = value;
+      }
+    }
+  }
+
+  private static final class FakeClass {
+    final int value;
+
+    FakeClass(final int value) {
+      this.value = value;
+    }
+  }
+}

--- a/src/test/java/games/strategy/test/Matchers.java
+++ b/src/test/java/games/strategy/test/Matchers.java
@@ -1,0 +1,79 @@
+package games.strategy.test;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.annotation.Nullable;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+
+/**
+ * A collection of matchers applicable for all types.
+ */
+public final class Matchers {
+  private Matchers() {}
+
+  /**
+   * Creates a matcher that matches when the examined object is logically equal to the specified object.
+   *
+   * <p>
+   * The returned matcher uses {@link TestUtil#equals(EqualityComparatorRegistry, Object, Object)} to compare the
+   * specified objects for equality. To customize how the equality comparisons are performed, pass an equality
+   * comparator registry with the required equality comparators to
+   * {@link IsEqual#withEqualityComparatorRegistry(EqualityComparatorRegistry)}. Any type that does not have a
+   * registered equality comparator will fall back to using {@link Object#equals(Object)}.
+   * </p>
+   *
+   * @param expected The expected value.
+   *
+   * @return A new matcher.
+   */
+  public static <T> IsEqual<T> equalTo(final @Nullable T expected) {
+    return new IsEqual<>(expected);
+  }
+
+  /**
+   * A matcher that matches two objects for equality using
+   * {@link TestUtil#equals(EqualityComparatorRegistry, Object, Object)}.
+   *
+   * @param <T> The type of object to compare for equality.
+   */
+  public static final class IsEqual<T> extends BaseMatcher<T> {
+    private EqualityComparatorRegistry equalityComparatorRegistry;
+    private final @Nullable Object expected;
+
+    private IsEqual(final @Nullable Object expected) {
+      this.expected = expected;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+      description.appendValue(expected);
+    }
+
+    @Override
+    public boolean matches(final @Nullable Object actual) {
+      return TestUtil.equals(getEqualityComparatorRegistry(), expected, actual);
+    }
+
+    private EqualityComparatorRegistry getEqualityComparatorRegistry() {
+      return (equalityComparatorRegistry != null)
+          ? equalityComparatorRegistry
+          : EqualityComparatorRegistry.newInstance();
+    }
+
+    /**
+     * Sets the equality comparator registry to use during the equality comparison.
+     *
+     * @param equalityComparatorRegistry The equality comparator registry to use.
+     *
+     * @return A reference to this matcher.
+     */
+    public IsEqual<T> withEqualityComparatorRegistry(final EqualityComparatorRegistry equalityComparatorRegistry) {
+      checkNotNull(equalityComparatorRegistry);
+
+      this.equalityComparatorRegistry = equalityComparatorRegistry;
+      return this;
+    }
+  }
+}

--- a/src/test/java/games/strategy/test/TestUtil.java
+++ b/src/test/java/games/strategy/test/TestUtil.java
@@ -1,7 +1,11 @@
 package games.strategy.test;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.File;
 import java.io.IOException;
+
+import javax.annotation.Nullable;
 
 import com.google.common.base.Throwables;
 import com.google.common.io.Files;
@@ -11,7 +15,8 @@ import games.strategy.ui.SwingAction;
 /**
  * A Utility class for test classes.
  */
-public class TestUtil {
+public final class TestUtil {
+  private TestUtil() {}
 
   /** Create and returns a simple delete on exit temp file with contents equal to the String parameter. */
   public static File createTempFile(final String contents) {
@@ -65,5 +70,32 @@ public class TestUtil {
 
   public static Class<?>[] getClassArrayFrom(final Class<?>... classes) {
     return classes;
+  }
+
+  /**
+   * Indicates the specified objects are equal.
+   *
+   * <p>
+   * This method uses the equality comparators in the specified registry to determine if the objects are equal. If an
+   * equality comparator is not available for a specific type, {@link Object#equals(Object)} will be used instead.
+   * </p>
+   *
+   * <p>
+   * This method correctly handles circular references between objects involved in the equality test.
+   * </p>
+   *
+   * @param equalityComparatorRegistry The registry containing the equality comparators to use during the equality test.
+   * @param o1 The first object to compare.
+   * @param o2 The second object to compare.
+   *
+   * @return {@code true} if the specified objects are equal; otherwise {@code false}.
+   */
+  public static boolean equals(
+      final EqualityComparatorRegistry equalityComparatorRegistry,
+      final @Nullable Object o1,
+      final @Nullable Object o2) {
+    checkNotNull(equalityComparatorRegistry);
+
+    return new EqualsPredicate(equalityComparatorRegistry).test(o1, o2);
   }
 }

--- a/src/test/java/games/strategy/util/CoreEqualityComparators.java
+++ b/src/test/java/games/strategy/util/CoreEqualityComparators.java
@@ -1,0 +1,69 @@
+package games.strategy.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+import games.strategy.test.EqualityComparator;
+
+/**
+ * A collection of equality comparators for core Java and TripleA types.
+ */
+public final class CoreEqualityComparators {
+  private CoreEqualityComparators() {}
+
+  public static final EqualityComparator COLLECTION = EqualityComparator.newInstance(
+      Collection.class,
+      (context, o1, o2) -> {
+        if (o1.size() != o2.size()) {
+          return false;
+        }
+
+        final Iterator<?> o1Iterator = o1.iterator();
+        final Iterator<?> o2Iterator = o2.iterator();
+        while (o1Iterator.hasNext()) {
+          if (!context.equals(o1Iterator.next(), o2Iterator.next())) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+
+  public static final EqualityComparator MAP = EqualityComparator.newInstance(
+      Map.class,
+      CoreEqualityComparators::mapEquals);
+
+  private static boolean mapEquals(
+      final EqualityComparator.Context context,
+      final Map<?, ?> o1,
+      final Map<?, ?> o2) {
+    if (o1.size() != o2.size()) {
+      return false;
+    }
+
+    for (final Map.Entry<?, ?> entry1 : o1.entrySet()) {
+      // NB: We can't simply lookup key1 in o2 because that will use Object#equals() instead of the EqualityComparator
+      boolean key1Found = false;
+      for (final Map.Entry<?, ?> entry2 : o2.entrySet()) {
+        if (context.equals(entry1.getKey(), entry2.getKey())) {
+          key1Found = true;
+          if (!context.equals(entry1.getValue(), entry2.getValue())) {
+            return false;
+          }
+          break;
+        }
+      }
+
+      if (!key1Found) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public static final EqualityComparator INTEGER_MAP = EqualityComparator.newInstance(
+      IntegerMap.class,
+      (context, o1, o2) -> mapEquals(context, o1.toMap(), o2.toMap()));
+}

--- a/src/test/java/games/strategy/util/CoreEqualityComparatorsTests.java
+++ b/src/test/java/games/strategy/util/CoreEqualityComparatorsTests.java
@@ -1,0 +1,129 @@
+package games.strategy.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import com.google.common.collect.ImmutableMap;
+
+import games.strategy.test.EqualityComparator;
+import games.strategy.test.EqualityComparatorRegistry;
+import games.strategy.test.TestUtil;
+
+@RunWith(Enclosed.class)
+public final class CoreEqualityComparatorsTests {
+  private static EqualityComparatorRegistry newEqualityComparatorRegistryOf(
+      final EqualityComparator primaryEqualityComparator,
+      final EqualityComparator... secondaryEqualityComparators) {
+    final Collection<EqualityComparator> equalityComparators = new ArrayList<>();
+    equalityComparators.add(primaryEqualityComparator);
+    equalityComparators.addAll(Arrays.asList(secondaryEqualityComparators));
+    return EqualityComparatorRegistry.newInstance(equalityComparators);
+  }
+
+  public static final class CollectionTest {
+    private final EqualityComparatorRegistry equalityComparatorRegistry = newEqualityComparatorRegistry();
+
+    private static EqualityComparatorRegistry newEqualityComparatorRegistry(
+        final EqualityComparator... equalityComparators) {
+      return newEqualityComparatorRegistryOf(CoreEqualityComparators.COLLECTION, equalityComparators);
+    }
+
+    @Test
+    public void shouldReturnFalseWhenCollectionsHaveDifferentSizes() {
+      assertFalse(TestUtil.equals(
+          equalityComparatorRegistry,
+          Arrays.asList(new Integer(1)),
+          Arrays.asList(new Integer(1), new Integer(2))));
+    }
+
+    @Test
+    public void shouldReturnTrueWhenEqual() {
+      assertTrue(TestUtil.equals(
+          equalityComparatorRegistry,
+          Arrays.asList(new Integer(1), new Integer(2)),
+          Arrays.asList(new Integer(1), new Integer(2))));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenNotEqual() {
+      assertFalse(TestUtil.equals(
+          equalityComparatorRegistry,
+          Arrays.asList(new Integer(1), new Integer(2)),
+          Arrays.asList(new Integer(1), new Integer(-2))));
+    }
+
+    @Test
+    public void shouldUseEqualityComparatorForElements() {
+      final EqualityComparatorRegistry equalityComparatorRegistry = newEqualityComparatorRegistry(
+          EqualityComparator.newInstance(Integer.class, (context, o1, o2) -> false));
+
+      assertFalse(TestUtil.equals(
+          equalityComparatorRegistry,
+          Arrays.asList(new Integer(1), new Integer(2)),
+          Arrays.asList(new Integer(1), new Integer(2))));
+    }
+  }
+
+  public static final class MapTest {
+    private final EqualityComparatorRegistry equalityComparatorRegistry = newEqualityComparatorRegistry();
+
+    private static EqualityComparatorRegistry newEqualityComparatorRegistry(
+        final EqualityComparator... equalityComparators) {
+      return newEqualityComparatorRegistryOf(CoreEqualityComparators.MAP, equalityComparators);
+    }
+
+    @Test
+    public void shouldReturnFalseWhenMapsHaveDifferentSizes() {
+      assertFalse(TestUtil.equals(
+          equalityComparatorRegistry,
+          ImmutableMap.of(new Integer(1), new Boolean(true)),
+          ImmutableMap.of(new Integer(1), new Boolean(true), new Integer(2), new Boolean(true))));
+    }
+
+    @Test
+    public void shouldReturnTrueWhenEqual() {
+      assertTrue(TestUtil.equals(
+          equalityComparatorRegistry,
+          ImmutableMap.of(new Integer(1), new Boolean(true), new Integer(2), new Boolean(true)),
+          ImmutableMap.of(new Integer(1), new Boolean(true), new Integer(2), new Boolean(true))));
+    }
+
+    @Test
+    public void shouldReturnFalseWhenNotEqual() {
+      assertFalse(TestUtil.equals(
+          equalityComparatorRegistry,
+          ImmutableMap.of(new Integer(1), new Boolean(true), new Integer(2), new Boolean(true)),
+          ImmutableMap.of(new Integer(1), new Boolean(true), new Integer(2), new Boolean(false))));
+    }
+
+    @Test
+    public void shouldUseEqualityComparatorForKeys() {
+      final EqualityComparatorRegistry equalityComparatorRegistry = newEqualityComparatorRegistry(
+          EqualityComparator.newInstance(Integer.class, (context, o1, o2) -> false));
+
+      assertFalse(TestUtil.equals(
+          equalityComparatorRegistry,
+          ImmutableMap.of(new Integer(1), new Boolean(true), new Integer(2), new Boolean(true)),
+          ImmutableMap.of(new Integer(1), new Boolean(true), new Integer(2), new Boolean(true))));
+    }
+
+    @Test
+    public void shouldUseEqualityComparatorForValues() {
+      final EqualityComparatorRegistry equalityComparatorRegistry = newEqualityComparatorRegistry(
+          EqualityComparator.newInstance(Boolean.class, (context, o1, o2) -> false));
+
+      assertFalse(TestUtil.equals(
+          equalityComparatorRegistry,
+          ImmutableMap.of(new Integer(1), new Boolean(true), new Integer(2), new Boolean(true)),
+          ImmutableMap.of(new Integer(1), new Boolean(true), new Integer(2), new Boolean(true))));
+    }
+  }
+}


### PR DESCRIPTION
This PR refactors the custom equality test framework introduced in the past couple of serialization proxy PRs.  As mentioned elsewhere, the framework was starting to get out of hand because all the custom equality comparators were dumped in a single file, and there are only more to come as new proxies are added.

The new framework introduces two primary changes:

1. The custom equality comparators are no longer in a single class nor even a single package.  They can now be located in more appropriate packages, most likely co-located with the types they are associated with.
1. The custom equality test now handles circular references correctly.  This is an issue for types that extend `GameDataComponent`, which refer back to their owning `GameData` instance, which subsequently refers to the component.  This hasn't been a problem so far, but I anticipate it to occur in the next 2-3 serialization proxy PRs.

Note that **ALL** code in this PR is non-production code.  Less than 45% of these changes are associated with the framework.  The remaining code is simply changes required in existing tests to use the new framework, as well as unit tests for the framework itself (the code was sufficiently complex that I thought unit tests would be a good idea).

I'll call out key areas of the code in a forthcoming review.  To stay focused on the core changes, I recommend starting with `TestUtil#equals()` and then moving on to `EqualsPredicate`, `EqualityComparator`, and `EqualityComparatorRegistry`.  `CoreEqualityComparators` and `EngineDataEqualityComparators` are the concrete implementations of `EqualityComparator`, but consist of basically the same code that previously existed in the `g.s.engine.data.Matchers` class.  The remaining code is mostly incidental.