### PR TITLE
Remove ByteArrayOutputStream2 class + Refactoring

### DIFF
--- a/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/src/main/java/games/strategy/net/nio/Encoder.java
@@ -45,7 +45,7 @@ class Encoder {
         logger.log(Level.FINER, "encoded  msg:" + header.getMessage() + " size:" + data.size());
       }
       writer.enque(data, to);
-    } catch (final Exception e) {
+    } catch (final IOException e) {
       // we arent doing any io, just writing in memory
       // so something is very wrong
       logger.log(Level.SEVERE, "Error writing object:" + header, e);

--- a/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/src/main/java/games/strategy/net/nio/Encoder.java
@@ -37,21 +37,20 @@ class Encoder {
     if (to == null) {
       throw new IllegalArgumentException("No to channel!");
     }
-    final ByteArrayOutputStream2 sink = new ByteArrayOutputStream2(512);
-    SocketWriteData data;
     try {
+      final ByteArrayOutputStream sink = new ByteArrayOutputStream(512);
       write(header, objectStreamFactory.create(sink), to);
-      data = new SocketWriteData(sink.getBuffer(), sink.size());
+      final SocketWriteData data = new SocketWriteData(sink.toByteArray(), sink.size());
+      if (logger.isLoggable(Level.FINER)) {
+        logger.log(Level.FINER, "encoded  msg:" + header.getMessage() + " size:" + data.size());
+      }
+      writer.enque(data, to);
     } catch (final Exception e) {
       // we arent doing any io, just writing in memory
       // so something is very wrong
       logger.log(Level.SEVERE, "Error writing object:" + header, e);
       return;
     }
-    if (logger.isLoggable(Level.FINER)) {
-      logger.log(Level.FINER, "encoded  msg:" + header.getMessage() + " size:" + data.size());
-    }
-    writer.enque(data, to);
   }
 
   private void write(final MessageHeader header, final ObjectOutputStream out, final SocketChannel remote)
@@ -90,18 +89,5 @@ class Encoder {
       out.writeObject(header.getMessage());
     }
     out.reset();
-  }
-
-  /**
-   * Provide access to the raw buffer.
-   */
-  private static final class ByteArrayOutputStream2 extends ByteArrayOutputStream {
-    ByteArrayOutputStream2(final int size) {
-      super(size);
-    }
-
-    byte[] getBuffer() {
-      return buf;
-    }
   }
 }


### PR DESCRIPTION
Sorry @ssoloff, I was faster 😛 
This PR removes the usage of the ByteArrayOutputStream2 class, which was used only once and is essentially a dirty hack to access the raw array in a Buffer instead of an exact copy.
Couldn't find any problems with this: The affected code is executed multiple times when joining the lobby, a game, hosting a game etc. Basically on every network operation this code is being executed.
Couldn't find any issues with this...