### PR TITLE
Checkstyle: Fix constant name violations in Matches (part 6)

### DIFF
--- a/src/main/java/games/strategy/engine/data/RelationshipInterpreter.java
+++ b/src/main/java/games/strategy/engine/data/RelationshipInterpreter.java
@@ -21,12 +21,12 @@ public class RelationshipInterpreter extends GameDataComponent {
    * @return whether player p1 is allied to player p2.
    */
   public boolean isAllied(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeIsAllied.match((getRelationshipType(p1, p2)));
+    return Matches.relationshipTypeIsAllied().match((getRelationshipType(p1, p2)));
   }
 
   public boolean isAlliedWithAnyOfThesePlayers(final PlayerID p1, final Collection<PlayerID> p2s) {
     for (final PlayerID p2 : p2s) {
-      if (Matches.RelationshipTypeIsAllied.match((getRelationshipType(p1, p2)))) {
+      if (Matches.relationshipTypeIsAllied().match((getRelationshipType(p1, p2)))) {
         return true;
       }
     }
@@ -36,7 +36,7 @@ public class RelationshipInterpreter extends GameDataComponent {
   public Set<PlayerID> getAllies(final PlayerID p1, final boolean includeSelf) {
     final Set<PlayerID> allies = new HashSet<>();
     for (final PlayerID player : getData().getPlayerList().getPlayers()) {
-      if (Matches.RelationshipTypeIsAllied.match(getRelationshipType(p1, player))) {
+      if (Matches.relationshipTypeIsAllied().match(getRelationshipType(p1, player))) {
         allies.add(player);
       }
     }
@@ -58,12 +58,12 @@ public class RelationshipInterpreter extends GameDataComponent {
    * @return whether p1 is at war with p2
    */
   public boolean isAtWar(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeIsAtWar.match((getRelationshipType(p1, p2)));
+    return Matches.relationshipTypeIsAtWar().match((getRelationshipType(p1, p2)));
   }
 
   public boolean isAtWarWithAnyOfThesePlayers(final PlayerID p1, final Collection<PlayerID> p2s) {
     for (final PlayerID p2 : p2s) {
-      if (Matches.RelationshipTypeIsAtWar.match((getRelationshipType(p1, p2)))) {
+      if (Matches.relationshipTypeIsAtWar().match((getRelationshipType(p1, p2)))) {
         return true;
       }
     }
@@ -73,7 +73,7 @@ public class RelationshipInterpreter extends GameDataComponent {
   public Set<PlayerID> getEnemies(final PlayerID p1) {
     final Set<PlayerID> enemies = new HashSet<>();
     for (final PlayerID player : getData().getPlayerList().getPlayers()) {
-      if (Matches.RelationshipTypeIsAtWar.match(getRelationshipType(p1, player))) {
+      if (Matches.relationshipTypeIsAtWar().match(getRelationshipType(p1, player))) {
         enemies.add(player);
       }
     }
@@ -89,12 +89,12 @@ public class RelationshipInterpreter extends GameDataComponent {
    * @return whether player1 is neutral to player2.
    */
   public boolean isNeutral(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeIsNeutral.match((getRelationshipType(p1, p2)));
+    return Matches.relationshipTypeIsNeutral().match((getRelationshipType(p1, p2)));
   }
 
   public boolean isNeutralWithAnyOfThesePlayers(final PlayerID p1, final Collection<PlayerID> p2s) {
     for (final PlayerID p2 : p2s) {
-      if (Matches.RelationshipTypeIsNeutral.match((getRelationshipType(p1, p2)))) {
+      if (Matches.relationshipTypeIsNeutral().match((getRelationshipType(p1, p2)))) {
         return true;
       }
     }
@@ -102,15 +102,15 @@ public class RelationshipInterpreter extends GameDataComponent {
   }
 
   public boolean canMoveLandUnitsOverOwnedLand(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeCanMoveLandUnitsOverOwnedLand.match(getRelationshipType(p1, p2));
+    return Matches.relationshipTypeCanMoveLandUnitsOverOwnedLand().match(getRelationshipType(p1, p2));
   }
 
   public boolean canMoveAirUnitsOverOwnedLand(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeCanMoveAirUnitsOverOwnedLand.match(getRelationshipType(p1, p2));
+    return Matches.relationshipTypeCanMoveAirUnitsOverOwnedLand().match(getRelationshipType(p1, p2));
   }
 
   public boolean canLandAirUnitsOnOwnedLand(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeCanLandAirUnitsOnOwnedLand.match(getRelationshipType(p1, p2));
+    return Matches.relationshipTypeCanLandAirUnitsOnOwnedLand().match(getRelationshipType(p1, p2));
   }
 
   public String getUpkeepCost(final PlayerID p1, final PlayerID p2) {
@@ -118,31 +118,31 @@ public class RelationshipInterpreter extends GameDataComponent {
   }
 
   public boolean alliancesCanChainTogether(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeIsAlliedAndAlliancesCanChainTogether.match(getRelationshipType(p1, p2));
+    return Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().match(getRelationshipType(p1, p2));
   }
 
   public boolean isDefaultWarPosition(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeIsDefaultWarPosition.match(getRelationshipType(p1, p2));
+    return Matches.relationshipTypeIsDefaultWarPosition().match(getRelationshipType(p1, p2));
   }
 
   public boolean canTakeOverOwnedTerritory(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeCanTakeOverOwnedTerritory.match(getRelationshipType(p1, p2));
+    return Matches.relationshipTypeCanTakeOverOwnedTerritory().match(getRelationshipType(p1, p2));
   }
 
   public boolean givesBackOriginalTerritories(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeGivesBackOriginalTerritories.match(getRelationshipType(p1, p2));
+    return Matches.relationshipTypeGivesBackOriginalTerritories().match(getRelationshipType(p1, p2));
   }
 
   public boolean canMoveIntoDuringCombatMove(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeCanMoveIntoDuringCombatMove.match(getRelationshipType(p1, p2));
+    return Matches.relationshipTypeCanMoveIntoDuringCombatMove().match(getRelationshipType(p1, p2));
   }
 
   public boolean canMoveThroughCanals(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeCanMoveThroughCanals.match(getRelationshipType(p1, p2));
+    return Matches.relationshipTypeCanMoveThroughCanals().match(getRelationshipType(p1, p2));
   }
 
   public boolean rocketsCanFlyOver(final PlayerID p1, final PlayerID p2) {
-    return Matches.RelationshipTypeRocketsCanFlyOver.match(getRelationshipType(p1, p2));
+    return Matches.relationshipTypeRocketsCanFlyOver().match(getRelationshipType(p1, p2));
   }
 
   /**

--- a/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
+++ b/src/main/java/games/strategy/engine/data/changefactory/RelationshipChange.java
@@ -44,7 +44,7 @@ class RelationshipChange extends Change {
     data.getRelationshipTracker().setRelationship(data.getPlayerList().getPlayerID(m_player1),
         data.getPlayerList().getPlayerID(m_player2), data.getRelationshipTypeList().getRelationshipType(m_NewRelation));
     // now redraw territories in case of new hostility
-    if (Matches.RelationshipTypeIsAtWar.match(data.getRelationshipTypeList().getRelationshipType(m_NewRelation))) {
+    if (Matches.relationshipTypeIsAtWar().match(data.getRelationshipTypeList().getRelationshipType(m_NewRelation))) {
       for (final Territory t : Match.getMatches(data.getMap().getTerritories(),
           Match.allOf(
               Matches.territoryHasUnitsOwnedBy(data.getPlayerList().getPlayerID(m_player1)),

--- a/src/main/java/games/strategy/triplea/ai/AbstractAI.java
+++ b/src/main/java/games/strategy/triplea/ai/AbstractAI.java
@@ -150,7 +150,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
   @Override
   public Unit whatShouldBomberBomb(final Territory territory, final Collection<Unit> potentialTargets,
       final Collection<Unit> bombers) {
-    final Collection<Unit> factories = Match.getMatches(potentialTargets, Matches.UnitCanProduceUnitsAndCanBeDamaged);
+    final Collection<Unit> factories = Match.getMatches(potentialTargets, Matches.unitCanProduceUnitsAndCanBeDamaged());
     if (factories.isEmpty()) {
       return potentialTargets.iterator().next();
     }
@@ -603,7 +603,7 @@ public abstract class AbstractAI extends AbstractBasePlayer implements ITripleAP
         final double random = Math.random();
         int maxWarActionsPerTurn = (random < .5 ? 0 : (random < .9 ? 1 : (random < .99 ? 2 : (int) numPlayers / 2)));
         if ((maxWarActionsPerTurn > 0)
-            && (Match.countMatches(data.getRelationshipTracker().getRelationships(id), Matches.RelationshipIsAtWar))
+            && (Match.countMatches(data.getRelationshipTracker().getRelationships(id), Matches.relationshipIsAtWar()))
                 / numPlayers < 0.4) {
           if (Math.random() < .9) {
             maxWarActionsPerTurn = 0;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProCombatMoveAI.java
@@ -719,7 +719,7 @@ class ProCombatMoveAI {
         Optional<Territory> maxBombingTerritory = Optional.empty();
         int maxBombingScore = MIN_BOMBING_SCORE;
         for (final Territory t : bomberMoveMap.get(unit)) {
-          final boolean territoryCanBeBombed = t.getUnits().anyMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
+          final boolean territoryCanBeBombed = t.getUnits().anyMatch(Matches.unitCanProduceUnitsAndCanBeDamaged());
           if (territoryCanBeBombed && canAirSafelyLandAfterAttack(unit, t)) {
             final int noAaBombingDefense = t.getUnits().anyMatch(Matches.unitIsAaForBombingThisUnitOnly()) ? 0 : 1;
             int maxDamage = 0;

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProNonCombatMoveAI.java
@@ -1887,7 +1887,7 @@ class ProNonCombatMoveAI {
             final int production = TerritoryAttachment.get(t).getProduction();
             double value = 0.1 * moveMap.get(t).getValue();
             if (ProMatches.territoryIsNotConqueredOwnedLand(player, data).match(t)
-                && Match.noneMatch(units, Matches.UnitCanProduceUnitsAndIsInfrastructure)) {
+                && Match.noneMatch(units, Matches.unitCanProduceUnitsAndIsInfrastructure())) {
               value = moveMap.get(t).getValue() * production + 0.01 * production;
             }
             ProLogger.trace(t.getName() + " has value=" + value + ", strategicValue=" + moveMap.get(t).getValue()

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPoliticsAI.java
@@ -65,7 +65,7 @@ class ProPoliticsAI {
         final PlayerID player2 = data.getPlayerList().getPlayerID(s[1]);
         final RelationshipType oldRelation = data.getRelationshipTracker().getRelationshipType(player1, player2);
         final RelationshipType newRelation = data.getRelationshipTypeList().getRelationshipType(s[2]);
-        if (!oldRelation.equals(newRelation) && Matches.RelationshipTypeIsAtWar.match(newRelation)
+        if (!oldRelation.equals(newRelation) && Matches.relationshipTypeIsAtWar().match(newRelation)
             && (player1.equals(player) || player2.equals(player))) {
           PlayerID warPlayer = player2;
           if (warPlayer.equals(player)) {

--- a/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/ProPurchaseAI.java
@@ -82,7 +82,7 @@ class ProPurchaseAI {
       ProLogger.debug("Factories can be damaged");
       final Map<Unit, Territory> unitsThatCanProduceNeedingRepair = new HashMap<>();
       for (final Territory fixTerr : rfactories) {
-        if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
+        if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.unitCanProduceUnitsAndCanBeDamaged())
             .match(fixTerr)) {
           continue;
         }
@@ -99,7 +99,7 @@ class ProPurchaseAI {
           if (fixUnit == null || !fixUnit.getType().equals(rrule.getResults().keySet().iterator().next())) {
             continue;
           }
-          if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
+          if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.unitCanProduceUnitsAndCanBeDamaged())
               .match(unitsThatCanProduceNeedingRepair.get(fixUnit))) {
             continue;
           }
@@ -713,7 +713,7 @@ class ProPurchaseAI {
       // Check if territory needs AA
       final boolean enemyCanBomb =
           Match.anyMatch(enemyAttackOptions.getMax(t).getMaxUnits(), Matches.UnitIsStrategicBomber);
-      final boolean territoryCanBeBombed = t.getUnits().anyMatch(Matches.UnitCanProduceUnitsAndCanBeDamaged);
+      final boolean territoryCanBeBombed = t.getUnits().anyMatch(Matches.unitCanProduceUnitsAndCanBeDamaged());
       final boolean hasAaBombingDefense = t.getUnits().anyMatch(Matches.unitIsAaForBombingThisUnitOnly());
       ProLogger.debug(t + ", enemyCanBomb=" + enemyCanBomb + ", territoryCanBeBombed=" + territoryCanBeBombed
           + ", hasAABombingDefense=" + hasAaBombingDefense);
@@ -1817,7 +1817,7 @@ class ProPurchaseAI {
 
       // Check if any units can be placed
       final PlaceableUnits placeableUnits =
-          placeDelegate.getPlaceableUnits(player.getUnits().getMatches(Matches.UnitIsNotConstruction), t);
+          placeDelegate.getPlaceableUnits(player.getUnits().getMatches(Matches.unitIsNotConstruction()), t);
       if (placeableUnits.isError()) {
         ProLogger.trace(t + " can't place units with error: " + placeableUnits.getErrorMessage());
         continue;
@@ -1875,7 +1875,7 @@ class ProPurchaseAI {
 
     ProLogger.info("Place land with isConstruction=" + isConstruction + ", units=" + player.getUnits().getUnits());
 
-    Match<Unit> unitMatch = Matches.UnitIsNotConstruction;
+    Match<Unit> unitMatch = Matches.unitIsNotConstruction();
     if (isConstruction) {
       unitMatch = Matches.unitIsConstruction();
     }

--- a/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
+++ b/src/main/java/games/strategy/triplea/ai/proAI/util/ProUtils.java
@@ -122,7 +122,7 @@ public class ProUtils {
     for (final Iterator<PlayerID> it = otherPlayers.iterator(); it.hasNext();) {
       final PlayerID otherPlayer = it.next();
       final RelationshipType relation = data.getRelationshipTracker().getRelationshipType(player, otherPlayer);
-      if (Matches.RelationshipTypeIsAllied.match(relation) || isNeutralPlayer(otherPlayer)) {
+      if (Matches.relationshipTypeIsAllied().match(relation) || isNeutralPlayer(otherPlayer)) {
         it.remove();
       }
     }

--- a/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
+++ b/src/main/java/games/strategy/triplea/ai/weakAI/WeakAI.java
@@ -696,7 +696,7 @@ public class WeakAI extends AbstractAI {
   private static void populateBomberCombat(final GameData data, final List<Collection<Unit>> moveUnits,
       final List<Route> moveRoutes, final PlayerID player) {
     final Match<Territory> enemyFactory = Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player,
-        Matches.UnitCanProduceUnitsAndCanBeDamaged);
+        Matches.unitCanProduceUnitsAndCanBeDamaged());
     final Match<Unit> ownBomber = Match.allOf(Matches.UnitIsStrategicBomber, Matches.unitIsOwnedBy(player));
     for (final Territory t : data.getMap().getTerritories()) {
       final Collection<Unit> bombers = t.getUnits().getMatches(ownBomber);
@@ -811,7 +811,7 @@ public class WeakAI extends AbstractAI {
       // we should sort this
       Collections.shuffle(rfactories);
       for (final Territory fixTerr : rfactories) {
-        if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
+        if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.unitCanProduceUnitsAndCanBeDamaged())
             .match(fixTerr)) {
           continue;
         }
@@ -845,7 +845,7 @@ public class WeakAI extends AbstractAI {
           if (!capUnit.getUnitType().equals(rrule.getResults().keySet().iterator().next())) {
             continue;
           }
-          if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
+          if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.unitCanProduceUnitsAndCanBeDamaged())
               .match(capitol)) {
             continue;
           }
@@ -884,7 +884,7 @@ public class WeakAI extends AbstractAI {
             if (fixUnit == null || !fixUnit.getType().equals(rrule.getResults().keySet().iterator().next())) {
               continue;
             }
-            if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.UnitCanProduceUnitsAndCanBeDamaged)
+            if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(player, Matches.unitCanProduceUnitsAndCanBeDamaged())
                 .match(unitsThatCanProduceNeedingRepair.get(fixUnit))) {
               continue;
             }

--- a/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -898,11 +898,11 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         return false;
       }
       if (!(relationCheck[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_ALLIED)
-          && Matches.RelationshipTypeIsAllied.match(currentRelationshipType)
+          && Matches.relationshipTypeIsAllied().match(currentRelationshipType)
           || relationCheck[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_NEUTRAL)
-              && Matches.RelationshipTypeIsNeutral.match(currentRelationshipType)
+              && Matches.relationshipTypeIsNeutral().match(currentRelationshipType)
           || relationCheck[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_WAR)
-              && Matches.RelationshipTypeIsAtWar.match(currentRelationshipType)
+              && Matches.relationshipTypeIsAtWar().match(currentRelationshipType)
           || currentRelationshipType
               .equals(getData().getRelationshipTypeList().getRelationshipType(relationCheck[2])))) {
         return false;

--- a/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2005,11 +2005,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         final RelationshipType currentRelation = data.getRelationshipTracker().getRelationshipType(player1, player2);
         if (s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY)
             || (s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_NEUTRAL)
-                && Matches.RelationshipTypeIsNeutral.match(currentRelation))
+                && Matches.relationshipTypeIsNeutral().match(currentRelation))
             || (s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_ALLIED)
-                && Matches.RelationshipTypeIsAllied.match(currentRelation))
+                && Matches.relationshipTypeIsAllied().match(currentRelation))
             || (s[2].equals(Constants.RELATIONSHIP_CONDITION_ANY_WAR)
-                && Matches.RelationshipTypeIsAtWar.match(currentRelation))
+                && Matches.relationshipTypeIsAtWar().match(currentRelation))
             || currentRelation.equals(data.getRelationshipTypeList().getRelationshipType(s[2]))) {
           final RelationshipType triggerNewRelation = data.getRelationshipTypeList().getRelationshipType(s[3]);
           change.add(ChangeFactory.relationshipChange(player1, player2, currentRelation, triggerNewRelation));
@@ -2022,7 +2022,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
           /*
            * creation of new battles is handled at the beginning of the battle delegate, in
            * "setupUnitsInSameTerritoryBattles", not here.
-           * if (Matches.RelationshipTypeIsAtWar.match(triggerNewRelation))
+           * if (Matches.relationshipTypeIsAtWar().match(triggerNewRelation))
            * triggerMustFightBattle(player1, player2, aBridge);
            */
         }

--- a/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
+++ b/src/main/java/games/strategy/triplea/delegate/AAInMoveUtil.java
@@ -99,7 +99,7 @@ class AAInMoveUtil implements Serializable {
       final Set<UnitType> airborneTypesTargettedToo = airborneTechTargetsAllowed.get(currentTypeAa);
       final Collection<Unit> validTargetedUnitsForThisRoll =
           Match.getMatches(units, Match.anyOf(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
-              Match.allOf(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
+              Match.allOf(Matches.unitIsAirborne(), Matches.unitIsOfTypes(airborneTypesTargettedToo))));
       // once we fire the AA guns, we can't undo
       // otherwise you could keep undoing and redoing
       // until you got the roll you wanted

--- a/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -832,7 +832,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       if (listedTerrs.contains(to)) {
         return "Cannot place these units in " + to.getName() + " due to Unit Placement Restrictions";
       }
-      if (Matches.UnitCanOnlyPlaceInOriginalTerritories.match(currentUnit)
+      if (Matches.unitCanOnlyPlaceInOriginalTerritories().match(currentUnit)
           && !Matches.territoryIsOriginallyOwnedBy(player).match(to)) {
         return "Cannot place these units in " + to.getName() + " as territory is not originally owned";
       }
@@ -880,9 +880,9 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     // we add factories and constructions later
     if (water || wasFactoryThereAtStart || (!water && isPlayerAllowedToPlacementAnyTerritoryOwnedLand(player))) {
       final Match<Unit> seaOrLandMatch = water ? Matches.UnitIsSea : Matches.UnitIsLand;
-      placeableUnits.addAll(Match.getMatches(units, Match.allOf(seaOrLandMatch, Matches.UnitIsNotConstruction)));
+      placeableUnits.addAll(Match.getMatches(units, Match.allOf(seaOrLandMatch, Matches.unitIsNotConstruction())));
       if (!water) {
-        placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.UnitIsNotConstruction)));
+        placeableUnits.addAll(Match.getMatches(units, Match.allOf(Matches.UnitIsAir, Matches.unitIsNotConstruction())));
       } else if (((isBid || canProduceFightersOnCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
           && Match.anyMatch(allProducedUnits, Matches.UnitIsCarrier))
           || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLHTRCarrierProduction(getData()))
@@ -945,7 +945,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       if (unitWhichRequiresUnitsHasRequiredUnits(to, false).invert().match(currentUnit)) {
         continue;
       }
-      if (Matches.UnitCanOnlyPlaceInOriginalTerritories.match(currentUnit)
+      if (Matches.unitCanOnlyPlaceInOriginalTerritories().match(currentUnit)
           && !Matches.territoryIsOriginallyOwnedBy(player).match(to)) {
         continue;
       }

--- a/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -639,13 +639,13 @@ public class AirBattle extends AbstractBattle {
   }
 
   static Match<Unit> attackingGroundSeaBattleEscorts(final PlayerID attacker, final GameData data) {
-    final Match<Unit> canIntercept = Matches.unitCanAirBattle;
+    final Match<Unit> canIntercept = Matches.unitCanAirBattle();
     return canIntercept;
   }
 
   private static Match<Unit> defendingGroundSeaBattleInterceptors(final PlayerID attacker, final GameData data) {
     final Match.CompositeBuilder<Unit> matchBuilder = Match.newCompositeBuilder(
-        Matches.unitCanAirBattle,
+        Matches.unitCanAirBattle(),
         Matches.unitIsEnemyOf(data, attacker),
         Matches.unitWasInAirBattle().invert());
     if (!Properties.getCanScrambleIntoAirBattles(data)) {
@@ -656,7 +656,7 @@ public class AirBattle extends AbstractBattle {
 
   private static Match<Unit> defendingBombingRaidInterceptors(final PlayerID attacker, final GameData data) {
     final Match.CompositeBuilder<Unit> matchBuilder = Match.newCompositeBuilder(
-        Matches.unitCanIntercept,
+        Matches.unitCanIntercept(),
         Matches.unitIsEnemyOf(data, attacker),
         Matches.unitWasInAirBattle().invert());
     if (!Properties.getCanScrambleIntoAirBattles(data)) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -390,7 +390,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final Collection<Unit> airTransports =
           Match.getMatches(battleSite.getUnits().getUnits(), Matches.UnitIsAirTransport);
       final Collection<Unit> paratroops =
-          Match.getMatches(battleSite.getUnits().getUnits(), Matches.UnitIsAirTransportable);
+          Match.getMatches(battleSite.getUnits().getUnits(), Matches.unitIsAirTransportable());
       if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
         final CompositeChange change = new CompositeChange();
         for (final Unit u : paratroops) {

--- a/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -179,8 +179,8 @@ public class BattleTracker implements Serializable {
         continue;
       }
       final Tuple<RelationshipType, RelationshipType> relations = t.getSecond();
-      if (!Matches.RelationshipTypeIsAtWar.match(relations.getFirst())) {
-        if (Matches.RelationshipTypeIsAtWar.match(relations.getSecond())) {
+      if (!Matches.relationshipTypeIsAtWar().match(relations.getFirst())) {
+        if (Matches.relationshipTypeIsAtWar().match(relations.getSecond())) {
           return true;
         }
       }

--- a/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -115,8 +115,8 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     final Collection<Unit> placeableUnits = new ArrayList<>();
     final Match<Unit> groundUnits =
         // we add factories and constructions later
-        Match.allOf(Matches.UnitIsLand, Matches.UnitIsNotConstruction);
-    final Match<Unit> airUnits = Match.allOf(Matches.UnitIsAir, Matches.UnitIsNotConstruction);
+        Match.allOf(Matches.UnitIsLand, Matches.unitIsNotConstruction());
+    final Match<Unit> airUnits = Match.allOf(Matches.UnitIsAir, Matches.unitIsNotConstruction());
     placeableUnits.addAll(Match.getMatches(units, groundUnits));
     placeableUnits.addAll(Match.getMatches(units, airUnits));
     if (Match.anyMatch(units, Matches.unitIsConstruction())) {

--- a/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -580,7 +580,7 @@ public final class Matches {
           return true;
         }
       }
-      return Match.anyMatch(targets, Match.allOf(Matches.UnitIsAirborne,
+      return Match.anyMatch(targets, Match.allOf(Matches.unitIsAirborne(),
           Matches.unitIsOfTypes(airborneTechTargetsAllowed.get(ua.getTypeAA()))));
     });
   }
@@ -708,18 +708,23 @@ public final class Matches {
     return unitIsInfantry().invert();
   }
 
-  public static final Match<Unit> UnitIsAirTransportable = Match.of(obj -> {
-    final TechAttachment ta = TechAttachment.get(obj.getOwner());
-    if (ta == null || !ta.getParatroopers()) {
-      return false;
-    }
-    final UnitType type = obj.getUnitType();
-    final UnitAttachment ua = UnitAttachment.get(type);
-    return ua.getIsAirTransportable();
-  });
+  /**
+   * Returns a match indicating the specified unit can be transported by air.
+   */
+  public static Match<Unit> unitIsAirTransportable() {
+    return Match.of(obj -> {
+      final TechAttachment ta = TechAttachment.get(obj.getOwner());
+      if (ta == null || !ta.getParatroopers()) {
+        return false;
+      }
+      final UnitType type = obj.getUnitType();
+      final UnitAttachment ua = UnitAttachment.get(type);
+      return ua.getIsAirTransportable();
+    });
+  }
 
   static Match<Unit> unitIsNotAirTransportable() {
-    return UnitIsAirTransportable.invert();
+    return unitIsAirTransportable().invert();
   }
 
   public static final Match<Unit> UnitIsAirTransport = Match.of(obj -> {
@@ -1557,7 +1562,7 @@ public final class Matches {
       // paratrooper on an air transport
       if (forceLoadParatroopersIfPossible) {
         final Collection<Unit> airTransports = Match.getMatches(units, Matches.UnitIsAirTransport);
-        final Collection<Unit> paratroops = Match.getMatches(units, Matches.UnitIsAirTransportable);
+        final Collection<Unit> paratroops = Match.getMatches(units, Matches.unitIsAirTransportable());
         if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
           if (TransportUtils.mapTransportsToLoad(paratroops, airTransports)
               .containsKey(dependent)) {
@@ -1884,44 +1889,54 @@ public final class Matches {
     return Match.of(obj -> unitTypeIsConstruction().match(obj.getType()));
   }
 
-  public static final Match<Unit> UnitIsNotConstruction = unitIsConstruction().invert();
+  public static Match<Unit> unitIsNotConstruction() {
+    return unitIsConstruction().invert();
+  }
 
-  public static final Match<Unit> UnitCanProduceUnitsAndIsInfrastructure =
-      Match.allOf(UnitCanProduceUnits, UnitIsInfrastructure);
+  public static Match<Unit> unitCanProduceUnitsAndIsInfrastructure() {
+    return Match.allOf(UnitCanProduceUnits, UnitIsInfrastructure);
+  }
 
-  public static final Match<Unit> UnitCanProduceUnitsAndCanBeDamaged =
-      Match.allOf(UnitCanProduceUnits, unitCanBeDamaged());
+  public static Match<Unit> unitCanProduceUnitsAndCanBeDamaged() {
+    return Match.allOf(UnitCanProduceUnits, unitCanBeDamaged());
+  }
 
   /**
    * See if a unit can invade. Units with canInvadeFrom not set, or set to "all", can invade from any other unit.
-   * Otherwise, units must have
-   * a specific unit in this list to be able to invade from that unit.
+   * Otherwise, units must have a specific unit in this list to be able to invade from that unit.
    */
-  public static final Match<Unit> UnitCanInvade = Match.of(unit -> {
-    // is the unit being transported?
-    final Unit transport = TripleAUnit.get(unit).getTransportedBy();
-    if (transport == null) {
-      // Unit isn't transported so can Invade
-      return true;
-    }
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-    return ua.canInvadeFrom(transport.getUnitType().getName());
-  });
+  public static Match<Unit> unitCanInvade() {
+    return Match.of(unit -> {
+      // is the unit being transported?
+      final Unit transport = TripleAUnit.get(unit).getTransportedBy();
+      if (transport == null) {
+        // Unit isn't transported so can Invade
+        return true;
+      }
+      final UnitAttachment ua = UnitAttachment.get(unit.getType());
+      return ua.canInvadeFrom(transport.getUnitType().getName());
+    });
+  }
 
-  public static final Match<RelationshipType> RelationshipTypeIsAllied =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().isAllied());
+  public static Match<RelationshipType> relationshipTypeIsAllied() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().isAllied());
+  }
 
-  public static final Match<RelationshipType> RelationshipTypeIsNeutral =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().isNeutral());
+  public static Match<RelationshipType> relationshipTypeIsNeutral() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().isNeutral());
+  }
 
-  public static final Match<RelationshipType> RelationshipTypeIsAtWar =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().isWar());
+  public static Match<RelationshipType> relationshipTypeIsAtWar() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().isWar());
+  }
 
-  public static final Match<Relationship> RelationshipIsAtWar =
-      Match.of(relationship -> relationship.getRelationshipType().getRelationshipTypeAttachment().isWar());
+  public static Match<Relationship> relationshipIsAtWar() {
+    return Match.of(relationship -> relationship.getRelationshipType().getRelationshipTypeAttachment().isWar());
+  }
 
-  public static final Match<RelationshipType> RelationshipTypeCanMoveLandUnitsOverOwnedLand =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveLandUnitsOverOwnedLand());
+  public static Match<RelationshipType> relationshipTypeCanMoveLandUnitsOverOwnedLand() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveLandUnitsOverOwnedLand());
+  }
 
   /**
    * If the territory is not land, returns true. Else, tests relationship of the owners.
@@ -1940,8 +1955,9 @@ public final class Matches {
     });
   }
 
-  public static final Match<RelationshipType> RelationshipTypeCanMoveAirUnitsOverOwnedLand =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveAirUnitsOverOwnedLand());
+  public static Match<RelationshipType> relationshipTypeCanMoveAirUnitsOverOwnedLand() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveAirUnitsOverOwnedLand());
+  }
 
   /**
    * If the territory is not land, returns true. Else, tests relationship of the owners.
@@ -1960,31 +1976,37 @@ public final class Matches {
     });
   }
 
-  public static final Match<RelationshipType> RelationshipTypeCanLandAirUnitsOnOwnedLand =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canLandAirUnitsOnOwnedLand());
+  public static Match<RelationshipType> relationshipTypeCanLandAirUnitsOnOwnedLand() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canLandAirUnitsOnOwnedLand());
+  }
 
-  public static final Match<RelationshipType> RelationshipTypeCanTakeOverOwnedTerritory =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canTakeOverOwnedTerritory());
+  public static Match<RelationshipType> relationshipTypeCanTakeOverOwnedTerritory() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canTakeOverOwnedTerritory());
+  }
 
-  public static final Match<RelationshipType> RelationshipTypeGivesBackOriginalTerritories =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().givesBackOriginalTerritories());
+  public static Match<RelationshipType> relationshipTypeGivesBackOriginalTerritories() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().givesBackOriginalTerritories());
+  }
 
-  public static final Match<RelationshipType> RelationshipTypeCanMoveIntoDuringCombatMove =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveIntoDuringCombatMove());
+  public static Match<RelationshipType> relationshipTypeCanMoveIntoDuringCombatMove() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveIntoDuringCombatMove());
+  }
 
-  public static final Match<RelationshipType> RelationshipTypeCanMoveThroughCanals =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveThroughCanals());
+  public static Match<RelationshipType> relationshipTypeCanMoveThroughCanals() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canMoveThroughCanals());
+  }
 
-  public static final Match<RelationshipType> RelationshipTypeRocketsCanFlyOver =
-      Match.of(relationship -> relationship.getRelationshipTypeAttachment().canRocketsFlyOver());
+  public static Match<RelationshipType> relationshipTypeRocketsCanFlyOver() {
+    return Match.of(relationship -> relationship.getRelationshipTypeAttachment().canRocketsFlyOver());
+  }
 
   public static Match<String> isValidRelationshipName(final GameData data) {
     return Match.of(relationshipName -> data.getRelationshipTypeList().getRelationshipType(relationshipName) != null);
   }
 
   public static Match<PlayerID> isAtWar(final PlayerID player, final GameData data) {
-    return Match.of(
-        player2 -> RelationshipTypeIsAtWar.match(data.getRelationshipTracker().getRelationshipType(player, player2)));
+    return Match.of(player2 -> relationshipTypeIsAtWar()
+        .match(data.getRelationshipTracker().getRelationshipType(player, player2)));
   }
 
   public static Match<PlayerID> isAtWarWithAnyOfThesePlayers(final Collection<PlayerID> players,
@@ -1993,8 +2015,8 @@ public final class Matches {
   }
 
   public static Match<PlayerID> isAllied(final PlayerID player, final GameData data) {
-    return Match.of(
-        player2 -> RelationshipTypeIsAllied.match(data.getRelationshipTracker().getRelationshipType(player, player2)));
+    return Match.of(player2 -> relationshipTypeIsAllied()
+        .match(data.getRelationshipTracker().getRelationshipType(player, player2)));
   }
 
   public static Match<PlayerID> isAlliedWithAnyOfThesePlayers(final Collection<PlayerID> players,
@@ -2075,16 +2097,18 @@ public final class Matches {
     return Match.of(paa -> paa.getCostPU() >= greaterThanEqualTo && paa.getCostPU() <= lessThanEqualTo);
   }
 
-  public static final Match<Unit> UnitCanOnlyPlaceInOriginalTerritories = Match.of(u -> {
-    final UnitAttachment ua = UnitAttachment.get(u.getType());
-    final Set<String> specialOptions = ua.getSpecial();
-    for (final String option : specialOptions) {
-      if (option.equals("canOnlyPlaceInOriginalTerritories")) {
-        return true;
+  static Match<Unit> unitCanOnlyPlaceInOriginalTerritories() {
+    return Match.of(u -> {
+      final UnitAttachment ua = UnitAttachment.get(u.getType());
+      final Set<String> specialOptions = ua.getSpecial();
+      for (final String option : specialOptions) {
+        if (option.equals("canOnlyPlaceInOriginalTerritories")) {
+          return true;
+        }
       }
-    }
-    return false;
-  });
+      return false;
+    });
+  }
 
   /**
    * Accounts for OccupiedTerrOf. Returns false if there is no territory attachment (like if it is water).
@@ -2104,16 +2128,18 @@ public final class Matches {
   }
 
   static Match<PlayerID> isAlliedAndAlliancesCanChainTogether(final PlayerID player, final GameData data) {
-    return Match.of(player2 -> RelationshipTypeIsAlliedAndAlliancesCanChainTogether
+    return Match.of(player2 -> relationshipTypeIsAlliedAndAlliancesCanChainTogether()
         .match(data.getRelationshipTracker().getRelationshipType(player, player2)));
   }
 
-  public static final Match<RelationshipType> RelationshipTypeIsAlliedAndAlliancesCanChainTogether = Match.of(rt -> {
-    return RelationshipTypeIsAllied.match(rt) && rt.getRelationshipTypeAttachment().canAlliancesChainTogether();
-  });
+  public static Match<RelationshipType> relationshipTypeIsAlliedAndAlliancesCanChainTogether() {
+    return Match.of(rt -> relationshipTypeIsAllied().match(rt)
+        && rt.getRelationshipTypeAttachment().canAlliancesChainTogether());
+  }
 
-  public static final Match<RelationshipType> RelationshipTypeIsDefaultWarPosition =
-      Match.of(rt -> rt.getRelationshipTypeAttachment().isDefaultWarPosition());
+  public static Match<RelationshipType> relationshipTypeIsDefaultWarPosition() {
+    return Match.of(rt -> rt.getRelationshipTypeAttachment().isDefaultWarPosition());
+  }
 
   /**
    * If player is null, this match Will return true if ANY of the relationship changes match the conditions. (since
@@ -2208,11 +2234,17 @@ public final class Matches {
     return Match.of(unit -> UnitAttachment.get(unit.getType()).getMaxScrambleDistance() >= route.getMovementCost(unit));
   }
 
-  public static final Match<Unit> unitCanIntercept = Match.of(u -> UnitAttachment.get(u.getType()).getCanIntercept());
+  static Match<Unit> unitCanIntercept() {
+    return Match.of(u -> UnitAttachment.get(u.getType()).getCanIntercept());
+  }
 
-  public static final Match<Unit> unitCanEscort = Match.of(u -> UnitAttachment.get(u.getType()).getCanEscort());
+  static Match<Unit> unitCanEscort() {
+    return Match.of(u -> UnitAttachment.get(u.getType()).getCanEscort());
+  }
 
-  public static final Match<Unit> unitCanAirBattle = Match.of(u -> UnitAttachment.get(u.getType()).getCanAirBattle());
+  static Match<Unit> unitCanAirBattle() {
+    return Match.of(u -> UnitAttachment.get(u.getType()).getCanAirBattle());
+  }
 
   static Match<Territory> territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(
       final PlayerID attacker) {
@@ -2226,7 +2258,7 @@ public final class Matches {
       if (!Matches.territoryIsPassableAndNotRestricted(attacker, t.getData()).match(t)) {
         return false;
       }
-      return RelationshipTypeCanTakeOverOwnedTerritory
+      return relationshipTypeCanTakeOverOwnedTerritory()
           .match(t.getData().getRelationshipTracker().getRelationshipType(attacker, t.getOwner()));
     });
   }
@@ -2290,7 +2322,9 @@ public final class Matches {
     });
   }
 
-  public static final Match<Unit> UnitIsAirborne = Match.of(obj -> ((TripleAUnit) obj).getAirborne());
+  static Match<Unit> unitIsAirborne() {
+    return Match.of(obj -> ((TripleAUnit) obj).getAirborne());
+  }
 
   public static <T> Match<T> isNotInList(final List<T> list) {
     return Match.of(not(list::contains));

--- a/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -150,7 +150,7 @@ public class MovePerformer implements Serializable {
         // are still dependent during the middle steps of the route.
         final Collection<Unit> dependentOnSomethingTilTheEndOfRoute = new ArrayList<>();
         final Collection<Unit> airTransports = Match.getMatches(arrived, Matches.UnitIsAirTransport);
-        final Collection<Unit> paratroops = Match.getMatches(arrived, Matches.UnitIsAirTransportable);
+        final Collection<Unit> paratroops = Match.getMatches(arrived, Matches.unitIsAirTransportable());
         if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
           final Map<Unit, Unit> transportingAir =
               TransportUtils.mapTransportsToLoad(paratroops, airTransports);
@@ -180,7 +180,7 @@ public class MovePerformer implements Serializable {
                   && Properties.getRaidsMayBePreceededByAirBattles(data)
                   && AirBattle.territoryCouldPossiblyHaveAirBattleDefenders(route.getEnd(), id, data, true);
           if (canCreateAirBattle) {
-            allBombingRaidBuilder.add(Matches.unitCanEscort);
+            allBombingRaidBuilder.add(Matches.unitCanEscort());
           }
           final boolean allCanBomb = !arrived.isEmpty() && Match.allMatch(arrived, allBombingRaidBuilder.any());
           final Collection<Unit> enemyTargets =
@@ -190,7 +190,7 @@ public class MovePerformer implements Serializable {
                           data)));
           final boolean targetsOrEscort = !enemyTargets.isEmpty()
               || (!enemyTargetsTotal.isEmpty() && canCreateAirBattle
-                  && !arrived.isEmpty() && Match.allMatch(arrived, Matches.unitCanEscort));
+                  && !arrived.isEmpty() && Match.allMatch(arrived, Matches.unitCanEscort()));
           boolean targetedAttack = false;
           // if it's all bombers and there's something to bomb
           if (allCanBomb && targetsOrEscort && GameStepPropertiesHelper.isCombatMove(data)) {
@@ -364,7 +364,9 @@ public class MovePerformer implements Serializable {
       return;
     }
     final GameData data = m_bridge.getData();
-    final Match<Unit> paratroopNAirTransports = Match.anyOf(Matches.UnitIsAirTransport, Matches.UnitIsAirTransportable);
+    final Match<Unit> paratroopNAirTransports = Match.anyOf(
+        Matches.UnitIsAirTransport,
+        Matches.unitIsAirTransportable());
     final boolean paratroopsLanding = Match.anyMatch(arrived, paratroopNAirTransports)
         && MoveValidator.allLandUnitsAreBeingParatroopered(arrived);
     final Map<Unit, Collection<Unit>> dependentAirTransportableUnits =

--- a/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -349,7 +349,7 @@ public class MoveValidator {
             .getUnitTypesThatLostBlitz((wasStartFoughtOver ? route.getAllTerritories() : route.getSteps())))));
         for (final Unit unit : nonBlitzingUnits) {
           // TODO: we need to actually test if the units is being air transported, or mech-land-transported.
-          if (Matches.UnitIsAirTransportable.match(unit)) {
+          if (Matches.unitIsAirTransportable().match(unit)) {
             continue;
           }
           if (Matches.unitIsInfantry().match(unit)) {
@@ -390,7 +390,7 @@ public class MoveValidator {
     }
     // See if we are doing invasions in combat phase, with units or transports that can't do invasion.
     if (route.isUnload() && Matches.isTerritoryEnemy(player, data).match(route.getEnd())) {
-      for (final Unit unit : Match.getMatches(units, Matches.UnitCanInvade.invert())) {
+      for (final Unit unit : Match.getMatches(units, Matches.unitCanInvade().invert())) {
         result.addDisallowedUnit(unit.getUnitType().getName() + " can't invade from "
             + TripleAUnit.get(unit).getTransportedBy().getUnitType().getName(), unit);
       }
@@ -600,7 +600,7 @@ public class MoveValidator {
       for (final Unit unit : moveTest) {
         if (!hasEnoughMovementForRoute.match(unit)) {
           boolean unitOk = false;
-          if ((Matches.UnitIsAirTransportable.match(unit) && Matches.unitHasNotMoved().match(unit))
+          if ((Matches.unitIsAirTransportable().match(unit) && Matches.unitHasNotMoved().match(unit))
               && (mechanizedSupportAvailable > 0 && Matches.unitHasNotMoved().match(unit) && Matches.unitIsInfantry()
                   .match(unit))) {
             // we have paratroopers and mechanized infantry, so we must check for both
@@ -620,7 +620,7 @@ public class MoveValidator {
             } else {
               mechanizedSupportAvailable--;
             }
-          } else if (Matches.UnitIsAirTransportable.match(unit) && Matches.unitHasNotMoved().match(unit)) {
+          } else if (Matches.unitIsAirTransportable().match(unit) && Matches.unitHasNotMoved().match(unit)) {
             for (final Unit airTransport : dependencies.keySet()) {
               if (dependencies.get(airTransport) == null || dependencies.get(airTransport).contains(unit)) {
                 unitOk = true;
@@ -851,7 +851,7 @@ public class MoveValidator {
       final List<Unit> transports =
           Match.getMatches(units, Match.anyOf(Matches.UnitIsTransport, Matches.UnitIsAirTransport));
       final List<Unit> transportable =
-          Match.getMatches(units, Match.anyOf(Matches.unitCanBeTransported(), Matches.UnitIsAirTransportable));
+          Match.getMatches(units, Match.anyOf(Matches.unitCanBeTransported(), Matches.unitIsAirTransportable()));
       // Check if there are transports in the group to be checked
       if (alreadyLoaded.keySet().containsAll(transports)) {
         // Check each transportable unit -vs those already loaded.
@@ -1164,14 +1164,14 @@ public class MoveValidator {
   static boolean allLandUnitsAreBeingParatroopered(final Collection<Unit> units) {
     // some units that can't be paratrooped
     if (units.isEmpty()
-        || !Match.allMatch(units, Match.anyOf(Matches.UnitIsAirTransportable, Matches.UnitIsAirTransport,
+        || !Match.allMatch(units, Match.anyOf(Matches.unitIsAirTransportable(), Matches.UnitIsAirTransport,
             Matches.UnitIsAir))) {
       return false;
     }
     // final List<Unit> paratroopsRequiringTransport = getParatroopsRequiringTransport(units, route);
     // due to various problems with units like tanks, we will assume that if we are in this method, then all the land
     // units need transports
-    final List<Unit> paratroopsRequiringTransport = Match.getMatches(units, Matches.UnitIsAirTransportable);
+    final List<Unit> paratroopsRequiringTransport = Match.getMatches(units, Matches.unitIsAirTransportable());
     if (paratroopsRequiringTransport.isEmpty()) {
       return false;
     }
@@ -1202,7 +1202,7 @@ public class MoveValidator {
   }
 
   private static List<Unit> getParatroopsRequiringTransport(final Collection<Unit> units, final Route route) {
-    return Match.getMatches(units, Match.allOf(Matches.UnitIsAirTransportable, Match.of(u -> {
+    return Match.getMatches(units, Match.allOf(Matches.unitIsAirTransportable(), Match.of(u -> {
       return TripleAUnit.get(u).getMovementLeft() < route.getMovementCost(u) || route.crossesWater()
           || route.getEnd().isWater();
     })));
@@ -1213,7 +1213,8 @@ public class MoveValidator {
     if (!TechAttachment.isAirTransportable(player)) {
       return result;
     }
-    if (Match.noneMatch(units, Matches.UnitIsAirTransportable) || Match.noneMatch(units, Matches.UnitIsAirTransport)) {
+    if (Match.noneMatch(units, Matches.unitIsAirTransportable())
+        || Match.noneMatch(units, Matches.UnitIsAirTransport)) {
       return result;
     }
     if (nonCombat && !isAirTransportableCanMoveDuringNonCombat(data)) {

--- a/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -235,7 +235,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // check)
     if (TechAttachment.isAirTransportable(m_attacker)) {
       final Collection<Unit> airTransports = Match.getMatches(units, Matches.UnitIsAirTransport);
-      final Collection<Unit> paratroops = Match.getMatches(units, Matches.UnitIsAirTransportable);
+      final Collection<Unit> paratroops = Match.getMatches(units, Matches.unitIsAirTransportable());
       if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
         // Load capable bombers by default>
         final Map<Unit, Unit> unitsToCapableAirTransports =
@@ -2170,7 +2170,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         final Collection<Unit> validAttackingUnitsForThisRoll =
             Match.getMatches((m_defending ? m_attackingUnits : m_defendingUnits),
                 Match.anyOf(Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
-                    Match.allOf(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
+                    Match.allOf(Matches.unitIsAirborne(), Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         final IExecutable rollDice = new IExecutable() {
           private static final long serialVersionUID = 6435935558879109347L;
 

--- a/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -177,12 +177,12 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     final Match<PoliticalActionAttachment> intoAlliedChainOrIntoOrOutOfWar =
         Match.anyOf(
             Matches.politicalActionIsRelationshipChangeOf(null,
-                Matches.RelationshipTypeIsAlliedAndAlliancesCanChainTogether.invert(),
-                Matches.RelationshipTypeIsAlliedAndAlliancesCanChainTogether, data),
-            Matches.politicalActionIsRelationshipChangeOf(null, Matches.RelationshipTypeIsAtWar.invert(),
-                Matches.RelationshipTypeIsAtWar, data),
-            Matches.politicalActionIsRelationshipChangeOf(null, Matches.RelationshipTypeIsAtWar,
-                Matches.RelationshipTypeIsAtWar.invert(), data));
+                Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().invert(),
+                Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether(), data),
+            Matches.politicalActionIsRelationshipChangeOf(null, Matches.relationshipTypeIsAtWar().invert(),
+                Matches.relationshipTypeIsAtWar(), data),
+            Matches.politicalActionIsRelationshipChangeOf(null, Matches.relationshipTypeIsAtWar(),
+                Matches.relationshipTypeIsAtWar().invert(), data));
     if (!Properties.getAlliancesCanChainTogether(data)
         || !intoAlliedChainOrIntoOrOutOfWar.match(paa)) {
       for (final PlayerID player : paa.getActionAccept()) {
@@ -442,8 +442,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       }
       final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
       final RelationshipType newType = data.getRelationshipTypeList().getRelationshipType(relationshipChange[2]);
-      if (Matches.RelationshipTypeIsAlliedAndAlliancesCanChainTogether.match(currentType)
-          && Matches.RelationshipTypeIsAlliedAndAlliancesCanChainTogether.invert().match(newType)) {
+      if (Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().match(currentType)
+          && Matches.relationshipTypeIsAlliedAndAlliancesCanChainTogether().invert().match(newType)) {
         for (final PlayerID p3 : p1AlliedWith) {
           final RelationshipType currentOther = data.getRelationshipTracker().getRelationshipType(p3, player);
           if (!currentOther.equals(newType)) {
@@ -481,8 +481,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       final PlayerID otherPlayer = (p1.equals(player) ? p2 : p1);
       final RelationshipType currentType = data.getRelationshipTracker().getRelationshipType(p1, p2);
       final RelationshipType newType = data.getRelationshipTypeList().getRelationshipType(relationshipChange[2]);
-      if (Matches.RelationshipTypeIsAtWar.match(currentType)
-          && Matches.RelationshipTypeIsAtWar.invert().match(newType)) {
+      if (Matches.relationshipTypeIsAtWar().match(currentType)
+          && Matches.relationshipTypeIsAtWar().invert().match(newType)) {
         final Collection<PlayerID> otherPlayersAlliedWith =
             Match.getMatches(players, Matches.isAlliedAndAlliancesCanChainTogether(otherPlayer, data));
         if (!otherPlayersAlliedWith.contains(otherPlayer)) {
@@ -494,7 +494,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
         for (final PlayerID p3 : p1AlliedWith) {
           for (final PlayerID p4 : otherPlayersAlliedWith) {
             final RelationshipType currentOther = data.getRelationshipTracker().getRelationshipType(p3, p4);
-            if (!currentOther.equals(newType) && Matches.RelationshipTypeIsAtWar.match(currentOther)) {
+            if (!currentOther.equals(newType) && Matches.relationshipTypeIsAtWar().match(currentOther)) {
               change.add(ChangeFactory.relationshipChange(p3, p4, currentOther, newType));
               bridge.getHistoryWriter()
                   .addChildToEvent(p3.getName() + " and " + p4.getName() + " sign a " + newType.getName() + " treaty");

--- a/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -231,7 +231,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
         result.addDisallowedUnit("Must Not Be Disabled", u);
       } else if (!Matches.unitHasNotMoved().match(u)) {
         result.addDisallowedUnit("Must Not Have Previously Moved Airborne Forces", u);
-      } else if (Matches.UnitIsAirborne.match(u)) {
+      } else if (Matches.unitIsAirborne().match(u)) {
         result.addDisallowedUnit("Cannot Move Units Already Airborne", u);
       } else {
         airborne.add(u);
@@ -293,7 +293,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   private static Match<Unit> getAirborneMatch(final Set<UnitType> types, final Collection<PlayerID> unitOwners) {
     return Match.allOf(Matches.unitIsOwnedByOfAnyOfThesePlayers(unitOwners),
         Matches.unitIsOfTypes(types), Matches.unitIsNotDisabled(), Matches.unitHasNotMoved(),
-        Matches.UnitIsAirborne.invert());
+        Matches.unitIsAirborne().invert());
   }
 
   private static Change getNewAssignmentOfNumberLaunchedChange(int newNumberLaunched, final Collection<Unit> bases,

--- a/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -359,7 +359,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         if (determineAttackers) {
           validAttackingUnitsForThisRoll = Match.getMatches(m_attackingUnits, Match.anyOf(
               Matches.unitIsOfTypes(targetUnitTypesForThisTypeAa),
-              Match.allOf(Matches.UnitIsAirborne, Matches.unitIsOfTypes(airborneTypesTargettedToo))));
+              Match.allOf(Matches.unitIsAirborne(), Matches.unitIsOfTypes(airborneTypesTargettedToo))));
         }
 
         final IExecutable roll = new IExecutable() {

--- a/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -476,7 +476,7 @@ public class MovePanel extends AbstractMovePanel {
       // if the player is invading only consider units that can invade
       if (!nonCombat && route.isUnload()
           && Matches.isTerritoryEnemy(getCurrentPlayer(), getData()).match(route.getEnd())) {
-        best = Match.getMatches(best, Matches.UnitCanInvade);
+        best = Match.getMatches(best, Matches.unitCanInvade());
         bestWithDependents = addMustMoveWith(best);
         lastResults = AbstractMoveDelegate.validateMove(moveType, bestWithDependents, route, getCurrentPlayer(),
             transportsToLoad, dependentUnits, nonCombat, getUndoableMoves(), getData());
@@ -848,7 +848,7 @@ public class MovePanel extends AbstractMovePanel {
           // TODO Transporting allied units
           // Get the potential units to load
           final Match.CompositeBuilder<Unit> unitsToLoadMatchBuilder = Match.newCompositeBuilder(
-              Matches.UnitIsAirTransportable,
+              Matches.unitIsAirTransportable(),
               Matches.unitIsOwnedBy(player),
               Matches.unitHasNotMoved());
           final Collection<Unit> unitsToLoad =
@@ -933,7 +933,7 @@ public class MovePanel extends AbstractMovePanel {
       final Set<Unit> defaultSelections = new HashSet<>();
       // Check to see if there's room for the selected units
       final Match<Collection<Unit>> unitsToLoadMatch = Match.of(units -> {
-        final Collection<Unit> unitsToLoad = Match.getMatches(units, Matches.UnitIsAirTransportable);
+        final Collection<Unit> unitsToLoad = Match.getMatches(units, Matches.unitIsAirTransportable());
         final Map<Unit, Unit> unitMap = TransportUtils.mapTransportsToLoad(unitsToLoad, airTransportsToLoad);
         boolean ableToLoad = true;
         for (final Unit unit : unitsToLoad) {
@@ -1093,7 +1093,7 @@ public class MovePanel extends AbstractMovePanel {
       Collection<Unit> transports = null;
       final Match.CompositeBuilder<Unit> paratroopNBombersBuilder = Match.newCompositeBuilder(
           Matches.UnitIsAirTransport,
-          Matches.UnitIsAirTransportable);
+          Matches.unitIsAirTransportable());
       final boolean paratroopsLanding = Match.anyMatch(units, paratroopNBombersBuilder.all());
       if (route.isLoad() && Match.anyMatch(units, Matches.UnitIsLand)) {
         transports = getTransportsToLoad(route, units, false);

--- a/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -183,7 +183,7 @@ public class PurchasePanel extends ActionPanel {
         }
         final PlayerID player = getCurrentPlayer();
         final Collection<Unit> unitsNeedingFactory =
-            Match.getMatches(player.getUnits().getUnits(), Matches.UnitIsNotConstruction);
+            Match.getMatches(player.getUnits().getUnits(), Matches.unitIsNotConstruction());
         if (!bid && totalProduced + unitsNeedingFactory.size() > totalProd && !isUnlimitedProduction(player)) {
           final String text = "You have purchased " + (totalProduced + unitsNeedingFactory.size())
               + " units, and can only place " + totalProd + " of them. Continue with purchase?";

--- a/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1197,7 +1197,7 @@ public class WW2V3Year41Test {
     final Territory france = territory("France", gameData);
     TechAttachment.get(germans).setParatroopers("true");
     final Route r = gameData.getMap().getRoute(france, territory("7 Sea Zone", gameData));
-    final Collection<Unit> paratroopers = france.getUnits().getMatches(Matches.UnitIsAirTransportable);
+    final Collection<Unit> paratroopers = france.getUnits().getMatches(Matches.unitIsAirTransportable());
     assertFalse(paratroopers.isEmpty());
     final MoveValidationResult results = MoveValidator.validateMove(paratroopers, r, germans,
         Collections.emptyList(), new HashMap<>(), false, null, gameData);
@@ -1250,7 +1250,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
-    List<Unit> paratrooper = germany.getUnits().getMatches(Matches.UnitIsAirTransportable);
+    List<Unit> paratrooper = germany.getUnits().getMatches(Matches.unitIsAirTransportable());
     paratrooper = paratrooper.subList(0, 1);
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratrooper);
     bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));
@@ -1271,7 +1271,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
-    final List<Unit> paratrooper = nwe.getUnits().getMatches(Matches.UnitIsAirTransportable);
+    final List<Unit> paratrooper = nwe.getUnits().getMatches(Matches.unitIsAirTransportable());
     move(paratrooper, new Route(nwe, germany));
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratrooper);
     bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));
@@ -1341,7 +1341,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
-    List<Unit> paratroopers = germany.getUnits().getMatches(Matches.UnitIsAirTransportable);
+    List<Unit> paratroopers = germany.getUnits().getMatches(Matches.unitIsAirTransportable());
     paratroopers = paratroopers.subList(0, 1);
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratroopers);
     bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));
@@ -1378,7 +1378,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
-    List<Unit> paratrooper = germany.getUnits().getMatches(Matches.UnitIsAirTransportable);
+    List<Unit> paratrooper = germany.getUnits().getMatches(Matches.unitIsAirTransportable());
     paratrooper = paratrooper.subList(0, 1);
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratrooper);
     bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.UnitIsAirTransport));


### PR DESCRIPTION
This PR fixes violations of the Checkstyle ConstantName rule in the `Matches` class by converting PascalCase fields to camelCase methods.

This is one part in a series of related PRs in order to keep the review size reasonable.