### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 5)

### DIFF
--- a/src/main/java/games/strategy/engine/data/PlayerID.java
+++ b/src/main/java/games/strategy/engine/data/PlayerID.java
@@ -155,7 +155,7 @@ public class PlayerID extends NamedAttachable implements NamedUnitHolder {
     boolean ownsLand = false;
     for (final Territory t : data.getMap().getTerritories()) {
       if (t.getUnits().anyMatch(Match.allOf(Matches.unitIsOwnedBy(this),
-          Matches.unitHasAttackValueOfAtLeast(1), Matches.UnitCanMove, Matches.UnitIsLand))) {
+          Matches.unitHasAttackValueOfAtLeast(1), Matches.unitCanMove(), Matches.UnitIsLand))) {
         return true;
       }
       if (t.getOwner().equals(this)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -1348,7 +1348,7 @@ class ProNonCombatMoveAI {
             if (moveMap.get(t).isCanHold() && !moveMap.get(t).getAllDefenders().isEmpty()
                 && Match.anyMatch(moveMap.get(t).getAllDefenders(), ProMatches.unitIsOwnedTransport(player))) {
               final List<Unit> defendingUnits =
-                  Match.getMatches(moveMap.get(t).getAllDefenders(), Matches.UnitIsNotLand);
+                  Match.getMatches(moveMap.get(t).getAllDefenders(), Matches.unitIsNotLand());
               if (moveMap.get(t).getBattleResult() == null) {
                 moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(t,
                     moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));
@@ -1392,7 +1392,7 @@ class ProNonCombatMoveAI {
                 continue;
               }
               final List<Unit> defendingUnits =
-                  Match.getMatches(moveMap.get(t).getAllDefenders(), Matches.UnitIsNotLand);
+                  Match.getMatches(moveMap.get(t).getAllDefenders(), Matches.unitIsNotLand());
               if (moveMap.get(t).getBattleResult() == null) {
                 moveMap.get(t).setBattleResult(calc.estimateDefendBattleResults(t,
                     moveMap.get(t).getMaxEnemyUnits(), defendingUnits, moveMap.get(t).getMaxEnemyBombardUnits()));

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -736,7 +736,7 @@ class ProPurchaseAI {
       for (final ProPurchaseOption ppo : purchaseOptionsForTerritory) {
         final boolean isAaForBombing = Matches.unitTypeIsAaForBombingThisUnitOnly().match(ppo.getUnitType());
         if (isAaForBombing && ppo.getCost() < minCost
-            && !Matches.UnitTypeConsumesUnitsOnCreation.match(ppo.getUnitType())) {
+            && !Matches.unitTypeConsumesUnitsOnCreation().match(ppo.getUnitType())) {
           bestAaOption = ppo;
           minCost = ppo.getCost();
         }
@@ -1877,7 +1877,7 @@ class ProPurchaseAI {
 
     Match<Unit> unitMatch = Matches.UnitIsNotConstruction;
     if (isConstruction) {
-      unitMatch = Matches.UnitIsConstruction;
+      unitMatch = Matches.unitIsConstruction();
     }
 
     // Loop through prioritized territories and place land units

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProTechAI.java
@@ -109,16 +109,16 @@ final class ProTechAI {
       final Match<Unit> enemyPlane = Match.allOf(
           Matches.UnitIsAir,
           Matches.unitIsOwnedBy(enemyPlayer),
-          Matches.UnitCanMove);
+          Matches.unitCanMove());
       final Match<Unit> enemyTransport = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
-          Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
+          Matches.UnitIsSea, Matches.UnitIsTransport, Matches.unitCanMove());
       final Match<Unit> enemyShip = Match.allOf(
           Matches.unitIsOwnedBy(enemyPlayer),
           Matches.UnitIsSea,
-          Matches.UnitCanMove);
+          Matches.unitCanMove());
       final Match<Unit> enemyTransportable = Match.allOf(Matches.unitIsOwnedBy(enemyPlayer),
-          Matches.unitCanBeTransported(), Matches.unitIsNotAa(), Matches.UnitCanMove);
-      final Match<Unit> transport = Match.allOf(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.UnitCanMove);
+          Matches.unitCanBeTransported(), Matches.unitIsNotAa(), Matches.unitCanMove());
+      final Match<Unit> transport = Match.allOf(Matches.UnitIsSea, Matches.UnitIsTransport, Matches.unitCanMove());
       final List<Territory> enemyFighterTerritories = findUnitTerr(data, enemyPlane);
       int maxFighterDistance = 0;
       // should change this to read production frontier and tech
@@ -366,7 +366,7 @@ final class ProTechAI {
     final HashSet<Integer> ignore = new HashSet<>();
     ignore.add(1);
     final Match<Unit> blitzUnit =
-        Match.allOf(Matches.unitIsOwnedBy(enemyPlayer), Matches.UnitCanBlitz, Matches.UnitCanMove);
+        Match.allOf(Matches.unitIsOwnedBy(enemyPlayer), Matches.UnitCanBlitz, Matches.unitCanMove());
     final Match<Territory> validBlitzRoute = Match.allOf(
         Matches.territoryHasNoEnemyUnits(enemyPlayer, data),
         Matches.territoryIsNotImpassableToLandUnits(enemyPlayer, data));
@@ -461,9 +461,9 @@ final class ProTechAI {
     final Queue<Territory> q = new LinkedList<>();
     Territory lz = null;
     Territory ac = null;
-    final Match<Unit> enemyPlane = Match.allOf(Matches.UnitIsAir, Matches.unitIsOwnedBy(player), Matches.UnitCanMove);
+    final Match<Unit> enemyPlane = Match.allOf(Matches.UnitIsAir, Matches.unitIsOwnedBy(player), Matches.unitCanMove());
     final Match<Unit> enemyCarrier =
-        Match.allOf(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player), Matches.UnitCanMove);
+        Match.allOf(Matches.UnitIsCarrier, Matches.unitIsOwnedBy(player), Matches.unitCanMove());
     q.add(start);
     Territory current = null;
     distance.put(start, 0);

--- a/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/data/ProPurchaseOptionMap.java
@@ -63,7 +63,7 @@ public class ProPurchaseOptionMap {
       // Add rule to appropriate purchase option list
       if ((UnitAttachment.get(unitType).getMovement(player) <= 0
           && !(UnitAttachment.get(unitType).getCanProduceUnits()))
-          || Matches.UnitTypeConsumesUnitsOnCreation.match(unitType) || UnitAttachment.get(unitType).getIsSuicide()) {
+          || Matches.unitTypeConsumesUnitsOnCreation().match(unitType) || UnitAttachment.get(unitType).getIsSuicide()) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         specialOptions.add(ppo);
         ProLogger.debug("Special: " + ppo);

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProMatches.java
@@ -453,7 +453,7 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsEnemyNotLand(final PlayerID player, final GameData data) {
-    return Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsNotLand);
+    return Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsNotLand());
   }
 
   static Match<Unit> unitIsEnemyNotNeutral(final PlayerID player, final GameData data) {
@@ -485,7 +485,7 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsOwnedNotLand(final PlayerID player) {
-    return Match.allOf(Matches.UnitIsNotLand, Matches.unitIsOwnedBy(player));
+    return Match.allOf(Matches.unitIsNotLand(), Matches.unitIsOwnedBy(player));
   }
 
   public static Match<Unit> unitIsOwnedTransport(final PlayerID player) {
@@ -493,12 +493,12 @@ public class ProMatches {
   }
 
   public static Match<Unit> unitIsOwnedTransportableUnit(final PlayerID player) {
-    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCanBeTransported(), Matches.UnitCanMove);
+    return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCanBeTransported(), Matches.unitCanMove());
   }
 
   public static Match<Unit> unitIsOwnedCombatTransportableUnit(final PlayerID player) {
     return Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCanBeTransported(),
-        Matches.unitCanNotMoveDuringCombatMove().invert(), Matches.UnitCanMove);
+        Matches.unitCanNotMoveDuringCombatMove().invert(), Matches.unitCanMove());
   }
 
   public static Match<Unit> unitIsOwnedTransportableUnitAndCanBeLoaded(final PlayerID player,
@@ -522,7 +522,7 @@ public class ProMatches {
    */
   public static Match<Unit> unitWhichRequiresUnitsHasRequiredUnits(final Territory t) {
     return Match.of(unitWhichRequiresUnits -> {
-      if (!Matches.UnitRequiresUnitsOnCreation.match(unitWhichRequiresUnits)) {
+      if (!Matches.unitRequiresUnitsOnCreation().match(unitWhichRequiresUnits)) {
         return true;
       }
       final Collection<Unit> unitsAtStartOfTurnInProducer = t.getUnits().getUnits();

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -449,7 +449,7 @@ public class WeakAI extends AbstractAI {
           Matches.unitIsOwnedBy(player),
           Matches.unitIsNotAa(),
           // we can never move factories
-          Matches.UnitCanMove,
+          Matches.unitCanMove(),
           Matches.UnitIsNotInfrastructure,
           Matches.UnitIsLand);
       final Match<Territory> moveThrough =
@@ -612,7 +612,7 @@ public class WeakAI extends AbstractAI {
           Collections.sort(unitsSortedByCost, AIUtils.getCostComparator());
           for (final Unit unit : unitsSortedByCost) {
             final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitIsLand,
-                Matches.UnitIsNotInfrastructure, Matches.UnitCanMove, Matches.unitIsNotAa(),
+                Matches.UnitIsNotInfrastructure, Matches.unitCanMove(), Matches.unitIsNotAa(),
                 Matches.unitCanNotMoveDuringCombatMove().invert());
             if (!unitsAlreadyMoved.contains(unit) && match.match(unit)) {
               moveRoutes.add(data.getMap().getRoute(attackFrom, enemy));
@@ -644,7 +644,7 @@ public class WeakAI extends AbstractAI {
             Matches.UnitIsStrategicBomber.invert(),
             Match.of(o -> !unitsAlreadyMoved.contains(o)),
             Matches.unitIsNotAa(),
-            Matches.UnitCanMove,
+            Matches.unitCanMove(),
             Matches.UnitIsNotInfrastructure,
             Matches.unitCanNotMoveDuringCombatMove().invert(),
             Matches.unitIsNotSea());
@@ -750,7 +750,7 @@ public class WeakAI extends AbstractAI {
           if (Matches.unitTypeIsSea().match(results) || Matches.unitTypeIsAir().match(results)
               || Matches.unitTypeIsInfrastructure().match(results) || Matches.unitTypeIsAaForAnything().match(results)
               || Matches.unitTypeHasMaxBuildRestrictions().match(results)
-              || Matches.UnitTypeConsumesUnitsOnCreation.match(results)
+              || Matches.unitTypeConsumesUnitsOnCreation().match(results)
               || Matches.unitTypeIsStatic(player).match(results)) {
             continue;
           }
@@ -945,7 +945,7 @@ public class WeakAI extends AbstractAI {
             || Matches.unitTypeIsInfrastructure().match(results)
             || Matches.unitTypeIsAaForAnything().match(results)
             || Matches.unitTypeHasMaxBuildRestrictions().match(results)
-            || Matches.UnitTypeConsumesUnitsOnCreation.match(results)
+            || Matches.unitTypeConsumesUnitsOnCreation().match(results)
             || Matches.unitTypeIsStatic(player).match(results)) {
           continue;
         }

--- a/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1260,7 +1260,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
           taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
           ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
           final List<UnitType> allSubs =
-              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.UnitTypeIsSub);
+              Match.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsSub());
           for (final UnitType sub : allSubs) {
             taa.setAttackBonus("1:" + sub.getName());
           }

--- a/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -363,7 +363,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       return 0;
     }
     final GameMap map = data.getMap();
-    final Collection<Territory> blockable = Match.getMatches(map.getTerritories(), Matches.territoryIsBlockadeZone);
+    final Collection<Territory> blockable = Match.getMatches(map.getTerritories(), Matches.territoryIsBlockadeZone());
     if (blockable.isEmpty()) {
       return 0;
     }

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -499,7 +499,7 @@ public class BattleTracker implements Serializable {
       // Also subtract transports & subs (if they can't control sea zones)
       totalMatches = arrivedUnits.size() - Match.countMatches(arrivedUnits, Matches.UnitIsLand)
           - Match.countMatches(arrivedUnits, Matches.UnitIsAir)
-          - Match.countMatches(arrivedUnits, Matches.UnitIsSubmerged);
+          - Match.countMatches(arrivedUnits, Matches.unitIsSubmerged());
       // If transports are restricted from controlling sea zones, subtract them
       final Match<Unit> transportsCanNotControl = Match.allOf(
           Matches.unitIsTransportAndNotDestroyer(),

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -119,10 +119,10 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     final Match<Unit> airUnits = Match.allOf(Matches.UnitIsAir, Matches.UnitIsNotConstruction);
     placeableUnits.addAll(Match.getMatches(units, groundUnits));
     placeableUnits.addAll(Match.getMatches(units, airUnits));
-    if (Match.anyMatch(units, Matches.UnitIsConstruction)) {
+    if (Match.anyMatch(units, Matches.unitIsConstruction())) {
       final IntegerMap<String> constructionsMap = howManyOfEachConstructionCanPlace(to, to, units, player);
       final Collection<Unit> skipUnit = new ArrayList<>();
-      for (final Unit currentUnit : Match.getMatches(units, Matches.UnitIsConstruction)) {
+      for (final Unit currentUnit : Match.getMatches(units, Matches.unitIsConstruction())) {
         final int maxUnits = howManyOfConstructionUnit(currentUnit, constructionsMap);
         if (maxUnits > 0) {
           // we are doing this because we could have multiple unitTypes with the same constructionType, so we have to be
@@ -137,8 +137,9 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       }
     }
     // remove any units that require other units to be consumed on creation (veqryn)
-    if (Match.anyMatch(placeableUnits, Matches.UnitConsumesUnitsOnCreation)) {
-      final Collection<Unit> unitsWhichConsume = Match.getMatches(placeableUnits, Matches.UnitConsumesUnitsOnCreation);
+    if (Match.anyMatch(placeableUnits, Matches.unitConsumesUnitsOnCreation())) {
+      final Collection<Unit> unitsWhichConsume =
+          Match.getMatches(placeableUnits, Matches.unitConsumesUnitsOnCreation());
       for (final Unit unit : unitsWhichConsume) {
         if (Matches.unitWhichConsumesUnitsHasRequiredUnits(unitsAtStartOfTurnInTo).invert().match(unit)) {
           placeableUnits.remove(unit);

--- a/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -74,7 +74,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final StringBuilder endTurnReport = new StringBuilder();
     final GameData data = getData();
     final PlayerID player = data.getSequence().getStep().getPlayerID();
-    final Match<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitCreatesUnits);
+    final Match<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCreatesUnits());
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> myCreators = Match.getMatches(t.getUnits().getUnits(), myCreatorsMatch);
@@ -165,7 +165,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     // Find total unit generated resources for all owned units
     final GameData data = getData();
     final PlayerID player = data.getSequence().getStep().getPlayerID();
-    final Match<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.UnitCreatesResources);
+    final Match<Unit> myCreatorsMatch = Match.allOf(Matches.unitIsOwnedBy(player), Matches.unitCreatesResources());
     final IntegerMap<Resource> resourceTotalsMap = new IntegerMap<>();
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> myCreators = Match.getMatches(t.getUnits().getUnits(), myCreatorsMatch);

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1633,10 +1633,7 @@ public final class Matches {
 
   static Match<Unit> unitCanRepairOthers() {
     return Match.of(unit -> {
-      if (unitIsDisabled().match(unit)) {
-        return false;
-      }
-      if (Matches.unitIsBeingTransported().match(unit)) {
+      if (unitIsDisabled().match(unit) || unitIsBeingTransported().match(unit)) {
         return false;
       }
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
@@ -1707,10 +1704,7 @@ public final class Matches {
   private static Match<Unit> unitCanGiveBonusMovement() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      if (ua == null) {
-        return false;
-      }
-      return ua.getGivesMovement().size() > 0 && Matches.unitIsBeingTransported().invert().match(unit);
+      return ua != null && ua.getGivesMovement().size() > 0 && unitIsBeingTransported().invert().match(unit);
     });
   }
 
@@ -1764,20 +1758,14 @@ public final class Matches {
   static Match<Unit> unitCreatesUnits() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      if (ua == null) {
-        return false;
-      }
-      return ua.getCreatesUnitsList() != null && ua.getCreatesUnitsList().size() > 0;
+      return ua != null && ua.getCreatesUnitsList() != null && ua.getCreatesUnitsList().size() > 0;
     });
   }
 
   static Match<Unit> unitCreatesResources() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      if (ua == null) {
-        return false;
-      }
-      return ua.getCreatesResourcesList() != null && ua.getCreatesResourcesList().size() > 0;
+      return ua != null && ua.getCreatesResourcesList() != null && ua.getCreatesResourcesList().size() > 0;
     });
   }
 
@@ -1787,20 +1775,14 @@ public final class Matches {
   public static Match<UnitType> unitTypeConsumesUnitsOnCreation() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit);
-      if (ua == null) {
-        return false;
-      }
-      return ua.getConsumesUnits() != null && ua.getConsumesUnits().size() > 0;
+      return ua != null && ua.getConsumesUnits() != null && ua.getConsumesUnits().size() > 0;
     });
   }
 
   static Match<Unit> unitConsumesUnitsOnCreation() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      if (ua == null) {
-        return false;
-      }
-      return ua.getConsumesUnits() != null && ua.getConsumesUnits().size() > 0;
+      return ua != null && ua.getConsumesUnits() != null && ua.getConsumesUnits().size() > 0;
     });
   }
 
@@ -1840,10 +1822,7 @@ public final class Matches {
   public static Match<Unit> unitRequiresUnitsOnCreation() {
     return Match.of(unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      if (ua == null) {
-        return false;
-      }
-      return ua.getRequiresUnits() != null && ua.getRequiresUnits().size() > 0;
+      return ua != null && ua.getRequiresUnits() != null && ua.getRequiresUnits().size() > 0;
     });
   }
 
@@ -1887,10 +1866,7 @@ public final class Matches {
   static Match<Territory> territoryIsBlockadeZone() {
     return Match.of(t -> {
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
-      if (ta != null) {
-        return ta.getBlockadeZone();
-      }
-      return false;
+      return ta != null && ta.getBlockadeZone();
     });
   }
 
@@ -1900,10 +1876,7 @@ public final class Matches {
   public static Match<UnitType> unitTypeIsConstruction() {
     return Match.of(type -> {
       final UnitAttachment ua = UnitAttachment.get(type);
-      if (ua == null) {
-        return false;
-      }
-      return ua.getIsConstruction();
+      return ua != null && ua.getIsConstruction();
     });
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -478,7 +478,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final Set<Unit> repairUnitsForThisUnit = new HashSet<>();
     final PlayerID owner = unitToBeRepaired.getOwner();
     final Match<Unit> repairUnit = Match.allOf(Matches.alliedUnit(owner, data),
-        Matches.UnitCanRepairOthers, Matches.unitCanRepairThisUnit(unitToBeRepaired));
+        Matches.unitCanRepairOthers(), Matches.unitCanRepairThisUnit(unitToBeRepaired));
     repairUnitsForThisUnit.addAll(territoryUnitIsIn.getUnits().getMatches(repairUnit));
     if (Matches.UnitIsSea.match(unitToBeRepaired)) {
       final Match<Unit> repairUnitLand = Match.allOf(repairUnit, Matches.UnitIsLand);

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -436,7 +436,7 @@ public class MoveValidator {
       if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
         final Match<Unit> friendlyOrSubmerged = Match.anyOf(
             Matches.enemyUnit(player, data).invert(),
-            Matches.UnitIsSubmerged);
+            Matches.unitIsSubmerged());
         if (!end.getUnits().allMatch(friendlyOrSubmerged)
             && !(!units.isEmpty() && Match.allMatch(units, Matches.UnitIsAir) && end.isWater())) {
           if (units.isEmpty() || !Match.allMatch(units, Matches.UnitIsSub)
@@ -753,7 +753,7 @@ public class MoveValidator {
    */
   static boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final PlayerID player, final GameData data) {
     final Match<Unit> alliedOrNonCombat =
-        Match.anyOf(Matches.UnitIsInfrastructure, Matches.enemyUnit(player, data).invert(), Matches.UnitIsSubmerged);
+        Match.anyOf(Matches.UnitIsInfrastructure, Matches.enemyUnit(player, data).invert(), Matches.unitIsSubmerged());
     // Submerged units do not interfere with movement
     for (final Territory current : route.getMiddleSteps()) {
       if (!current.getUnits().allMatch(alliedOrNonCombat)) {
@@ -1087,7 +1087,7 @@ public class MoveValidator {
         return result.setErrorReturnResult("Units cannot move before loading onto transports");
       }
       final Match<Unit> enemyNonSubmerged =
-          Match.allOf(Matches.enemyUnit(player, data), Matches.UnitIsSubmerged.invert());
+          Match.allOf(Matches.enemyUnit(player, data), Matches.unitIsSubmerged().invert());
       if (route.getEnd().getUnits().anyMatch(enemyNonSubmerged) && nonParatroopersPresent(player, landAndAir)) {
         if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
           if (!AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(player,

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -267,7 +267,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // we dont want to change the movement of transported land units if this is a sea battle
     // so restrict non air to remove land units
     if (m_battleSite.isWater()) {
-      nonAir = Match.getMatches(nonAir, Matches.UnitIsNotLand);
+      nonAir = Match.getMatches(nonAir, Matches.unitIsNotLand());
     }
     // TODO This checks for ignored sub/trns and skips the set of the attackers to 0 movement left
     // If attacker stops in an occupied territory, movement stops (battle is optional)
@@ -1218,7 +1218,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         Matches.enemyUnit(m_attacker, m_data),
         Matches.UnitIsNotInfrastructure,
         Matches.unitIsBeingTransported().invert(),
-        Matches.UnitIsSubmerged.invert());
+        Matches.unitIsSubmerged().invert());
     if (Properties.getIgnoreSubInMovement(m_data)) {
       enemyUnitsThatPreventRetreatBuilder.add(Matches.unitIsNotSub());
     }
@@ -1747,15 +1747,15 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // Get all ALLIED, sea & air units in the territory (that are NOT submerged)
     final Match<Unit> alliedUnitsMatch = Match.allOf(
         Matches.isUnitAllied(player, m_data),
-        Matches.UnitIsNotLand,
-        Matches.UnitIsSubmerged.invert());
+        Matches.unitIsNotLand(),
+        Matches.unitIsSubmerged().invert());
     final Collection<Unit> alliedUnits = Match.getMatches(m_battleSite.getUnits().getUnits(), alliedUnitsMatch);
     // If transports are unescorted, check opposing forces to see if the Trns die automatically
     if (alliedTransports.size() == alliedUnits.size()) {
       // Get all the ENEMY sea and air units (that can attack) in the territory
       final Match<Unit> enemyUnitsMatch = Match.allOf(
-          Matches.UnitIsNotLand,
-          Matches.UnitIsSubmerged.invert(),
+          Matches.unitIsNotLand(),
+          Matches.unitIsSubmerged().invert(),
           Matches.unitCanAttack(player));
       final Collection<Unit> enemyUnits = Match.getMatches(m_battleSite.getUnits().getUnits(), enemyUnitsMatch);
       // If there are attackers set their movement to 0 and kill the transports
@@ -1778,7 +1778,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       return;
     }
     final Match.CompositeBuilder<Unit> notSubmergedAndTypeBuilder = Match.newCompositeBuilder(
-        Matches.UnitIsSubmerged.invert());
+        Matches.unitIsSubmerged().invert());
     if (Matches.TerritoryIsLand.match(m_battleSite)) {
       notSubmergedAndTypeBuilder.add(Matches.UnitIsSea.invert());
     } else {

--- a/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -145,7 +145,7 @@ public class RocketsFireHelper {
 
   Match<Unit> rocketMatch(final PlayerID player, final GameData data) {
     return Match.allOf(Matches.unitIsRocket(), Matches.unitIsOwnedBy(player), Matches.unitIsNotDisabled(),
-        Matches.unitIsBeingTransported().invert(), Matches.UnitIsSubmerged.invert(), Matches.unitHasNotMoved());
+        Matches.unitIsBeingTransported().invert(), Matches.unitIsSubmerged().invert(), Matches.unitHasNotMoved());
   }
 
   private static Set<Territory> getTargetsWithinRange(final Territory territory, final GameData data,

--- a/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
+++ b/src/main/java/games/strategy/triplea/oddsCalculator/ta/OddsCalculator.java
@@ -654,9 +654,9 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
         final List<Unit> notKilled = new ArrayList<>(selectFrom);
         notKilled.removeAll(killedUnits);
         // no land units left, but we have a non land unit to kill and land unit was killed
-        if (!Match.anyMatch(notKilled, Matches.UnitIsLand) && Match.anyMatch(notKilled, Matches.UnitIsNotLand)
+        if (!Match.anyMatch(notKilled, Matches.UnitIsLand) && Match.anyMatch(notKilled, Matches.unitIsNotLand())
             && Match.anyMatch(killedUnits, Matches.UnitIsLand)) {
-          final List<Unit> notKilledAndNotLand = Match.getMatches(notKilled, Matches.UnitIsNotLand);
+          final List<Unit> notKilledAndNotLand = Match.getMatches(notKilled, Matches.unitIsNotLand());
           // sort according to cost
           Collections.sort(notKilledAndNotLand, AIUtils.getCostComparator());
           // remove the last killed unit, this should be the strongest

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -336,7 +336,7 @@ public class MovePanel extends AbstractMovePanel {
      * this will restrict selection to units with 1 or more movement
      */
     if (!Properties.getSelectableZeroMovementUnits(getData())) {
-      movableBuilder.add(Matches.UnitCanMove);
+      movableBuilder.add(Matches.unitCanMove());
     }
     if (!nonCombat) {
       movableBuilder.add(Matches.unitCanNotMoveDuringCombatMove().invert());
@@ -349,7 +349,7 @@ public class MovePanel extends AbstractMovePanel {
         return TripleAUnit.get(u).getMovementLeft() >= route.getMovementCost(u);
       });
       if (route.isUnload()) {
-        final Match<Unit> notLandAndCanMove = Match.allOf(enoughMovement, Matches.UnitIsNotLand);
+        final Match<Unit> notLandAndCanMove = Match.allOf(enoughMovement, Matches.unitIsNotLand());
         final Match<Unit> landOrCanMove = Match.anyOf(Matches.UnitIsLand, notLandAndCanMove);
         movableBuilder.add(landOrCanMove);
       } else {
@@ -359,7 +359,7 @@ public class MovePanel extends AbstractMovePanel {
     if (route != null && route.getEnd() != null) {
       final boolean water = route.getEnd().isWater();
       if (water && !route.isLoad()) {
-        movableBuilder.add(Matches.UnitIsNotLand);
+        movableBuilder.add(Matches.unitIsNotLand());
       }
       if (!water) {
         movableBuilder.add(Matches.unitIsNotSea());
@@ -1231,7 +1231,7 @@ public class MovePanel extends AbstractMovePanel {
         return;
       }
       final PlayerID owner = getUnitOwner(selectedUnits);
-      final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(owner), Matches.UnitCanMove);
+      final Match<Unit> match = Match.allOf(Matches.unitIsOwnedBy(owner), Matches.unitCanMove());
       final boolean someOwned = Match.anyMatch(units, match);
       final boolean isCorrectTerritory = firstSelectedTerritory == null || firstSelectedTerritory == territory;
       if (someOwned && isCorrectTerritory) {

--- a/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -176,7 +176,7 @@ public class PurchasePanel extends ActionPanel {
           final NamedAttachable resourceOrUnit = rule.getResults().keySet().iterator().next();
           if (resourceOrUnit instanceof UnitType) {
             final UnitType type = (UnitType) resourceOrUnit;
-            if (!Matches.UnitTypeIsConstruction.match(type)) {
+            if (!Matches.unitTypeIsConstruction().match(type)) {
               totalProduced += purchase.getInt(rule) * rule.getResults().totalValues();
             }
           }


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is one part in a series of related PRs in order to keep the review size reasonable.