### PR TITLE
TripleA protocol handler: Fix urlencoding + quotes on linux (#2286)

### DIFF
--- a/build.install4j
+++ b/build.install4j
@@ -451,7 +451,7 @@ if(System.getenv("XDG_DATA_HOME") != null || (shareFolder.exists() &amp;&amp; sh
         while(scanner.hasNextLine()){
             String nextLine = scanner.nextLine();
             if(nextLine.startsWith("Exec=") &amp;&amp; !nextLine.contains("%u")){
-                builder.append(nextLine).append(" \"%u\"\n");
+                builder.append(nextLine).append(" %u\n");
             } else if(!nextLine.startsWith(mimeTypePrefix)){
                 builder.append(nextLine).append('\n');
             }

--- a/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -26,7 +26,7 @@ public class ArgParser {
           args[0] = GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY + "="
               + URLDecoder.decode(args[0].substring(TRIPLEA_PROTOCOL.length()), encoding);
         } catch (UnsupportedEncodingException e) {
-          throw new IllegalStateException(encoding + " is not a supported encoding!", e);
+          throw new AssertionError(encoding + " is not a supported encoding!", e);
         }
       } else {
         args[0] = GameRunner.TRIPLEA_GAME_PROPERTY + "=" + args[0];

--- a/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -1,5 +1,8 @@
 package games.strategy.engine.framework;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import games.strategy.triplea.settings.ClientSetting;
@@ -18,7 +21,13 @@ public class ArgParser {
     if (args.length == 1 && !args[0].contains("=")) {
       // assume a default single arg, convert the format so we can process as normally.
       if (args[0].startsWith(TRIPLEA_PROTOCOL)) {
-        args[0] = GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY + "=" + args[0].substring(TRIPLEA_PROTOCOL.length());
+        final String encoding = StandardCharsets.UTF_8.displayName();
+        try {
+          args[0] = GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY + "="
+              + URLDecoder.decode(args[0].substring(TRIPLEA_PROTOCOL.length()), encoding);
+        } catch (UnsupportedEncodingException e) {
+          throw new IllegalStateException(encoding + " is not a supported encoding!", e);
+        }
       } else {
         args[0] = GameRunner.TRIPLEA_GAME_PROPERTY + "=" + args[0];
       }

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -6,8 +6,6 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.junit.After;
@@ -79,12 +77,11 @@ public class ArgParserTest {
 
   @Test
   public void singleUrlArgIsUrlDecoded() throws UnsupportedEncodingException {
-    final String propvalue = "Something with spaces and Special chars 🤔";
-    final String testUrl = "triplea:" + URLEncoder.encode(propvalue, StandardCharsets.UTF_8.displayName());
+    final String testUrl = "triplea:Something%20with+spaces%20and%20Special%20chars%20%F0%9F%A4%94";
     ArgParser.handleCommandLineArgs(new String[] {testUrl}, new String[] {GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY});
     assertThat("if we pass only one arg prefixed with 'triplea:',"
         + " it should be properly URL-decoded as it's probably coming from a browser",
-        System.getProperty(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY), is(propvalue));
+        System.getProperty(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY), is("Something with spaces and Special chars 🤔"));
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 
 import org.junit.After;
@@ -76,7 +75,7 @@ public class ArgParserTest {
   }
 
   @Test
-  public void singleUrlArgIsUrlDecoded() throws UnsupportedEncodingException {
+  public void singleUrlArgIsUrlDecoded() {
     final String testUrl = "triplea:Something%20with+spaces%20and%20Special%20chars%20%F0%9F%A4%94";
     ArgParser.handleCommandLineArgs(new String[] {testUrl}, new String[] {GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY});
     assertThat("if we pass only one arg prefixed with 'triplea:',"

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -5,6 +5,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.junit.After;
@@ -72,6 +75,16 @@ public class ArgParserTest {
     assertThat("if we pass only one arg prefixed with 'triplea:',"
         + " it's assumed to mean we are specifying the 'map download property'",
         System.getProperty(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY), is(TestData.propValue));
+  }
+
+  @Test
+  public void singleUrlArgIsUrlDecoded() throws UnsupportedEncodingException {
+    final String propvalue = "Something with spaces and Special chars \uD83E\uDD14";
+    final String testUrl = "triplea:" + URLEncoder.encode(propvalue, StandardCharsets.UTF_8.displayName());
+    ArgParser.handleCommandLineArgs(new String[] {testUrl}, new String[] {GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY});
+    assertThat("if we pass only one arg prefixed with 'triplea:',"
+        + " it should be properly URL-decoded as it's probably coming from a browser",
+        System.getProperty(GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY), is(propvalue));
   }
 
   @Test

--- a/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -79,7 +79,7 @@ public class ArgParserTest {
 
   @Test
   public void singleUrlArgIsUrlDecoded() throws UnsupportedEncodingException {
-    final String propvalue = "Something with spaces and Special chars \uD83E\uDD14";
+    final String propvalue = "Something with spaces and Special chars 🤔";
     final String testUrl = "triplea:" + URLEncoder.encode(propvalue, StandardCharsets.UTF_8.displayName());
     ArgParser.handleCommandLineArgs(new String[] {testUrl}, new String[] {GameRunner.TRIPLEA_MAP_DOWNLOAD_PROPERTY});
     assertThat("if we pass only one arg prefixed with 'triplea:',"


### PR DESCRIPTION
With some delay: This PR fixes #2286

Small thing I noticed while testing stuff: It seems TripleA is incompatible with java 9, it crashed on start, when I forgot to set the JDK back to java 8