### PR TITLE
Checkstyle: Upgrade to version 7.8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,7 @@ check {
 }
 
 checkstyle {
-    toolVersion = "7.6.1"
+    toolVersion = "7.8.2"
     configProperties = [samedir: configFile.parent]
 }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
@@ -97,6 +97,11 @@
             <property name="id" value="SeparatorWrapComma"/>
             <property name="tokens" value="COMMA"/>
             <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
         </module>
         <module name="PackageName">
             <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>


### PR DESCRIPTION
This PR upgrades the Checkstyle engine and the Google ruleset to version 7.8.2.  There were no new violations introduced.

No dev changes are required as the latest Eclipse Checkstyle plugin for the 7.x release remains version 7.6.0.

Note that the latest version of Checkstyle is 8.1.  However, several breaking changes were introduced in the 8.x release that trigger several hundred new violations.  I need to digest those changes and get input from the team about which changes we should accept and which we should ignore.  So the purpose of this PR is to simply get up-to-date on the latest 7.x release before we upgrade to 8.x.