### PR TITLE
Revert #2291

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,7 @@ check {
 }
 
 checkstyle {
-    toolVersion = "7.8.2"
+    toolVersion = "7.6.1"
     configProperties = [samedir: configFile.parent]
 }
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
           "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
@@ -97,11 +97,6 @@
             <property name="id" value="SeparatorWrapComma"/>
             <property name="tokens" value="COMMA"/>
             <property name="option" value="EOL"/>
-        </module>
-        <module name="SeparatorWrap">
-            <property name="id" value="SeparatorWrapMethodRef"/>
-            <property name="tokens" value="METHOD_REF"/>
-            <property name="option" value="nl"/>
         </module>
         <module name="PackageName">
             <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>


### PR DESCRIPTION
This PR reverts the upgrade to Checkstyle 7.8.2 in #2291.  I thought I checked how the updated Google rules behave with version 7.6.0 of the Eclipse Checkstyle plugin we're currently using, but apparently I didn't check it well enough.  There is an incompatibility with the new SeparatorWrap rule added to the 7.8.2 Google rules that causes the 7.6.0 Checkstyle plugin to fail.

Since the only newer version of the Eclipse Checkstyle plugin is 8.0, we're going to have to upgrade to 8.0 all at once.