### PR TITLE
Use org.json Wrapper objects for yaml parsing

### DIFF
--- a/src/main/java/games/strategy/engine/config/client/LobbyPropertyFileParser.java
+++ b/src/main/java/games/strategy/engine/config/client/LobbyPropertyFileParser.java
@@ -37,7 +37,7 @@ class LobbyPropertyFileParser {
 
     return StreamSupport.stream(lobbyProps.spliterator(), false)
         .map(JSONObject.class::cast)
-        .filter(props -> currentVersion.equals(props.opt("version")))
+        .filter(props -> currentVersion.equals(new Version(props.getString("version"))))
         .findFirst()
         .orElse(lobbyProps.getJSONObject(0));
   }

--- a/src/main/java/games/strategy/engine/config/client/LobbyPropertyFileParser.java
+++ b/src/main/java/games/strategy/engine/config/client/LobbyPropertyFileParser.java
@@ -6,9 +6,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.yaml.snakeyaml.Yaml;
 
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
@@ -23,33 +23,33 @@ class LobbyPropertyFileParser {
 
 
   public static LobbyServerProperties parse(final File file, final Version currentVersion) {
-    final List<Map<String, Object>> lobbyProperties;
+    final JSONArray lobbyProperties;
     try {
       lobbyProperties = loadYaml(file);
     } catch (final IOException e) {
       throw new RuntimeException("Failed loading file: " + file.getAbsolutePath() + ", please try again, if the "
           + "problem does not go away please report a bug: " + UrlConstants.GITHUB_ISSUES);
     }
-    final Map<String, Object> configForThisVersion = matchCurrentVersion(lobbyProperties, currentVersion);
-    return new LobbyServerProperties(configForThisVersion);
+    return new LobbyServerProperties(matchCurrentVersion(lobbyProperties, currentVersion).toMap());
   }
 
-  private static Map<String, Object> matchCurrentVersion(
-      final List<Map<String, Object>> lobbyProps,
+  private static JSONObject matchCurrentVersion(
+      final JSONArray lobbyProps,
       final Version currentVersion) {
     checkNotNull(lobbyProps);
 
-    final Optional<Map<String, Object>> matchingVersionProps = lobbyProps.stream()
-        .filter(props -> currentVersion.equals(props.get("version")))
-        .findFirst();
-    return matchingVersionProps.orElse(lobbyProps.get(0));
+    for (int i = 0; i < lobbyProps.length(); i++) {
+      final JSONObject currentObject = lobbyProps.getJSONObject(i);
+      if (currentVersion.equals(currentObject.opt("version"))) {
+        return currentObject;
+      }
+    }
+    return lobbyProps.getJSONObject(0);
   }
 
-  private static List<Map<String, Object>> loadYaml(final File yamlFile) throws IOException {
+  private static JSONArray loadYaml(final File yamlFile) throws IOException {
     final String yamlContent = new String(Files.readAllBytes(yamlFile.toPath()));
     final Yaml yaml = new Yaml();
-    @SuppressWarnings("unchecked")
-    final List<Map<String, Object>> yamlData = (List<Map<String, Object>>) yaml.load(yamlContent);
-    return yamlData;
+    return new JSONArray(yaml.loadAs(yamlContent, List.class));
   }
 }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -34,7 +34,7 @@ final class DownloadFileParser {
       final JSONObject yaml = yamlData.getJSONObject(i);
       final String url = yaml.getString(Tags.url.toString());
       final String description = yaml.getString(Tags.description.toString());
-      final String mapName = yaml.optString(Tags.mapName.toString());
+      final String mapName = yaml.getString(Tags.mapName.toString());
 
       final Object versionObject = yaml.opt(Tags.version.toString());
       final Version version = versionObject != null ? new Version(versionObject.toString()) : null;

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -51,7 +51,7 @@ final class DownloadFileParser {
         mapCategory = DownloadFileDescription.MapCategory.valueOf(mapCategoryString);
       }
 
-      final String img = yaml.optString(Tags.img.toString(), "");
+      final String img = yaml.optString(Tags.img.toString());
       final DownloadFileDescription dl =
           new DownloadFileDescription(url, description, mapName, version, downloadType, mapCategory, img);
       rVal.add(dl);

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -3,6 +3,7 @@ package games.strategy.engine.framework.map.download;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.StreamSupport;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -30,8 +31,7 @@ final class DownloadFileParser {
     final JSONArray yamlData = new JSONArray(new Yaml().loadAs(is, List.class));
 
     final List<DownloadFileDescription> rVal = new ArrayList<>();
-    for (int i = 0; i < yamlData.length(); i++) {
-      final JSONObject yaml = yamlData.getJSONObject(i);
+    StreamSupport.stream(yamlData.spliterator(), false).map(JSONObject.class::cast).forEach(yaml -> {
       final String url = yaml.getString(Tags.url.toString());
       final String description = yaml.getString(Tags.description.toString());
       final String mapName = yaml.getString(Tags.mapName.toString());
@@ -51,7 +51,7 @@ final class DownloadFileParser {
       final DownloadFileDescription dl =
           new DownloadFileDescription(url, description, mapName, version, downloadType, mapCategory, img);
       rVal.add(dl);
-    }
+    });
     return rVal;
   }
 }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -34,7 +34,7 @@ final class DownloadFileParser {
       final JSONObject yaml = yamlData.getJSONObject(i);
       final String url = yaml.getString(Tags.url.toString());
       final String description = yaml.getString(Tags.description.toString());
-      final String mapName = yaml.getString(Tags.mapName.toString());
+      final String mapName = yaml.optString(Tags.mapName.toString());
 
       final Object versionObject = yaml.opt(Tags.version.toString());
       final Version version = versionObject != null ? new Version(versionObject.toString()) : null;

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -37,18 +37,15 @@ final class DownloadFileParser {
       final String mapName = yaml.getString(Tags.mapName.toString());
 
       final Version version = new Version(yaml.getInt(Tags.version.toString()), 0);
-      DownloadFileDescription.DownloadType downloadType = DownloadFileDescription.DownloadType.MAP;
+      final DownloadFileDescription.DownloadType downloadType = yaml.optEnum(
+          DownloadFileDescription.DownloadType.class,
+          Tags.mapType.toString(),
+          DownloadFileDescription.DownloadType.MAP);
 
-      final String mapTypeString = yaml.optString(Tags.mapType.toString(), null);
-      if (mapTypeString != null) {
-        downloadType = DownloadFileDescription.DownloadType.valueOf(mapTypeString);
-      }
-
-      DownloadFileDescription.MapCategory mapCategory = DownloadFileDescription.MapCategory.EXPERIMENTAL;
-      final String mapCategoryString = yaml.optString(Tags.mapCategory.toString(), null);
-      if (mapCategoryString != null) {
-        mapCategory = DownloadFileDescription.MapCategory.valueOf(mapCategoryString);
-      }
+      final DownloadFileDescription.MapCategory mapCategory = yaml.optEnum(
+          DownloadFileDescription.MapCategory.class,
+          Tags.mapCategory.toString(),
+          DownloadFileDescription.MapCategory.EXPERIMENTAL);
 
       final String img = yaml.optString(Tags.img.toString());
       final DownloadFileDescription dl =

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -36,8 +36,7 @@ final class DownloadFileParser {
       final String description = yaml.getString(Tags.description.toString());
       final String mapName = yaml.getString(Tags.mapName.toString());
 
-      final Object versionObject = yaml.opt(Tags.version.toString());
-      final Version version = versionObject != null ? new Version(versionObject.toString()) : null;
+      final Version version = new Version(yaml.getInt(Tags.version.toString()), 0);
       DownloadFileDescription.DownloadType downloadType = DownloadFileDescription.DownloadType.MAP;
 
       final String mapTypeString = yaml.optString(Tags.mapType.toString(), null);

--- a/src/test/java/games/strategy/engine/config/client/LobbyPropertyFileParserTest.java
+++ b/src/test/java/games/strategy/engine/config/client/LobbyPropertyFileParserTest.java
@@ -54,6 +54,7 @@ public class LobbyPropertyFileParserTest {
     testProps.port = TestData.port;
     testProps.errorMessage = TestData.errorMessage;
     testProps.message = TestData.message;
+    testProps.version = TestData.clientCurrentVersion;
 
     final File testFile = createTempFile(testProps);
 
@@ -67,8 +68,8 @@ public class LobbyPropertyFileParserTest {
 
   private static File createTempFile(final TestProps... testProps) throws Exception {
     final File f = File.createTempFile("testing", ".tmp");
-    for (final TestProps testProp : Arrays.asList(testProps)) {
-      try (FileWriter writer = new FileWriter(f)) {
+    try (FileWriter writer = new FileWriter(f)) {
+      for (final TestProps testProp : Arrays.asList(testProps)) {
         writer.write(testProp.toYaml());
       }
     }

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
@@ -61,22 +61,26 @@ public class DownloadFileParserTest {
     String xml = "";
     xml += "- url: http://example.com/games/game.zip\n";
     xml += "  mapName: " + GAME_NAME + "\n";
+    xml += "  version: 1\n";
     xml += createTypeTag(DownloadFileParser.ValueType.MAP);
     xml += "  description: |\n";
     xml += "     <pre>Some notes about the game, simple html allowed.\n";
     xml += "     </pre>\n";
     xml += "- url: http://example.com/games/mod.zip\n";
     xml += "  mapName: modName\n";
+    xml += "  version: 1\n";
     // missing map type defaults to map
     xml += "  description: |\n";
     xml += "      map mod\n";
     xml += "- url: http://example.com/games/skin.zip\n";
     xml += "  mapName: skin\n";
+    xml += "  version: 1\n";
     xml += createTypeTag(DownloadFileParser.ValueType.MAP_SKIN);
     xml += "  description: |\n";
     xml += "      map skin\n";
     xml += "- url: http://example.com/games/tool.zip\n";
     xml += "  mapName: mapToolName\n";
+    xml += "  version: 1\n";
     xml += createTypeTag(DownloadFileParser.ValueType.MAP_TOOL);
     xml += "  description: |\n";
     xml += "       <pre>\n";
@@ -100,6 +104,7 @@ public class DownloadFileParserTest {
     String xml = "";
     xml += "- url: http://example.com/games/mod.zip\n";
     xml += "  mapName: " + GAME_NAME + "\n";
+    xml += "  version: 1\n";
     xml += "  description: |\n";
     xml += "      description\n";
     return xml.getBytes();

--- a/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/map/download/DownloadFileParserTest.java
@@ -66,6 +66,7 @@ public class DownloadFileParserTest {
     xml += "     <pre>Some notes about the game, simple html allowed.\n";
     xml += "     </pre>\n";
     xml += "- url: http://example.com/games/mod.zip\n";
+    xml += "  mapName: modName\n";
     // missing map type defaults to map
     xml += "  description: |\n";
     xml += "      map mod\n";


### PR DESCRIPTION
Due to the similarities of JSON and YAML (as of YAML 1.2 valid JSON is also valid YAML), we can use JSON wrapper objects, in order make parsing more readable.