### PR TITLE
Include Consumed Units in TUV

### DIFF
--- a/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -364,14 +364,15 @@ class EditPanel extends ActionPanel {
           return;
         }
         // all owned by one player
-        units.retainAll(Match.getMatches(units, Matches.unitIsOwnedBy(units.iterator().next().getOwner())));
+        final PlayerID player = units.get(0).getOwner();
+        units.retainAll(Match.getMatches(units, Matches.unitIsOwnedBy(player)));
         if (units.isEmpty()) {
           cancelEditAction.actionPerformed(null);
           return;
         }
         sortUnitsToRemove(units);
         Collections.sort(units, new UnitBattleComparator(false,
-            TuvUtils.getCostsForTuvForAllPlayersMergedAndAveraged(getData()), null, getData(), true, false));
+            TuvUtils.getCostsForTuv(player, getData()), null, getData(), true, false));
         Collections.reverse(units);
         // unit mapped to <max, min, current>
         final HashMap<Unit, Triple<Integer, Integer, Integer>> currentDamageMap =
@@ -411,14 +412,15 @@ class EditPanel extends ActionPanel {
           return;
         }
         // all owned by one player
-        units.retainAll(Match.getMatches(units, Matches.unitIsOwnedBy(units.iterator().next().getOwner())));
+        final PlayerID player = units.get(0).getOwner();
+        units.retainAll(Match.getMatches(units, Matches.unitIsOwnedBy(player)));
         if (units.isEmpty()) {
           cancelEditAction.actionPerformed(null);
           return;
         }
         sortUnitsToRemove(units);
         Collections.sort(units, new UnitBattleComparator(false,
-            TuvUtils.getCostsForTuvForAllPlayersMergedAndAveraged(getData()), null, getData(), true, false));
+            TuvUtils.getCostsForTuv(player, getData()), null, getData(), true, false));
         Collections.reverse(units);
         // unit mapped to <max, min, current>
         final HashMap<Unit, Triple<Integer, Integer, Integer>> currentDamageMap =

--- a/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1048,7 +1048,7 @@ public class TripleAFrame extends MainGameFrame {
         for (final Entry<Territory, Collection<Unit>> entry : possibleUnitsToAttack.entrySet()) {
           final List<Unit> units = new ArrayList<>(entry.getValue());
           Collections.sort(units,
-              new UnitBattleComparator(false, TuvUtils.getCostsForTuvForAllPlayersMergedAndAveraged(data),
+              new UnitBattleComparator(false, TuvUtils.getCostsForTuv(units.get(0).getOwner(), data),
                   TerritoryEffectHelper.getEffects(entry.getKey()), data, true, false));
           Collections.reverse(units);
           possibleUnitsToAttackStringForm.put(entry.getKey().getName(), units);

--- a/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -88,20 +88,6 @@ public class TuvUtils {
     return costs;
   }
 
-  private static int getTotalTuv(UnitType unitType, IntegerMap<UnitType> costs, Set<UnitType> alreadyAdded) {
-    int tuv = costs.getInt(unitType);
-    final UnitAttachment ua = UnitAttachment.get(unitType);
-    if (ua == null || ua.getConsumesUnits().isEmpty() || alreadyAdded.contains(unitType)) {
-      return tuv;
-    }
-    alreadyAdded.add(unitType);
-    for (final UnitType ut : ua.getConsumesUnits().keySet()) {
-      tuv += getTotalTuv(ut, costs, alreadyAdded);
-    }
-    alreadyAdded.remove(unitType);
-    return tuv;
-  }
-
   /**
    * Return a map where key are unit types and values are the AVERAGED for all RULES (not for all players).
    * Any production rule that produces multiple units
@@ -109,7 +95,7 @@ public class TuvUtils {
    * will have their costs rounded up on a per unit basis.
    * Therefore, this map should NOT be used for Purchasing information!
    */
-  public static IntegerMap<UnitType> getCostsForTuvForAllPlayersMergedAndAveraged(final GameData data) {
+  private static IntegerMap<UnitType> getCostsForTuvForAllPlayersMergedAndAveraged(final GameData data) {
     final Resource pus;
     data.acquireReadLock();
     try {
@@ -148,6 +134,20 @@ public class TuvUtils {
       costs.put(ut, averagedCost);
     }
     return costs;
+  }
+
+  private static int getTotalTuv(UnitType unitType, IntegerMap<UnitType> costs, Set<UnitType> alreadyAdded) {
+    int tuv = costs.getInt(unitType);
+    final UnitAttachment ua = UnitAttachment.get(unitType);
+    if (ua == null || ua.getConsumesUnits().isEmpty() || alreadyAdded.contains(unitType)) {
+      return tuv;
+    }
+    alreadyAdded.add(unitType);
+    for (final UnitType ut : ua.getConsumesUnits().keySet()) {
+      tuv += getTotalTuv(ut, costs, alreadyAdded);
+    }
+    alreadyAdded.remove(unitType);
+    return tuv;
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -82,22 +82,23 @@ public class TuvUtils {
 
     // Add value for consumesUnits
     for (final UnitType unitType : costs.keySet()) {
-      costs.put(unitType, getTotalTuv(unitType, costs));
+      costs.put(unitType, getTotalTuv(unitType, costs, new HashSet<>()));
     }
 
     return costs;
   }
 
-  // TODO: consider cycles
-  private static int getTotalTuv(UnitType unitType, IntegerMap<UnitType> costs) {
+  private static int getTotalTuv(UnitType unitType, IntegerMap<UnitType> costs, Set<UnitType> alreadyAdded) {
     int tuv = costs.getInt(unitType);
     final UnitAttachment ua = UnitAttachment.get(unitType);
-    if (ua == null || ua.getConsumesUnits().isEmpty()) {
+    if (ua == null || ua.getConsumesUnits().isEmpty() || alreadyAdded.contains(unitType)) {
       return tuv;
     }
+    alreadyAdded.add(unitType);
     for (final UnitType ut : ua.getConsumesUnits().keySet()) {
-      tuv += getTotalTuv(ut, costs);
+      tuv += getTotalTuv(ut, costs, alreadyAdded);
     }
+    alreadyAdded.remove(unitType);
     return tuv;
   }
 

--- a/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -136,7 +136,8 @@ public class TuvUtils {
     return costs;
   }
 
-  private static int getTotalTuv(UnitType unitType, IntegerMap<UnitType> costs, Set<UnitType> alreadyAdded) {
+  private static int getTotalTuv(final UnitType unitType, final IntegerMap<UnitType> costs,
+      final Set<UnitType> alreadyAdded) {
     int tuv = costs.getInt(unitType);
     final UnitAttachment ua = UnitAttachment.get(unitType);
     if (ua == null || ua.getConsumesUnits().isEmpty() || alreadyAdded.contains(unitType)) {

--- a/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -192,6 +192,13 @@ public class GameDataTestUtil {
   }
 
   /**
+   * Returns a factory_upgrade UnitType object for the specified GameData object.
+   */
+  public static UnitType factoryUpgrade(final GameData data) {
+    return unitType("factory_upgrade", data);
+  }
+
+  /**
    * Returns a UnitType object matching the given name for the specified GameData object if present.
    */
   private static UnitType unitType(final String name, final GameData data) {

--- a/src/test/java/games/strategy/triplea/util/TuvUtilsTest.java
+++ b/src/test/java/games/strategy/triplea/util/TuvUtilsTest.java
@@ -31,6 +31,7 @@ public class TuvUtilsTest {
   public void testCostsForTuvWithConsumesUnit() {
     final PlayerID british = GameDataTestUtil.british(gameData);
     final IntegerMap<UnitType> result = TuvUtils.getCostsForTuv(british, gameData);
+    System.out.println(result);
     assertEquals(20, result.getInt(GameDataTestUtil.factoryUpgrade(gameData)));
   }
 

--- a/src/test/java/games/strategy/triplea/util/TuvUtilsTest.java
+++ b/src/test/java/games/strategy/triplea/util/TuvUtilsTest.java
@@ -1,0 +1,37 @@
+package games.strategy.triplea.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.xml.TestMapGameData;
+import games.strategy.util.IntegerMap;
+
+public class TuvUtilsTest {
+  private GameData gameData;
+
+  @Before
+  public void setUp() throws Exception {
+    gameData = TestMapGameData.GLOBAL1940.getGameData();
+  }
+
+  @Test
+  public void testCostsForTuv() {
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    final IntegerMap<UnitType> result = TuvUtils.getCostsForTuv(british, gameData);
+    assertEquals(3, result.getInt(GameDataTestUtil.infantry(gameData)));
+  }
+
+  @Test
+  public void testCostsForTuvWithConsumesUnit() {
+    final PlayerID british = GameDataTestUtil.british(gameData);
+    final IntegerMap<UnitType> result = TuvUtils.getCostsForTuv(british, gameData);
+    assertEquals(20, result.getInt(GameDataTestUtil.factoryUpgrade(gameData)));
+  }
+
+}

--- a/src/test/java/games/strategy/triplea/util/TuvUtilsTest.java
+++ b/src/test/java/games/strategy/triplea/util/TuvUtilsTest.java
@@ -31,8 +31,7 @@ public class TuvUtilsTest {
   public void testCostsForTuvWithConsumesUnit() {
     final PlayerID british = GameDataTestUtil.british(gameData);
     final IntegerMap<UnitType> result = TuvUtils.getCostsForTuv(british, gameData);
-    System.out.println(result);
-    assertEquals(20, result.getInt(GameDataTestUtil.factoryUpgrade(gameData)));
+    assertEquals(32, result.getInt(GameDataTestUtil.factoryUpgrade(gameData)));
   }
 
 }


### PR DESCRIPTION
Addresses: https://forums.triplea-game.org/topic/159/tuv-for-units-that-have-consumesunits-property

Adds value of all consumeUnits for each unit. For example on Global 1940, Factory_Upgrade is worth 32 (12+20). It does this recursively and checks to ensure to count each unit only once if there are cycles (unitA -> unitB -> unitA = unitA + unitB).