### PR TITLE
Convert applicable INFO logs to WARNING or SEVERE (#1950)

### DIFF
--- a/src/main/java/games/strategy/engine/chat/ChatIgnoreList.java
+++ b/src/main/java/games/strategy/engine/chat/ChatIgnoreList.java
@@ -9,7 +9,7 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 class ChatIgnoreList {
-  private static final Logger log = Logger.getLogger(ChatIgnoreList.class.getName());
+  private static final Logger logger = Logger.getLogger(ChatIgnoreList.class.getName());
   private final Object lock = new Object();
   private final Set<String> ignore = new HashSet<>();
 
@@ -18,7 +18,7 @@ class ChatIgnoreList {
     try {
       Collections.addAll(ignore, prefs.keys());
     } catch (final BackingStoreException e) {
-      log.log(Level.FINE, e.getMessage(), e);
+      logger.log(Level.FINE, e.getMessage(), e);
     }
   }
 
@@ -30,7 +30,7 @@ class ChatIgnoreList {
       try {
         prefs.flush();
       } catch (final BackingStoreException e) {
-        log.log(Level.FINE, e.getMessage(), e);
+        logger.log(Level.FINE, e.getMessage(), e);
       }
     }
   }
@@ -47,7 +47,7 @@ class ChatIgnoreList {
       try {
         prefs.flush();
       } catch (final BackingStoreException e) {
-        log.log(Level.FINE, e.getMessage(), e);
+        logger.log(Level.FINE, e.getMessage(), e);
       }
     }
   }

--- a/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -49,7 +49,7 @@ public class DownloadMapsWindow extends JFrame {
   }
 
   private static final long serialVersionUID = -1542210716764178580L;
-  private static final Logger LOGGER = Logger.getLogger(DownloadMapsWindow.class.getName());
+  private static final Logger logger = Logger.getLogger(DownloadMapsWindow.class.getName());
   private static final int WINDOW_WIDTH = 1200;
   private static final int WINDOW_HEIGHT = 700;
   private static final int DIVIDER_POSITION = WINDOW_HEIGHT - 150;
@@ -182,7 +182,7 @@ public class DownloadMapsWindow extends JFrame {
 
   private static void logMapDownloadRequestIgnored(final Collection<String> mapNames) {
     if (!mapNames.isEmpty()) {
-      LOGGER.info("ignoring request to download maps because window initialization has already started");
+      logger.info("ignoring request to download maps because window initialization has already started");
     }
   }
 

--- a/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
@@ -6,7 +6,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -31,8 +30,7 @@ public class BadWordController {
         logger.info("Tried to create duplicate banned word:" + word + " error:" + sqle.getMessage());
         return;
       }
-      logger.log(Level.SEVERE, "Error inserting banned word:" + word, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error inserting banned word:" + word, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -48,8 +46,7 @@ public class BadWordController {
       ps.close();
       con.commit();
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error deleting banned word:" + word, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error deleting banned word:" + word, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -69,8 +66,7 @@ public class BadWordController {
       ps.close();
       return rVal;
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error reading bad words", sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error reading bad words", sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
@@ -32,7 +32,7 @@ public class BadWordController {
         return;
       }
       logger.log(Level.SEVERE, "Error inserting banned word:" + word, sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -49,7 +49,7 @@ public class BadWordController {
       con.commit();
     } catch (final SQLException sqle) {
       logger.log(Level.SEVERE, "Error deleting banned word:" + word, sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -69,8 +69,8 @@ public class BadWordController {
       ps.close();
       return rVal;
     } catch (final SQLException sqle) {
-      logger.info("Error reading bad words error:" + sqle.getMessage());
-      throw new IllegalStateException(sqle.getMessage());
+      logger.log(Level.SEVERE, "Error reading bad words", sqle);
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -6,7 +6,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import games.strategy.util.Tuple;
@@ -55,8 +54,7 @@ public class BannedMacController {
         logger.info("Tried to create duplicate banned mac:" + mac + " error:" + sqle.getMessage());
         return;
       }
-      logger.log(Level.SEVERE, "Error inserting banned mac:" + mac, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error inserting banned mac:" + mac, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -72,8 +70,7 @@ public class BannedMacController {
       ps.close();
       con.commit();
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error deleting banned mac:" + mac, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error deleting banned mac:" + mac, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -105,8 +102,7 @@ public class BannedMacController {
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error for testing banned mac existence:" + mac, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error for testing banned mac existence:" + mac, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedMacController.java
@@ -56,7 +56,7 @@ public class BannedMacController {
         return;
       }
       logger.log(Level.SEVERE, "Error inserting banned mac:" + mac, sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -73,7 +73,7 @@ public class BannedMacController {
       con.commit();
     } catch (final SQLException sqle) {
       logger.log(Level.SEVERE, "Error deleting banned mac:" + mac, sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -105,8 +105,8 @@ public class BannedMacController {
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      logger.info("Error for testing banned mac existence:" + mac + " error:" + sqle.getMessage());
-      throw new IllegalStateException(sqle.getMessage());
+      logger.log(Level.SEVERE, "Error for testing banned mac existence:" + mac, sqle);
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -57,7 +57,7 @@ public class BannedUsernameController {
         return;
       }
       logger.log(Level.SEVERE, "Error inserting banned username:" + username, sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -74,7 +74,7 @@ public class BannedUsernameController {
       con.commit();
     } catch (final SQLException sqle) {
       logger.log(Level.SEVERE, "Error deleting banned username:" + username, sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -106,8 +106,8 @@ public class BannedUsernameController {
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      logger.info("Error for testing banned username existence:" + username + " error:" + sqle.getMessage());
-      throw new IllegalStateException(sqle.getMessage());
+      logger.log(Level.SEVERE, "Error for testing banned username existence:" + username, sqle);
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -6,7 +6,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import games.strategy.util.Tuple;
@@ -56,8 +55,7 @@ public class BannedUsernameController {
         logger.info("Tried to create duplicate banned username:" + username + " error:" + sqle.getMessage());
         return;
       }
-      logger.log(Level.SEVERE, "Error inserting banned username:" + username, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error inserting banned username:" + username, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -73,8 +71,7 @@ public class BannedUsernameController {
       ps.close();
       con.commit();
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error deleting banned username:" + username, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error deleting banned username:" + username, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -106,8 +103,7 @@ public class BannedUsernameController {
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error for testing banned username existence:" + username, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error for testing banned username existence:" + username, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/Database.java
@@ -260,6 +260,6 @@ public class Database {
         logger.log(Level.WARNING, se.getMessage(), se);
       }
     }
-    logger.info("Databse shut down");
+    logger.info("Database shut down");
   }
 }

--- a/src/main/java/games/strategy/engine/lobby/server/db/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/Database.java
@@ -234,7 +234,7 @@ public class Database {
       logger.severe("Could not create backup dir" + backupDirName);
       return;
     }
-    logger.log(Level.INFO, "Backing up database to " + backupDir.getAbsolutePath());
+    logger.info("Backing up database to " + backupDir.getAbsolutePath());
     try (final Connection con = getDerbyConnection()) {
       // http://www-128.ibm.com/developerworks/db2/library/techarticle/dm-0502thalamati/
       final String sqlstmt = "CALL SYSCS_UTIL.SYSCS_BACKUP_DATABASE(?)";
@@ -245,7 +245,7 @@ public class Database {
     } catch (final Exception e) {
       logger.log(Level.SEVERE, "Could not back up database", e);
     }
-    logger.log(Level.INFO, "Done backing up database");
+    logger.info("Done backing up database");
   }
 
   private static File getBackupDir() {

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -6,7 +6,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -53,8 +52,7 @@ public class MutedMacController {
         logger.info("Tried to create duplicate muted mac:" + mac + " error:" + sqle.getMessage());
         return;
       }
-      logger.log(Level.SEVERE, "Error inserting muted mac:" + mac, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error inserting muted mac:" + mac, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -70,8 +68,7 @@ public class MutedMacController {
       ps.close();
       con.commit();
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error deleting muted mac:" + mac, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error deleting muted mac:" + mac, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -112,8 +109,7 @@ public class MutedMacController {
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error for testing muted mac existence:" + mac, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error for testing muted mac existence:" + mac, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedMacController.java
@@ -54,7 +54,7 @@ public class MutedMacController {
         return;
       }
       logger.log(Level.SEVERE, "Error inserting muted mac:" + mac, sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -71,7 +71,7 @@ public class MutedMacController {
       con.commit();
     } catch (final SQLException sqle) {
       logger.log(Level.SEVERE, "Error deleting muted mac:" + mac, sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -112,8 +112,8 @@ public class MutedMacController {
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      logger.info("Error for testing muted mac existence:" + mac + " error:" + sqle.getMessage());
-      throw new IllegalStateException(sqle.getMessage());
+      logger.log(Level.SEVERE, "Error for testing muted mac existence:" + mac, sqle);
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -55,7 +55,7 @@ public class MutedUsernameController {
         return;
       }
       logger.log(Level.SEVERE, "Error inserting muted username:" + username, sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -72,7 +72,7 @@ public class MutedUsernameController {
       con.commit();
     } catch (final SQLException sqle) {
       logger.log(Level.SEVERE, "Error deleting muted username:" + username, sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -113,8 +113,8 @@ public class MutedUsernameController {
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      logger.info("Error for testing muted username existence:" + username + " error:" + sqle.getMessage());
-      throw new IllegalStateException(sqle.getMessage());
+      logger.log(Level.SEVERE, "Error for testing muted username existence:" + username, sqle);
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/MutedUsernameController.java
@@ -6,7 +6,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -54,8 +53,7 @@ public class MutedUsernameController {
         logger.info("Tried to create duplicate muted username:" + username + " error:" + sqle.getMessage());
         return;
       }
-      logger.log(Level.SEVERE, "Error inserting muted username:" + username, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error inserting muted username:" + username, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -71,8 +69,7 @@ public class MutedUsernameController {
       ps.close();
       con.commit();
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error deleting muted username:" + username, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error deleting muted username:" + username, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -113,8 +110,7 @@ public class MutedUsernameController {
       rs.close();
       ps.close();
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error for testing muted username existence:" + username, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error for testing muted username existence:" + username, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
@@ -6,8 +6,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.mindrot.jbcrypt.BCrypt;
 
@@ -17,9 +15,6 @@ import games.strategy.engine.lobby.server.userDB.DBUser;
 
 // TODO: Lobby DB Migration - merge with DbUserController once completed
 public class UserController implements UserDao {
-
-  private static final Logger logger = Logger.getLogger(DbUserController.class.getName());
-
   private final Supplier<Connection> connectionSupplier;
 
   UserController(final Supplier<Connection> connectionSupplier) {
@@ -45,8 +40,7 @@ public class UserController implements UserDao {
       ps.close();
       return returnValue == null ? null : new HashedPassword(returnValue);
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error getting password for user:" + userName, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error getting password for user:" + userName, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -65,8 +59,7 @@ public class UserController implements UserDao {
       ps.close();
       return found;
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error testing for existence of user:" + userName, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error testing for existence of user:" + userName, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -87,9 +80,9 @@ public class UserController implements UserDao {
       }
       con.commit();
     } catch (final SQLException e) {
-      logger.log(Level.SEVERE,
-          "Error updating name:" + user.getName() + " email: " + user.getEmail() + " pwd: " + hashedPassword.mask(), e);
-      throw new IllegalStateException(e);
+      throw new IllegalStateException(
+          "Error updating name:" + user.getName() + " email: " + user.getEmail() + " pwd: " + hashedPassword.mask(),
+          e);
     }
   }
 
@@ -111,9 +104,11 @@ public class UserController implements UserDao {
       }
       con.commit();
     } catch (final SQLException e) {
-      logger.log(Level.SEVERE, String.format("Error inserting name: %s, email: %s, (masked) pwd: %s", user.getName(),
-          user.getEmail(), hashedPassword.mask()), e);
-      throw new RuntimeException(e);
+      throw new RuntimeException(
+          String.format(
+              "Error inserting name: %s, email: %s, (masked) pwd: %s",
+              user.getName(), user.getEmail(), hashedPassword.mask()),
+          e);
     }
   }
 
@@ -151,9 +146,9 @@ public class UserController implements UserDao {
         return true;
       }
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error validating password name:" + userName + " : " + " pwd:" + hashedPassword.mask(),
+      throw new IllegalStateException(
+          "Error validating password name:" + userName + " : " + " pwd:" + hashedPassword.mask(),
           sqle);
-      throw new IllegalStateException(sqle);
     }
   }
 
@@ -176,8 +171,7 @@ public class UserController implements UserDao {
       ps.close();
       return user;
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error getting user:" + userName, sqle);
-      throw new IllegalStateException(sqle);
+      throw new IllegalStateException("Error getting user:" + userName, sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
@@ -45,8 +45,8 @@ public class UserController implements UserDao {
       ps.close();
       return returnValue == null ? null : new HashedPassword(returnValue);
     } catch (final SQLException sqle) {
-      logger.info("Error for testing user existence:" + userName + " error:" + sqle.getMessage());
-      throw new IllegalStateException(sqle.getMessage());
+      logger.log(Level.SEVERE, "Error for testing user existence:" + userName, sqle);
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -65,8 +65,8 @@ public class UserController implements UserDao {
       ps.close();
       return found;
     } catch (final SQLException sqle) {
-      logger.info("Error for testing user existence:" + userName + " error:" + sqle.getMessage());
-      throw new IllegalStateException(sqle.getMessage());
+      logger.log(Level.SEVERE, "Error for testing user existence:" + userName, sqle);
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }
@@ -153,7 +153,7 @@ public class UserController implements UserDao {
     } catch (final SQLException sqle) {
       logger.log(Level.SEVERE, "Error validating password name:" + userName + " : " + " pwd:" + hashedPassword.mask(),
           sqle);
-      throw new IllegalStateException(sqle.getMessage());
+      throw new IllegalStateException(sqle);
     }
   }
 
@@ -176,8 +176,8 @@ public class UserController implements UserDao {
       ps.close();
       return user;
     } catch (final SQLException sqle) {
-      logger.info("Error for testing user existence:" + userName + " error:" + sqle.getMessage());
-      throw new IllegalStateException(sqle.getMessage());
+      logger.log(Level.SEVERE, "Error for testing user existence:" + userName, sqle);
+      throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
     }

--- a/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/UserController.java
@@ -45,7 +45,7 @@ public class UserController implements UserDao {
       ps.close();
       return returnValue == null ? null : new HashedPassword(returnValue);
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error for testing user existence:" + userName, sqle);
+      logger.log(Level.SEVERE, "Error getting password for user:" + userName, sqle);
       throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
@@ -65,7 +65,7 @@ public class UserController implements UserDao {
       ps.close();
       return found;
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error for testing user existence:" + userName, sqle);
+      logger.log(Level.SEVERE, "Error testing for existence of user:" + userName, sqle);
       throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);
@@ -176,7 +176,7 @@ public class UserController implements UserDao {
       ps.close();
       return user;
     } catch (final SQLException sqle) {
-      logger.log(Level.SEVERE, "Error for testing user existence:" + userName, sqle);
+      logger.log(Level.SEVERE, "Error getting user:" + userName, sqle);
       throw new IllegalStateException(sqle);
     } finally {
       DbUtil.closeConnection(con);

--- a/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/src/main/java/games/strategy/net/ServerMessenger.java
@@ -662,7 +662,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     notifyPlayerRemoval(nodeToRemove);
     final SocketChannel channel = nodeToChannel.remove(nodeToRemove);
     if (channel == null) {
-      logger.info("Could not remove connection to node:" + nodeToRemove);
+      logger.warning("Could not remove connection to node:" + nodeToRemove);
       return;
     }
     channelToNode.remove(channel);

--- a/src/main/java/games/strategy/net/nio/NioReader.java
+++ b/src/main/java/games/strategy/net/nio/NioReader.java
@@ -92,7 +92,7 @@ class NioReader {
           // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4729342
           selector.select();
         } catch (final Exception e) {
-          logger.log(Level.INFO, "error reading selection", e);
+          logger.log(Level.SEVERE, "error reading selection", e);
         }
         if (!running) {
           continue;

--- a/src/main/java/games/strategy/net/nio/NioWriter.java
+++ b/src/main/java/games/strategy/net/nio/NioWriter.java
@@ -84,7 +84,7 @@ class NioWriter {
           // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4729342
           selector.select();
         } catch (final Exception e) {
-          logger.log(Level.INFO, "error reading selection", e);
+          logger.log(Level.SEVERE, "error reading selection", e);
         }
         if (!running) {
           continue;

--- a/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
@@ -23,7 +23,7 @@ import games.strategy.util.ThreadUtil;
  */
 class BattleStepsPanel extends JPanel implements Active {
   private static final long serialVersionUID = 911638924664810435L;
-  private static final Logger log = Logger.getLogger(BattleStepsPanel.class.getName());
+  private static final Logger logger = Logger.getLogger(BattleStepsPanel.class.getName());
   // if this is the target step, we want to walk to the last step
   private static final String LAST_STEP = "NULL MARKER FOR LAST STEP";
   private final DefaultListModel<String> listModel = new DefaultListModel<>();
@@ -170,7 +170,7 @@ class BattleStepsPanel extends JPanel implements Active {
       if (listModel.indexOf(step) != -1) {
         targetStep = step;
       } else {
-        log.warning("Could not find step name:" + step);
+        logger.warning("Could not find step name:" + step);
       }
     }
     goToTarget();

--- a/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
@@ -170,7 +170,7 @@ class BattleStepsPanel extends JPanel implements Active {
       if (listModel.indexOf(step) != -1) {
         targetStep = step;
       } else {
-        log.info("Could not find step name:" + step);
+        log.warning("Could not find step name:" + step);
       }
     }
     goToTarget();


### PR DESCRIPTION
As mentioned in [#1950](https://github.com/triplea-game/triplea/issues/1950#issuecomment-309639988), there are some `INFO` logs that are actually errors and should have their level increased to either `WARNING` or `SEVERE`.  The purpose of this PR is to identify those instances and increase their level accordingly before proceeding further with fixing #1950.

There are 50 instances of `INFO` logs in the codebase.  These were identified by searching for references to `Logger#info()` and `Logger#log(Level.INFO, ...)`.  The initial commit in this PR simply identifies those instances, and adds a comment immediately before it containing the proposed log level.  I believe most of the logs will remain at the `INFO` level.

Please review and comment on any proposed log levels you do not agree with.  Once an agreement has been reached, I'll update the PR accordingly.

**UPDATE:** All applicable `INFO` logs have been upgraded to either `WARNING` or `SEVERE`.  See [this comment](https://github.com/triplea-game/triplea/pull/2263#issuecomment-324822288) for additional changes that were made.