### PR TITLE
Serialization proxy: Add proxy for RepairFrontier

### DIFF
--- a/src/main/java/games/strategy/engine/data/ProductionFrontier.java
+++ b/src/main/java/games/strategy/engine/data/ProductionFrontier.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -7,19 +9,19 @@ import java.util.List;
 
 public class ProductionFrontier extends DefaultNamed implements Iterable<ProductionRule> {
   private static final long serialVersionUID = -5967251608158552892L;
-  private final List<ProductionRule> m_rules = new ArrayList<>();
+  private final List<ProductionRule> m_rules;
   private List<ProductionRule> m_cachedRules;
 
-  /**
-   * Creates new ProductionFrontier.
-   *
-   * @param name
-   *        name of production frontier
-   * @param data
-   *        game data
-   */
   public ProductionFrontier(final String name, final GameData data) {
+    this(name, data, Collections.emptyList());
+  }
+
+  public ProductionFrontier(final String name, final GameData data, final List<ProductionRule> rules) {
     super(name, data);
+
+    checkNotNull(rules);
+
+    m_rules = new ArrayList<>(rules);
   }
 
   public void addRule(final ProductionRule rule) {

--- a/src/main/java/games/strategy/engine/data/RepairFrontier.java
+++ b/src/main/java/games/strategy/engine/data/RepairFrontier.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -7,19 +9,19 @@ import java.util.List;
 
 public class RepairFrontier extends DefaultNamed implements Iterable<RepairRule> {
   private static final long serialVersionUID = -5148536624986056753L;
-  private final List<RepairRule> m_rules = new ArrayList<>();
+  private final List<RepairRule> m_rules;
   private List<RepairRule> m_cachedRules;
 
-  /**
-   * Creates new RepairFrontier.
-   *
-   * @param name
-   *        name of new repair frontier
-   * @param data
-   *        game data
-   */
   public RepairFrontier(final String name, final GameData data) {
+    this(name, data, Collections.emptyList());
+  }
+
+  public RepairFrontier(final String name, final GameData data, final List<RepairRule> rules) {
     super(name, data);
+
+    checkNotNull(rules);
+
+    m_rules = new ArrayList<>(rules);
   }
 
   void addRule(final RepairRule rule) {

--- a/src/main/java/games/strategy/engine/data/RepairRule.java
+++ b/src/main/java/games/strategy/engine/data/RepairRule.java
@@ -1,15 +1,30 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import games.strategy.util.IntegerMap;
 
 public class RepairRule extends DefaultNamed {
   private static final long serialVersionUID = -45646671022993959L;
-  private final IntegerMap<Resource> m_cost = new IntegerMap<>();
-  private final IntegerMap<NamedAttachable> m_results = new IntegerMap<>();
+  private final IntegerMap<Resource> m_cost;
+  private final IntegerMap<NamedAttachable> m_results;
 
-  /** Creates new RepairRule. */
   public RepairRule(final String name, final GameData data) {
+    this(name, data, new IntegerMap<>(), new IntegerMap<>());
+  }
+
+  public RepairRule(
+      final String name,
+      final GameData data,
+      final IntegerMap<NamedAttachable> results,
+      final IntegerMap<Resource> costs) {
     super(name, data);
+
+    checkNotNull(results);
+    checkNotNull(costs);
+
+    m_cost = costs.copy();
+    m_results = results.copy();
   }
 
   protected void addCost(final Resource resource, final int quantity) {

--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -5,6 +5,7 @@ import games.strategy.internal.persistence.serializable.IntegerMapProxy;
 import games.strategy.internal.persistence.serializable.ProductionFrontierProxy;
 import games.strategy.internal.persistence.serializable.ProductionRuleProxy;
 import games.strategy.internal.persistence.serializable.PropertyBagMementoProxy;
+import games.strategy.internal.persistence.serializable.RepairFrontierProxy;
 import games.strategy.internal.persistence.serializable.RepairRuleProxy;
 import games.strategy.internal.persistence.serializable.ResourceCollectionProxy;
 import games.strategy.internal.persistence.serializable.ResourceProxy;
@@ -27,6 +28,7 @@ final class ProxyRegistries {
         ProductionFrontierProxy.FACTORY,
         ProductionRuleProxy.FACTORY,
         PropertyBagMementoProxy.FACTORY,
+        RepairFrontierProxy.FACTORY,
         RepairRuleProxy.FACTORY,
         ResourceProxy.FACTORY,
         ResourceCollectionProxy.FACTORY,

--- a/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
+++ b/src/main/java/games/strategy/engine/framework/ProxyRegistries.java
@@ -5,6 +5,7 @@ import games.strategy.internal.persistence.serializable.IntegerMapProxy;
 import games.strategy.internal.persistence.serializable.ProductionFrontierProxy;
 import games.strategy.internal.persistence.serializable.ProductionRuleProxy;
 import games.strategy.internal.persistence.serializable.PropertyBagMementoProxy;
+import games.strategy.internal.persistence.serializable.RepairRuleProxy;
 import games.strategy.internal.persistence.serializable.ResourceCollectionProxy;
 import games.strategy.internal.persistence.serializable.ResourceProxy;
 import games.strategy.internal.persistence.serializable.TripleAProxy;
@@ -26,6 +27,7 @@ final class ProxyRegistries {
         ProductionFrontierProxy.FACTORY,
         ProductionRuleProxy.FACTORY,
         PropertyBagMementoProxy.FACTORY,
+        RepairRuleProxy.FACTORY,
         ResourceProxy.FACTORY,
         ResourceCollectionProxy.FACTORY,
         TripleAProxy.FACTORY,

--- a/src/main/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxy.java
@@ -36,8 +36,6 @@ public final class ProductionFrontierProxy implements Proxy {
 
   @Override
   public Object readResolve() {
-    final ProductionFrontier productionFrontier = new ProductionFrontier(name, gameData);
-    rules.forEach(productionFrontier::addRule);
-    return productionFrontier;
+    return new ProductionFrontier(name, gameData, rules);
   }
 }

--- a/src/main/java/games/strategy/internal/persistence/serializable/RepairFrontierProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/RepairFrontierProxy.java
@@ -1,0 +1,40 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.List;
+
+import javax.annotation.concurrent.Immutable;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.RepairFrontier;
+import games.strategy.engine.data.RepairRule;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+
+/**
+ * A serializable proxy for the {@link RepairFrontier} class.
+ */
+@Immutable
+public final class RepairFrontierProxy implements Proxy {
+  private static final long serialVersionUID = -2983755741123633255L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(RepairFrontier.class, RepairFrontierProxy::new);
+
+  private final GameData gameData;
+  private final String name;
+  private final List<RepairRule> rules;
+
+  public RepairFrontierProxy(final RepairFrontier repairFrontier) {
+    checkNotNull(repairFrontier);
+
+    gameData = repairFrontier.getData();
+    name = repairFrontier.getName();
+    rules = repairFrontier.getRules();
+  }
+
+  @Override
+  public Object readResolve() {
+    return new RepairFrontier(name, gameData, rules);
+  }
+}

--- a/src/main/java/games/strategy/internal/persistence/serializable/RepairRuleProxy.java
+++ b/src/main/java/games/strategy/internal/persistence/serializable/RepairRuleProxy.java
@@ -1,0 +1,42 @@
+package games.strategy.internal.persistence.serializable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.annotation.concurrent.Immutable;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.NamedAttachable;
+import games.strategy.engine.data.RepairRule;
+import games.strategy.engine.data.Resource;
+import games.strategy.persistence.serializable.Proxy;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.util.IntegerMap;
+
+/**
+ * A serializable proxy for the {@link RepairRule} class.
+ */
+@Immutable
+public final class RepairRuleProxy implements Proxy {
+  private static final long serialVersionUID = 8614634243250168588L;
+
+  public static final ProxyFactory FACTORY = ProxyFactory.newInstance(RepairRule.class, RepairRuleProxy::new);
+
+  private final IntegerMap<Resource> costs;
+  private final GameData gameData;
+  private final String name;
+  private final IntegerMap<NamedAttachable> results;
+
+  public RepairRuleProxy(final RepairRule repairRule) {
+    checkNotNull(repairRule);
+
+    costs = repairRule.getCosts();
+    gameData = repairRule.getData();
+    name = repairRule.getName();
+    results = repairRule.getResults();
+  }
+
+  @Override
+  public Object readResolve() {
+    return new RepairRule(name, gameData, results, costs);
+  }
+}

--- a/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
+++ b/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
@@ -32,6 +32,13 @@ public final class EngineDataEqualityComparators {
           && context.equals(o1.getCosts(), o2.getCosts())
           && context.equals(o1.getResults(), o2.getResults()));
 
+  public static final EqualityComparator REPAIR_RULE = EqualityComparator.newInstance(
+      RepairRule.class,
+      (context, o1, o2) -> context.equals(o1.getData(), o2.getData())
+          && context.equals(o1.getName(), o2.getName())
+          && context.equals(o1.getCosts(), o2.getCosts())
+          && context.equals(o1.getResults(), o2.getResults()));
+
   public static final EqualityComparator RESOURCE = EqualityComparator.newInstance(
       Resource.class,
       (context, o1, o2) -> context.equals(o1.getAttachments(), o2.getAttachments())

--- a/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
+++ b/src/test/java/games/strategy/engine/data/EngineDataEqualityComparators.java
@@ -32,6 +32,12 @@ public final class EngineDataEqualityComparators {
           && context.equals(o1.getCosts(), o2.getCosts())
           && context.equals(o1.getResults(), o2.getResults()));
 
+  public static final EqualityComparator REPAIR_FRONTIER = EqualityComparator.newInstance(
+      RepairFrontier.class,
+      (context, o1, o2) -> context.equals(o1.getData(), o2.getData())
+          && context.equals(o1.getName(), o2.getName())
+          && context.equals(o1.getRules(), o2.getRules()));
+
   public static final EqualityComparator REPAIR_RULE = EqualityComparator.newInstance(
       RepairRule.class,
       (context, o1, o2) -> context.equals(o1.getData(), o2.getData())

--- a/src/test/java/games/strategy/engine/data/TestGameDataComponentFactory.java
+++ b/src/test/java/games/strategy/engine/data/TestGameDataComponentFactory.java
@@ -22,13 +22,34 @@ public final class TestGameDataComponentFactory {
     checkNotNull(gameData);
     checkNotNull(name);
 
-    final IntegerMap<NamedAttachable> resources = new IntegerMap<>();
-    resources.add(newResource(gameData, "resource1"), 11);
-    resources.add(newResource(gameData, "resource2"), 22);
+    final IntegerMap<NamedAttachable> results = new IntegerMap<>();
+    results.add(newResource(gameData, "resource1"), 11);
+    results.add(newResource(gameData, "resource2"), 22);
     final IntegerMap<Resource> costs = new IntegerMap<>();
     costs.add(newResource(gameData, "resource3"), 33);
     costs.add(newResource(gameData, "resource4"), 44);
-    return new ProductionRule(name, gameData, resources, costs);
+    return new ProductionRule(name, gameData, results, costs);
+  }
+
+  /**
+   * Creates a new {@link RepairRule} instance.
+   *
+   * @param gameData The game data associated with the repair rule.
+   * @param name The repair rule name.
+   *
+   * @return A new {@link RepairRule} instance.
+   */
+  public static RepairRule newRepairRule(final GameData gameData, final String name) {
+    checkNotNull(gameData);
+    checkNotNull(name);
+
+    final IntegerMap<NamedAttachable> results = new IntegerMap<>();
+    results.add(newResource(gameData, "resource1"), 11);
+    results.add(newResource(gameData, "resource2"), 22);
+    final IntegerMap<Resource> costs = new IntegerMap<>();
+    costs.add(newResource(gameData, "resource3"), 33);
+    costs.add(newResource(gameData, "resource4"), 44);
+    return new RepairRule("repairRule", gameData, results, costs);
   }
 
   /**

--- a/src/test/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/ProductionFrontierProxyAsProxyTest.java
@@ -26,10 +26,9 @@ public final class ProductionFrontierProxyAsProxyTest extends AbstractProxyTestC
 
   private static ProductionFrontier newProductionFrontier() {
     final GameData gameData = TestGameDataFactory.newValidGameData();
-    final ProductionFrontier productionFrontier = new ProductionFrontier("productionFrontier", gameData);
-    productionFrontier.addRule(TestGameDataComponentFactory.newProductionRule(gameData, "productionRule1"));
-    productionFrontier.addRule(TestGameDataComponentFactory.newProductionRule(gameData, "productionRule2"));
-    return productionFrontier;
+    return new ProductionFrontier("productionFrontier", gameData, Arrays.asList(
+        TestGameDataComponentFactory.newProductionRule(gameData, "productionRule1"),
+        TestGameDataComponentFactory.newProductionRule(gameData, "productionRule2")));
   }
 
   @Override

--- a/src/test/java/games/strategy/internal/persistence/serializable/RepairFrontierProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/RepairFrontierProxyAsProxyTest.java
@@ -1,0 +1,53 @@
+package games.strategy.internal.persistence.serializable;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.engine.data.EngineDataEqualityComparators;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.RepairFrontier;
+import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
+import games.strategy.engine.data.TestGameDataComponentFactory;
+import games.strategy.engine.data.TestGameDataFactory;
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
+import games.strategy.util.CoreEqualityComparators;
+
+public final class RepairFrontierProxyAsProxyTest extends AbstractProxyTestCase<RepairFrontier> {
+  public RepairFrontierProxyAsProxyTest() {
+    super(RepairFrontier.class);
+  }
+
+  @Override
+  protected Collection<RepairFrontier> createPrincipals() {
+    return Arrays.asList(newRepairFrontier());
+  }
+
+  private static RepairFrontier newRepairFrontier() {
+    final GameData gameData = TestGameDataFactory.newValidGameData();
+    return new RepairFrontier("repairFrontier", gameData, Arrays.asList(
+        TestGameDataComponentFactory.newRepairRule(gameData, "repairRule1"),
+        TestGameDataComponentFactory.newRepairRule(gameData, "repairRule2")));
+  }
+
+  @Override
+  protected Collection<EqualityComparator> getEqualityComparators() {
+    return TestEqualityComparatorCollectionBuilder.forGameData()
+        .add(CoreEqualityComparators.INTEGER_MAP)
+        .add(EngineDataEqualityComparators.REPAIR_FRONTIER)
+        .add(EngineDataEqualityComparators.REPAIR_RULE)
+        .add(EngineDataEqualityComparators.RESOURCE)
+        .build();
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getProxyFactories() {
+    return TestProxyFactoryCollectionBuilder.forGameData()
+        .add(IntegerMapProxy.FACTORY)
+        .add(RepairFrontierProxy.FACTORY)
+        .add(RepairRuleProxy.FACTORY)
+        .add(ResourceProxy.FACTORY)
+        .build();
+  }
+}

--- a/src/test/java/games/strategy/internal/persistence/serializable/RepairRuleProxyAsProxyTest.java
+++ b/src/test/java/games/strategy/internal/persistence/serializable/RepairRuleProxyAsProxyTest.java
@@ -1,0 +1,45 @@
+package games.strategy.internal.persistence.serializable;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import games.strategy.engine.data.EngineDataEqualityComparators;
+import games.strategy.engine.data.RepairRule;
+import games.strategy.engine.data.TestEqualityComparatorCollectionBuilder;
+import games.strategy.engine.data.TestGameDataComponentFactory;
+import games.strategy.engine.data.TestGameDataFactory;
+import games.strategy.persistence.serializable.AbstractProxyTestCase;
+import games.strategy.persistence.serializable.ProxyFactory;
+import games.strategy.test.EqualityComparator;
+import games.strategy.util.CoreEqualityComparators;
+
+public final class RepairRuleProxyAsProxyTest extends AbstractProxyTestCase<RepairRule> {
+  public RepairRuleProxyAsProxyTest() {
+    super(RepairRule.class);
+  }
+
+  @Override
+  protected Collection<RepairRule> createPrincipals() {
+    return Arrays.asList(TestGameDataComponentFactory.newRepairRule(
+        TestGameDataFactory.newValidGameData(),
+        "repairRule"));
+  }
+
+  @Override
+  protected Collection<EqualityComparator> getEqualityComparators() {
+    return TestEqualityComparatorCollectionBuilder.forGameData()
+        .add(CoreEqualityComparators.INTEGER_MAP)
+        .add(EngineDataEqualityComparators.REPAIR_RULE)
+        .add(EngineDataEqualityComparators.RESOURCE)
+        .build();
+  }
+
+  @Override
+  protected Collection<ProxyFactory> getProxyFactories() {
+    return TestProxyFactoryCollectionBuilder.forGameData()
+        .add(IntegerMapProxy.FACTORY)
+        .add(RepairRuleProxy.FACTORY)
+        .add(ResourceProxy.FACTORY)
+        .build();
+  }
+}


### PR DESCRIPTION
This PR adds a serialization proxy for `RepairFrontier` and its dependency `RepairRule`.

I also refactored the proxy-related stuff for `ProductionFrontier` from the last PR a bit.  I added a new constructor to allow the specification of all fields at the time of creation.  This is the pattern many other `GameDataComponent`s follow because they restrict the visibility of methods that mutate state so that they can only be called by `GameParser`.  For some reason, `ProductionFrontier` had these methods as public, and I just used them.  The change in this PR makes the usage of the `ProductionFrontier` proxy consistent with the other `GameDataComponent` proxies.