### PR TITLE
Remove unused methods from IntegerMap and LinkedIntegerMap

### DIFF
--- a/src/main/java/games/strategy/util/IntegerMap.java
+++ b/src/main/java/games/strategy/util/IntegerMap.java
@@ -1,7 +1,6 @@
 package games.strategy.util;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -49,17 +48,6 @@ public final class IntegerMap<T> implements Cloneable, Serializable {
     mapValues = new HashMap<>(integerMap.size());
     for (final T t : integerMap.keySet()) {
       mapValues.put(t, integerMap.getInt(t));
-    }
-  }
-
-  /**
-   * This will make a new IntegerMap.
-   * The Objects will be linked, but the integers mapped to them will not be linked.
-   */
-  public IntegerMap(final IntegerMap<T>[] integerMaps) {
-    mapValues = new HashMap<>();
-    for (final IntegerMap<T> integerMap : integerMaps) {
-      this.add(integerMap);
     }
   }
 
@@ -149,28 +137,6 @@ public final class IntegerMap<T> implements Cloneable, Serializable {
     return mapValues.keySet();
   }
 
-  public Collection<Integer> values() {
-    return mapValues.values();
-  }
-
-  /**
-   * If empty, will return false.
-   *
-   * @return true if at least one value and all values are the same.
-   */
-  public boolean allValuesAreSame() {
-    if (mapValues.isEmpty()) {
-      return false;
-    }
-    final int first = mapValues.values().iterator().next();
-    for (final int value : mapValues.values()) {
-      if (first != value) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   /**
    * If empty, will return false.
    *
@@ -186,56 +152,6 @@ public final class IntegerMap<T> implements Cloneable, Serializable {
       }
     }
     return true;
-  }
-
-  /**
-   * Will return zero if empty.
-   */
-  public int highestValue() {
-    if (mapValues.isEmpty()) {
-      return 0;
-    }
-    int max = Integer.MIN_VALUE;
-    for (final int value : mapValues.values()) {
-      if (value > max) {
-        max = value;
-      }
-    }
-    return max;
-  }
-
-  /**
-   * Will return zero if empty.
-   */
-  public int lowestValue() {
-    if (mapValues.isEmpty()) {
-      return 0;
-    }
-    int min = Integer.MAX_VALUE;
-    for (final int value : mapValues.values()) {
-      if (value < min) {
-        min = value;
-      }
-    }
-    return min;
-  }
-
-  /**
-   * Will return null if empty.
-   */
-  public T highestKey() {
-    if (mapValues.isEmpty()) {
-      return null;
-    }
-    int maxValue = Integer.MIN_VALUE;
-    T maxKey = null;
-    for (final Map.Entry<T, Integer> entry : mapValues.entrySet()) {
-      if (entry.getValue() > maxValue) {
-        maxValue = entry.getValue();
-        maxKey = entry.getKey();
-      }
-    }
-    return maxKey;
   }
 
   /**
@@ -322,33 +238,8 @@ public final class IntegerMap<T> implements Cloneable, Serializable {
     }
   }
 
-  private Collection<T> getKeyMatches(final Match<T> matcher) {
-    final Collection<T> values = new ArrayList<>();
-    for (final T obj : mapValues.keySet()) {
-      if (matcher.match(obj)) {
-        values.add(obj);
-      }
-    }
-    return values;
-  }
-
-  public void removeNonMatchingKeys(final Match<T> match) {
-    removeMatchingKeys(match.invert());
-  }
-
-  public void removeMatchingKeys(final Match<T> match) {
-    final Collection<T> badKeys = getKeyMatches(match);
-    removeKeys(badKeys);
-  }
-
   public void removeKey(final T key) {
     mapValues.remove(key);
-  }
-
-  private void removeKeys(final Collection<T> keys) {
-    for (final T key : keys) {
-      removeKey(key);
-    }
   }
 
   public boolean containsKey(final T key) {

--- a/src/main/java/games/strategy/util/LinkedIntegerMap.java
+++ b/src/main/java/games/strategy/util/LinkedIntegerMap.java
@@ -1,11 +1,9 @@
 package games.strategy.util;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.Map.Entry;
 import java.util.Set;
 
 /**
@@ -26,10 +24,6 @@ public final class LinkedIntegerMap<T> implements Cloneable, Serializable {
 
   public LinkedIntegerMap(final int size) {
     m_values = new LinkedHashMap<>(size);
-  }
-
-  public LinkedIntegerMap(final int size, final float loadFactor) {
-    m_values = new LinkedHashMap<>(size, loadFactor);
   }
 
   public LinkedIntegerMap(final T object, final int value) {
@@ -57,26 +51,11 @@ public final class LinkedIntegerMap<T> implements Cloneable, Serializable {
     }
   }
 
-  /**
-   * This will make a new IntegerMap.
-   * The Objects will be linked, but the integers mapped to them will not be linked.
-   */
-  public LinkedIntegerMap(final LinkedIntegerMap<T>[] integerMaps) {
-    m_values = new LinkedHashMap<>();
-    for (final LinkedIntegerMap<T> integerMap : integerMaps) {
-      this.add(integerMap);
-    }
-  }
-
   public int size() {
     return m_values.size();
   }
 
-  public void put(final T key, final Integer value) {
-    m_values.put(key, value);
-  }
-
-  public void put(final T key, final int value) {
+  private void put(final T key, final int value) {
     final Integer obj = Integer.valueOf(value);
     m_values.put(key, obj);
   }
@@ -99,10 +78,6 @@ public final class LinkedIntegerMap<T> implements Cloneable, Serializable {
     return val;
   }
 
-  public void add(final T key, final Integer value) {
-    add(key, value.intValue());
-  }
-
   public void add(final T key, final int value) {
     if (m_values.get(key) == null) {
       put(key, value);
@@ -119,188 +94,8 @@ public final class LinkedIntegerMap<T> implements Cloneable, Serializable {
     }
   }
 
-  /**
-   * Will multiply all values by a given double.
-   * Can be used to divide all numbers, if given a fractional double
-   * (ie: to divide by 2, use 0.5 as the double)
-   *
-   * @param roundType
-   *        (1 = floor, 2 = round, 3 = ceil)
-   */
-  public void multiplyAllValuesBy(final double multiplyBy, final int roundType) {
-    for (final T t : keySet()) {
-      double val = m_values.get(t);
-      switch (roundType) {
-        case 1:
-          val = Math.floor(val * multiplyBy);
-          break;
-        case 2:
-          val = Math.round(val * multiplyBy);
-          break;
-        case 3:
-          val = Math.ceil(val * multiplyBy);
-          break;
-        default:
-          val = val * multiplyBy;
-          break;
-      }
-      put(t, (int) val);
-    }
-  }
-
-  public void clear() {
-    m_values.clear();
-  }
-
   public Set<T> keySet() {
     return m_values.keySet();
-  }
-
-  public Collection<Integer> values() {
-    return m_values.values();
-  }
-
-  /**
-   * If empty, will return false.
-   *
-   * @return true if at least one value and all values are the same.
-   */
-  public boolean allValuesAreSame() {
-    if (m_values.isEmpty()) {
-      return false;
-    }
-    final int first = m_values.values().iterator().next();
-    for (final int value : m_values.values()) {
-      if (first != value) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * If empty, will return false.
-   *
-   * @return true if all values are equal to the given integer.
-   */
-  public boolean allValuesEqual(final int integer) {
-    if (m_values.isEmpty()) {
-      return false;
-    }
-    for (final int value : m_values.values()) {
-      if (integer != value) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * Will return zero if empty.
-   */
-  public int highestValue() {
-    if (m_values.isEmpty()) {
-      return 0;
-    }
-    int max = Integer.MIN_VALUE;
-    for (final int value : m_values.values()) {
-      if (value > max) {
-        max = value;
-      }
-    }
-    return max;
-  }
-
-  /**
-   * Will return zero if empty.
-   */
-  public int lowestValue() {
-    if (m_values.isEmpty()) {
-      return 0;
-    }
-    int min = Integer.MAX_VALUE;
-    for (final int value : m_values.values()) {
-      if (value < min) {
-        min = value;
-      }
-    }
-    return min;
-  }
-
-  /**
-   * Will return null if empty.
-   */
-  public T highestKey() {
-    if (m_values.isEmpty()) {
-      return null;
-    }
-    int maxValue = Integer.MIN_VALUE;
-    T maxKey = null;
-    for (final Entry<T, Integer> entry : m_values.entrySet()) {
-      if (entry.getValue() > maxValue) {
-        maxValue = entry.getValue();
-        maxKey = entry.getKey();
-      }
-    }
-    return maxKey;
-  }
-
-  /**
-   * Will return null if empty.
-   */
-  public T lowestKey() {
-    if (m_values.isEmpty()) {
-      return null;
-    }
-    int minValue = Integer.MAX_VALUE;
-    T minKey = null;
-    for (final Entry<T, Integer> entry : m_values.entrySet()) {
-      if (entry.getValue() < minValue) {
-        minValue = entry.getValue();
-        minKey = entry.getKey();
-      }
-    }
-    return minKey;
-  }
-
-  /**
-   * @return The sum of all keys.
-   */
-  public int totalValues() {
-    int sum = 0;
-    for (final Integer value : m_values.values()) {
-      sum += value;
-    }
-    return sum;
-  }
-
-  /**
-   * By >= we mean that each of our entries is greater
-   * than or equal to each entry in the other map. We do not take into
-   * account entries that are in our map but not in the second map. <br>
-   * It is possible that for two maps a and b
-   * a.greaterThanOrEqualTo(b) is false, and b.greaterThanOrEqualTo(a) is false, and
-   * that a and b are not equal.
-   */
-  public boolean greaterThanOrEqualTo(final LinkedIntegerMap<T> map) {
-    for (final T key : map.keySet()) {
-      if (!(this.getInt(key) >= map.getInt(key))) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /**
-   * True if all values are >= 0.
-   */
-  public boolean isPositive() {
-    for (final T key : m_values.keySet()) {
-      if (getInt(key) < 0) {
-        return false;
-      }
-    }
-    return true;
   }
 
   private LinkedIntegerMap<T> copy() {
@@ -314,54 +109,8 @@ public final class LinkedIntegerMap<T> implements Cloneable, Serializable {
     return copy();
   }
 
-  /**
-   * Add map * multiple.
-   */
-  public void addMultiple(final LinkedIntegerMap<T> map, final int multiple) {
-    for (final T key : map.keySet()) {
-      add(key, map.getInt(key) * multiple);
-    }
-  }
-
-  private Collection<T> getKeyMatches(final Match<T> matcher) {
-    final Collection<T> values = new ArrayList<>();
-    for (final T obj : m_values.keySet()) {
-      if (matcher.match(obj)) {
-        values.add(obj);
-      }
-    }
-    return values;
-  }
-
-  public void removeNonMatchingKeys(final Match<T> match) {
-    removeMatchingKeys(match.invert());
-  }
-
-  public void removeMatchingKeys(final Match<T> match) {
-    final Collection<T> badKeys = getKeyMatches(match);
-    removeKeys(badKeys);
-  }
-
   public void removeKey(final T key) {
     m_values.remove(key);
-  }
-
-  private void removeKeys(final Collection<T> keys) {
-    for (final T key : keys) {
-      removeKey(key);
-    }
-  }
-
-  public boolean containsKey(final T key) {
-    return m_values.containsKey(key);
-  }
-
-  public boolean isEmpty() {
-    return m_values.isEmpty();
-  }
-
-  public Set<Entry<T, Integer>> entrySet() {
-    return m_values.entrySet();
   }
 
   @Override


### PR DESCRIPTION
While in this area of code recently, I discovered several unused methods in the `IntegerMap` and `LinkedIntegerMap` classes.  This PR simply removes them.