### PR TITLE
Send WARNING/SEVERE logs to stderr; all others to stdout (#1950)

### DIFF
--- a/src/main/java/games/strategy/debug/ConsoleHandler.java
+++ b/src/main/java/games/strategy/debug/ConsoleHandler.java
@@ -1,0 +1,105 @@
+package games.strategy.debug;
+
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.logging.ErrorManager;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.SimpleFormatter;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * A {@link Handler} that publishes log records of level {@link Level#WARNING} or {@link Level#SEVERE} to
+ * {@code System.err} and log records of all other levels to {@code System.out}.
+ *
+ * <p>
+ * <strong>Configuration:</string> This handler does not currently support configuration through the {@link LogManager}.
+ * It always uses the following default configuration:
+ * </p>
+ *
+ * <ul>
+ * <li>Level: {@code Level.ALL}</li>
+ * <li>Filter: No {@code Filter}</li>
+ * <li>Formatter: {@code java.util.logging.SimpleFormatter}</li>
+ * <li>Encoding: default platform encoding</li>
+ * </ul>
+ */
+public final class ConsoleHandler extends Handler {
+  private final Supplier<PrintStream> errSupplier;
+  private final Supplier<PrintStream> outSupplier;
+
+  public ConsoleHandler() {
+    this(() -> System.out, () -> System.err);
+  }
+
+  @VisibleForTesting
+  ConsoleHandler(final Supplier<PrintStream> outSupplier, final Supplier<PrintStream> errSupplier) {
+    this.errSupplier = errSupplier;
+    this.outSupplier = outSupplier;
+    configure();
+  }
+
+  private void configure() {
+    setLevel(Level.ALL);
+    setFilter(null);
+    setFormatter(new SimpleFormatter());
+    try {
+      setEncoding(null);
+    } catch (final UnsupportedEncodingException e) {
+      throw new AssertionError("default platform encoding should always be available", e);
+    }
+  }
+
+  @Override
+  public void close() {
+    flush();
+  }
+
+  @Override
+  public void flush() {
+    errSupplier.get().flush();
+    outSupplier.get().flush();
+  }
+
+  @Override
+  public boolean isLoggable(final LogRecord record) {
+    return record != null && super.isLoggable(record);
+  }
+
+  @Override
+  public void publish(final LogRecord record) {
+    if (!isLoggable(record)) {
+      return;
+    }
+
+    formatRecord(record).ifPresent(message -> writeMessage(record.getLevel(), message));
+  }
+
+  private Optional<String> formatRecord(final LogRecord record) {
+    try {
+      return Optional.of(getFormatter().format(record));
+    } catch (final RuntimeException e) {
+      reportError(null, e, ErrorManager.FORMAT_FAILURE);
+      return Optional.empty();
+    }
+  }
+
+  private void writeMessage(final Level level, final String message) {
+    final PrintStream stream = getStreamFor(level);
+    try {
+      stream.print(message);
+      stream.flush();
+    } catch (final RuntimeException e) {
+      reportError(null, e, ErrorManager.WRITE_FAILURE);
+    }
+  }
+
+  private PrintStream getStreamFor(final Level level) {
+    return level.intValue() >= Level.WARNING.intValue() ? errSupplier.get() : outSupplier.get();
+  }
+}

--- a/src/main/java/games/strategy/debug/LoggingConfiguration.java
+++ b/src/main/java/games/strategy/debug/LoggingConfiguration.java
@@ -1,0 +1,49 @@
+package games.strategy.debug;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.logging.LogManager;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Provides support for configuring the Java platform's core logging facilities.
+ */
+public final class LoggingConfiguration {
+  private LoggingConfiguration() {}
+
+  /**
+   * Initializes the application logging configuration.
+   *
+   * <p>
+   * The default application logging configuration is read from the {@code logging.properties} file located in this
+   * package. The logging configuration can be overridden in production using the standard {@link LogManager} system
+   * properties "java.util.logging.config.class" or "java.util.logging.config.file".
+   * </p>
+   */
+  public static void initialize() {
+    initialize(LogManager.getLogManager(), System.getProperties());
+  }
+
+  @VisibleForTesting
+  static void initialize(final LogManager logManager, final Properties systemProperties) {
+    if (systemProperties.containsKey(SystemPropertyKeys.LOGGING_CONFIGURATION_CLASS_NAME)
+        || systemProperties.containsKey(SystemPropertyKeys.LOGGING_CONFIGURATION_FILE_NAME)) {
+      return;
+    }
+
+    try (final InputStream is = LoggingConfiguration.class.getResourceAsStream("logging.properties")) {
+      logManager.readConfiguration(is);
+    } catch (final IOException e) {
+      System.err.println("unable to set custom logging configuration using logging.properties");
+      System.err.println(e);
+    }
+  }
+
+  @VisibleForTesting
+  interface SystemPropertyKeys {
+    String LOGGING_CONFIGURATION_CLASS_NAME = "java.util.logging.config.class";
+    String LOGGING_CONFIGURATION_FILE_NAME = "java.util.logging.config.file";
+  }
+}

--- a/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -30,6 +30,7 @@ import org.triplea.client.ui.javafx.TripleA;
 
 import games.strategy.debug.ClientLogger;
 import games.strategy.debug.ErrorConsole;
+import games.strategy.debug.LoggingConfiguration;
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.chat.Chat;
@@ -118,6 +119,8 @@ public class GameRunner {
    * Warning: game engine code invokes this method to spawn new game clients.
    */
   public static void main(final String[] args) {
+    LoggingConfiguration.initialize();
+
     if (!ClientContext.gameEnginePropertyReader().useJavaFxUi()) {
       ErrorConsole.getConsole();
     }

--- a/src/main/resources/games/strategy/debug/logging.properties
+++ b/src/main/resources/games/strategy/debug/logging.properties
@@ -1,0 +1,7 @@
+# Global properties
+
+handlers=games.strategy.debug.ConsoleHandler
+
+# Logger-specific properties
+
+.level=INFO

--- a/src/test/java/games/strategy/debug/ConsoleHandlerTest.java
+++ b/src/test/java/games/strategy/debug/ConsoleHandlerTest.java
@@ -1,0 +1,139 @@
+package games.strategy.debug;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintStream;
+import java.util.logging.ErrorManager;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public final class ConsoleHandlerTest {
+  private ConsoleHandler consoleHandler;
+
+  @Mock
+  private PrintStream err;
+
+  @Mock
+  private ErrorManager errorManager;
+
+  @Mock
+  private Formatter formatter;
+
+  @Mock
+  private PrintStream out;
+
+  @Before
+  public void setUp() {
+    consoleHandler = new ConsoleHandler(() -> out, () -> err);
+    consoleHandler.setErrorManager(errorManager);
+  }
+
+  @Test
+  public void close_ShouldFlushButNotCloseStreams() {
+    consoleHandler.close();
+
+    verify(err).flush();
+    verify(err, never()).close();
+    verify(out).flush();
+    verify(out, never()).close();
+  }
+
+  @Test
+  public void flush_ShouldFlushStreams() {
+    consoleHandler.flush();
+
+    verify(err).flush();
+    verify(out).flush();
+  }
+
+  @Test
+  public void isLoggable_ShouldReturnFalseWhenRecordIsNull() {
+    assertThat(consoleHandler.isLoggable(null), is(false));
+  }
+
+  @Test
+  public void publish_ShouldWriteToErrStreamWhenLevelIsWarningOrGreater() {
+    consoleHandler.publish(newLogRecordForLevel(Level.SEVERE));
+    consoleHandler.publish(newLogRecordForLevel(Level.WARNING));
+
+    verify(err, times(2)).print(anyString());
+    verify(out, never()).print(anyString());
+  }
+
+  private static LogRecord newLogRecordForLevel(final Level level) {
+    return new LogRecord(level, "message");
+  }
+
+  @Test
+  public void publish_ShouldWriteToOutStreamWhenLevelIsInfoOrLower() {
+    consoleHandler.publish(newLogRecordForLevel(Level.INFO));
+    consoleHandler.publish(newLogRecordForLevel(Level.CONFIG));
+    consoleHandler.publish(newLogRecordForLevel(Level.FINE));
+    consoleHandler.publish(newLogRecordForLevel(Level.FINER));
+    consoleHandler.publish(newLogRecordForLevel(Level.FINEST));
+
+    verify(out, times(5)).print(anyString());
+    verify(err, never()).print(anyString());
+  }
+
+  @Test
+  public void publish_ShouldDoNothingWhenLogRecordIsNotLoggable() {
+    consoleHandler.publish(null);
+
+    verify(err, never()).print(anyString());
+    verify(out, never()).print(anyString());
+    verify(errorManager, never()).error(any(), any(), anyInt());
+  }
+
+  @Test
+  public void publish_ShouldWriteMessageSuppliedByFormatter() {
+    final String message = "the message";
+    when(formatter.format(any(LogRecord.class))).thenReturn(message);
+    consoleHandler.setFormatter(formatter);
+
+    consoleHandler.publish(newLogRecordForLevel(Level.INFO));
+
+    verify(out).print(message);
+  }
+
+  @Test
+  public void publish_ShouldReportErrorWhenFormatterThrowsException() {
+    final Exception exception = new RuntimeException();
+    when(formatter.format(any(LogRecord.class))).thenThrow(exception);
+    consoleHandler.setFormatter(formatter);
+
+    consoleHandler.publish(newLogRecordForLevel(Level.INFO));
+
+    verify(errorManager).error(any(), eq(exception), eq(ErrorManager.FORMAT_FAILURE));
+    verify(out, never()).print(nullable(String.class));
+  }
+
+  @Test
+  public void publish_ShouldReportErrorWhenStreamThrowsException() {
+    final Exception exception = new RuntimeException();
+    doThrow(exception).when(out).print(anyString());
+
+    consoleHandler.publish(newLogRecordForLevel(Level.INFO));
+
+    verify(errorManager).error(any(), eq(exception), eq(ErrorManager.WRITE_FAILURE));
+  }
+}

--- a/src/test/java/games/strategy/debug/LoggingConfigurationTest.java
+++ b/src/test/java/games/strategy/debug/LoggingConfigurationTest.java
@@ -1,0 +1,46 @@
+package games.strategy.debug;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Properties;
+import java.util.logging.LogManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public final class LoggingConfigurationTest {
+  @Spy
+  private final LogManager logManager = LogManager.getLogManager();
+
+  private final Properties systemProperties = new Properties();
+
+  @Test
+  public void initialize_ShouldDoNothingWhenLoggingConfigurationClassNameSystemPropertyIsPresent() throws Exception {
+    systemProperties.setProperty(LoggingConfiguration.SystemPropertyKeys.LOGGING_CONFIGURATION_CLASS_NAME, "");
+
+    LoggingConfiguration.initialize(logManager, systemProperties);
+
+    verify(logManager, never()).readConfiguration(any());
+  }
+
+  @Test
+  public void initialize_ShouldDoNothingWhenLoggingConfigurationFileNameSystemPropertyIsPresent() throws Exception {
+    systemProperties.setProperty(LoggingConfiguration.SystemPropertyKeys.LOGGING_CONFIGURATION_FILE_NAME, "");
+
+    LoggingConfiguration.initialize(logManager, systemProperties);
+
+    verify(logManager, never()).readConfiguration(any());
+  }
+
+  @Test
+  public void initialize_ShouldReadCustomConfigurationWhenUserDoesNotOverrideLoggingConfiguration() throws Exception {
+    LoggingConfiguration.initialize(logManager, systemProperties);
+
+    verify(logManager).readConfiguration(any());
+  }
+}


### PR DESCRIPTION
This PR addresses the issue reported in #1950.  It uses a custom logger `Handler` to send `WARNING` and `SEVERE` logs to stderr, while the remaining logs are sent to stdout.  This prevents the `ErrorConsole` from automatically opening when, for example, `INFO` messages are logged, as reported in #1950.

#### Functional changes

* Added the `g.s.debug.ConsoleHandler` class to split logs between stderr and stdout depending on level.
    * This handler does not support customizing the configuration by an end user.  I don't think it's necessary at this time to support custom filters, formatters, etc.  We can easily add it in the future, if needed.
* Added the `g.s.debug.LoggingConfiguration` class to initialize the Java logging system with a custom configuration stored in `g/s/debug/logging.properties`.  This custom configuration is basically the same as the default Java logging configuration with the exception that we register our custom handler instead of the default `java.util.logging.ConsoleHandler` handler.
    * `LoggingConfiguration` will not load our custom configuration if the user launches the application with either the "java.util.logging.config.class" or "java.util.logging.config.file" system properties defined per the Java `LogManager` docs.  This allows users/devs to specify their own configuration, if needed for debugging.

#### Functional issues for review

I made some questionable choices in the design that I'll highlight in a forthcoming review.

#### Testing

I verified that `INFO` logs no longer cause the `ErrorConsole` to open (I used hosting a network game as the test scenario).  I also verified that a `WARNING` log did cause the `ErrorConsole` to open (I simply added a previously non-existent `logger.warning()` call to a common code path).