### PR TITLE
Ensure application exits after selecting Quit from main menu (#2226)

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -157,8 +157,7 @@ public class GameRunner {
     } else {
       SwingUtilities.invokeLater(() -> {
         setupPanelModel.showSelectType();
-        final MainPanel mainPanel = new MainPanel(setupPanelModel);
-        mainFrame = SwingComponents.newJFrame("TripleA", mainPanel);
+        mainFrame = newMainFrame();
       });
 
       showMainFrame();
@@ -166,6 +165,19 @@ public class GameRunner {
       new Thread(GameRunner::checkLocalSystem).start();
       new Thread(GameRunner::checkForUpdates).start();
     }
+  }
+
+  private static JFrame newMainFrame() {
+    final JFrame frame = new JFrame("TripleA");
+
+    frame.add(new MainPanel(setupPanelModel));
+    frame.pack();
+
+    frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    frame.setIconImage(getGameIcon(frame));
+    frame.setLocationRelativeTo(null);
+
+    return frame;
   }
 
   public static FileDialog newFileDialog() {

--- a/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/src/main/java/games/strategy/ui/SwingComponents.java
@@ -2,7 +2,6 @@ package games.strategy.ui;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Frame;
@@ -50,7 +49,6 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import games.strategy.engine.framework.GameRunner;
 import games.strategy.net.OpenFileUtility;
 import games.strategy.triplea.UrlConstants;
 
@@ -147,19 +145,6 @@ public class SwingComponents {
         keyDownAction.run();
       }
     });
-  }
-
-
-  public static JFrame newJFrame(final String title, final JComponent contents) {
-    final JFrame frame = new JFrame(title);
-    frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-
-    frame.setIconImage(GameRunner.getGameIcon(frame));
-    frame.getContentPane().add(contents, BorderLayout.CENTER);
-    frame.pack();
-
-    frame.setLocationRelativeTo(null);
-    return frame;
   }
 
   public static JTabbedPane newJTabbedPane() {


### PR DESCRIPTION
This PR ensures the application exits after selecting **Quit** from the main menu, particularly when the error console is open, as described in #2226.

#### Functional changes

Changed the default close operation for the main frame from `DISPOSE_ON_CLOSE` to `EXIT_ON_CLOSE`.  This behavior is effectively identical to the in-game **Exit Program** command, which explicitly calls `System#exit()` to terminate the application.

#### Refactoring changes

* Extracted the main frame creation code to the new method `GameRunner#newMainFrame()`.
* Inlined the `SwingComponents#newJFrame()` method in `GameRunner`, as that was its only caller.

#### Testing

I verified the application now exits as expected after following the repro steps in #2226.

I also tested a few other scenarios that involve exiting the application:

##### Host network game

* Select **Host Networked Game** from main menu.
    * Observe: Error console is opened due to #1950.
* Select **Quit** from main menu
    * Observe: Error console is closed.
    * Observe: Application terminated.

##### Lobby

* Connect to lobby.
* Join an in-progress game.
* Exit game via **File > Exit Program**.
    * Observe: Client application terminated.
* Exit lobby via **File > Exit**.
    * Observe: Lobby window closed and main menu re-opened.
* Select **Quit** from main menu.
    * Observe: Application terminated.