### PR TITLE
Use try-with-resources instead of explicitly closing resources

### DIFF
--- a/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -40,10 +40,9 @@ public class GameDataUtils {
   public static <T> T translateIntoOtherGameData(final T object, final GameData translateInto) {
     try {
       ByteArrayOutputStream sink = new ByteArrayOutputStream(1024);
-      final GameObjectOutputStream out = new GameObjectOutputStream(sink);
-      out.writeObject(object);
-      out.flush();
-      out.close();
+      try (final GameObjectOutputStream out = new GameObjectOutputStream(sink)) {
+        out.writeObject(object);
+      }
       final ByteArrayInputStream source = new ByteArrayInputStream(sink.toByteArray());
       sink = null;
       final GameObjectStreamFactory factory = new GameObjectStreamFactory(translateInto);

--- a/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -322,8 +322,6 @@ public class ServerLauncher extends AbstractLauncher {
   private static byte[] gameDataToBytes(final GameData data) throws IOException {
     final ByteArrayOutputStream sink = new ByteArrayOutputStream(25000);
     GameDataManager.saveGame(sink, data);
-    sink.flush();
-    sink.close();
     return sink.toByteArray();
   }
 

--- a/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/FileBackedGamePropertiesCache.java
@@ -46,9 +46,9 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
       if (!cache.getParentFile().exists()) {
         cache.getParentFile().mkdirs();
       }
-      final ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(cache));
-      out.writeObject(serializableMap);
-      out.close();
+      try (final ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(cache))) {
+        out.writeObject(serializableMap);
+      }
     } catch (final IOException e) {
       ClientLogger.logQuietly(e);
     }
@@ -67,15 +67,15 @@ public class FileBackedGamePropertiesCache implements IGamePropertiesCache {
     final File cache = getCacheFile(gameData);
     try {
       if (cache.exists()) {
-        final ObjectInputStream in = new ObjectInputStream(new FileInputStream(cache));
-        final Map<String, Serializable> serializedMap = (Map<String, Serializable>) in.readObject();
-        for (final IEditableProperty property : gameData.getProperties().getEditableProperties()) {
-          final Serializable ser = serializedMap.get(property.getName());
-          if (ser != null) {
-            property.setValue(ser);
+        try (final ObjectInputStream in = new ObjectInputStream(new FileInputStream(cache))) {
+          final Map<String, Serializable> serializedMap = (Map<String, Serializable>) in.readObject();
+          for (final IEditableProperty property : gameData.getProperties().getEditableProperties()) {
+            final Serializable ser = serializedMap.get(property.getName());
+            if (ser != null) {
+              property.setValue(ser);
+            }
           }
         }
-        in.close();
       }
     } catch (IOException | ClassNotFoundException e) {
       ClientLogger.logQuietly(e);

--- a/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
+++ b/src/main/java/games/strategy/engine/framework/startup/ui/editors/EmailSenderEditor.java
@@ -156,9 +156,9 @@ public class EmailSenderEditor extends EditorPanel {
         final String html = "<html><body><h1>Success</h1><p>This was a test email sent by TripleA<p></body></html>";
         final File dummy = new File(ClientFileSystemHelper.getUserRootFolder(), "dummySave.txt");
         dummy.deleteOnExit();
-        final FileOutputStream fout = new FileOutputStream(dummy);
-        fout.write("This file would normally be a save game".getBytes());
-        fout.close();
+        try (final FileOutputStream fout = new FileOutputStream(dummy)) {
+          fout.write("This file would normally be a save game".getBytes());
+        }
         ((IEmailSender) getBean()).sendEmail("TripleA Test", html, dummy, "dummy.txt");
         // email was sent, or an exception would have been thrown
         message = "Email sent, it should arrive shortly, otherwise check your spam folder";

--- a/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/LobbyGameController.java
@@ -123,10 +123,8 @@ class LobbyGameController implements ILobbyGameController {
     final int port = description.getPort();
     final String host = description.getHostedBy().getAddress().getHostAddress();
     logger.fine("Testing game connection on host:" + host + " port:" + port);
-    final Socket s = new Socket();
-    try {
+    try (final Socket s = new Socket()) {
       s.connect(new InetSocketAddress(host, port), 10 * 1000);
-      s.close();
       logger.fine("Connection test passed for host:" + host + " port:" + port);
       return null;
     } catch (final IOException e) {

--- a/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BadWordController.java
@@ -18,10 +18,10 @@ public class BadWordController {
     logger.fine("Adding bad word word:" + word);
     final Connection con = Database.getDerbyConnection();
     try {
-      final PreparedStatement ps = con.prepareStatement("insert into bad_words (word) values (?)");
-      ps.setString(1, word);
-      ps.execute();
-      ps.close();
+      try (final PreparedStatement ps = con.prepareStatement("insert into bad_words (word) values (?)")) {
+        ps.setString(1, word);
+        ps.execute();
+      }
       con.commit();
     } catch (final SQLException sqle) {
       if (sqle.getErrorCode() == 30000) {
@@ -40,10 +40,10 @@ public class BadWordController {
     logger.fine("Removing banned word:" + word);
     final Connection con = Database.getDerbyConnection();
     try {
-      final PreparedStatement ps = con.prepareStatement("delete from bad_words where word = ?");
-      ps.setString(1, word);
-      ps.execute();
-      ps.close();
+      try (final PreparedStatement ps = con.prepareStatement("delete from bad_words where word = ?")) {
+        ps.setString(1, word);
+        ps.execute();
+      }
       con.commit();
     } catch (final SQLException sqle) {
       throw new IllegalStateException("Error deleting banned word:" + word, sqle);
@@ -56,15 +56,14 @@ public class BadWordController {
     final String sql = "select word from bad_words";
     final Connection con = Database.getDerbyConnection();
     try {
-      final PreparedStatement ps = con.prepareStatement(sql);
-      final ResultSet rs = ps.executeQuery();
-      final List<String> rVal = new ArrayList<>();
-      while (rs.next()) {
-        rVal.add(rs.getString(1));
+      try (final PreparedStatement ps = con.prepareStatement(sql);
+          final ResultSet rs = ps.executeQuery()) {
+        final List<String> rVal = new ArrayList<>();
+        while (rs.next()) {
+          rVal.add(rs.getString(1));
+        }
+        return rVal;
       }
-      rs.close();
-      ps.close();
-      return rVal;
     } catch (final SQLException sqle) {
       throw new IllegalStateException("Error reading bad words", sqle);
     } finally {

--- a/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/BannedUsernameController.java
@@ -41,12 +41,12 @@ public class BannedUsernameController {
     logger.fine("Banning username:" + username);
     final Connection con = Database.getDerbyConnection();
     try {
-      final PreparedStatement ps =
-          con.prepareStatement("insert into banned_usernames (username, ban_till) values (?, ?)");
-      ps.setString(1, username);
-      ps.setTimestamp(2, banTillTs);
-      ps.execute();
-      ps.close();
+      try (final PreparedStatement ps =
+          con.prepareStatement("insert into banned_usernames (username, ban_till) values (?, ?)")) {
+        ps.setString(1, username);
+        ps.setTimestamp(2, banTillTs);
+        ps.execute();
+      }
       con.commit();
     } catch (final SQLException sqle) {
       if (sqle.getErrorCode() == 30000) {
@@ -65,10 +65,10 @@ public class BannedUsernameController {
     logger.fine("Removing banned username:" + username);
     final Connection con = Database.getDerbyConnection();
     try {
-      final PreparedStatement ps = con.prepareStatement("delete from banned_usernames where username = ?");
-      ps.setString(1, username);
-      ps.execute();
-      ps.close();
+      try (final PreparedStatement ps = con.prepareStatement("delete from banned_usernames where username = ?")) {
+        ps.setString(1, username);
+        ps.execute();
+      }
       con.commit();
     } catch (final SQLException sqle) {
       throw new IllegalStateException("Error deleting banned username:" + username, sqle);
@@ -88,20 +88,20 @@ public class BannedUsernameController {
     final String sql = "select username, ban_till from banned_usernames where username = ?";
     final Connection con = Database.getDerbyConnection();
     try {
-      final PreparedStatement ps = con.prepareStatement(sql);
-      ps.setString(1, username);
-      final ResultSet rs = ps.executeQuery();
-      found = rs.next();
-      // If the ban has expired, allow the username
-      if (found) {
-        banTill = rs.getTimestamp(2);
-        if (banTill != null && banTill.getTime() < System.currentTimeMillis()) {
-          logger.fine("Ban expired for:" + username);
-          expired = true;
+      try (final PreparedStatement ps = con.prepareStatement(sql)) {
+        ps.setString(1, username);
+        try (final ResultSet rs = ps.executeQuery()) {
+          found = rs.next();
+          // If the ban has expired, allow the username
+          if (found) {
+            banTill = rs.getTimestamp(2);
+            if (banTill != null && banTill.getTime() < System.currentTimeMillis()) {
+              logger.fine("Ban expired for:" + username);
+              expired = true;
+            }
+          }
         }
       }
-      rs.close();
-      ps.close();
     } catch (final SQLException sqle) {
       throw new IllegalStateException("Error for testing banned username existence:" + username, sqle);
     } finally {

--- a/src/main/java/games/strategy/engine/lobby/server/db/Database.java
+++ b/src/main/java/games/strategy/engine/lobby/server/db/Database.java
@@ -114,59 +114,61 @@ public class Database {
         if (areDbTablesCreated) {
           return;
         }
-        final ResultSet rs = conn.getMetaData().getTables(null, null, null, null);
+
         final List<String> existing = new ArrayList<>();
-        while (rs.next()) {
-          existing.add(rs.getString("TABLE_NAME").toUpperCase());
+        try (final ResultSet rs = conn.getMetaData().getTables(null, null, null, null)) {
+          while (rs.next()) {
+            existing.add(rs.getString("TABLE_NAME").toUpperCase());
+          }
         }
-        rs.close();
+
         if (!existing.contains("TA_USERS")) {
-          final Statement s = conn.createStatement();
-          s.execute("create table ta_users" + "(" + "userName varchar(40) NOT NULL PRIMARY KEY, "
-              + "password varchar(40) NOT NULL, " + "email varchar(40) NOT NULL, " + "joined timestamp NOT NULL, "
-              + "lastLogin timestamp NOT NULL, " + "admin integer NOT NULL " + ")");
-          s.close();
+          try (final Statement s = conn.createStatement()) {
+            s.execute("create table ta_users" + "(" + "userName varchar(40) NOT NULL PRIMARY KEY, "
+                + "password varchar(40) NOT NULL, " + "email varchar(40) NOT NULL, " + "joined timestamp NOT NULL, "
+                + "lastLogin timestamp NOT NULL, " + "admin integer NOT NULL " + ")");
+          }
         }
         if (!existing.contains("BANNED_USERNAMES")) {
-          final Statement s = conn.createStatement();
-          s.execute("create table banned_usernames" + "(" + "username varchar(40) NOT NULL PRIMARY KEY, "
-              + "ban_till timestamp  " + ")");
-          s.close();
+          try (final Statement s = conn.createStatement()) {
+            s.execute("create table banned_usernames" + "(" + "username varchar(40) NOT NULL PRIMARY KEY, "
+                + "ban_till timestamp  " + ")");
+          }
         }
         if (!existing.contains("BANNED_IPS")) {
-          final Statement s = conn.createStatement();
-          s.execute(
-              "create table banned_ips" + "(" + "ip varchar(40) NOT NULL PRIMARY KEY, " + "ban_till timestamp  " + ")");
-          s.close();
+          try (final Statement s = conn.createStatement()) {
+            s.execute("create table banned_ips" + "(" + "ip varchar(40) NOT NULL PRIMARY KEY, "
+                + "ban_till timestamp  " + ")");
+          }
         }
         if (!existing.contains("BANNED_MACS")) {
-          final Statement s = conn.createStatement();
-          s.execute("create table banned_macs" + "(" + "mac varchar(40) NOT NULL PRIMARY KEY, " + "ban_till timestamp  "
-              + ")");
-          s.close();
+          try (final Statement s = conn.createStatement()) {
+            s.execute("create table banned_macs" + "(" + "mac varchar(40) NOT NULL PRIMARY KEY, "
+                + "ban_till timestamp  " + ")");
+          }
         }
         if (!existing.contains("MUTED_USERNAMES")) {
-          final Statement s = conn.createStatement();
-          s.execute("create table muted_usernames" + "(" + "username varchar(40) NOT NULL PRIMARY KEY, "
-              + "mute_till timestamp  " + ")");
-          s.close();
+          try (final Statement s = conn.createStatement()) {
+            s.execute("create table muted_usernames" + "(" + "username varchar(40) NOT NULL PRIMARY KEY, "
+                + "mute_till timestamp  " + ")");
+          }
         }
         if (!existing.contains("MUTED_IPS")) {
-          final Statement s = conn.createStatement();
-          s.execute(
-              "create table muted_ips" + "(" + "ip varchar(40) NOT NULL PRIMARY KEY, " + "mute_till timestamp  " + ")");
-          s.close();
+          try (final Statement s = conn.createStatement()) {
+            s.execute("create table muted_ips" + "(" + "ip varchar(40) NOT NULL PRIMARY KEY, "
+                + "mute_till timestamp  " + ")");
+          }
         }
         if (!existing.contains("MUTED_MACS")) {
-          final Statement s = conn.createStatement();
-          s.execute("create table muted_macs" + "(" + "mac varchar(40) NOT NULL PRIMARY KEY, " + "mute_till timestamp  "
-              + ")");
-          s.close();
+          try (final Statement s = conn.createStatement()) {
+            s.execute("create table muted_macs" + "(" + "mac varchar(40) NOT NULL PRIMARY KEY, "
+                + "mute_till timestamp  " + ")");
+          }
         }
         if (!existing.contains("BAD_WORDS")) {
-          final Statement s = conn.createStatement();
-          s.execute("create table bad_words" + "(" + "word varchar(40) NOT NULL PRIMARY KEY " + ")");
-          s.close();
+          try (final Statement s = conn.createStatement()) {
+            s.execute("create table bad_words" + "(" + "word varchar(40) NOT NULL PRIMARY KEY " + ")");
+          }
         }
         areDbTablesCreated = true;
       } catch (final SQLException sqle) {
@@ -238,10 +240,10 @@ public class Database {
     try (final Connection con = getDerbyConnection()) {
       // http://www-128.ibm.com/developerworks/db2/library/techarticle/dm-0502thalamati/
       final String sqlstmt = "CALL SYSCS_UTIL.SYSCS_BACKUP_DATABASE(?)";
-      final CallableStatement cs = con.prepareCall(sqlstmt);
-      cs.setString(1, backupDir.getAbsolutePath());
-      cs.execute();
-      cs.close();
+      try (final CallableStatement cs = con.prepareCall(sqlstmt)) {
+        cs.setString(1, backupDir.getAbsolutePath());
+        cs.execute();
+      }
     } catch (final Exception e) {
       logger.log(Level.SEVERE, "Could not back up database", e);
     }

--- a/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
+++ b/src/main/java/games/strategy/engine/random/PBEMDiceRoller.java
@@ -276,24 +276,19 @@ public class PBEMDiceRoller implements IRandomSource {
         appendText("Text from dice server:\n" + text + "\n");
         notifyError();
       } catch (final IOException ex) {
-        try {
-          appendText("An error has occured!\n");
-          appendText("Possible reasons the error could have happened:\n");
-          appendText("  1: An invalid e-mail address\n");
-          appendText("  2: Firewall could be blocking TripleA from connecting to the Dice Server\n");
-          appendText("  3: The e-mail address does not exist\n");
-          appendText("  4: An unknown error, please see the error console and consult the forums for help\n");
-          appendText("     Visit https://forums.triplea-game.org  for extra help\n");
-          if (text != null) {
-            appendText("Text from dice server:\n" + text + "\n");
-          }
-          final StringWriter writer = new StringWriter();
-          ex.printStackTrace(new PrintWriter(writer));
-          writer.close();
-          appendText(writer.toString());
-        } catch (final IOException ex1) {
-          ex1.printStackTrace();
+        appendText("An error has occured!\n");
+        appendText("Possible reasons the error could have happened:\n");
+        appendText("  1: An invalid e-mail address\n");
+        appendText("  2: Firewall could be blocking TripleA from connecting to the Dice Server\n");
+        appendText("  3: The e-mail address does not exist\n");
+        appendText("  4: An unknown error, please see the error console and consult the forums for help\n");
+        appendText("     Visit https://forums.triplea-game.org  for extra help\n");
+        if (text != null) {
+          appendText("Text from dice server:\n" + text + "\n");
         }
+        final StringWriter writer = new StringWriter();
+        ex.printStackTrace(new PrintWriter(writer));
+        appendText(writer.toString());
         notifyError();
       }
     }

--- a/src/main/java/games/strategy/net/MacFinder.java
+++ b/src/main/java/games/strategy/net/MacFinder.java
@@ -175,19 +175,19 @@ public class MacFinder {
     }
     try {
       final StringBuilder builder = new StringBuilder();
-      final BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()));
-      while (true) {
-        try {
-          final String line = in.readLine();
-          if (line == null) {
+      try (final BufferedReader in = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+        while (true) {
+          try {
+            final String line = in.readLine();
+            if (line == null) {
+              break;
+            }
+            builder.append(line).append("\r\n");
+          } catch (final IOException e) {
             break;
           }
-          builder.append(line).append("\r\n");
-        } catch (final IOException e) {
-          break;
         }
       }
-      in.close();
       return builder.toString();
     } catch (final IOException e) {
       ClientLogger.logQuietly("IOException while executing command: " + command, e);

--- a/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
+++ b/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
@@ -47,19 +47,18 @@ public class PlayerOrder {
         playerSet.add(currentPlayerId);
       }
     }
-    FileWriter turnWriter = null;
     printData.getOutDir().mkdir();
     final File outFile = new File(printData.getOutDir(), "General Information.csv");
-    turnWriter = new FileWriter(outFile, true);
-    turnWriter.write("Turn Order\r\n");
-    final Set<PlayerID> noDuplicates = removeDups(playerSet);
-    final Iterator<PlayerID> playerIterator = noDuplicates.iterator();
-    int count = 1;
-    while (playerIterator.hasNext()) {
-      final PlayerID currentPlayerId = playerIterator.next();
-      turnWriter.write(count + ". " + currentPlayerId.getName() + "\r\n");
-      count++;
+    try (final FileWriter turnWriter = new FileWriter(outFile, true)) {
+      turnWriter.write("Turn Order\r\n");
+      final Set<PlayerID> noDuplicates = removeDups(playerSet);
+      final Iterator<PlayerID> playerIterator = noDuplicates.iterator();
+      int count = 1;
+      while (playerIterator.hasNext()) {
+        final PlayerID currentPlayerId = playerIterator.next();
+        turnWriter.write(count + ". " + currentPlayerId.getName() + "\r\n");
+        count++;
+      }
     }
-    turnWriter.close();
   }
 }

--- a/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/src/main/java/tools/image/AutoPlacementFinder.java
@@ -98,43 +98,44 @@ public class AutoPlacementFinder {
           final String scaleProperty = MapData.PROPERTY_UNITS_SCALE + "=";
           final String widthProperty = MapData.PROPERTY_UNITS_WIDTH + "=";
           final String heightProperty = MapData.PROPERTY_UNITS_HEIGHT + "=";
-          final FileReader reader = new FileReader(file);
-          final LineNumberReader reader2 = new LineNumberReader(reader);
-          int i = 0;
-          while (true) {
-            reader2.setLineNumber(i);
-            final String line = reader2.readLine();
-            if (line == null) {
-              break;
-            }
-            if (line.contains(scaleProperty)) {
-              try {
-                scale = Double.parseDouble(line.substring(line.indexOf(scaleProperty) + scaleProperty.length()).trim());
-                found = true;
-              } catch (final NumberFormatException ex) {
-                // ignore malformed input
+          try (final FileReader reader = new FileReader(file);
+              final LineNumberReader reader2 = new LineNumberReader(reader)) {
+            int i = 0;
+            while (true) {
+              reader2.setLineNumber(i);
+              final String line = reader2.readLine();
+              if (line == null) {
+                break;
+              }
+              if (line.contains(scaleProperty)) {
+                try {
+                  scale =
+                      Double.parseDouble(line.substring(line.indexOf(scaleProperty) + scaleProperty.length()).trim());
+                  found = true;
+                } catch (final NumberFormatException ex) {
+                  // ignore malformed input
+                }
+              }
+              if (line.contains(widthProperty)) {
+                try {
+                  width = Integer.parseInt(line.substring(line.indexOf(widthProperty) + widthProperty.length()).trim());
+                  found = true;
+                } catch (final NumberFormatException ex) {
+                  // ignore malformed input
+                }
+              }
+              if (line.contains(heightProperty)) {
+                try {
+                  height =
+                      Integer.parseInt(line.substring(line.indexOf(heightProperty) + heightProperty.length()).trim());
+                  found = true;
+                } catch (final NumberFormatException ex) {
+                  // ignore malformed input
+                }
               }
             }
-            if (line.contains(widthProperty)) {
-              try {
-                width = Integer.parseInt(line.substring(line.indexOf(widthProperty) + widthProperty.length()).trim());
-                found = true;
-              } catch (final NumberFormatException ex) {
-                // ignore malformed input
-              }
-            }
-            if (line.contains(heightProperty)) {
-              try {
-                height =
-                    Integer.parseInt(line.substring(line.indexOf(heightProperty) + heightProperty.length()).trim());
-                found = true;
-              } catch (final NumberFormatException ex) {
-                // ignore malformed input
-              }
-            }
+            i++;
           }
-          reader2.close();
-          i++;
           if (found) {
             final int result = JOptionPane.showConfirmDialog(new JPanel(),
                 "A map.properties file was found in the map's folder, "

--- a/src/main/java/tools/image/CenterPicker.java
+++ b/src/main/java/tools/image/CenterPicker.java
@@ -236,10 +236,9 @@ public class CenterPicker extends JFrame {
       if (fileName == null) {
         return;
       }
-      final FileOutputStream out = new FileOutputStream(fileName);
-      PointFileReaderWriter.writeOneToOne(out, centers);
-      out.flush();
-      out.close();
+      try (final FileOutputStream out = new FileOutputStream(fileName)) {
+        PointFileReaderWriter.writeOneToOne(out, centers);
+      }
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
     } catch (final Exception ex) {
       ClientLogger.logQuietly(ex);

--- a/src/main/java/tools/image/DecorationPlacer.java
+++ b/src/main/java/tools/image/DecorationPlacer.java
@@ -462,12 +462,9 @@ public class DecorationPlacer extends JFrame {
       if (fileName == null) {
         return;
       }
-      final FileOutputStream out = new FileOutputStream(fileName);
-
-      PointFileReaderWriter.writeOneToMany(out, new HashMap<>(currentPoints));
-
-      out.flush();
-      out.close();
+      try (final FileOutputStream out = new FileOutputStream(fileName)) {
+        PointFileReaderWriter.writeOneToMany(out, new HashMap<>(currentPoints));
+      }
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
     } catch (final Exception ex) {
       ClientLogger.logQuietly(ex);

--- a/src/main/java/tools/image/PolygonGrabber.java
+++ b/src/main/java/tools/image/PolygonGrabber.java
@@ -375,10 +375,9 @@ public class PolygonGrabber extends JFrame {
       if (polyName == null) {
         return;
       }
-      final FileOutputStream out = new FileOutputStream(polyName);
-      PointFileReaderWriter.writeOneToManyPolygons(out, polygons);
-      out.flush();
-      out.close();
+      try (final FileOutputStream out = new FileOutputStream(polyName)) {
+        PointFileReaderWriter.writeOneToManyPolygons(out, polygons);
+      }
       System.out.println("Data written to :" + new File(polyName).getCanonicalPath());
     } catch (final Exception ex) {
       ClientLogger.logQuietly("file save name: " + polyName, ex);

--- a/src/main/java/tools/image/XmlUpdater.java
+++ b/src/main/java/tools/image/XmlUpdater.java
@@ -49,9 +49,9 @@ public class XmlUpdater {
       trans.transform(xmlSource, new StreamResult(resultBuf));
     }
     gameXmlFile.renameTo(new File(gameXmlFile.getAbsolutePath() + ".backup"));
-    final FileOutputStream outStream = new FileOutputStream(gameXmlFile);
-    outStream.write(resultBuf.toByteArray());
-    outStream.close();
+    try (final FileOutputStream outStream = new FileOutputStream(gameXmlFile)) {
+      outStream.write(resultBuf.toByteArray());
+    }
     System.out.println("Successfully updated:" + gameXmlFile);
   }
 

--- a/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/src/main/java/tools/map/making/ConnectionFinder.java
@@ -185,13 +185,12 @@ public class ConnectionFinder {
         }
         System.out.println(connectionsString.toString());
       } else {
-        final FileOutputStream out = new FileOutputStream(fileName);
-        if (territoryDefinitions != null) {
-          out.write(String.valueOf(territoryDefinitions).getBytes());
+        try (final FileOutputStream out = new FileOutputStream(fileName)) {
+          if (territoryDefinitions != null) {
+            out.write(String.valueOf(territoryDefinitions).getBytes());
+          }
+          out.write(String.valueOf(connectionsString).getBytes());
         }
-        out.write(String.valueOf(connectionsString).getBytes());
-        out.flush();
-        out.close();
         System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
       }
     } catch (final Exception ex) {

--- a/src/main/java/tools/map/making/ImageShrinker.java
+++ b/src/main/java/tools/map/making/ImageShrinker.java
@@ -55,14 +55,14 @@ public class ImageShrinker {
     graphics2D.drawImage(baseImg, 0, 0, thumbWidth, thumbHeight, null);
     // save thumbnail image to OUTFILE
     final File file = new File(new File(mapFile.getPath()).getParent() + File.separatorChar + "smallMap.jpeg");
-    final FileImageOutputStream out = new FileImageOutputStream(file);
-    final ImageWriter encoder = ImageIO.getImageWritersByFormatName("JPEG").next();
-    final JPEGImageWriteParam param = new JPEGImageWriteParam(null);
-    param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
-    param.setCompressionQuality((float) 1.0);
-    encoder.setOutput(out);
-    encoder.write(null, new IIOImage(thumbImage, null, null), param);
-    out.close();
+    try (final FileImageOutputStream out = new FileImageOutputStream(file)) {
+      final ImageWriter encoder = ImageIO.getImageWritersByFormatName("JPEG").next();
+      final JPEGImageWriteParam param = new JPEGImageWriteParam(null);
+      param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+      param.setCompressionQuality((float) 1.0);
+      encoder.setOutput(out);
+      encoder.write(null, new IIOImage(thumbImage, null, null), param);
+    }
     System.out.println("Image successfully written to " + file.getPath());
     System.exit(0);
   }

--- a/src/main/java/tools/map/making/MapPropertiesMaker.java
+++ b/src/main/java/tools/map/making/MapPropertiesMaker.java
@@ -343,10 +343,9 @@ public class MapPropertiesMaker extends JFrame {
       }
       final FileOutputStream sink = new FileOutputStream(fileName);
       final String stringToWrite = getOutPutString();
-      final OutputStreamWriter out = new OutputStreamWriter(sink);
-      out.write(stringToWrite);
-      out.flush();
-      out.close();
+      try (final OutputStreamWriter out = new OutputStreamWriter(sink)) {
+        out.write(stringToWrite);
+      }
       System.out.println("");
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
       System.out.println("");

--- a/src/main/java/tools/map/making/PlacementPicker.java
+++ b/src/main/java/tools/map/making/PlacementPicker.java
@@ -164,43 +164,44 @@ public class PlacementPicker extends JFrame {
           final String scaleProperty = MapData.PROPERTY_UNITS_SCALE + "=";
           final String widthProperty = MapData.PROPERTY_UNITS_WIDTH + "=";
           final String heightProperty = MapData.PROPERTY_UNITS_HEIGHT + "=";
-          final FileReader reader = new FileReader(file);
-          final LineNumberReader reader2 = new LineNumberReader(reader);
-          int i = 0;
-          while (true) {
-            reader2.setLineNumber(i);
-            final String line = reader2.readLine();
-            if (line == null) {
-              break;
-            }
-            if (line.contains(scaleProperty)) {
-              try {
-                scale = Double.parseDouble(line.substring(line.indexOf(scaleProperty) + scaleProperty.length()).trim());
-                found = true;
-              } catch (final NumberFormatException ex) {
-                // ignore malformed input
+          try (final FileReader reader = new FileReader(file);
+              final LineNumberReader reader2 = new LineNumberReader(reader)) {
+            int i = 0;
+            while (true) {
+              reader2.setLineNumber(i);
+              final String line = reader2.readLine();
+              if (line == null) {
+                break;
+              }
+              if (line.contains(scaleProperty)) {
+                try {
+                  scale =
+                      Double.parseDouble(line.substring(line.indexOf(scaleProperty) + scaleProperty.length()).trim());
+                  found = true;
+                } catch (final NumberFormatException ex) {
+                  // ignore malformed input
+                }
+              }
+              if (line.contains(widthProperty)) {
+                try {
+                  width = Integer.parseInt(line.substring(line.indexOf(widthProperty) + widthProperty.length()).trim());
+                  found = true;
+                } catch (final NumberFormatException ex) {
+                  // ignore malformed input
+                }
+              }
+              if (line.contains(heightProperty)) {
+                try {
+                  height =
+                      Integer.parseInt(line.substring(line.indexOf(heightProperty) + heightProperty.length()).trim());
+                  found = true;
+                } catch (final NumberFormatException ex) {
+                  // ignore malformed input
+                }
               }
             }
-            if (line.contains(widthProperty)) {
-              try {
-                width = Integer.parseInt(line.substring(line.indexOf(widthProperty) + widthProperty.length()).trim());
-                found = true;
-              } catch (final NumberFormatException ex) {
-                // ignore malformed input
-              }
-            }
-            if (line.contains(heightProperty)) {
-              try {
-                height =
-                    Integer.parseInt(line.substring(line.indexOf(heightProperty) + heightProperty.length()).trim());
-                found = true;
-              } catch (final NumberFormatException ex) {
-                // ignore malformed input
-              }
-            }
+            i++;
           }
-          reader2.close();
-          i++;
           if (found) {
             final int result = JOptionPane.showConfirmDialog(new JPanel(),
                 "A map.properties file was found in the map's folder, "
@@ -489,10 +490,9 @@ public class PlacementPicker extends JFrame {
       if (fileName == null) {
         return;
       }
-      final FileOutputStream out = new FileOutputStream(fileName);
-      PointFileReaderWriter.writeOneToMany(out, new HashMap<>(placements));
-      out.flush();
-      out.close();
+      try (final FileOutputStream out = new FileOutputStream(fileName)) {
+        PointFileReaderWriter.writeOneToMany(out, new HashMap<>(placements));
+      }
       System.out.println("Data written to :" + new File(fileName).getCanonicalPath());
     } catch (final Exception ex) {
       ClientLogger.logQuietly("fileName = " + fileName, ex);

--- a/src/test/java/games/strategy/engine/config/PropertyFileReaderTest.java
+++ b/src/test/java/games/strategy/engine/config/PropertyFileReaderTest.java
@@ -23,13 +23,11 @@ public class PropertyFileReaderTest {
     final File tempFile = File.createTempFile("test", "tmp");
     tempFile.deleteOnExit();
 
-    final FileWriter writer = new FileWriter(tempFile);
-
-    writer.write("a=b\n");
-    writer.write(" 1 = 2 \n");
-    writer.write("whitespace =      \n");
-
-    writer.close();
+    try (final FileWriter writer = new FileWriter(tempFile)) {
+      writer.write("a=b\n");
+      writer.write(" 1 = 2 \n");
+      writer.write("whitespace =      \n");
+    }
 
     testObj = new PropertyFileReader(tempFile);
   }

--- a/src/test/java/games/strategy/engine/data/ChangeTest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTest.java
@@ -31,17 +31,14 @@ public class ChangeTest {
 
   private Change serialize(final Change change) throws Exception {
     final ByteArrayOutputStream sink = new ByteArrayOutputStream();
-    final ObjectOutputStream output = new GameObjectOutputStream(sink);
-    output.writeObject(change);
-    output.flush();
-    // System.out.println("bytes:" + sink.toByteArray().length);
+    try (final ObjectOutputStream output = new GameObjectOutputStream(sink)) {
+      output.writeObject(change);
+    }
     final InputStream source = new ByteArrayInputStream(sink.toByteArray());
-    final ObjectInputStream input =
-        new GameObjectInputStream(new GameObjectStreamFactory(gameData), source);
-    final Change newChange = (Change) input.readObject();
-    input.close();
-    output.close();
-    return newChange;
+    try (final ObjectInputStream input =
+        new GameObjectInputStream(new GameObjectStreamFactory(gameData), source)) {
+      return (Change) input.readObject();
+    }
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
+++ b/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
@@ -32,17 +32,14 @@ public class ChangeTripleATest {
 
   private Change serialize(final Change change) throws Exception {
     final ByteArrayOutputStream sink = new ByteArrayOutputStream();
-    final ObjectOutputStream output = new GameObjectOutputStream(sink);
-    output.writeObject(change);
-    output.flush();
-    // System.out.println("bytes:" + sink.toByteArray().length);
+    try (final ObjectOutputStream output = new GameObjectOutputStream(sink)) {
+      output.writeObject(change);
+    }
     final InputStream source = new ByteArrayInputStream(sink.toByteArray());
-    final ObjectInputStream input =
-        new GameObjectInputStream(new GameObjectStreamFactory(gameData), source);
-    final Change newChange = (Change) input.readObject();
-    input.close();
-    output.close();
-    return newChange;
+    try (final ObjectInputStream input =
+        new GameObjectInputStream(new GameObjectStreamFactory(gameData), source)) {
+      return (Change) input.readObject();
+    }
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/data/SerializationTest.java
+++ b/src/test/java/games/strategy/engine/data/SerializationTest.java
@@ -27,16 +27,14 @@ public class SerializationTest {
 
   private Object serialize(final Object anObject) throws Exception {
     final ByteArrayOutputStream sink = new ByteArrayOutputStream();
-    final ObjectOutputStream output = new GameObjectOutputStream(sink);
-    output.writeObject(anObject);
-    output.flush();
+    try (final ObjectOutputStream output = new GameObjectOutputStream(sink)) {
+      output.writeObject(anObject);
+    }
     final InputStream source = new ByteArrayInputStream(sink.toByteArray());
-    final ObjectInputStream input =
-        new GameObjectInputStream(new GameObjectStreamFactory(gameDataSource), source);
-    final Object obj = input.readObject();
-    input.close();
-    output.close();
-    return obj;
+    try (final ObjectInputStream input =
+        new GameObjectInputStream(new GameObjectStreamFactory(gameDataSource), source)) {
+      return input.readObject();
+    }
   }
 
   @Test


### PR DESCRIPTION
While recently updating log messages in the lobby database, I noticed several `AutoCloseable` resources that were being closed explicitly outside of a `finally` block.  I searched the code and found a lot of other places where we were doing the same thing.  This PR simply wraps each applicable resource in a try-with-resources statement and removes the explicit `close()` and `flush()` calls.

Due to having to increase the indentation level of the affected code, some reformatting was required, but is minimal.  Also, for this reason, reviewing this PR with whitespace changes ignored (`?w=1`) will be much more pleasant.