### PR TITLE
Checkstyle: Fix line length violations in Matches

### DIFF
--- a/src/main/java/games/strategy/engine/data/Territory.java
+++ b/src/main/java/games/strategy/engine/data/Territory.java
@@ -38,7 +38,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   }
 
   /**
-   * May be null if not owned.
+   * @return The territory owner; will be {@link #NULL_PLAYERID} if the territory is not owned.
    */
   public PlayerID getOwner() {
     return m_owner;

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.attachments;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -144,6 +146,11 @@ public class TerritoryAttachment extends DefaultAttachment {
       throw new IllegalStateException("No territory attachment for:" + t.getName() + " with name:" + nameOfAttachment);
     }
     return rVal;
+  }
+
+  public static void remove(final Territory territory) {
+    checkNotNull(territory);
+    territory.removeAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
   }
 
   /**

--- a/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -148,8 +148,27 @@ public class TerritoryAttachment extends DefaultAttachment {
     return rVal;
   }
 
+  /**
+   * Adds the specified territory attachment to the specified territory.
+   *
+   * @param territory The territory that will receive the territory attachment.
+   * @param territoryAttachment The territory attachment.
+   */
+  public static void add(final Territory territory, final TerritoryAttachment territoryAttachment) {
+    checkNotNull(territory);
+    checkNotNull(territoryAttachment);
+
+    territory.addAttachment(Constants.TERRITORY_ATTACHMENT_NAME, territoryAttachment);
+  }
+
+  /**
+   * Removes any territory attachment from the specified territory.
+   *
+   * @param territory The territory from which the attachment will be removed.
+   */
   public static void remove(final Territory territory) {
     checkNotNull(territory);
+
     territory.removeAttachment(Constants.TERRITORY_ATTACHMENT_NAME);
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -574,7 +574,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final Iterator<Territory> battleTerritories = Match
         .getMatches(
             data.getMap().getTerritories(),
-            Matches.territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWater(player, data))
+            Match.allOf(
+                Matches.territoryIsNotUnownedWater(),
+                Matches.territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemy(player, data)))
         .iterator();
     // all territories that contain enemy units, where the territory is owned by an enemy of these units
     while (battleTerritories.hasNext()) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -571,8 +571,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       return;
     }
     final PlayerID player = bridge.getPlayerID();
-    final Iterator<Territory> battleTerritories = Match.getMatches(data.getMap().getTerritories(), Matches
-        .territoryHasEnemyUnitsThatCanCaptureTerritoryAndTerritoryOwnedByTheirEnemyAndIsNotUnownedWater(player, data))
+    final Iterator<Territory> battleTerritories = Match
+        .getMatches(
+            data.getMap().getTerritories(),
+            Matches.territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWater(player, data))
         .iterator();
     // all territories that contain enemy units, where the territory is owned by an enemy of these units
     while (battleTerritories.hasNext()) {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1475,9 +1475,6 @@ public final class Matches {
   static Match<Territory> territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWater(
       final PlayerID player, final GameData data) {
     return Match.of(t -> {
-      if (t.getOwner() == null) {
-        return false;
-      }
       if (t.isWater() && TerritoryAttachment.get(t) == null && t.getOwner().isNull()) {
         return false;
       }

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1468,18 +1468,6 @@ public final class Matches {
     return Match.of(t -> t.getUnits().anyMatch(enemyUnit(player, data)));
   }
 
-  /**
-   * The territory is owned by the enemy of those enemy units (ie: probably owned by you or your ally, but not
-   * necessarily so in an FFA type
-   * game) and is not unowned water.
-   */
-  static Match<Territory> territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWater(
-      final PlayerID player, final GameData data) {
-    return Match.allOf(
-        territoryIsNotUnownedWater(),
-        territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemy(player, data));
-  }
-
   static Match<Territory> territoryIsNotUnownedWater() {
     return Match.of(t -> !(t.isWater() && TerritoryAttachment.get(t) == null && t.getOwner().isNull()));
   }

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameStep;
@@ -1474,16 +1475,30 @@ public final class Matches {
    */
   static Match<Territory> territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWater(
       final PlayerID player, final GameData data) {
+    return Match.allOf(
+        territoryIsNotUnownedWater(),
+        territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemy(player, data));
+  }
+
+  static Match<Territory> territoryIsNotUnownedWater() {
+    return Match.of(t -> !(t.isWater() && TerritoryAttachment.get(t) == null && t.getOwner().isNull()));
+  }
+
+  /**
+   * The territory is owned by the enemy of those enemy units (i.e. probably owned by you or your ally, but not
+   * necessarily so in an FFA type game).
+   */
+  static Match<Territory> territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemy(
+      final PlayerID player, final GameData gameData) {
     return Match.of(t -> {
-      if (t.isWater() && TerritoryAttachment.get(t) == null && t.getOwner().isNull()) {
-        return false;
-      }
-      final Set<PlayerID> enemies = new HashSet<>();
-      for (final Unit u : t.getUnits()
-          .getMatches(Match.allOf(enemyUnit(player, data), unitIsNotAir(), UnitIsNotInfrastructure))) {
-        enemies.add(u.getOwner());
-      }
-      return (Matches.isAtWarWithAnyOfThesePlayers(enemies, data)).match(t.getOwner());
+      final List<Unit> enemyUnits = t.getUnits().getMatches(Match.allOf(
+          enemyUnit(player, gameData),
+          unitIsNotAir(),
+          UnitIsNotInfrastructure));
+      final Collection<PlayerID> enemyPlayers = enemyUnits.stream()
+          .map(Unit::getOwner)
+          .collect(Collectors.toSet());
+      return isAtWarWithAnyOfThesePlayers(enemyPlayers, gameData).match(t.getOwner());
     });
   }
 

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1472,7 +1472,7 @@ public final class Matches {
    * necessarily so in an FFA type
    * game) and is not unowned water.
    */
-  public static Match<Territory> territoryHasEnemyUnitsThatCanCaptureTerritoryAndTerritoryOwnedByTheirEnemyAndIsNotUnownedWater(
+  static Match<Territory> territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWater(
       final PlayerID player, final GameData data) {
     return Match.of(t -> {
       if (t.getOwner() == null) {

--- a/src/test/java/games/strategy/triplea/delegate/MatchesTests.java
+++ b/src/test/java/games/strategy/triplea/delegate/MatchesTests.java
@@ -59,179 +59,6 @@ public final class MatchesTests {
     };
   }
 
-  public static final class TerritoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWaterTest {
-    private GameData gameData;
-    private PlayerID player;
-    private PlayerID alliedPlayer;
-    private PlayerID enemyPlayer;
-    private Territory landTerritory;
-    private Territory seaTerritory;
-
-    private Match<Territory> newMatch() {
-      return Matches.territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWater(player, gameData);
-    }
-
-    private Unit newAirUnitFor(final PlayerID player) {
-      return GameDataTestUtil.fighter(gameData).create(player);
-    }
-
-    private Unit newInfrastructureUnitFor(final PlayerID player) {
-      return GameDataTestUtil.aaGun(gameData).create(player);
-    }
-
-    private Unit newLandUnitFor(final PlayerID player) {
-      return GameDataTestUtil.infantry(gameData).create(player);
-    }
-
-    private Unit newSeaUnitFor(final PlayerID player) {
-      return GameDataTestUtil.battleship(gameData).create(player);
-    }
-
-    @Before
-    public void setUp() throws Exception {
-      gameData = TestMapGameData.DELEGATE_TEST.getGameData();
-
-      player = GameDataTestUtil.germans(gameData);
-      alliedPlayer = GameDataTestUtil.japanese(gameData);
-      assertThat(gameData.getRelationshipTracker().isAtWar(player, alliedPlayer), is(false));
-      enemyPlayer = GameDataTestUtil.russians(gameData);
-      assertThat(gameData.getRelationshipTracker().isAtWar(player, enemyPlayer), is(true));
-
-      landTerritory = gameData.getMap().getTerritory("Germany");
-      landTerritory.setOwner(player);
-      landTerritory.getUnits().clear();
-
-      seaTerritory = gameData.getMap().getTerritory("Baltic Sea Zone");
-      seaTerritory.setOwner(player);
-      seaTerritory.getUnits().clear();
-    }
-
-    @Test
-    public void shouldNotMatchWhenLandTerritoryContainsOnlyAlliedLandUnits() {
-      landTerritory.getUnits().add(newLandUnitFor(alliedPlayer));
-
-      assertThat(newMatch(), notMatches(landTerritory));
-    }
-
-    @Test
-    public void shouldMatchWhenLandTerritoryContainsOnlyEnemyLandUnits() {
-      landTerritory.getUnits().add(newLandUnitFor(enemyPlayer));
-
-      assertThat(newMatch(), matches(landTerritory));
-    }
-
-    @Test
-    public void shouldMatchWhenLandTerritoryContainsEnemyLandUnitsAndIsUnowned() {
-      landTerritory.setOwner(PlayerID.NULL_PLAYERID);
-      TerritoryAttachment.remove(landTerritory);
-      landTerritory.getUnits().add(newLandUnitFor(enemyPlayer));
-
-      assertThat(newMatch(), matches(landTerritory));
-    }
-
-    @Test
-    public void shouldNotMatchWhenLandTerritoryContainsOnlyEnemyAirUnits() {
-      landTerritory.getUnits().add(newAirUnitFor(enemyPlayer));
-
-      assertThat(newMatch(), notMatches(landTerritory));
-    }
-
-    @Test
-    public void shouldNotMatchWhenLandTerritoryContainsOnlyEnemyInfrastructureUnits() {
-      landTerritory.getUnits().add(newInfrastructureUnitFor(enemyPlayer));
-
-      assertThat(newMatch(), notMatches(landTerritory));
-    }
-
-    @Test
-    public void shouldNotMatchWhenSeaTerritoryContainsOnlyAlliedSeaUnits() {
-      seaTerritory.getUnits().add(newSeaUnitFor(alliedPlayer));
-
-      assertThat(newMatch(), notMatches(seaTerritory));
-    }
-
-    @Test
-    public void shouldMatchWhenSeaTerritoryContainsOnlyEnemySeaUnits() {
-      seaTerritory.getUnits().add(newSeaUnitFor(enemyPlayer));
-
-      assertThat(newMatch(), matches(seaTerritory));
-    }
-
-    @Test
-    public void shouldNotMatchWhenSeaTerritoryContainsEnemySeaUnitsAndIsUnowned() {
-      seaTerritory.setOwner(PlayerID.NULL_PLAYERID);
-      TerritoryAttachment.remove(seaTerritory);
-      seaTerritory.getUnits().add(newSeaUnitFor(enemyPlayer));
-
-      assertThat(newMatch(), notMatches(seaTerritory));
-    }
-
-    @Test
-    public void shouldNotMatchWhenSeaTerritoryContainsOnlyEnemyAirUnits() {
-      seaTerritory.getUnits().add(newAirUnitFor(enemyPlayer));
-
-      assertThat(newMatch(), notMatches(seaTerritory));
-    }
-
-    @Test
-    public void shouldNotMatchWhenSeaTerritoryContainsOnlyEnemyInfrastructureUnits() {
-      seaTerritory.getUnits().add(newInfrastructureUnitFor(enemyPlayer));
-
-      assertThat(newMatch(), notMatches(seaTerritory));
-    }
-  }
-
-  public static final class TerritoryIsNotUnownedWaterTest {
-    private GameData gameData;
-    private PlayerID player;
-    private Territory landTerritory;
-    private Territory seaTerritory;
-
-    private static Match<Territory> newMatch() {
-      return Matches.territoryIsNotUnownedWater();
-    }
-
-    @Before
-    public void setUp() throws Exception {
-      gameData = TestMapGameData.DELEGATE_TEST.getGameData();
-
-      player = GameDataTestUtil.germans(gameData);
-
-      landTerritory = gameData.getMap().getTerritory("Germany");
-      seaTerritory = gameData.getMap().getTerritory("Baltic Sea Zone");
-    }
-
-    @Test
-    public void shouldMatchWhenLandTerritoryIsOwned() {
-      landTerritory.setOwner(player);
-
-      assertThat(newMatch(), matches(landTerritory));
-    }
-
-    @Test
-    public void shouldMatchWhenLandTerritoryIsUnowned() {
-      landTerritory.setOwner(PlayerID.NULL_PLAYERID);
-      TerritoryAttachment.remove(landTerritory);
-
-      assertThat(newMatch(), matches(landTerritory));
-    }
-
-    @Test
-    public void shouldMatchWhenSeaTerritoryIsOwned() {
-      seaTerritory.setOwner(player);
-
-      assertThat(newMatch(), matches(seaTerritory));
-    }
-
-    @Test
-    public void shouldNotMatchWhenSeaTerritoryIsUnowned() {
-      seaTerritory.setOwner(PlayerID.NULL_PLAYERID);
-      TerritoryAttachment.remove(seaTerritory);
-
-      assertThat(newMatch(), notMatches(seaTerritory));
-    }
-  }
-
   public static final class TerritoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyTest {
     private GameData gameData;
     private PlayerID player;
@@ -296,6 +123,57 @@ public final class MatchesTests {
       territory.getUnits().add(newInfrastructureUnitFor(enemyPlayer));
 
       assertThat(newMatch(), notMatches(territory));
+    }
+  }
+
+  public static final class TerritoryIsNotUnownedWaterTest {
+    private GameData gameData;
+    private PlayerID player;
+    private Territory landTerritory;
+    private Territory seaTerritory;
+
+    private static Match<Territory> newMatch() {
+      return Matches.territoryIsNotUnownedWater();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+      gameData = TestMapGameData.DELEGATE_TEST.getGameData();
+
+      player = GameDataTestUtil.germans(gameData);
+
+      landTerritory = gameData.getMap().getTerritory("Germany");
+      seaTerritory = gameData.getMap().getTerritory("Baltic Sea Zone");
+    }
+
+    @Test
+    public void shouldMatchWhenLandTerritoryIsOwned() {
+      landTerritory.setOwner(player);
+
+      assertThat(newMatch(), matches(landTerritory));
+    }
+
+    @Test
+    public void shouldMatchWhenLandTerritoryIsUnowned() {
+      landTerritory.setOwner(PlayerID.NULL_PLAYERID);
+      TerritoryAttachment.remove(landTerritory);
+
+      assertThat(newMatch(), matches(landTerritory));
+    }
+
+    @Test
+    public void shouldMatchWhenSeaTerritoryIsOwned() {
+      seaTerritory.setOwner(player);
+
+      assertThat(newMatch(), matches(seaTerritory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenSeaTerritoryIsUnowned() {
+      seaTerritory.setOwner(PlayerID.NULL_PLAYERID);
+      TerritoryAttachment.remove(seaTerritory);
+
+      assertThat(newMatch(), notMatches(seaTerritory));
     }
   }
 }

--- a/src/test/java/games/strategy/triplea/delegate/MatchesTests.java
+++ b/src/test/java/games/strategy/triplea/delegate/MatchesTests.java
@@ -1,0 +1,209 @@
+package games.strategy.triplea.delegate;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import javax.annotation.Nullable;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerID;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.xml.TestMapGameData;
+import games.strategy.util.Match;
+
+@RunWith(Enclosed.class)
+public final class MatchesTests {
+  public static final class TerritoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWaterTest {
+    private GameData gameData;
+    private PlayerID player;
+    private PlayerID alliedPlayer;
+    private PlayerID enemyPlayer;
+    private Territory landTerritory;
+    private Territory seaTerritory;
+
+    private Match<Territory> newMatch() {
+      return Matches.territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWater(player, gameData);
+    }
+
+    private Unit newAirUnitFor(final PlayerID player) {
+      return GameDataTestUtil.fighter(gameData).create(player);
+    }
+
+    private Unit newInfrastructureUnitFor(final PlayerID player) {
+      return GameDataTestUtil.aaGun(gameData).create(player);
+    }
+
+    private Unit newLandUnitFor(final PlayerID player) {
+      return GameDataTestUtil.infantry(gameData).create(player);
+    }
+
+    private Unit newSeaUnitFor(final PlayerID player) {
+      return GameDataTestUtil.battleship(gameData).create(player);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+      gameData = TestMapGameData.DELEGATE_TEST.getGameData();
+
+      player = GameDataTestUtil.germans(gameData);
+      alliedPlayer = GameDataTestUtil.japanese(gameData);
+      assertThat(gameData.getRelationshipTracker().isAtWar(player, alliedPlayer), is(false));
+      enemyPlayer = GameDataTestUtil.russians(gameData);
+      assertThat(gameData.getRelationshipTracker().isAtWar(player, enemyPlayer), is(true));
+
+      landTerritory = gameData.getMap().getTerritory("Germany");
+      landTerritory.setOwner(player);
+      landTerritory.getUnits().clear();
+
+      seaTerritory = gameData.getMap().getTerritory("Baltic Sea Zone");
+      seaTerritory.setOwner(player);
+      seaTerritory.getUnits().clear();
+    }
+
+    @Ignore("territory owner cannot be set to null")
+    @Test
+    public void shouldNotMatchWhenTerritoryOwnerIsNull() {
+      landTerritory.setOwner(null);
+      landTerritory.getUnits().add(newLandUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), notMatches(landTerritory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenLandTerritoryContainsOnlyAlliedLandUnits() {
+      landTerritory.getUnits().add(newLandUnitFor(alliedPlayer));
+
+      assertThat(newMatch(), notMatches(landTerritory));
+    }
+
+    @Test
+    public void shouldMatchWhenLandTerritoryContainsEnemyLandUnits() {
+      landTerritory.getUnits().add(newLandUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), matches(landTerritory));
+    }
+
+    @Test
+    public void shouldMatchWhenLandTerritoryContainsEnemyLandUnitsAndIsUnowned() {
+      landTerritory.setOwner(PlayerID.NULL_PLAYERID);
+      TerritoryAttachment.remove(landTerritory);
+      landTerritory.getUnits().add(newLandUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), matches(landTerritory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenLandTerritoryContainsOnlyEnemyAirUnits() {
+      landTerritory.getUnits().add(newAirUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), notMatches(landTerritory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenLandTerritoryContainsOnlyEnemyInfrastructureUnits() {
+      landTerritory.getUnits().add(newInfrastructureUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), notMatches(landTerritory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenSeaTerritoryContainsOnlyAlliedSeaUnits() {
+      seaTerritory.getUnits().add(newSeaUnitFor(alliedPlayer));
+
+      assertThat(newMatch(), notMatches(seaTerritory));
+    }
+
+    @Test
+    public void shouldMatchWhenSeaTerritoryContainsEnemySeaUnits() {
+      seaTerritory.getUnits().add(newSeaUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), matches(seaTerritory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenSeaTerritoryContainsEnemySeaUnitsAndIsUnowned() {
+      seaTerritory.setOwner(PlayerID.NULL_PLAYERID);
+      TerritoryAttachment.remove(seaTerritory);
+      seaTerritory.getUnits().add(newSeaUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), notMatches(seaTerritory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenSeaTerritoryContainsOnlyEnemyAirUnits() {
+      seaTerritory.getUnits().add(newAirUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), notMatches(seaTerritory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenSeaTerritoryContainsOnlyEnemyInfrastructureUnits() {
+      seaTerritory.getUnits().add(newInfrastructureUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), notMatches(seaTerritory));
+    }
+  }
+
+  private static <T> Matcher<Match<T>> matches(final @Nullable T value) {
+    return new IsMatch<>(value);
+  }
+
+  private static final class IsMatch<T> extends TypeSafeDiagnosingMatcher<Match<T>> {
+    private final @Nullable T value;
+
+    private IsMatch(final @Nullable T value) {
+      this.value = value;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+      description.appendText("matcher matches using ").appendValue(value);
+    }
+
+    @Override
+    public boolean matchesSafely(final Match<T> match, final Description description) {
+      if (!match.match(value)) {
+        description.appendText("it does not match");
+        return false;
+      }
+      return true;
+    }
+  }
+
+  private static <T> Matcher<Match<T>> notMatches(final @Nullable T value) {
+    return new IsNotMatch<>(value);
+  }
+
+  private static final class IsNotMatch<T> extends TypeSafeDiagnosingMatcher<Match<T>> {
+    private final @Nullable T value;
+
+    private IsNotMatch(final @Nullable T value) {
+      this.value = value;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+      description.appendText("matcher does not match using ").appendValue(value);
+    }
+
+    @Override
+    public boolean matchesSafely(final Match<T> match, final Description description) {
+      if (match.match(value)) {
+        description.appendText("it matches");
+        return false;
+      }
+      return true;
+    }
+  }
+}

--- a/src/test/java/games/strategy/triplea/delegate/MatchesTests.java
+++ b/src/test/java/games/strategy/triplea/delegate/MatchesTests.java
@@ -9,7 +9,6 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
@@ -69,15 +68,6 @@ public final class MatchesTests {
       seaTerritory = gameData.getMap().getTerritory("Baltic Sea Zone");
       seaTerritory.setOwner(player);
       seaTerritory.getUnits().clear();
-    }
-
-    @Ignore("territory owner cannot be set to null")
-    @Test
-    public void shouldNotMatchWhenTerritoryOwnerIsNull() {
-      landTerritory.setOwner(null);
-      landTerritory.getUnits().add(newLandUnitFor(enemyPlayer));
-
-      assertThat(newMatch(), notMatches(landTerritory));
     }
 
     @Test

--- a/src/test/java/games/strategy/triplea/delegate/MatchesTests.java
+++ b/src/test/java/games/strategy/triplea/delegate/MatchesTests.java
@@ -23,6 +23,42 @@ import games.strategy.util.Match;
 
 @RunWith(Enclosed.class)
 public final class MatchesTests {
+  private static <T> Matcher<Match<T>> matches(final @Nullable T value) {
+    return new TypeSafeDiagnosingMatcher<Match<T>>() {
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText("matcher matches using ").appendValue(value);
+      }
+
+      @Override
+      public boolean matchesSafely(final Match<T> match, final Description description) {
+        if (!match.match(value)) {
+          description.appendText("it does not match");
+          return false;
+        }
+        return true;
+      }
+    };
+  }
+
+  private static <T> Matcher<Match<T>> notMatches(final @Nullable T value) {
+    return new TypeSafeDiagnosingMatcher<Match<T>>() {
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText("matcher does not match using ").appendValue(value);
+      }
+
+      @Override
+      public boolean matchesSafely(final Match<T> match, final Description description) {
+        if (match.match(value)) {
+          description.appendText("it matches");
+          return false;
+        }
+        return true;
+      }
+    };
+  }
+
   public static final class TerritoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyAndIsNotUnownedWaterTest {
     private GameData gameData;
     private PlayerID player;
@@ -78,7 +114,7 @@ public final class MatchesTests {
     }
 
     @Test
-    public void shouldMatchWhenLandTerritoryContainsEnemyLandUnits() {
+    public void shouldMatchWhenLandTerritoryContainsOnlyEnemyLandUnits() {
       landTerritory.getUnits().add(newLandUnitFor(enemyPlayer));
 
       assertThat(newMatch(), matches(landTerritory));
@@ -115,7 +151,7 @@ public final class MatchesTests {
     }
 
     @Test
-    public void shouldMatchWhenSeaTerritoryContainsEnemySeaUnits() {
+    public void shouldMatchWhenSeaTerritoryContainsOnlyEnemySeaUnits() {
       seaTerritory.getUnits().add(newSeaUnitFor(enemyPlayer));
 
       assertThat(newMatch(), matches(seaTerritory));
@@ -145,55 +181,121 @@ public final class MatchesTests {
     }
   }
 
-  private static <T> Matcher<Match<T>> matches(final @Nullable T value) {
-    return new IsMatch<>(value);
+  public static final class TerritoryIsNotUnownedWaterTest {
+    private GameData gameData;
+    private PlayerID player;
+    private Territory landTerritory;
+    private Territory seaTerritory;
+
+    private static Match<Territory> newMatch() {
+      return Matches.territoryIsNotUnownedWater();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+      gameData = TestMapGameData.DELEGATE_TEST.getGameData();
+
+      player = GameDataTestUtil.germans(gameData);
+
+      landTerritory = gameData.getMap().getTerritory("Germany");
+      seaTerritory = gameData.getMap().getTerritory("Baltic Sea Zone");
+    }
+
+    @Test
+    public void shouldMatchWhenLandTerritoryIsOwned() {
+      landTerritory.setOwner(player);
+
+      assertThat(newMatch(), matches(landTerritory));
+    }
+
+    @Test
+    public void shouldMatchWhenLandTerritoryIsUnowned() {
+      landTerritory.setOwner(PlayerID.NULL_PLAYERID);
+      TerritoryAttachment.remove(landTerritory);
+
+      assertThat(newMatch(), matches(landTerritory));
+    }
+
+    @Test
+    public void shouldMatchWhenSeaTerritoryIsOwned() {
+      seaTerritory.setOwner(player);
+
+      assertThat(newMatch(), matches(seaTerritory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenSeaTerritoryIsUnowned() {
+      seaTerritory.setOwner(PlayerID.NULL_PLAYERID);
+      TerritoryAttachment.remove(seaTerritory);
+
+      assertThat(newMatch(), notMatches(seaTerritory));
+    }
   }
 
-  private static final class IsMatch<T> extends TypeSafeDiagnosingMatcher<Match<T>> {
-    private final @Nullable T value;
+  public static final class TerritoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemyTest {
+    private GameData gameData;
+    private PlayerID player;
+    private PlayerID alliedPlayer;
+    private PlayerID enemyPlayer;
+    private Territory territory;
 
-    private IsMatch(final @Nullable T value) {
-      this.value = value;
+    private Match<Territory> newMatch() {
+      return Matches.territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemy(player, gameData);
     }
 
-    @Override
-    public void describeTo(final Description description) {
-      description.appendText("matcher matches using ").appendValue(value);
+    private Unit newAirUnitFor(final PlayerID player) {
+      return GameDataTestUtil.fighter(gameData).create(player);
     }
 
-    @Override
-    public boolean matchesSafely(final Match<T> match, final Description description) {
-      if (!match.match(value)) {
-        description.appendText("it does not match");
-        return false;
-      }
-      return true;
-    }
-  }
-
-  private static <T> Matcher<Match<T>> notMatches(final @Nullable T value) {
-    return new IsNotMatch<>(value);
-  }
-
-  private static final class IsNotMatch<T> extends TypeSafeDiagnosingMatcher<Match<T>> {
-    private final @Nullable T value;
-
-    private IsNotMatch(final @Nullable T value) {
-      this.value = value;
+    private Unit newInfrastructureUnitFor(final PlayerID player) {
+      return GameDataTestUtil.aaGun(gameData).create(player);
     }
 
-    @Override
-    public void describeTo(final Description description) {
-      description.appendText("matcher does not match using ").appendValue(value);
+    private Unit newLandUnitFor(final PlayerID player) {
+      return GameDataTestUtil.infantry(gameData).create(player);
     }
 
-    @Override
-    public boolean matchesSafely(final Match<T> match, final Description description) {
-      if (match.match(value)) {
-        description.appendText("it matches");
-        return false;
-      }
-      return true;
+    @Before
+    public void setUp() throws Exception {
+      gameData = TestMapGameData.DELEGATE_TEST.getGameData();
+
+      player = GameDataTestUtil.germans(gameData);
+      alliedPlayer = GameDataTestUtil.japanese(gameData);
+      assertThat(gameData.getRelationshipTracker().isAtWar(player, alliedPlayer), is(false));
+      enemyPlayer = GameDataTestUtil.russians(gameData);
+      assertThat(gameData.getRelationshipTracker().isAtWar(player, enemyPlayer), is(true));
+
+      territory = gameData.getMap().getTerritory("Germany");
+      territory.setOwner(player);
+      territory.getUnits().clear();
+    }
+
+    @Test
+    public void shouldNotMatchWhenTerritoryContainsOnlyAlliedLandUnits() {
+      territory.getUnits().add(newLandUnitFor(alliedPlayer));
+
+      assertThat(newMatch(), notMatches(territory));
+    }
+
+    @Test
+    public void shouldMatchWhenTerritoryContainsOnlyEnemyLandUnits() {
+      territory.getUnits().add(newLandUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), matches(territory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenTerritoryContainsOnlyEnemyAirUnits() {
+      territory.getUnits().add(newAirUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), notMatches(territory));
+    }
+
+    @Test
+    public void shouldNotMatchWhenTerritoryContainsOnlyEnemyInfrastructureUnits() {
+      territory.getUnits().add(newInfrastructureUnitFor(enemyPlayer));
+
+      assertThat(newMatch(), notMatches(territory));
     }
   }
 }


### PR DESCRIPTION
This PR fixes a single violation of the Checkstyle LineLength rule in the `Matches` class.